### PR TITLE
x64: eliminate implicit narrowing conversions (full dim_t widening effort)

### DIFF
--- a/src/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.cpp
+++ b/src/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.cpp
@@ -98,7 +98,8 @@ dnnl_status_t ref_gemm_s8x8s32(const char *transa, const char *transb,
         double coffset = OCisR ? i2d(co[j]) : OCisC ? i2d(co[i]) : i2d(co[0]);
         double val = ((*beta == 0.0f) ? 0.0 : f2d(*beta) * i2d(C[i + j * ldc]))
                 + f2d(*alpha) * dC[i + j * ldc] + coffset;
-        C[i + j * ldc] = q10n::out_round<int32_t>(q10n::saturate<int32_t>(val));
+        C[i + j * ldc] = q10n::out_round<int32_t>(
+                static_cast<float>(q10n::saturate<int32_t>(val)));
     });
 
     free(dA);

--- a/src/cpu/gemm/s8x8s32/simple_gemm_s8s8s32.cpp
+++ b/src/cpu/gemm/s8x8s32/simple_gemm_s8s8s32.cpp
@@ -65,8 +65,8 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                 val += a[(i + j * blocking_factor * lda) + jb * lda];
             }
             if (alpha != 1.0f) {
-                val = q10n::out_round<int32_t>(
-                        q10n::saturate<int32_t>((double)val * alpha * -128.0));
+                val = q10n::out_round<int32_t>(static_cast<float>(
+                        q10n::saturate<int32_t>((double)val * alpha * -128.0)));
             } else {
                 val *= -128;
             }
@@ -80,8 +80,9 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                     val += a[i + j * lda];
                 }
                 if (alpha != 1.0f) {
-                    val = q10n::out_round<int32_t>(q10n::saturate<int32_t>(
-                            (double)val * alpha * -128.0));
+                    val = q10n::out_round<int32_t>(
+                            static_cast<float>(q10n::saturate<int32_t>(
+                                    (double)val * alpha * -128.0)));
                 } else {
                     val *= -128;
                 }
@@ -95,8 +96,8 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                 val += a[j + i * lda];
             }
             if (alpha != 1.0f) {
-                val = q10n::out_round<int32_t>(
-                        q10n::saturate<int32_t>((double)val * alpha * -128.0));
+                val = q10n::out_round<int32_t>(static_cast<float>(
+                        q10n::saturate<int32_t>((double)val * alpha * -128.0)));
             } else {
                 val *= -128;
             }

--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -87,7 +87,7 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
             + (ptrdiff_t)ithr * jcp.is * jcp.ic;
 
     dim_t g {0}, n {0}, ohb {0}, owb {0};
-    dim_t start = 0, end = 0;
+    int start_i {0}, end_i {0};
     const bool is_problem_3d = pd()->ndims() == 5;
 
     assert(IMPLICATION(is_problem_3d,
@@ -95,11 +95,13 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
                     && jcp.ic_block == jcp.ic));
     assert(IMPLICATION(jcp.ow_block != jcp.ow, jcp.oh_block == 1));
 
-    const dim_t nb_oh = div_up(jcp.oh, jcp.oh_block);
-    const dim_t nb_ow = div_up(jcp.ow, jcp.ow_block);
+    const int nb_oh = static_cast<int>(div_up(jcp.oh, jcp.oh_block));
+    const int nb_ow = static_cast<int>(div_up(jcp.ow, jcp.ow_block));
     // threads share work across mini-batch, groups, and blocked width/height
-    const dim_t work_amount = jcp.mb * jcp.ngroups * nb_oh * nb_ow;
-    balance211(work_amount, nthr, ithr, start, end);
+    const int work_amount
+            = static_cast<int>(jcp.mb * jcp.ngroups * nb_oh * nb_ow);
+    balance211(work_amount, nthr, ithr, start_i, end_i);
+    dim_t start = start_i, end = end_i;
     nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ohb, nb_oh, owb, nb_ow);
 
     if (jcp.im2col_sz && is_problem_3d) {
@@ -116,8 +118,10 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const data_t *__restrict wei = wei_base + g * wei_g_stride;
 
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const int h_step
+                = static_cast<int>(nstl::min<dim_t>(jcp.oh_block, jcp.oh - oh));
+        const int w_step
+                = static_cast<int>(nstl::min<dim_t>(jcp.ow_block, jcp.ow - ow));
         if (jcp.im2col_sz && is_problem_3d) {
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
         }
@@ -264,8 +268,9 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
             for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
                 _col[i] = (data_t)0;
         }
-        auto inner_ker = [&](int spatial, const im_pos_t &curr, im_pos_t &prev,
-                                 im_pos_t &step, const im_pos_t &end) {
+        auto inner_ker
+                = [&](dim_t spatial, const im_pos_t &curr, im_pos_t &prev,
+                          im_pos_t &step, const im_pos_t &end) {
             const data_t *_src
                     = src + curr.n * src_mb_stride + curr.g * src_g_stride;
             step.oc = nstl::min(
@@ -282,8 +287,8 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                     jit_gemm_convolution_utils::im2col<float>(jcp, _src, _col,
                             curr.sp, step.sp, curr.ic, step.ic);
                 else
-                    jit_gemm_convolution_utils::im2col_3d<float>(
-                            jcp, _src, _col, curr.od, 0, jcp.os);
+                    jit_gemm_convolution_utils::im2col_3d<float>(jcp, _src,
+                            _col, curr.od, 0, static_cast<int>(jcp.os));
             }
             const data_t one = 1.0;
 
@@ -312,7 +317,8 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                 // TODO: for "outer threading" we have parallel section within
                 // outermost "parallel". It is not good. Consider to use
                 // "parallel" here with number of threads passed as parameter
-                const int oc_start = curr.g * jcp.oc + curr.oc;
+                const int oc_start
+                        = static_cast<int>(curr.g * jcp.oc + curr.oc);
                 if (jcp.with_eltwise || jcp.with_binary) {
                     bool fast_relu_done = false;
                     if (jcp.with_eltwise && jcp.post_ops.len() == 1) {
@@ -479,9 +485,10 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_thr_nspc(
             : nullptr;
 
     dim_t n {0}, g {0};
-    dim_t start = 0, end = 0;
+    dim_t start_i {0}, end_i {0};
 
-    balance211(work_amount, nthr, ithr, start, end);
+    balance211(work_amount, nthr, ithr, start_i, end_i);
+    dim_t start = start_i, end = end_i;
     nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups);
 
     for (dim_t iwork = start; iwork < end; ++iwork) {
@@ -550,7 +557,7 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_ncsp(
     const dim_t K = jcp.oc;
     const dim_t N = jcp.ic * jcp.ks;
 
-    const dim_t work_amount = (size_t)jcp.ngroups * jcp.mb;
+    const dim_t work_amount = jcp.ngroups * jcp.mb;
     const bool is_problem_3d = pd()->ndims() == 5;
 
     std::atomic<status_t> st(status::success);
@@ -558,8 +565,9 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_ncsp(
         data_t *_col = col + (ptrdiff_t)ithr * jcp.im2col_sz;
 
         dim_t g {0}, n {0};
-        dim_t start = 0, end = 0;
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
         nd_iterator_init(start, g, jcp.ngroups, n, jcp.mb);
         for (dim_t iwork = start; iwork < end; ++iwork) {
 
@@ -636,11 +644,13 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
     std::atomic<status_t> st(status::success);
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                ithr_mb, nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
 
@@ -651,8 +661,8 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                 + (ptrdiff_t)ithr * jcp.id * jcp.ic * jcp.is;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -670,11 +680,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
             data_t *weights_reduce = weights_reduce_base
                     + ithr_mb * weights_g_size * jcp.ks * jcp.ic;
 
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 data_t *_diff_weights = need_reduction
                         ? weights_reduce
                         : diff_weights + g * weights_g_size;
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const data_t *_src
                             = src + mb * jcp.ngroups * src_step + g * jcp.ic;
                     if (jcp.im2col_sz && is_problem_3d)
@@ -730,17 +740,20 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0};
             size_t mb_start {0}, mb_end {0};
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g,
+                    nthr_g, ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
 
             if (need_reduction && ithr_g != -1 && ithr_mb != -1) {
-                balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-                balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+                balance211(static_cast<size_t>(jcp.ngroups), nthr_g, ithr_g,
+                        g_start, g_end);
+                balance211(static_cast<size_t>(jcp.mb), nthr_mb, ithr_mb,
+                        mb_start, mb_end);
 
                 assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -765,7 +778,7 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                         + ((static_cast<size_t>(mb) * jcp.od + od) * jcp.oh
                                   + oh)
                                 * jcp.ow * jcp.ngroups * jcp.oc;
-                const int width_stride = jcp.ngroups * jcp.oc;
+                const dim_t width_stride = jcp.ngroups * jcp.oc;
 
                 PRAGMA_OMP_SIMD(reduction(+ : db))
                 for (dim_t ow = 0; ow < jcp.ow; ++ow) {
@@ -806,9 +819,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
         size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                ithr_mb, nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
         const int need_reduction = nthr_mb != 1;
@@ -897,10 +912,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0};
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g,
+                    nthr_g, ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -55,7 +55,7 @@ namespace jit_gemm_convolution_utils {
 
 template <typename data_type_t>
 void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
-        data_type_t *col, dim_t od, int spatial_step, int spatial_block) {
+        data_type_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block) {
     using data_t =
             typename conditional<data_traits_t<data_type_t>::data_type == bf16,
                     uint16_t, data_type_t>::type;
@@ -226,10 +226,10 @@ void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
 }
 
 template void im2col_3d(const conv_gemm_conf_t &jcp, const float *im,
-        float *col, dim_t od, int spatial_step, int spatial_block);
+        float *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 template void im2col_3d(const conv_gemm_conf_t &jcp, const bfloat16_t *im,
-        bfloat16_t *col, dim_t od, int spatial_step, int spatial_block);
+        bfloat16_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 /* imtr[ic][od][oh][ow] <-- im[id][ih][iw][ic]*/
 template <typename T>
@@ -253,11 +253,12 @@ void transpose_dt(const conv_gemm_conf_t &jcp, const T *__restrict im,
                 T *__restrict imtr_icb = imtr_w + icb * ic_block * ic_stride;
                 PRAGMA_OMP_SIMD()
                 for (dim_t ic = 0; ic < ic_block; ic++) {
-                    imtr_icb[ic * ic_stride] = im_icb[ic] + shift;
+                    imtr_icb[ic * ic_stride]
+                            = static_cast<T>(im_icb[ic] + shift);
                 }
             }
             for (dim_t ic = ic_blocked; ic < jcp.ic; ic++) {
-                imtr_w[ic * ic_stride] = im_w[ic] + shift;
+                imtr_w[ic * ic_stride] = static_cast<T>(im_w[ic] + shift);
             }
         }
     });
@@ -647,8 +648,8 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
                         for (dim_t ow = 0; ow < ow_start; ++ow)
                             col[col_idx_oh + ow] = shift;
                         for (dim_t ow = ow_start; ow < ow_end; ++ow)
-                            col[col_idx_oh + ow]
-                                    = imtr[imtr_idx_oh + ow] + shift;
+                            col[col_idx_oh + ow] = static_cast<col_dt>(
+                                    imtr[imtr_idx_oh + ow] + shift);
                         for (dim_t ow = ow_end; ow < wb; ++ow)
                             col[col_idx_oh + ow] = shift;
                     }
@@ -683,7 +684,8 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
                 for (dim_t ow = ow_start; ow < ow_end; ow++) {
                     const dim_t iw = iw_base + ow * sw;
                     const ptrdiff_t im_idx = im_idx_base + iw * im_iw_stride;
-                    col[col_idx_base + ow] = im[im_idx] + shift;
+                    col[col_idx_base + ow]
+                            = static_cast<col_dt>(im[im_idx] + shift);
                 }
                 for (dim_t ow = ow_end; ow < wb; ow++)
                     col[col_idx_base + ow] = shift;
@@ -790,7 +792,7 @@ template void col2im_dt<bfloat16_t>(const conv_gemm_conf_t &jcp,
         const bfloat16_t *__restrict col, bfloat16_t *__restrict im);
 
 void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        dim_t od, int spatial_step, int spatial_block) {
+        dim_t od, dim_t spatial_step, dim_t spatial_block) {
 
     auto sp_blocked_ker = [&](dim_t ic) {
         const size_t col_step = jcp.ks * spatial_block;
@@ -892,7 +894,7 @@ void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
 }
 
 void col2im(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        int spatial_step, int spatial_block) {
+        dim_t spatial_step, dim_t spatial_block) {
     const size_t col_step = jcp.ks * spatial_block;
     const size_t im_step = jcp.ih * jcp.iw;
     const dim_t iS = jcp.ih * jcp.iw;
@@ -1297,8 +1299,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         dim_t nb_h = div_up(oh, h_block);
                         dim_t work = jcp.ngroups * jcp.mb * jcp.od * nb_h;
-                        float disb = (float)oh / rnd_up(oh, h_block);
-                        thr_eff = (float)work / rnd_up(work, max_threads);
+                        float disb = (float)oh / (float)rnd_up(oh, h_block);
+                        thr_eff = (float)work
+                                / (float)rnd_up(work, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff >= thr_eff_treshold) break;
                         h_block = rnd_dn(h_block - 4, 4);
@@ -1308,13 +1311,13 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                         < thr_eff_treshold) // we didn't find suitable h_block
                 {
                     h_block = 1;
-                    int nb_h = oh;
+                    dim_t nb_h = oh;
                     do {
                         dim_t nb_w = div_up(ow, w_block);
                         dim_t work_amount = jcp.ngroups * jcp.mb * nb_h * nb_w;
-                        float disb = (float)ow / rnd_up(ow, w_block);
+                        float disb = (float)ow / (float)rnd_up(ow, w_block);
                         thr_eff = (float)work_amount
-                                / rnd_up(work_amount, max_threads);
+                                / (float)rnd_up(work_amount, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff > thr_eff_treshold) break;
                         w_block = rnd_dn(w_block - simd_w, simd_w);
@@ -1323,8 +1326,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 h_block = nstl::max(dim_t(1), h_block);
                 w_block = nstl::max(dim_t(1), w_block);
                 dim_t inner_work = div_up(os, simd_w) * div_up(oc, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 if (thr_eff >= inner_thr_eff / 2 && h_block > 0
                         && w_block > 0) {
                     jcp.oh_block = h_block;
@@ -1346,12 +1349,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 bool is_depthwise
                         = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
                 const dim_t outer_work = jcp.ngroups * jcp.mb;
-                const float outer_thr_eff
-                        = (float)outer_work / rnd_up(outer_work, max_threads);
+                const float outer_thr_eff = (float)outer_work
+                        / (float)rnd_up(outer_work, max_threads);
                 const size_t inner_work
                         = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 jcp.outer_threading
                         = (is_depthwise
                                   || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1377,12 +1380,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
 
             bool is_depthwise = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
             const size_t outer_work = jcp.ngroups * jcp.mb;
-            const float outer_thr_eff
-                    = (float)outer_work / rnd_up(outer_work, max_threads);
+            const float outer_thr_eff = (float)outer_work
+                    / (float)rnd_up(outer_work, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = !is_3d
                     && (is_depthwise
                             || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1459,8 +1462,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         size_t nb_h = div_up(oh, h_block);
                         size_t work = jcp.ngroups * jcp.mb * jcp.od * nb_h;
-                        float disb = (float)oh / rnd_up(oh, h_block);
-                        thr_eff = (float)work / rnd_up(work, max_threads);
+                        float disb = (float)oh / (float)rnd_up(oh, h_block);
+                        thr_eff = (float)work
+                                / (float)rnd_up(work, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff >= thr_eff_treshold) break;
 
@@ -1478,9 +1482,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         size_t nb_w = div_up(ow, w_block);
                         size_t work_amount = jcp.ngroups * jcp.mb * nb_h * nb_w;
-                        float disb = (float)ow / rnd_up(ow, w_block);
+                        float disb = (float)ow / (float)rnd_up(ow, w_block);
                         thr_eff = (float)work_amount
-                                / rnd_up(work_amount, max_threads);
+                                / (float)rnd_up(work_amount, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff > thr_eff_treshold) break;
 
@@ -1494,8 +1498,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 w_block = nstl::max(size_t {1}, w_block);
                 const size_t inner_work
                         = div_up(os, simd_w) * div_up(oc, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 if (thr_eff >= inner_thr_eff / 2 && h_block > 0
                         && w_block > 0) {
                     jcp.oh_block = static_cast<int>(h_block);
@@ -1517,12 +1521,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 bool is_depthwise
                         = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
                 const size_t outer_work = jcp.ngroups * jcp.mb;
-                const float outer_thr_eff
-                        = (float)outer_work / rnd_up(outer_work, max_threads);
+                const float outer_thr_eff = (float)outer_work
+                        / (float)rnd_up(outer_work, max_threads);
                 const size_t inner_work
                         = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 jcp.outer_threading
                         = (is_depthwise
                                   || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1571,7 +1575,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                             // threading work
                             || jcp.os < jcp.mb * jcp.ngroups * jcp.od
                             // im2col is big
-                            || (sw == 1 && K <= 0.05 * jcp.oc))
+                            || (sw == 1 && (double)K <= 0.05 * (double)jcp.oc))
                     // heuristic condition
                     && (jcp.im2col_sz
                             || (jcp.ic / jcp.oc < 42
@@ -1704,7 +1708,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                                     = nstl::min(oc_max_os_min, oc_min_os_max);
                         }
                     }
-                    auto thr_disb = (float)min_thr_size / max_thr_size;
+                    auto thr_disb = (float)min_thr_size / (float)max_thr_size;
 
                     const dim_t oc_per_thr = max_oc;
                     const dim_t os_per_thr = max_os;
@@ -1717,8 +1721,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                             nthr_oc, ocb, osb, oc_per_thr, os_per_thr);
                     // if we don't fit into cache then access to memory is
                     // expensive
-                    dim_t mem_access_cost
-                            = (max_ic_block < 1) ? non_cache_access : 1;
+                    dim_t mem_access_cost = static_cast<dim_t>(
+                            (max_ic_block < 1) ? non_cache_access : 1);
                     max_ic_block = nstl::max(dim_t(1), max_ic_block);
                     // "jcp.ic == 0 ? dim_t(1) : " is to avoid msvc warning 'potential divide by zero'
                     dim_t icb = nstl::max(dim_t(1),
@@ -1742,12 +1746,16 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     // TODO: simplify calculations
                     if (jcp.im2col_sz) {
                         inp_ops = mem_access_cost * jcp.ks * inp_size;
-                        const float col_tail_koeff = (float)osb_caligned / osb;
-                        col_ops = mem_access_cost
-                                * (jcp.ks * inp_size * col_tail_koeff
-                                        + jcp.ks * inp_size * col_tail_koeff);
+                        const float col_tail_koeff
+                                = (float)osb_caligned / (float)osb;
+                        col_ops = static_cast<size_t>((float)mem_access_cost
+                                * ((float)jcp.ks * (float)inp_size
+                                                * col_tail_koeff
+                                        + (float)jcp.ks * (float)inp_size
+                                                * col_tail_koeff));
                         if (sw != 1) // im2col with strides is much slower
-                            col_ops *= strided_im2col_k;
+                            col_ops = static_cast<size_t>(
+                                    (float)col_ops * strided_im2col_k);
                     } else {
                         inp_ops = mem_access_cost * jcp.ks * inp_size;
                     }
@@ -1756,23 +1764,28 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     const size_t wei_ops = mem_access_cost * wei_size;
                     // ratio of real FMA to number of memory ops
                     const float thr_mem_eff
-                            = (((float)os_per_thr / simd_w) * oc_per_thr * K)
-                            / (inp_ops + col_ops + wei_ops + out_ops);
+                            = (((float)os_per_thr / (float)simd_w)
+                                      * (float)oc_per_thr * (float)K)
+                            / (float)(inp_ops + col_ops + wei_ops + out_ops);
 
-                    auto oc_disb = (float)oc_per_thr / rnd_up(oc_per_thr, ocb);
-                    auto os_disb = (float)os_max / rnd_up(os_max, osb);
-                    auto ic_disb = (float)jcp.ic / rnd_up(jcp.ic, icb);
+                    auto oc_disb = (float)oc_per_thr
+                            / (float)rnd_up(oc_per_thr, ocb);
+                    auto os_disb = (float)os_max / (float)rnd_up(os_max, osb);
+                    auto ic_disb = (float)jcp.ic / (float)rnd_up(jcp.ic, icb);
 
-                    auto reg_osb_disb = (float)osb / rnd_up(osb, 3 * simd_w);
+                    auto reg_osb_disb
+                            = (float)osb / (float)rnd_up(osb, 3 * simd_w);
 
                     // Heuristics
-                    const float gemm_eff = ((float)osb * ocb * kb)
-                            / ((float)oc_per_thr * os_per_thr * K);
+                    const float gemm_eff = ((float)osb * (float)ocb * (float)kb)
+                            / ((float)oc_per_thr * (float)os_per_thr
+                                    * (float)K);
 
                     // number of FMA to memory size
                     const float gemm_calc_eff
-                            = (((float)osb / simd_w) * ocb * kb)
-                            / (osb_caligned * kb + ocb * kb_caligned
+                            = (((float)osb / (float)simd_w) * (float)ocb
+                                      * (float)kb)
+                            / (float)(osb_caligned * kb + ocb * kb_caligned
                                     + ocb * osb_caligned);
                     // optimization: remove pow, when corresponding weight is 1
                     const float res_eff = pow(pow(thr_disb, thr_disb_k)
@@ -1900,7 +1913,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     }
                 }
                 jcp.outer_threading = true;
-                jcp.nthr_oc = best_nthr_oc;
+                jcp.nthr_oc = static_cast<int>(best_nthr_oc);
                 jcp.oc_block = best_ocb;
                 jcp.os_block = best_osb;
                 jcp.ic_block = best_icb;
@@ -1912,11 +1925,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
             } else {
                 const size_t outer_work_amount = jcp.ngroups * jcp.mb * jcp.od;
                 const float outer_thr_eff = (float)outer_work_amount
-                        / rnd_up(outer_work_amount, max_threads);
+                        / (float)rnd_up(outer_work_amount, max_threads);
                 const size_t inner_work_amount
                         = div_up(jcp.os, simd_w) * div_up(jcp.oc, simd_w);
                 const float inner_thr_eff = (float)inner_work_amount
-                        / rnd_up(inner_work_amount, max_threads);
+                        / (float)rnd_up(inner_work_amount, max_threads);
                 jcp.outer_threading = jcp.os / max_threads < 512
                         && IMPLICATION(
                                 jcp.od == 1, jcp.mb != 1 || jcp.ngroups > 2)
@@ -1944,12 +1957,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
 
             bool is_depthwise = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
             const size_t outer_work = jcp.ngroups * jcp.mb;
-            const float outer_thr_eff
-                    = (float)outer_work / rnd_up(outer_work, max_threads);
+            const float outer_thr_eff = (float)outer_work
+                    / (float)rnd_up(outer_work, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = !is_3d
                     && (is_depthwise
                             || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1967,11 +1980,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
         } else if (!jcp.is_nspc && is_bwd_d) {
             const size_t outer_work_amount = jcp.ngroups * jcp.mb;
             const float outer_thr_eff = (float)outer_work_amount
-                    / rnd_up(outer_work_amount, max_threads);
+                    / (float)rnd_up(outer_work_amount, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = (jcp.os / max_threads < 512 || jcp.ks < 64)
                     && (jcp.mb != 1 || jcp.ngroups > 2)
                     && (outer_thr_eff / inner_thr_eff >= 1.f
@@ -2107,9 +2120,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     // dimensions.
                     // TODO: better heuristic to determine os_block based
                     // on cache efficiency
-                    float _coef = is_bwd_w ? 0.05 : 0.1;
+                    float _coef = is_bwd_w ? 0.05f : 0.1f;
                     jcp.os_block = nstl::max(
-                            min_os_block, (int)(max_os_block * _coef));
+                            min_os_block, (int)((float)max_os_block * _coef));
                     jcp.os_nb_block = div_up(jcp.os, jcp.os_block);
                     jcp.im2col_sz = (ptrdiff_t)jcp.ic * jcp.ks * jcp.os_block;
                     gemm_col_memory_sz = jcp.nthr * jcp.im2col_sz;

--- a/src/cpu/gemm_convolution_utils.hpp
+++ b/src/cpu/gemm_convolution_utils.hpp
@@ -87,7 +87,7 @@ struct single_gemm_conv_chunk_desc_t {
 namespace jit_gemm_convolution_utils {
 template <typename data_type_t>
 void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
-        data_type_t *col, dim_t od, int spatial_step, int spatial_block);
+        data_type_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 template <typename T>
 void transpose_dt(const conv_gemm_conf_t &jcp, const T *__restrict im,
@@ -110,9 +110,9 @@ template <typename T>
 void col2im_dt(
         const conv_gemm_conf_t &jcp, const T *__restrict col, T *__restrict im);
 void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        dim_t od, int spatial_step, int spatial_block);
+        dim_t od, dim_t spatial_step, dim_t spatial_block);
 void col2im(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        int spatial_step, int spatial_block);
+        dim_t spatial_step, dim_t spatial_block);
 
 status_t init_conf(conv_gemm_conf_t &jcp,
         memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -92,9 +92,9 @@ static zero_point_call_params_t prepare_zp_params(const conv_gemm_conf_t &jcp,
         const auto zp_comp_size = jcp.oc * jcp.ngroups;
 
         if (jcp.zp.src_is_common) {
-            zp_src_comp = mul_zp_src_comp_from_wei_by_zp_src(zp_comp_size,
-                    zp_src_comp_scratch, zp_src_comp_from_wei,
-                    *src_zero_points);
+            zp_src_comp = mul_zp_src_comp_from_wei_by_zp_src(
+                    static_cast<int>(zp_comp_size), zp_src_comp_scratch,
+                    zp_src_comp_from_wei, *src_zero_points);
         } else
             zp_src_comp = zp_src_comp_from_wei;
 
@@ -228,15 +228,15 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
     status_t st = status::success;
 
     for (dim_t iwork = start; iwork < end; ++iwork) {
-        const int oh = ohb * jcp.oh_block;
-        const int ow = owb * jcp.ow_block;
+        const dim_t oh = ohb * jcp.oh_block;
+        const dim_t ow = owb * jcp.ow_block;
         const char *__restrict src
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const int8_t *__restrict wei = wei_base + g * wei_g_stride;
         const int32_t *__restrict wei_comp
                 = _wei_comp ? _wei_comp + g * jcp.oc : nullptr;
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const dim_t h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
+        const dim_t w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt<char>(jcp, src, imtr);
 
@@ -308,7 +308,8 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
                 balance211(N * jcp.oc, nthr, ithr, _start, _end);
 
                 (*pp_ker_)(dst, acc, bia_base, scales, dst_scales[0], sum_scale,
-                        1.f / wei_adj_scale, g, n, _start, _end, zp,
+                        1.f / wei_adj_scale, static_cast<int>(g),
+                        static_cast<int>(n), _start, _end, zp,
                         post_ops_binary_rhs_arg_vec, dst_base, ctx,
                         *pd()->dst_md(), chunk_desc);
             });

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -168,7 +168,7 @@ template <typename src_dt>
 void pp_src_and_weights_zero_points(std::vector<int32_t> &src_comp,
         std::vector<int32_t> &wei_comp, dim_t M, dim_t N, dim_t K,
         const src_dt *src, dim_t src_s0, dim_t src_s1, const int8_t *wei,
-        dim_t wei_s0, dim_t wei_s1, int32_t *acc, int ldc,
+        dim_t wei_s0, dim_t wei_s1, int32_t *acc, dim_t ldc,
         int32_t src_zero_point, int32_t wei_zero_point) {
     if (wei_zero_point) {
         for_(dim_t m = 0; m < M; ++m)

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -44,9 +44,9 @@ void ref_matmul_t::pd_t::init_scratchpad() {
     if (dst_scales.is_dynamic()) {
         auto scratchpad = scratchpad_registry().registrar();
         const memory_desc_wrapper dst_d(dst_md());
-        dim_t group_size = dst_scales.get_group_size();
-        dim_t work_amount = dst_d.nelems() / group_size;
-        ntasks_ = std::min<dim_t>(nthr_, work_amount);
+        const dim_t group_size = dst_scales.get_group_size();
+        const dim_t work_amount = dst_d.nelems() / group_size;
+        ntasks_ = static_cast<int>(nstl::min<dim_t>(nthr_, work_amount));
         scratchpad.template book<float>(
                 key_matmul_dst_in_acc_dt, ntasks_ * group_size);
     }
@@ -320,8 +320,15 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                         d /= dst_scale;
                     }
                     if (dst_rnd_mode == rounding_mode::stochastic)
-                        d = math::stochastic_round_fwd(d, dst_off,
-                                dropout_seed_val, dst_d.data_type());
+                        // NOTE: dst_off is truncated to 32 bits here. For
+                        // tensors with > 2^32 elements, different offsets
+                        // may alias to the same random seed --
+                        // stochastic_round_fwd does not support a 64-bit
+                        // index space.
+                        d = math::stochastic_round_fwd(d,
+                                static_cast<uint32_t>(dst_off),
+                                static_cast<uint32_t>(dropout_seed_val),
+                                dst_d.data_type());
                     io::store_float_value(dst_d.data_type(), d, dst, dst_off);
                     utils::dim_iterator(
                             dst_d.dims(), dst_dims_idx, batch_ndims);
@@ -385,8 +392,15 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                     d *= dst_group_scale;
 
                     if (dst_rnd_mode == rounding_mode::stochastic)
-                        d = math::stochastic_round_fwd(d, dst_off,
-                                dropout_seed_val, dst_d.data_type());
+                        // NOTE: dst_off is truncated to 32 bits here. For
+                        // tensors with > 2^32 elements, different offsets
+                        // may alias to the same random seed --
+                        // stochastic_round_fwd does not support a 64-bit
+                        // index space.
+                        d = math::stochastic_round_fwd(d,
+                                static_cast<uint32_t>(dst_off),
+                                static_cast<uint32_t>(dropout_seed_val),
+                                dst_d.data_type());
                     io::store_float_value(dst_d.data_type(), d, dst, dst_off);
                     utils::dim_iterator(
                             dst_d.dims(), dst_dims_idx, batch_ndims);

--- a/src/cpu/matmul/ref_sparse_matmul.cpp
+++ b/src/cpu/matmul/ref_sparse_matmul.cpp
@@ -144,12 +144,12 @@ status_t ref_sparse_matmul_t::execute(const exec_ctx_t &ctx) const {
 }
 
 void ref_sparse_matmul_t::cvt_coo_indices_to_csr_pointers(
-        const int32_t *indices, int32_t *pointers, const int nnz,
-        const int nrows) const {
+        const int32_t *indices, int32_t *pointers, const dim_t nnz,
+        const dim_t nrows) const {
     parallel_nd(
             nnz, [=](dim_t i) { fetch_and_add(&pointers[indices[i] + 1], 1); });
     parallel(1, [=](int, int) {
-        for (int i = 0; i < nrows; ++i) {
+        for (dim_t i = 0; i < nrows; ++i) {
             pointers[i + 1] += pointers[i];
         }
     });

--- a/src/cpu/matmul/ref_sparse_matmul.hpp
+++ b/src/cpu/matmul/ref_sparse_matmul.hpp
@@ -141,7 +141,7 @@ struct ref_sparse_matmul_t : public primitive_t {
     // COO sparse encodings are converted to CSR format by
     // compressing the respective row indices into CSR pointers.
     void cvt_coo_indices_to_csr_pointers(const int32_t *indices,
-            int32_t *pointers, const int nnz, const int nrows) const;
+            int32_t *pointers, const dim_t nnz, const dim_t nrows) const;
 
     // Executes the matrix mutiplication, C = A x B where one of the input
     // matrices is dense. Operation indices are determined depending on

--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -82,9 +82,10 @@ status_t nchw_pooling_fwd_t<data_type::f32>::execute_forward(
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[ws_offset] = value;
+                ws[ws_offset] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset] = value;
+                reinterpret_cast<int *>(ws)[ws_offset]
+                        = static_cast<int>(value);
         }
     };
 
@@ -284,9 +285,10 @@ status_t nchw_pooling_fwd_t<d_type>::execute_forward(
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[ws_offset] = value;
+                ws[ws_offset] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset] = value;
+                reinterpret_cast<int *>(ws)[ws_offset]
+                        = static_cast<int>(value);
         }
     };
 

--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -183,7 +183,7 @@ struct nchw_pooling_bwd_t : public primitive_t {
 
         dim_t channel_block_size_ {1};
         int nthr_; // To not exceed the limit in execute used for set up.
-        int nbuf_ {0};
+        dim_t nbuf_ {0};
 
     private:
         void init_scratchpad() {

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -82,7 +82,7 @@ void nhwc_pooling_fwd_t<d_type>::array_add(
 template <data_type_t d_type>
 void nhwc_pooling_fwd_t<d_type>::array_nhwc_max(const dim_t n, ker_data_t *dst,
         const ker_data_t *src, unsigned char *ws, const size_t ws_offset,
-        const data_type_t ws_dt, const int index) const {
+        const data_type_t ws_dt, const dim_t index) const {
     assert(ws);
 #if SAFE_TO_USE_OMP_SIMD
     PRAGMA_OMP_SIMD()
@@ -98,9 +98,10 @@ void nhwc_pooling_fwd_t<d_type>::array_nhwc_max(const dim_t n, ker_data_t *dst,
             assert(ws_dt == data_type::u8 || ws_dt == data_type::s32);
             if (ws_dt == data_type::u8) {
                 assert(0 <= index && index <= 255);
-                ws[ws_offset + oc] = index;
+                ws[ws_offset + oc] = static_cast<unsigned char>(index);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset + oc] = index;
+                reinterpret_cast<int *>(ws)[ws_offset + oc]
+                        = static_cast<int>(index);
         }
 #else
         // Need to add explicit predicates for GCC to vectorize this.

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -140,7 +140,7 @@ private:
     void array_add(const dim_t n, const ker_data_t *src, ker_data_t *dst) const;
     void array_nhwc_max(const dim_t n, ker_data_t *dst, const ker_data_t *src,
             unsigned char *ws, const size_t ws_offset, const data_type_t ws_dt,
-            const int index) const;
+            const dim_t index) const;
     void array_nhwc_initialize(const dim_t n, ker_data_t *dst,
             unsigned char *ws, const size_t ws_offset,
             const data_type_t ws_dt) const;

--- a/src/cpu/ref_convolution.cpp
+++ b/src/cpu/ref_convolution.cpp
@@ -218,8 +218,8 @@ status_t ref_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         args.dst_md = pd()->dst_md();
         ref_post_ops->execute(d, args);
         if (dst_rnd_mode == rounding_mode::stochastic)
-            d = math::stochastic_round_fwd(
-                    d, dst_off, rnd_seed[0], dst_d.data_type());
+            d = math::stochastic_round_fwd(d, static_cast<uint32_t>(dst_off),
+                    rnd_seed[0], dst_d.data_type());
 
         io::store_float_value(dst_d.data_type(), d, dst, dst_off);
     });

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -311,8 +311,8 @@ static void compute_src_zp_compensation(const exec_ctx_t &ctx,
     const auto ndims = wei_d.ndims() - (with_groups ? 1 : 0);
     const auto get_wei_off
             = [=](dim_t g, dim_t oc, dim_t ic, dim_t kd, dim_t kh, dim_t kw) {
-        return get_weights_off(
-                wei_d, with_groups, ndims, g, oc, ic, kd, kh, kw);
+        return get_weights_off(wei_d, with_groups, ndims, g,
+                oc, ic, kd, kh, kw);
     };
 
     parallel_nd(G, OC, [=](const dim_t g, const dim_t oc) {
@@ -365,8 +365,8 @@ prepare_zp_pad_comp_ker(const dim_t ndims, const int32_t *src_zero_points,
     const memory_desc_wrapper wei_d(deconv_pd->weights_md());
     const auto get_wei_off
             = [=](dim_t g, dim_t oc, dim_t ic, dim_t kd, dim_t kh, dim_t kw) {
-        return get_weights_off(
-                wei_d, with_groups, ndims, g, oc, ic, kd, kh, kw);
+        return get_weights_off(wei_d, with_groups, static_cast<int>(ndims), g,
+                oc, ic, kd, kh, kw);
     };
 
     return [=](const dim_t g, const dim_t oc, const dim_t od, const dim_t oh,

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -90,9 +90,9 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[off] = value;
+                ws[off] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[off] = value;
+                reinterpret_cast<int *>(ws)[off] = static_cast<int>(value);
         }
     };
 
@@ -137,7 +137,7 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 }
             }
         }
-        int num_summands;
+        dim_t num_summands;
         if (alg == alg_kind::pooling_avg_include_padding)
             num_summands = KW * KH * KD;
         else {
@@ -165,7 +165,7 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                     * (KH - ih_start_excluded - ih_end_excluded)
                     * (KW - iw_start_excluded - iw_end_excluded);
         }
-        d /= num_summands;
+        d /= static_cast<float>(num_summands);
     };
 
     const bool is_max_pool = alg == alg_kind::pooling_max;

--- a/src/cpu/ref_reduction.cpp
+++ b/src/cpu/ref_reduction.cpp
@@ -63,7 +63,7 @@ void accumulate(T &acc, const T &src, alg_kind_t alg, float p) {
         case reduction_norm_lp_sum:
         case reduction_norm_lp_power_p_max:
         case reduction_norm_lp_power_p_sum:
-            acc += powf(nstl::abs(src), p);
+            acc += static_cast<T>(powf(nstl::abs(src), p));
             break;
         default: assert(!"unknown alg");
     }

--- a/src/cpu/ref_shuffle.cpp
+++ b/src/cpu/ref_shuffle.cpp
@@ -47,16 +47,16 @@ status_t ref_shuffle_t::execute_(const exec_ctx_t &ctx) const {
     CHECK(status);
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
-    auto scratchpad_ptr = scratchpad.template get<int>(
+    auto scratchpad_ptr = scratchpad.template get<dim_t>(
             memory_tracking::names::key_shuffle_precompute_transpose);
 
     const auto axis = pd()->axis();
     const auto axis_size = pd()->axis_size();
     const auto group_size = pd()->group_size();
 
-    const int transpose_row
+    const dim_t transpose_row
             = pd()->is_fwd() ? group_size : axis_size / group_size;
-    const int transpose_col
+    const dim_t transpose_col
             = pd()->is_fwd() ? axis_size / group_size : group_size;
 
     // Precompute transposed axis helper array

--- a/src/cpu/ref_softmax.cpp
+++ b/src/cpu/ref_softmax.cpp
@@ -120,11 +120,12 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
         // The code below makes the compiler generate maxps instruction.
         // rather than maxss, which is generated for the 'else' code path
         auto max_wrapper = [](float a, float b) { return nstl::max(a, b); };
-        auto min_wrapper = [](int a, int b) { return nstl::min(a, b); };
+        auto min_wrapper
+                = [](dim_t a, dim_t b) { return nstl::min<dim_t>(a, b); };
 
         if (channels_ < unroll_factor) {
             float max_val = -FLT_MAX;
-            for (int i = 0; i < channels_; i++) {
+            for (dim_t i = 0; i < channels_; i++) {
                 max_val = max_wrapper(max_val,
                         io::load_float_value(src_d.data_type(), src_data, i));
             }
@@ -136,8 +137,8 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
                 max_values[i]
                         = io::load_float_value(src_d.data_type(), src_data, i);
             }
-            for (int i = unroll_factor; i < channels_; i += unroll_factor) {
-                int offset = min_wrapper(i, channels_ - unroll_factor);
+            for (dim_t i = unroll_factor; i < channels_; i += unroll_factor) {
+                dim_t offset = min_wrapper(i, channels_ - unroll_factor);
                 for (int j = 0; j < unroll_factor; j++) {
                     max_values[j] = max_wrapper(max_values[j],
                             io::load_float_value(
@@ -151,14 +152,14 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
             space_max = max_val;
         }
 #else
-        for (int c = 0; c < channels_; ++c)
+        for (dim_t c = 0; c < channels_; ++c)
             space_max = nstl::max(space_max,
                     io::load_float_value(src_d.data_type(), src_data, c));
 #endif
 
         // sub + exp + sum
-        int tail = channels_ % unroll_factor;
-        for (int i = 0; i < channels_ - tail; i += unroll_factor) {
+        int tail = static_cast<int>(channels_ % unroll_factor);
+        for (dim_t i = 0; i < channels_ - tail; i += unroll_factor) {
             PRAGMA_OMP_SIMD(reduction(+ : space_denom))
             for (int j = 0; j < unroll_factor; j++) {
                 float s = io::load_float_value(
@@ -174,7 +175,7 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
                 io::store_float_value(interim_dt, d, interim_ptr, i + j);
             }
         }
-        for (int i = channels_ - tail; i < channels_; i++) {
+        for (dim_t i = channels_ - tail; i < channels_; i++) {
             float s = io::load_float_value(src_d.data_type(), src_data, i);
             float d = s - space_max;
             if (pd()->is_softmax()) {
@@ -192,7 +193,7 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
         } else if (pd()->is_logsoftmax()) {
             space_denom = logf(space_denom);
         }
-        for (int c = 0; c < channels_; ++c) {
+        for (dim_t c = 0; c < channels_; ++c) {
             float d = io::load_float_value(interim_dt, interim_ptr, c);
             float val = 0;
             if (pd()->is_softmax()) {
@@ -316,16 +317,16 @@ status_t ref_softmax_fwd_t::execute_forward_generic(
         utils::array_set(space_max, -FLT_MAX, inner_size_);
         utils::array_set(space_denom, 0, inner_size_);
 
-        for (int in = 0; in < inner_size_; in++) {
+        for (dim_t in = 0; in < inner_size_; in++) {
             dim_t ou_in_offset = ou * channels_ * inner_size_ + in;
 
-            for (int c = 0; c < channels_; c++) {
+            for (dim_t c = 0; c < channels_; c++) {
                 size_t off = src_d.off_l(ou_in_offset + c * inner_size_);
                 float s = io::load_float_value(src_d.data_type(), src, off);
                 space_max[in] = nstl::max(space_max[in], s);
             }
 
-            for (int c = 0; c < channels_; c++) {
+            for (dim_t c = 0; c < channels_; c++) {
                 size_t src_off = src_d.off_l(ou_in_offset + c * inner_size_);
                 float s = io::load_float_value(src_d.data_type(), src, src_off);
                 float d = s - space_max[in];
@@ -346,7 +347,7 @@ status_t ref_softmax_fwd_t::execute_forward_generic(
                 space_denom[in] = logf(space_denom[in]);
             }
 
-            for (int c = 0; c < channels_; c++) {
+            for (dim_t c = 0; c < channels_; c++) {
                 size_t dst_off = dst_d.off_l(ou_in_offset + c * inner_size_);
                 size_t interim_off = pd()->need_intermediate_scratchpad()
                         ? thr_shift + c
@@ -472,7 +473,7 @@ status_t ref_softmax_bwd_t::execute_backward_generic(
             [= COMPAT_THIS_CAPTURE](dim_t ou, dim_t in) {
         dim_t ou_in_offset = ou * channels_ * inner_size_ + in;
         float sbr = 0;
-        for (int c = 0; c < channels_; ++c) {
+        for (dim_t c = 0; c < channels_; ++c) {
             auto diff_dst_off
                     = diff_dst_d.off_l(ou_in_offset + c * inner_size_);
             float dd = io::load_float_value(
@@ -486,7 +487,7 @@ status_t ref_softmax_bwd_t::execute_backward_generic(
             }
         }
 
-        for (int c = 0; c < channels_; ++c) {
+        for (dim_t c = 0; c < channels_; ++c) {
             auto diff_dst_off
                     = diff_dst_d.off_l(ou_in_offset + c * inner_size_);
             auto dst_off = dst_d.off_l(ou_in_offset + c * inner_size_);

--- a/src/cpu/ref_softmax.hpp
+++ b/src/cpu/ref_softmax.hpp
@@ -152,7 +152,7 @@ struct ref_softmax_fwd_t : public primitive_t {
 
         auto axis = pd()->axis();
         dim_t axis_blk_size = 1;
-        for (int iblk = 0; iblk < bd.inner_nblks; ++iblk)
+        for (dim_t iblk = 0; iblk < bd.inner_nblks; ++iblk)
             if (bd.inner_idxs[iblk] == axis)
                 axis_blk_size *= bd.inner_blks[iblk];
 
@@ -183,7 +183,7 @@ private:
 
     std::unique_ptr<ref_post_ops_t> ref_post_ops;
     bool use_dense_;
-    int outer_size_, channels_, inner_size_;
+    dim_t outer_size_, channels_, inner_size_;
 };
 
 struct ref_softmax_bwd_t : public primitive_t {
@@ -223,7 +223,7 @@ struct ref_softmax_bwd_t : public primitive_t {
 
         auto axis = pd()->axis();
         dim_t axis_blk_size = 1;
-        for (int iblk = 0; iblk < bd.inner_nblks; ++iblk)
+        for (dim_t iblk = 0; iblk < bd.inner_nblks; ++iblk)
             if (bd.inner_idxs[iblk] == axis)
                 axis_blk_size *= bd.inner_blks[iblk];
 
@@ -245,7 +245,7 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
     bool use_dense_;
-    int outer_size_, channels_, inner_size_;
+    dim_t outer_size_, channels_, inner_size_;
 };
 
 } // namespace cpu

--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -1160,8 +1160,8 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                         ? &dst_scales[dst_scales_mask == 0 ? 0 : _offset]
                         : nullptr;
                 ker(i, o, (order_keep && req_comp) ? &cp[_offset] : nullptr,
-                        zp_ptr, src_scales_ptr, dst_scales_ptr, d0_block,
-                        d1_block);
+                        zp_ptr, src_scales_ptr, dst_scales_ptr,
+                        static_cast<int>(d0_block), static_cast<int>(d1_block));
             }
         });
 
@@ -2416,13 +2416,14 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 const dim_t src_zps_off
                         = get_quant_off(input_idx, ndims, src_zps_mask,
                                 src_zps_group0, src_zps_group1, src_zps_md);
-                src_zp_val = io::load_float_value(
-                        src_zps_d.data_type(), src_zero_points, src_zps_off);
+                src_zp_val = static_cast<int>(io::load_float_value(
+                        src_zps_d.data_type(), src_zero_points, src_zps_off));
             }
 
             const auto i_off = input_d.off_l(idx);
             const auto o_off = output_d.off_l(idx);
-            output[o_off] = src_scale * (wspace[i_off] - src_zp_val);
+            output[o_off] = src_scale
+                    * (wspace[i_off] - static_cast<float>(src_zp_val));
         });
 
         return status::success;
@@ -2654,15 +2655,17 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 const dim_t src_zps_off
                         = get_quant_off(input_idx, ndims, src_zps_mask,
                                 src_zps_group0, src_zps_group1, src_zps_md);
-                src_zp_val = io::load_float_value(
-                        src_zps_d.data_type(), src_zero_points, src_zps_off);
+                src_zp_val = static_cast<int>(io::load_float_value(
+                        src_zps_d.data_type(), src_zero_points, src_zps_off));
             }
 
             const auto i_off = input_d.off_l(idx);
             const auto o_off = output_d.off_l(idx);
-            float d = src_scale * (input[i_off] - src_zp_val);
-            if (beta) d += beta * output[o_off];
-            d = d / dst_scale + dst_zp;
+            float d = src_scale
+                    * (static_cast<float>(input[i_off])
+                            - static_cast<float>(src_zp_val));
+            if (beta != 0.f) d += beta * static_cast<float>(output[o_off]);
+            d = d / dst_scale + static_cast<float>(dst_zp);
             output[o_off] = _qz_a1b0<data_type::f32, type_o>()(d);
         });
         return status::success;

--- a/src/cpu/rnn/brgemm_cell_common.cpp
+++ b/src/cpu/rnn/brgemm_cell_common.cpp
@@ -85,9 +85,9 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     typename brgemm_dst_layer_iter_t::postgemm_fused_t fused_postgemm;
 
     if (!rnn.unfused_post_gemm) {
-        fused_postgemm
-                = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
-                          scratch_t *C_n, scratch_t *C_cell_n, int block_step) {
+        fused_postgemm = [&](dim_t m, dim_t n, dim_t nb_i,
+                                 const src_iter_t *Ai_m, scratch_t *C_n,
+                                 scratch_t *C_cell_n, dim_t block_step) {
             const auto Dpg_n = (dst_postgemm != nullptr)
                     ? dst_postgemm + m * LDDl + n
                     : nullptr;
@@ -125,7 +125,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
             fused_postgemm_gru_part1
                     = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
                               scratch_t *C_gates_n, scratch_t *C_cell_n,
-                              int block_step) {
+                              dim_t block_step) {
                 const auto Dpg_n = (dst_postgemm != nullptr)
                         ? dst_postgemm + m * LDDl + n
                         : nullptr;
@@ -152,7 +152,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
             fused_postgemm_gru_part2
                     = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
                               scratch_t *C_gates_n, scratch_t *C_cell_n,
-                              int block_step) {
+                              dim_t block_step) {
                 const auto Dpg_n = (dst_postgemm != nullptr)
                         ? dst_postgemm + m * LDDl + n
                         : nullptr;
@@ -214,7 +214,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         gemm_acc_t *const Cp = (rnn.dt_conf == all_f32)
                 ? reinterpret_cast<gemm_acc_t *>(dst_layer_)
                 : scratch_gates_;
-        const int pLDDl = rnn.dst_layer_ld(cell_position, true);
+        const dim_t pLDDl = rnn.dst_layer_ld(cell_position, true);
         const int pmask
                 = this->pd_->attr()->rnn_weights_projection_qparams_.mask_;
 
@@ -223,8 +223,8 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         typename brgemm_dst_proj_t::postgemm_fused_t fused_postgemm_proj;
 
         if (!rnn.unfused_post_gemm) {
-            fused_postgemm_proj
-                    = [&](dim_t m, dim_t n, gemm_acc_t *Cp_n, int block_step) {
+            fused_postgemm_proj = [&](dim_t m, dim_t n, gemm_acc_t *Cp_n,
+                                          dim_t block_step) {
                 const auto weights_scales_n
                         = wscales_proj_postgemm + (pmask ? n : 0);
                 const auto Di_n = (dst_iter_ != nullptr)

--- a/src/cpu/rnn/cell_common.cpp
+++ b/src/cpu/rnn/cell_common.cpp
@@ -80,7 +80,7 @@ rnn_cell_execution_sig(
         assert(rnn.scratch_gates_ld >= rnn.dlc);
         gemm_acc_t *dst_proj = rnn.dt_conf == all_f32 ? (gemm_acc_t *)dst_layer_
                                                       : scratch_gates_;
-        const int dst_proj_ld
+        const dim_t dst_proj_ld
                 = rnn.dt_conf == all_f32 ? dst_layer_ld : rnn.scratch_gates_ld;
 
         CHECK((this->*gemm_projection_func)('N', 'N', rnn.dic, rnn.mb, rnn.dhc,
@@ -109,8 +109,8 @@ void lstm_bwd_weights_peephole_and_bias(const rnn_utils::rnn_conf_t &rnn,
         cell_position_t cell_position, const void *src_iter_c_,
         const void *dst_iter_c_, const scratch_data_t *scratch_gates_,
         float *diff_weights_peephole_, acc_data_t *diff_bias_) {
-    const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
-    const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+    const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+    const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
 
     const auto dst_iter_c = rnn_utils::make_raw_aoc(dst_iter_c_,
             types::data_type_size(rnn.dst_iter_c_dt), rnn.ws_states_iter_c_nld,
@@ -125,13 +125,13 @@ void lstm_bwd_weights_peephole_and_bias(const rnn_utils::rnn_conf_t &rnn,
             rnn, diff_weights_peephole_);
 
     parallel(0, [&](int ithr, int nthr) {
-        int g_dhc_start {}, g_dhc_stop {};
+        dim_t g_dhc_start {}, g_dhc_stop {};
         const int gates_to_process = 5; // 3 -- weights peephole +
                 // 2 -- bias (process a pair at once)
-        balance211(gates_to_process * rnn.dhc, nthr, ithr, g_dhc_start,
-                g_dhc_stop);
-        int g = g_dhc_start / rnn.dhc;
-        int dhc = g_dhc_start % rnn.dhc;
+        balance211(gates_to_process * rnn.dhc, nthr, ithr,
+                g_dhc_start, g_dhc_stop);
+        dim_t g = g_dhc_start / rnn.dhc;
+        dim_t dhc = g_dhc_start % rnn.dhc;
         while (g_dhc_start++ < g_dhc_stop) {
             if (g < 3) {
                 // weights peephole
@@ -139,17 +139,17 @@ void lstm_bwd_weights_peephole_and_bias(const rnn_utils::rnn_conf_t &rnn,
                 const auto c_states_dt
                         = g < 2 ? rnn.src_iter_c_dt : rnn.dst_iter_c_dt;
 
-                const int scratch_g = g < 2 ? g : 3;
+                const dim_t scratch_g = g < 2 ? g : 3;
                 if (rnn.diff_weights_overwrite && (cell_position & last_iter))
                     diff_weights_peephole(g, dhc) = 0;
-                for (int mb = 0; mb < rnn.mb; ++mb) {
+                for (dim_t mb = 0; mb < rnn.mb; ++mb) {
                     diff_weights_peephole(g, dhc)
                             += to_float(c_states(mb, dhc), c_states_dt)
                             * scratch_gates(mb, scratch_g, dhc);
                 }
             } else {
                 // bias
-                const int bias_g_start = 2 * (g - 3);
+                const int bias_g_start = static_cast<int>(2 * (g - 3));
                 const int bias_g_end = bias_g_start + 2;
                 for (int bias_g = bias_g_start; bias_g < bias_g_end; ++bias_g) {
                     if (rnn.diff_weights_overwrite
@@ -194,7 +194,7 @@ dnnl_status_t common_bwd_cell_exec_template(T1 gemm_layer_f, T2 gemm_iter_f,
     if (rnn.is_lstm_projection) {
         parallel_nd(rnn.mb, [&](dim_t i) {
             PRAGMA_OMP_SIMD()
-            for (int j = 0; j < rnn.dlc; j++)
+            for (dim_t j = 0; j < rnn.dlc; j++)
                 scratch_diff_ht_[i * rnn.scratch_diff_ht_ld + j]
                         = diff_dst_layer_[i * rnn.ws_diff_states_layer_ld + j]
                         + diff_dst_iter_[i * rnn.ws_diff_states_iter_ld + j];
@@ -315,7 +315,7 @@ rnn_merged_layer_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     // hence we cannot merge all iterations.
     // This is not applicable for the first layer though, since
     // all the states come from user's `src_layer_`.
-    const int n_iter
+    const dim_t n_iter
             = (cell_position & first_layer) && rnn.skip_src_layer_copy()
             ? rnn.n_iter
             : rnn.n_iter - (rnn.skip_dst_iter_copy() ? 1 : 0);
@@ -338,7 +338,7 @@ rnn_merged_layer_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
     // hence we cannot merge all iterations.
     // This is not applicable for the first layer though, since
     // all the states come from user's `src_layer_`.
-    const int n_iter
+    const dim_t n_iter
             = (cell_position & first_layer) && rnn.skip_src_layer_copy()
             ? rnn.n_iter
             : rnn.n_iter - (rnn.skip_dst_iter_copy() ? 1 : 0);

--- a/src/cpu/rnn/cell_gru.cpp
+++ b/src/cpu/rnn/cell_gru.cpp
@@ -72,7 +72,8 @@ rnn_cell_execution_sig(
             augru_attention_, dst_layer_, nullptr, src_iter_, nullptr,
             diff_src_layer_, diff_augru_attention_, diff_src_iter_, nullptr,
             diff_dst_layer_, diff_dst_iter_, nullptr, nullptr, bias_[0],
-            nullptr, nullptr, dst_iter_, weights_scales, rnn.dhc);
+            nullptr, nullptr, dst_iter_, weights_scales,
+            rnn.dhc);
 
     // 4. gemm Wh[2],h~t
     if (rnn.use_matmul) {
@@ -190,8 +191,8 @@ template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
 rnn_cell_execution_sig(
         (ref_rnn_bwd_t<src_type, weights_type, acc_type>::cell_execution_gru)) {
     auto gemm_iter_f
-            = [&](int m, int n, int k, const weights_t *A, const gemm_data_t *B,
-                      float beta, gemm_acc_t *C) {
+            = [&](dim_t m, dim_t n, dim_t k, const weights_t *A,
+                      const gemm_data_t *B, float beta, gemm_acc_t *C) {
         return (this->*gemm_iter_func)('N', 'N', m, n, k, 1.0f, A,
                 rnn.weights_iter_ld, B, rnn.scratch_gates_ld, beta, C,
                 rnn.ws_diff_states_iter_ld);
@@ -203,15 +204,15 @@ rnn_cell_execution_sig(
                 rnn.scratch_gates_ld, 0.0, C, rnn.ws_diff_states_layer_ld);
     };
     auto gemm_weights_layer_f = [&](const gemm_data_t *A, const weights_t *B,
-                                        int ldb, gemm_acc_t *C) {
+                                        dim_t ldb, gemm_acc_t *C) {
         const float beta = rnn.diff_weights_beta(cell_position);
         return gemm('N', 'T', rnn.n_gates * rnn.dhc, rnn.slc, rnn.mb, 1.0, A,
                 rnn.scratch_gates_ld, B, ldb, beta, C,
                 rnn.diff_weights_layer_ld);
     };
     auto gemm_weights_iter_f
-            = [&](int m, int n, int k, const weights_t *A, const gemm_data_t *B,
-                      int ldb, gemm_acc_t *C) {
+            = [&](dim_t m, dim_t n, dim_t k, const weights_t *A,
+                      const gemm_data_t *B, dim_t ldb, gemm_acc_t *C) {
         const float beta = rnn.diff_weights_beta(cell_position);
         return gemm('N', 'T', m, n, k, 1.0f, A, rnn.ws_gates_ld, B, ldb, beta,
                 C, rnn.diff_weights_iter_ld);

--- a/src/cpu/rnn/cell_gru_lbr.cpp
+++ b/src/cpu/rnn/cell_gru_lbr.cpp
@@ -160,15 +160,15 @@ rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
                 rnn.n_gates * rnn.dhc, 1.0f, A, rnn.weights_iter_ld, B,
                 rnn.ws_gates_ld, 1.0f, C, rnn.ws_diff_states_iter_ld);
     };
-    const auto gemm_weights_layer
-            = [&](const scratch_t *A, const src_layer_t *B, int ldb, float *C) {
+    const auto gemm_weights_layer =
+            [&](const scratch_t *A, const src_layer_t *B, dim_t ldb, float *C) {
         const float beta = rnn.diff_weights_beta(cell_position);
         return gemm('N', 'T', rnn.n_gates * rnn.dhc, rnn.slc, rnn.mb, 1.0f, A,
                 rnn.scratch_gates_ld, B, ldb, beta, C,
                 rnn.diff_weights_layer_ld);
     };
-    const auto gemm_weights_iter
-            = [&](const scratch_t *A, const src_iter_t *B, int ldb, float *C) {
+    const auto gemm_weights_iter = [&](const scratch_t *A, const src_iter_t *B,
+                                           dim_t ldb, float *C) {
         const float beta = rnn.diff_weights_beta(cell_position);
         return gemm('N', 'T', rnn.n_gates * rnn.dhc, rnn.sic, rnn.mb, 1.0f, A,
                 rnn.ws_gates_ld, B, ldb, beta, C, rnn.diff_weights_iter_ld);

--- a/src/cpu/rnn/ref_postgemm_gru.cpp
+++ b/src/cpu/rnn/ref_postgemm_gru.cpp
@@ -43,13 +43,13 @@ void gru_fwd_part1_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
         rnn_utils::cell_position_t cell_position, src_data_t *ws_gates_,
         scratch_data_t *scratch_gates_, const src_data_t *augru_attention_,
         src_data_t *dst_layer_, src_data_t *dst_iter_,
-        const src_data_t *src_iter_, const void *bias_, int block_step) {
+        const src_data_t *src_iter_, const void *bias_, dim_t block_step) {
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
     const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
 
@@ -66,10 +66,10 @@ void gru_fwd_part1_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
 
     const float *scales_G1 = scales ? scales + 1 : nullptr;
 
-    const auto postgemm_call = [&](int i) {
-        const int n_elem = block_step;
+    const auto postgemm_call = [&](dim_t i) {
+        const dim_t n_elem = block_step;
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             const auto G0 // default func1 is sigmoid
                     = func1(scales,
                             acc_to_float(scratch_gates(i, 0, j), 0, j)
@@ -107,13 +107,13 @@ void gru_fwd_part2_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
         rnn_utils::cell_position_t cell_position, src_data_t *ws_gates_,
         scratch_data_t *scratch_gates_, const src_data_t *augru_attention_,
         src_data_t *dst_layer_, src_data_t *dst_iter_,
-        const src_data_t *src_iter_, const void *bias_, int block_step) {
+        const src_data_t *src_iter_, const void *bias_, dim_t block_step) {
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
     const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
 
@@ -131,10 +131,10 @@ void gru_fwd_part2_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
 
     const float *scales_G2 = scales ? scales + 2 : nullptr;
 
-    const auto postgemm_call = [&](int i) {
-        const int n_elem = block_step;
+    const auto postgemm_call = [&](dim_t i) {
+        const dim_t n_elem = block_step;
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             auto G0 = reinterpret_as_float(scratch_gates(i, 0, j));
             const auto G2 // default func1 is tanh
                     = func1(scales_G2,
@@ -175,7 +175,7 @@ rnn_postgemm_sig((rnn_postgemm_fwd_t<src_type, scratch_type,
 
     const auto cvt_from_f32 = [](float f) { return static_cast<gates_t>(f); };
     const auto cvt_to_f32 = [](gates_t b) { return float(b); };
-    const auto deq_id = [](float f, int i, int j) { return f; };
+    const auto deq_id = [](float f, int i, dim_t j) { return f; };
     const auto id = [](float f) { return f; };
 
     if (!this->pd_->attr()->rnn_tparams_.test_mode_)
@@ -201,7 +201,7 @@ rnn_postgemm_sig((rnn_postgemm_fwd_t<src_type, scratch_type,
 
     const auto cvt_from_f32 = [](float f) { return static_cast<gates_t>(f); };
     const auto cvt_to_f32 = [](gates_t b) { return float(b); };
-    const auto deq_id = [](float f, int i, int j) { return f; };
+    const auto deq_id = [](float f, int i, dim_t j) { return f; };
     const auto id = [](float f) { return f; };
 
     if (!this->pd_->attr()->rnn_tparams_.test_mode_)
@@ -242,11 +242,12 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::gru_part1_postgemm) {
         return (dst_layer_t)mxcsr_cvt(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, dim_t j) {
         const float wscale = pd_->attr()->rnn_weights_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[gate * rnn.dhc + j];
-        return q10n::saturate<float>(s) * (1.f / (wscale * data_scale));
+        return static_cast<float>(q10n::saturate<float>(s))
+                * (1.f / (wscale * data_scale));
     };
 
     const auto dequantize_u8_f32 = [&](src_iter_t s) {
@@ -288,11 +289,12 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::gru_part2_postgemm) {
         return (dst_layer_t)mxcsr_cvt(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, dim_t j) {
         const float wscale = pd_->attr()->rnn_weights_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[gate * rnn.dhc + j];
-        return q10n::saturate<float>(s) * (1.f / (wscale * data_scale));
+        return static_cast<float>(q10n::saturate<float>(s))
+                * (1.f / (wscale * data_scale));
     };
 
     const auto dequantize_u8_f32 = [&](src_iter_t s) {
@@ -359,7 +361,7 @@ void gru_bwd_part1_postgemm_template(T to_src, const rnn_utils::rnn_conf_t &rnn,
     parallel_nd(rnn.mb, [&](dim_t i) {
         acc_data_t diff_attention = 0.0f;
         PRAGMA_OMP_SIMD(reduction(+ : diff_attention))
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float h = src_iter(i, j);
             const float dHt = diff_dst_iter(i, j) + diff_dst_layer(i, j);
             const float dG2 = (1.0f - ws_gates(i, 0, j)) * dHt
@@ -412,7 +414,7 @@ void gru_bwd_part2_postgemm_template(T to_src, const rnn_utils::rnn_conf_t &rnn,
     // h * G1 (required for dWh)
     parallel_nd(rnn.mb, [&](dim_t i) {
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float h = src_iter(i, j);
             const float G1 = ws_gates(i, 1, j);
             diff_src_iter(i, j) += dhG1(i, j) * G1;

--- a/src/cpu/rnn/ref_postgemm_gru_lbr.cpp
+++ b/src/cpu/rnn/ref_postgemm_gru_lbr.cpp
@@ -40,7 +40,7 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
         scratch_data_t *scratch_gates_, const src_data_t *augru_attention_,
         src_data_t *dst_layer_, src_data_t *dst_iter_,
         const src_data_t *src_iter_, const void *bias_, src_data_t *ws_grid_,
-        scratch_data_t *scratch_cell_, int block_step) {
+        scratch_data_t *scratch_cell_, dim_t block_step) {
 
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
@@ -60,7 +60,7 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
 
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
     const scratch_gates_aoc_t<scratch_data_t> scratch_cell(rnn, scratch_cell_);
@@ -74,7 +74,7 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
 
     const auto postgemm = [&](dim_t i) {
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float Wh_b = scratch_cell(i, 2, j) + bias(3, j);
             auto G0 = func1(scales, // default func1 is sigmoid
                     scratch_gates(i, 0, j) + scratch_cell(i, 0, j)
@@ -101,9 +101,9 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
     };
 
     const auto postgemm_brgemm = [&](dim_t i) {
-        const int n_elem = block_step;
+        const dim_t n_elem = block_step;
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             const float Wh_b = scratch_cell(i, 0, j) + bias(3, j);
             auto G0 = func1(scales, // default func1 is sigmoid
                     scratch_gates(i, 0, j) + bias(0, j));
@@ -213,7 +213,7 @@ void gru_lbr_bwd_postgemm_template(T1 to_src, const rnn_utils::rnn_conf_t &rnn,
     parallel_nd(rnn.mb, [&](dim_t i) {
         acc_data_t diff_attention = 0.0f;
         PRAGMA_OMP_SIMD(reduction(+ : diff_attention))
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float h = src_iter(i, j);
             const float dHt = diff_dst_iter(i, j) + diff_dst_layer(i, j);
             float dG0 = (h - ws_gates(i, 2, j)) * dHt

--- a/src/cpu/rnn/ref_postgemm_lstm.cpp
+++ b/src/cpu/rnn/ref_postgemm_lstm.cpp
@@ -42,7 +42,7 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
         scratch_data_t *scratch_gates_, src_data_t *dst_layer_,
         src_data_t *dst_iter_, void *dst_iter_c_, const src_data_t *src_iter_,
         const void *src_iter_c_, const float *weights_peephole_,
-        const void *bias_, int block_step) {
+        const void *bias_, dim_t block_step) {
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
     const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
@@ -50,7 +50,7 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
             rnn, weights_peephole_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return rnn_utils::to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
     // If lstmp, instead of dst_layer, we use scratch_ht if inference or ws_ht if training
@@ -58,8 +58,8 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
             ? rnn.scratch_ht_ld
             : rnn.dst_layer_ld(cell_position);
     const auto dst_iter_ld = rnn.dst_iter_ld(cell_position);
-    const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
-    const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+    const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+    const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
 
     const ws_states_layer_aoc_t<src_data_t> dst_layer(
             rnn, dst_layer_, dst_layer_ld);
@@ -74,11 +74,12 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
             types::data_type_size(rnn.src_iter_c_dt), rnn.ws_states_iter_c_nld,
             src_iter_c_ld);
 
-    const auto src_iter_c = [&](int mb_id, int dhc_id) {
+    const auto src_iter_c = [&](dim_t mb_id, dim_t dhc_id) {
         return rnn_utils::to_float(
                 src_iter_c_aoc(mb_id, dhc_id), rnn.src_iter_c_dt);
     };
-    const auto dst_iter_c_assign = [&](int mb_id, int dhc_id, float c_state) {
+    const auto dst_iter_c_assign
+            = [&](dim_t mb_id, dim_t dhc_id, float c_state) {
         const auto dst_iter_c_ptr
                 = const_cast<void *>(dst_iter_c(mb_id, dhc_id));
 
@@ -92,10 +93,10 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
                     = cpu::q10n::saturate_and_round<float16_t>(c_state);
     };
 
-    const auto postgemm_call = [&](int i) {
-        const int n_elem = block_step / (int)sizeof(scratch_data_t);
+    const auto postgemm_call = [&](dim_t i) {
+        const dim_t n_elem = block_step / sizeof(scratch_data_t);
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             float gate_i_arg
                     = to_float(scratch_gates(i, 0, j), 0, j) + bias(0, j);
             if (rnn.is_lstm_peephole)
@@ -154,7 +155,7 @@ rnn_postgemm_sig(
     const float *scales = this->pd_->attr()->rnn_tparams_.scales_;
     const float *cscale = &(this->pd_->attr()->rnn_tparams_.cscale_);
     const auto to_src_dt = [&](float f) { return gates_t(f); };
-    const auto deq_id = [&](float f, int i, int j) { return f; };
+    const auto deq_id = [&](float f, int i, dim_t j) { return f; };
 
     const auto linear_f
             = [](const float *scale, float a) { return *scale * a; };
@@ -193,12 +194,13 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::lstm_postgemm) {
         return q10n::qz_a1b0_t<float, dst_layer_t>()(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, dim_t j) {
         const float wscale = pd_->attr()->rnn_weights_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[gate * rnn.dhc + j];
 
-        return q10n::saturate<float>(s) * (1.f / (wscale * data_scale));
+        return static_cast<float>(q10n::saturate<float>(s))
+                * (1.f / (wscale * data_scale));
     };
 
     const auto linear_f
@@ -234,12 +236,13 @@ rnn_postgemm_sig(rnn_postgemm_fwd_s8_t::lstm_postgemm) {
         return q10n::qz_a1b0_t<float, dst_layer_t>()(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, dim_t j) {
         float wscale = pd_->attr()->rnn_weights_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[gate * rnn.dhc + j];
 
-        return q10n::saturate<float>(s) * (1.f / (wscale * data_scale));
+        return static_cast<float>(q10n::saturate<float>(s))
+                * (1.f / (wscale * data_scale));
     };
 
     const auto linear_f
@@ -276,19 +279,19 @@ void lstm_bwd_postgemm_template(T1 func1, T2 to_src_dt, const float *cscale,
             rnn, scratch_gates_);
     const weights_peephole_aoc_t<const float> weights_peephole(
             rnn, weights_peephole_);
-    const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
-    const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+    const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+    const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
     const auto src_iter_c_aoc = rnn_utils::make_raw_aoc(src_iter_c_,
             types::data_type_size(rnn.src_iter_c_dt), rnn.ws_states_iter_c_nld,
             src_iter_c_ld);
-    const auto src_iter_c = [&](int mb_id, int dhc_id) {
+    const auto src_iter_c = [&](dim_t mb_id, dim_t dhc_id) {
         return rnn_utils::to_float(
                 src_iter_c_aoc(mb_id, dhc_id), rnn.src_iter_c_dt);
     };
     const auto dst_iter_c_aoc = rnn_utils::make_raw_aoc(dst_iter_c_,
             types::data_type_size(rnn.dst_iter_c_dt), rnn.ws_states_iter_c_nld,
             dst_iter_c_ld);
-    const auto dst_iter_c = [&](int mb_id, int dhc_id) {
+    const auto dst_iter_c = [&](dim_t mb_id, dim_t dhc_id) {
         return rnn_utils::to_float(
                 dst_iter_c_aoc(mb_id, dhc_id), rnn.dst_iter_c_dt);
     };
@@ -304,7 +307,7 @@ void lstm_bwd_postgemm_template(T1 func1, T2 to_src_dt, const float *cscale,
 
     parallel_nd(rnn.mb, [&](dim_t i) {
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float Ct = dst_iter_c(i, j);
             /// @todo save it in the workspace in fwd pass or recompute it to
             /// save bw

--- a/src/cpu/rnn/ref_postgemm_lstm_projection.cpp
+++ b/src/cpu/rnn/ref_postgemm_lstm_projection.cpp
@@ -37,7 +37,7 @@ namespace {
 template <typename dst_layer_t, typename dst_iter_t>
 void proj_dst_copy(const rnn_utils::rnn_conf_t &rnn,
         rnn_utils::cell_position_t cell_position, dst_iter_t *dst_iter_,
-        const dst_layer_t *dst_layer_, int block_step) {
+        const dst_layer_t *dst_layer_, dim_t block_step) {
     assert(rnn.dic == rnn.dlc);
     static_assert(sizeof(dst_layer_t) == sizeof(dst_iter_t),
             "memcpy requires the same data type size for src and dst");
@@ -72,9 +72,9 @@ rnn_postgemm_sig((rnn_postgemm_fwd_t<src_type, scratch_type,
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position, true);
 
     // Currently, scratch_gates_ contains the output of the projection
-    const int n_elem = block_step / (int)sizeof(dst_layer_t);
+    const dim_t n_elem = block_step / sizeof(dst_layer_t);
 
-    const int m_block
+    const dim_t m_block
             = (rnn.is_brgemm && !rnn.unfused_post_gemm) ? rnn.m_block : rnn.mb;
 
     for (int i = 0; i < m_block; i++)
@@ -107,22 +107,23 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::lstm_projection_postgemm) {
         return q10n::qz_a1b0_t<float, dst_layer_t>()(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, dim_t j) {
         const float wscale
                 = pd_->attr()->rnn_weights_projection_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[j];
         const float wcomp = w_proj_comp[j] * data_shift;
 
-        return (q10n::saturate<float>(s) - wcomp) / (wscale * data_scale);
+        return (static_cast<float>(q10n::saturate<float>(s)) - wcomp)
+                / (wscale * data_scale);
     };
 
-    auto postgemm_call = [&](int i) {
-        const int n_elem = block_step / (int)sizeof(dst_layer_t);
+    auto postgemm_call = [&](dim_t i) {
+        const dim_t n_elem = block_step / sizeof(dst_layer_t);
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
-            const int scratch_off = i * rnn.scratch_gates_ld + j;
-            const int dst_off = i * dst_layer_ld + j;
+        for (dim_t j = 0; j < n_elem; j++) {
+            const dim_t scratch_off = i * rnn.scratch_gates_ld + j;
+            const dim_t dst_off = i * dst_layer_ld + j;
             const float tmp
                     = dequantize_s32_f32(scratch_gates_[scratch_off], j);
             dst_layer_[dst_off] = quantize_f32_u8(tmp);
@@ -152,21 +153,22 @@ rnn_postgemm_sig(rnn_postgemm_fwd_s8_t::lstm_projection_postgemm) {
         return q10n::qz_a1b0_t<float, dst_layer_t>()(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, dim_t j) {
         const float wscale
                 = pd_->attr()->rnn_weights_projection_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[j];
 
-        return (q10n::saturate<float>(s)) / (wscale * data_scale);
+        return static_cast<float>(q10n::saturate<float>(s))
+                / (wscale * data_scale);
     };
 
     const auto postgemm_call = [&](dim_t i) {
-        const int n_elem = block_step / (int)sizeof(dst_layer_t);
+        const dim_t n_elem = block_step / sizeof(dst_layer_t);
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
-            const int scratch_off = i * rnn.scratch_gates_ld + j;
-            const int dst_off = i * dst_layer_ld + j;
+        for (dim_t j = 0; j < n_elem; j++) {
+            const dim_t scratch_off = i * rnn.scratch_gates_ld + j;
+            const dim_t dst_off = i * dst_layer_ld + j;
             const float tmp
                     = dequantize_s32_f32(scratch_gates_[scratch_off], j);
             dst_layer_[dst_off] = quantize_f32_s8(tmp);

--- a/src/cpu/rnn/ref_postgemm_rnn.cpp
+++ b/src/cpu/rnn/ref_postgemm_rnn.cpp
@@ -66,14 +66,14 @@ void rnn_fwd_postgemm_template(T func1, const float *scales, float alpha,
         rnn_utils::cell_position_t cell_position, src_data_t *ws_gates_,
         scratch_data_t *scratch_gates_, src_data_t *dst_layer_,
         src_data_t *dst_iter_, const src_data_t *src_iter_, const void *bias_,
-        int block_step) {
+        dim_t block_step) {
 
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
     const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
@@ -85,10 +85,10 @@ void rnn_fwd_postgemm_template(T func1, const float *scales, float alpha,
 
     if (scales != nullptr) alpha = scales[0];
 
-    const int n_elem = block_step / sizeof(scratch_data_t);
+    const dim_t n_elem = block_step / sizeof(scratch_data_t);
 
     const auto postgemm_call = [&](dim_t i) {
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             const float h
                     = func1(scratch_gates(i, 0, j) + bias(0, j), alpha, 0);
             if (dst_layer_ != nullptr) dst_layer(i, j) = h;

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -585,7 +585,7 @@ void ref_rnn_common_t<aprop, src_type, weights_type,
                       alg_kind::vanilla_augru)
             ? 2
             : 1;
-    const int ptr_wei_sz = rnn_.n_layer * rnn_.n_dir * max_nparts;
+    const dim_t ptr_wei_sz = rnn_.n_layer * rnn_.n_dir * max_nparts;
     scratchpad.template book<float *>(key_rnn_ptrs_wei_layer, ptr_wei_sz);
     scratchpad.template book<float *>(key_rnn_ptrs_wei_iter, ptr_wei_sz);
     scratchpad.template book<float *>(key_rnn_ptrs_wei_projection, ptr_wei_sz);
@@ -1042,7 +1042,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
     // We run the grid of computation
     for_(int dir = 0; dir < rnn.n_dir; dir++)
     for (int j = 0; j < rnn.n_layer; j++) {
-        const int lay = (aprop == prop_kind::forward) ? j : rnn.n_layer - j - 1;
+        const int lay = static_cast<int>(
+                (aprop == prop_kind::forward) ? j : rnn.n_layer - j - 1);
 
         CHECK(compute_merged_layer_part_if_applicable(
                 prop_kind::forward, dir, lay));
@@ -1050,8 +1051,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         // TODO: enable merging projection gemm in bwd lstm projection
 
         for (int i = 0; i < rnn.n_iter; i++) {
-            const int iter
-                    = (aprop == prop_kind::forward) ? i : rnn.n_iter - i - 1;
+            const int iter = static_cast<int>(
+                    (aprop == prop_kind::forward) ? i : rnn.n_iter - i - 1);
 
             // We set parameters to the cell execution call
 
@@ -1210,8 +1211,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
             // Note 1: here we assume no change in datatypes for src_iter, ws_iter and dst_iter
 
             const dst_iter_t *states_iter = nullptr;
-            int states_iter_ld = 0;
-            int niter_merge_gemm_iter = 0;
+            dim_t states_iter_ld = 0;
+            dim_t niter_merge_gemm_iter = 0;
 
             states_iter = &(
                     ws_states_iter(lay + 1, dir, rnn.skip_src_iter_copy(), 0));
@@ -1274,8 +1275,8 @@ void copy_init_layer_fwd_template(const rnn_conf_t &rnn,
                         (bfloat16_t *)ws_l2r_ptr, (const float *)xxt, rnn.slc);
             } else {
                 PRAGMA_OMP_SIMD()
-                for (int c = 0; c < rnn.slc; c++)
-                    ws_l2r_ptr[c] = xxt[c];
+                for (dim_t c = 0; c < rnn.slc; c++)
+                    ws_l2r_ptr[c] = static_cast<src_data_t>(xxt[c]);
             }
         }
         if (rnn.exec_dir != l2r) {
@@ -1284,8 +1285,8 @@ void copy_init_layer_fwd_template(const rnn_conf_t &rnn,
                         (bfloat16_t *)ws_r2l_ptr, (const float *)xxt, rnn.slc);
             } else {
                 PRAGMA_OMP_SIMD()
-                for (int c = 0; c < rnn.slc; c++)
-                    ws_r2l_ptr[c] = xxt[c];
+                for (dim_t c = 0; c < rnn.slc; c++)
+                    ws_r2l_ptr[c] = static_cast<src_data_t>(xxt[c]);
             }
         }
     });
@@ -1415,7 +1416,8 @@ void copy_init_iter_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
             return (src_data_t)f;
     };
     const src_data_t zero = maybe_q(0.f);
-    const auto zero_ws_iter_c = [&](int lay, int dir, int mb_id, int sic_id) {
+    const auto zero_ws_iter_c
+            = [&](dim_t lay, dim_t dir, dim_t mb_id, dim_t sic_id) {
         void *ws_states_iter_c = const_cast<void *>(
                 ws_states_iter_c_aoc(lay, dir, 0, mb_id, sic_id));
         if (rnn.src_iter_c_dt == data_type::f32)
@@ -1432,7 +1434,7 @@ void copy_init_iter_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
             const auto *ss = &src_iter_[src_iter_d.blk_off(lay, dir, b, 0)];
             auto *dd = &ws_states_iter(lay + 1, dir, 0, b, 0);
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.sic; s++)
+            for (dim_t s = 0; s < rnn.sic; s++)
                 dd[s] = maybe_q(ss[s]);
         });
     } else {
@@ -1556,11 +1558,11 @@ void copy_res_layer_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
     const auto copy_vec = [&](dst_layer_dt *dd, const src_data_t *ss) {
         if (dequantize_at_copy) {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++)
+            for (dim_t s = 0; s < rnn.dlc; s++)
                 dd[s] = (dst_layer_dt)(((float)ss[s] - shift) / scale);
         } else {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++)
+            for (dim_t s = 0; s < rnn.dlc; s++)
                 dd[s] = (dst_layer_dt)ss[s];
         }
     };
@@ -1568,7 +1570,7 @@ void copy_res_layer_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
     const auto acc_vec = [&](dst_layer_dt *dd, const src_data_t *ss) {
         if (dequantize) {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++) {
+            for (dim_t s = 0; s < rnn.dlc; s++) {
                 float val = (float)ss[s] + dd[s];
                 val = q10n::qz_a1b0_t<float, src_data_t>()(val);
                 dd[s] = (dst_layer_dt)((val - 2 * shift) / scale);
@@ -1576,12 +1578,13 @@ void copy_res_layer_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
         } else if (rnn_u8u8_case
                 || rnn_s8s8_case) { // instead of checking for rnn.is_int8()
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++)
-                dd[s] = q10n::saturate<dst_layer_dt, int16_t>(
-                        (int16_t)dd[s] + (int16_t)ss[s]);
+            for (dim_t s = 0; s < rnn.dlc; s++)
+                dd[s] = static_cast<dst_layer_dt>(
+                        q10n::saturate<dst_layer_dt, int16_t>(
+                                (int16_t)dd[s] + (int16_t)ss[s]));
         } else {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++)
+            for (dim_t s = 0; s < rnn.dlc; s++)
                 dd[s] += (dst_layer_dt)ss[s];
         }
     };
@@ -1612,7 +1615,7 @@ void copy_res_layer_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
     });
     if (rnn.skip_dst_iter_copy()) {
         parallel_nd(rnn.mb, [&](dim_t b) {
-            const int it = rnn.n_iter - 1;
+            const dim_t it = rnn.n_iter - 1;
             int dir = 0;
             if (rnn.exec_dir != r2l) {
                 const auto *ss = dst_iter_
@@ -1716,11 +1719,11 @@ void copy_res_iter_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
     const auto copy_vec = [&](dst_iter_dt *dd, const src_data_t *ss) {
         if (dequantize) {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dic; s++)
+            for (dim_t s = 0; s < rnn.dic; s++)
                 dd[s] = (dst_iter_dt)(((float)ss[s] - data_shift) / data_scale);
         } else {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dic; s++)
+            for (dim_t s = 0; s < rnn.dic; s++)
                 dd[s] = (dst_iter_dt)ss[s];
         }
     };
@@ -1825,9 +1828,9 @@ rnn_bias_prepare_sig_templ(copy_bias_to_scratch) {
             scratch_bias_, rnn.n_layer, rnn.n_dir, rnn.n_bias * rnn.dhc);
 
     parallel_nd(static_cast<dim_t>(rnn.n_layer) * rnn.n_dir, [&](dim_t i) {
-        const int off = i * rnn.n_bias * rnn.dhc;
+        const dim_t off = i * rnn.n_bias * rnn.dhc;
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < rnn.n_bias * rnn.dhc; j++)
+        for (dim_t j = 0; j < rnn.n_bias * rnn.dhc; j++)
             scratch_bias_[off + j] = b_[off + j];
     });
 }

--- a/src/cpu/rnn/rnn_reorders.hpp
+++ b/src/cpu/rnn/rnn_reorders.hpp
@@ -77,7 +77,8 @@ static inline void quantize_igo(int8_t *scratch_quantized,
                 const float s = scales[(mask == 0) ? 0 : go];
                 scratch_quantized[ldi * G * O + go]
                         = q10n::qz_b0_t<in_data_t, int8_t>()(
-                                src[ldi * G * O + go], s);
+                                static_cast<in_data_t>(src[ldi * G * O + go]),
+                                s);
             }
         }
     });
@@ -101,7 +102,9 @@ static inline void quantize_goi(int8_t *scratch_quantized,
         for (dim_t i = 0; i < I; i++) {
             scratch_quantized[ld * I * G * O + i * G * O + go]
                     = q10n::qz_b0_t<in_data_t, int8_t>()(
-                            src[ld * G * O * I + go * I + i], s);
+                            static_cast<in_data_t>(
+                                    src[ld * G * O * I + go * I + i]),
+                            s);
         }
     });
 }
@@ -117,8 +120,9 @@ static inline void compensate_igo(float *compensation,
     // We parallelize on LD and GO
     // TODO: maybe restrict parallelism as we might have large
     // parallelisation overhead if dimensions are small
-    const int LD_nthr = nstl::min(L * D, dim_t(nthr));
-    const int GO_nthr = nstl::min(G * O, dim_t(nthr / LD_nthr));
+    const int LD_nthr = static_cast<int>(nstl::min(L * D, dim_t(nthr)));
+    const int GO_nthr
+            = static_cast<int>(nstl::min(G * O, dim_t(nthr / LD_nthr)));
     parallel(nthr, [=](const int ithr, const int nthr) {
         int LD_ithr = -1;
         int GO_ithr = -1;
@@ -136,8 +140,9 @@ static inline void compensate_igo(float *compensation,
             if (I == 1) {
                 PRAGMA_OMP_SIMD()
                 for (dim_t go = GO_s; go < GO_e; go++)
-                    compensation[ld * G * O + go] = q10n::saturate<float>(
-                            scratch_quantized[ld * I * G * O + go]);
+                    compensation[ld * G * O + go]
+                            = static_cast<float>(q10n::saturate<float>(
+                                    scratch_quantized[ld * I * G * O + go]));
             } else {
                 // We split the loop on I in three to avoid conditionals or zeroing compensation
                 dim_t i = 0;
@@ -155,9 +160,10 @@ static inline void compensate_igo(float *compensation,
                 // i = I-1
                 PRAGMA_OMP_SIMD()
                 for (dim_t go = GO_s; go < GO_e; go++)
-                    compensation[ld * G * O + go] = q10n::saturate<float>(
-                            compensation_s32[go]
-                            + scratch_quantized[go + G * O * (i + I * (ld))]);
+                    compensation[ld * G * O + go] = static_cast<float>(
+                            q10n::saturate<float>(compensation_s32[go]
+                                    + scratch_quantized[go
+                                            + G * O * (i + I * (ld))]));
             }
         }
     });
@@ -181,7 +187,8 @@ static inline void compensate_goi(float *compensation,
         // going to be added to a bias (e.g. like in lstm
         // projection where it is directly added to the s32
         // accumulators)
-        compensation[ld * G * O + go] = q10n::saturate<float>(compensation_s32);
+        compensation[ld * G * O + go]
+                = static_cast<float>(q10n::saturate<float>(compensation_s32));
     });
 }
 
@@ -857,7 +864,8 @@ private:
             return status::success;
         }
 
-        const int o_block = dst_d.blocking_desc().inner_blks[0];
+        const int o_block
+                = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
         static constexpr int i_block = 4;
 
         dim_t L, D, I, G, O;
@@ -925,7 +933,8 @@ private:
             return row + col;
         };
         const auto kernel_plain_to_blocked
-                = [=](const out_data_t *inp, out_data_t *out, int ib, int ob) {
+                = [=](const out_data_t *inp, out_data_t *out, dim_t ib,
+                          dim_t ob) {
             PRAGMA_OMP_SIMD()
             for (int i = 0; i < i_block * o_block; i++)
                 out[i] = 0;

--- a/src/cpu/rnn/rnn_utils.cpp
+++ b/src/cpu/rnn/rnn_utils.cpp
@@ -93,10 +93,10 @@ bool rnn_utils::is_ldio_blocked(const memory_desc_wrapper &mdw) {
     return md_format_tag != format_tag::undef;
 }
 
-int rnn_utils::get_good_ld(int dim, int sizeof_dt) {
+dim_t rnn_utils::get_good_ld(dim_t dim, int sizeof_dt) {
     // we want matrices leading dimentions to be 64-byte aligned,
     // and not divisible by 256 to avoid 4K aliasing effects
-    const int ld = rnd_up(dim, 64 / sizeof_dt);
+    const dim_t ld = rnd_up(dim, 64 / sizeof_dt);
     return (ld % 256 == 0) ? ld + 64 / sizeof_dt : ld;
 }
 
@@ -229,8 +229,10 @@ status_t rnn_utils::set_expected_desc(rnn_conf_t &rnn,
                 rnn_pdata.format = rnn.is_fwd
                         ? rnn_packed_memory_format_t::ldigo_p
                         : rnn_packed_memory_format_t::ldgoi_p;
-                rnn_pdata.ldb = rnn.ws_states_iter_ld;
-                rnn_pdata.n = rnn.mb;
+                assert(rnn.ws_states_iter_ld <= INT_MAX);
+                assert(rnn.mb <= INT_MAX);
+                rnn_pdata.ldb = static_cast<int>(rnn.ws_states_iter_ld);
+                rnn_pdata.n = static_cast<int>(rnn.mb);
                 rnn_pdata.n_parts = rnn.n_parts_weights_iter;
                 array_copy(rnn_pdata.parts, rnn.parts_weights_iter,
                         DNNL_RNN_MAX_N_PARTS);
@@ -243,9 +245,13 @@ status_t rnn_utils::set_expected_desc(rnn_conf_t &rnn,
                 rnn_pdata.format = rnn.is_fwd
                         ? rnn_packed_memory_format_t::ldigo_p
                         : rnn_packed_memory_format_t::ldgoi_p;
-                rnn_pdata.ldb = rnn.ws_states_layer_ld;
-                rnn_pdata.n
-                        = rnn.merge_gemm_layer ? rnn.n_iter * rnn.mb : rnn.mb;
+                assert(rnn.ws_states_layer_ld <= INT_MAX);
+                assert(!rnn.merge_gemm_layer || rnn.n_iter * rnn.mb <= INT_MAX);
+                assert(rnn.mb <= INT_MAX);
+                rnn_pdata.ldb = static_cast<int>(rnn.ws_states_layer_ld);
+                rnn_pdata.n = static_cast<int>(rnn.merge_gemm_layer
+                                ? rnn.n_iter * rnn.mb
+                                : rnn.mb);
                 rnn_pdata.n_parts = rnn.n_parts_weights_layer;
                 array_copy(rnn_pdata.parts, rnn.parts_weights_layer,
                         DNNL_RNN_MAX_N_PARTS);
@@ -257,8 +263,10 @@ status_t rnn_utils::set_expected_desc(rnn_conf_t &rnn,
             case weights_type_t::projection:
                 // TODO: add ldoi_p for bwd?
                 rnn_pdata.format = rnn_packed_memory_format_t::ldio_p;
-                rnn_pdata.ldb = rnn.proj_ht_ld;
-                rnn_pdata.n = rnn.mb;
+                assert(rnn.proj_ht_ld <= INT_MAX);
+                assert(rnn.mb <= INT_MAX);
+                rnn_pdata.ldb = static_cast<int>(rnn.proj_ht_ld);
+                rnn_pdata.n = static_cast<int>(rnn.mb);
                 rnn_pdata.n_parts = rnn.n_parts_weights_projection;
                 array_copy(rnn_pdata.parts, rnn.parts_weights_projection,
                         DNNL_RNN_MAX_N_PARTS);
@@ -279,7 +287,7 @@ status_t rnn_utils::set_expected_desc(rnn_conf_t &rnn,
     } else {
         using namespace format_tag;
         if (rnn.is_brgemm) {
-            const int n_block = rnn.n_block;
+            const int n_block = static_cast<int>(rnn.n_block);
             format_tag_t tag = format_tag::undef;
 
             if (weights_type == weights_type_t::projection) {
@@ -353,7 +361,7 @@ float rnn_utils::to_float(const void *data, const data_type_t dt) {
 }
 
 const void *rnn_utils::inc_ptr(
-        const void *data, data_type_t data_type, int offset) {
+        const void *data, data_type_t data_type, dim_t offset) {
     if (data_type == data_type::f32)
         return static_cast<const float *>(data) + offset;
     else if (data_type == data_type::bf16)
@@ -364,7 +372,7 @@ const void *rnn_utils::inc_ptr(
         return data;
 }
 
-void *rnn_utils::inc_ptr(void *data, data_type_t data_type, int offset) {
+void *rnn_utils::inc_ptr(void *data, data_type_t data_type, dim_t offset) {
     return const_cast<void *>(
             inc_ptr(static_cast<const void *>(data), data_type, offset));
 }

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -44,7 +44,7 @@
             gemm_acc_t *diff_dst_layer_, gemm_acc_t *diff_dst_iter_, \
             gemm_acc_t *diff_dst_iter_c_, const float *weights_peephole_, \
             const void *bias_, gates_t *ws_grid_, scratch_t *scratch_cell_, \
-            dst_iter_t *dst_iter_, float *weights_scales_, int block_step
+            dst_iter_t *dst_iter_, float *weights_scales_, dim_t block_step
 
 #define rnn_postgemm_sig(f) void f(rnn_postgemm_sig_args) const
 
@@ -282,7 +282,7 @@ struct diff_src_brgemm_conf_t {
 
     brgemm_rnn_execute_loop_order_t loop_order
             = brgemm_rnn_execute_loop_order_t::undefined;
-    int gates_block;
+    dim_t gates_block;
 };
 
 struct diff_wei_brgemm_conf_t {
@@ -313,9 +313,9 @@ struct rnn_conf_t {
     data_type_t src_iter_c_dt = data_type::undef;
     data_type_t dst_iter_c_dt = data_type::undef;
 
-    int n_layer = 0, n_iter = 0, n_dir = 0, n_gates = 0, n_states = 0;
-    int mb = 0;
-    int slc = 0, sic = 0, dhc = 0, dic = 0, dlc = 0;
+    dim_t n_layer = 0, n_iter = 0, n_dir = 0, n_gates = 0, n_states = 0;
+    dim_t mb = 0;
+    dim_t slc = 0, sic = 0, dhc = 0, dic = 0, dlc = 0;
     //int gates_ld, gates_nld, gates_ws_ld;
 
     int n_parts_weights_layer = 0;
@@ -330,7 +330,9 @@ struct rnn_conf_t {
     int parts_weights_projection[DNNL_RNN_MAX_N_PARTS];
     size_t part_weights_projection_pack_size[DNNL_RNN_MAX_N_PARTS];
 
-    int n_bias = 0, n_parts_bias = 0, parts_bias[DNNL_RNN_MAX_N_PARTS];
+    dim_t n_bias = 0;
+    int n_parts_bias = 0;
+    int parts_bias[DNNL_RNN_MAX_N_PARTS];
 
     /* Size of packed data in bytes */
     size_t weights_layer_comp_offset = 0, weights_layer_pack_size = 0;
@@ -338,36 +340,37 @@ struct rnn_conf_t {
     size_t weights_projection_comp_offset = 0, weights_projection_pack_size = 0;
 
     bool copy_bias = false;
-    int weights_layer_ld = 0, weights_layer_nld = 0;
-    int diff_weights_layer_ld = 0, diff_weights_layer_nld = 0;
-    int weights_iter_ld = 0, weights_iter_nld = 0;
-    int diff_weights_iter_ld = 0, diff_weights_iter_nld = 0;
-    int weights_projection_ld = 0, weights_projection_nld = 0;
-    int diff_weights_projection_ld = 0, diff_weights_projection_nld = 0;
+    dim_t weights_layer_ld = 0, weights_layer_nld = 0;
+    dim_t diff_weights_layer_ld = 0, diff_weights_layer_nld = 0;
+    dim_t weights_iter_ld = 0, weights_iter_nld = 0;
+    dim_t diff_weights_iter_ld = 0, diff_weights_iter_nld = 0;
+    dim_t weights_projection_ld = 0, weights_projection_nld = 0;
+    dim_t diff_weights_projection_ld = 0, diff_weights_projection_nld = 0;
 
-    int proj_ht_ld = 0, proj_ht_nld = 0;
+    dim_t proj_ht_ld = 0, proj_ht_nld = 0;
 
-    int ws_gates_ld = 0, ws_gates_nld = 0;
-    int ws_ht_ld = 0, ws_ht_nld = 0;
-    int ws_states_layer_ld = 0, ws_states_layer_nld = 0;
-    int ws_states_iter_ld = 0, ws_states_iter_nld = 0;
-    int ws_states_iter_c_ld = 0, ws_states_iter_c_nld = 0;
-    int ws_diff_states_layer_ld = 0, ws_diff_states_layer_nld = 0;
-    int ws_diff_states_iter_ld = 0, ws_diff_states_iter_nld = 0;
-    int ws_diff_states_iter_c_ld = 0, ws_diff_states_iter_c_nld = 0;
+    dim_t ws_gates_ld = 0, ws_gates_nld = 0;
+    dim_t ws_ht_ld = 0, ws_ht_nld = 0;
+    dim_t ws_states_layer_ld = 0, ws_states_layer_nld = 0;
+    dim_t ws_states_iter_ld = 0, ws_states_iter_nld = 0;
+    dim_t ws_states_iter_c_ld = 0, ws_states_iter_c_nld = 0;
+    dim_t ws_diff_states_layer_ld = 0, ws_diff_states_layer_nld = 0;
+    dim_t ws_diff_states_iter_ld = 0, ws_diff_states_iter_nld = 0;
+    dim_t ws_diff_states_iter_c_ld = 0, ws_diff_states_iter_c_nld = 0;
 
-    int scratch_gates_ld = 0, scratch_gates_nld = 0;
-    int scratch_ht_ld = 0, scratch_ht_nld = 0;
-    int scratch_diff_ht_ld = 0, scratch_diff_ht_nld = 0;
+    dim_t scratch_gates_ld = 0, scratch_gates_nld = 0;
+    dim_t scratch_ht_ld = 0, scratch_ht_nld = 0;
+    dim_t scratch_diff_ht_ld = 0, scratch_diff_ht_nld = 0;
 
-    int src_layer_ld_ = 0, src_layer_nld_ = 0;
-    int src_iter_ld_ = 0, src_iter_nld_ = 0;
-    int src_iter_c_ld_ = 0, src_iter_c_nld_ = 0;
-    int dst_layer_ld_ = 0, dst_layer_nld_ = 0;
-    int dst_iter_ld_ = 0, dst_iter_nld_ = 0;
-    int dst_iter_c_ld_ = 0, dst_iter_c_nld_ = 0;
+    dim_t src_layer_ld_ = 0, src_layer_nld_ = 0;
+    dim_t src_iter_ld_ = 0, src_iter_nld_ = 0;
+    dim_t src_iter_c_ld_ = 0, src_iter_c_nld_ = 0;
+    dim_t dst_layer_ld_ = 0, dst_layer_nld_ = 0;
+    dim_t dst_iter_ld_ = 0, dst_iter_nld_ = 0;
+    dim_t dst_iter_c_ld_ = 0, dst_iter_c_nld_ = 0;
 
-    int weights_iter_compensation_size = 0, weights_layer_compensation_size = 0;
+    dim_t weights_iter_compensation_size = 0,
+          weights_layer_compensation_size = 0;
     bool is_fwd = false, is_training = false, is_lbr = false,
          is_lstm_peephole = false, is_lstm_projection = false, is_augru = false,
          is_orig_gru = false;
@@ -406,7 +409,7 @@ struct rnn_conf_t {
     bool merge_gemm_iter = false, merge_gemm_layer = false,
          force_nocopy = false, use_layer_packed_gemm = false,
          use_iter_packed_gemm = false, use_projection_packed_gemm = false;
-    int n_iter_scratch_gates = 0;
+    dim_t n_iter_scratch_gates = 0;
 
     bool diff_weights_overwrite = false;
     bool use_matmul = false;
@@ -650,7 +653,7 @@ struct rnn_conf_t {
 
     dim_t Nproj, Nproj_blocks, nproj_tail;
     dim_t LDAproj, LDBproj, LDCproj[4];
-    int dhc_block_peephole, dhc_tail_peephole, dhc_blocks_peephole;
+    dim_t dhc_block_peephole, dhc_tail_peephole, dhc_blocks_peephole;
     bool brgemm_fwd_iter_layer_fuse_possible = false;
 
     int nthr;
@@ -677,7 +680,7 @@ bool is_ldgoi_blocked(const memory_desc_wrapper &md);
 bool is_ldio_blocked(const memory_desc_wrapper &md);
 bool is_ldoi_blocked(const memory_desc_wrapper &md);
 
-int get_good_ld(int dim, int sizeof_dt);
+dim_t get_good_ld(dim_t dim, int sizeof_dt);
 
 template <typename T>
 bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
@@ -778,7 +781,9 @@ bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
     rnn.sic = weights_iter_d.dims()[2];
     rnn.slc = weights_layer_d.dims()[2];
     rnn.dhc = weights_layer_d.dims()[4];
-    rnn.dlc = rnn.is_lstm_projection ? weights_projection_d.dims()[3] : rnn.dhc;
+    rnn.dlc = rnn.is_lstm_projection
+            ? weights_projection_d.dims()[3]
+            : rnn.dhc;
     // All supported cells have dic == dlc
     rnn.dic = rnn.dlc;
 
@@ -836,9 +841,9 @@ bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
     // temporary: we also use it in lstmp as temporary scratchpad
     // between projection and downconversion, hence the max with dlc
     rnn.scratch_gates_nld = rnn.mb;
-    rnn.scratch_gates_ld
-            = get_good_ld(nstl::max(rnn.dlc, rnn.n_gates * rnn.dhc),
-                    sizeof(typename T::scratch_t));
+    rnn.scratch_gates_ld = get_good_ld(
+            nstl::max(rnn.dlc, rnn.n_gates * rnn.dhc),
+            sizeof(typename T::scratch_t));
     rnn.scratch_ht_nld = rnn.proj_ht_nld;
     rnn.scratch_ht_ld = rnn.proj_ht_ld;
 
@@ -866,18 +871,19 @@ bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
     rnn.is_orig_gru = utils::one_of(
             rd.cell_kind, alg_kind::vanilla_gru, alg_kind::vanilla_augru);
     rnn.n_parts_weights_layer = 1;
-    rnn.parts_weights_layer[0] = rnn.n_gates;
+    rnn.parts_weights_layer[0] = static_cast<int>(rnn.n_gates);
     rnn.parts_weights_layer[1] = 0;
 
     rnn.n_parts_weights_iter = rnn.is_orig_gru ? 2 : 1;
-    rnn.parts_weights_iter[0] = rnn.is_orig_gru ? 2 : rnn.n_gates;
+    rnn.parts_weights_iter[0]
+            = rnn.is_orig_gru ? 2 : static_cast<int>(rnn.n_gates);
     rnn.parts_weights_iter[1] = rnn.is_orig_gru ? 1 : 0;
 
     rnn.n_parts_weights_projection = 1;
     rnn.parts_weights_projection[0] = 1;
 
     rnn.n_parts_bias = 1;
-    rnn.parts_bias[0] = rnn.n_bias;
+    rnn.parts_bias[0] = static_cast<int>(rnn.n_bias);
     rnn.parts_bias[1] = 0;
 
     rnn.use_matmul = !rnn.is_brgemm && rnn.is_fwd // TODO: Enable BWD
@@ -976,7 +982,7 @@ bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
     const auto set_pack_sizes
             = [&](bool merge, bool &do_pack, size_t &weights_pack_size,
                       int &n_parts, int *parts, size_t *parts_pack_size,
-                      size_t &comp_offset, int ic, int oc, int weights_oc,
+                      size_t &comp_offset, dim_t ic, dim_t oc, dim_t weights_oc,
                       dim_t data_ld) -> bool {
         bool pack = true;
         weights_pack_size = 0;
@@ -1075,21 +1081,21 @@ void set_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
 
     // Set leading dimensions for input weights arrays depending on input format
     const auto set_dims
-            = [&](const memory_desc_wrapper &md, int &ld, int &nld) {
+            = [&](const memory_desc_wrapper &md, dim_t &ld, dim_t &nld) {
         ld = 0;
         nld = 0;
         if (md.is_blocking_desc()) {
             if (is_ldigo(md)) {
-                ld = (int)md.blocking_desc().strides[2];
+                ld = md.blocking_desc().strides[2];
                 nld = md.dims()[2];
             } else if (is_ldgoi(md)) {
-                ld = (int)md.blocking_desc().strides[4];
+                ld = md.blocking_desc().strides[4];
                 nld = md.dims()[3] * md.dims()[4];
             } else if (is_ldoi(md)) {
-                ld = (int)md.blocking_desc().strides[3];
+                ld = md.blocking_desc().strides[3];
                 nld = md.dims()[3];
             } else if (is_ldio(md)) {
-                ld = (int)md.blocking_desc().strides[2];
+                ld = md.blocking_desc().strides[2];
                 nld = md.dims()[2];
             } else
                 assert(!"unsupported weights format");
@@ -1246,7 +1252,7 @@ private:
 
     const byte *const base_ptr_;
     const size_t dt_size_;
-    const int dims_[Tdims];
+    const dim_t dims_[Tdims];
 };
 
 template <typename... Targs>
@@ -1261,13 +1267,13 @@ template <typename T>
 struct ws_gates_aoc_t {
     ws_gates_aoc_t(const rnn_conf_t &rnn, T *data)
         : gates_(data, rnn.ws_gates_nld, rnn.ws_gates_ld), DHC_(rnn.dhc) {}
-    T &operator()(int batch, int gate, int dhc) const {
+    T &operator()(dim_t batch, dim_t gate, dim_t dhc) const {
         return gates_(batch, gate * DHC_ + dhc);
     }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> gates_;
-    const int DHC_;
+    const dim_t DHC_;
 };
 
 template <typename T>
@@ -1275,20 +1281,22 @@ struct scratch_gates_aoc_t {
     scratch_gates_aoc_t(const rnn_conf_t &rnn, T *data)
         : gates_(data, rnn.scratch_gates_nld, rnn.scratch_gates_ld)
         , DHC_(rnn.dhc) {}
-    T &operator()(int batch, int gate, int dhc) const {
+    T &operator()(dim_t batch, dim_t gate, dim_t dhc) const {
         return gates_(batch, gate * DHC_ + dhc);
     }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> gates_;
-    const int DHC_;
+    const dim_t DHC_;
 };
 
 template <typename T>
 struct weights_peephole_aoc_t {
     weights_peephole_aoc_t(const rnn_conf_t &rnn, T *data)
         : weights_peephole_(data, 3, rnn.dhc) {}
-    T &operator()(int g, int dhc) const { return weights_peephole_(g, dhc); }
+    T &operator()(dim_t g, dim_t dhc) const {
+        return weights_peephole_(g, dhc);
+    }
 
 private:
     const utils::array_offset_calculator<T, 2> weights_peephole_;
@@ -1319,7 +1327,7 @@ struct bias_linear_exec_aoc_t {
             assert(!"unsupported data type");
     }
 
-    void **operator()(int layer, int dir) const {
+    void **operator()(dim_t layer, dim_t dir) const {
         if (bias_present_) {
             if (bias_dt_ == data_type::f32)
                 return reinterpret_cast<void **>(
@@ -1364,11 +1372,11 @@ private:
 
 template <typename T>
 struct ws_states_layer_aoc_t {
-    ws_states_layer_aoc_t(const rnn_conf_t &rnn, T *data, int leading_dim)
+    ws_states_layer_aoc_t(const rnn_conf_t &rnn, T *data, dim_t leading_dim)
         : state_(data, rnn.ws_states_layer_nld, leading_dim) {}
     ws_states_layer_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.ws_states_layer_nld, rnn.ws_states_layer_ld) {}
-    T &operator()(int batch, int dhc) const { return state_(batch, dhc); }
+    T &operator()(dim_t batch, dim_t dhc) const { return state_(batch, dhc); }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> state_;
@@ -1376,11 +1384,11 @@ private:
 
 template <typename T>
 struct ws_states_iter_aoc_t {
-    ws_states_iter_aoc_t(const rnn_conf_t &rnn, T *data, int leading_dim)
+    ws_states_iter_aoc_t(const rnn_conf_t &rnn, T *data, dim_t leading_dim)
         : state_(data, rnn.ws_states_iter_nld, leading_dim) {}
     ws_states_iter_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.ws_states_iter_nld, rnn.ws_states_iter_ld) {}
-    T &operator()(int batch, int dhc) const { return state_(batch, dhc); }
+    T &operator()(dim_t batch, dim_t dhc) const { return state_(batch, dhc); }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> state_;
@@ -1390,7 +1398,7 @@ template <typename T>
 struct augru_attention_aoc_t {
     augru_attention_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.mb) {}
-    T &operator()(int batch) const { return state_(batch); }
+    T &operator()(dim_t batch) const { return state_(batch); }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 1> state_;
@@ -1401,7 +1409,7 @@ struct ws_diff_states_layer_aoc_t {
     ws_diff_states_layer_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_layer_(data, rnn.ws_diff_states_layer_nld,
                   rnn.ws_diff_states_layer_ld) {}
-    T &operator()(int batch, int dhc) const {
+    T &operator()(dim_t batch, dim_t dhc) const {
         return diff_states_layer_(batch, dhc);
     }
 
@@ -1414,7 +1422,7 @@ struct ws_diff_states_iter_aoc_t {
     ws_diff_states_iter_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_iter_(data, rnn.ws_diff_states_iter_nld,
                   rnn.ws_diff_states_iter_ld) {}
-    T &operator()(int batch, int dhc) const {
+    T &operator()(dim_t batch, dim_t dhc) const {
         return diff_states_iter_(batch, dhc);
     }
 
@@ -1427,7 +1435,7 @@ struct ws_diff_states_iter_c_aoc_t {
     ws_diff_states_iter_c_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_iter_c_(data, rnn.ws_diff_states_iter_c_nld,
                   rnn.ws_diff_states_iter_c_ld) {}
-    T &operator()(int batch, int dhc) const {
+    T &operator()(dim_t batch, dim_t dhc) const {
         return diff_states_iter_c_(batch, dhc);
     }
 
@@ -1440,18 +1448,18 @@ struct ws_diff_w_iter_aoc_t {
         : diff_weights_iter_(
                   data, rnn.diff_weights_iter_nld, rnn.diff_weights_iter_ld)
         , DHC_(rnn.dhc) {}
-    float &operator()(int sic, int gate, int dhc) const {
+    float &operator()(dim_t sic, dim_t gate, dim_t dhc) const {
         return diff_weights_iter_(sic, gate * DHC_ + dhc);
     }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<float, 2>
             diff_weights_iter_;
-    const int DHC_;
+    const dim_t DHC_;
 };
 
-const void *inc_ptr(const void *data, data_type_t data_type, int offset);
-void *inc_ptr(void *data, data_type_t data_type, int offset);
+const void *inc_ptr(const void *data, data_type_t data_type, dim_t offset);
+void *inc_ptr(void *data, data_type_t data_type, dim_t offset);
 
 } // namespace rnn_utils
 } // namespace cpu

--- a/src/cpu/simple_q10n.hpp
+++ b/src/cpu/simple_q10n.hpp
@@ -103,7 +103,8 @@ struct qz_a1b0_t<in_t, out_t,
 template <typename in_t, typename out_t>
 struct qz_a1_t {
     out_t operator()(in_t in, out_t out, float beta) {
-        return saturate_and_round<out_t>((float)in + beta * out);
+        return saturate_and_round<out_t>(
+                (float)in + beta * static_cast<float>(out));
     }
 };
 
@@ -118,7 +119,7 @@ struct qz_a1_t<in_t, float> {
 template <typename in_t, typename out_t>
 struct qz_b0_t {
     out_t operator()(in_t in, float alpha) {
-        return saturate_and_round<out_t>(alpha * in);
+        return saturate_and_round<out_t>(alpha * static_cast<float>(in));
     }
 };
 
@@ -131,42 +132,45 @@ struct qz_b0_t<in_t, float> {
 template <typename in_t, typename out_t>
 struct qz_t {
     out_t operator()(in_t in, out_t out, float alpha, float beta) {
-        return saturate_and_round<out_t>(alpha * in + (beta ? beta * out : 0));
+        return saturate_and_round<out_t>(alpha * static_cast<float>(in)
+                + (beta != 0.f ? beta * static_cast<float>(out) : 0.f));
     }
 };
 
 template <typename in_t>
 struct qz_t<in_t, float> {
     float operator()(in_t in, float out, float alpha, float beta) {
-        return alpha * in + (beta ? beta * out : 0);
+        return alpha * in + (beta != 0.f ? beta * out : 0);
     }
 };
 
 template <>
 struct qz_t<bfloat16_t, bfloat16_t> {
     float operator()(bfloat16_t in, bfloat16_t out, float alpha, float beta) {
-        return (bfloat16_t)(alpha * (float)in + (beta ? beta * (float)out : 0));
+        return (bfloat16_t)(alpha * (float)in
+                + (beta != 0.f ? beta * (float)out : 0));
     }
 };
 
 template <>
 struct qz_t<float, bfloat16_t> {
     float operator()(float in, bfloat16_t out, float alpha, float beta) {
-        return (bfloat16_t)(alpha * in + (beta ? beta * out : 0));
+        return (bfloat16_t)(alpha * in + (beta != 0.f ? beta * out : 0));
     }
 };
 
 template <>
 struct qz_t<float16_t, float16_t> {
     float operator()(float16_t in, float16_t out, float alpha, float beta) {
-        return (float16_t)(alpha * (float)in + (beta ? beta * (float)out : 0));
+        return (float16_t)(alpha * (float)in
+                + (beta != 0.f ? beta * (float)out : 0));
     }
 };
 
 template <>
 struct qz_t<float, float16_t> {
     float operator()(float in, float16_t out, float alpha, float beta) {
-        return (float16_t)(alpha * in + (beta ? beta * out : 0));
+        return (float16_t)(alpha * in + (beta != 0.f ? beta * out : 0));
     }
 };
 

--- a/src/cpu/simple_resampling.cpp
+++ b/src/cpu/simple_resampling.cpp
@@ -82,13 +82,13 @@ status_t simple_resampling_kernel_t::init() {
 }
 
 status_t simple_resampling_kernel_t::execute(const exec_ctx_t &ctx) const {
-    const int OD = pd_->OD();
-    const int OH = pd_->OH();
-    const int OW = pd_->OW();
-    const int ID = pd_->ID();
-    const int IH = pd_->IH();
-    const int IW = pd_->IW();
-    const int NB_CH = utils::div_up(pd_->C(), inner_stride_);
+    const dim_t OD = pd_->OD();
+    const dim_t OH = pd_->OH();
+    const dim_t OW = pd_->OW();
+    const dim_t ID = pd_->ID();
+    const dim_t IH = pd_->IH();
+    const dim_t IW = pd_->IW();
+    const dim_t NB_CH = utils::div_up(pd_->C(), inner_stride_);
 
     if (pd_->is_fwd()) {
         const auto src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -347,9 +347,10 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
 
     brg->with_bias = (dt_bias == data_type::undef) ? false : true;
     brg->dt_bias = dt_bias;
+    // Type sizes are always 1/2/4/8, safe to narrow.
     brg->typesize_bias = (dt_bias == data_type::undef)
             ? 0
-            : types::data_type_size(brg->dt_bias);
+            : static_cast<int>(types::data_type_size(brg->dt_bias));
 
     brg->LDD = LDD;
     brg->is_runtime_ldd = is_runtime_value(LDD);
@@ -427,7 +428,8 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         return status::unimplemented;
 
     brg->dt_d = dt_d;
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    // Type sizes are always 1/2/4/8, safe to narrow.
+    brg->typesize_D = static_cast<int>(types::data_type_size(brg->dt_d));
 
     if (!IMPLICATION(brg->is_int8 && brg->dt_d == bf16,
                 is_superset(brg->isa_impl, avx512_core)
@@ -637,7 +639,7 @@ status_t brgemm_desc_set_attr(
 status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
     if (brg == nullptr) return status::invalid_arguments;
 
-    const int max_vpad = nstl::max(
+    const dim_t max_vpad = nstl::max(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
 
     if (brg->is_dgmm)
@@ -648,7 +650,7 @@ status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
     if (!brg->is_dgmm) {
         // virtual padding is restricted by bd_block size due to
         // brgemm_kernel implementation. TODO: remove this restriction
-        const int min_bd_block
+        const dim_t min_bd_block
                 = brg->bdb_tail > 0 ? brg->bdb_tail : brg->bd_block;
         if ((max_vpad > min_bd_block)) return status::unimplemented;
     }
@@ -742,12 +744,12 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
     for (int i = 0; i < max_palette_size_in_bytes; i++)
         _tc[i] = 0;
 
-    const int typesize_A
+    const dim_t typesize_A
             = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_A;
-    const int typesize_B
+    const dim_t typesize_B
             = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_B;
 
-    const int rd_step = 4 / typesize_A;
+    const dim_t rd_step = 4 / typesize_A;
 
     const auto Ac = typesize_A * rd_block;
 

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -798,7 +798,7 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
         }
     }
 
-    buff->palette_id = amx::get_target_palette();
+    buff->palette_id = static_cast<uint8_t>(amx::get_target_palette());
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -80,7 +80,7 @@ void brgemm_desc_t::cleanup_dst_md() {
     dst_md_ = nullptr;
 }
 
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
     brgemm_kernel_params_t brgemm_p;
@@ -108,7 +108,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
@@ -136,7 +136,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch,
         const brgemm_dynamic_values_t *dynamic_values) {
@@ -179,7 +179,7 @@ void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
     (*brg_kernel)(&brgemm_p);
 }
 
-void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch,

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -213,7 +213,7 @@ status_t DNNL_API brgemm_kernel_destroy(brgemm_kernel_t *brg_kernel);
 ///     * In rest scenarios is not used.
 /// @param dynamic_values TODO: missing doc
 ///
-void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const brgemm_batch_element_t *batch, void *ptr_C,
         void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);
@@ -240,7 +240,7 @@ void DNNL_API brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
 ///     * In rest scenarios is not used.
 /// @param dynamic_values TODO: missing doc
 ///
-void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
+void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, dim_t bs,
         const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C,
         void *scratch = nullptr,
@@ -269,7 +269,7 @@ void brgemm_kernel_execute(const brgemm_kernel_t *brg_kernel, int bs,
 /// @param dynamic_values TODO: missing doc
 ///
 void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
-        int bs, const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
+        dim_t bs, const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);
 
@@ -299,7 +299,7 @@ void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
 /// @param dynamic_values TODO: missing doc
 ///
 void DNNL_API brgemm_kernel_execute_postops(const brgemm_kernel_t *brg_kernel,
-        int bs, const void *addr_A, const void *addr_B,
+        dim_t bs, const void *addr_A, const void *addr_B,
         const brgemm_batch_element_t *batch, void *ptr_C, void *ptr_D,
         const brgemm_post_ops_data_t &post_ops_data, void *scratch = nullptr,
         const brgemm_dynamic_values_t *dynamic_values = nullptr);

--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -39,7 +39,7 @@ brgemm_kernel_container_t::get_set() {
     return set_;
 }
 
-bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
+bool brgemm_desc_container_t::insert(int idx, brgemm_desc_t &brg,
         const std::vector<char> &bd_mask,
         const std::vector<brgemm_batch_element_t> &static_offsets) {
     bd_mask_list_.push_back(bd_mask);
@@ -49,7 +49,7 @@ bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
 
     const auto ret = map_.insert({brg, idx});
-    const int ref_size = refs_.size();
+    const int ref_size = static_cast<int>(refs_.size());
     if (idx > ref_size - 1) { refs_.resize(idx + 1); }
     refs_[idx] = &(ret.first->first);
     // if there was no insertion then clean bd_mask and static_offsets
@@ -68,7 +68,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
 
     static_offsets_list_.push_back(static_offsets);
     brg.brgattr.static_offsets = static_offsets_list_.back().data();
-    const int ref_size = refs_.size();
+    const int ref_size = static_cast<int>(refs_.size());
     const auto ret = map_.insert({brg, -1});
     if (!ret.second) {
         // if there was no insertion then clean bd_mask and static_offsets
@@ -77,7 +77,7 @@ int brgemm_desc_container_t::insert(brgemm_desc_t &brg,
         return ret.first->second;
     }
 
-    int idx = map_.size() - 1;
+    int idx = static_cast<int>(map_.size()) - 1;
     if (idx > ref_size - 1) {
         if (ref_size == 0)
             refs_.resize(1);
@@ -100,7 +100,7 @@ bool brgemm_kernel_container_t::brgemm_kernel_cmp(
     return (std::memcmp(lcode, rcode, lsz) < 0);
 }
 
-status_t brgemm_kernel_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
+status_t brgemm_kernel_container_t::insert(int idx, const brgemm_desc_t *brg) {
     // Use two level hashing of brgemm kernels:
     // 1. Try to find entry in local brgemm_map_ using brgemm descriptor as a
     // key (we can check if brgemm descriptor is unique inside brgemm primitive)
@@ -123,7 +123,7 @@ status_t brgemm_kernel_container_t::insert(dim_t idx, const brgemm_desc_t *brg) 
     return status::success;
 }
 
-bool brgemm_palette_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
+bool brgemm_palette_container_t::insert(int idx, const brgemm_desc_t *brg) {
     S_t kernel_palette;
     auto status = brgemm_init_tiles(*brg, kernel_palette.data());
     if (status != status::success) return false;

--- a/src/cpu/x64/brgemm/brgemm_containers.cpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.cpp
@@ -39,7 +39,7 @@ brgemm_kernel_container_t::get_set() {
     return set_;
 }
 
-bool brgemm_desc_container_t::insert(int idx, brgemm_desc_t &brg,
+bool brgemm_desc_container_t::insert(dim_t idx, brgemm_desc_t &brg,
         const std::vector<char> &bd_mask,
         const std::vector<brgemm_batch_element_t> &static_offsets) {
     bd_mask_list_.push_back(bd_mask);
@@ -100,7 +100,7 @@ bool brgemm_kernel_container_t::brgemm_kernel_cmp(
     return (std::memcmp(lcode, rcode, lsz) < 0);
 }
 
-status_t brgemm_kernel_container_t::insert(int idx, const brgemm_desc_t *brg) {
+status_t brgemm_kernel_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
     // Use two level hashing of brgemm kernels:
     // 1. Try to find entry in local brgemm_map_ using brgemm descriptor as a
     // key (we can check if brgemm descriptor is unique inside brgemm primitive)
@@ -123,7 +123,7 @@ status_t brgemm_kernel_container_t::insert(int idx, const brgemm_desc_t *brg) {
     return status::success;
 }
 
-bool brgemm_palette_container_t::insert(int idx, const brgemm_desc_t *brg) {
+bool brgemm_palette_container_t::insert(dim_t idx, const brgemm_desc_t *brg) {
     S_t kernel_palette;
     auto status = brgemm_init_tiles(*brg, kernel_palette.data());
     if (status != status::success) return false;

--- a/src/cpu/x64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.hpp
@@ -37,15 +37,18 @@ public:
     brgemm_desc_container_t() = default;
     brgemm_desc_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
-    inline const brgemm_desc_t *operator[](int idx) const { return refs_[idx]; }
+    inline const brgemm_desc_t *operator[](int idx) const {
+        assert(idx >= 0);
+        return refs_[idx];
+    }
 
-    bool insert(dim_t idx, brgemm_desc_t &brg) {
+    bool insert(int idx, brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
         std::vector<brgemm_batch_element_t> dummy_static_offsets;
         return insert(idx, brg, dummy_bd_mask, dummy_static_offsets);
     }
 
-    bool insert(dim_t idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
+    bool insert(int idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
             const std::vector<brgemm_batch_element_t> &static_offsets);
 
     int insert(brgemm_desc_t &brg) {
@@ -75,10 +78,11 @@ struct brgemm_kernel_container_t {
     brgemm_kernel_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
     inline const brgemm_kernel_t *operator[](int idx) const {
+        assert(idx >= 0);
         return refs_[idx];
     }
 
-    status_t insert(dim_t idx, const brgemm_desc_t *brg);
+    status_t insert(int idx, const brgemm_desc_t *brg);
     static bool brgemm_kernel_cmp(const std::shared_ptr<brgemm_kernel_t> &lhs,
             const std::shared_ptr<brgemm_kernel_t> &rhs);
 
@@ -117,12 +121,15 @@ struct brgemm_palette_container_t {
     brgemm_palette_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
 
-    inline const char *operator[](dim_t idx) const { return refs_[idx]->data(); }
+    inline const char *operator[](int idx) const {
+        assert(idx >= 0);
+        return refs_[idx]->data();
+    }
 
-    bool insert(dim_t idx, const brgemm_desc_t *brg);
-    bool insert(dim_t idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
+    bool insert(int idx, const brgemm_desc_t *brg);
+    bool insert(int idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
 
-    inline void maybe_tile_configure(bool is_amx, dim_t &idx, dim_t new_idx) const {
+    inline void maybe_tile_configure(bool is_amx, int &idx, int new_idx) const {
         if (idx == new_idx) return;
         if (is_amx && (idx < 0 || refs_[idx] != refs_[new_idx]))
             amx_tile_configure(refs_[new_idx]->data());

--- a/src/cpu/x64/brgemm/brgemm_containers.hpp
+++ b/src/cpu/x64/brgemm/brgemm_containers.hpp
@@ -39,13 +39,13 @@ public:
     void resize(size_t ns) { refs_.resize(ns); }
     inline const brgemm_desc_t *operator[](int idx) const { return refs_[idx]; }
 
-    bool insert(int idx, brgemm_desc_t &brg) {
+    bool insert(dim_t idx, brgemm_desc_t &brg) {
         std::vector<char> dummy_bd_mask;
         std::vector<brgemm_batch_element_t> dummy_static_offsets;
         return insert(idx, brg, dummy_bd_mask, dummy_static_offsets);
     }
 
-    bool insert(int idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
+    bool insert(dim_t idx, brgemm_desc_t &brg, const std::vector<char> &bd_mask,
             const std::vector<brgemm_batch_element_t> &static_offsets);
 
     int insert(brgemm_desc_t &brg) {
@@ -78,7 +78,7 @@ struct brgemm_kernel_container_t {
         return refs_[idx];
     }
 
-    status_t insert(int idx, const brgemm_desc_t *brg);
+    status_t insert(dim_t idx, const brgemm_desc_t *brg);
     static bool brgemm_kernel_cmp(const std::shared_ptr<brgemm_kernel_t> &lhs,
             const std::shared_ptr<brgemm_kernel_t> &rhs);
 
@@ -117,12 +117,12 @@ struct brgemm_palette_container_t {
     brgemm_palette_container_t(size_t ns) { resize(ns); }
     void resize(size_t ns) { refs_.resize(ns); }
 
-    inline const char *operator[](int idx) const { return refs_[idx]->data(); }
+    inline const char *operator[](dim_t idx) const { return refs_[idx]->data(); }
 
-    bool insert(int idx, const brgemm_desc_t *brg);
-    bool insert(int idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
+    bool insert(dim_t idx, const brgemm_desc_t *brg);
+    bool insert(dim_t idx, const brgemm_desc_t &brg) { return insert(idx, &brg); }
 
-    inline void maybe_tile_configure(bool is_amx, int &idx, int new_idx) const {
+    inline void maybe_tile_configure(bool is_amx, dim_t &idx, dim_t new_idx) const {
         if (idx == new_idx) return;
         if (is_amx && (idx < 0 || refs_[idx] != refs_[new_idx]))
             amx_tile_configure(refs_[new_idx]->data());

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -167,7 +167,10 @@ struct DNNL_API brgemm_attr_t {
     // if unrolled kernel is used (use_uker == true)
     // then "max_bs" is the the only batch size that can be used on kernel call
     // else "max_bs" is the maximum batch size that can be used
-    int max_bs;
+    dim_t max_bs;
+    // Virtual/batch padding amounts along the M dimension. Bounded by
+    // brgemm_desc_t::MAX_VPAD (100), checked in brgemm_desc_init(), so these
+    // are small code-generation values, not tensor-scale ones.
     int max_top_vpad, max_bottom_vpad;
     int max_top_bpad, max_bottom_bpad;
     dim_t hint_expected_A_size, hint_expected_B_size, hint_expected_C_size;
@@ -215,7 +218,7 @@ struct DNNL_API brgemm_attr_t {
     // bd block. By default are equal to regular leading dimension parameters
     // specified on brgemm creation.
     // Supported by brgemm unrolled kernel for now.
-    int LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
+    dim_t LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
     // If "true" then batchsize is allowed to change on each kernel call
     // and there is no unrolling by batchsize in kernel
     bool var_bs {false};
@@ -223,6 +226,8 @@ struct DNNL_API brgemm_attr_t {
     // Hint for bs_group value in brgemm_desc_t
     int hint_bs_group {0};
 
+    // Blocking-factor hints: bounded code-generation tile sizes (AMX-tile
+    // and register-blocking limited), not tensor-scale values.
     int hint_bd_block {0};
     int hint_ld_block {0};
     int hint_bd_block2 {0};
@@ -257,13 +262,13 @@ struct brgemm_desc_t {
 
     // Note: new added parameters must be taken into account in the brgemm
     // comparison function
-    int bcast_dim = 0; // M;
-    int load_dim = 0; // N;
-    int reduce_dim = 0; // K;
-    int LDA = 0;
-    int LDB = 0;
-    int LDC = 0;
-    int LDD = 0;
+    dim_t bcast_dim = 0; // M;
+    dim_t load_dim = 0; // N;
+    dim_t reduce_dim = 0; // K;
+    dim_t LDA = 0;
+    dim_t LDB = 0;
+    dim_t LDC = 0;
+    dim_t LDD = 0;
 
     bool fused_copy_a = false;
     // we use two isa_ variables
@@ -328,22 +333,39 @@ struct brgemm_desc_t {
     // parallel task.
     bool with_dst_scales = false;
     data_type_t dt_wei_scales = data_type::undef;
-    // Grouping in batch used by brdgmm kernel
+    // Grouping in batch used by brdgmm kernel. Bounded by AMX_TILES_NUM-like
+    // small grouping factors, not a tensor-scale value.
     int bs_group {0};
 
     brgemm_attr_t brgattr;
 
     // Derived  parameters
-    int LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
+    dim_t LDA2 {0}, LDB2 {0}, LDC2_M {0}, LDC2_N {0};
     bool is_blocked = false;
 
-    int bdb = 0, bd_block = 0, bdb_tail = 0;
-    int bdb2 = 0, bd_block2 = 0, bdb2_tail = 0;
-    int ldb = 0, ld_block = 0, ldb_tail = 0;
-    int ldb2 = 0, ld_block2 = 0, ldb2_tail = 0;
-    int rdb = 0, rd_block = 0, rdb_tail = 0;
+    // bdb/ldb/rdb (block counts) scale with the tensor dimension divided by
+    // a small blocking factor, so they stay dim_t. bd_block/ld_block/rd_block
+    // (the blocking factor itself) and the *_tail remainders (always smaller
+    // than their respective block) are bounded code-generation values and
+    // stay int. bd_block2/ld_block2 (AMX tile grouping, bounded by
+    // AMX_TILES_NUM) stay int; bdb2/ldb2 (= bdb/ldb divided by a small
+    // block2 factor) still scale with the tensor dimension and stay dim_t,
+    // while their *_tail remainders stay int.
+    dim_t bdb = 0;
+    int bd_block = 0, bdb_tail = 0;
+    dim_t bdb2 = 0;
+    int bd_block2 = 0, bdb2_tail = 0;
+    dim_t ldb = 0;
+    int ld_block = 0, ldb_tail = 0;
+    dim_t ldb2 = 0;
+    int ld_block2 = 0, ldb2_tail = 0;
+    dim_t rdb = 0;
+    int rd_block = 0, rdb_tail = 0;
+    // rd_step/ld_step are VNNI granularity / f16-non-AMX-VNNI step values:
+    // small, fixed hardware constants.
     int rd_step = 0, ld_step = 0;
 
+    // Type sizes are always 1/2/4/8: bounded code-generation values.
     int typesize_A = 0;
     int typesize_B = 0;
     int typesize_C = 0;
@@ -374,7 +396,8 @@ struct brgemm_desc_t {
     // by kernel API.
     bool with_weights_scale_adjust = false;
     brgemm_kernel_innermost_loop_t innermost_loop = brgemm_ld_loop_innermost;
-    int is_M_tail = false;
+    // is_M_tail is used purely as a boolean flag.
+    bool is_M_tail = false;
     bool interleave_tilestores_ = false;
     brgemm_prf_t prfA, prfB, prfC;
     bool is_runtime_lda = false;
@@ -390,10 +413,11 @@ struct brgemm_desc_t {
     bool is_gemv = false;
     // Controls whether y is treated as a row in GEMV-specific code paths.
     bool treat_y_as_row = false;
-    // GEMV transA register-blocking unroll factor.
+    // GEMV transA register-blocking unroll factor: a fixed small constant.
     int gemv_transa_bd_unroll = 0;
     // non-transA: tail along the reduction dimension.
     // transA:     number of valid elements in the final vector accumulator.
+    // Bounded: always < simd width.
     int gemv_tail = 0;
 
     static constexpr int MAX_VPAD = 100;
@@ -413,7 +437,7 @@ struct brgemm_desc_t {
     // transA:
     //  - number of full vector accumulators updated per reduction step
     //  - equal to `gemv_transa_bd_unroll`
-    dim_t gemv_bd_block() const {
+    int gemv_bd_block() const {
         assert(is_gemv);
         if (!is_gemv) return 0;
         return transA ? gemv_transa_bd_unroll : bd_block;
@@ -428,7 +452,7 @@ struct brgemm_desc_t {
     //   - number of full vector accumulators in the tail block
     //   - the remaining first-level register tail is stored separately in
     //     `gemv_tail`
-    dim_t gemv_bdb_tail() const {
+    int gemv_bdb_tail() const {
         assert(is_gemv);
         if (!is_gemv) return 0;
         const int gemv_transa_simd_w
@@ -465,13 +489,13 @@ struct brgemm_desc_t {
     //                    defined by `gemv_bdb_tail()`
     //   - if `gemv_tail > 0`, one additional accumulator is included for the
     //     final partial vector
-    dim_t gemv_num_acc_blocks(bool is_bdb_tail) const {
+    int gemv_num_acc_blocks(bool is_bdb_tail) const {
         assert(is_gemv);
         if (!gemv_acc_is_vector())
             return is_bdb_tail ? gemv_bdb_tail() : gemv_bd_block();
 
         const bool has_tail_acc = is_bdb_tail && gemv_tail > 0;
-        const dim_t full_accs = is_bdb_tail ? gemv_bdb_tail() : gemv_bd_block();
+        const int full_accs = is_bdb_tail ? gemv_bdb_tail() : gemv_bd_block();
         return full_accs + has_tail_acc;
     }
 
@@ -519,15 +543,16 @@ struct brgemm_desc_t {
         return layout == brgemm_row_major;
     }
 
-    // Tile register decomposition
+    // Tile register decomposition. All of these are AMX tile indices/counts,
+    // bounded by AMX_TILES_NUM (8), not tensor-scale values.
     int get_bd_block2() const noexcept {
-        auto res = (bdb <= bd_block2) ? bdb : (bd_block2 + (bdb_tail ? 1 : 0));
-        return res;
+        return static_cast<int>(
+                (bdb <= bd_block2) ? bdb : (bd_block2 + (bdb_tail ? 1 : 0)));
     }
 
     int get_ld_block2() const noexcept {
-        auto res = (ldb <= ld_block2) ? ldb : (ld_block2 + (ldb_tail ? 1 : 0));
-        return res;
+        return static_cast<int>(
+                (ldb <= ld_block2) ? ldb : (ld_block2 + (ldb_tail ? 1 : 0)));
     }
 
     int get_num_C_tiles() const noexcept {
@@ -571,16 +596,16 @@ struct brgemm_desc_t {
         return (get_num_C_tiles() + get_num_A_tiles() + N);
     }
 
-    int get_convert_wsp_buffer_size() const noexcept {
+    dim_t get_convert_wsp_buffer_size() const noexcept {
         if (!is_input_convert()) return 0;
-        const int n_bdb = bd_block2;
-        const int n_rdb = rdb + (rdb_tail != 0);
-        const int n_ldb = ldb + (ldb_tail != 0);
-        const int downcvt_tiles = brgattr.max_bs * n_rdb * (n_bdb + n_ldb);
+        const dim_t n_bdb = bd_block2;
+        const dim_t n_rdb = rdb + (rdb_tail != 0);
+        const dim_t n_ldb = ldb + (ldb_tail != 0);
+        const dim_t downcvt_tiles = brgattr.max_bs * n_rdb * (n_bdb + n_ldb);
         return downcvt_tiles * tilesize;
     }
 
-    int get_fused_copy_a_wsp_buffer_size() const noexcept {
+    dim_t get_fused_copy_a_wsp_buffer_size() const noexcept {
         if (fused_copy_a)
             return brgattr.max_bs * bcast_dim
                     * dnnl::impl::utils::rnd_up(reduce_dim, max_rd_block())
@@ -588,8 +613,8 @@ struct brgemm_desc_t {
         return 0;
     }
 
-    int get_wsp_buffer_size() const noexcept {
-        int sz = 0;
+    dim_t get_wsp_buffer_size() const noexcept {
+        dim_t sz = 0;
         if (is_tmm) {
             sz = get_num_C_tiles() * tilesize; // postops buffer
             sz += get_convert_wsp_buffer_size();

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -209,6 +209,9 @@ void set_brg_vmm(brgemm_desc_t *brg) {
             = !brg->is_zmm && mayiuse(avx2) && is_superset(brg->isa_impl, avx2);
 }
 
+// Returns the number of ld_block2 tiles (or the ldb2 tail count), a
+// register-blocking factor bounded by the number of available vector
+// registers, not a tensor-scale value.
 int calculate_ldb_params(brgemm_desc_t *brg, const int try_ld_block2) {
     brg->ld_block2 = try_ld_block2;
     brg->ldb2 = brg->ldb / brg->ld_block2;
@@ -225,6 +228,9 @@ int calculate_ldb_params(brgemm_desc_t *brg, const int try_ld_block2) {
     return nstl::max(1, adj_ld_block2);
 }
 
+// Returns the maximum bcast (M) block size that fits in the available vector
+// registers: a register-blocking factor bounded by the number of vector
+// registers, not a tensor-scale value.
 int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
 
     // TODO: Calculating the number of available registers should be re-factored
@@ -277,9 +283,11 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     // ----- post-ops and store accumulators -----
     const int beta_regs = !one_of(brg->beta, 1.f, 0.f);
 
+    // aux_vec_count() returns size_t but the post-ops register count is
+    // always small and bounded by the number of vector registers.
     const int postops_regs = brg->attr()
-            ? injector::aux_vec_count(
-                      brg->attr()->post_ops_, brg->isa_impl, true)
+            ? static_cast<int>(injector::aux_vec_count(
+                      brg->attr()->post_ops_, brg->isa_impl, true))
             : 0;
 
     // Emulators: fp8 emulation are supported for amx only
@@ -318,10 +326,11 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     brg->ldb = LD / brg->ld_block;
     brg->ldb_tail = LD % brg->ld_block;
 
-    auto find_bdb_bd_mask = [&](int bd_block, int &bdb, int &bdb_tail) {
+    auto find_bdb_bd_mask = [&](int bd_block, dim_t &bdb, int &bdb_tail) {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) {
             bdb = div_up(BD, bd_block);
-            bdb_tail = BD % bd_block;
+            // BD % bd_block is a remainder bounded by bd_block, safe to narrow.
+            bdb_tail = static_cast<int>(BD % bd_block);
             return;
         }
 
@@ -334,7 +343,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
             } else {
                 i += bd_block;
                 if (i > BD) {
-                    bdb_tail = BD - i + bd_block;
+                    // Remainder bounded by bd_block, safe to narrow.
+                    bdb_tail = static_cast<int>(BD - i + bd_block);
                     if (brg->brgattr.use_uker) bdb++;
                 } else
                     bdb++;
@@ -345,11 +355,13 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     auto find_bd_block_for_bd_mask = [&]() {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) return false;
 
-        auto min_bdb = INT_MAX;
-        const auto start_bd_block = nstl::min(max_width, BD);
+        dim_t min_bdb = INT_MAX;
+        // start_bd_block is bounded by max_width (16), safe to narrow.
+        const int start_bd_block
+                = static_cast<int>(nstl::min<dim_t>(max_width, BD));
         auto best_bd_block = start_bd_block;
         for (auto bd_block = start_bd_block; bd_block > 0; bd_block--) {
-            int bdb = 0;
+            dim_t bdb = 0;
             int bdb_tail = 0;
             find_bdb_bd_mask(bd_block, bdb, bdb_tail);
             // bcast_dim should be divided by bd_block
@@ -380,14 +392,17 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                     : 1;
         }
         brg->ldb2 = brg->ldb / brg->ld_block2;
-        brg->ldb2_tail = brg->ldb % brg->ld_block2;
+        // Remainder bounded by ld_block2, safe to narrow.
+        brg->ldb2_tail = static_cast<int>(brg->ldb % brg->ld_block2);
 
         // Re-adjust the bd_block2 if possible
         if (brg->ld_block2 == 1 && !brg->is_M_tail && brg->ldb_tail == 0) {
             brg->bd_block2 = (brg->bdb >= 3) ? 3 : (brg->bdb >= 2) ? 2 : 1;
             brg->bdb2 = brg->bdb / brg->bd_block2;
-            brg->bdb2_tail = (brg->bd_block2 == 1) ? brg->bdb
-                                                   : brg->bdb % brg->bd_block2;
+            // Remainder bounded by bd_block2, safe to narrow.
+            brg->bdb2_tail = static_cast<int>((brg->bd_block2 == 1)
+                            ? brg->bdb
+                            : brg->bdb % brg->bd_block2);
         }
     };
 
@@ -398,12 +413,14 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
             if (!find_bd_block_for_bd_mask()) {
                 brg->bd_block = max_width;
                 brg->bdb = div_up(BD, brg->bd_block);
-                brg->bdb_tail = BD % brg->bd_block;
+                // Remainder bounded by bd_block, safe to narrow.
+                brg->bdb_tail = static_cast<int>(BD % brg->bd_block);
                 brg->is_M_tail = true;
             }
             brg->bd_block2 = width_step;
             brg->bdb2 = brg->bdb / brg->bd_block2;
-            brg->bdb2_tail = brg->bdb % brg->bd_block2;
+            // Remainder bounded by bd_block2, safe to narrow.
+            brg->bdb2_tail = static_cast<int>(brg->bdb % brg->bd_block2);
             set_decomposition_by_ld();
             return true;
         }
@@ -419,10 +436,13 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 }
             }
             if (brg->bd_block == 1) {
-                brg->bd_block = nstl::min(max_width, BD);
-                brg->bdb_tail = BD % max_width;
+                // Bounded by max_width, safe to narrow.
+                brg->bd_block
+                        = static_cast<int>(nstl::min<dim_t>(max_width, BD));
+                brg->bdb_tail = static_cast<int>(BD % max_width);
                 for (int i = max_width; i >= min_width; i--) {
-                    const auto i_tail = BD % i;
+                    // Remainder bounded by i (<= max_width), safe to narrow.
+                    const int i_tail = static_cast<int>(BD % i);
                     if (i_tail > brg->bdb_tail || i_tail == 0) {
                         brg->bd_block = i;
                         brg->bdb_tail = i_tail;
@@ -431,13 +451,15 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 }
             }
             brg->bdb = BD / brg->bd_block;
-            brg->bdb_tail = BD % brg->bd_block;
+            // Remainder bounded by bd_block, safe to narrow.
+            brg->bdb_tail = static_cast<int>(BD % brg->bd_block);
         }
 
         brg->bd_block2 = (brg->bdb >= 2) ? 2 : 1;
         brg->bdb2 = brg->bdb / brg->bd_block2;
-        brg->bdb2_tail
-                = (brg->bd_block2 == 1) ? brg->bdb : brg->bdb % brg->bd_block2;
+        // Remainder bounded by bd_block2, safe to narrow.
+        brg->bdb2_tail = static_cast<int>(
+                (brg->bd_block2 == 1) ? brg->bdb : brg->bdb % brg->bd_block2);
 
         brg->is_M_tail = false;
 
@@ -458,7 +480,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
         if (new_ld_block != 0) {
             brg->ld_block = new_ld_block;
             brg->ldb = div_up(LD, brg->ld_block);
-            brg->ldb_tail = LD % brg->ld_block;
+            // Remainder bounded by ld_block, safe to narrow.
+            brg->ldb_tail = static_cast<int>(LD % brg->ld_block);
         }
 
         if (new_bd_block2 != 0) {
@@ -470,7 +493,9 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 if (brg->bdb_tail && brg->bd_block2 > 1) brg->bd_block2--;
                 auto full_bd_blocks = brg->bdb - (brg->bdb_tail != 0 ? 1 : 0);
                 brg->bdb2 = full_bd_blocks / brg->bd_block2;
-                brg->bdb2_tail = full_bd_blocks % brg->bd_block2;
+                // Remainder bounded by bd_block2, safe to narrow.
+                brg->bdb2_tail
+                        = static_cast<int>(full_bd_blocks % brg->bd_block2);
             }
         }
 
@@ -483,7 +508,9 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 if (brg->ldb_tail && brg->ld_block2 > 1) brg->ld_block2--;
                 auto full_ld_blocks = brg->ldb - (brg->ldb_tail != 0 ? 1 : 0);
                 brg->ldb2 = full_ld_blocks / brg->ld_block2;
-                brg->ldb2_tail = full_ld_blocks % brg->ld_block2;
+                // Remainder bounded by ld_block2, safe to narrow.
+                brg->ldb2_tail
+                        = static_cast<int>(full_ld_blocks % brg->ld_block2);
             }
         }
     };
@@ -594,9 +621,12 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
             recalc_blocking(0, 16, 2, 2);
         } else if (BD <= 16) {
             // Have to call recalc_blocking twice to calculate ldb
-            recalc_blocking(BD, 16, 0, 0);
-            const auto ld_block2 = nstl::min(
-                    ldb_tail_16 ? ((brg->ldb > 4) ? 3 : 4) : 5, div_up(LD, 16));
+            // BD <= 16 here, safe to narrow into the bd_block parameter.
+            recalc_blocking(static_cast<int>(BD), 16, 0, 0);
+            // Bounded register-blocking factor, safe to narrow.
+            const int ld_block2 = static_cast<int>(
+                    nstl::min<dim_t>(ldb_tail_16 ? ((brg->ldb > 4) ? 3 : 4) : 5,
+                            div_up(LD, 16)));
             recalc_blocking(0, 0, 1, ld_block2);
         } else if (bdb_tail_only && weak_bdb && BD > 64) {
             recalc_blocking(16, 16, 1, 2);
@@ -611,8 +641,10 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
             // Have to call recalc_blocking twice to calculate bdb
             // we can't use ld_block other than 16
             recalc_blocking(16, 16, 0, 0);
-            const auto bd_block2 = nstl::min(
-                    brg->bdb_tail ? (brg->bdb > 4 ? 3 : 4) : 5, div_up(BD, 16));
+            // Bounded register-blocking factor, safe to narrow.
+            const int bd_block2 = static_cast<int>(
+                    nstl::min<dim_t>(brg->bdb_tail ? (brg->bdb > 4 ? 3 : 4) : 5,
+                            div_up(BD, 16)));
             recalc_blocking(0, 0, bd_block2, 1);
         } else if (bdb_block_tail && ldb_tail_16 && BD_R16 == 32 && LD_R16 == 32
                 && (weak_ldb || weak_bdb)) {
@@ -660,8 +692,9 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     const auto rd_block_step = brg->rd_block_step();
     const auto max_rd_block = brg->max_rd_block();
     if (brg->amx_may_extend_k()) {
-        brg->rd_block = nstl::min(
-                rnd_up(brg->reduce_dim, brg->rd_step), max_rd_block);
+        // Bounded by max_rd_block (small, register-blocking bound).
+        brg->rd_block = static_cast<int>(nstl::min<dim_t>(
+                rnd_up(brg->reduce_dim, brg->rd_step), max_rd_block));
     } else if (brg->fused_copy_a) {
         brg->rd_block = max_rd_block;
     } else {
@@ -675,7 +708,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     }
 
     brg->rdb = brg->reduce_dim / brg->rd_block;
-    brg->rdb_tail = brg->reduce_dim % brg->rd_block;
+    // Remainder bounded by rd_block, safe to narrow.
+    brg->rdb_tail = static_cast<int>(brg->reduce_dim % brg->rd_block);
 
     // Remove these guards in the future (add tail processing by reduction
     // dimension)
@@ -798,21 +832,25 @@ status_t brgemm_blocking_vmm_gemv(brgemm_desc_t *brg) {
     if (!brg->transA) {
         brg->ld_block = 1;
         brg->ldb = brg->load_dim / brg->ld_block;
-        brg->ldb_tail = brg->load_dim % brg->ld_block;
+        // Remainder bounded by ld_block, safe to narrow.
+        brg->ldb_tail = static_cast<int>(brg->load_dim % brg->ld_block);
         assert(brg->ldb_tail == 0);
 
         brg->ld_block2 = 1;
         brg->ldb2 = brg->ldb / brg->ld_block2;
-        brg->ldb2_tail = brg->ldb % brg->ld_block2;
+        // Remainder bounded by ld_block2, safe to narrow.
+        brg->ldb2_tail = static_cast<int>(brg->ldb % brg->ld_block2);
         assert(brg->ldb2_tail == 0);
 
         brg->bd_block = 8;
         brg->bdb = brg->bcast_dim / brg->bd_block;
-        brg->bdb_tail = brg->bcast_dim % brg->bd_block;
+        // Remainder bounded by bd_block, safe to narrow.
+        brg->bdb_tail = static_cast<int>(brg->bcast_dim % brg->bd_block);
 
         brg->rd_block = brg->gemv_use_vdpbf16ps() ? 2 * simd_w : simd_w;
         brg->rdb = brg->reduce_dim / brg->rd_block;
-        brg->rdb_tail = brg->reduce_dim % brg->rd_block;
+        // Remainder bounded by rd_block, safe to narrow.
+        brg->rdb_tail = static_cast<int>(brg->reduce_dim % brg->rd_block);
 
         brg->gemv_tail = brg->rdb_tail;
 
@@ -822,22 +860,26 @@ status_t brgemm_blocking_vmm_gemv(brgemm_desc_t *brg) {
     // Blocking parameters for the transposed case.
     brg->ld_block = 1;
     brg->ldb = brg->load_dim / brg->ld_block;
-    brg->ldb_tail = brg->load_dim % brg->ld_block;
+    // Remainder bounded by ld_block, safe to narrow.
+    brg->ldb_tail = static_cast<int>(brg->load_dim % brg->ld_block);
     assert(brg->ldb_tail == 0);
 
     brg->ld_block2 = 1;
     brg->ldb2 = brg->ldb / brg->ld_block2;
-    brg->ldb2_tail = brg->ldb % brg->ld_block2;
+    // Remainder bounded by ld_block2, safe to narrow.
+    brg->ldb2_tail = static_cast<int>(brg->ldb % brg->ld_block2);
     assert(brg->ldb2_tail == 0);
 
     brg->gemv_transa_bd_unroll = 8;
     brg->bd_block = simd_w * brg->gemv_transa_bd_unroll;
     brg->bdb = brg->bcast_dim / brg->bd_block;
-    brg->bdb_tail = brg->bcast_dim % brg->bd_block;
+    // Remainder bounded by bd_block, safe to narrow.
+    brg->bdb_tail = static_cast<int>(brg->bcast_dim % brg->bd_block);
 
     brg->rd_block = 1;
     brg->rdb = brg->reduce_dim / brg->rd_block;
-    brg->rdb_tail = brg->reduce_dim % brg->rd_block;
+    // Remainder bounded by rd_block, safe to narrow.
+    brg->rdb_tail = static_cast<int>(brg->reduce_dim % brg->rd_block);
 
     brg->gemv_tail = brg->bdb_tail % simd_w;
 
@@ -851,7 +893,8 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     const int simd_w = is_superset(brg->isa_impl, avx512_core) ? 16 : 8;
     brg->ld_block = simd_w;
     brg->ldb = brg->load_dim / brg->ld_block;
-    brg->ldb_tail = brg->load_dim % brg->ld_block;
+    // Remainder bounded by ld_block, safe to narrow.
+    brg->ldb_tail = static_cast<int>(brg->load_dim % brg->ld_block);
 
     const int max_vpad = nstl::max(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
@@ -867,7 +910,8 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
         brg->n_bcast_1_load
                 = (few_regs && adj_ld_block2 == 4) || hint_n_bcast_1_load;
         max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
-        const auto bdb_tail = brg->bcast_dim % max_bcast_block;
+        // Remainder bounded by max_bcast_block, safe to narrow.
+        const int bdb_tail = static_cast<int>(brg->bcast_dim % max_bcast_block);
         min_bcast_block = bdb_tail > 0 ? bdb_tail : max_bcast_block;
         if (min_bcast_block >= max_vpad) break;
     }
@@ -899,16 +943,20 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
         }
     }
     brg->bdb = brg->bcast_dim / brg->bd_block;
-    brg->bdb_tail = brg->bcast_dim % brg->bd_block;
+    // Remainder bounded by bd_block, safe to narrow.
+    brg->bdb_tail = static_cast<int>(brg->bcast_dim % brg->bd_block);
 
     const int rd_unroll = 4;
     const data_type_t rd_block_dt = get_mac_emu_data_type(
             brg->dt_a, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
     if (rd_block_dt == dnnl_data_type_undef) return status::unimplemented;
-    const int vnni_granularity = data_type_vnni_granularity(rd_block_dt);
+    // VNNI granularity is a small fixed hardware value (1/2/4), safe to narrow.
+    const int vnni_granularity
+            = static_cast<int>(data_type_vnni_granularity(rd_block_dt));
     brg->rd_block = rd_unroll * vnni_granularity;
     brg->rdb = brg->reduce_dim / brg->rd_block;
-    brg->rdb_tail = brg->reduce_dim % brg->rd_block;
+    // Remainder bounded by rd_block, safe to narrow.
+    brg->rdb_tail = static_cast<int>(brg->reduce_dim % brg->rd_block);
 
     brg->is_M_tail = false;
     // avx2_vnni_2 kernel with xf16 data type requires blocked weights.
@@ -922,12 +970,14 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
 status_t brgemm_blocking(brgemm_desc_t *brg) {
     const data_type_t ld_step_compute_dt = get_mac_emu_data_type(
             brg->dt_b, brg->isa_impl, brg->isa_impl != avx2_vnni_2);
+    // VNNI granularity is a small fixed hardware value, safe to narrow.
     brg->ld_step = brg->is_f16_b_non_amx_vnni()
             ? 2
-            : data_type_vnni_granularity(ld_step_compute_dt);
+            : static_cast<int>(data_type_vnni_granularity(ld_step_compute_dt));
     const data_type_t rd_step_compute_dt
             = get_mac_emu_data_type(brg->dt_b, brg->isa_impl);
-    brg->rd_step = data_type_vnni_granularity(rd_step_compute_dt);
+    brg->rd_step
+            = static_cast<int>(data_type_vnni_granularity(rd_step_compute_dt));
 
     set_isa_impl(brg);
     if (brg->isa_impl == isa_undef) return status::unimplemented;
@@ -965,6 +1015,7 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
     if (brg->isa_impl == isa_undef) return status::unimplemented;
 
     set_brg_vmm(brg); // Needed to dispatch into the right kernel later.
+    // Register count, bounded by the ISA's vector register file size.
     const int max_vregs = isa_num_vregs(brg->isa_impl);
 
     const int simd_w = isa_max_vlen(brg->isa_impl) / brg->typesize_C;
@@ -995,20 +1046,24 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
     const int n_block1_num_steps = is_avx2_vnni_2_xf16 ? 2 : 1;
     n_block1 = n_block1_num_steps * simd_w;
     nb_n_block1 = div_up(N, n_block1);
-    n_block1_tail = N % n_block1;
+    // Remainder bounded by n_block1, safe to narrow.
+    n_block1_tail = static_cast<int>(N % n_block1);
 
     const int max_n_block2_vmms = 4;
     const int max_n_block2 = max_n_block2_vmms / n_block1_num_steps;
-    n_block2 = nstl::min(max_n_block2, nb_n_block1);
+    // Bounded by max_n_block2 (small register-blocking constant).
+    n_block2 = static_cast<int>(nstl::min<dim_t>(max_n_block2, nb_n_block1));
 
     const int aux_vregs
             = jit_brdgmm_kernel_base_t<Xbyak::Zmm>::get_aux_vmm_count(*brg);
     const int compute_vregs
             = jit_brdgmm_kernel_base_t<Xbyak::Zmm>::get_compute_vmm_count(*brg);
     const int bf16_emu_vregs = brg->is_bf16_emu * 4;
+    // aux_vec_count() returns size_t but the post-ops register count is
+    // always small and bounded by the number of vector registers.
     const int postops_regs = brg->attr()
-            ? injector::aux_vec_count(
-                      brg->attr()->post_ops_, brg->isa_impl, true)
+            ? static_cast<int>(injector::aux_vec_count(
+                      brg->attr()->post_ops_, brg->isa_impl, true))
             : 0;
 
     const int max_acc_vmms = max_vregs
@@ -1027,20 +1082,25 @@ status_t brdgmm_blocking(brgemm_desc_t *brg) {
     if (brg->bs_group > 1) n_block2 = n_block2 % 2 == 0 ? 2 : 1;
 
     nb_n_block2 = div_up(nb_n_block1, n_block2);
-    n_block2_tail = nb_n_block1 % n_block2;
+    // Remainder bounded by n_block2, safe to narrow.
+    n_block2_tail = static_cast<int>(nb_n_block1 % n_block2);
 
     m_block1 = 1;
     nb_m_block1 = M / m_block1;
-    m_block1_tail = M % m_block1;
+    // Remainder bounded by m_block1, safe to narrow.
+    m_block1_tail = static_cast<int>(M % m_block1);
 
-    m_block2 = nstl::min(nb_m_block1,
-            brg->bs_group > 1 ? (max_acc_vmms / (n_block2 * n_block1_num_steps)
-                                        - brg->bs_group + 1)
+    // Bounded by the register-derived acc-block limit computed above.
+    m_block2 = static_cast<int>(nstl::min<dim_t>(nb_m_block1,
+            brg->bs_group > 1
+                    ? (max_acc_vmms / (n_block2 * n_block1_num_steps)
+                              - brg->bs_group + 1)
                             / 2
-                              : max_acc_vmms / (n_block2 * n_block1_num_steps));
+                    : max_acc_vmms / (n_block2 * n_block1_num_steps)));
     assert(m_block2 > 0);
     nb_m_block2 = div_up(nb_m_block1, m_block2);
-    m_block2_tail = nb_m_block1 % m_block2;
+    // Remainder bounded by m_block2, safe to narrow.
+    m_block2_tail = static_cast<int>(nb_m_block1 % m_block2);
 
     return status::success;
 }
@@ -1074,10 +1134,11 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->dt_d = brg->dt_c;
     brg->dt_bias = brg->dt_c;
 
-    brg->typesize_A = types::data_type_size(brg->dt_a);
-    brg->typesize_B = types::data_type_size(brg->dt_b);
-    brg->typesize_C = types::data_type_size(brg->dt_c);
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    // Type sizes are always 1/2/4/8, safe to narrow.
+    brg->typesize_A = static_cast<int>(types::data_type_size(brg->dt_a));
+    brg->typesize_B = static_cast<int>(types::data_type_size(brg->dt_b));
+    brg->typesize_C = static_cast<int>(types::data_type_size(brg->dt_c));
+    brg->typesize_D = static_cast<int>(types::data_type_size(brg->dt_d));
 
     brg->isa_user = isa;
 
@@ -1109,19 +1170,19 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->req_s8s8_compensation
             = brg->req_src_s8_shift && !brg->with_per_mn_compensation;
 
-    CHECK(safe_dim_to_int(brg->LDA, (brg->is_row_major()) ? LDA : LDB));
+    brg->LDA = (brg->is_row_major()) ? LDA : LDB;
     brg->is_runtime_lda = (brg->is_row_major()) ? is_runtime_value(LDA)
                                                 : is_runtime_value(LDB);
-    CHECK(safe_dim_to_int(brg->LDB, (brg->is_row_major()) ? LDB : LDA));
+    brg->LDB = (brg->is_row_major()) ? LDB : LDA;
     brg->is_runtime_ldb = (brg->is_row_major()) ? is_runtime_value(LDB)
                                                 : is_runtime_value(LDA);
-    CHECK(safe_dim_to_int(brg->LDC, LDC));
-    CHECK(safe_dim_to_int(brg->LDD, LDC));
+    brg->LDC = LDC;
+    brg->LDD = LDC;
     brg->is_runtime_ldc = brg->is_runtime_ldd = is_runtime_value(LDC);
 
-    CHECK(safe_dim_to_int(brg->bcast_dim, (brg->is_row_major()) ? M : N));
-    CHECK(safe_dim_to_int(brg->load_dim, (brg->is_row_major()) ? N : M));
-    CHECK(safe_dim_to_int(brg->reduce_dim, K));
+    brg->bcast_dim = (brg->is_row_major()) ? M : N;
+    brg->load_dim = (brg->is_row_major()) ? N : M;
+    brg->reduce_dim = K;
 
     brg->bd_block2 = 0;
     brg->bdb2 = 0;
@@ -1148,10 +1209,11 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->dt_d = brg->dt_c;
     brg->dt_bias = brg->dt_c;
 
-    brg->typesize_A = types::data_type_size(brg->dt_a);
-    brg->typesize_B = types::data_type_size(brg->dt_b);
-    brg->typesize_C = types::data_type_size(brg->dt_c);
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    // Type sizes are always 1/2/4/8, safe to narrow.
+    brg->typesize_A = static_cast<int>(types::data_type_size(brg->dt_a));
+    brg->typesize_B = static_cast<int>(types::data_type_size(brg->dt_b));
+    brg->typesize_C = static_cast<int>(types::data_type_size(brg->dt_c));
+    brg->typesize_D = static_cast<int>(types::data_type_size(brg->dt_d));
 
     brg->isa_user = isa;
     auto is_isa_ok = [&](cpu_isa_t isa) {
@@ -1181,12 +1243,12 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
 
     brg->is_dgmm = true;
 
-    CHECK(safe_dim_to_int(brg->LDA, LDA));
-    CHECK(safe_dim_to_int(brg->LDC, LDC));
-    CHECK(safe_dim_to_int(brg->LDD, LDC));
+    brg->LDA = LDA;
+    brg->LDC = LDC;
+    brg->LDD = LDC;
 
-    CHECK(safe_dim_to_int(brg->bcast_dim, M));
-    CHECK(safe_dim_to_int(brg->load_dim, N));
+    brg->bcast_dim = M;
+    brg->load_dim = N;
 
     return status::success;
 }

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -565,8 +565,9 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     if (brg->can_dispatch_uker()) {
         // Blocking heuristics for some shapes
         // TODO: Review these criteria
-        const size_t eff_K
-                = brg->reduce_dim * brg->typesize_A * brg->brgattr.K_koef;
+        const size_t eff_K = static_cast<size_t>(
+                static_cast<float>(brg->reduce_dim * brg->typesize_A)
+                * brg->brgattr.K_koef);
         const auto low_K = (L1 - 4 * 1024) / (6 * 16);
 
         // TODO: if rdb_tail != 0 then we should limit
@@ -928,14 +929,17 @@ status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
         const auto bd_block_disb = (brg->bcast_dim <= 0 || bd_block == 0)
                 ? 0.f
                 : static_cast<float>(brg->bcast_dim)
-                        / rnd_up(brg->bcast_dim, bd_block);
+                        / static_cast<float>(rnd_up(brg->bcast_dim, bd_block));
         const auto brgemm_microkernel_eff
-                = (static_cast<float>(adj_ld_block2) * bd_block)
-                / (((adj_ld_block2) + bd_block) * max_bcast_block);
+                = (static_cast<float>(adj_ld_block2)
+                          * static_cast<float>(bd_block))
+                / static_cast<float>(
+                        ((adj_ld_block2) + bd_block) * max_bcast_block);
         const auto bd_block_eff = bd_block_disb * brgemm_microkernel_eff;
 
-        float block_foot_print = static_cast<float>(brg->typesize_A) * bd_block
-                * brg->reduce_dim;
+        float block_foot_print = static_cast<float>(brg->typesize_A)
+                * static_cast<float>(bd_block)
+                * static_cast<float>(brg->reduce_dim);
         if (block_foot_print <= static_cast<float>(L1)
                 && (bd_block_eff > best_bd_block_eff)) {
             brg->bd_block = bd_block;

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -57,14 +57,14 @@ jit_brdgmm_kernel_base_t<Wmm>::jit_brdgmm_kernel_base_t(
         static constexpr bool preserve_vmm = false;
         static constexpr bool use_exact_tail_scalar_bcast = false;
         const auto dst_md_wrapper = memory_desc_wrapper(brg.dst_md());
-        const size_t tail = tail_length();
+        const int tail = tail_length();
 
         static const bcast_set_t enabled_bcast_strategy
                 = {broadcasting_strategy_t::scalar,
                         broadcasting_strategy_t::per_oc,
                         broadcasting_strategy_t::no_broadcast};
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(vmm_b().getIdx()), r14, r15, r13,
+                vmm_b().getIdx(), r14, r15, r13,
                 preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
                 dst_md_wrapper, tail, k_mask, use_exact_tail_scalar_bcast};
@@ -228,7 +228,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::set_A_B_matrices() {
     }
 
     add(reg_aux_A, reg_a_offset);
-    lea(reg_aux_B, ptr[reg_aux_B + reg_aux_N * brg.typesize_B]);
+    lea(reg_aux_B,
+            ptr[reg_aux_B + reg_aux_N * xbyak_address_scale(brg.typesize_B)]);
 }
 
 template <typename Wmm>
@@ -459,7 +460,9 @@ void jit_brdgmm_kernel_base_t<Wmm>::store_accumulators_apply_post_ops(
 
     if (brg.with_bias) {
         reg_aux_bias.restore();
-        lea(reg_aux_bias, ptr[reg_aux_bias + reg_aux_N * brg.typesize_bias]);
+        lea(reg_aux_bias,
+                ptr[reg_aux_bias
+                        + reg_aux_N * xbyak_address_scale(brg.typesize_bias)]);
     }
 
     for_(int v_i = 0; v_i < v_substep; ++v_i)
@@ -710,7 +713,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_int8_compensation(
     for (int n = 0; n < n_blocks; n++) {
         const int substep_simd = get_substep_simd(n, v_i, has_n_tail);
         if (substep_simd <= 0) continue;
-        const size_t offset = comp_offset(n);
+        const dim_t offset = comp_offset(n);
         if (brg.req_s8s8_compensation) {
             const Vmm vmm_comp = vmm_s8s8_comp();
             uni_vmovups(vmm_comp,
@@ -902,7 +905,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::comp_dot_product(
             const Vmm vmm_zp = isa_has_masks(brg.isa_impl)
                     ? maybe_mask(vmm_zp_comp(), is_tail_block, false)
                     : vmm_zp_comp();
-            const size_t offset = comp_offset(n);
+            const dim_t offset = comp_offset(n);
             if (IMPLICATION(is_tail_block, isa_has_masks(brg.isa_impl))) {
                 if (is_src_zp_bcast_) {
                     if (is_superset(brg.isa_impl, avx512_core))
@@ -1046,7 +1049,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
     const int v_substep = vnni_substep();
     assert(max_bvmms > 0);
 
-    auto dot_product = [&](Vmm vmma, Vmm vmmb, int m_i, int n_i, int v_i) {
+    auto dot_product
+            = [&](Vmm vmma, Vmm vmmb, int m_i, int n_i, int v_i) {
         auto vmm_acc = accm(m_blocks, n_blocks, m_i, n_i, v_i);
         if (brg.is_f32) {
             if (is_fma_embd()) {
@@ -1185,8 +1189,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::brdgmm_microkernel(int m_blocks,
 }
 
 template <typename Wmm>
-void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(
-        const int m_blocks) {
+void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(int m_blocks) {
     const bool do_check_effective_padding = check_effective_padding();
     Label no_top_padding;
 
@@ -1194,7 +1197,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::get_vertical_padding_info(
         if (do_check_effective_padding) {
             Label done_adjust_bottom_padding;
             mov(reg_aux_A_vpad_bottom, reg_aux_M);
-            add(reg_aux_A_vpad_bottom, m_blocks - M());
+            sub(reg_aux_A_vpad_bottom, M() - m_blocks);
             add(reg_aux_A_vpad_bottom,
                     ptr[reg_aux_batch_addr
                             + GET_OFF_BATCH_ELEMENT(vvpad.bottom)]);
@@ -1235,7 +1238,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::get_batch_padding_info() {
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
-        const int m_blocks, const int n_blocks, bool has_n_tail) {
+        int m_blocks, int n_blocks, bool has_n_tail) {
     const int tpad = brg.brgattr.max_top_vpad;
     const int bpad = brg.brgattr.max_bottom_vpad;
     if (tpad > 0) {
@@ -1264,7 +1267,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::vertical_pad_kernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::call_brdgmm_microkernel(
-        const int m_blocks, const int n_blocks, bool has_n_tail, int shift_a) {
+        int m_blocks, int n_blocks, bool has_n_tail, int shift_a) {
 
     // padding for vertical dimensions
     const int tpad = brg.brgattr.max_top_vpad;
@@ -1294,7 +1297,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::call_brdgmm_microkernel(
 
 template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::batch_loop(
-        const int m_blocks, const int n_blocks, bool has_n_tail) {
+        int m_blocks, int n_blocks, bool has_n_tail) {
 
     Label bs_loop_label, done_bs_loop;
     load_accumulators(m_blocks, n_blocks);
@@ -1340,14 +1343,14 @@ template <typename Wmm>
 void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
     const bool has_m_block2_tail = m_block2_tail() > 0;
-    const int loop_m = (nb_m_block2() - has_m_block2_tail);
+    const dim_t loop_m = nb_m_block2() - has_m_block2_tail;
     const bool do_loop_m = loop_m > 1;
 
     const bool has_n_block2_tail = n_block2_tail() > 0;
     const bool need_separate_n_block1_tail_block = n_block1_tail() != 0
             && !has_n_block2_tail && nb_n_block2() > 1
             && !isa_has_masks(brg.isa_impl);
-    const int loop_n = nb_n_block2() - has_n_block2_tail
+    const dim_t loop_n = nb_n_block2() - has_n_block2_tail
             - need_separate_n_block1_tail_block;
     const bool do_loop_n = loop_n > 1;
     const bool loop_n_update_aux_ptrs = do_loop_n || (loop_n < nb_n_block2());
@@ -1355,8 +1358,8 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
     auto n_loop = [&](int m_blocks) {
         Label n_loop_label;
         const int n_blocks = n_block2();
-        const int n_loop_step = oc_logical_offset(n_blocks);
-        const int n_loop_work = loop_n * n_blocks * n_block1();
+        const dim_t n_loop_step = oc_logical_offset(n_blocks);
+        const dim_t n_loop_work = loop_n * n_blocks * n_block1();
         const bool vlen_tail_in_loop = n_block1_tail() != 0
                 && !need_separate_n_block1_tail_block && !has_n_block2_tail;
 
@@ -1418,13 +1421,24 @@ void jit_brdgmm_kernel_base_t<Wmm>::compute_loop() {
 
             if (do_loop_m || has_m_block2_tail) {
                 add(reg_aux_M, m_blocks);
-                const int n_loop_offset
+                const dim_t n_loop_offset
                         = loop_n_update_aux_ptrs * loop_n * n_block2();
-                add(reg_a_offset, A_offset(m_blocks, -n_loop_offset));
+                // n_loop_offset is a tensor-scale N position (in n_block1
+                // units); A_offset/C_offset/D_offset's `n` parameter is the
+                // bounded per-iteration block index, so narrow explicitly at
+                // this documented boundary.
+                const int n_loop_offset_i = static_cast<int>(n_loop_offset);
+                const dim_t a_shift = A_offset(m_blocks, 0)
+                        - A_offset(0, n_loop_offset_i);
+                const dim_t c_shift = C_offset(m_blocks, 0, 0)
+                        - C_offset(0, n_loop_offset_i, 0);
+                const dim_t d_shift = D_offset(m_blocks, 0, 0)
+                        - D_offset(0, n_loop_offset_i, 0);
+                add(reg_a_offset, a_shift);
                 reg_aux_C.restore();
-                add(reg_aux_C, C_offset(m_blocks, -n_loop_offset, 0));
+                add(reg_aux_C, c_shift);
                 reg_aux_C.save();
-                add(reg_aux_D, D_offset(m_blocks, -n_loop_offset, 0));
+                add(reg_aux_D, d_shift);
             }
 
             if (do_loop_m) {

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -258,6 +258,9 @@ private:
     // note 2: zmm0 collides with vmm_permute, hence need to write this value
     // before every loop.
 
+    // SIMD width and max vector-register count are hardware/ISA-bounded
+    // code-generation values, not tensor-scale quantities, so they stay
+    // `int` rather than `dim_t`.
     const int simd_w_;
     const int max_vmms_;
     const bool compute_dst_zp_, compute_src_zp_;
@@ -271,17 +274,17 @@ private:
 
     bool with_binary_non_scalar_bcast_ = false;
 
-    inline int M() { return brg.bcast_dim; }
-    inline int N() { return brg.load_dim; }
+    inline dim_t M() { return brg.bcast_dim; }
+    inline dim_t N() { return brg.load_dim; }
     inline int m_block2() { return brg.bd_block2; }
-    inline int nb_m_block2() { return brg.bdb2; }
+    inline dim_t nb_m_block2() { return brg.bdb2; }
     inline int m_block2_tail() { return brg.bdb2_tail; }
 
     inline int n_block1() { return brg.ld_block; }
-    inline int nb_n_block1() { return brg.ldb; }
+    inline dim_t nb_n_block1() { return brg.ldb; }
     inline int n_block1_tail() { return brg.ldb_tail; }
     inline int n_block2() { return brg.ld_block2; }
-    inline int nb_n_block2() { return brg.ldb2; }
+    inline dim_t nb_n_block2() { return brg.ldb2; }
     inline int n_block2_tail() { return brg.ldb2_tail; }
     int tail_length() { return n_block1_tail() % simd_w_; }
 
@@ -322,11 +325,14 @@ private:
         assert(idx_a < (vmm_alloc.get_idx_vmm_b() + is_fma_embd()));
         return Vmm(idx_a);
     }
-    Vmm vmm_b(int bi = 0) { return Vmm(vmm_alloc.get_idx_vmm_b() + bi); }
+    Vmm vmm_b(int bi = 0) {
+        return Vmm(vmm_alloc.get_idx_vmm_b() + bi);
+    }
     Vmm accm(int m_blocks, int n_blocks, int m, int n, int vnni_idx) {
         assert(m_blocks <= m_block2() && m < m_blocks);
         assert(n_blocks <= n_block2() && n < n_blocks);
-        const int accm_start = max_vmms_ - m_blocks * n_blocks * vnni_substep();
+        const int accm_start
+                = max_vmms_ - m_blocks * n_blocks * vnni_substep();
         const int accm_rel_idx
                 = m * n_blocks * vnni_substep() + n * vnni_substep() + vnni_idx;
         const int idx = accm_start + accm_rel_idx;
@@ -357,8 +363,8 @@ private:
     void set_A_B_matrices();
     void advance_A_B_matrices();
     void load_a(Vmm vmma, int m_i, int n_i, int v_i, bool has_n_tail);
-    void load_b(
-            Vmm vmmb, int n_i, int v_i, bool has_n_tail, bool wei_zp = false);
+    void load_b(Vmm vmmb, int n_i, int v_i, bool has_n_tail,
+            bool wei_zp = false);
     void comp_dot_product(compute_pad_kernel_t kernel_type, Vmm vmm_acc,
             Vmm vmmb, int n,
             bool is_tail_block); // int8 compensation dot_product (zp and s8s8)
@@ -367,46 +373,48 @@ private:
             const std::function<int(int)> &get_mi, bool has_tail = false);
     void vertical_pad_kernel(int m_blocks, int n_blocks, bool has_tail);
     void batch_pad_kernel(int m_blocks, int n_blocks, bool has_tail = false);
-    void brdgmm_microkernel(int m_blocks, int n_blocks, bool has_top_padding,
-            bool has_bottom_padding, bool has_tail, int shift_a);
+    void brdgmm_microkernel(int m_blocks, int n_blocks,
+            bool has_top_padding, bool has_bottom_padding, bool has_tail,
+            int shift_a);
     void compute_loop();
     void get_batch_padding_info();
-    void get_vertical_padding_info(const int m_blocks);
-    void call_brdgmm_microkernel(const int m_blocks, const int n_blocks,
-            bool has_n_tail, int shift_a);
-    void batch_loop(const int m_blocks, const int n_blocks, bool has_n_tail);
+    void get_vertical_padding_info(int m_blocks);
+    void call_brdgmm_microkernel(
+            int m_blocks, int n_blocks, bool has_n_tail, int shift_a);
+    void batch_loop(int m_blocks, int n_blocks, bool has_n_tail);
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag, bool store);
     void apply_post_ops(int m_blocks, int n_blocks, bool has_n_tail);
     void maybe_transpose_interleaved_vnni_to_plain(
             int m_blocks, int n_blocks, bool has_n_tail);
     void load_src_zp();
-    void compute_int8_compensation(int m_blocks, int n_blocks, bool has_n_tail);
+    void compute_int8_compensation(
+            int m_blocks, int n_blocks, bool has_n_tail);
     void store_accumulators(int m_blocks, int n_blocks, bool has_n_tail);
     void store_accumulators_without_post_ops(
             int m_blocks, int n_blocks, bool has_n_tail);
     void store_accumulators_apply_post_ops(
             int m_blocks, int n_blocks, bool has_n_tail);
     bool check_effective_padding() { return has_vpad_ && M() > m_block2(); }
-    int oc_logical_offset(int n) { return n * n_block1(); }
-    int A_offset(int m, int n) {
+    dim_t oc_logical_offset(int n) { return n * n_block1(); }
+    dim_t A_offset(int m, int n) {
         return brg.typesize_A * (m * brg.LDA + n * n_block1());
     }
-    int B_offset(int n) { return brg.typesize_B * n * n_block1(); }
-    int C_offset(int m, int n, int v) {
+    dim_t B_offset(int n) { return brg.typesize_B * n * n_block1(); }
+    dim_t C_offset(int m, int n, int v) {
         return brg.typesize_C * (m * brg.LDC + n * n_block1() + v * simd_w_);
     }
-    int D_offset(int m, int n, int v) {
+    dim_t D_offset(int m, int n, int v) {
         return brg.typesize_D * (m * brg.LDD + n * n_block1() + v * simd_w_);
     }
-    int bias_offset(int n, int v) {
+    dim_t bias_offset(int n, int v) {
         return brg.typesize_bias * (n * n_block1() + v * simd_w_);
     }
-    int wei_scales_offset(int n, int v) {
-        return sizeof(float) * brg.is_per_n_wei_scales
+    dim_t wei_scales_offset(int n, int v) {
+        return static_cast<dim_t>(sizeof(float)) * brg.is_per_n_wei_scales
                 * (n * n_block1() + v * simd_w_);
     }
-    size_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
+    dim_t comp_offset(int n) { return sizeof(int32_t) * n * n_block1(); }
 
     void generate() override;
 };

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -317,7 +317,7 @@ private:
         if (has_n_tail && n_i + 1 == last_n_block_sz) {
             return nstl::min(simd_w_, n_block1_tail() - v_i * simd_w_);
         } else {
-            return simd_w_;
+            return xbyak_register_index(simd_w_);
         }
     }
     Vmm vmm_a(int m, int n) {

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -253,10 +253,10 @@ private:
     // iteration_map_t) describe the structure of cycles and are used for
     // JIT code generation
     struct iteration_block_t {
-        int block = 0;
+        dim_t block = 0;
         dim_t pos = 0;
         bool is_tail = false;
-        iteration_block_t(dim_t pos_, int block_, bool is_tail_ = false)
+        iteration_block_t(dim_t pos_, dim_t block_, bool is_tail_ = false)
             : block(block_), pos(pos_), is_tail(is_tail_) {}
         bool operator==(const iteration_block_t &rhs) const {
             return block == rhs.block && is_tail == rhs.is_tail;
@@ -283,7 +283,7 @@ private:
             return (blocks[b].pos - blocks[0].pos);
         }
 
-        int block(size_t b) const {
+        dim_t block(size_t b) const {
             assert(b < blocks.size());
             return blocks[b].block;
         }
@@ -293,9 +293,9 @@ private:
             return blocks[b].is_tail;
         }
 
-        int block2() const { return static_cast<int>(blocks.size()); }
+        dim_t block2() const { return static_cast<dim_t>(blocks.size()); }
 
-        int length() const {
+        dim_t length() const {
             if (blocks.empty()) return 0;
             const int n = static_cast<int>(blocks.size());
             // only last block may be different
@@ -374,9 +374,9 @@ private:
 
     struct prf_t {
         brgemm_kernel_prefetching_t pft = brgemm_prf_default;
-        int dist = -1;
-        int vec = 0;
-        void set(brgemm_kernel_prefetching_t pft_, int dist_) {
+        dim_t dist = -1;
+        dim_t vec = 0;
+        void set(brgemm_kernel_prefetching_t pft_, dim_t dist_) {
             pft = pft_;
             dist = dist_;
             vec = 0;
@@ -405,8 +405,8 @@ private:
     // saved parameters for storing
     brgemm_iteration_t prev_bi_;
     // current storing coordinates
-    int ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
-    int ils_bd_step_ = 3; // heuristic value
+    dim_t ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
+    dim_t ils_bd_step_ = 3; // heuristic value
     prf_t prf0A, prf1A, prf2A, prfntaA, prf0B, prf1B, prf2B, prfntaB, prf0C,
             prf1C;
 
@@ -441,22 +441,22 @@ private:
     const Xbyak::Zmm zmm_ubound = zmm9;
 
     // zmm_bias, zmm_bias and accm shouldn't be overlapped
-    Xbyak::Zmm accm(int bd) const {
+    Xbyak::Zmm accm(dim_t bd) const {
         assert(bd < 16);
-        return Xbyak::Zmm(31 - (bd % ils_bd_step_));
+        return Xbyak::Zmm(xbyak_register_index(31 - (bd % ils_bd_step_)));
     }
 
-    Xbyak::Zmm zmm_bias(int ldb) const {
+    Xbyak::Zmm zmm_bias(dim_t ldb) const {
         assert(ldb < 5);
         // zmm10 - zmm14
-        return Xbyak::Zmm(10 + ldb);
+        return Xbyak::Zmm(xbyak_register_index(10 + ldb));
     }
 
-    Xbyak::Zmm zmm_scales(int ldb) const {
+    Xbyak::Zmm zmm_scales(dim_t ldb) const {
         assert(ldb < 5);
         assert(ils_bd_step_ < 10);
         // zmm15 - zmm19
-        return Xbyak::Zmm(15 + ldb);
+        return Xbyak::Zmm(xbyak_register_index(15 + ldb));
     }
 
     template <typename U>
@@ -473,19 +473,19 @@ private:
     void maybe_saturation(Xbyak::Zmm &zmm);
     void apply_alpha_beta_to_vector(
             int idx, const Address &addr, bool is_ld_tail);
-    void apply_post_ops_to_range(brgemm_iteration_t &bi, int bd_start,
-            int bd_finish, int bdb, int ldb);
+    void apply_post_ops_to_range(brgemm_iteration_t &bi, dim_t bd_start,
+            dim_t bd_finish, dim_t bdb, dim_t ldb);
     void store_vector_with_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, int ldb);
+    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, dim_t ldb);
     void prepare_post_ops_registers(brgemm_iteration_t &bi);
 
     bool bi_shift_output(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
     bool bi_shift_A(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
     bool bi_shift_B(
-            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
 
     void uni_prefetch(const Address &addr, brgemm_kernel_prefetching_t pft,
             bool for_write);
@@ -502,13 +502,13 @@ private:
             prf_t &prf, bool prefetch_all);
     void prefetching(brgemm_iteration_t &bi, bool prefetch_all);
 
-    void process_output_range(brgemm_iteration_t &bi, int bd_start,
-            int bd_finish, int bdb, int ldb);
+    void process_output_range(brgemm_iteration_t &bi, dim_t bd_start,
+            dim_t bd_finish, dim_t bdb, dim_t ldb);
     void store_vector_without_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void store_vector(brgemm_iteration_t &bi, int bdb, int bd, int ldb);
-    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb, const int idx);
+    void store_vector(brgemm_iteration_t &bi, dim_t bdb, dim_t bd, dim_t ldb);
+    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, dim_t bdb,
+            dim_t inp_bd, dim_t ldb, const int idx);
 
     void interleave_store(brgemm_iteration_t &bi, bool store_all);
 
@@ -536,24 +536,24 @@ private:
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
 
-    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, int bdb,
+    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, dim_t bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk, bool use_memadvice);
 
     bool process_k_tail_only_last_tile();
 
-    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, int bdb,
+    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, dim_t bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset_src, dim_t offset_dst,
             bool mem_advice_A);
 
     void maybe_tileloadd_nt(
-            brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset);
+            brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset);
 
-    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, int bdb);
+    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, dim_t bdb);
 
     void maybe_sprinkle_prefetches();
 
-    void tdpbxxd(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
+    void tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
 
     void gemm_microkernel_amx(brgemm_iteration_t &bi);
@@ -588,20 +588,20 @@ private:
                 && !skip_accumulation);
     }
 
-    dim_t A_offset(
-            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+    dim_t A_offset(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t A_offset_wsp(
-            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
+    dim_t A_offset_wsp(const brgemm_iteration_t &bi, dim_t bdb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t A_offset_line(const brgemm_iteration_t &bi, int bdb, int rdb = 0,
-            int bd_elem_idx = 0) const noexcept;
+    dim_t A_offset_line(const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb = 0,
+            dim_t bd_elem_idx = 0) const noexcept;
 
-    dim_t B_offset(
-            const brgemm_iteration_t &bi, int ldb, int rdb = 0) const noexcept;
+    dim_t B_offset(const brgemm_iteration_t &bi, dim_t ldb,
+            dim_t rdb = 0) const noexcept;
 
-    dim_t B_offset_line(const brgemm_iteration_t &bi, int ldb, int rdb = 0,
-            int rd_elem_idx = 0) const noexcept;
+    dim_t B_offset_line(const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb = 0,
+            dim_t rd_elem_idx = 0) const noexcept;
 
     dim_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
             dim_t ldb) const noexcept;
@@ -625,9 +625,9 @@ private:
     bool is_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
     dim_t get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
 
-    void maybe_tilestore(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
+    void maybe_tilestore(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
-    int get_C_tensor(brgemm_iteration_t &bi, int m, int n) const noexcept;
+    dim_t get_C_tensor(brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept;
     void top_loop(brgemm_iteration_t &bi);
     bd_iteration_t *find_similar(const bd_iteration_t *bdi, bool apply_postops);
 
@@ -639,7 +639,7 @@ private:
 };
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_output(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     if (shift == 0) return true;
 
@@ -669,7 +669,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_output(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_A(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nbdis = tloop.bdis.size();
@@ -689,7 +689,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_A(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_B(
-        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nldis = tloop.ldis.size();
@@ -708,8 +708,8 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_B(
     return true;
 }
 
-int jit_brgemm_amx_uker_base_t::get_C_tensor(
-        brgemm_iteration_t &bi, int m, int n) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::get_C_tensor(
+        brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept {
     return brg.get_C_tensor(m, n, bi.bdi->is_tail(m), bi.ldi->is_tail(n));
 }
 
@@ -744,7 +744,7 @@ dim_t jit_brgemm_amx_uker_base_t::skipped_bd_mask(dim_t inp_bd) noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
-        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
     // Full WSP buffer layout:
     //   1. partial C results.
     //   2. data type conversion.
@@ -764,7 +764,7 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset(
-        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.A
             : 0;
@@ -775,12 +775,12 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_line(const brgemm_iteration_t &bi,
-        int bdb, int rdb, int bd_elem_idx) const noexcept {
+        dim_t bdb, dim_t rdb, dim_t bd_elem_idx) const noexcept {
     return A_offset(bi, bdb, rdb) + bd_elem_idx * LDA2_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset(
-        const brgemm_iteration_t &bi, int ldb, int rdb) const noexcept {
+        const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.B
             : 0;
@@ -796,7 +796,7 @@ dim_t jit_brgemm_amx_uker_base_t::B_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset_line(const brgemm_iteration_t &bi,
-        int ldb, int rdb, int rd_elem_idx) const noexcept {
+        dim_t ldb, dim_t rdb, dim_t rd_elem_idx) const noexcept {
     return B_offset(bi, ldb, rdb) + rd_elem_idx * LDB_size_;
 }
 
@@ -856,7 +856,7 @@ dim_t jit_brgemm_amx_uker_base_t::zp_comp_b_offset(dim_t bd) const noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_c_values_offset(
-        brgemm_iteration_t &bi, int ldb) const noexcept {
+        brgemm_iteration_t &bi, dim_t ldb) const noexcept {
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         return (bi.ldi->is_tail(ldb)) ? ldb_tail_zp_size_
                                       : bi.ldi->pos(ldb) * ld_block_zp_size_;
@@ -881,7 +881,7 @@ dim_t jit_brgemm_amx_uker_base_t::per_mn_comp_offset(
 }
 
 bool jit_brgemm_amx_uker_base_t::is_out_bd(
-        const bd_iteration_t *bdi, int bdb, int inp_bd) const {
+        const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const {
     const auto bd = bdi->pos(bdb) + inp_bd;
     return IMPLICATION(
             brg.brgattr.bd_mask_level, bdi->bd_mask[bd - bdi->pos(0)] != 0);
@@ -978,17 +978,17 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
         ils_shift = need_ils_shift ? bi.bdi->C_shift : 0;
     }
 
-    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
             auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
-            tileloadd(Tmm(get_C_tensor(bi, bdb, ldb)),
+            tileloadd(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))),
                     ptr[reg_C + c_offset + reg_stride_ld_block]);
         } else {
             // call tilezero on very first iteration
             if (!brg.interleave_tilestores_
                     || everyone_is(0u, bi.bdi->idx, bi.ldi->idx))
-                tilezero(Tmm(get_C_tensor(bi, bdb, ldb)));
+                tilezero(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
@@ -1035,8 +1035,8 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     }
 }
 
-void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
-        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
+void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(brgemm_iteration_t &bi,
+        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     const auto ldb_pos = bi.ldi->pos(ldb);
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
@@ -1127,7 +1127,7 @@ void jit_brgemm_amx_uker_base_t::maybe_saturation(Xbyak::Zmm &zmm) {
 }
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
-        brgemm_iteration_t &bi, int ldb) {
+        brgemm_iteration_t &bi, dim_t ldb) {
     if (!bi.apply_postops) return;
     auto k_mask = (!bi.ldi->is_tail(ldb)) ? ld_full_mask : ld_tail_mask;
 
@@ -1168,7 +1168,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     // This must happen for both apply_postops and non-apply_postops paths.
     if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1212,7 +1212,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 case data_type::f32:
                 default: vbroadcastss(zmm_src_sc, src_sc_addr); break;
             }
-            for (int ldb = 0; ldb < ldi->block2(); ldb++)
+            for (dim_t ldb = 0; ldb < ldi->block2(); ldb++)
                 vmulps(zmm_scales(ldb), zmm_scales(ldb), zmm_src_sc);
         }
     }
@@ -1222,7 +1222,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
 
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto ptr_bias
                     = EVEX_compress_addr(reg_bias, bias_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1233,7 +1233,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_src_scales && !brg.is_per_k_src_scales
             && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
             auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
@@ -1261,7 +1261,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
 
     if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1345,10 +1345,10 @@ void jit_brgemm_amx_uker_base_t::uni_prefetch(
 }
 
 void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
-        brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish, int bdb,
-        int ldb) {
+        brgemm_kernel_prefetching_t pft, dim_t bd_start, dim_t bd_finish,
+        dim_t bdb, dim_t ldb) {
     const auto ldb_pos = bi.ldi->pos(ldb);
-    for (int bd = bd_start; bd < bd_finish; bd++) {
+    for (dim_t bd = bd_start; bd < bd_finish; bd++) {
         if (!is_out_bd(bi.bdi, bdb, bd)) continue;
         if (bi.apply_postops) {
             const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
@@ -1394,7 +1394,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
             = (are_post_ops_applicable_ && !prev_bi_.apply_postops)
             ? brg.typesize_C
             : brg.typesize_D;
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / bdb_row;
         const auto vec_in_bdb_row = prf.vec - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / pfo_bi.bdi->block(bdb);
@@ -1418,7 +1418,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_A(brgemm_iteration_t &bi,
             ? tot_vecs
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / pfo_bi.bdi->block(0);
         const auto bd = prf.vec % pfo_bi.bdi->block(0);
 
@@ -1442,7 +1442,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_B(brgemm_iteration_t &bi,
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
     // TODO: check these addressing for correctness
-    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
 
         const auto ldb = prf.vec / pfo_bi.rdi->block(0);
         const auto rb = prf.vec % pfo_bi.rdi->block(0);
@@ -1505,7 +1505,8 @@ void jit_brgemm_amx_uker_base_t::prefetching(
 }
 
 void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
-        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb, const int idx) {
+        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb,
+        const int idx) {
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
     auto zmm = Zmm(idx);
@@ -1526,8 +1527,8 @@ void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
     vaddps(zmm_masked, zmm, zmm_zp_comp_a);
 }
 
-void jit_brgemm_amx_uker_base_t::process_output_range(
-        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
+void jit_brgemm_amx_uker_base_t::process_output_range(brgemm_iteration_t &bi,
+        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
 
     const auto k_mask = bi.ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
 
@@ -1778,7 +1779,7 @@ void jit_brgemm_amx_uker_base_t::store_vector_without_post_ops(
 }
 
 void jit_brgemm_amx_uker_base_t::store_vector(
-        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb) {
+        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb) {
 
     if (!is_out_bd(bi.bdi, bdb, inp_bd)) return;
 
@@ -1838,7 +1839,7 @@ void jit_brgemm_amx_uker_base_t::interleave_store(
     const auto bdb_row = prev_bi_.bdi->block(0) * prev_bi_.ldi->block2();
     const auto total_vectors = prev_bi_.bdi->length() * prev_bi_.ldi->block2();
     const auto nvecs = store_all ? total_vectors : ils_vecs_per_store;
-    for (int vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
+    for (dim_t vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
         const auto bdb = ils_vec_ / bdb_row;
         const auto vec_in_bdb_row = ils_vec_ - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / prev_bi_.bdi->block(bdb);
@@ -1887,8 +1888,8 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
     if (store_by_vectors && !real_ils && !prepare_post_ops_registers_once_)
         prepare_post_ops_registers(bi);
 
-    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (store_by_vectors) {
             if (!brg.interleave_tilestores_ && !bi.skip_accumulation) {
                 const auto wsp_offset = use_ils_
@@ -1896,13 +1897,13 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
                                 * ld_block_C_size_
                         : 0;
                 tilestored(ptr[reg_buf + reg_stride_ld_block + wsp_offset],
-                        Tmm(get_C_tensor(bi, bdb, ldb)));
+                        Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
             }
             if (real_ils) continue;
 
             prepare_post_ops_registers_ldb(bi, ldb);
 
-            for (int bd_step = 0; bd_step < bi.bdi->block(bdb);
+            for (dim_t bd_step = 0; bd_step < bi.bdi->block(bdb);
                     bd_step += ils_bd_step_) {
                 auto bd_finish
                         = nstl::min(bd_step + ils_bd_step_, bi.bdi->block(bdb));
@@ -1914,7 +1915,7 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
         } else if (!brg.interleave_tilestores_) {
             const auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb));
             tilestored(ptr[reg_C + reg_stride_ld_block + c_offset],
-                    Tmm(get_C_tensor(bi, bdb, ldb)));
+                    Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))));
         }
     }
 }
@@ -2025,13 +2026,14 @@ void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
     current_num_amx_ops++;
 }
 void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
-        brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset) {
+        brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset) {
 
     const bool is_A = mk == matrix_kind_t::matrix_A;
     bool load_nt = is_A ? brg.load_nt_A : brg.load_nt_B;
 
-    auto t1 = Tmm(is_A ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
-                       : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb)));
+    auto t1 = Tmm(xbyak_register_index(is_A
+                    ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
+                    : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb))));
     auto reg_base = is_A ? reg_A : reg_B;
     auto reg_stride = is_A ? reg_stride_lda : reg_stride_ldb;
 
@@ -2066,8 +2068,9 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
 }
 
 void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
-        brgemm_iteration_t &bi, int bdb) {
-    auto t1 = Tmm(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb)));
+        brgemm_iteration_t &bi, dim_t bdb) {
+    auto t1 = Tmm(
+            xbyak_register_index(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb))));
 
     auto load_a_tile_from_wsp = [&]() {
         if (brg.load_nt_A) {
@@ -2106,7 +2109,7 @@ void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
     };
 }
 void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
-        int bdb_idx, int ldb_idx, bool do_pre_tilestore,
+        dim_t bdb_idx, dim_t ldb_idx, bool do_pre_tilestore,
         bool do_post_tilestore) {
     if (bi.skip_accumulation) return;
     auto current_tensor_idx = get_C_tensor(bi, bdb_idx, ldb_idx);
@@ -2134,7 +2137,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
         ldb_idx = store_tensor_idx % bi.ldi->block2();
     }
     const bool store_by_vectors = get_store_by_vectors(bi.apply_postops);
-    Tmm acc = Tmm(store_tensor_idx);
+    Tmm acc = Tmm(xbyak_register_index(store_tensor_idx));
     if (store_by_vectors) {
         const auto wsp_offset = (use_ils_ || brg.interleave_tilestores_)
                 ? (bdb_idx * bi.ldi->block2() + ldb_idx) * bi.bdi->block(0)
@@ -2151,14 +2154,17 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     tilezero(acc);
 }
 
-void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
-        int ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
+void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx,
+        dim_t ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
     prefetching(bi, false);
     maybe_tilestore(bi, bdb_idx, ldb_idx, do_pre_tilestore, false);
 
-    const Tmm &x1 = Tmm(get_C_tensor(bi, bdb_idx, ldb_idx));
-    const Tmm &x2 = Tmm(brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx)));
-    const Tmm &x3 = Tmm(brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx)));
+    const Tmm &x1
+            = Tmm(xbyak_register_index(get_C_tensor(bi, bdb_idx, ldb_idx)));
+    const Tmm &x2 = Tmm(xbyak_register_index(
+            brg.get_A_tensor(bdb_idx, bi.bdi->is_tail(bdb_idx))));
+    const Tmm &x3 = Tmm(xbyak_register_index(
+            brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx))));
 
     using namespace data_type;
     if (brg.is_tf32) {
@@ -2198,9 +2204,9 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert(brgemm_iteration_t &bi,
         int num_rows, int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
         reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt) {
     const auto rd_block = bi.rdi->block(0);
-    const int max_num_cols
-            = nstl::min<int>(tile_num_col_bytes / sizeof(float16_t), rd_block);
-    const int col_tail = max_num_cols % 32;
+    const dim_t max_num_cols = nstl::min<dim_t>(
+            tile_num_col_bytes / sizeof(float16_t), rd_block);
+    const dim_t col_tail = max_num_cols % 32;
     auto zmm_1 = zmm_tmp_1();
     auto zmm_1_masked = col_tail ? zmm_1 | fp_col_mask | T_z : zmm_1;
 
@@ -2290,22 +2296,22 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
     lea(reg_data_aux, ptr[reg_data + offset]);
 
     const int vnni_granularity = 2;
-    const int r_end = utils::div_up(rd_block, vnni_granularity);
+    const dim_t r_end = utils::div_up(rd_block, vnni_granularity);
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf);
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf);
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf);
     else
         assert(!"unsupported data type");
 
     // zero rest of the tile data
     if (r_end < num_rows) {
         vpxord(zmm_2, zmm_2, zmm_2);
-        for (int r = r_end; r < num_rows; ++r)
+        for (dim_t r = r_end; r < num_rows; ++r)
             vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_2);
     }
 }
@@ -2349,7 +2355,7 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
     const int r_end
             = nstl::min(utils::div_up(rd_block, vnni_granularity), num_rows);
 
-    for (int r = 0; r < r_end; ++r) {
+    for (dim_t r = 0; r < r_end; ++r) {
         load(zmm_1, ptr[reg_data_aux]);
 
         if (r * vnni_granularity + 1 >= rd_block) {
@@ -2362,13 +2368,15 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
         vpermw(zmm_1, zmm_bf32_permute, zmm_1);
         vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_1);
         lea(reg_data_aux,
-                ptr[reg_data_aux + vnni_granularity * reg_data_stride]);
+                ptr[reg_data_aux
+                        + reg_data_stride
+                                * xbyak_address_scale(vnni_granularity)]);
     }
 
     // zero rest of the tile data
     if (r_end < num_rows) {
         vpxord(zmm_2, zmm_2, zmm_2);
-        for (int r = r_end; r < num_rows; ++r)
+        for (dim_t r = r_end; r < num_rows; ++r)
             vmovups(ptr[reg_buf + r * zmm_width_in_bytes], zmm_2);
     }
 }
@@ -2459,7 +2467,7 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
 }
 
 void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset_src, dim_t offset_dst, bool mem_advice_A) {
     if (offset_dst) add(reg_buf, offset_dst);
     copy_k_tail_to_wsp(t1, reg_base, offset_src, reg_stride_lda, mem_advice_A);
@@ -2476,7 +2484,7 @@ bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
 }
 
 bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset, reg64_t reg_stride, matrix_kind_t mk,
         bool use_memadvice) {
     const auto &tloop = imap_[bi.apply_postops];
@@ -2582,7 +2590,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
     else
         mov(reg_stride_ld_block, LDC_size_);
 
-    for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+    for (dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++) {
         if (brg.fused_copy_a) {
             maybe_fused_copy_A_nt_load(bi, bdb);
         } else {
@@ -2590,7 +2598,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
                     bi, matrix_kind_t::matrix_A, bdb, A_offset(bi, bdb));
         }
 
-        for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+        for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
             if (bdb == 0)
                 maybe_tileloadd_nt(
                         bi, matrix_kind_t::matrix_B, ldb, B_offset(bi, ldb));
@@ -2837,8 +2845,8 @@ void jit_brgemm_amx_uker_base_t::top_loop(brgemm_iteration_t &bi) {
     if (brg.interleave_tilestores_) {
         prev_bi_ = bi;
         was_prev_bi_ = true;
-        for_(int bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
-        for (int ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
+        for_(dim_t bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
+        for (dim_t ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
             maybe_tilestore(prev_bi_, bdb, ldb, true, false);
         }
     }

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -85,10 +85,10 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
             const auto dst_md_wrapper = memory_desc_wrapper(brg.dst_md());
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
-                    static_cast<size_t>(Xbyak::Zmm(1).getIdx()), this->r14,
-                    this->r15, this->r13, preserve_gpr, preserve_vmm,
+                    Xbyak::Zmm(1).getIdx(), this->r14, this->r15, this->r13,
+                    preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<size_t>(brg.ldb_tail),
+                    dst_md_wrapper, static_cast<dim_t>(brg.ldb_tail),
                     ld_tail_mask, use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp(this->param1,
@@ -297,7 +297,7 @@ private:
 
         int length() const {
             if (blocks.empty()) return 0;
-            auto n = blocks.size();
+            const int n = static_cast<int>(blocks.size());
             // only last block may be different
             return ((n - 1) * blocks[0].block + blocks[n - 1].block);
         }
@@ -492,7 +492,7 @@ private:
     void prefetch_CD_range(brgemm_iteration_t &bi,
             brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish,
             int bdb, int ldb);
-    int calc_ops_CD(brgemm_iteration_t &bi) const noexcept;
+    dim_t calc_ops_CD(brgemm_iteration_t &bi) const noexcept;
     void prefetch_CD(brgemm_iteration_t &bi, brgemm_iteration_t &pfo_bi,
             prf_t &prf, bool prefetch_all);
 
@@ -514,22 +514,22 @@ private:
 
     void store_accumulators(brgemm_iteration_t &bi);
 
-    void set_A_B_matrices(int bs);
+    void set_A_B_matrices(dim_t bs);
     void set_A_B_matrices();
 
     void bf32_downconvert(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf);
     void fp8_to_f16_upconvert(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt);
 
     void fp8_to_f16_upconvert_to_vnni(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt);
 
     void bf32_downconvert_to_vnni(brgemm_iteration_t &bi, int num_rows,
-            int tile_num_col_bytes, reg64_t reg_data, int offset,
+            int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
             reg64_t reg_data_stride, reg64_t reg_buf);
 
     void maybe_pre_process_data(brgemm_iteration_t &bi, const Tmm &t1,
@@ -573,7 +573,7 @@ private:
     void generate() override;
 
     void prepare_bd_mask() noexcept;
-    int skipped_bd_mask(int inp_bd) noexcept;
+    dim_t skipped_bd_mask(dim_t inp_bd) noexcept;
 
     bool get_store_by_vectors(bool apply_post_ops) const {
         const bool need_to_apply_post_ops
@@ -604,26 +604,26 @@ private:
             int rd_elem_idx = 0) const noexcept;
 
     dim_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
+            dim_t ldb) const noexcept;
 
     dim_t D_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
+            dim_t ldb) const noexcept;
 
     dim_t lda() const noexcept;
     dim_t ldb() const noexcept;
 
-    dim_t bias_offset(int ldb) const noexcept;
+    dim_t bias_offset(dim_t ldb) const noexcept;
 
-    dim_t scales_offset(int ldb) const noexcept;
-    dim_t zp_comp_a_offset(int ldb) const noexcept;
+    dim_t scales_offset(dim_t ldb) const noexcept;
+    dim_t zp_comp_a_offset(dim_t ldb) const noexcept;
     dim_t zp_comp_pad_a_offset(const brgemm_iteration_t &bi, int bdb,
-            int inp_bd, int ldb) const noexcept;
-    dim_t zp_comp_b_offset(int bd) const noexcept;
+            int inp_bd, dim_t ldb) const noexcept;
+    dim_t zp_comp_b_offset(dim_t bd) const noexcept;
     dim_t zp_c_values_offset(brgemm_iteration_t &bi, int ldb) const noexcept;
     dim_t per_mn_comp_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
-            int ldb) const noexcept;
+            dim_t ldb) const noexcept;
     bool is_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
-    int get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
+    dim_t get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
 
     void maybe_tilestore(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
@@ -720,8 +720,8 @@ void jit_brgemm_amx_uker_base_t::prepare_bd_mask() noexcept {
     adj_bd_mask_buffer_.resize(bd_mask_size);
     skipped_bd_mask_buffer_.resize(bd_mask_size);
     if (bd_mask_buffer_ptr_ != nullptr) {
-        int out_ibd = 0;
-        for (int i = 0; i < bd_mask_size; i++) {
+        dim_t out_ibd = 0;
+        for (dim_t i = 0; i < bd_mask_size; i++) {
             adj_bd_mask_buffer_[i] = out_ibd;
             out_ibd += bd_mask_buffer_ptr_[i];
             skipped_bd_mask_buffer_[i] = i;
@@ -736,7 +736,7 @@ void jit_brgemm_amx_uker_base_t::prepare_bd_mask() noexcept {
         assert(!"struct nullptr error");
 }
 
-int jit_brgemm_amx_uker_base_t::skipped_bd_mask(int inp_bd) noexcept {
+dim_t jit_brgemm_amx_uker_base_t::skipped_bd_mask(dim_t inp_bd) noexcept {
     if (brg.brgattr.bd_mask_level != 2)
         return inp_bd;
     else
@@ -801,7 +801,7 @@ dim_t jit_brgemm_amx_uker_base_t::B_offset_line(const brgemm_iteration_t &bi,
 }
 
 dim_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
-        int bdb, int inp_bd, int ldb) const noexcept {
+        int bdb, int inp_bd, dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -814,7 +814,7 @@ dim_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
 }
 
 dim_t jit_brgemm_amx_uker_base_t::D_offset(const brgemm_iteration_t &bi,
-        int bdb, int inp_bd, int ldb) const noexcept {
+        int bdb, int inp_bd, dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -829,21 +829,21 @@ dim_t jit_brgemm_amx_uker_base_t::ldb() const noexcept {
     return LDB_size_ * brg.rd_step;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::bias_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::bias_offset(dim_t ldb) const noexcept {
     return ldb * ld_block_bias_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::scales_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::scales_offset(dim_t ldb) const noexcept {
     return brg.is_per_n_wei_scales * ldb * ld_block_scales_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(int ldb) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::zp_comp_a_offset(dim_t ldb) const noexcept {
     return ldb * ld_block_zp_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_comp_pad_a_offset(
         const brgemm_iteration_t &bi, int bdb, int inp_bd,
-        int ldb) const noexcept {
+        dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     const auto bd_shift = bd - (ununroll_bd_loop ? bi_bd_start : 0);
@@ -851,7 +851,7 @@ dim_t jit_brgemm_amx_uker_base_t::zp_comp_pad_a_offset(
             + (dim_t)ldb * ld_block_zp_size_;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::zp_comp_b_offset(int bd) const noexcept {
+dim_t jit_brgemm_amx_uker_base_t::zp_comp_b_offset(dim_t bd) const noexcept {
     return sizeof(int32_t) * bd;
 }
 
@@ -867,7 +867,7 @@ dim_t jit_brgemm_amx_uker_base_t::zp_c_values_offset(
 
 dim_t jit_brgemm_amx_uker_base_t::per_mn_comp_offset(
         const brgemm_iteration_t &bi, int bdb, int inp_bd,
-        int ldb) const noexcept {
+        dim_t ldb) const noexcept {
     const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
     const auto bd = get_out_bd(bi.bdi, bdb, inp_bd);
     assert(bd >= 0);
@@ -887,7 +887,7 @@ bool jit_brgemm_amx_uker_base_t::is_out_bd(
             brg.brgattr.bd_mask_level, bdi->bd_mask[bd - bdi->pos(0)] != 0);
 }
 
-int jit_brgemm_amx_uker_base_t::get_out_bd(
+dim_t jit_brgemm_amx_uker_base_t::get_out_bd(
         const bd_iteration_t *bdi, int bdb, int inp_bd) const {
     if (!is_out_bd(bdi, bdb, inp_bd)) return -1;
     const auto bd = bdi->pos(bdb) + inp_bd;
@@ -1371,11 +1371,11 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
     }
 }
 
-int jit_brgemm_amx_uker_base_t::calc_ops_CD(
+dim_t jit_brgemm_amx_uker_base_t::calc_ops_CD(
         brgemm_iteration_t &bi) const noexcept {
     const auto &tloop = imap_[bi.apply_postops];
-    return tloop.rdis.size() * bi.ldi->block2() * bi.bdi->block2()
-            * (brg.brgattr.var_bs ? 1 : brg.brgattr.max_bs);
+    return static_cast<dim_t>(tloop.rdis.size()) * bi.ldi->block2()
+            * bi.bdi->block2() * (brg.brgattr.var_bs ? 1 : brg.brgattr.max_bs);
 }
 
 void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
@@ -1919,7 +1919,7 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
     }
 }
 
-void jit_brgemm_amx_uker_base_t::set_A_B_matrices(int bs) {
+void jit_brgemm_amx_uker_base_t::set_A_B_matrices(dim_t bs) {
     if (one_of(brg.type, brgemm_static_offs)) return;
     assert(one_of(brg.type, brgemm_addr, brgemm_offs));
     if (brg.brgattr.max_bs == 1) return;
@@ -2121,7 +2121,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
 
     const auto &store_bi = do_pre_tilestore ? prev_bi_ : bi;
     const int max_store_tensor_number
-            = store_bi.bdi->blocks.size() * store_bi.ldi->blocks.size();
+            = store_bi.bdi->block2() * store_bi.ldi->block2();
     bool perform_store
             = (do_pre_tilestore
                       && (store_tensor_number >= 2
@@ -2195,7 +2195,7 @@ void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
 // This method up-converts the data from bf8 to f16 and saves at reg_buf.
 // Generally used by matrix_A, where no vnni transformation of data is needed.
 void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert(brgemm_iteration_t &bi,
-        int num_rows, int tile_num_col_bytes, reg64_t reg_data, int offset,
+        int num_rows, int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
         reg64_t reg_data_stride, reg64_t reg_buf, data_type_t dt) {
     const auto rd_block = bi.rdi->block(0);
     const int max_num_cols
@@ -2232,10 +2232,10 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert(brgemm_iteration_t &bi,
 // This method down-converts the data from f32 to bf16 and saves at reg_buf.
 // Generally used by matrix_A, where no vnni transformation of data is needed.
 void jit_brgemm_amx_uker_base_t::bf32_downconvert(brgemm_iteration_t &bi,
-        int num_rows, int tile_num_col_bytes, reg64_t reg_data, int offset,
+        int num_rows, int tile_num_col_bytes, reg64_t reg_data, dim_t offset,
         reg64_t reg_data_stride, reg64_t reg_buf) {
     const auto rd_block = bi.rdi->block(0);
-    const auto max_num_cols
+    const int max_num_cols
             = nstl::min<int>(tile_num_col_bytes / sizeof(bfloat16_t), rd_block);
     const auto col_tail = max_num_cols % simd_w;
     auto zmm_1 = zmm_tmp_1();
@@ -2276,8 +2276,8 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert(brgemm_iteration_t &bi,
 // format. Generally used by matrix_B.
 void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
         brgemm_iteration_t &bi, int num_rows, int tile_num_col_bytes,
-        reg64_t reg_data, int offset, reg64_t reg_data_stride, reg64_t reg_buf,
-        data_type_t dt) {
+        reg64_t reg_data, dim_t offset, reg64_t reg_data_stride,
+        reg64_t reg_buf, data_type_t dt) {
     const int num_cols_ele = tile_num_col_bytes / 2; // 32 for full tile
     const int num_N = num_cols_ele / 2; // 16 for full tile
     const auto zmm_2 = zmm_tmp_2();
@@ -2314,7 +2314,7 @@ void jit_brgemm_amx_uker_base_t::fp8_to_f16_upconvert_to_vnni(
 // format. Generally used by matrix_B.
 void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
         brgemm_iteration_t &bi, int num_rows, int tile_num_col_bytes,
-        reg64_t reg_data, int offset, reg64_t reg_data_stride,
+        reg64_t reg_data, dim_t offset, reg64_t reg_data_stride,
         reg64_t reg_buf) {
     const auto num_cols_ele = tile_num_col_bytes / sizeof(bfloat16_t);
     const auto num_N = num_cols_ele / sizeof(bfloat16_t);
@@ -2342,9 +2342,11 @@ void jit_brgemm_amx_uker_base_t::bf32_downconvert_to_vnni(
     lea(reg_data_aux, ptr[reg_data + offset]);
 
     const auto rd_block = bi.rdi->block(0);
-    const int vnni_granularity
-            = data_type_vnni_granularity(data_type_t::dnnl_bf16);
-    const auto r_end
+    // data_type_vnni_granularity() returns size_t but is always a tiny,
+    // fixed ISA constant (1, 2 or 4), so narrow it at this boundary.
+    const int vnni_granularity = static_cast<int>(
+            data_type_vnni_granularity(data_type_t::dnnl_bf16));
+    const int r_end
             = nstl::min(utils::div_up(rd_block, vnni_granularity), num_rows);
 
     for (int r = 0; r < r_end; ++r) {
@@ -2401,9 +2403,9 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
     const auto matrix_a_offset = transform_offset;
     const auto matrix_b_offset = transform_offset
             + brgemm_desc_t::tilesize
-                    * (nstl::max<int>(should_save_transform(mk),
+                    * nstl::max<dim_t>(should_save_transform(mk),
                             should_save_transform(matrix_A) * brg.brgattr.max_bs
-                                    * max_bdb2 * max_rdb));
+                                    * max_bdb2 * static_cast<dim_t>(max_rdb));
     const auto matrix_offset = is_A ? matrix_a_offset : matrix_b_offset;
     const std::string key
             = std::to_string(bi.bsi->pos) + "_" + std::to_string(offset);
@@ -2415,7 +2417,10 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
         return;
     }
 
-    auto buf_offt = matrix_offset;
+    // buf_offt may be reassigned below using a dim_t-scale buf_idx
+    // (bounded by brgattr.max_bs), so keep it dim_t even though
+    // matrix_offset itself is a bounded int tile-buffer offset.
+    dim_t buf_offt = matrix_offset;
     // save offset of the transformation if required.
     if (should_save_transform(mk)) {
         auto buf_idx = transform_buf.size();
@@ -2466,7 +2471,7 @@ bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
     // The check is on the last tile on K dim and tile before last on M dim. If
     // loading that tile exceeds the A matrix, then we need to process K tail
     // on every M tile.
-    int last_bd_block = brg.bdb_tail == 0 ? brg.bd_block : brg.bdb_tail;
+    const dim_t last_bd_block = brg.bdb_tail == 0 ? brg.bd_block : brg.bdb_tail;
     return brg.rd_block - brg.rdb_tail <= last_bd_block * brg.reduce_dim;
 }
 
@@ -2513,7 +2518,7 @@ void jit_brgemm_amx_uker_base_t::copy_k_tail_to_wsp(const Tmm &t1,
     const auto num_col_bytes = palette_.cols[t1.getIdx()];
 
     const auto max_num_cols
-            = nstl::min<int>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
+            = nstl::min<dim_t>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
     const size_t col_tail
             = max_num_cols % (zmm_width_in_bytes / brg.typesize_A);
     if (col_tail) {
@@ -2713,7 +2718,7 @@ void jit_brgemm_amx_uker_base_t::bs_loop(brgemm_iteration_t &bi) {
         store_accumulators(bi);
     } else {
         if (brg.alpha != 0.f) {
-            for (int bs = 0; bs < brg.brgattr.max_bs; bs++) {
+            for (dim_t bs = 0; bs < brg.brgattr.max_bs; bs++) {
                 bi.bsi = &(tloop.bsis[bs]);
                 bi.first_bsi = bi.bsi->is_first;
                 bi.last_bsi = bi.bsi->is_last;
@@ -2867,13 +2872,13 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         auto bdi_pos = skipped_bd_mask(0);
         bd_iteration_t bdi;
         bdi.blocks.reserve(brg.bd_block2);
-        int prefetch_distance_m = brg.bcast_dim;
+        dim_t prefetch_distance_m = brg.bcast_dim;
         bd_iteration_t bdi_prefetch;
         bi_prefetch.bdi = &bdi_prefetch;
 
-        for (int bdb = 0; bdb < brg.bdb; bdb += brg.bd_block2) {
+        for (dim_t bdb = 0; bdb < brg.bdb; bdb += brg.bd_block2) {
             bdi.blocks.clear();
-            for (int ibdb = 0; ibdb < brg.bd_block2; ibdb++) {
+            for (dim_t ibdb = 0; ibdb < brg.bd_block2; ibdb++) {
                 auto abdb = bdb + ibdb;
                 if (abdb >= brg.bdb) break;
                 if (brg.bdb_tail && abdb == brg.bdb - 1) {
@@ -2920,16 +2925,16 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
             tloop.bdis.push_back(bdi);
         }
 
-        size_t ldi_pos = 0;
+        dim_t ldi_pos = 0;
         dim_iteration_t ldi;
         ldi.blocks.reserve(brg.ld_block2);
-        size_t prefetch_distance_n = (size_t)brg.ldb;
+        dim_t prefetch_distance_n = brg.ldb;
         bd_iteration_t ldi_prefetch;
         bi_prefetch.ldi = &ldi_prefetch;
 
-        for (int ldb = 0; ldb < brg.ldb; ldb += brg.ld_block2) {
+        for (dim_t ldb = 0; ldb < brg.ldb; ldb += brg.ld_block2) {
             ldi.blocks.clear();
-            for (int ildb = 0; ildb < brg.ld_block2; ildb++) {
+            for (dim_t ildb = 0; ildb < brg.ld_block2; ildb++) {
                 auto aldb = ldb + ildb;
                 if (aldb >= brg.ldb) break;
                 if (brg.ldb_tail && aldb == brg.ldb - 1) {
@@ -2952,13 +2957,13 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
             tloop.ldis.push_back(ldi);
         }
 
-        size_t rdi_pos = 0;
+        dim_t rdi_pos = 0;
         dim_iteration_t rdi;
         rdi.blocks.reserve(1);
         dim_iteration_t rdi_prefetch;
         bi_prefetch.rdi = &rdi_prefetch;
 
-        for (int rdb = 0; rdb < brg.rdb; rdb++) {
+        for (dim_t rdb = 0; rdb < brg.rdb; rdb++) {
             rdi.blocks.clear();
             rdi.blocks.emplace_back(rdi_pos, brg.rd_block);
             if (brg.prfA.sprinkled || brg.prfB.sprinkled) {
@@ -2982,7 +2987,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         // is not supported. In order to support prefetches in this case,
         // current_num_amx_ops needs to be an array per bs in bs_max.
         bs_iteration_t bsi;
-        for (int bs = 0; bs < brg.brgattr.max_bs; bs++) {
+        for (dim_t bs = 0; bs < brg.brgattr.max_bs; bs++) {
             bsi.pos = bs;
             bsi.is_first = (bs == 0);
             bsi.is_last = (bs == brg.brgattr.max_bs - 1);
@@ -2996,7 +3001,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
                         = find_similar(&(tloop.bdis[ibdi]), apply_postops);
             }
         }
-        size_t rdb_including_tail = brg.rdb + (brg.rdb_tail > 0 ? 1 : 0);
+        const dim_t rdb_including_tail = brg.rdb + (brg.rdb_tail > 0 ? 1 : 0);
         num_amx_ops = brg.bdb * rdb_including_tail * brg.ldb;
         current_num_amx_ops = 0;
         // Calculate the offsets of A's cache lines to prefetch
@@ -3004,10 +3009,12 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         if (brg.prfA.sprinkled) {
             for (size_t bdb = 0; bdb < bdi_prefetch.blocks.size(); ++bdb) {
                 for (size_t rdb = 0; rdb < rdi_prefetch.blocks.size(); ++rdb) {
-                    int bd_block_size = bdi_prefetch.blocks[bdb].block;
+                    const int bd_block_size = bdi_prefetch.blocks[bdb].block;
                     for (int bd = 0; bd < bd_block_size; bd++) {
                         prf_sprinkled_a.prefetch_offsets.push_back(
-                                A_offset_line(bi_prefetch, bdb, rdb, bd));
+                                A_offset_line(bi_prefetch,
+                                        static_cast<int>(bdb),
+                                        static_cast<int>(rdb), bd));
                     }
                 }
             }
@@ -3020,10 +3027,12 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
         if (brg.prfB.sprinkled) {
             for (size_t ldb = 0; ldb < ldi_prefetch.blocks.size(); ++ldb) {
                 for (size_t rdb = 0; rdb < rdi_prefetch.blocks.size(); ++rdb) {
-                    int rd_block_size = rdi_prefetch.blocks[rdb].block;
+                    const int rd_block_size = rdi_prefetch.blocks[rdb].block;
                     for (int rd = 0; rd < rd_block_size; rd += brg.rd_step) {
                         prf_sprinkled_b.prefetch_offsets.push_back(
-                                B_offset_line(bi_prefetch, ldb, rdb, rd));
+                                B_offset_line(bi_prefetch,
+                                        static_cast<int>(ldb),
+                                        static_cast<int>(rdb), rd));
                     }
                 }
             }
@@ -3035,7 +3044,7 @@ void jit_brgemm_amx_uker_base_t::fill_imap() {
 
 void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
     was_prev_bi_ = false;
-    const auto bdb2_to_unroll = nstl::max(0,
+    const auto bdb2_to_unroll = nstl::max<dim_t>(0,
             brg.bdb2
                     - (actual_ils(bi.apply_postops, bi.skip_accumulation) ? 1
                                                                           : 0));

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -253,10 +253,10 @@ private:
     // iteration_map_t) describe the structure of cycles and are used for
     // JIT code generation
     struct iteration_block_t {
-        dim_t block = 0;
+        int block = 0;
         dim_t pos = 0;
         bool is_tail = false;
-        iteration_block_t(dim_t pos_, dim_t block_, bool is_tail_ = false)
+        iteration_block_t(dim_t pos_, int block_, bool is_tail_ = false)
             : block(block_), pos(pos_), is_tail(is_tail_) {}
         bool operator==(const iteration_block_t &rhs) const {
             return block == rhs.block && is_tail == rhs.is_tail;
@@ -283,7 +283,7 @@ private:
             return (blocks[b].pos - blocks[0].pos);
         }
 
-        dim_t block(size_t b) const {
+        int block(size_t b) const {
             assert(b < blocks.size());
             return blocks[b].block;
         }
@@ -293,9 +293,9 @@ private:
             return blocks[b].is_tail;
         }
 
-        dim_t block2() const { return static_cast<dim_t>(blocks.size()); }
+        int block2() const { return static_cast<int>(blocks.size()); }
 
-        dim_t length() const {
+        int length() const {
             if (blocks.empty()) return 0;
             const int n = static_cast<int>(blocks.size());
             // only last block may be different
@@ -374,9 +374,9 @@ private:
 
     struct prf_t {
         brgemm_kernel_prefetching_t pft = brgemm_prf_default;
-        dim_t dist = -1;
-        dim_t vec = 0;
-        void set(brgemm_kernel_prefetching_t pft_, dim_t dist_) {
+        int dist = -1;
+        int vec = 0;
+        void set(brgemm_kernel_prefetching_t pft_, int dist_) {
             pft = pft_;
             dist = dist_;
             vec = 0;
@@ -405,8 +405,8 @@ private:
     // saved parameters for storing
     brgemm_iteration_t prev_bi_;
     // current storing coordinates
-    dim_t ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
-    dim_t ils_bd_step_ = 3; // heuristic value
+    int ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
+    int ils_bd_step_ = 3; // heuristic value
     prf_t prf0A, prf1A, prf2A, prfntaA, prf0B, prf1B, prf2B, prfntaB, prf0C,
             prf1C;
 
@@ -441,18 +441,18 @@ private:
     const Xbyak::Zmm zmm_ubound = zmm9;
 
     // zmm_bias, zmm_bias and accm shouldn't be overlapped
-    Xbyak::Zmm accm(dim_t bd) const {
+    Xbyak::Zmm accm(int bd) const {
         assert(bd < 16);
         return Xbyak::Zmm(xbyak_register_index(31 - (bd % ils_bd_step_)));
     }
 
-    Xbyak::Zmm zmm_bias(dim_t ldb) const {
+    Xbyak::Zmm zmm_bias(int ldb) const {
         assert(ldb < 5);
         // zmm10 - zmm14
         return Xbyak::Zmm(xbyak_register_index(10 + ldb));
     }
 
-    Xbyak::Zmm zmm_scales(dim_t ldb) const {
+    Xbyak::Zmm zmm_scales(int ldb) const {
         assert(ldb < 5);
         assert(ils_bd_step_ < 10);
         // zmm15 - zmm19
@@ -473,19 +473,19 @@ private:
     void maybe_saturation(Xbyak::Zmm &zmm);
     void apply_alpha_beta_to_vector(
             int idx, const Address &addr, bool is_ld_tail);
-    void apply_post_ops_to_range(brgemm_iteration_t &bi, dim_t bd_start,
-            dim_t bd_finish, dim_t bdb, dim_t ldb);
+    void apply_post_ops_to_range(brgemm_iteration_t &bi, int bd_start,
+            int bd_finish, int bdb, int ldb);
     void store_vector_with_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, dim_t ldb);
+    void prepare_post_ops_registers_ldb(brgemm_iteration_t &bi, int ldb);
     void prepare_post_ops_registers(brgemm_iteration_t &bi);
 
     bool bi_shift_output(
-            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
     bool bi_shift_A(
-            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
     bool bi_shift_B(
-            brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi);
+            brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi);
 
     void uni_prefetch(const Address &addr, brgemm_kernel_prefetching_t pft,
             bool for_write);
@@ -502,13 +502,13 @@ private:
             prf_t &prf, bool prefetch_all);
     void prefetching(brgemm_iteration_t &bi, bool prefetch_all);
 
-    void process_output_range(brgemm_iteration_t &bi, dim_t bd_start,
-            dim_t bd_finish, dim_t bdb, dim_t ldb);
+    void process_output_range(brgemm_iteration_t &bi, int bd_start,
+            int bd_finish, int bdb, int ldb);
     void store_vector_without_post_ops(
             int idx, const Address &addr, bool is_ld_tail);
-    void store_vector(brgemm_iteration_t &bi, dim_t bdb, dim_t bd, dim_t ldb);
-    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, dim_t bdb,
-            dim_t inp_bd, dim_t ldb, const int idx);
+    void store_vector(brgemm_iteration_t &bi, int bdb, int bd, int ldb);
+    void apply_comp_pad_to_vector(brgemm_iteration_t &bi, int bdb, int inp_bd,
+            int ldb, const int idx);
 
     void interleave_store(brgemm_iteration_t &bi, bool store_all);
 
@@ -536,24 +536,24 @@ private:
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
 
-    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, dim_t bdb,
+    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, int bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk, bool use_memadvice);
 
     bool process_k_tail_only_last_tile();
 
-    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, dim_t bdb,
+    void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, int bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset_src, dim_t offset_dst,
             bool mem_advice_A);
 
     void maybe_tileloadd_nt(
-            brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset);
+            brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset);
 
-    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, dim_t bdb);
+    void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, int bdb);
 
     void maybe_sprinkle_prefetches();
 
-    void tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
+    void tdpbxxd(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
 
     void gemm_microkernel_amx(brgemm_iteration_t &bi);
@@ -588,20 +588,20 @@ private:
                 && !skip_accumulation);
     }
 
-    dim_t A_offset(const brgemm_iteration_t &bi, dim_t bdb,
-            dim_t rdb = 0) const noexcept;
+    dim_t A_offset(
+            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
 
-    dim_t A_offset_wsp(const brgemm_iteration_t &bi, dim_t bdb,
-            dim_t rdb = 0) const noexcept;
+    dim_t A_offset_wsp(
+            const brgemm_iteration_t &bi, int bdb, int rdb = 0) const noexcept;
 
-    dim_t A_offset_line(const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb = 0,
-            dim_t bd_elem_idx = 0) const noexcept;
+    dim_t A_offset_line(const brgemm_iteration_t &bi, int bdb, int rdb = 0,
+            int bd_elem_idx = 0) const noexcept;
 
-    dim_t B_offset(const brgemm_iteration_t &bi, dim_t ldb,
-            dim_t rdb = 0) const noexcept;
+    dim_t B_offset(
+            const brgemm_iteration_t &bi, int ldb, int rdb = 0) const noexcept;
 
-    dim_t B_offset_line(const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb = 0,
-            dim_t rd_elem_idx = 0) const noexcept;
+    dim_t B_offset_line(const brgemm_iteration_t &bi, int ldb, int rdb = 0,
+            int rd_elem_idx = 0) const noexcept;
 
     dim_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
             dim_t ldb) const noexcept;
@@ -625,9 +625,9 @@ private:
     bool is_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
     dim_t get_out_bd(const bd_iteration_t *bdi, int bdb, int inp_bd) const;
 
-    void maybe_tilestore(brgemm_iteration_t &bi, dim_t bdb_idx, dim_t ldb_idx,
+    void maybe_tilestore(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
-    dim_t get_C_tensor(brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept;
+    int get_C_tensor(brgemm_iteration_t &bi, int m, int n) const noexcept;
     void top_loop(brgemm_iteration_t &bi);
     bd_iteration_t *find_similar(const bd_iteration_t *bdi, bool apply_postops);
 
@@ -639,7 +639,7 @@ private:
 };
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_output(
-        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     if (shift == 0) return true;
 
@@ -669,7 +669,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_output(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_A(
-        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nbdis = tloop.bdis.size();
@@ -689,7 +689,7 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_A(
 }
 
 bool jit_brgemm_amx_uker_base_t::bi_shift_B(
-        brgemm_iteration_t &bi, dim_t shift, brgemm_iteration_t &res_bi) {
+        brgemm_iteration_t &bi, int shift, brgemm_iteration_t &res_bi) {
     res_bi = bi;
     const auto &tloop = imap_[bi.apply_postops];
     const auto nldis = tloop.ldis.size();
@@ -708,8 +708,8 @@ bool jit_brgemm_amx_uker_base_t::bi_shift_B(
     return true;
 }
 
-dim_t jit_brgemm_amx_uker_base_t::get_C_tensor(
-        brgemm_iteration_t &bi, dim_t m, dim_t n) const noexcept {
+int jit_brgemm_amx_uker_base_t::get_C_tensor(
+        brgemm_iteration_t &bi, int m, int n) const noexcept {
     return brg.get_C_tensor(m, n, bi.bdi->is_tail(m), bi.ldi->is_tail(n));
 }
 
@@ -744,7 +744,7 @@ dim_t jit_brgemm_amx_uker_base_t::skipped_bd_mask(dim_t inp_bd) noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
-        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
+        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
     // Full WSP buffer layout:
     //   1. partial C results.
     //   2. data type conversion.
@@ -764,7 +764,7 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset(
-        const brgemm_iteration_t &bi, dim_t bdb, dim_t rdb) const noexcept {
+        const brgemm_iteration_t &bi, int bdb, int rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.A
             : 0;
@@ -775,12 +775,12 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_line(const brgemm_iteration_t &bi,
-        dim_t bdb, dim_t rdb, dim_t bd_elem_idx) const noexcept {
+        int bdb, int rdb, int bd_elem_idx) const noexcept {
     return A_offset(bi, bdb, rdb) + bd_elem_idx * LDA2_size_;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset(
-        const brgemm_iteration_t &bi, dim_t ldb, dim_t rdb) const noexcept {
+        const brgemm_iteration_t &bi, int ldb, int rdb) const noexcept {
     const auto bs_offs = (brg.type == brgemm_static_offs)
             ? brg.brgattr.static_offsets[bi.bsi->idx].offset.B
             : 0;
@@ -796,7 +796,7 @@ dim_t jit_brgemm_amx_uker_base_t::B_offset(
 }
 
 dim_t jit_brgemm_amx_uker_base_t::B_offset_line(const brgemm_iteration_t &bi,
-        dim_t ldb, dim_t rdb, dim_t rd_elem_idx) const noexcept {
+        int ldb, int rdb, int rd_elem_idx) const noexcept {
     return B_offset(bi, ldb, rdb) + rd_elem_idx * LDB_size_;
 }
 
@@ -856,7 +856,7 @@ dim_t jit_brgemm_amx_uker_base_t::zp_comp_b_offset(dim_t bd) const noexcept {
 }
 
 dim_t jit_brgemm_amx_uker_base_t::zp_c_values_offset(
-        brgemm_iteration_t &bi, dim_t ldb) const noexcept {
+        brgemm_iteration_t &bi, int ldb) const noexcept {
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         return (bi.ldi->is_tail(ldb)) ? ldb_tail_zp_size_
                                       : bi.ldi->pos(ldb) * ld_block_zp_size_;
@@ -881,7 +881,7 @@ dim_t jit_brgemm_amx_uker_base_t::per_mn_comp_offset(
 }
 
 bool jit_brgemm_amx_uker_base_t::is_out_bd(
-        const bd_iteration_t *bdi, dim_t bdb, dim_t inp_bd) const {
+        const bd_iteration_t *bdi, int bdb, int inp_bd) const {
     const auto bd = bdi->pos(bdb) + inp_bd;
     return IMPLICATION(
             brg.brgattr.bd_mask_level, bdi->bd_mask[bd - bdi->pos(0)] != 0);
@@ -978,8 +978,8 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
         ils_shift = need_ils_shift ? bi.bdi->C_shift : 0;
     }
 
-    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
             auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
             tileloadd(Tmm(xbyak_register_index(get_C_tensor(bi, bdb, ldb))),
@@ -1035,8 +1035,8 @@ void jit_brgemm_amx_uker_base_t::apply_alpha_beta_to_vector(
     }
 }
 
-void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(brgemm_iteration_t &bi,
-        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
+void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
+        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     const auto ldb_pos = bi.ldi->pos(ldb);
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
@@ -1127,7 +1127,7 @@ void jit_brgemm_amx_uker_base_t::maybe_saturation(Xbyak::Zmm &zmm) {
 }
 
 void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers_ldb(
-        brgemm_iteration_t &bi, dim_t ldb) {
+        brgemm_iteration_t &bi, int ldb) {
     if (!bi.apply_postops) return;
     auto k_mask = (!bi.ldi->is_tail(ldb)) ? ld_full_mask : ld_tail_mask;
 
@@ -1168,7 +1168,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     // This must happen for both apply_postops and non-apply_postops paths.
     if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1212,7 +1212,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                 case data_type::f32:
                 default: vbroadcastss(zmm_src_sc, src_sc_addr); break;
             }
-            for (dim_t ldb = 0; ldb < ldi->block2(); ldb++)
+            for (int ldb = 0; ldb < ldi->block2(); ldb++)
                 vmulps(zmm_scales(ldb), zmm_scales(ldb), zmm_src_sc);
         }
     }
@@ -1222,7 +1222,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
 
-        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto ptr_bias
                     = EVEX_compress_addr(reg_bias, bias_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1233,7 +1233,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (brg.with_src_scales && !brg.is_per_k_src_scales
             && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
-        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
             auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
@@ -1261,7 +1261,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
 
     if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
         mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
-        for (dim_t ldb = 0; ldb < ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
                     reg_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
@@ -1345,10 +1345,10 @@ void jit_brgemm_amx_uker_base_t::uni_prefetch(
 }
 
 void jit_brgemm_amx_uker_base_t::prefetch_CD_range(brgemm_iteration_t &bi,
-        brgemm_kernel_prefetching_t pft, dim_t bd_start, dim_t bd_finish,
-        dim_t bdb, dim_t ldb) {
+        brgemm_kernel_prefetching_t pft, int bd_start, int bd_finish, int bdb,
+        int ldb) {
     const auto ldb_pos = bi.ldi->pos(ldb);
-    for (dim_t bd = bd_start; bd < bd_finish; bd++) {
+    for (int bd = bd_start; bd < bd_finish; bd++) {
         if (!is_out_bd(bi.bdi, bdb, bd)) continue;
         if (bi.apply_postops) {
             const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
@@ -1394,7 +1394,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_CD(brgemm_iteration_t &bi,
             = (are_post_ops_applicable_ && !prev_bi_.apply_postops)
             ? brg.typesize_C
             : brg.typesize_D;
-    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / bdb_row;
         const auto vec_in_bdb_row = prf.vec - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / pfo_bi.bdi->block(bdb);
@@ -1418,7 +1418,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_A(brgemm_iteration_t &bi,
             ? tot_vecs
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
-    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
         const auto bdb = prf.vec / pfo_bi.bdi->block(0);
         const auto bd = prf.vec % pfo_bi.bdi->block(0);
 
@@ -1442,7 +1442,7 @@ void jit_brgemm_amx_uker_base_t::prefetch_B(brgemm_iteration_t &bi,
             : nstl::min(pfo_vecs_per_store, tot_vecs - prf.vec);
 
     // TODO: check these addressing for correctness
-    for (dim_t iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
+    for (int iv = 0; iv < nvecs && prf.vec < tot_vecs; iv++) {
 
         const auto ldb = prf.vec / pfo_bi.rdi->block(0);
         const auto rb = prf.vec % pfo_bi.rdi->block(0);
@@ -1505,8 +1505,7 @@ void jit_brgemm_amx_uker_base_t::prefetching(
 }
 
 void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
-        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb,
-        const int idx) {
+        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb, const int idx) {
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
     auto zmm = Zmm(idx);
@@ -1527,8 +1526,8 @@ void jit_brgemm_amx_uker_base_t::apply_comp_pad_to_vector(
     vaddps(zmm_masked, zmm, zmm_zp_comp_a);
 }
 
-void jit_brgemm_amx_uker_base_t::process_output_range(brgemm_iteration_t &bi,
-        dim_t bd_start, dim_t bd_finish, dim_t bdb, dim_t ldb) {
+void jit_brgemm_amx_uker_base_t::process_output_range(
+        brgemm_iteration_t &bi, int bd_start, int bd_finish, int bdb, int ldb) {
 
     const auto k_mask = bi.ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
 
@@ -1779,7 +1778,7 @@ void jit_brgemm_amx_uker_base_t::store_vector_without_post_ops(
 }
 
 void jit_brgemm_amx_uker_base_t::store_vector(
-        brgemm_iteration_t &bi, dim_t bdb, dim_t inp_bd, dim_t ldb) {
+        brgemm_iteration_t &bi, int bdb, int inp_bd, int ldb) {
 
     if (!is_out_bd(bi.bdi, bdb, inp_bd)) return;
 
@@ -1839,7 +1838,7 @@ void jit_brgemm_amx_uker_base_t::interleave_store(
     const auto bdb_row = prev_bi_.bdi->block(0) * prev_bi_.ldi->block2();
     const auto total_vectors = prev_bi_.bdi->length() * prev_bi_.ldi->block2();
     const auto nvecs = store_all ? total_vectors : ils_vecs_per_store;
-    for (dim_t vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
+    for (int vec = 0; vec < nvecs && ils_vec_ < total_vectors; vec++) {
         const auto bdb = ils_vec_ / bdb_row;
         const auto vec_in_bdb_row = ils_vec_ - bdb * bdb_row;
         const auto ldb = vec_in_bdb_row / prev_bi_.bdi->block(bdb);
@@ -1888,8 +1887,8 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
     if (store_by_vectors && !real_ils && !prepare_post_ops_registers_once_)
         prepare_post_ops_registers(bi);
 
-    for_(dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++)
-    for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+    for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
+    for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (store_by_vectors) {
             if (!brg.interleave_tilestores_ && !bi.skip_accumulation) {
                 const auto wsp_offset = use_ils_
@@ -1903,7 +1902,7 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
 
             prepare_post_ops_registers_ldb(bi, ldb);
 
-            for (dim_t bd_step = 0; bd_step < bi.bdi->block(bdb);
+            for (int bd_step = 0; bd_step < bi.bdi->block(bdb);
                     bd_step += ils_bd_step_) {
                 auto bd_finish
                         = nstl::min(bd_step + ils_bd_step_, bi.bdi->block(bdb));
@@ -2001,11 +2000,13 @@ void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
         // Calculate the number of cache lines to jit
         float total_cache_lines_to_prefetch
                 = (float)prf_sprinkled.prefetch_offsets.size();
-        float cache_lines_per_amx_op
-                = total_cache_lines_to_prefetch / num_amx_ops;
+        float cache_lines_per_amx_op = total_cache_lines_to_prefetch
+                / static_cast<float>(num_amx_ops);
         int num_prefetches_to_jit
-                = (int)((current_num_amx_ops + 1) * cache_lines_per_amx_op)
-                - (int)(current_num_amx_ops * cache_lines_per_amx_op);
+                = (int)(static_cast<float>(current_num_amx_ops + 1)
+                          * cache_lines_per_amx_op)
+                - (int)(static_cast<float>(current_num_amx_ops)
+                        * cache_lines_per_amx_op);
 
         // Jit the prefetches
         for (size_t i = prf_sprinkled.current_prefetch_idx;
@@ -2026,7 +2027,7 @@ void jit_brgemm_amx_uker_base_t::maybe_sprinkle_prefetches() {
     current_num_amx_ops++;
 }
 void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
-        brgemm_iteration_t &bi, matrix_kind_t mk, dim_t xdb, dim_t offset) {
+        brgemm_iteration_t &bi, matrix_kind_t mk, int xdb, dim_t offset) {
 
     const bool is_A = mk == matrix_kind_t::matrix_A;
     bool load_nt = is_A ? brg.load_nt_A : brg.load_nt_B;
@@ -2068,7 +2069,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
 }
 
 void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
-        brgemm_iteration_t &bi, dim_t bdb) {
+        brgemm_iteration_t &bi, int bdb) {
     auto t1 = Tmm(
             xbyak_register_index(brg.get_A_tensor(bdb, bi.bdi->is_tail(bdb))));
 
@@ -2109,7 +2110,7 @@ void jit_brgemm_amx_uker_base_t::maybe_fused_copy_A_nt_load(
     };
 }
 void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
-        dim_t bdb_idx, dim_t ldb_idx, bool do_pre_tilestore,
+        int bdb_idx, int ldb_idx, bool do_pre_tilestore,
         bool do_post_tilestore) {
     if (bi.skip_accumulation) return;
     auto current_tensor_idx = get_C_tensor(bi, bdb_idx, ldb_idx);
@@ -2154,8 +2155,8 @@ void jit_brgemm_amx_uker_base_t::maybe_tilestore(brgemm_iteration_t &bi,
     tilezero(acc);
 }
 
-void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, dim_t bdb_idx,
-        dim_t ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
+void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
+        int ldb_idx, bool do_pre_tilestore, bool do_post_tilestore) {
     prefetching(bi, false);
     maybe_tilestore(bi, bdb_idx, ldb_idx, do_pre_tilestore, false);
 
@@ -2467,7 +2468,7 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
 }
 
 void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
-        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset_src, dim_t offset_dst, bool mem_advice_A) {
     if (offset_dst) add(reg_buf, offset_dst);
     copy_k_tail_to_wsp(t1, reg_base, offset_src, reg_stride_lda, mem_advice_A);
@@ -2484,7 +2485,7 @@ bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
 }
 
 bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
-        brgemm_iteration_t &bi, dim_t bdb, const Tmm &t1, reg64_t reg_base,
+        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
         dim_t offset, reg64_t reg_stride, matrix_kind_t mk,
         bool use_memadvice) {
     const auto &tloop = imap_[bi.apply_postops];
@@ -2590,7 +2591,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
     else
         mov(reg_stride_ld_block, LDC_size_);
 
-    for (dim_t bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+    for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
         if (brg.fused_copy_a) {
             maybe_fused_copy_A_nt_load(bi, bdb);
         } else {
@@ -2598,7 +2599,7 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
                     bi, matrix_kind_t::matrix_A, bdb, A_offset(bi, bdb));
         }
 
-        for (dim_t ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+        for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
             if (bdb == 0)
                 maybe_tileloadd_nt(
                         bi, matrix_kind_t::matrix_B, ldb, B_offset(bi, ldb));
@@ -2845,8 +2846,8 @@ void jit_brgemm_amx_uker_base_t::top_loop(brgemm_iteration_t &bi) {
     if (brg.interleave_tilestores_) {
         prev_bi_ = bi;
         was_prev_bi_ = true;
-        for_(dim_t bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
-        for (dim_t ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
+        for_(int bdb = 0; bdb < prev_bi_.bdi->block2(); bdb++)
+        for (int ldb = 0; ldb < prev_bi_.ldi->block2(); ldb++) {
             maybe_tilestore(prev_bi_, bdb, ldb, true, false);
         }
     }
@@ -3200,7 +3201,7 @@ void jit_brgemm_amx_uker_base_t::generate() {
 
     // if beta == 1 and C datatype is f32 it is better to perform addition by
     // reading tiles directly from C instead of by reading/writing by vectors
-    may_load_accumulators_ = one_of(brg.alpha, 0, 1) && brg.beta == 1.f
+    may_load_accumulators_ = one_of(brg.alpha, 0.f, 1.f) && brg.beta == 1.f
             && brg.dt_c == brg.dt_d
             && IMPLICATION(brg.is_input_convert(), brg.is_fp8_via_convert())
             && IMPLICATION(

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -108,16 +108,16 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
             // one element can be safely loaded. Therefore, we need to
             // provide information about what the tail size would have
             // been in a non-GEMV case.
-            const dim_t tail_size = !brg.is_gemv
+            const int tail_size = !brg.is_gemv
                     ? brg.ldb_tail
                     : (brg.gemv_acc_is_vector() ? brg.gemv_tail : 1);
             const auto k_mask = !brg.is_gemv ? ld_tail_mask : gemv_partial_mask;
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
-                    static_cast<size_t>(vmm_tmp(0).getIdx()), this->r14,
+                    vmm_tmp(0).getIdx(), this->r14,
                     this->r15, this->r13, preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<size_t>(tail_size), k_mask,
+                    dst_md_wrapper, static_cast<dim_t>(tail_size), k_mask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {this->param1,
@@ -304,49 +304,50 @@ private:
         return isa_num_vregs(brg.isa_impl) - used_vregs;
     }
 
-    Vmm accm(dim_t ld_block, dim_t bd, dim_t ld) const noexcept {
-        return Vmm(max_effective_vregs - 1 - (bd * ld_block + ld));
+    Vmm accm(int ld_block, int bd, int ld) const noexcept {
+        return Vmm(xbyak_register_index(
+                max_effective_vregs - 1 - (bd * ld_block + ld)));
     }
 
-    Vmm bcst(dim_t bd = 0) const noexcept {
+    Vmm bcst(int bd = 0) const noexcept {
         if (brg.n_bcast_1_load) {
-            dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
+            int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - bd;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(xbyak_register_index(idx));
         } else
             return Vmm(0);
     }
 
-    Vmm load(dim_t ld = 0) const noexcept {
+    Vmm load(int ld = 0) const noexcept {
         if (brg.n_bcast_1_load) {
             return Vmm(0);
         } else {
-            dim_t idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
+            int idx = max_effective_vregs - 1 - (brg.ld_block2 * brg.bd_block)
                     - ld;
             assert(idx > 0);
-            return Vmm(idx);
+            return Vmm(xbyak_register_index(idx));
         }
     }
 
     Vmm gemv_load_a() const noexcept {
         assert(brg.is_gemv);
-        const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 0;
-        return Vmm(idx);
+        const int idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 0;
+        return Vmm(xbyak_register_index(idx));
     }
 
     Vmm gemv_load_b() const noexcept {
         assert(brg.is_gemv);
-        const dim_t idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 1;
-        return Vmm(idx);
+        const int idx = max_effective_vregs - 1 - brg.gemv_bd_block() - 1;
+        return Vmm(xbyak_register_index(idx));
     }
 
     Vmm vmm_tmp(dim_t i) const noexcept {
-        const dim_t bd_block = brg.is_gemv ? brg.gemv_bd_block() : brg.bd_block;
+        const int bd_block = brg.is_gemv ? brg.gemv_bd_block() : brg.bd_block;
         MAYBE_UNUSED(bd_block);
         assert(IMPLICATION(!brg.is_tmm,
                 i >= 0 && i < max_effective_vregs - bd_block * brg.ld_block2));
-        return Vmm(i);
+        return Vmm(xbyak_register_index(i));
     }
 
     Vmm vmm_tail_mask() const noexcept { return vmm_tmp(1); }
@@ -414,128 +415,125 @@ private:
 
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag, bool store, Xbyak::Opmask ktail_mask,
-            dim_t tail_size);
+            int tail_size);
 
     void advance_ldb_post_op_regs();
-    void restore_ldb_post_op_regs(dim_t ld_block2);
-    void advance_bdb_post_op_regs(dim_t adj_bd_block);
-    void restore_bdb_post_op_regs(dim_t bd_block2);
-    void ldb_regs_shift(dim_t ld_block2, bool is_tail = false);
-    void advance_bd_block2_post_op_regs(dim_t bd_block2);
+    void restore_ldb_post_op_regs(int ld_block2);
+    void advance_bdb_post_op_regs(int adj_bd_block);
+    void restore_bdb_post_op_regs(int bd_block2);
+    void ldb_regs_shift(int ld_block2, bool is_tail = false);
+    void advance_bd_block2_post_op_regs(int bd_block2);
 
     void copy_post_ops_stack_values_to_aux(bool is_reg_tail);
     void read_params();
-    void zero_accumulators(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
+    void zero_accumulators(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_ld_tail, bool skip_accumulation);
 
-    void fp8_to_f16_upconvert(dim_t num_rows, dim_t tile_num_col_bytes,
+    void fp8_to_f16_upconvert(int num_rows, int tile_num_col_bytes,
             reg64_t reg_base, dim_t offset, reg64_t reg_data_stride,
             data_type_t dt, bool is_rd_tail);
-    void fp8_to_f16_upconvert_to_vnni(dim_t num_rows, dim_t tile_num_col_bytes,
+    void fp8_to_f16_upconvert_to_vnni(int num_rows, int tile_num_col_bytes,
             reg64_t reg_base, dim_t offset, reg64_t reg_data_stride,
             data_type_t dt, bool is_rd_tail);
-    void reduce_gemv_accumulators(dim_t bd_block);
-    void store_accumulators(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
+    void reduce_gemv_accumulators(int bd_block);
+    void store_accumulators(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_ld_tail, bool skip_accumulation);
     void store_accumulators_without_post_ops(
-            dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
-    void store_accumulators_apply_post_ops(dim_t bd_block, dim_t ld_block,
+            int bd_block, int ld_block, bool is_ld_tail, bool is_bdb_tail);
+    void store_accumulators_apply_post_ops(int bd_block, int ld_block,
             dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
     void apply_zp_s8s8_compensation(
-            dim_t bd_block, dim_t ld_block, bool is_ld_tail);
-    void apply_per_mn_compensation(
-            dim_t bd_block, dim_t ld_block, bool is_ld_tail);
+            int bd_block, int ld_block, bool is_ld_tail);
+    void apply_per_mn_compensation(int bd_block, int ld_block, bool is_ld_tail);
     void apply_alpha_beta(
-            dim_t bd_block, dim_t ld_block, bool is_ld_tail, bool is_bdb_tail);
-    void apply_wei_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail,
+            int bd_block, int ld_block, bool is_ld_tail, bool is_bdb_tail);
+    void apply_wei_scales(int bd_block, int ld_block2, bool is_ld_tail,
             bool dq2ps_required, bool &dq2ps_cvt_done);
-    void apply_src_scales_per_k(dim_t bd_block, dim_t ld_block2,
+    void apply_src_scales_per_k(int bd_block, int ld_block2,
             bool dq2ps_required, bool &dq2ps_cvt_done);
-    void apply_scales(dim_t bd_block, dim_t ld_block2, bool is_ld_tail);
-    void apply_post_ops(dim_t bd_block, dim_t ld_block2,
-            dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail);
-    void gemv_apply_bias(dim_t bd_block, bool is_bdb_tail);
-    void gemv_apply_wei_scales(dim_t bd_block, bool is_bdb_tail);
+    void apply_scales(int bd_block, int ld_block2, bool is_ld_tail);
+    void apply_post_ops(int bd_block, int ld_block2, dim_t ldb_and_bdb_offset,
+            bool is_ld_tail, bool is_bdb_tail);
+    void gemv_apply_bias(int bd_block, bool is_bdb_tail);
+    void gemv_apply_wei_scales(int bd_block, bool is_bdb_tail);
 
     void restore_A_B_matrices();
     void set_A_B_matrices();
 
-    void compute_int8_compensation(dim_t rd_loop, dim_t bd_b, dim_t bd_e,
-            dim_t bd_block, dim_t ld_block2, bool is_ld_tail, dim_t vpad);
+    void compute_int8_compensation(int rd_loop, int bd_b, int bd_e,
+            int bd_block, int ld_block2, bool is_ld_tail, int vpad);
     void maybe_pre_process_data(
             data_type_t dt, const Vmm &vmm_out1, const Vmm &vmm_out2);
     void maybe_pre_process_data(matrix_kind_t matrix_kind, const Tmm &t1,
-            reg64_t reg_base, dim_t offset, reg64_t reg_stride, dim_t num_rows,
-            dim_t num_col_bytes, bool is_rd_tail);
+            reg64_t reg_base, dim_t offset, reg64_t reg_stride, int num_rows,
+            int num_col_bytes, bool is_rd_tail);
     bool maybe_pre_process_k_tail(bool last_bdb, bool is_rd_tail, const Tmm &t1,
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
-    void maybe_tileloadd_nt(matrix_kind_t matrix_kind, dim_t idx, dim_t offset,
+    void maybe_tileloadd_nt(matrix_kind_t matrix_kind, int idx, dim_t offset,
             bool is_rd_tail, bool is_tail, bool last_bdb);
     void load_scales_to_vmm(const data_type_t type_in, const Vmm &scales,
             const Xbyak::Operand &op, bool is_ld_tail, bool is_single_scale);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
-    void gemm_microkernel(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
-            bool is_rd_tail, bool is_ld_tail, dim_t vpad,
-            dim_t rows_for_rd_tail);
-    void gemv_microkernel(bool is_bdb_tail, dim_t ld_block, bool is_rd_tail);
-    void gemm_microkernel_amx(dim_t bd_block2, bool is_bdb_tail,
-            dim_t ld_block2, bool is_rd_tail, bool is_ld_tail, bool last_bdb);
+    void gemm_microkernel(int bd_block2, bool is_bdb_tail, int ld_block,
+            bool is_rd_tail, bool is_ld_tail, int vpad, int rows_for_rd_tail);
+    void gemv_microkernel(bool is_bdb_tail, int ld_block, bool is_rd_tail);
+    void gemm_microkernel_amx(int bd_block2, bool is_bdb_tail, int ld_block2,
+            bool is_rd_tail, bool is_ld_tail, bool last_bdb);
 
-    void bs_loop(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
-            bool is_ld_tail, bool first_bdb, bool last_bdb,
-            dim_t rows_for_rd_tail, bool skip_accumulation);
+    void bs_loop(int bd_block2, bool is_bdb_tail, int ld_block, bool is_ld_tail,
+            bool first_bdb, bool last_bdb, int rows_for_rd_tail,
+            bool skip_accumulation);
 
-    void ldb_loop(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
+    void ldb_loop(int bd_block2, bool is_bdb_tail, int ld_block,
             dim_t ldb_loop_length, bool is_reg_tail, bool is_ld_tail,
-            bool first_bdb, bool last_bdb, dim_t rows_for_rd_tail,
+            bool first_bdb, bool last_bdb, int rows_for_rd_tail,
             bool skip_accumulation);
     void bdb_loop();
 
     void generate() override;
 
-    bool gemv_is_tail_acc(
-            dim_t bd, dim_t bd_end, bool is_bdb_tail) const noexcept;
-    dim_t gemv_elems_per_vector_acc() const noexcept;
+    bool gemv_is_tail_acc(int bd, int bd_end, bool is_bdb_tail) const noexcept;
+    int gemv_elems_per_vector_acc() const noexcept;
 
-    dim_t A_offset(dim_t bd, dim_t rd, bool is_amx = false) const noexcept;
-    dim_t B_offset(dim_t ld, dim_t rd, bool is_amx = false) const noexcept;
-    dim_t C_offset(dim_t bd, dim_t ld) const noexcept;
-    dim_t D_offset(dim_t bd, dim_t ld) const noexcept;
+    dim_t A_offset(int bd, int rd, bool is_amx = false) const noexcept;
+    dim_t B_offset(int ld, int rd, bool is_amx = false) const noexcept;
+    dim_t C_offset(int bd, int ld) const noexcept;
+    dim_t D_offset(int bd, int ld) const noexcept;
 
     dim_t rdb_A_offset() const noexcept;
     dim_t rdb_B_offset() const noexcept;
 
-    dim_t ldb_B_offset(dim_t ld_block2, bool is_tail = false) const noexcept;
-    dim_t ldb_C_offset(dim_t ld_block2, bool is_tail = false) const noexcept;
-    dim_t ldb_D_offset(dim_t ld_block2, bool is_tail = false) const noexcept;
-    dim_t ldb_po_offset(dim_t ld_block2, bool is_tail = false) const noexcept;
+    dim_t ldb_B_offset(int ld_block2, bool is_tail = false) const noexcept;
+    dim_t ldb_C_offset(int ld_block2, bool is_tail = false) const noexcept;
+    dim_t ldb_D_offset(int ld_block2, bool is_tail = false) const noexcept;
+    dim_t ldb_po_offset(int ld_block2, bool is_tail = false) const noexcept;
 
-    dim_t bdb_A_offset(dim_t bd_block2) const noexcept;
-    dim_t bdb_C_offset(dim_t bd_block2) const noexcept;
-    dim_t bdb_D_offset(dim_t bd_block2) const noexcept;
-    dim_t bdb_po_offset(dim_t bd_block2) const noexcept;
+    dim_t bdb_A_offset(int bd_block2) const noexcept;
+    dim_t bdb_C_offset(int bd_block2) const noexcept;
+    dim_t bdb_D_offset(int bd_block2) const noexcept;
+    dim_t bdb_po_offset(int bd_block2) const noexcept;
 
-    dim_t bias_offset(dim_t ld, bool is_tail = false) const noexcept;
-    dim_t oc_logical_offset(dim_t ld, bool is_tail = false) const noexcept;
+    dim_t bias_offset(int ld, bool is_tail = false) const noexcept;
+    dim_t oc_logical_offset(int ld, bool is_tail = false) const noexcept;
 
-    dim_t compensations_offset(dim_t ld, bool is_tail = false) const noexcept;
-    dim_t bdb_compensation_offset(dim_t bd_block2) const noexcept;
-    dim_t bd_compensation_offset(dim_t ld, dim_t bd) const noexcept;
-    dim_t wei_scales_offset(dim_t ld, bool is_tail = false) const noexcept;
-    dim_t zp_comp_a_offset(dim_t ld, bool is_tail = false) const noexcept;
-    dim_t bd_zp_comp_a_offset(dim_t ld, dim_t bd) const noexcept;
-    dim_t bdb_zp_comp_a_offset(dim_t bd_block2) const noexcept;
-    dim_t zp_comp_b_offset(dim_t bd) const noexcept;
-    dim_t bdb_zp_comp_b_offset(dim_t bd_block2) const noexcept;
-    dim_t zp_c_values_offset(dim_t ld, bool is_tail = false) const noexcept;
+    dim_t compensations_offset(int ld, bool is_tail = false) const noexcept;
+    dim_t bdb_compensation_offset(int bd_block2) const noexcept;
+    dim_t bd_compensation_offset(int ld, int bd) const noexcept;
+    dim_t wei_scales_offset(int ld, bool is_tail = false) const noexcept;
+    dim_t zp_comp_a_offset(int ld, bool is_tail = false) const noexcept;
+    dim_t bd_zp_comp_a_offset(int ld, int bd) const noexcept;
+    dim_t bdb_zp_comp_a_offset(int bd_block2) const noexcept;
+    dim_t zp_comp_b_offset(int bd) const noexcept;
+    dim_t bdb_zp_comp_b_offset(int bd_block2) const noexcept;
+    dim_t zp_c_values_offset(int ld, bool is_tail = false) const noexcept;
 
     // Offsets into the per-(M,N) f32 compensation buffer. The buffer mirrors
     // buf_C layout but with f32 stride (= brg.LDC elements).
-    dim_t per_mn_comp_offset(dim_t bd, dim_t ld) const noexcept;
+    dim_t per_mn_comp_offset(int bd, int ld) const noexcept;
     dim_t ldb_per_mn_comp_offset(
-            dim_t ld_block2, bool is_tail = false) const noexcept;
-    dim_t bdb_per_mn_comp_offset(dim_t bd_block2) const noexcept;
+            int ld_block2, bool is_tail = false) const noexcept;
+    dim_t bdb_per_mn_comp_offset(int bd_block2) const noexcept;
 
     bool vpad_exist = false;
     bool need_comp_pads = false;
@@ -555,7 +553,7 @@ private:
  */
 template <typename Wmm>
 bool jit_brgemm_kernel_t<Wmm>::gemv_is_tail_acc(
-        dim_t bd, dim_t bd_end, bool is_bdb_tail) const noexcept {
+        int bd, int bd_end, bool is_bdb_tail) const noexcept {
     assert(brg.is_gemv);
     if (!brg.gemv_acc_is_vector()) return false;
     return (bd + 1) == bd_end && is_bdb_tail && brg.gemv_tail > 0;
@@ -573,7 +571,7 @@ bool jit_brgemm_kernel_t<Wmm>::gemv_is_tail_acc(
  * by the number of accumulator indices.
  */
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::gemv_elems_per_vector_acc() const noexcept {
+int jit_brgemm_kernel_t<Wmm>::gemv_elems_per_vector_acc() const noexcept {
     assert(brg.is_gemv && brg.gemv_acc_is_vector());
     if (!brg.is_gemv || !brg.gemv_acc_is_vector()) return 1;
     return brg.bd_block / brg.gemv_bd_block();
@@ -581,7 +579,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::gemv_elems_per_vector_acc() const noexcept {
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::A_offset(
-        dim_t bd, dim_t rd, bool is_amx) const noexcept {
+        int bd, int rd, bool is_amx) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_A * bd * gemv_elems_per_vector_acc();
 
@@ -591,7 +589,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::A_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::B_offset(
-        dim_t ld, dim_t rd, bool is_amx) const noexcept {
+        int ld, int rd, bool is_amx) const noexcept {
     if (is_amx) {
         return brg.typesize_B * (brg.rd_step * ld * brg.ld_block);
     } else {
@@ -606,7 +604,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::B_offset(
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::C_offset(dim_t bd, dim_t ld) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::C_offset(int bd, int ld) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_C * bd * gemv_elems_per_vector_acc() * brg.LDC;
 
@@ -615,7 +613,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::C_offset(dim_t bd, dim_t ld) const noexcept {
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::D_offset(dim_t bd, dim_t ld) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::D_offset(int bd, int ld) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_D * bd * gemv_elems_per_vector_acc() * brg.LDD;
 
@@ -639,40 +637,40 @@ dim_t jit_brgemm_kernel_t<Wmm>::rdb_B_offset() const noexcept {
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_B_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? brg.typesize_B * brg.ldb_tail * brg.ld_step
                      : brg.typesize_B * ld_block2 * brg.ld_block * brg.ld_step;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_C_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? brg.typesize_C * brg.ldb_tail
                      : brg.typesize_C * ld_block2 * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_D_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? brg.typesize_D * brg.ldb_tail
                      : brg.typesize_D * ld_block2 * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_po_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? brg.ldb_tail : ld_block2 * brg.ld_block;
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_A_offset(dim_t bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_A_offset(int bd_block2) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_A * bd_block2 * brg.bd_block;
     return brg.typesize_A * bd_block2 * brg.bd_block * brg.LDA;
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_C_offset(dim_t bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_C_offset(int bd_block2) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_C * bd_block2 * brg.bd_block * brg.LDC;
     return bd_block2 * brg.bd_block
@@ -680,7 +678,7 @@ dim_t jit_brgemm_kernel_t<Wmm>::bdb_C_offset(dim_t bd_block2) const noexcept {
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_D_offset(dim_t bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_D_offset(int bd_block2) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return brg.typesize_D * bd_block2 * brg.bd_block * brg.LDD;
     return bd_block2 * brg.bd_block
@@ -688,13 +686,13 @@ dim_t jit_brgemm_kernel_t<Wmm>::bdb_D_offset(dim_t bd_block2) const noexcept {
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_po_offset(dim_t bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_po_offset(int bd_block2) const noexcept {
     return bd_block2 * brg.bd_block * brg.LDD;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bias_offset(
-        dim_t bias_dim, bool is_tail) const noexcept {
+        int bias_dim, bool is_tail) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return bias_dim * gemv_elems_per_vector_acc() * brg.typesize_bias;
 
@@ -704,32 +702,32 @@ dim_t jit_brgemm_kernel_t<Wmm>::bias_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::oc_logical_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     return (is_tail) ? brg.ldb_tail : ld * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::compensations_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     return (is_tail) ? sizeof(int32_t) * brg.ldb_tail
                      : sizeof(int32_t) * ld * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_compensation_offset(
-        dim_t bd_block2) const noexcept {
+        int bd_block2) const noexcept {
     return sizeof(int32_t) * bd_block2 * brg.bd_block * brg.LDB;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bd_compensation_offset(
-        dim_t ld, dim_t bd) const noexcept {
+        int ld, int bd) const noexcept {
     return sizeof(int32_t) * (ld * brg.ld_block + bd * brg.LDB);
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return ld * (brg.bd_block / brg.gemv_bd_block())
                 * brg.is_per_n_wei_scales
@@ -742,37 +740,37 @@ dim_t jit_brgemm_kernel_t<Wmm>::wei_scales_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::zp_comp_a_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     return (is_tail) ? sizeof(int32_t) * brg.ldb_tail
                      : sizeof(int32_t) * ld * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_zp_comp_a_offset(
-        dim_t bd_block2) const noexcept {
+        int bd_block2) const noexcept {
     return sizeof(int32_t) * bd_block2 * brg.bd_block * brg.LDB;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bd_zp_comp_a_offset(
-        dim_t ld, dim_t bd) const noexcept {
+        int ld, int bd) const noexcept {
     return sizeof(int32_t) * (ld * brg.ld_block + bd * brg.LDB);
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::zp_comp_b_offset(dim_t bd) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::zp_comp_b_offset(int bd) const noexcept {
     return sizeof(int32_t) * bd;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_zp_comp_b_offset(
-        dim_t bd_block2) const noexcept {
+        int bd_block2) const noexcept {
     return zp_comp_b_offset(bd_block2 * brg.bd_block);
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::zp_c_values_offset(
-        dim_t ld, bool is_tail) const noexcept {
+        int ld, bool is_tail) const noexcept {
     if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
         return (is_tail) ? sizeof(int32_t) * brg.ldb_tail
                          : sizeof(int32_t) * ld * brg.ld_block;
@@ -783,20 +781,20 @@ dim_t jit_brgemm_kernel_t<Wmm>::zp_c_values_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::per_mn_comp_offset(
-        dim_t bd, dim_t ld) const noexcept {
+        int bd, int ld) const noexcept {
     return sizeof(float) * (bd * brg.LDC + ld * brg.ld_block);
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_per_mn_comp_offset(
-        dim_t ld_block2, bool is_tail) const noexcept {
+        int ld_block2, bool is_tail) const noexcept {
     return (is_tail) ? sizeof(float) * brg.ldb_tail
                      : sizeof(float) * ld_block2 * brg.ld_block;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_per_mn_comp_offset(
-        dim_t bd_block2) const noexcept {
+        int bd_block2) const noexcept {
     return sizeof(float) * bd_block2 * brg.bd_block * brg.LDC;
 }
 template <typename Wmm>
@@ -821,7 +819,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_set_avx_mask(bool is_tail) {
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::cvt2ps(data_type_t type_in, const Vmm vmm_in,
         const Xbyak::Operand &op, bool mask_flag, bool store,
-        Xbyak::Opmask ktail_mask, dim_t tail_size) {
+        Xbyak::Opmask ktail_mask, int tail_size) {
     Vmm vmm = vmm_in;
     const bool has_tail = op.isMEM()
             && tail_size != vreg_traits_t<Vmm>::vlen / sizeof(float);
@@ -880,7 +878,7 @@ void jit_brgemm_kernel_t<Wmm>::advance_ldb_post_op_regs() {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(dim_t ld_block2) {
+void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(int ld_block2) {
     if (brg.with_bias) {
         reg_aux_bias.restore();
         sub(reg_aux_bias, bias_offset(ld_block2 - 1));
@@ -909,7 +907,7 @@ void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(dim_t ld_block2) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::advance_bdb_post_op_regs(dim_t adj_bd_block) {
+void jit_brgemm_kernel_t<Wmm>::advance_bdb_post_op_regs(int adj_bd_block) {
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_b.restore();
         add(reg_aux_zp_comp_b, bdb_zp_comp_b_offset(1));
@@ -924,7 +922,7 @@ void jit_brgemm_kernel_t<Wmm>::advance_bdb_post_op_regs(dim_t adj_bd_block) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::restore_bdb_post_op_regs(dim_t bd_block2) {
+void jit_brgemm_kernel_t<Wmm>::restore_bdb_post_op_regs(int bd_block2) {
     bool post_processed = false;
     if (bd_block2 > 1) {
         if (brg.zp_type_b != brgemm_broadcast_t::none) {
@@ -944,7 +942,7 @@ void jit_brgemm_kernel_t<Wmm>::restore_bdb_post_op_regs(dim_t bd_block2) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(dim_t ld_block2, bool is_tail) {
+void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(int ld_block2, bool is_tail) {
     dim_t C_offset
             = (is_tail) ? ldb_C_offset(1, true) : ldb_C_offset(ld_block2);
     dim_t D_offset
@@ -999,7 +997,7 @@ void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(dim_t ld_block2, bool is_tail) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::advance_bd_block2_post_op_regs(dim_t bd_block2) {
+void jit_brgemm_kernel_t<Wmm>::advance_bd_block2_post_op_regs(int bd_block2) {
     if (brg.req_comp_pads_with_bcast && brg.req_s8s8_compensation) {
         reg_buf.restore();
         add(reg_buf, bdb_compensation_offset(bd_block2));
@@ -1135,13 +1133,19 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
 
     if (brg.is_runtime_ldc) {
         mov(reg_stride_ld_block, ptr[param1 + GET_OFF(dynamic_LDC)]);
-        if (brg.typesize_C > 1) shl(reg_stride_ld_block, (brg.typesize_C >> 1));
+        // typesize_C is always 1/2/4/8, so this shift amount is provably
+        // bounded regardless of typesize_C's declared (dim_t) type.
+        if (brg.typesize_C > 1)
+            shl(reg_stride_ld_block, static_cast<int>(brg.typesize_C >> 1));
         reg_stride_ld_block.save();
     }
 
     if (brg.is_runtime_ldd) {
         mov(reg_D_shift_bytes, ptr[param1 + GET_OFF(dynamic_LDD)]);
-        if (brg.typesize_D > 1) shl(reg_D_shift_bytes, (brg.typesize_D >> 1));
+        // typesize_D is always 1/2/4/8, so this shift amount is provably
+        // bounded regardless of typesize_D's declared (dim_t) type.
+        if (brg.typesize_D > 1)
+            shl(reg_D_shift_bytes, static_cast<int>(brg.typesize_D >> 1));
         reg_D_shift_bytes.save();
     }
 
@@ -1159,26 +1163,27 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::zero_accumulators(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_ld_tail,
+void jit_brgemm_kernel_t<Wmm>::zero_accumulators(int bd_block2,
+        bool is_bdb_tail, int ld_block2, bool is_ld_tail,
         bool skip_accumulation) {
     if (brg.is_tmm) {
         // avoid usage of tile registers if there is no accumulation
         if (skip_accumulation) return;
-        for_(dim_t bdb = 0; bdb < bd_block2; bdb++)
-        for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
-            dim_t idx = (is_ld_tail) ? brg.ld_block2 : ldb;
-            tilezero(Tmm(brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail)));
+        for_(int bdb = 0; bdb < bd_block2; bdb++)
+        for (int ldb = 0; ldb < ld_block2; ldb++) {
+            int idx = (is_ld_tail) ? brg.ld_block2 : ldb;
+            tilezero(Tmm(xbyak_register_index(
+                    brg.get_C_tensor(bdb, idx, is_bdb_tail, is_ld_tail))));
         }
     } else if (brg.is_gemv) {
-        for (dim_t bd = 0; bd < brg.gemv_bd_block(); bd++) {
+        for (int bd = 0; bd < brg.gemv_bd_block(); bd++) {
             auto vmm = accm(1, bd, 0);
             uni_vpxor(vmm, vmm, vmm);
         }
     } else {
-        dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
-        for_(dim_t bd = 0; bd < bd_block; bd++)
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+        for_(int bd = 0; bd < bd_block; bd++)
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm = accm(ld_block2, bd, ld);
             uni_vpxor(vmm, vmm, vmm);
         }
@@ -1188,11 +1193,11 @@ void jit_brgemm_kernel_t<Wmm>::zero_accumulators(dim_t bd_block2,
 // This method up-converts the data from bf8 to f16 and saves at reg_buf.
 // Generally used by matrix_A, where no vnni transformation of data is needed.
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(dim_t num_rows,
-        dim_t tile_num_col_bytes, reg64_t reg_base, dim_t offset,
+void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(int num_rows,
+        int tile_num_col_bytes, reg64_t reg_base, dim_t offset,
         reg64_t reg_data_stride, data_type_t dt, bool is_rd_tail) {
 
-    dim_t rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
+    int rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
 
     const dim_t max_num_cols
             = rd_block; //tile_num_col_bytes / sizeof(float16_t);
@@ -1227,8 +1232,8 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert(dim_t num_rows,
 // This method up-converts and transforms the data from fp8_vnni to f16_vnni
 // format. Generally used by matrix_B.
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
-        dim_t tile_num_col_bytes, reg64_t reg_base, dim_t offset,
+void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(int num_rows,
+        int tile_num_col_bytes, reg64_t reg_base, dim_t offset,
         reg64_t reg_data_stride, data_type_t dt, bool is_rd_tail) {
     const dim_t num_cols_ele = tile_num_col_bytes / 2; // 32 for full tile
     const dim_t num_N = num_cols_ele / 2; // 16 for full tile
@@ -1240,17 +1245,17 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
     const auto reg_data_aux = reg_tmp_gpr;
     lea(reg_data_aux, ptr[reg_base + offset]);
 
-    dim_t rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
+    int rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
     const dim_t vnni_granularity = data_type_vnni_granularity(data_type::f16);
     const dim_t r_end = utils::div_up(rd_block, vnni_granularity);
     assert(r_end <= num_rows && "bad tile parameters");
 
     if (dt == data_type::f8_e5m2)
-        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+        f8_e5m2_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf_aux);
     else if (dt == data_type::f8_e4m3)
-        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(
-                r_end, reg_data_aux, reg_data_stride, reg_buf_aux);
+        f8_e4m3_cvt_->vcvt_f8_to_f16_vnni_block(xbyak_register_index(r_end),
+                reg_data_aux, reg_data_stride, reg_buf_aux);
     else
         assert(!"unsupported data type");
 
@@ -1347,8 +1352,7 @@ void jit_brgemm_kernel_t<Wmm>::fp8_to_f16_upconvert_to_vnni(dim_t num_rows,
  * are consistent with the GEMV blocking model used in the kernel.
  */
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
-        dim_t bd_block, bool is_bdb_tail) {
+void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(int bd_block, bool is_bdb_tail) {
 
     reg_aux_bias.restore();
 
@@ -1372,7 +1376,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
         }
     }
 
-    for (dim_t bd = 0; bd < bd_block; bd++) {
+    for (int bd = 0; bd < bd_block; bd++) {
         auto acc = accm(1, bd, 0);
 
         if (is_bias_scalar) {
@@ -1465,7 +1469,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_bias(
  */
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
-        dim_t bd_block, bool is_bdb_tail) {
+        int bd_block, bool is_bdb_tail) {
 
     reg_aux_wei_scales.restore();
 
@@ -1490,7 +1494,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
         }
     }
 
-    for (dim_t bd = 0; bd < bd_block; bd++) {
+    for (int bd = 0; bd < bd_block; bd++) {
         auto acc = accm(1, bd, 0);
 
         if (brg.gemv_single_wei_scale()) {
@@ -1540,7 +1544,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_apply_wei_scales(
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail, bool is_bdb_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail, bool is_bdb_tail) {
     const bool apply_alpha = brg.alpha != 1.f;
 
     auto vmm_alpha = vmm_tmp(0);
@@ -1550,8 +1554,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
         uni_vbroadcastss(vmm_alpha, Xmm(vmm_alpha.getIdx()));
     }
 
-    for_(dim_t bd = 0; bd < bd_block; bd++)
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for_(int bd = 0; bd < bd_block; bd++)
+    for (int ld = 0; ld < ld_block2; ld++) {
         auto vmm = accm(ld_block2, bd, ld);
         if (brg.do_dq2ps_cvt()) uni_vcvtdq2ps(vmm, vmm);
         if (apply_alpha) uni_vmulps(vmm, vmm, vmm_alpha);
@@ -1571,8 +1575,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
             {{{&reg_aux_C}, brg.is_runtime_ldc && bd_block > 1},
                     {{&reg64_fp8_aux}, brg.is_fp8_via_convert()}});
 
-    for_(dim_t bd = 0; bd < bd_block; bd++)
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for_(int bd = 0; bd < bd_block; bd++)
+    for (int ld = 0; ld < ld_block2; ld++) {
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
         const auto k_mask = is_tail ? ld_tail_mask : ld_full_mask;
         auto vmm = accm(ld_block2, bd, ld);
@@ -1609,7 +1613,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
             }
         } else {
             assert(!brg.is_gemv && "int8 data type is not supported for gemv");
-            const dim_t ld_size = is_tail ? brg.ldb_tail : brg.ld_block;
+            const int ld_size = is_tail ? brg.ldb_tail : brg.ld_block;
             cvt2ps(brg.dt_c, vmm_prev_dst, ptr_C, is_tail, false, k_mask,
                     ld_size);
             if (brg.beta == 1.f)
@@ -1625,7 +1629,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_alpha_beta(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
+void jit_brgemm_kernel_t<Wmm>::apply_post_ops(int bd_block, int ld_block2,
         dim_t ldb_and_bdb_offset, bool is_ld_tail, bool is_bdb_tail) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     reg64_savable_guard_t registers_guard({{{&param1_backup}, true},
@@ -1633,16 +1637,16 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
 
     if (brg.with_binary) param1.restore();
 
-    const dim_t bd_block_shift = brg.is_runtime_ldd ? 1 : bd_block;
-    for (dim_t bd_block_idx = 0; bd_block_idx < bd_block;
+    const int bd_block_shift = brg.is_runtime_ldd ? 1 : bd_block;
+    for (int bd_block_idx = 0; bd_block_idx < bd_block;
             bd_block_idx += bd_block_shift) {
-        dim_t bd_start = bd_block_idx;
-        dim_t bd_end = bd_start + bd_block_shift;
+        int bd_start = bd_block_idx;
+        int bd_end = bd_start + bd_block_shift;
 
         const auto set_binary_injecotr_params = [&] {
             if (!brg.with_binary || !with_binary_non_scalar_bcast_) return;
-            for_(dim_t bd = bd_start; bd < bd_end; bd++)
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+            for_(int bd = bd_start; bd < bd_end; bd++)
+            for (int ld = 0; ld < ld_block2; ld++) {
                 const auto vmm_idx = accm(ld_block2, bd, ld).getIdx();
 
                 rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_aux_D);
@@ -1699,8 +1703,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                     }
                 }
 
-                for_(dim_t bd = bd_start; bd < bd_end; bd++)
-                for (dim_t ld = 0; ld < ld_block2; ld++) {
+                for_(int bd = bd_start; bd < bd_end; bd++)
+                for (int ld = 0; ld < ld_block2; ld++) {
                     const auto vmm = accm(ld_block2, bd, ld);
                     const auto addr = ptr[reg_aux_D + D_offset(bd, ld)];
                     const auto vmm_prev_dst = vmm_tmp(0);
@@ -1708,7 +1712,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
                         const auto k_mask
                                 = is_tail ? ld_tail_mask : ld_full_mask;
-                        const dim_t ld_size
+                        const int ld_size
                                 = is_tail ? brg.ldb_tail : brg.ld_block;
                         cvt2ps(brg.sum_dt, vmm_prev_dst, addr, is_tail, false,
                                 k_mask, ld_size);
@@ -1718,7 +1722,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
                         const auto k_mask = use_partial_mask ? gemv_partial_mask
                                                              : gemv_full_mask;
 
-                        const dim_t elements_to_load = use_partial_mask
+                        const int elements_to_load = use_partial_mask
                                 ? brg.gemv_acc_is_vector() ? brg.gemv_tail : 1
                                 : brg.bd_block / brg.gemv_bd_block();
                         cvt2ps(brg.sum_dt, vmm_prev_dst, addr, use_partial_mask,
@@ -1759,10 +1763,10 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(dim_t bd_block, dim_t ld_block2,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::reduce_gemv_accumulators(dim_t bd_block) {
+void jit_brgemm_kernel_t<Wmm>::reduce_gemv_accumulators(int bd_block) {
     // At this point the broadcast registers are not used.
     auto workspace = bcst();
-    for (dim_t bd = 0; bd < bd_block; bd++) {
+    for (int bd = 0; bd < bd_block; bd++) {
         auto acc = accm(1, bd, 0);
         regops::horizontal_add_ps(this, acc, workspace);
     }
@@ -1823,10 +1827,10 @@ void jit_brgemm_kernel_t<Wmm>::load_scales_to_vmm(const data_type_t type_in,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
+void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(int bd_block, int ld_block2,
         bool is_ld_tail, bool dq2ps_required, bool &dq2ps_cvt_done) {
     reg_aux_wei_scales.restore();
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for (int ld = 0; ld < ld_block2; ld++) {
         const auto addr = ptr[reg_aux_wei_scales + wei_scales_offset(ld)];
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
 
@@ -1834,7 +1838,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
         load_scales_to_vmm(brg.dt_wei_scales, vmm_wei_scales, addr, is_tail,
                 brg.is_single_wei_scale);
 
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
             uni_vmulps(vmm, vmm, vmm_wei_scales);
@@ -1844,16 +1848,16 @@ void jit_brgemm_kernel_t<Wmm>::apply_wei_scales(dim_t bd_block, dim_t ld_block2,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::apply_src_scales_per_k(dim_t bd_block,
-        dim_t ld_block2, bool dq2ps_required, bool &dq2ps_cvt_done) {
+void jit_brgemm_kernel_t<Wmm>::apply_src_scales_per_k(int bd_block,
+        int ld_block2, bool dq2ps_required, bool &dq2ps_cvt_done) {
     reg_src_scales.restoreTo(reg_aux_src_scales);
     const auto vmm_src_sc = vmm_tmp(0);
-    for (dim_t bd = 0; bd < bd_block; bd++) {
+    for (int bd = 0; bd < bd_block; bd++) {
         const auto src_sc_addr
                 = ptr[reg_aux_src_scales + bd * brg.src_scale_m_stride];
         load_scales_to_vmm(brg.dt_src_scales, vmm_src_sc, src_sc_addr,
                 /*is_ld_tail=*/false, /*is_single_scale=*/true);
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm = accm(ld_block2, bd, ld);
             if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
             uni_vmulps(vmm, vmm, vmm_src_sc);
@@ -1867,7 +1871,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_src_scales_per_k(dim_t bd_block,
 // f32 so apply_alpha_beta uses vaddps against f32 buffer C.
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_scales(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail) {
     assert(brg.has_per_k_scales());
     const bool dq2ps_required = brg.is_int8;
     // When per-MN compensation was applied before this call, dq2ps is
@@ -1881,8 +1885,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_scales(
         apply_src_scales_per_k(
                 bd_block, ld_block2, dq2ps_required, dq2ps_cvt_done);
     if (dq2ps_required && !dq2ps_cvt_done) {
-        for_(dim_t ld = 0; ld < ld_block2; ld++)
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for_(int ld = 0; ld < ld_block2; ld++)
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             uni_vcvtdq2ps(vmm, vmm);
         }
@@ -1890,8 +1894,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_scales(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
-        dim_t ld_block2, dim_t ldb_and_bdb_offset, bool is_ld_tail,
+void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(int bd_block,
+        int ld_block2, dim_t ldb_and_bdb_offset, bool is_ld_tail,
         bool is_bdb_tail) {
     auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
 
@@ -1922,8 +1926,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                     ptr[reg_aux_src_scales],
                     /*is_ld_tail=*/false, /*is_single_scale=*/true);
 
-        for_(dim_t ld = 0; ld < ld_block2; ld++)
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for_(int ld = 0; ld < ld_block2; ld++)
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
 
@@ -1954,8 +1958,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         uni_vmovq(xmm_scale_adjust, reg_aux_scale_adjust);
         uni_vbroadcastss(vmm_scale_adjust, xmm_scale_adjust);
 
-        for_(dim_t ld = 0; ld < ld_block2; ld++)
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for_(int ld = 0; ld < ld_block2; ld++)
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
             uni_vmulps(vmm, vmm, vmm_scale_adjust);
@@ -1968,7 +1972,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     if (!brg.is_gemv) {
         reg_aux_bias.restore();
 
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm_bias = vmm_tmp(0);
             if (brg.with_bias) {
                 auto ptr_bias = ptr[reg_aux_bias + bias_offset(ld)];
@@ -1976,7 +1980,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                 cvt2ps(brg.dt_bias, vmm_bias, ptr_bias, is_tail, false, k_mask,
                         is_tail ? brg.ldb_tail : brg.ld_block);
             }
-            for (dim_t bd = 0; bd < bd_block; bd++) {
+            for (int bd = 0; bd < bd_block; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 if (dq2ps_required && !dq2ps_cvt_done) uni_vcvtdq2ps(vmm, vmm);
                 if (brg.with_bias) uni_vaddps(vmm, vmm, vmm_bias);
@@ -1996,8 +2000,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         auto vmm_dst_scales = vmm_tmp(0);
         vbroadcastss(vmm_dst_scales, ptr[reg_dst_scales]);
 
-        for_(dim_t ld = 0; ld < ld_block2; ld++)
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for_(int ld = 0; ld < ld_block2; ld++)
+        for (int bd = 0; bd < bd_block; bd++) {
             auto vmm = accm(ld_block2, bd, ld);
             vmulps(vmm, vmm, vmm_dst_scales);
         }
@@ -2018,7 +2022,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
         }
         if (brg.is_fp8_via_convert()) reg64_fp8_aux.save();
 
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
             if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
                 dim_t zp_c_off = zp_c_values_offset(ld);
@@ -2033,7 +2037,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                             k_mask, is_tail ? brg.ldb_tail : brg.ld_block);
                 }
             }
-            for (dim_t bd = 0; bd < bd_block; bd++) {
+            for (int bd = 0; bd < bd_block; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 uni_vaddps(vmm, vmm, vmm_zp_c);
             }
@@ -2049,8 +2053,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     if (dt_requires_saturation) {
         init_saturate_f32(vmm_lbound(), vmm_ubound(), reg_tmp_gpr,
                 data_type::f32, brg.dt_d, false, use_sat_cvt);
-        for (dim_t bd = 0; bd < bd_block; bd++) {
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int bd = 0; bd < bd_block; bd++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 saturate_cvt_f32(vmm, vmm_lbound(), vmm_ubound(), brg.dt_d,
                         false, use_sat_cvt);
@@ -2072,8 +2076,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
     else if (brg.brgattr.hint_prefetchw == brgemm_prfw_store)
         prefetchw(ptr[reg_aux_D]);
 
-    for_(dim_t bd = 0; bd < bd_block; bd++)
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for_(int bd = 0; bd < bd_block; bd++)
+    for (int ld = 0; ld < ld_block2; ld++) {
         auto addr = ptr[reg_aux_D + D_offset(bd, ld)];
         auto vmm = accm(ld_block2, bd, ld);
         auto vmm_lower = Vmm_lower_t(vmm.getIdx());
@@ -2154,7 +2158,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
                 }
             }
         } else {
-            const dim_t ld_block = is_tail ? brg.ldb_tail : brg.ld_block;
+            const int ld_block = is_tail ? brg.ldb_tail : brg.ld_block;
             if (is_tail && types::data_type_size(brg.dt_b) == sizeof(float))
                 vmaskmovps(addr, vmm_tail_mask(), vmm);
             else
@@ -2169,7 +2173,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(dim_t bd_block,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail) {
     assert(!brg.is_gemv && "compensation is not supported for gemv");
     // apply compensation to accumulated values
     // to avoid the loss of accuracy when converting s32 to f32
@@ -2182,9 +2186,9 @@ void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
 
         reg_aux_zp_comp_a.restore();
         const auto vmm_zp_comp_a = vmm_tmp(0);
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-            for (dim_t bd = 0; bd < bd_block; bd++) {
+            for (int bd = 0; bd < bd_block; bd++) {
                 if (IMPLICATION(!brg.req_comp_pads_with_bcast, bd == 0)) {
                     const auto zp_comp_a_addr = ptr[reg_aux_zp_comp_a
                             + bd_zp_comp_a_offset(ld, bd)];
@@ -2209,9 +2213,9 @@ void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
 
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_b.restore();
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             dim_t zp_comp_b_off = zp_comp_b_offset(bd);
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 if (is_superset(brg.isa_impl, avx512_core)) {
                     const auto zp_comp_b_addr = EVEX_compress_addr(
@@ -2230,9 +2234,9 @@ void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
     if (!brg.req_cal_comp_pads && brg.req_s8s8_compensation) {
         reg_aux_compensation.restore();
         auto vmm_comp = vmm_tmp(0);
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
-            for (dim_t bd = 0; bd < bd_block; bd++) {
+            for (int bd = 0; bd < bd_block; bd++) {
                 if (IMPLICATION(!brg.req_comp_pads_with_bcast, bd == 0)) {
                     const auto comp_addr = ptr[reg_aux_compensation
                             + bd_compensation_offset(ld, bd)];
@@ -2253,15 +2257,15 @@ void jit_brgemm_kernel_t<Wmm>::apply_zp_s8s8_compensation(
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::apply_per_mn_compensation(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail) {
     assert(brg.with_per_mn_compensation);
     assert(!brg.is_gemv && "per-(M,N) compensation is not supported for gemv");
     assert(!brg.is_integer_acc()
             && "per-(M,N) compensation is not supported for int accumulation");
 
     if (brg.is_int8) {
-        for_(dim_t bd = 0; bd < bd_block; bd++)
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for_(int bd = 0; bd < bd_block; bd++)
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm = accm(ld_block2, bd, ld);
             uni_vcvtdq2ps(vmm, vmm);
         }
@@ -2270,8 +2274,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_per_mn_compensation(
     const auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
     reg_aux_per_mn_comp.restore();
     const auto vmm_delta = vmm_tmp(0);
-    for_(dim_t bd = 0; bd < bd_block; bd++)
-    for (dim_t ld = 0; ld < ld_block2; ld++) {
+    for_(int bd = 0; bd < bd_block; bd++)
+    for (int ld = 0; ld < ld_block2; ld++) {
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
         const auto delta_addr
                 = ptr[reg_aux_per_mn_comp + per_mn_comp_offset(bd, ld)];
@@ -2289,7 +2293,7 @@ void jit_brgemm_kernel_t<Wmm>::apply_per_mn_compensation(
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
-        dim_t bd_block, dim_t ld_block2, bool is_ld_tail, bool is_bdb_tail) {
+        int bd_block, int ld_block2, bool is_ld_tail, bool is_bdb_tail) {
     // if (brg.is_int8 && alpha_or_beta_applicable && !beta_uses_vadd) ->
     // accumulated values are converted to ps in apply_alpha_beta()
     const bool alpha_or_beta_applicable = brg.alpha != 1.0f || brg.beta != 0.f;
@@ -2303,8 +2307,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
     if (dt_requires_saturation) {
         init_saturate_f32(vmm_lbound(), vmm_ubound(), reg_tmp_gpr,
                 data_type::f32, brg.dt_d, false, use_sat_cvt);
-        for (dim_t bd = 0; bd < bd_block; bd++) {
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for (int bd = 0; bd < bd_block; bd++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 saturate_cvt_f32(vmm, vmm_lbound(), vmm_ubound(), brg.dt_d,
                         false, use_sat_cvt);
@@ -2323,7 +2327,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
         prefetchw(ptr[reg_aux_C]);
 
     if (brg.is_gemv) {
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             const bool need_prefetch
                     = brg.brgattr.hint_prefetchw == brgemm_prfw_loop_store
                     && !is_superset(brg.isa_impl, avx10_2);
@@ -2352,8 +2356,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
             }
         }
     } else {
-        for_(dim_t bd = 0; bd < bd_block; bd++)
-        for (dim_t ld = 0; ld < ld_block2; ld++) {
+        for_(int bd = 0; bd < bd_block; bd++)
+        for (int ld = 0; ld < ld_block2; ld++) {
             auto vmm = accm(ld_block2, bd, ld);
             const auto addr_c = ptr[reg_aux_C + C_offset(bd, ld)];
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
@@ -2374,8 +2378,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_without_post_ops(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_ld_tail,
+void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
+        bool is_bdb_tail, int ld_block2, bool is_ld_tail,
         bool skip_accumulation) {
     const bool has_zero_points = !everyone_is(brgemm_broadcast_t::none,
             brg.zp_type_a, brg.zp_type_b, brg.zp_type_c);
@@ -2409,7 +2413,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
             const bool do_accum_ops = need_to_apply_alpha_beta
                     || are_post_ops_applicable || apply_zp_a_compensation;
-            const dim_t adj_bd_block = (brg.is_M_tail && is_bdb_tail)
+            const int adj_bd_block = (brg.is_M_tail && is_bdb_tail)
                     ? brg.bdb_tail
                     : brg.bd_block;
 
@@ -2428,21 +2432,21 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
             reg_buf.restore();
 
-            for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
-                for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
-                    const dim_t idx = is_ld_tail ? brg.ld_block2 : ldb;
+            for (int bdb = 0; bdb < bd_block2; bdb++) {
+                for (int ldb = 0; ldb < ld_block2; ldb++) {
+                    const int idx = is_ld_tail ? brg.ld_block2 : ldb;
                     const int c_tensor = brg.get_C_tensor(
                             bdb, idx, is_bdb_tail, is_ld_tail);
                     if (do_accum_ops) {
                         if (skip_accumulation) {
-                            for (dim_t bd = 0; bd < adj_bd_block; bd++) {
+                            for (int bd = 0; bd < adj_bd_block; bd++) {
                                 auto vreg_acc = accm(1, bd, 0);
                                 uni_vpxor(vreg_acc, vreg_acc, vreg_acc);
                             }
                         } else {
                             tilestored(ptr[reg_buf + reg_stride_ld_block],
-                                    Tmm(c_tensor));
-                            for (dim_t bd = 0; bd < adj_bd_block; bd++) {
+                                    Tmm(xbyak_register_index(c_tensor)));
+                            for (int bd = 0; bd < adj_bd_block; bd++) {
                                 const size_t buf_offset
                                         = (bd * brg.ld_block) * brg.typesize_C;
                                 auto vreg_acc = is_ld_tail
@@ -2481,7 +2485,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
 
                         reg_buf.restore();
                     } else {
-                        auto tmm = Tmm(c_tensor);
+                        auto tmm = Tmm(xbyak_register_index(c_tensor));
                         if (skip_accumulation) tilezero(tmm);
                         tilestored(ptr[reg_aux_C + reg_stride_ld_block], tmm);
                         if (ldb < ld_block2 - 1)
@@ -2563,7 +2567,7 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(dim_t bd_block2,
         store_accumulators_amx(false);
         L_aligned(label_done);
     } else {
-        dim_t bd_block = 0;
+        int bd_block = 0;
         if (brg.is_gemv)
             bd_block = brg.gemv_num_acc_blocks(is_bdb_tail);
         else
@@ -2704,7 +2708,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(matrix_kind_t matrix_kind,
         const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
-        dim_t num_rows, dim_t num_col_bytes, bool is_rd_tail) {
+        int num_rows, int num_col_bytes, bool is_rd_tail) {
     const auto transform_offset = brg.brgattr.use_interleave_stores
             ? brg.get_num_C_tiles() * brgemm_desc_t::tilesize
             : 0;
@@ -2729,13 +2733,13 @@ void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(matrix_kind_t matrix_kind,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
-        dim_t idx, dim_t offset, bool is_rd_tail, bool is_tail, bool last_bdb) {
+        int idx, dim_t offset, bool is_rd_tail, bool is_tail, bool last_bdb) {
 
     const bool is_A = matrix_kind == matrix_kind_t::matrix_A;
 
-    const dim_t tmm_idx = is_A ? brg.get_A_tensor(idx, is_tail)
-                               : brg.get_B_tensor(idx, is_tail);
-    auto t1 = Tmm(tmm_idx);
+    const int tmm_idx = is_A ? brg.get_A_tensor(idx, is_tail)
+                             : brg.get_B_tensor(idx, is_tail);
+    auto t1 = Tmm(xbyak_register_index(tmm_idx));
 
     auto reg_base = is_A ? reg_aux_A : reg_aux_B;
 
@@ -2744,25 +2748,24 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
             == (is_A ? brgemm_bd_loop_innermost : brgemm_ld_loop_innermost);
 
     if (brg.is_fp8_via_convert()) {
-        const dim_t typesize_A
+        const int typesize_A
                 = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_A;
-        const dim_t typesize_B
+        const int typesize_B
                 = brg.is_input_convert() ? sizeof(int16_t) : brg.typesize_B;
-        dim_t rd_step = 4 / typesize_A;
-        dim_t rd_block
-                = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
+        int rd_step = 4 / typesize_A;
+        int rd_block = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
         if (brg.is_input_convert()) {
-            const int vnni_granularity
+            const auto vnni_granularity
                     = data_type_vnni_granularity(data_type::f16);
             rd_block = utils::rnd_up(rd_block, vnni_granularity);
         }
 
-        dim_t A_col = typesize_A * rd_block;
-        dim_t A_row = is_tail ? brg.bdb_tail : brg.bd_block;
+        int A_col = typesize_A * rd_block;
+        int A_row = is_tail ? brg.bdb_tail : brg.bd_block;
 
-        dim_t B_col = (is_tail ? brg.ldb_tail : brg.ld_block) * typesize_B
+        int B_col = (is_tail ? brg.ldb_tail : brg.ld_block) * typesize_B
                 * rd_step;
-        dim_t B_row = brg.typesize_C != 0 ? A_col / brg.typesize_C : 0;
+        int B_row = brg.typesize_C != 0 ? A_col / brg.typesize_C : 0;
         reg64_savable_guard_t reg_fp8_buf_guard({&reg64_fp8_aux, &reg_buf_aux});
 
         reg_buf.restoreTo(reg_buf_aux);
@@ -2806,8 +2809,8 @@ bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool last_bdb,
     //TODO: reuse transformed data from matrix A for ldi > 0
     const int max_tiles = amx::get_max_palette_size();
     JIT_ASSERT_RET(t1.getIdx() >= 0 && t1.getIdx() < max_tiles, false);
-    const dim_t num_rows = palette_.rows[t1.getIdx()];
-    const dim_t num_col_bytes = palette_.cols[t1.getIdx()];
+    const int num_rows = palette_.rows[t1.getIdx()];
+    const int num_col_bytes = palette_.cols[t1.getIdx()];
 
     const auto max_num_cols
             = nstl::min<dim_t>(num_col_bytes / brg.typesize_A, brg.rdb_tail);
@@ -2854,8 +2857,8 @@ bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool last_bdb,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail, bool is_ld_tail,
+void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(int bd_block2,
+        bool is_bdb_tail, int ld_block2, bool is_rd_tail, bool is_ld_tail,
         bool last_bdb) {
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
         using namespace data_type;
@@ -2889,22 +2892,24 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
     };
     dim_t rbd_block = (is_rd_tail) ? 1 : brg.rdb;
     for (dim_t rdb = 0; rdb < rbd_block; rdb++) {
-        for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
+        for (int bdb = 0; bdb < bd_block2; bdb++) {
             maybe_tileloadd_nt(matrix_kind_t::matrix_A, bdb,
                     rdb * rdb_A_offset() + A_offset(bdb, 0, true), is_rd_tail,
                     is_bdb_tail, last_bdb && bdb == bd_block2 - 1);
         }
-        for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
+        for (int ldb = 0; ldb < ld_block2; ldb++) {
 
-            const dim_t idx = (is_ld_tail) ? brg.ld_block2 : ldb;
+            const int idx = (is_ld_tail) ? brg.ld_block2 : ldb;
             maybe_tileloadd_nt(matrix_kind_t::matrix_B, idx,
                     rdb * rdb_B_offset() + B_offset(ldb, 0, true), is_rd_tail,
                     is_ld_tail, false);
-            for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
-                tdpbxxd(Tmm(brg.get_C_tensor(
-                                bdb, idx, is_bdb_tail, is_ld_tail)),
-                        Tmm(brg.get_A_tensor(bdb, is_bdb_tail)),
-                        Tmm(brg.get_B_tensor(idx, is_ld_tail)));
+            for (int bdb = 0; bdb < bd_block2; bdb++) {
+                tdpbxxd(Tmm(xbyak_register_index(brg.get_C_tensor(
+                                bdb, idx, is_bdb_tail, is_ld_tail))),
+                        Tmm(xbyak_register_index(
+                                brg.get_A_tensor(bdb, is_bdb_tail))),
+                        Tmm(xbyak_register_index(
+                                brg.get_B_tensor(idx, is_ld_tail))));
             }
         }
     }
@@ -2940,13 +2945,12 @@ void jit_brgemm_kernel_t<Wmm>::dot_product(Vmm v1, Vmm v2, Vmm v3) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
-        dim_t bd_b, dim_t bd_e, dim_t bd_block, dim_t ld_block2,
-        bool is_ld_tail, dim_t vpad) {
+void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(int rd_loop, int bd_b,
+        int bd_e, int bd_block, int ld_block2, bool is_ld_tail, int vpad) {
     assert(brg.is_int8);
 
     auto compensation_padding = [this, ld_block2](Vmm vmm_load, Vmm vmm_tmp,
-                                        dim_t ld, dim_t bd_b, dim_t bd_e) {
+                                        int ld, int bd_b, int bd_e) {
         // req_cal_comp_pads -> only calculate compensation along with
         // computation and do not use pre-calculated compensation.
         // Calculate comp padding as:
@@ -2957,7 +2961,7 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
                 dot_product(vmm_tmp, vmm_load, vmm_inp_shift());
             }
 
-            for (dim_t bd = bd_b; bd < bd_e; bd++) {
+            for (int bd = bd_b; bd < bd_e; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 if (brg.req_cal_comp_pads) {
                     uni_vpsubd(vmm, vmm, vmm_tmp);
@@ -2972,7 +2976,7 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
             dot_product(vmm_tmp, vmm_load, vmm_one_bytes());
             uni_vpmulld(vmm_tmp, vmm_tmp, vmm_zp_a_shift());
 
-            for (dim_t bd = bd_b; bd < bd_e; bd++) {
+            for (int bd = bd_b; bd < bd_e; bd++) {
                 auto vmm = accm(ld_block2, bd, ld);
                 if (brg.req_cal_comp_pads) {
                     uni_vpsubd(vmm, vmm, vmm_tmp);
@@ -2992,15 +2996,15 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
         uni_vpbroadcastd(vmm_zp_a_shift(), reg32_scratch);
     }
 
-    for_(dim_t rd = 0; rd < rd_loop; rd += brg.rd_step)
-    for (dim_t ld = 0; ld < ld_block2; ++ld) {
+    for_(int rd = 0; rd < rd_loop; rd += brg.rd_step)
+    for (int ld = 0; ld < ld_block2; ++ld) {
         const auto addr = ptr[reg_aux_B + B_offset(ld, rd)];
         const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
         if (IMPLICATION(is_tail, is_superset(brg.isa_impl, avx512_core))) {
             auto vmm_store = vmm_mask(load(), is_tail, false, ld_tail_mask);
             uni_vmovups(vmm_store, addr);
         } else {
-            load_bytes(load(), addr, ldb_B_offset(0, true));
+            load_bytes(load(), addr, static_cast<int>(ldb_B_offset(0, true)));
         }
 
         if (brg.req_cal_comp_pads) {
@@ -3015,13 +3019,13 @@ void jit_brgemm_kernel_t<Wmm>::compute_int8_compensation(dim_t rd_loop,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
-        bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail) {
+        bool is_bdb_tail, int ld_block2, bool is_rd_tail) {
 
     assert(brg.is_gemv);
     assert(brg.ld_block == 1);
     assert(ld_block2 == 1);
 
-    const dim_t bd_block = brg.gemv_num_acc_blocks(is_bdb_tail);
+    const int bd_block = brg.gemv_num_acc_blocks(is_bdb_tail);
 
     const auto load_and_convert_to_f32
             = [this](const Vmm vmm, const Xbyak::Address addr,
@@ -3093,7 +3097,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
             load_and_convert_to_f32(b_vmm, b_addr, brg.dt_b, is_rd_tail);
         }
 
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             const auto acc = accm(1, bd, 0);
             const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
 
@@ -3123,7 +3127,7 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
         const bool do_pf = is_superset(brg.isa_impl, avx512_core);
 
         bcast_and_convert_to_f32(gemv_load_b(), ptr[reg_aux_B], brg.dt_b);
-        for (dim_t bd = 0; bd < bd_block; bd++) {
+        for (int bd = 0; bd < bd_block; bd++) {
             const bool is_tail_acc
                     = gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
             const auto a_addr = ptr[reg_aux_A + A_offset(bd, 0)];
@@ -3140,13 +3144,13 @@ void jit_brgemm_kernel_t<Wmm>::gemv_microkernel(
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail, bool is_ld_tail,
-        dim_t vpad, dim_t rows_for_rd_tail) {
+void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
+        int ld_block2, bool is_rd_tail, bool is_ld_tail, int vpad,
+        int rows_for_rd_tail) {
 
     MAYBE_UNUSED(bd_block2);
-    dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
-    const auto bd_b = nstl::max(dim_t(0), vpad);
+    int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+    const auto bd_b = nstl::max(0, vpad);
     const auto bd_e = nstl::min(bd_block, bd_block + vpad);
     const auto is_valid_bd
             = need_comp_pads && vpad != 0 ? bd_b <= bd_e : bd_b < bd_e;
@@ -3154,7 +3158,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     bool is_emdbd = brg.embd_bcst;
 
-    dim_t rd_loop = 0, rd_tail_size = 0;
+    int rd_loop = 0, rd_tail_size = 0;
     if (is_rd_tail) {
         if (brg.is_bf16 || brg.is_f16 || brg.is_int8 || brg.is_fp8) {
             rd_tail_size = brg.rdb_tail % brg.rd_step;
@@ -3175,7 +3179,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     auto broadcast_A
             = [this, rd_tail_size, is_rd_tail, rd_loop, rows_for_rd_tail, bd_e](
-                      Vmm vmm_bcast, dim_t bd, dim_t rd) {
+                      Vmm vmm_bcast, int bd, int rd) {
         const auto offset = A_offset(bd, rd);
         const auto dt = brg.dt_a;
         const bool maybe_load_bytes
@@ -3191,8 +3195,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
         const auto is_tail = have_to_load_bytes && bd_by_load_bytes;
         if (is_tail) {
             Xmm xmm_tmp = Xmm(vmm_bcast.getIdx());
-            load_bytes(
-                    xmm_tmp, reg_aux_A, offset, rd_tail_size * brg.typesize_A);
+            load_bytes(xmm_tmp, reg_aux_A, offset,
+                    static_cast<int>(rd_tail_size * brg.typesize_A));
             uni_vpbroadcastd(vmm_bcast, xmm_tmp);
         } else {
             if (dt == data_type::f32) {
@@ -3221,7 +3225,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             uni_vpaddb(vmm_bcast, vmm_bcast, vmm_inp_shift());
     };
 
-    auto load_B = [this, is_ld_tail](dim_t vmm_load_idx, dim_t rd, dim_t ld) {
+    auto load_B = [this, is_ld_tail](int vmm_load_idx, int rd, int ld) {
         const bool mem_advice_B
                 = utils::one_of(brg.brgattr.mem_advice,
                           brgemm_hint_mem_advice_B, brgemm_hint_mem_advice_A_B)
@@ -3255,7 +3259,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                     vpermw(vmm_load, f16_perm_odd_vreg(), vmm_load);
                 vcvtph2psx(vmm_load, Vmm_lower_t(vmm_load.getIdx()));
             } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr,
+                        static_cast<int>(ldb_B_offset(0, true)));
                 vcvtph2ps(vmm_load, Xmm(vmm_load.getIdx()));
             } else {
                 uni_vcvtph2psx(vmm_load, addr);
@@ -3271,7 +3276,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                 uni_vpmovzxwd(vmm_load, addr);
                 uni_vpslld(vmm_load, vmm_load, 16);
             } else if (is_ld_tail && !is_superset(brg.isa_impl, avx512_core)) {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr,
+                        static_cast<int>(ldb_B_offset(0, true)));
             } else {
                 uni_vmovups(vmm_load, addr);
             }
@@ -3279,7 +3285,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             if (is_superset(brg.isa_impl, avx512_core)) {
                 uni_vmovups(vmm_load, addr);
             } else {
-                load_bytes(vmm_load, addr, ldb_B_offset(0, true));
+                load_bytes(vmm_load, addr,
+                        static_cast<int>(ldb_B_offset(0, true)));
             }
         } else {
             uni_vmovups(vmm_load, addr);
@@ -3303,15 +3310,15 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 
     if (brg.is_fp8_via_convert()) reg64_fp8_aux.save();
 
-    for (dim_t rd = 0; rd < rd_loop; rd += brg.rd_step) {
+    for (int rd = 0; rd < rd_loop; rd += brg.rd_step) {
         if (brg.n_bcast_1_load) {
-            for (dim_t bd = bd_b; bd < bd_e && !is_emdbd; bd++)
+            for (int bd = bd_b; bd < bd_e && !is_emdbd; bd++)
                 broadcast_A(bcst(bd), bd, rd);
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
                 load_B(0, rd, ld);
                 if (brg.is_fp8_via_convert_non_amx())
                     maybe_pre_process_data(brg.dt_b, load(), vmm_fp8_load());
-                for (dim_t bd = bd_b; bd < bd_e; bd++) {
+                for (int bd = bd_b; bd < bd_e; bd++) {
                     auto vmm = accm(ld_block2, bd, ld);
                     if (is_emdbd)
                         uni_vfmadd231ps(vmm, load(),
@@ -3330,12 +3337,12 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
             }
 
         } else {
-            dim_t prefetch_count_B = 0;
-            for (dim_t ld = 0; ld < ld_block2; ld++) {
+            int prefetch_count_B = 0;
+            for (int ld = 0; ld < ld_block2; ld++) {
                 load_B(ld, rd, ld);
             }
 
-            for (dim_t bd = bd_b; bd < bd_e; bd++) {
+            for (int bd = bd_b; bd < bd_e; bd++) {
                 if (!is_emdbd) broadcast_A(bcst(), bd, rd);
                 if (brg.is_fp8_via_convert_non_amx())
                     maybe_pre_process_data(brg.dt_a, bcst(), vmm_fp8_bcst());
@@ -3358,7 +3365,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
                         }
                     }
                 }
-                for (dim_t ld = 0; ld < ld_block2; ld++) {
+                for (int ld = 0; ld < ld_block2; ld++) {
                     auto vmm = accm(ld_block2, bd, ld);
                     if (is_emdbd)
                         uni_vfmadd231ps(vmm, load(ld),
@@ -3384,15 +3391,15 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(dim_t bd_block2,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
-        dim_t ld_block2, bool is_ld_tail, bool first_bdb, bool last_bdb,
-        dim_t rows_for_rd_tail, bool skip_accumulation) {
+void jit_brgemm_kernel_t<Wmm>::bs_loop(int bd_block2, bool is_bdb_tail,
+        int ld_block2, bool is_ld_tail, bool first_bdb, bool last_bdb,
+        int rows_for_rd_tail, bool skip_accumulation) {
 
-    auto bs_loop_body = [&](dim_t vpad, bool last_bdb) {
+    auto bs_loop_body = [&](int vpad, bool last_bdb) {
         set_A_B_matrices();
 
-        dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
-        const auto bd_b = nstl::max(dim_t(0), vpad);
+        int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+        const auto bd_b = nstl::max(0, vpad);
         const auto bd_e = nstl::min(bd_block, bd_block + vpad);
         const auto is_valid_bd
                 = need_comp_pads && vpad != 0 ? bd_b <= bd_e : bd_b < bd_e;
@@ -3477,7 +3484,7 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
                 } else
                     xor_(reg_aux_A_vpad, reg_aux_A_vpad);
 
-                for (dim_t vpad = vpad_first; vpad <= vpad_last; vpad++) {
+                for (int vpad = vpad_first; vpad <= vpad_last; vpad++) {
                     const auto label_vpad = vpad - vpad_first;
                     L(Vpad_loop_iter_label[label_vpad]);
                     if (!first_bdb && vpad > 0) continue;
@@ -3522,9 +3529,9 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::ldb_loop(dim_t bd_block2, bool is_bdb_tail,
-        dim_t ld_block2, dim_t ldb_loop_length, bool is_reg_tail,
-        bool is_ld_tail, bool first_bdb, bool last_bdb, dim_t rows_for_rd_tail,
+void jit_brgemm_kernel_t<Wmm>::ldb_loop(int bd_block2, bool is_bdb_tail,
+        int ld_block2, dim_t ldb_loop_length, bool is_reg_tail, bool is_ld_tail,
+        bool first_bdb, bool last_bdb, int rows_for_rd_tail,
         bool skip_accumulation) {
 
     Label ldb_loop_label;
@@ -3576,8 +3583,8 @@ void jit_brgemm_kernel_t<Wmm>::ldb_loop(dim_t bd_block2, bool is_bdb_tail,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
-    auto do_ldb_loop = [this](dim_t bd_block2, bool is_bdb_tail, bool first_bdb,
-                               bool last_bdb, dim_t rows_for_rd_tail,
+    auto do_ldb_loop = [this](int bd_block2, bool is_bdb_tail, bool first_bdb,
+                               bool last_bdb, int rows_for_rd_tail,
                                bool skip_accumulation) {
         if (brg.ldb2 > 0) {
             const bool is_ld_reg_tail = false;
@@ -3602,10 +3609,9 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         }
     };
 
-    auto bdb_loop_body
-            = [this, do_ldb_loop](dim_t bd_block2, bool is_bdb_tail,
-                      bool first_bdb, bool last_bdb, dim_t rows_for_rd_tail,
-                      bool skip_accumulation) {
+    auto bdb_loop_body = [this, do_ldb_loop](int bd_block2, bool is_bdb_tail,
+                                 bool first_bdb, bool last_bdb,
+                                 int rows_for_rd_tail, bool skip_accumulation) {
         do_ldb_loop(bd_block2, is_bdb_tail, first_bdb, last_bdb,
                 rows_for_rd_tail, skip_accumulation);
 
@@ -3655,7 +3661,7 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         advance_bd_block2_post_op_regs(bd_block2);
     };
 
-    dim_t rows_for_rd_tail, bd_blocks_for_rd_tail;
+    int rows_for_rd_tail, bd_blocks_for_rd_tail;
 
     if (brg.is_tmm) {
         rows_for_rd_tail = 0;
@@ -3670,7 +3676,7 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
                     : 0;
         }
         bd_blocks_for_rd_tail
-                = div_up(nstl::max(dim_t(0),
+                = div_up(nstl::max(0,
                                  rows_for_rd_tail - brg.bdb_tail
                                          + brg.brgattr.max_bottom_vpad),
                         brg.bd_block);
@@ -3925,9 +3931,9 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
 
     align(32);
 
-    const dim_t simd = vreg_traits_t<Vmm>::vlen / sizeof(float);
+    const int simd = vreg_traits_t<Vmm>::vlen / sizeof(float);
     if (!isa_has_masks(brg.isa_impl) && (brg.ldb_tail || brg.gemv_tail)) {
-        const dim_t tail_size = brg.is_gemv ? brg.gemv_tail : brg.ldb_tail;
+        const int tail_size = brg.is_gemv ? brg.gemv_tail : brg.ldb_tail;
         L(avx_tail_mask_);
         for (dim_t i = 0; i < tail_size; ++i)
             dd(0xffffffff);
@@ -3940,7 +3946,7 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
         L(sum_zp_scale_data_);
         const dim_t scale_int = float2int(brg.sum_scale);
         for (dim_t i = 0; i < simd; ++i)
-            dd(scale_int);
+            dd(static_cast<uint32_t>(scale_int));
     }
 
     if (brg.is_fp8_via_convert()) {

--- a/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
+++ b/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
@@ -63,13 +63,13 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
 
     int kerneltype = ((typea << 1) | typeb);
 
-    dim_t SHIFT_UNROLL_M = 4, SHIFT_UNROLL_N = 4, SHIFT_UNROLL_K = 2;
-    dim_t SHIFT_UNROLL_MM = 5, SHIFT_UNROLL_NN = 5, SHIFT_UNROLL_KK = 6;
-    dim_t SHIFT_A = 0, SHIFT_B = 0, SHIFT_C = 2;
+    int SHIFT_UNROLL_M = 4, SHIFT_UNROLL_N = 4, SHIFT_UNROLL_K = 2;
+    int SHIFT_UNROLL_MM = 5, SHIFT_UNROLL_NN = 5, SHIFT_UNROLL_KK = 6;
+    int SHIFT_A = 0, SHIFT_B = 0, SHIFT_C = 2;
 
-    dim_t UNROLL_M = 0, UNROLL_N = 0, UNROLL_K = 0;
-    dim_t UNROLL_MM = 0, UNROLL_NN = 0, UNROLL_KK = 0;
-    dim_t SIZE_A = 0, SIZE_B = 0, SIZE_C = 0;
+    int UNROLL_M = 0, UNROLL_N = 0, UNROLL_K = 0;
+    int UNROLL_MM = 0, UNROLL_NN = 0, UNROLL_KK = 0;
+    int SIZE_A = 0, SIZE_B = 0, SIZE_C = 0;
 
     if (typec == 0) {
         // Floatingpoint Operation
@@ -81,17 +81,17 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
         kerneltype = 4;
     }
 
-    UNROLL_M = (((dim_t)1) << SHIFT_UNROLL_M);
-    UNROLL_N = (((dim_t)1) << SHIFT_UNROLL_N);
-    UNROLL_K = (((dim_t)1) << SHIFT_UNROLL_K);
+    UNROLL_M = (1 << SHIFT_UNROLL_M);
+    UNROLL_N = (1 << SHIFT_UNROLL_N);
+    UNROLL_K = (1 << SHIFT_UNROLL_K);
 
-    UNROLL_MM = (((dim_t)1) << SHIFT_UNROLL_MM);
-    UNROLL_NN = (((dim_t)1) << SHIFT_UNROLL_NN);
-    UNROLL_KK = (((dim_t)1) << SHIFT_UNROLL_KK);
+    UNROLL_MM = (1 << SHIFT_UNROLL_MM);
+    UNROLL_NN = (1 << SHIFT_UNROLL_NN);
+    UNROLL_KK = (1 << SHIFT_UNROLL_KK);
 
-    SIZE_A = (((dim_t)1) << SHIFT_A);
-    SIZE_B = (((dim_t)1) << SHIFT_B);
-    SIZE_C = (((dim_t)1) << SHIFT_C);
+    SIZE_A = (1 << SHIFT_A);
+    SIZE_B = (1 << SHIFT_B);
+    SIZE_C = (1 << SHIFT_C);
 
     Xbyak::Label loopE, loopM, loopN, loopK;
     Xbyak::Label l0, l1, l2, l3, l4, l5, l6, l7, l8, l9, la, lb;

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
@@ -731,7 +731,7 @@ dnnl_status_t sgemm_smalln_tn(const dim_t m, const dim_t n, const dim_t k,
 
     static dnnl_status_t st = dnnl_success;
     std::call_once(initialized, [&] {
-        for (dim_t N : {1, 2, 3, 4}) {
+        for (int N : {1, 2, 3, 4}) {
             for (float al : {0.0f, 1.0f, 2.0f}) {
                 for (float be : {0.0f, 1.0f, 2.0f}) {
                     auto &kern = kernels[N - 1][(dim_t)al][(dim_t)be];
@@ -761,7 +761,7 @@ dnnl_status_t sgemm_smalln_tn(const dim_t m, const dim_t n, const dim_t k,
 #define MROW_ALIGN 1
 #define MINROWS 16 // Min rows each thread should process
 
-static dim_t smalln_set_num_threads(dim_t m, dim_t k, dim_t nthr_to_use) {
+static int smalln_set_num_threads(dim_t m, dim_t k, int nthr_to_use) {
     /**
      * Simple heuristics for determining num threads to use
      */
@@ -773,7 +773,7 @@ static dim_t smalln_set_num_threads(dim_t m, dim_t k, dim_t nthr_to_use) {
     if ((m & 15) == 0) { // Special handling if m is multiple of 16
         // nthr_16: number of threads such that each thread works on
         // 2^n * 16 number of rows.
-        nthr_16 = m >> 4;
+        nthr_16 = static_cast<int>(m >> 4);
         while (nthr_16 > nthr_to_use && (nthr_16 & 1) == 0)
             nthr_16 = nthr_16 >> 1;
         // Ideal number of threads is more than what we can use.

--- a/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
@@ -1445,7 +1445,7 @@ struct xbyak_gemm_t : public jit_generator_t {
                             = AO1 + (ld_step + section * 4 - OFFSET) * SIZE;
                     for (int off = 0; off < 4; ++off)
                         pextrd(ptr[dst_addr + unroll_m * off * SIZE],
-                                Xmm(ld_step % 2), off);
+                                Xmm(ld_step % 2), static_cast<uint8_t>(off));
                 };
 
                 el_cp(0, 0);
@@ -2127,13 +2127,14 @@ private:
     const Address ARG_A = ptr[rsp + OFFSET_SHADOWSPACE + STACKSIZE];
     const Address ARG_LDA
             = qword[rsp + OFFSET_SHADOWSPACE + sizeof(float *) + STACKSIZE];
-    const int stackOffset = OFFSET_SHADOWSPACE + sizeof(float *) + STACKSIZE;
+    const int stackOffset = OFFSET_SHADOWSPACE + sizeof(float *)
+            + static_cast<int>(STACKSIZE);
     const Reg64 A = rsi;
     const Reg64 LDA = rdi;
 #else
     const Reg64 ARG_A = r8;
     const Reg64 ARG_LDA = r9;
-    const int stackOffset = STACKSIZE;
+    const int stackOffset = static_cast<int>(STACKSIZE);
     const Reg64 A = ARG_A;
     const Reg64 LDA = ARG_LDA;
 #endif

--- a/src/cpu/x64/gemm/gemm_driver.cpp
+++ b/src/cpu/x64/gemm/gemm_driver.cpp
@@ -135,7 +135,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         c_float += (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                static_cast<float>(c_data[i + j * ldc]) * beta);
                         c_data[i + j * ldc] += ctemp;
                     }
                 }
@@ -149,7 +150,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         c_float -= (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                static_cast<float>(c_data[i + j * ldc]) * beta);
                         c_data[i + j * ldc] -= ctemp;
                     }
                 }
@@ -159,7 +161,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         double c_float = alpha * (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] = alpha * ctemp;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                alpha * static_cast<float>(ctemp));
                     }
 
                 } else {
@@ -168,8 +171,11 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                                 + beta * (double)c_data[i + j * ldc];
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
-                        c_data[i + j * ldc] += alpha * ctemp;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                static_cast<float>(c_data[i + j * ldc]) * beta);
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                static_cast<float>(c_data[i + j * ldc])
+                                + alpha * static_cast<float>(ctemp));
                     }
                 }
             }
@@ -423,8 +429,8 @@ void gemm_kernel(dim_t m, dim_t n, const dim_t k, const float alpha,
     c_type *row_offset = row_offset_ws ? row_offset_ws : row_offset_stk;
 
     if (is_int8) {
-        c_type ao = arg->ao;
-        c_type bo = arg->bo;
+        c_type ao = static_cast<c_type>(arg->ao);
+        c_type bo = static_cast<c_type>(arg->bo);
         c_type co_0 = offsetc == offset_type::none ? 0 : co[0];
 
         if (bo != 0 || offsetc == offset_type::column) col_req = true;
@@ -952,7 +958,9 @@ static inline bool nocopy_checker_avx2(const int nthr, const int transa,
     static const double FORCE_NOCOPY_THRESH = 0.0038;
 
     // Crude threshold to nocopy kernels if copy overhead is significant.
-    if (1.0 / m + 1.0 / n >= FORCE_NOCOPY_THRESH) { return true; }
+    if (1.0 / (double)m + 1.0 / (double)n >= FORCE_NOCOPY_THRESH) {
+        return true;
+    }
 
     const dim_t LIMIT = 378;
     if (m <= LIMIT && n <= LIMIT && k >= nthr * LIMIT) return false;
@@ -1008,7 +1016,7 @@ static inline bool nocopy_checker_avx512(int nthr, const int transa,
         return false;
 
     // Crude threshold for nocopy kernels if copy overhead is significant.
-    if (1.0 / m + 1.0 / n >= FORCE_NOCOPY_THRESH
+    if (1.0 / (double)m + 1.0 / (double)n >= FORCE_NOCOPY_THRESH
             && !(is_lda_verybad && is_NT)) {
         return true;
     }
@@ -1281,11 +1289,11 @@ static inline void set_thread_opts_pack(int nthrs,
         block_z = utils::rnd_up(block_z, block_align);
         thread_z = num_blk * block_z;
         if (thread_z * nthr_z > size_z)
-            nthr_z = utils::div_up(size_z, thread_z);
+            nthr_z = static_cast<int>(utils::div_up(size_z, thread_z));
     };
 
     auto choose_m_blocking = [&]() {
-        auto align = get_vector_length<c_type>();
+        dim_t align = get_vector_length<c_type>();
         align = do_m_blocking_only ? arg->um : align;
         choose_blocking(m, thread_m, nthr_m, arg->bm, block_m, align);
     };
@@ -1623,9 +1631,9 @@ static inline void adjust_thread_count(dim_t m, dim_t n, dim_t k, int *nthrs) {
     if (is_only_avx2)
         if (m > 10 * n && n < *nthrs)
             if (m / *nthrs < veclen * 3)
-                *nthrs = nstl::max(m / veclen / 3, dim_t(1));
+                *nthrs = static_cast<int>(nstl::max(m / veclen / 3, dim_t(1)));
 
-    double gemm_cycles = m * n * k / fp_per_cycle;
+    double gemm_cycles = (double)(m * n * k) / fp_per_cycle;
     gemm_cycles *= is_f32 ? 2.0 : 8.0;
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL

--- a/src/cpu/x64/gemm/gemm_info.cpp
+++ b/src/cpu/x64/gemm/gemm_info.cpp
@@ -378,7 +378,7 @@ void gemm_info_t<a_t, b_t, c_t>::jit_init(void) {
     }
 
     // Note: um is fixed for a given set of data types and ISA.
-    const int um = this->um;
+    const int um = static_cast<int>(this->um);
 
     static std::once_flag initialized;
     static std::atomic<dnnl_status_t> st(dnnl_success);

--- a/src/cpu/x64/gemm/gemv_driver.cpp
+++ b/src/cpu/x64/gemm/gemv_driver.cpp
@@ -404,8 +404,8 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
     // Quick return if possible.
     if (m <= 0 || n <= 0) return;
 
-    dim_t nthr_max = dnnl_get_current_num_threads();
-    dim_t nthr_goal = thread_checker<a_t>(nthr_max, m, n, trans);
+    int nthr_max = dnnl_get_current_num_threads();
+    int nthr_goal = thread_checker<a_t>(nthr_max, m, n, trans);
 
     if (nthr_goal == 1) {
         gemv_kernel_driver(
@@ -425,10 +425,11 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
 
     // Always use the maximum number of threads to avoid OMP overhead that can
     // occur due to change thread counts.
-    auto nthr_spawn = dnnl_thr_syncable() ? nthr_max : nthr_goal;
+    const int nthr_spawn
+            = static_cast<int>(dnnl_thr_syncable() ? nthr_max : nthr_goal);
     int nbufs_used = 0;
     parallel(nthr_spawn, [&](int ithr, int nthr) {
-        int nthr_eff = nstl::min(nthr_goal, static_cast<dim_t>(nthr));
+        int nthr_eff = nstl::min(nthr_goal, nthr);
 
         dim_t thread_m = m, off_m = 0;
         dim_t thread_n = n, off_n = 0;

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -41,9 +41,9 @@ using namespace dnnl::impl::cpu::x64::bf16_support;
 // "declared with greater visibility than the type of its field"
 // when one lambda function is delcared whithin the other one
 void store_bfloat16_in_parallel(bfloat16_t *output_data, const float *acc_data,
-        size_t parallel_work, size_t parallel_work_size, bool do_in_parallel) {
+        dim_t parallel_work, dim_t parallel_work_size, bool do_in_parallel) {
     parallel(do_in_parallel ? 0 : 1, [&](const int ithr, const int nthr) {
-        size_t start = 0, end = 0;
+        dim_t start = 0, end = 0;
         balance211(parallel_work, nthr, ithr, start, end);
         if (start < end)
             cvt_float_to_bfloat16(&output_data[start * parallel_work_size],
@@ -52,11 +52,11 @@ void store_bfloat16_in_parallel(bfloat16_t *output_data, const float *acc_data,
     });
 }
 
-void cvt_acc_to_dst(const conv_gemm_conf_t &jcp, size_t g_start, size_t g_end,
+void cvt_acc_to_dst(const conv_gemm_conf_t &jcp, dim_t g_start, dim_t g_end,
         const float *acc_base, bfloat16_t *diff_weights) {
-    const size_t parallel_work_size = jcp.ic * jcp.ks;
+    const dim_t parallel_work_size = jcp.ic * jcp.ks;
     parallel(jcp.nthr == 1 ? 0 : 1, [&](const int ithr, const int nthr) {
-        size_t w_start = 0, w_end = 0;
+        dim_t w_start = 0, w_end = 0;
         balance211(parallel_work_size, nthr, ithr, w_start, w_end);
         for_(auto w = w_start; w < w_end; ++w)
         for (auto g = g_start; g < g_end; ++g) {
@@ -135,7 +135,7 @@ gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
 
 template <data_type_t dst_data_type>
 void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::apply_postops(
-        const bool apply_mask, const size_t out_offset, const int vmm_idx) {
+        const bool apply_mask, const dim_t out_offset, const int vmm_idx) {
 #define PARAM_OFF(x) offsetof(ker_args_t, x)
     if (jcp_.with_eltwise || jcp_.with_binary) {
         if (jcp_.with_binary) {
@@ -178,7 +178,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
 
     // Load accumulated value, apply sum (if any), bias (if any)
     // and relu (if any); then convert to destination type and store
-    auto compute = [&](size_t offset, int idx, bool apply_mask) {
+    auto compute = [&](dim_t offset, int idx, bool apply_mask) {
         auto acc_addr = ptr[reg_acc + offset * sizeof(acc_data_t)];
         auto vreg_dst_ = vreg_dst(idx);
 
@@ -231,9 +231,9 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
     };
 
     // Advance all pointers by an immediate
-    auto advance_ptrs_imm = [&](size_t offset) {
-        add(reg_dst, offset * sizeof(dst_data_t));
-        add(reg_acc, offset * sizeof(acc_data_t));
+    auto advance_ptrs_imm = [&](dim_t offset) {
+        add(reg_dst, offset * static_cast<dim_t>(sizeof(dst_data_t)));
+        add(reg_acc, offset * static_cast<dim_t>(sizeof(acc_data_t)));
     };
 
     Xbyak::Label oc_loop, oc_loop_end;
@@ -258,7 +258,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
         const int unroll = 1 << i; // 4, 2, 1
         L(l_simd_loop[i + 1]);
         {
-            const int loop_len = unroll * vlen_;
+            const int loop_len = static_cast<int>(unroll * vlen_);
             cmp(reg_len_iter, loop_len);
             jl(l_simd_loop[i], T_NEAR);
             for (int j = 0; j < unroll; j++)
@@ -393,17 +393,17 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
     const conv_gemm_conf_t &jcp = pd()->jcp_;
 
     // Src Format: mb-spatial-groups-input_channels
-    const size_t src_mb_stride = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw
+    const dim_t src_mb_stride = jcp.id * jcp.ih * jcp.iw
             * jcp.ngroups * jcp.ic;
-    const size_t src_g_stride = jcp.ic;
+    const dim_t src_g_stride = jcp.ic;
     // Wei Format: spatial-input_channels-groups-output_channels
-    const size_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
+    const dim_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
 
     // Dst Format: mb-spatial-groups-output_channels
-    const size_t dst_mb_stride = static_cast<size_t>(jcp.od) * jcp.oh * jcp.ow
+    const dim_t dst_mb_stride = jcp.od * jcp.oh * jcp.ow
             * jcp.ngroups * jcp.oc;
-    const size_t dst_g_stride = jcp.oc;
-    const size_t dst_os_stride = jcp.ngroups * jcp.oc;
+    const dim_t dst_g_stride = jcp.oc;
+    const dim_t dst_os_stride = jcp.ngroups * jcp.oc;
 
     src_data_t *__restrict col = scratchpad.get<src_data_t>(key_conv_gemm_col)
             + (ptrdiff_t)ithr * jcp.im2col_sz;
@@ -439,18 +439,18 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
         constexpr uint16_t zero_val = 0;
 
         PRAGMA_OMP_SIMD()
-        for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+        for (dim_t i = 0; i < jcp.im2col_sz; i++)
             col_r[i] = zero_val;
     }
     for (dim_t iwork = start; iwork < end; ++iwork) {
-        int oh = ohb * jcp.oh_block;
-        int ow = owb * jcp.ow_block;
+        dim_t oh = ohb * jcp.oh_block;
+        dim_t ow = owb * jcp.ow_block;
         const src_data_t *__restrict src
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const wei_data_t *__restrict wei = wei_base + g * wei_g_stride;
 
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const dim_t h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
+        const dim_t w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
 
@@ -488,7 +488,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
             const bool do_postprocess = pd()->is_postprocess_required();
             if (do_postprocess) {
                 parallel_nd_ext(jcp.nthr == 1 ? 0 : 1, N,
-                        [&](size_t ithr, size_t nthr, size_t os) {
+                        [&](int ithr, int nthr, dim_t os) {
                     const float *__restrict acc_arr = acc + os * jcp.oc;
                     const float *__restrict bia_arr = (bia_base == nullptr)
                             ? nullptr
@@ -550,22 +550,22 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
     const float sum_scale = do_sum ? post_ops.entry_[0].sum.scale : 0;
 
     const dim_t M = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * M;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-    const size_t weights_oc_size = jcp.ic * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * M;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+    const dim_t weights_oc_size = jcp.ic * jcp.ks;
 
     const dim_t LDB = weights_oc_size;
     const dim_t work_amount
-            = (size_t)jcp.ngroups * jcp.mb * jcp.od * jcp.os_nb_block;
+            = jcp.ngroups * jcp.mb * jcp.od * jcp.os_nb_block;
     const bool is_problem_3d = pd()->ndims() == 5;
     std::atomic<status_t> st(status::success);
 
-    auto inner_ker = [&](const int ic, const int oc, const int groups,
-                             const int od, const int spatial,
+    auto inner_ker = [&](const dim_t ic, const dim_t oc, const dim_t groups,
+                             const dim_t od, const dim_t spatial,
                              const src_data_t *src, const wei_data_t *weights,
                              src_data_t *col, dst_data_t *dst_im,
-                             acc_data_t *acc, int ic_block, int oc_block) {
+                             acc_data_t *acc, dim_t ic_block, dim_t oc_block) {
         const dim_t os_block = nstl::min(
                 (dim_t)jcp.os_block, (dim_t)jcp.os - spatial * jcp.os_block);
 
@@ -600,8 +600,8 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
         }
 
         if (this->pd()->is_postprocess_required() && ic + ic_block >= jcp.ic) {
-            size_t acc_str = LDC;
-            size_t dst_str = M;
+            const dim_t acc_str = LDC;
+            const dim_t dst_str = M;
             float *bias_ptr = bias ? bias + groups * jcp.oc + oc : nullptr;
             (*pp_ker_)(dst_local, acc, bias_ptr, sum_scale, dst_str, acc_str, m,
                     oc_block, post_ops_binary_rhs_arg_vec.data(), dst,
@@ -614,7 +614,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
         if (is_problem_3d) {
             // jit_gemm_convolution_utils::im2col_3d() requires external
             // data initialization by zeroes
-            for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+            for (dim_t i = 0; i < jcp.im2col_sz; i++)
                 _col[i] = (src_data_t)0;
         }
         dim_t g {0}, n {0}, od {0}, nb_os {0};
@@ -691,18 +691,18 @@ status_t gemm_bf16_convolution_bwd_data_t<
     const conv_gemm_conf_t &jcp = pd()->jcp_;
 
     // Diff_dst Format: mb-spatial-groups-output_channels
-    const size_t diff_dst_mb_stride = static_cast<size_t>(jcp.od) * jcp.oh
+    const dim_t diff_dst_mb_stride = jcp.od * jcp.oh
             * jcp.ow * jcp.ngroups * jcp.oc;
-    const size_t diff_dst_g_stride = jcp.oc;
+    const dim_t diff_dst_g_stride = jcp.oc;
 
     // Wei Format: spatial-input_channels-groups-output_channels
-    const size_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
+    const dim_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
 
     // Diff_src Format: mb-spatial-groups-input_channels
-    const size_t diff_src_mb_stride = static_cast<size_t>(jcp.id) * jcp.ih
+    const dim_t diff_src_mb_stride = jcp.id * jcp.ih
             * jcp.iw * jcp.ngroups * jcp.ic;
-    const size_t diff_src_g_stride = jcp.ic;
-    const size_t diff_src_os_stride = jcp.ngroups * jcp.ic;
+    const dim_t diff_src_g_stride = jcp.ic;
+    const dim_t diff_src_os_stride = jcp.ngroups * jcp.ic;
 
     // threads share work across mini-batch and groups
     const dim_t work_amount = jcp.ngroups * jcp.mb;
@@ -743,11 +743,11 @@ status_t gemm_bf16_convolution_bwd_data_t<
 
         if (is_diff_src_bf16 && jcp.ngroups == 1 && jcp.nthr != 1) {
             cvt_float_to_bfloat16((bfloat16_t *)diff_src, (const float *)acc,
-                    static_cast<size_t>(jcp.is) * jcp.id * jcp.ic);
+                    jcp.is * jcp.id * jcp.ic);
         } else if (is_diff_src_bf16) {
             parallel_nd_ext(jcp.nthr == 1 ? 0 : 1,
-                    static_cast<size_t>(jcp.is) * jcp.id,
-                    [&](size_t ithr, size_t nthr, size_t is) {
+                    jcp.is * jcp.id,
+                    [&](int ithr, int nthr, dim_t is) {
                 diff_src_data_t *__restrict diff_src_loc
                         = diff_src + is * diff_src_os_stride;
                 const acc_data_t *__restrict acc_loc = acc + is * jcp.ic;
@@ -757,8 +757,8 @@ status_t gemm_bf16_convolution_bwd_data_t<
         } else {
             assert(diff_src_data_type == data_type::f32);
             parallel_nd_ext(jcp.nthr == 1 ? 0 : 1,
-                    static_cast<size_t>(jcp.is) * jcp.id,
-                    [&](size_t ithr, size_t nthr, size_t is) {
+                    jcp.is * jcp.id,
+                    [&](int ithr, int nthr, dim_t is) {
                 diff_src_data_t *__restrict diff_src_loc
                         = diff_src + is * diff_src_os_stride;
                 const acc_data_t *__restrict acc_loc = acc + is * jcp.ic;
@@ -789,15 +789,15 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
     const conv_gemm_conf_t &jcp = this->pd()->jcp_;
 
     const dim_t M = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * M;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * M;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
 
     const dim_t m = jcp.os_block;
     const dim_t K = jcp.oc;
     const dim_t N = jcp.ic * jcp.ks;
 
-    const dim_t work_amount = (size_t)jcp.ngroups * jcp.mb;
+    const dim_t work_amount = jcp.ngroups * jcp.mb;
     const bool is_problem_3d = pd()->ndims() == 5;
 
     std::atomic<status_t> st(status::success);
@@ -820,7 +820,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
             if (is_problem_3d && jcp.im2col_sz > 0) {
                 // jit_gemm_convolution_utils::col2im_3d() assumes that the
                 // accumulator is initialized by zeroes
-                for (size_t i = 0; i < src_step; i++)
+                for (dim_t i = 0; i < src_step; i++)
                     acc[i] = (acc_data_t)0;
             }
 
@@ -854,7 +854,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
                 }
             }
             if (diff_src_data_type == data_type::bf16) {
-                size_t spatial_size = (size_t)jcp.ih * jcp.iw * jcp.id;
+                const dim_t spatial_size = jcp.ih * jcp.iw * jcp.id;
                 store_bfloat16_in_parallel((bfloat16_t *)diff_src_local,
                         (const float *)acc, jcp.ic, spatial_size,
                         jcp.nthr == 1);
@@ -869,7 +869,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
 template <data_type_t diff_wei_data_type>
 void gemm_bf16_convolution_bwd_weights_t<
         diff_wei_data_type>::bf16_bwd_weights_reduction_par_nspc(int ithr_mb,
-        int nthr_mb, size_t g_start, size_t g_end, const conv_gemm_conf_t &jcp,
+        int nthr_mb, dim_t g_start, dim_t g_end, const conv_gemm_conf_t &jcp,
         const acc_data_t *weights_reduce_base,
         diff_wei_data_t *weights_base) const {
     assert(nthr_mb > 1); // no reduction for nthr_mb == 1
@@ -911,20 +911,20 @@ void gemm_bf16_convolution_bwd_weights_t<
     assert(nthr_mb > 1); // no reduction for nthr_mb == 1
 
     const bool is_bf16_out = diff_wei_data_type == data_type::bf16;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-    size_t weights_start {0}, weights_end {0};
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+    dim_t weights_start {0}, weights_end {0};
     balance211(weights_g_size, nthr_mb, ithr_mb, weights_start, weights_end);
 
     if (weights_start >= weights_end) return; // nothing to do
 
-    size_t acc_size = weights_end - weights_start;
+    const dim_t acc_size = weights_end - weights_start;
     float *wei_reduced = is_bf16_out
             ? (float *)weights_reduce_base + weights_start
             : (float *)weights_base + weights_start;
     if (!is_bf16_out) {
         // f32 diff_weights require initialization by weights_reduce
         // for thr_mb = 0
-        for (size_t i = 0; i < acc_size; i++)
+        for (dim_t i = 0; i < acc_size; i++)
             wei_reduced[i] = ((float *)weights_reduce_base + weights_start)[i];
     }
 
@@ -970,11 +970,10 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             diff_bias = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
     }
 
-    const dim_t K = jcp.os * static_cast<size_t>(jcp.od);
-    const size_t src_step
-            = static_cast<size_t>(jcp.ic) * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = jcp.oc * K;
-    const size_t weights_g_size = jcp.oc;
+    const dim_t K = jcp.os * jcp.od;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * K;
+    const dim_t weights_g_size = jcp.oc;
 
     const dim_t k = jcp.os;
     const dim_t M = jcp.oc;
@@ -987,11 +986,14 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                ngroups_for_balance, mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
 
@@ -1002,8 +1004,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 + (ptrdiff_t)ithr * jcp.id * jcp.ic * jcp.is;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1017,7 +1019,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 constexpr uint16_t zero_val = 0;
 
                 PRAGMA_OMP_SIMD()
-                for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+                for (dim_t i = 0; i < jcp.im2col_sz; i++)
                     _col_r[i] = zero_val;
             }
 
@@ -1028,7 +1030,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
 
             const bool use_diff_wei
                     = ithr_mb == 0 && diff_wei_data_type == data_type::f32;
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 acc_data_t *_diff_weights = use_diff_wei
                         ? (acc_data_t *)diff_weights + g * weights_g_size
                         : need_reduction ? weights_reduce
@@ -1036,7 +1038,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 const dim_t LDC = use_diff_wei ? jcp.ngroups * jcp.oc
                         : need_reduction       ? jcp.oc
                                                : jcp.ngroups * jcp.oc;
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const src_data_t *_src
                             = src + mb * jcp.ngroups * src_step + g * jcp.ic;
                     if (jcp.im2col_sz && is_problem_3d)
@@ -1094,19 +1096,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     if (jcp.need_wei_reduction && !dnnl_thr_syncable()) {
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
-            size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+            dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    ngroups_for_balance, mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
 
             if (need_reduction && ithr_g != -1 && ithr_mb != -1) {
-                balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-                balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+                balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+                balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
                 assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1178,9 +1182,9 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     }
 
     const dim_t K = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * K;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * K;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
 
     const dim_t k = jcp.os_block;
     const dim_t N = jcp.oc;
@@ -1190,18 +1194,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     std::atomic<status_t> st(status::success);
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                ngroups_for_balance, mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
         const int need_reduction = nthr_mb != 1;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1210,7 +1217,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             // external data initialization by zeroes
             const bool outer_padding = jcp.os_nb_block == 1;
             if (outer_padding && is_problem_3d) {
-                for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+                for (dim_t i = 0; i < jcp.im2col_sz; i++)
                     _col[i] = (src_data_t)0;
             }
 
@@ -1219,11 +1226,11 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             acc_data_t *weights_reduce
                     = weights_reduce_base + ithr_mb * weights_g_size;
 
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 acc_data_t *acc = need_reduction
                         ? weights_reduce
                         : (acc_base + g * weights_g_size);
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const src_data_t *_src
                             = src + (mb * jcp.ngroups + g) * src_step;
                     for_(dim_t od = 0; od < jcp.od; ++od)
@@ -1275,8 +1282,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                         weights_reduce_base, weights_base);
             } else if (diff_wei_data_type == data_type::bf16
                     && g_end > g_start) {
-                const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-                const size_t work_size = (g_end - g_start) * weights_g_size;
+                const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+                const dim_t work_size = (g_end - g_start) * weights_g_size;
                 bfloat16_t *diff_weights_local
                         = (bfloat16_t *)diff_weights + g_start * weights_g_size;
                 const float *acc_local
@@ -1294,19 +1301,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     if (jcp.need_wei_reduction && !dnnl_thr_syncable()) {
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
-            size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+            dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    ngroups_for_balance, mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
 
             if (need_reduction && ithr_g != -1 && ithr_mb != -1) {
-                balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-                balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+                balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+                balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
                 assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1322,7 +1331,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     }
 
     if (jcp.with_bias) {
-        parallel_nd(jcp.ngroups, jcp.oc, [&](size_t g, size_t oc) {
+        parallel_nd(jcp.ngroups, jcp.oc, [&](dim_t g, dim_t oc) {
             acc_data_t db = 0;
             dim_t offset_ = g * dst_step + oc * K;
             for (dim_t mb = 0; mb < jcp.mb; ++mb) {

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -205,7 +205,7 @@ private:
         std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
                 postops_injector_;
 
-        void apply_postops(const bool apply_mask, const size_t out_offset,
+        void apply_postops(const bool apply_mask, const dim_t out_offset,
                 const int vmm_idx);
         void generate() override;
         int vreg_dst_idx(int iter) {
@@ -369,7 +369,7 @@ private:
             const conv_gemm_conf_t &jcp, const acc_data_t *weights_reduce_base,
             diff_wei_data_t *weights_base) const;
     void bf16_bwd_weights_reduction_par_nspc(int ithr_mb, int nthr_mb,
-            size_t g_start, size_t g_end, const conv_gemm_conf_t &jcp,
+            dim_t g_start, dim_t g_end, const conv_gemm_conf_t &jcp,
             const acc_data_t *weights_reduce_base,
             diff_wei_data_t *weights_base) const;
 

--- a/src/cpu/x64/gemm_bf16_inner_product.hpp
+++ b/src/cpu/x64/gemm_bf16_inner_product.hpp
@@ -283,7 +283,7 @@ struct gemm_bf16_inner_product_bwd_weights_t : public primitive_t {
             dim_t OCB_per_thread = utils::div_up(OCB, bias_reduction_nthr_);
 
             OC_per_thread = OCB_per_thread * bias_blksize;
-            nthr_OCB = utils::div_up(OCB, OCB_per_thread);
+            nthr_OCB = static_cast<int>(utils::div_up(OCB, OCB_per_thread));
             nthr_MB = bias_reduction_nthr_ / nthr_OCB;
 
             assert(nthr_OCB * nthr_MB <= bias_reduction_nthr_);

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -23,16 +23,16 @@ namespace cpu {
 namespace x64 {
 namespace injector_utils {
 
-static std::size_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
+static dim_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
     static constexpr int byte_size_bits = 8;
     return vmm.getBit() / byte_size_bits;
 }
 
-static std::size_t calc_vmm_to_preserve_size_bytes(
+static dim_t calc_vmm_to_preserve_size_bytes(
         const std::initializer_list<Xbyak::Xmm> &vmm_to_preserve) {
 
     return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(),
-            std::size_t(0u), [](std::size_t accum, const Xbyak::Xmm &vmm) {
+            dim_t(0), [](dim_t accum, const Xbyak::Xmm &vmm) {
         return accum + get_vmm_size_bytes(vmm);
     });
 }
@@ -214,7 +214,7 @@ void reg64_savable_t::addTo(const Xbyak::Reg64 &reg) const {
         regscratchpad_.jit().add(reg, *this);
 }
 
-void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, int imm) const {
+void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, dim_t imm) const {
     if (booking_ >= 0)
         regscratchpad_.jit().imul(reg, getStoragePtr(), imm);
     else

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -30,8 +30,8 @@ namespace cpu {
 namespace x64 {
 namespace injector_utils {
 
-using vmm_index_set_t = typename std::set<size_t>;
-using vmm_index_set_iterator_t = typename std::set<size_t>::iterator;
+using vmm_index_set_t = typename std::set<int>;
+using vmm_index_set_iterator_t = typename std::set<int>::iterator;
 
 enum class layout_t { ncsp, c_blocked, nspc, cspn, unsupported };
 
@@ -67,7 +67,7 @@ private:
     jit_generator_t *host_;
     std::stack<Xbyak::Reg64> reg64_stack_;
     std::stack<Xbyak::Xmm> vmm_stack_;
-    size_t vmm_to_preserve_size_bytes_;
+    dim_t vmm_to_preserve_size_bytes_;
 };
 
 class conditional_register_preserve_guard_t : public register_preserve_guard_t {
@@ -151,7 +151,7 @@ public:
     void restoreTo(const Xbyak::Reg64 &reg) const;
     void restoreTo(const Xbyak::Reg32 &reg32) const;
     void addTo(const Xbyak::Reg64 &reg) const;
-    void imulTo(const Xbyak::Reg64 &reg, int imm) const;
+    void imulTo(const Xbyak::Reg64 &reg, dim_t imm) const;
     Xbyak::Address getStoragePtr() const {
         return regscratchpad_.getPtr(booking_);
     }

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -269,7 +269,7 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
         const std::vector<const void *> &orig_post_ops_binary_rhs_arg_vec,
         std::vector<const void *> &post_ops_binary_rhs_arg_vec,
         uint8_t *expanded_rhs, const std::vector<dim_t> &expanded_elems_len) {
-    size_t offset = 0;
+    dim_t offset = 0;
     const int po_len = post_ops.len();
     auto binary_post_op_idx = 0;
 
@@ -287,7 +287,7 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
             auto *dst = expanded_rhs + offset;
 
             for (dim_t j = 0; j < expanded_elems_len[i]; ++j) {
-                const size_t src_idx = j % rhs_len;
+                const dim_t src_idx = j % rhs_len;
                 memcpy(dst + j * dt_size, src + src_idx * dt_size, dt_size);
             }
 
@@ -322,56 +322,50 @@ static_params_t::static_params_t(const Xbyak::Reg64 &param1,
     : static_params_t(param1, get_all_strategies_supported_by_injector(),
               rhs_arg_static_params) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, dim_t tail_size,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, Xbyak::Opmask(2), use_exact_tail_scalar_bcast,
               rhs_helper_reg, false /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, dim_t tail_size,
+        const Xbyak::Opmask &tail_opmask, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, tail_opmask, use_exact_tail_scalar_bcast,
               rhs_helper_reg, true /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        const Xbyak::Reg64 &reg_tail_size, bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, dim_t tail_size,
+        const Xbyak::Opmask &tail_opmask, const Xbyak::Reg64 &reg_tail_size,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, tail_opmask, use_exact_tail_scalar_bcast,
               reg_tail_size, true /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        bool use_exact_tail_scalar_bcast, const Xbyak::Reg64 &reg_tail_size,
-        bool is_opmask_set)
+        bool preserve_vmm_helper, dim_t abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, dim_t tail_size,
+        const Xbyak::Opmask &tail_opmask, bool use_exact_tail_scalar_bcast,
+        const Xbyak::Reg64 &reg_tail_size, bool is_opmask_set)
     : rhs_dt_helper_vmm_idx(rhs_dt_helper_vmm_idx)
     , rhs_addr_reg(rhs_addr_reg)
     , rhs_helper_reg(rhs_helper_reg)
@@ -412,14 +406,17 @@ static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
         const rhs_arg_dynamic_params_t &rhs_arg_params,
         broadcasting_strategy_t rhs_broadcasting_strategy) {
 
+    const int vmm_idx1_int = jit_generator_t::xbyak_register_index(vmm_idx1);
+    const int vmm_idx2_int = jit_generator_t::xbyak_register_index(vmm_idx2);
+
     const auto &out_addr = rhs_arg_params.vmm_idx_to_out_addr;
     const auto &out_reg = rhs_arg_params.vmm_idx_to_out_reg;
     const auto &out_elem_off_val = rhs_arg_params.vmm_idx_to_out_elem_off_val;
 
     if (rhs_broadcasting_strategy != broadcasting_strategy_t::scalar) {
-        return params_differ(out_addr, vmm_idx1, vmm_idx2)
-                || params_differ(out_reg, vmm_idx1, vmm_idx2)
-                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2);
+        return params_differ(out_addr, vmm_idx1_int, vmm_idx2_int)
+                || params_differ(out_reg, vmm_idx1_int, vmm_idx2_int)
+                || params_differ(out_elem_off_val, vmm_idx1_int, vmm_idx2_int);
     }
     return false;
 }
@@ -496,20 +493,19 @@ std::pair<bool, int> jit_uni_binary_injector_t<isa, Vmm>::should_preserve_vmm(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(size_t start_idx,
-        size_t end_idx, std::size_t rhs_arg_idx,
-        const dnnl_post_ops::entry_t &post_op,
+void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(int start_idx,
+        int end_idx, dim_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
     injector_utils::vmm_index_set_t vmm_idxs;
-    for (size_t i = start_idx; i < end_idx; i++)
+    for (int i = start_idx; i < end_idx; i++)
         vmm_idxs.emplace(i);
     compute_vector_range(vmm_idxs, rhs_arg_idx, post_op, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
-        const injector_utils::vmm_index_set_t &vmm_idxs,
-        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+        const injector_utils::vmm_index_set_t &vmm_idxs, dim_t rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
 
     if (vmm_idxs.empty()) return;
@@ -547,7 +543,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
     const bool use_offset_conversions
             = (!rhs_arg_params.vmm_idx_to_out_addr.empty()
                     || !rhs_arg_params.vmm_idx_to_out_reg.empty());
@@ -641,7 +638,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
     Xbyak::Address rhs2_arg_addr {};
 
     // Phase 3 Apply binary post-op over all vmms.
-    for (const auto vmm_idx : vmm_idxs) {
+    for (const auto set_vmm_idx : vmm_idxs) {
+        const int vmm_idx = set_vmm_idx;
         const bool is_start_idx = vmm_idx == start_idx;
         const bool with_tail = rhs_arg_static_params_.is_tail
                 && vmm_tail_idx.find(vmm_idx) != vmm_tail_idx.cend()
@@ -720,8 +718,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::compute_vector_range(
 
 template <cpu_isa_t isa, typename Vmm>
 Xbyak::Address jit_uni_binary_injector_t<isa, Vmm>::prepare_rhs_arg_addr(
-        std::size_t vmm_idx, std::size_t rhs_arg_idx,
-        const dnnl_post_ops::entry_t &post_op,
+        int vmm_idx, dim_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params,
         const broadcasting_strategy_t rhs_broadcasting_strategy, bool is_first,
         bool is_ternary_input) const {
@@ -852,9 +849,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first, bool cache_addr) const {
+        dim_t elem_size_bytes, bool is_first, bool cache_addr) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -870,7 +867,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_no_broadcast_offset(
         if (is_first || !cache_addr) {
             calculate_no_broadcast_base(out_addr, tmp_reg);
             if (elem_size_bytes > 1) {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->sal(tmp_reg, shift_val);
             }
             host_->add(addr_reg, tmp_reg);
@@ -898,14 +896,14 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_base(
     host_->sub(out_reg,
             host_->ptr[param1_ + rhs_arg_static_params_.dst_orig_offset]);
     host_->shr(out_reg,
-            std::log2(types::data_type_size(
-                    rhs_arg_static_params_.dst_d.data_type())));
+            static_cast<int>(std::log2(types::data_type_size(
+                    rhs_arg_static_params_.dst_d.data_type()))));
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_no_broadcast_partial(
-        const std::size_t offset, const Xbyak::Reg64 &out_reg,
-        std::size_t elem_size_bytes) const {
+        const dim_t offset, const Xbyak::Reg64 &out_reg,
+        dim_t elem_size_bytes) const {
     const auto offset_adj = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     host_->mov(out_reg,
@@ -917,9 +915,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -971,7 +969,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1026,8 +1025,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = (offset % strides[0]) / strides[1]
     const auto offset_adj
             = ((offset >> math::ilog2q(types::data_type_size(
@@ -1047,7 +1046,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
     const auto r8 = host_->r8;
@@ -1072,11 +1072,12 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     const auto offset_adj = ((offset_shr % strides[0]) / strides[1]) * blk_size
@@ -1104,8 +1105,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = offset % C
     const auto C = rhs_arg_static_params_.dst_d.dims()[1];
     const auto offset_adj = (offset >> math::ilog2q(types::data_type_size(
@@ -1132,8 +1133,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = offset / strides[1]
     const auto offset_adj = (offset >> math::ilog2q(types::data_type_size(
                                      rhs_arg_static_params_.dst_d.data_type())))
@@ -1147,9 +1148,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -1190,7 +1191,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_d_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1250,8 +1252,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_d_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_d_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // dst_offset % dstride[0] / dstride[2] = b*C + c
     const auto offset_adj
             = ((offset >> math::ilog2q(types::data_type_size(
@@ -1267,9 +1269,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first,
+        dim_t elem_size_bytes, bool is_first,
         const memory_desc_wrapper &rhs_d) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
@@ -1328,7 +1330,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_sp_offset(
                 if (elem_size_bytes == 1) {
                     host_->add(addr_reg, rax);
                 } else {
-                    const int shift_val = std::log2(elem_size_bytes);
+                    const int shift_val
+                            = static_cast<int>(std::log2(elem_size_bytes));
                     host_->mov(tmp_reg, rax);
                     host_->sal(tmp_reg, shift_val);
                     host_->add(addr_reg, tmp_reg);
@@ -1374,7 +1377,7 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
         const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
         const dim_t *dst_strides, const Xbyak::Reg64 &addr_reg,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const {
     // offset = n*dst_stride_n + c*dst_stride_c + d*dst_stride_d + h*dst_stride_h + w*dst_stride_w
     // rhs_off = n*rhs_stride_n + d*rhs_stride_d + h*rhs_stride_h + w*rhs_stride_w
     // per_mb_spatial: channel c is broadcast, so rem = (offset % dst_stride_n) % dst_stride_c.
@@ -1448,7 +1451,7 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, r8);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = static_cast<int>(std::log2(elem_size_bytes));
         host_->mov(tmp_reg, r8);
         host_->sal(tmp_reg, shift_val);
         host_->add(addr_reg, tmp_reg);
@@ -1459,9 +1462,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa,
         Vmm>::calculate_mb_sp_ncsp_partial_rhs_strided(const memory_desc_wrapper
                                                                &dst_d,
-        const memory_desc_wrapper &rhs_d, std::size_t dst_offset_bytes,
+        const memory_desc_wrapper &rhs_d, dim_t dst_offset_bytes,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes) const {
+        dim_t elem_size_bytes) const {
     const dim_t rhs_offset
             = rhs_offset_per_mb_spatial(dst_d, rhs_d, dst_offset_bytes);
     if (rhs_offset == 0) return;
@@ -1469,7 +1472,7 @@ void jit_uni_binary_injector_t<isa,
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, rhs_offset);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = static_cast<int>(std::log2(elem_size_bytes));
         const uint64_t rhs_offset_bytes = static_cast<uint64_t>(rhs_offset)
                 << shift_val;
         host_->mov(tmp_reg, rhs_offset_bytes);
@@ -1523,8 +1526,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_sp_off = (n * (stride_n/C)) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW)
@@ -1555,7 +1558,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
     const auto dst_d = rhs_arg_static_params_.dst_d;
     const int simd_w = cpu_isa_traits_t<isa>::vlen
             / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
 
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
@@ -1577,8 +1581,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
 
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1587,7 +1591,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_blocked_partial(
     const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
     const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
     const auto W = (ndims >= 3) ? dst_d.dims()[ndims - 1] : 1;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = jit_generator_t::xbyak_register_index(
+            dst_d.blocking_desc().inner_blks[0]);
 
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
@@ -1619,8 +1624,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_sp_off = nDHW + dHW + hW + w
     // mb_sp_off = offset / C
@@ -1652,8 +1657,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_sp_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_sp_off = dHWN + hWN + wN + n
     // mb_sp_off = offset % stride_c
@@ -1669,9 +1674,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -1724,7 +1729,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1821,8 +1827,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1852,8 +1858,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_blocked_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
     calculate_mb_w_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
@@ -1912,8 +1918,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_w_off = nW + w
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1962,8 +1968,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_w_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_w_off = wN + n
     const auto ndims = rhs_arg_static_params_.dst_d.ndims();
@@ -1980,9 +1986,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2034,7 +2040,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2067,8 +2074,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_hw_offset(
 }
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_hw_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nCHW + cHW + hW + w (for 4D)
     // per_spatial_off = offset % HW
 
@@ -2114,9 +2121,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2168,7 +2175,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2233,8 +2241,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // w_off = w * stride_w
     const auto ndims = rhs_arg_static_params_.dst_d.ndims();
@@ -2255,8 +2263,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_blocked_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     calculate_w_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
 
@@ -2289,8 +2297,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // w_off = w
     const auto ndims = rhs_arg_static_params_.dst_d.ndims();
@@ -2313,8 +2321,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_w_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // w_off = w
     calculate_w_nspc_partial(strides, offset, tmp_reg, elem_size_bytes);
@@ -2324,9 +2332,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2378,7 +2386,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2431,8 +2440,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_off = offset / stride_n
     // mb_off = n
@@ -2454,8 +2463,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_off = n;
     calculate_mb_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
@@ -2483,8 +2492,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_off = offset % N = offset % strides[ndims-1]
     // mb_off = n
@@ -2501,9 +2510,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2555,7 +2564,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_oc_spatial_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2606,8 +2616,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // oc_spatial_off = offset % stride_n
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2628,8 +2638,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // oc_spatial_off = offset % stride_n
     calculate_oc_spatial_ncsp_partial(
@@ -2655,8 +2665,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_oc_spatial_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // oc_spatial_off = offset / strides[ndims - 1]
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2672,9 +2682,9 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2726,7 +2736,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::append_mb_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val
+                        = static_cast<int>(std::log2(elem_size_bytes));
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2777,8 +2788,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_ncsp_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nCDHW + cDHW + dHW + hW + w
     // mb_oc_off = offset / DHW
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2820,8 +2831,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_nspc_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_oc_off = nC + c
     // mb_oc_off = (offset / DHWC) * C + offset % C
@@ -2869,8 +2880,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_cspn_base(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::calculate_mb_oc_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_oc_off = cN + n
     // mb_oc_off = (offset / DHWN) * N + offset % N
@@ -3277,14 +3288,14 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_with_opmask(
 
 static constexpr int xmm_size_elem = 4;
 
-static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
-        std::size_t tail_size, const std::function<void()> &init_op,
+static void load_tail_avx(jit_generator_t *host, int ymm_idx, dim_t tail_size,
+        const std::function<void()> &init_op,
         const std::function<void(int, bool)> &ymm_upper_half_op,
         const std::function<void(int)> &ymm_lower_half_op) {
 
     if (init_op) init_op();
 
-    const auto res = std::div(tail_size, xmm_size_elem);
+    const auto res = std::div(static_cast<int>(tail_size), xmm_size_elem);
     const auto &ymm_upper_half_op_data_size = res.rem;
     const bool should_load_lower_half = res.quot;
 
@@ -3306,8 +3317,7 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
     }
 }
 
-static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
-        std::size_t tail_size,
+static void load_tail_avx(jit_generator_t *host, int ymm_idx, dim_t tail_size,
         const std::function<void(int, bool)> &ymm_upper_half_op,
         const std::function<void(int)> &ymm_lower_half_op) {
     load_tail_avx(host, ymm_idx, tail_size, nullptr, ymm_upper_half_op,
@@ -3316,12 +3326,13 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
 
 static Xbyak::uint8 MM_SHUFFLE(
         Xbyak::uint8 z, Xbyak::uint8 y, Xbyak::uint8 x, Xbyak::uint8 w) {
-    return (((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
+    return static_cast<Xbyak::uint8>(
+            ((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
 }
 
 static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
         const Xbyak::Ymm &vmm, const Xbyak::Address &rhs_addr,
-        std::size_t tail_size) {
+        dim_t tail_size) {
 
     const auto vmm_idx = vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
@@ -3346,7 +3357,7 @@ static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
 
 static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
         const Xbyak::Xmm &vmm, const Xbyak::Address &rhs_addr,
-        std::size_t tail_size) {
+        dim_t tail_size) {
 
     const auto vmm_idx = vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
@@ -3365,7 +3376,7 @@ struct helper_bcast_tail_t {};
 template <typename Vmm>
 struct helper_bcast_tail_t<avx2, Vmm> {
     static void execute_broadcast_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const data_type_t &data_type,
+            const dim_t tail_size, const data_type_t &data_type,
             const Vmm &tmp_vmm, const Xbyak::Address &rhs_addr) {
         host->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
@@ -3373,8 +3384,9 @@ struct helper_bcast_tail_t<avx2, Vmm> {
             execute_broadcast_f32_tail_avx(host, tmp_vmm, rhs_addr, tail_size);
         } else if (data_type == data_type::u8 || data_type == data_type::s8) {
             const auto tmp_xmm = Xbyak::Xmm(tmp_vmm.getIdx());
-            for (std::size_t i = 0; i < tail_size; i++)
-                host->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, i);
+            for (int i = 0; i < tail_size; i++)
+                host->vpinsrb(
+                        tmp_xmm, tmp_xmm, rhs_addr, static_cast<uint8_t>(i));
 
             if (data_type == data_type::s8)
                 host->vpmovsxbd(tmp_vmm, tmp_xmm);
@@ -3388,7 +3400,7 @@ struct helper_bcast_tail_t<avx2, Vmm> {
 template <typename Vmm>
 struct helper_bcast_tail_t<avx2_vnni_2, Vmm> {
     static void execute_broadcast_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const data_type_t &data_type,
+            const dim_t tail_size, const data_type_t &data_type,
             const Vmm &tmp_vmm, const Xbyak::Address &rhs_addr,
             fp8_conversion_e5m2_t *f8_e5m2_cvt,
             fp8_conversion_e4m3_t *f8_e4m3_cvt) {
@@ -3397,7 +3409,8 @@ struct helper_bcast_tail_t<avx2_vnni_2, Vmm> {
             const auto tmp_lower_vmm =
                     typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
             host->load_bytes(tmp_lower_vmm, rhs_addr,
-                    tail_size * types::data_type_size(data_type));
+                    static_cast<int>(
+                            tail_size * types::data_type_size(data_type)));
             if (data_type == data_type::bf16) {
                 host->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
                 host->vpslld(tmp_vmm, tmp_vmm, 16);
@@ -3416,7 +3429,7 @@ struct helper_bcast_tail_t<avx2_vnni_2, Vmm> {
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_injector_t<isa, Vmm>::execute_broadcast_tail_statically(
         const data_type_t &data_type, const Vmm &tmp_vmm,
-        const Xbyak::Address &rhs_addr, const std::size_t tail_size) const {
+        const Xbyak::Address &rhs_addr, const dim_t tail_size) const {
     assert(!"unsupported tail load mode");
 }
 
@@ -3425,7 +3438,7 @@ void jit_uni_binary_injector_t<avx2_vnni_2,
         Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
     helper_bcast_tail_t<avx2_vnni_2,
             Xbyak::Ymm>::execute_broadcast_tail_statically(host_, tail_size,
             data_type, tmp_vmm, rhs_addr, f8_e5m2_cvt_, f8_e4m3_cvt_);
@@ -3436,7 +3449,7 @@ void jit_uni_binary_injector_t<avx2_vnni_2,
         Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
     helper_bcast_tail_t<avx2_vnni_2,
             Xbyak::Xmm>::execute_broadcast_tail_statically(host_, tail_size,
             data_type, tmp_vmm, rhs_addr, f8_e5m2_cvt_, f8_e4m3_cvt_);
@@ -3447,7 +3460,7 @@ void jit_uni_binary_injector_t<avx2,
         Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
     helper_bcast_tail_t<avx2, Xbyak::Ymm>::execute_broadcast_tail_statically(
             host_, tail_size, data_type, tmp_vmm, rhs_addr);
 }
@@ -3457,7 +3470,7 @@ void jit_uni_binary_injector_t<avx2,
         Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
     helper_bcast_tail_t<avx2, Xbyak::Xmm>::execute_broadcast_tail_statically(
             host_, tail_size, data_type, tmp_vmm, rhs_addr);
 }
@@ -3467,7 +3480,7 @@ void jit_uni_binary_injector_t<avx,
         Xbyak::Ymm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Ymm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
@@ -3513,13 +3526,13 @@ void jit_uni_binary_injector_t<avx,
         Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
     const auto load_tail_avx_xmm = [&]() {
-        for (size_t i = 0; i < tail_size; i++)
-            host_->vpinsrb(tmp_vmm, tmp_vmm, rhs_addr, i);
+        for (int i = 0; i < tail_size; i++)
+            host_->vpinsrb(tmp_vmm, tmp_vmm, rhs_addr, static_cast<uint8_t>(i));
     };
 
     if (data_type == data_type::f32 || data_type == data_type::s32) {
@@ -3539,7 +3552,7 @@ void jit_uni_binary_injector_t<sse41,
         Xbyak::Xmm>::execute_broadcast_tail_statically(const data_type_t
                                                                &data_type,
         const Xbyak::Xmm &tmp_vmm, const Xbyak::Address &rhs_addr,
-        const std::size_t tail_size) const {
+        const dim_t tail_size) const {
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
     if (data_type == data_type::f32 || data_type == data_type::s32) {
@@ -3550,8 +3563,8 @@ void jit_uni_binary_injector_t<sse41,
         if (tail_size > 1) host_->shufps(tmp_vmm, tmp_vmm, imms[tail_size - 2]);
 
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        for (std::size_t i = 0; i < tail_size; i++)
-            host_->pinsrb(tmp_vmm, rhs_addr, i);
+        for (int i = 0; i < tail_size; i++)
+            host_->pinsrb(tmp_vmm, rhs_addr, static_cast<uint8_t>(i));
 
         if (data_type == data_type::s8)
             host_->pmovsxbd(tmp_vmm, tmp_vmm);
@@ -3729,7 +3742,7 @@ struct helper_load_tail_t {};
 template <typename Vmm>
 struct helper_load_tail_t<avx2, Vmm> {
     static void load_rhs_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
+            const dim_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
             const data_type_t &data_type, const Vmm &tmp_vmm,
             const Xbyak::Address &rhs_addr) {
 
@@ -3737,21 +3750,22 @@ struct helper_load_tail_t<avx2, Vmm> {
                     data_type::s8, data_type::u8))
             assert(!"unsupported data type");
 
-        host->load_data(data_type, tmp_vmm, rhs_addr_reg, 0, tail_size);
+        host->load_data(data_type, tmp_vmm, rhs_addr_reg, 0,
+                static_cast<int>(tail_size));
     }
 };
 
 template <typename Vmm>
 struct helper_load_tail_t<avx2_vnni_2, Vmm> {
     static void load_rhs_tail_statically(jit_generator_t *host,
-            const size_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
+            const dim_t tail_size, const Xbyak::Reg64 &rhs_addr_reg,
             const data_type_t &data_type, const Vmm &tmp_vmm,
             const Xbyak::Address &rhs_addr) {
         if (utils::one_of(data_type, data_type::bf16, data_type::f16)) {
             const auto tmp_lower_vmm =
                     typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
             host->load_bytes(tmp_lower_vmm, rhs_addr_reg, 0,
-                    tail_size * sizeof(bfloat16_t));
+                    static_cast<int>(tail_size * sizeof(bfloat16_t)));
             if (data_type == data_type::bf16) {
                 host->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
                 host->vpslld(tmp_vmm, tmp_vmm, 16);
@@ -3814,7 +3828,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
 
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
     static constexpr int xmm_size_elem = 4;
-    const auto res = std::div(tail_size, xmm_size_elem);
+    const auto res = std::div(static_cast<int>(tail_size), xmm_size_elem);
     const auto vmm_idx = tmp_vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
 
@@ -3827,7 +3841,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
             for (int i = 0; i < res.rem; i++)
                 host_->vpinsrd(tmp_xmm, tmp_xmm,
                         host_->ptr[rhs_addr_reg + offset + i * sizeof(float)],
-                        i);
+                        static_cast<uint8_t>(i));
         };
 
         const auto lower_half_op = [&](int upper_half_data_size) {
@@ -3849,7 +3863,7 @@ void jit_uni_binary_injector_t<avx, Xbyak::Ymm>::load_rhs_tail_statically(
             for (int i = 0; i < upper_half_data_size; i++)
                 host_->vpinsrb(tmp_xmm, tmp_xmm,
                         host_->ptr[rhs_addr_reg + offset + i * sizeof(int8_t)],
-                        i);
+                        static_cast<uint8_t>(i));
             cvt_to_dword(tmp_xmm);
         };
 
@@ -3870,13 +3884,15 @@ void jit_uni_binary_injector_t<avx, Xbyak::Xmm>::load_rhs_tail_statically(
     host_->uni_vxorps(tmp_vmm, tmp_vmm, tmp_vmm);
 
     if (data_type == data_type::f32 || data_type == data_type::s32) {
-        for (size_t i = 0; i < tail_size; i++)
+        for (int i = 0; i < tail_size; i++)
             host_->vpinsrd(tmp_vmm, tmp_vmm,
-                    host_->ptr[rhs_addr_reg + i * sizeof(float)], i);
+                    host_->ptr[rhs_addr_reg + i * sizeof(float)],
+                    static_cast<uint8_t>(i));
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
-        for (size_t i = 0; i < tail_size; i++)
+        for (int i = 0; i < tail_size; i++)
             host_->vpinsrb(tmp_vmm, tmp_vmm,
-                    host_->ptr[rhs_addr_reg + i * sizeof(int8_t)], i);
+                    host_->ptr[rhs_addr_reg + i * sizeof(int8_t)],
+                    static_cast<uint8_t>(i));
         if (data_type == data_type::s8)
             host_->vpmovsxbd(tmp_vmm, tmp_vmm);
         else
@@ -3895,7 +3911,7 @@ void jit_uni_binary_injector_t<sse41, Xbyak::Xmm>::load_rhs_tail_statically(
 
     const auto &tail_size = rhs_arg_static_params_.tail_size;
     host_->load_data(data_type, tmp_vmm, rhs_arg_static_params_.rhs_addr_reg, 0,
-            tail_size);
+            static_cast<int>(tail_size));
 }
 
 // Support compare with Address param only when isa is avx512.
@@ -3914,7 +3930,7 @@ jit_uni_binary_injector_t<isa, Vmm>::execute_cmp_binary(const Vmm &dst,
     const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
 
     push_opmask(host_, cmp_mask);
-    host_->vcmpps(cmp_mask, lhs, rhs, cmp_predicate);
+    host_->vcmpps(cmp_mask, lhs, rhs, static_cast<uint8_t>(cmp_predicate));
     host_->mov(reg_tmp, float2int(1));
     host_->uni_vmovq(xreg_one, reg_tmp);
     // broadcast 1.0f with mask
@@ -4083,8 +4099,8 @@ void jit_uni_binary_injector_t<isa, Vmm>::execute_prelu(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_binary_injector_t<isa, Vmm>::compute_vector(size_t idx,
-        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+void jit_uni_binary_injector_t<isa, Vmm>::compute_vector(int idx,
+        dim_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
     compute_vector_range({idx}, rhs_arg_idx, post_op, rhs_arg_params);
 }

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -110,57 +110,56 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
  * for load with tail in runtime.
  */
 struct rhs_arg_static_params_t {
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size = 0u,
-            bool use_exact_tail_scalar_bcast = false);
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            bool preserve_vmm_helper, dim_t abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            dim_t tail_size = 0u, bool use_exact_tail_scalar_bcast = false);
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, dim_t abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
             bool use_exact_tail_scalar_bcast);
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, dim_t abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
             const Xbyak::Reg64 &reg_tail_size,
             bool use_exact_tail_scalar_bcast);
 
     bool is_opmask_set() const noexcept { return is_opmask_set_; }
 
-    mutable std::size_t rhs_dt_helper_vmm_idx;
+    mutable int rhs_dt_helper_vmm_idx;
     Xbyak::Reg64 rhs_addr_reg;
     Xbyak::Reg64 rhs_helper_reg;
     Xbyak::Reg64 rhs_addr_cache_reg;
     bool preserve_gpr_helpers;
     bool preserve_vmm_helper;
-    std::size_t abi_param_offset;
-    std::size_t dst_orig_offset;
+    dim_t abi_param_offset;
+    dim_t dst_orig_offset;
     memory_desc_wrapper dst_d;
-    std::size_t tail_size;
+    dim_t tail_size;
     Xbyak::Opmask tail_opmask;
     bool use_exact_tail_scalar_bcast;
     Xbyak::Reg64 reg_tail_size;
     bool is_tail;
 
 private:
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, dim_t abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            dim_t tail_size, const Xbyak::Opmask &tail_opmask,
             bool use_exact_tail_scalar_bcast, const Xbyak::Reg64 &reg_tail_size,
             bool is_opmask_set);
 
@@ -237,7 +236,7 @@ enum class tail_lode_mode_t { STATIC, DYNAMIC, DEFAULT };
 struct rhs_arg_dynamic_params_t {
     std::map<int, Xbyak::Address> vmm_idx_to_out_addr;
     std::map<int, Xbyak::Reg64> vmm_idx_to_out_reg;
-    std::map<int, size_t> vmm_idx_to_out_elem_off_val;
+    std::map<int, dim_t> vmm_idx_to_out_elem_off_val;
 
     std::unordered_set<int> vmm_tail_idx_;
     tail_lode_mode_t tail_load_mode = tail_lode_mode_t::DEFAULT;
@@ -281,7 +280,7 @@ public:
      * described inside rhs_arg_params.
      */
     void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            dim_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
     /*
@@ -291,8 +290,8 @@ public:
      * determined broadcast strategy and information about stored data in particular
      * vmm described inside rhs_arg_params.
      */
-    void compute_vector_range(size_t start_idx, size_t end_idx,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+    void compute_vector_range(int start_idx, int end_idx, dim_t rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
     /*
@@ -301,7 +300,7 @@ public:
      * for computations based on internally determined broadcast strategy and information
      * about stored data in particular vmm described inside rhs_arg_params.
      */
-    void compute_vector(size_t idx, std::size_t rhs_arg_idx,
+    void compute_vector(int idx, dim_t rhs_arg_idx,
             const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
@@ -319,8 +318,8 @@ private:
      * address of rhs tensor slice needed for binary operation and returns
      * ptr to it.
      */
-    Xbyak::Address prepare_rhs_arg_addr(std::size_t vmm_idx,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+    Xbyak::Address prepare_rhs_arg_addr(int vmm_idx, dim_t rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params,
             const broadcasting_strategy_t rhs_broadcasting_strategy,
             bool is_first, bool is_ternary_input) const;
@@ -343,229 +342,207 @@ private:
     void append_no_broadcast_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
-            bool is_first, bool cache_addr) const;
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes, bool is_first,
+            bool cache_addr) const;
     void calculate_no_broadcast_base(
             Xbyak::Address addr, const Xbyak::Reg64 &out_reg) const;
-    void calculate_no_broadcast_partial(const std::size_t offset,
-            const Xbyak::Reg64 &out_reg, std::size_t elem_size_bytes) const;
+    void calculate_no_broadcast_partial(const dim_t offset,
+            const Xbyak::Reg64 &out_reg, dim_t elem_size_bytes) const;
 
     void append_oc_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_blocked_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_oc_d_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_d_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_d_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_d_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_sp_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
-            bool is_first, const memory_desc_wrapper &rhs_d) const;
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes, bool is_first,
+            const memory_desc_wrapper &rhs_d) const;
     void calculate_mb_sp_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_ncsp_base_rhs_strided(const memory_desc_wrapper &dst_d,
             const memory_desc_wrapper &rhs_d, const dim_t *dst_strides,
             const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            dim_t elem_size_bytes) const;
     void calculate_mb_sp_ncsp_partial_rhs_strided(
             const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
-            std::size_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const;
+            dim_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_mb_sp_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_mb_sp_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_w_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_w_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_w_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_mb_w_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_mb_w_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_w_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_w_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_w_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_w_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_w_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_w_blocked_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_w_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_w_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_w_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_w_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_w_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_oc_spatial_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_spatial_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_oc_spatial_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_oc_spatial_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
 
     void append_hw_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_hw_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_hw_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_hw_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_oc_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_oc_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_oc_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_oc_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     template <typename T>
     typename std::enable_if<std::is_same<T, Xbyak::Zmm>::value
@@ -598,7 +575,7 @@ private:
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr) const;
     void execute_broadcast_tail_statically(const data_type_t &data_type,
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr,
-            const std::size_t tail_size) const;
+            const dim_t tail_size) const;
     void execute_broadcast_tail_with_gpr(const data_type_t &data_type,
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr) const;
     void load_rhs_tail_dynamically_with_opmask(const data_type_t &data_type,

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -64,7 +64,7 @@ bool is_supported(cpu_isa_t isa, alg_kind_t alg, data_type_t dt) {
 using namespace Xbyak;
 
 template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::get_stack_vmm_space() {
+dim_t jit_uni_eltwise_injector_t<isa, Wmm>::get_stack_vmm_space() {
     return (save_state_ * preserve_vmm_ * n_vregs_to_preserve_
                    + op_vecs_count(alg_, is_fwd_))
             * vlen_;
@@ -83,7 +83,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
 
     n_vregs_preserved_ = 0;
     assert(IMPLICATION(!vmm_aux_indices.empty(),
-            vmm_aux_indices.size() == n_vregs_to_preserve_));
+            static_cast<int>(vmm_aux_indices.size()) == n_vregs_to_preserve_));
 
     const auto start_idx = *(vmm_compute_idxs.begin());
     const auto end_idx = *(vmm_compute_idxs.rbegin()) + 1;
@@ -99,21 +99,21 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
 
     // `n_vregs_preserved_` is 0 for isa higher than `sse41`.
     // Note that by happy coincidence, idx=0 is skipped for `sse41`.
-    for (size_t idx = n_vregs_preserved_; idx < n_vregs_; idx++) {
+    for (int idx = n_vregs_preserved_; idx < n_vregs_; idx++) {
         // Once reserved enough vmm registers, break the loop.
         if (n_vregs_preserved_ >= n_vregs_to_preserve_) break;
 
         // Thanks to `std::set` LegacyBidirectionalIterator `iterator` member
         // that doesn't have operator+ defined.
-        size_t external_idx = 0;
+        int external_idx = 0;
         if (!vmm_aux_indices.empty()) {
             auto it = vmm_aux_indices.begin();
-            for (size_t i = 0; i < idx; i++)
+            for (int i = 0; i < idx; i++)
                 it++;
             external_idx = *it;
             assert(it != vmm_aux_indices.end());
         }
-        size_t preserve_idx = vmm_aux_indices.empty() ? idx : external_idx;
+        int preserve_idx = vmm_aux_indices.empty() ? idx : external_idx;
 
         // `start_idx` and `end_idx` is the range of indices passed to the
         // injector to apply `alg_` on top of them. Thus, they don't need to
@@ -145,8 +145,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     // injector will take first `n_vregs_not_preserved` from `vmm_compute_idxs`
     // to have legit generated code. This fact is saved through
     // `start_idx_tail_it` iterator and a second round of compute will happen.
-    size_t n_vregs_not_preserved = n_vregs_to_preserve_ - n_vregs_preserved_;
-    for (size_t i = 0; i < n_vregs_not_preserved; i++) {
+    int n_vregs_not_preserved = n_vregs_to_preserve_ - n_vregs_preserved_;
+    for (int i = 0; i < n_vregs_not_preserved; i++) {
         preserved_vmm_indices_[n_vregs_preserved_ - need_vmm_mask_register_]
                 = *start_idx_tail_it;
         n_vregs_preserved_++;
@@ -155,8 +155,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     assert(n_vregs_preserved_ == n_vregs_to_preserve_);
 
     // Preserve GPRs.
-    size_t preserved_gprs_count = 0;
-    size_t n_gprs_to_preserve = aux_gprs_count(alg_, is_fwd_, alpha_);
+    int preserved_gprs_count = 0;
+    int n_gprs_to_preserve = aux_gprs_count(alg_, is_fwd_, alpha_);
     if (n_gprs_to_preserve > 0) {
         // Allocate GPRs from the end not to mess with ABI compatibility.
         for (int gpr_idx = Operand::R15; gpr_idx >= 0; gpr_idx--) {
@@ -175,7 +175,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
     if (save_state_) {
         if (preserve_p_table_) h->push(p_table_);
 
-        for (size_t i = 0; i < preserved_gprs_count; ++i)
+        for (int i = 0; i < preserved_gprs_count; ++i)
             h->push(Reg64(preserved_gpr_indices_[i]));
     }
 
@@ -202,13 +202,12 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
             assert(vmm_aux_indices.empty());
 
             if (need_vmm_mask_register_) {
-                size_t i = 0;
+                int i = 0;
                 h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
                         Vmm(preserved_vmm_tail_indices_[i]));
             }
 
-            for (size_t i = need_vmm_mask_register_; i < n_vregs_preserved_;
-                    ++i)
+            for (int i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
                 h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
                         Vmm(preserved_vmm_indices_[i
                                 - need_vmm_mask_register_]));
@@ -224,11 +223,11 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble(
 
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
-        size_t n_vregs_not_preserved) {
+        int n_vregs_not_preserved) {
     // There was enough vmm registers to compute everything in one round.
     if (n_vregs_not_preserved == 0) return;
 
-    const size_t idx_off = n_vregs_to_preserve_ - n_vregs_not_preserved;
+    const int idx_off = n_vregs_to_preserve_ - n_vregs_not_preserved;
     assert(idx_off < n_vregs_to_preserve_); // Overflow is undesired.
 
     if (save_state_) {
@@ -236,7 +235,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
         // an issue and `!preserve_vmm_` case never reaches this piece.
         assert(preserve_vmm_);
 
-        for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+        for (int i = 0; i < n_vregs_not_preserved; ++i)
             h->uni_vmovups(Vmm(preserved_vmm_indices_[idx_off + i
                                    - need_vmm_mask_register_]),
                     h->ptr[reg_vmm_stack_ptr_
@@ -246,12 +245,12 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
     // Update the rightmost indices. The injector uses vmms with indices coming
     // after compute vmm indices.
     // TODO: is it always a valid index?
-    for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+    for (int i = 0; i < n_vregs_not_preserved; ++i)
         preserved_vmm_indices_[idx_off + i - need_vmm_mask_register_]
                 += n_vregs_not_preserved;
 
     if (save_state_ && preserve_vmm_) {
-        for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+        for (int i = 0; i < n_vregs_not_preserved; ++i)
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_
                                    + (i - n_vregs_not_preserved) * vlen_],
                     Vmm(preserved_vmm_indices_[idx_off + i
@@ -264,17 +263,17 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_preamble_tail(
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::injector_postamble() {
     using namespace Xbyak::util;
-    const int stack_vmm_space = get_stack_vmm_space();
+    const dim_t stack_vmm_space = get_stack_vmm_space();
 
     if (save_state_ && preserve_vmm_) {
-        for (size_t i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
+        for (int i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
             h->uni_vmovups(
                     Vmm(preserved_vmm_indices_[i - need_vmm_mask_register_]),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_preserved_) * vlen_]);
 
         if (need_vmm_mask_register_) {
-            size_t i = 0;
+            int i = 0;
             h->uni_vmovups(Vmm(preserved_vmm_tail_indices_[i]),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_preserved_) * vlen_]);
@@ -288,8 +287,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::injector_postamble() {
     }
 
     if (!save_state_) return;
-    for (int i = static_cast<int>(aux_gprs_count(alg_, is_fwd_, alpha_)) - 1;
-            i >= 0; --i)
+    for (int i = aux_gprs_count(alg_, is_fwd_, alpha_) - 1; i >= 0; --i)
         h->pop(Reg64(preserved_gpr_indices_[i]));
 
     if (preserve_p_table_) h->pop(p_table_);
@@ -312,9 +310,10 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
                     eltwise_exp_use_dst_for_bwd);
 
     if (preserve_vec_for_avx) {
-        vmm_tmp_ = Vmm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
-        ymm_tmp_ = Ymm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
-        xmm_tmp_ = Xmm(preserved_vmm_indices_[n_vregs_to_preserve_ - 1]);
+        const int idx = preserved_vmm_indices_[n_vregs_to_preserve_ - 1];
+        vmm_tmp_ = Vmm(idx);
+        ymm_tmp_ = Ymm(idx);
+        xmm_tmp_ = Xmm(idx);
     }
 }
 
@@ -323,7 +322,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::assign_regs() {
 // initialized with stock values from the injector, or with external values
 // provided by the user.
 template <cpu_isa_t isa, typename Wmm>
-Wmm jit_uni_eltwise_injector_t<isa, Wmm>::vmm_aux(size_t idx) {
+Wmm jit_uni_eltwise_injector_t<isa, Wmm>::vmm_aux(int idx) {
     assert(idx < (n_vregs_preserved_ - need_vmm_mask_register_));
     return Vmm(preserved_vmm_indices_[idx]);
 }
@@ -344,11 +343,11 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::vec_shift(const Vmm &vmm_dst,
         if (vmm_dst.getIdx() != vmm_src.getIdx()) h->vmovups(ymm_dst, ymm_src);
         h->vextractf128(xmm_tmp_, ymm_dst, 1);
         if (shift_left) {
-            h->vpslld(xmm_dst, xmm_dst, imm);
-            h->vpslld(xmm_tmp_, xmm_tmp_, imm);
+            h->vpslld(xmm_dst, xmm_dst, static_cast<uint8_t>(imm));
+            h->vpslld(xmm_tmp_, xmm_tmp_, static_cast<uint8_t>(imm));
         } else {
-            h->vpsrld(xmm_dst, xmm_dst, imm);
-            h->vpsrld(xmm_tmp_, xmm_tmp_, imm);
+            h->vpsrld(xmm_dst, xmm_dst, static_cast<uint8_t>(imm));
+            h->vpsrld(xmm_tmp_, xmm_tmp_, static_cast<uint8_t>(imm));
         }
         h->vinsertf128(ymm_dst, ymm_dst, xmm_tmp_, 1);
     }
@@ -360,7 +359,8 @@ template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::compute_cmp_mask(const Vmm &vmm_src,
         const Xbyak::Operand &compare_operand, int cmp_predicate) {
     if (is_avx512_) {
-        h->vcmpps(k_mask_, vmm_src, compare_operand, cmp_predicate);
+        h->vcmpps(k_mask_, vmm_src, compare_operand,
+                static_cast<uint8_t>(cmp_predicate));
     } else {
         h->uni_vcmpps(vmm_mask_, vmm_src, compare_operand, cmp_predicate);
     }
@@ -551,12 +551,14 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
         switch (isa) {
             case sse41:
                 for (int i = 0; i < XMM_float_lanes_count; ++i)
-                    h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx, i);
+                    h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx,
+                            static_cast<uint8_t>(i));
                 break;
             case avx: {
                 Xmm xmm_pol_idx = Xmm(vmm_pol_idx.getIdx());
                 for (int i = 0; i < XMM_float_lanes_count; ++i)
-                    h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx, i);
+                    h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx,
+                            static_cast<uint8_t>(i));
             } break;
             case avx2_vnni_2:
             case avx2:
@@ -578,7 +580,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
                     Xbyak::Address coeff_addr
                             = ptr[p_table_ + coeffs_off(coeff_idx)
                                     + gpr_idx[idx] * sizeof(float)];
-                    h->pinsrd(vmm_coeff, coeff_addr, idx);
+                    h->pinsrd(vmm_coeff, coeff_addr, static_cast<uint8_t>(idx));
                 }
                 break;
             case avx: {
@@ -587,7 +589,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::tanh_compute_vector_fwd(
                     Xbyak::Address coeff_addr
                             = ptr[p_table_ + coeffs_off(coeff_idx)
                                     + gpr_idx[idx] * sizeof(float)];
-                    h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr, idx);
+                    h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr,
+                            static_cast<uint8_t>(idx));
                 }
             } break;
             case avx2_vnni_2:
@@ -1052,7 +1055,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
     const auto table_start_idx = (*it).second.off;
 
     auto gather_table_values
-            = [&](const Vmm &vmm_dst, const Vmm &vmm_idxs, size_t offt = 0) {
+            = [&](const Vmm &vmm_dst, const Vmm &vmm_idxs, dim_t offt = 0) {
         Xbyak::Address table_idx = h->ptr[p_table_ + table_start_idx + offt
                 + vmm_idxs * sizeof(float)];
         if (is_avx512_) {
@@ -1075,7 +1078,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::log_compute_vector_fwd(
             // fetched values into vector register.
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + vlen_], vmm_idxs);
 
-            for (size_t i = 0; i < vlen_ / sizeof(float); ++i) {
+            for (dim_t i = 0; i < vlen_ / static_cast<dim_t>(sizeof(float));
+                    ++i) {
                 h->mov(reg_tmp.cvt32(),
                         h->ptr[reg_vmm_stack_ptr_ + vlen_ + i * sizeof(float)]);
                 h->shl(reg_tmp.cvt32(), 2); // multiply by simd_w
@@ -1191,21 +1195,21 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
     } else { // general path
         // caller obligation to save gprs as callee may use them
-        size_t gpr_size = 8;
+        int gpr_size = 8;
         Xbyak::Operand gprs_to_save[] = {h->r8, h->r9, h->r10, h->r11, h->r12,
                 h->rax, h->rcx, h->rdx, h->rdi, h->rsi, h->rbx};
-        size_t n_gprs_to_save = sizeof(gprs_to_save) / sizeof(gprs_to_save[0]);
+        int n_gprs_to_save = sizeof(gprs_to_save) / sizeof(gprs_to_save[0]);
 
         h->sub(h->rsp, n_gprs_to_save * gpr_size);
-        for (size_t i = 0; i < n_gprs_to_save; ++i)
+        for (int i = 0; i < n_gprs_to_save; ++i)
             h->mov(h->ptr[h->rsp + i * gpr_size], gprs_to_save[i]);
 
         // caller obligation to save k-regs as callee may use them
         static constexpr int k_mask_size = 8;
-        size_t n_k_regs_to_save = 8;
+        int n_k_regs_to_save = 8;
         if (is_avx512_) {
             h->sub(h->rsp, n_k_regs_to_save * k_mask_size);
-            for (size_t i = 0; i < n_k_regs_to_save; ++i) {
+            for (int i = 0; i < n_k_regs_to_save; ++i) {
                 if (mayiuse(avx512_core))
                     h->kmovq(h->ptr[h->rsp + i * k_mask_size], Opmask(i));
                 else
@@ -1220,7 +1224,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         // `isa` as the injector. Once the assumption is wrong, `n_vregs_` and
         // `vlen_` should be replaced with `host_isa::vlen_` and
         // `host_isa::n_vregs_`.
-        for (size_t i = 2; i < n_vregs_ + 2; ++i)
+        for (int i = 2; i < n_vregs_ + 2; ++i)
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_], Vmm(i - 2));
         h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_], vmm_src); // src
         h->uni_vmovups(vmm_src, table_val(beta));
@@ -1246,7 +1250,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
 
         // Take src, apply powf on it and replace value on a stack with dst.
         Xmm xmm0 = Xmm(0), xmm1 = Xmm(1);
-        for (size_t i = 0; i < vlen_ / sizeof(float); ++i) {
+        for (int i = 0; i < vlen_ / static_cast<int>(sizeof(float)); ++i) {
             const Address &source
                     = h->ptr[reg_vmm_stack_ptr_ + i * sizeof(float)];
             h->uni_vmovss(xmm0, source);
@@ -1261,7 +1265,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::pow_compute_vector_fwd(
         h->add(h->rsp, h->rbx);
 
         // restore vector registers
-        for (size_t i = n_vregs_ + 1; i >= 2; --i)
+        for (int i = n_vregs_ + 1; i >= 2; --i)
             h->uni_vmovups(Vmm(i - 2), h->ptr[reg_vmm_stack_ptr_ + i * vlen_]);
         h->uni_vmovups(vmm_src, h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_]);
 
@@ -1801,7 +1805,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::round_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_gprs_count(
+int jit_uni_eltwise_injector_t<isa, Wmm>::aux_gprs_count(
         alg_kind_t alg, bool is_fwd, float alpha) {
     using namespace alg_kind;
     int ret = 0;
@@ -1821,7 +1825,7 @@ bool jit_uni_eltwise_injector_t<isa, Wmm>::need_vmm_stack_ptr(
 }
 
 template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
+int jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
         alg_kind_t alg, bool is_fwd) {
     using namespace alg_kind;
     int ret = 0;
@@ -1843,11 +1847,11 @@ size_t jit_uni_eltwise_injector_t<isa, Wmm>::op_vecs_count(
 }
 
 template <cpu_isa_t isa, typename Wmm>
-size_t jit_uni_eltwise_injector_t<isa, Wmm>::aux_vecs_count(
+int jit_uni_eltwise_injector_t<isa, Wmm>::aux_vecs_count(
         alg_kind_t alg, bool is_fwd, float alpha) {
     // For avx we need a register to save the upper part of Ymm
     const bool extra_avx_vmm = isa == avx;
-    size_t n_vmms = 0;
+    int n_vmms = 0;
 
     using namespace alg_kind;
     if (is_fwd) {
@@ -2003,7 +2007,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_body(
         const injector_utils::vmm_index_set_iterator_t &start_idx_it,
         const injector_utils::vmm_index_set_iterator_t &end_idx_it) {
     using namespace alg_kind;
-    std::for_each(start_idx_it, end_idx_it, [&](size_t idx) {
+    std::for_each(start_idx_it, end_idx_it, [&](int idx) {
         if (is_fwd_) {
             switch (alg_) {
                 case eltwise_relu_use_dst_for_bwd:
@@ -2105,10 +2109,10 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_body(
 
 template <cpu_isa_t isa, typename Wmm>
 void jit_uni_eltwise_injector_t<isa, Wmm>::compute_vector_range(
-        size_t start_compute_idx, size_t end_compute_idx,
+        int start_compute_idx, int end_compute_idx,
         const injector_utils::vmm_index_set_t &vmm_aux_indices) {
     injector_utils::vmm_index_set_t vmm_compute_idxs;
-    for (size_t i = start_compute_idx; i < end_compute_idx; i++)
+    for (int i = start_compute_idx; i < end_compute_idx; i++)
         vmm_compute_idxs.emplace(i);
     compute_vector_range(vmm_compute_idxs, vmm_aux_indices);
 }
@@ -2129,8 +2133,12 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::compute_vector_range(
     injector_preamble(vmm_compute_idxs, start_idx_tail_it, vmm_aux_indices);
     compute_body(start_idx_tail_it, end_idx_it);
 
-    size_t n_vregs_not_preserved
-            = std::distance(start_idx_it, start_idx_tail_it);
+    // `std::distance` on a `std::set<int>` iterator returns a
+    // `ptrdiff_t`; this is the one genuine, documented boundary where we
+    // narrow it down to the bounded vmm-register count expected by
+    // `injector_preamble_tail`.
+    const int n_vregs_not_preserved
+            = static_cast<int>(std::distance(start_idx_it, start_idx_tail_it));
     injector_preamble_tail(n_vregs_not_preserved);
     compute_body(start_idx_it, start_idx_tail_it);
     injector_postamble();
@@ -2150,7 +2158,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::prepare_table(bool gen_table) {
     // when we set the offsets. We verify that in asserts.
     // table_entry_val_t is assumed to be 32 bits
 #ifndef NDEBUG
-    size_t off = 0;
+    dim_t off = 0;
     key_t curr_key = undef_key;
     int key_occurences = 0;
 #endif
@@ -2158,8 +2166,8 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::prepare_table(bool gen_table) {
     // Run through the map and insert values stored there
     for (auto it = entry_map_.begin(); it != entry_map_.end(); it++) {
         const auto &te = (*it).second; // get map entry for a given key
-        const auto len = te.bcast ? vlen_ : sizeof(table_entry_val_t);
-        for (size_t d = 0; d < len; d += sizeof(table_entry_val_t))
+        const dim_t len = te.bcast ? vlen_ : sizeof(table_entry_val_t);
+        for (dim_t d = 0; d < len; d += sizeof(table_entry_val_t))
             h->dd(te.val);
 
 #ifndef NDEBUG
@@ -2170,7 +2178,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::prepare_table(bool gen_table) {
             key_occurences = 0;
         }
         key_occurences++;
-        auto expected_off = table_off(key, key_occurences - 1);
+        const dim_t expected_off = table_off(key, key_occurences - 1);
         assert(off == expected_off);
         MAYBE_UNUSED(expected_off);
         off += len;
@@ -2917,7 +2925,7 @@ void jit_uni_eltwise_injector_t<isa, Wmm>::register_table_entries() {
     // entries should be registered after this point.  This allows to
     // expect the same order when injecting the table entries in
     // prepare_table.
-    size_t off = 0;
+    dim_t off = 0;
     for (auto it = entry_map_.begin(); it != entry_map_.end(); it++) {
         auto &te = (*it).second;
         te.off = off;

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
@@ -128,12 +128,12 @@ struct jit_uni_eltwise_injector_t {
                   eltwise.beta, eltwise.scale, dt, save_state, p_table, k_mask,
                   is_fwd, use_dst, preserve_vmm, preserve_p_table) {}
 
-    void compute_vector_range(size_t start_compute_idx, size_t end_compute_idx,
+    void compute_vector_range(int start_compute_idx, int end_compute_idx,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {});
     void compute_vector_range(
             const injector_utils::vmm_index_set_t &vmm_compute_idxs,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {});
-    void compute_vector(size_t compute_idx,
+    void compute_vector(int compute_idx,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {}) {
         compute_vector_range({compute_idx}, vmm_aux_indices);
     }
@@ -143,7 +143,7 @@ struct jit_uni_eltwise_injector_t {
     // This call is `static` and `public` to make a decision on the injector's
     // saving state if the caller can supply the necessary number of vmms. The
     // decision must be made BEFORE constructing the injector, thus, `static`.
-    static size_t aux_vecs_count(alg_kind_t alg, bool is_fwd, float alpha);
+    static int aux_vecs_count(alg_kind_t alg, bool is_fwd, float alpha);
 
 private:
     const alg_kind_t alg_;
@@ -179,21 +179,21 @@ private:
 
     const bool is_avx512_ = is_superset(isa, avx512_core);
 
-    static constexpr size_t vlen_ = vreg_traits_t<Vmm>::vlen;
-    static constexpr size_t preserved_vecs_max_ = 6;
-    static constexpr size_t preserved_gprs_max_ = 5;
-    static constexpr size_t n_vregs_ = cpu_isa_traits_t<isa>::n_vregs;
+    static constexpr dim_t vlen_ = vreg_traits_t<Vmm>::vlen;
+    static constexpr dim_t preserved_vecs_max_ = 6;
+    static constexpr dim_t preserved_gprs_max_ = 5;
+    static constexpr int n_vregs_ = cpu_isa_traits_t<isa>::n_vregs;
     static constexpr int n_mantissa_bits_ = 23;
 
-    const size_t n_vregs_to_preserve_;
-    size_t n_vregs_preserved_ = 0;
+    const int n_vregs_to_preserve_;
+    int n_vregs_preserved_ = 0;
     bool need_vmm_mask_register_ = false;
     // Default initialization will put zeros. Putting any value to trigger a
     // potential error to Xbyak is not working as Xbyak cycles vmm indices
     // over 32 value.
-    size_t preserved_vmm_indices_[preserved_vecs_max_] = {};
-    size_t preserved_vmm_tail_indices_[preserved_vecs_max_] = {};
-    size_t preserved_gpr_indices_[preserved_gprs_max_] = {};
+    int preserved_vmm_indices_[preserved_vecs_max_] = {};
+    int preserved_vmm_tail_indices_[preserved_vecs_max_] = {};
+    int preserved_gpr_indices_[preserved_gprs_max_] = {};
 
     Vmm vmm_mask_;
     Vmm vmm_tmp_;
@@ -201,10 +201,10 @@ private:
     Xbyak::Xmm xmm_tmp_;
 
     static bool need_mask_register(alg_kind_t alg, bool is_fwd, float alpha);
-    static size_t aux_gprs_count(alg_kind_t alg, bool is_fwd, float alpha);
+    static int aux_gprs_count(alg_kind_t alg, bool is_fwd, float alpha);
     static bool need_vmm_stack_ptr(alg_kind_t alg, bool is_fwd, float alpha);
-    static size_t op_vecs_count(alg_kind_t alg, bool is_fwd);
-    size_t get_stack_vmm_space();
+    static int op_vecs_count(alg_kind_t alg, bool is_fwd);
+    dim_t get_stack_vmm_space();
 
     void compute_body(
             const injector_utils::vmm_index_set_iterator_t &start_idx_it,
@@ -212,10 +212,10 @@ private:
     void injector_preamble(const injector_utils::vmm_index_set_t &vmm_idxs,
             injector_utils::vmm_index_set_iterator_t &start_idx_tail_it,
             const injector_utils::vmm_index_set_t &vmm_aux_indices);
-    void injector_preamble_tail(size_t n_vregs_not_preserved);
+    void injector_preamble_tail(int n_vregs_not_preserved);
     void injector_postamble();
     void assign_regs();
-    Wmm vmm_aux(size_t idx);
+    Wmm vmm_aux(int idx);
     void vec_shift(const Vmm &vmm_dst, const Vmm &vmm_src, bool shift_left,
             const int imm);
     void compute_cmp_mask(const Vmm &vmm_src,

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -26,8 +26,8 @@ namespace injector {
 #define VCHECK_PO_INJ_BOOL(cond, msg) \
     VCONDCHECK(primitive, create, check, postops_injector, cond, false, msg);
 
-size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd) {
-    size_t res = 0;
+int aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd) {
+    int res = 0;
 #define CASE_ELTWISE_SUPERSET(_isa) \
     if (is_superset(isa, _isa)) { \
         res = nstl::max(res, \
@@ -252,19 +252,19 @@ jit_uni_postops_injector_base_t<Vmm>::create(jit_generator_t *host,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
-        size_t start_idx, size_t end_idx,
+void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(int start_idx,
+        int end_idx,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
     injector_utils::vmm_index_set_t vmm_idxs;
-    for (size_t i = start_idx; i < end_idx; i++)
+    for (int i = start_idx; i < end_idx; i++)
         vmm_idxs.emplace(i);
     compute_vector_range(vmm_idxs, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
-        size_t start_idx, size_t end_idx) {
+        int start_idx, int end_idx) {
     compute_vector_range(
             start_idx, end_idx, binary_injector::rhs_arg_dynamic_params_t());
 }
@@ -274,7 +274,7 @@ void jit_uni_postops_injector_t<isa, Vmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
-    std::size_t rhs_arg_idx = 0;
+    dim_t rhs_arg_idx = 0;
     for (int i = 0; i < post_ops_.len(); i++) {
         const auto &post_op = post_ops_.entry_[i];
         if (post_op.is_eltwise()) {
@@ -305,13 +305,13 @@ void jit_uni_postops_injector_t<isa, Vmm>::prepare_table(bool gen_table) {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(size_t idx,
+void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(int idx,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
     compute_vector_range({idx}, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(size_t idx) {
+void jit_uni_postops_injector_t<isa, Vmm>::compute_vector(int idx) {
     compute_vector_range({idx});
 }
 

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -46,7 +46,7 @@ namespace injector {
 using lambda_jit_injectors_t
         = std::map<dnnl_primitive_kind_t, std::function<void()>>;
 
-size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd);
+int aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd);
 
 // A base isa-agnostic post-ops injector abstract class.
 //
@@ -90,18 +90,18 @@ public:
     // Generates code of post_ops chain injected to host primitive. Applied to
     // range <start_idx, end_idx) of vector registers' indexes.
     // @rhs_arg_params: see jit_uni_binary_injector description
-    virtual void compute_vector_range(size_t start_idx, size_t end_idx,
+    virtual void compute_vector_range(int start_idx, int end_idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
             = 0;
-    virtual void compute_vector_range(size_t start_idx, size_t end_idx) = 0;
+    virtual void compute_vector_range(int start_idx, int end_idx) = 0;
 
     // Generates code of post_ops chain injected to host primitive. Applied to
     // a single vector register index.
     // @rhs_arg_params: see jit_uni_binary_injector description
-    virtual void compute_vector(size_t idx,
+    virtual void compute_vector(int idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
             = 0;
-    virtual void compute_vector(size_t idx) = 0;
+    virtual void compute_vector(int idx) = 0;
 
     // Thin wrapper for eltwise injector specific function
     virtual void prepare_table(bool gen_table) = 0;
@@ -154,17 +154,17 @@ public:
             const injector_utils::vmm_index_set_t &vmm_idxs) override;
 
     // See `jit_uni_postops_injector_base_t::compute_vector_range(...)`
-    void compute_vector_range(size_t start_idx, size_t end_idx,
+    void compute_vector_range(int start_idx, int end_idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
             override;
 
-    void compute_vector_range(size_t start_idx, size_t end_idx) override;
+    void compute_vector_range(int start_idx, int end_idx) override;
 
     // See `jit_uni_postops_injector_base_t::compute_vector(...)`
-    void compute_vector(size_t idx,
+    void compute_vector(int idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params)
             override;
-    void compute_vector(size_t idx) override;
+    void compute_vector(int idx) override;
 
     /*
      * Thin wrapper for eltwise injector specific function

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -55,7 +55,7 @@ jit_avx2_1x1_conv_kernel_f32_t::jit_avx2_1x1_conv_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
 
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r13, r14,
                 r15, preserve_gpr, preserve_vmm,
@@ -83,9 +83,9 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        const int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             if (i == num_substeps - 1) L(large_tail);
             generate_reduce_loop(load_loop_blk, jcp.ur);
             if (i < num_substeps - 1) {
@@ -132,7 +132,7 @@ static Ymm vreg_accum(const int load_loop_blk, int i, int j) {
 }
 
 template <typename F>
-void iterate(const int load_loop_blk, const int ur, const int load_dim_tail,
+void iterate(const int load_loop_blk, const int ur, const dim_t load_dim_tail,
         const F &f) {
     for (int i = 0; i < load_loop_blk; ++i) {
         const bool mask_flag = (load_dim_tail > 0) && (i == load_loop_blk - 1);
@@ -146,7 +146,7 @@ void iterate(const int load_loop_blk, const int ur, const F &f) {
 }
 
 void jit_avx2_1x1_conv_kernel_f32_t::apply_postops(
-        const int load_loop_blk, const int ur, const int load_dim_tail) {
+        const int load_loop_blk, const int ur, const dim_t load_dim_tail) {
     if (jcp.with_eltwise || jcp.with_binary) {
         assert(ur * load_loop_blk < 14);
 
@@ -217,14 +217,14 @@ void jit_avx2_1x1_conv_kernel_f32_t::apply_postops(
 
 void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
         int load_loop_blk, int ur) {
-    const int load_dim_tail
+    const dim_t load_dim_tail
             = ((jcp.with_binary
                        && one_of(jcp.prop_kind, forward_training,
                                forward_inference))
                               ? jcp.oc_without_padding
                               : jcp.load_dim)
             % jcp.load_block;
-    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+    const dim_t reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
 
     auto vreg_load = [ur, load_loop_blk](
                              int i) { return Ymm(ur * load_loop_blk + i); };
@@ -233,24 +233,24 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
         return ptr[reg_bias_data + sizeof(float) * jcp.oc_block * i];
     };
 
-    auto bcast_ptr = [this](int u, int j) {
+    auto bcast_ptr = [this](dim_t u, int j) {
         assert(j < jcp.ur);
         assert(u <= jcp.reduce_loop_unroll);
-        const size_t offset = get_bcast_offset(jcp, u, j);
+        const size_t offset = get_bcast_offset(jcp, static_cast<int>(u), j);
         return make_safe_addr(aux_reg_bcast_data, offset, reg_long_offt);
     };
 
-    auto get_load_offset_bwd_w = [this](int u, int i) {
-        size_t u0 = u % jcp.reduce_loop_unroll;
-        size_t u1 = u / jcp.reduce_loop_unroll;
+    auto get_load_offset_bwd_w = [this](dim_t u, int i) {
+        const int u0 = static_cast<int>(u % jcp.reduce_loop_unroll);
+        const dim_t u1 = u / jcp.reduce_loop_unroll;
         return u1 * jcp.reduce_loop_load_step
                 + sizeof(float) * get_load_bwd_w_offset(jcp, i, u0);
     };
 
-    auto load_ptr = [this](int u, int i) {
+    auto load_ptr = [this](dim_t u, int i) {
         size_t offt;
-        size_t u0 = u % jcp.reduce_loop_unroll;
-        size_t u1 = u / jcp.reduce_loop_unroll;
+        const int u0 = static_cast<int>(u % jcp.reduce_loop_unroll);
+        const dim_t u1 = u / jcp.reduce_loop_unroll;
         switch (jcp.prop_kind) {
             case backward_data:
                 offt = (i * jcp.oc_block + u0) * jcp.ic_block;
@@ -310,7 +310,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                         L(load_bias_tail);
                         load_bytes(vreg_accum(load_loop_blk, i, j),
                                 reg_bias_data, i * jcp.oc_block * sizeof(float),
-                                load_dim_tail * sizeof(float));
+                                static_cast<int>(
+                                        load_dim_tail * sizeof(float)));
                         L(load_bias_done);
                     } else {
                         vmovups(vreg_accum(load_loop_blk, i, j), bias_ptr(i));
@@ -341,7 +342,7 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                 L(load_init_tail);
                 load_bytes(vreg_load(i), aux_reg_load_data,
                         get_load_offset_bwd_w(0, i),
-                        load_dim_tail * sizeof(float));
+                        static_cast<int>(load_dim_tail * sizeof(float)));
                 L(load_init_done);
             } else {
                 vmovups(vreg_load(i), load_ptr(0, i));
@@ -373,7 +374,7 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                     L(sum_tail);
                     load_bytes(vtmp, aux_reg_output_data,
                             get_output_offset(i, j),
-                            load_dim_tail * sizeof(float));
+                            static_cast<int>(load_dim_tail * sizeof(float)));
                     vaddps(r, r, vtmp);
                     L(sum_done);
                 } else {
@@ -425,7 +426,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                         }
                         store_bytes(vreg_accum(load_loop_blk, i, j),
                                 aux_reg_output_data, get_output_offset(i, j),
-                                load_dim_tail * sizeof(float));
+                                static_cast<int>(
+                                        load_dim_tail * sizeof(float)));
                     }
                     L(store_done);
                 } else {
@@ -440,8 +442,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
 
     auto fma_block = [&](bool last_block) {
         const bool is_tail = reduce_dim_tail && last_block;
-        const int u_end = is_tail ? reduce_dim_tail : jcp.reduce_loop_unroll;
-        for (int u = 0; u < u_end; ++u) {
+        const dim_t u_end = is_tail ? reduce_dim_tail : jcp.reduce_loop_unroll;
+        for (dim_t u = 0; u < u_end; ++u) {
             for (int j = 0; j < ur; ++j) {
                 for (int i = 0; i < load_loop_blk; ++i) {
                     if (jcp.isa == avx2)
@@ -466,7 +468,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                             L(fma_load_tail);
                             load_bytes(vreg_load(i), aux_reg_load_data,
                                     get_load_offset_bwd_w(u + 1, i),
-                                    load_dim_tail * sizeof(float));
+                                    static_cast<int>(
+                                            load_dim_tail * sizeof(float)));
                             L(fma_load_done);
                         } else {
                             vmovups(vreg_load(i), load_ptr(u + 1, i));
@@ -557,7 +560,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_diff_bias_loop(
 
     for (int i = 0; i < load_loop_blk; i++)
         vmovups(diff_bias_ptr(i), diff_bias_reg(i));
-    add(reg_diff_bias_data, load_loop_blk * jcp.oc_block * sizeof(float));
+    safe_add(reg_diff_bias_data, load_loop_blk * jcp.oc_block * sizeof(float),
+            reg_long_offt);
     mov(ptr[rsp + reg_diff_bias_data_stack_offt], reg_diff_bias_data);
 
     L(diff_bias_loop_out);
@@ -598,7 +602,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate() {
 
     auto generate_load_loop_body = [&](int load_loop_blk) {
         generate_bcast_loop(load_loop_blk);
-        add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
+        safe_add(reg_load_data, load_loop_blk * jcp.load_loop_load_step,
+                reg_long_offt);
         const size_t offst_with_dw_conv
                 = get_load_loop_output_fwd_offset(jcp, load_loop_blk);
         const size_t offst_wo_dw_conv
@@ -606,13 +611,15 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate() {
         switch (jcp.prop_kind) {
             case forward_training:
             case forward_inference:
-                add(reg_bias_data,
-                        load_loop_blk * jcp.oc_block * sizeof(float));
+                safe_add(reg_bias_data,
+                        load_loop_blk * jcp.oc_block * sizeof(float),
+                        reg_long_offt);
                 safe_add(reg_output_data, offst_with_dw_conv, reg_long_offt);
                 if (jcp.with_binary && jcp.with_dw_conv) {
                     mov(aux_reg_load_data, ptr[rsp + reg_dw_binary_output_off]);
                     add(aux_reg_load_data,
-                            offst_wo_dw_conv - offst_with_dw_conv);
+                            static_cast<uint32_t>(
+                                    offst_wo_dw_conv - offst_with_dw_conv));
                     mov(ptr[rsp + reg_dw_binary_output_off], aux_reg_load_data);
                 }
                 break;
@@ -691,8 +698,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     if (!mayiuse(avx)) return status::unimplemented;
     jcp.isa = mayiuse(avx2) ? avx2 : avx;
 
-    // Big int (> INT_MAX) values are unsupported and jcp fields may overflow
-    // TODO: change data type of jcp fields to size_t
+    // Values larger than INT_MAX are unsupported at JIT/API boundaries.
     VDISPATCH_CONV_IC(!has_large_size(cd, src_d, weights_d, dst_d),
             VERBOSE_BAD_PARAM, "large size is not supported");
 
@@ -736,8 +742,8 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
             != format_kind::undef;
 
-    jcp.os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
-    jcp.is = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw;
+    jcp.os = jcp.od * jcp.oh * jcp.ow;
+    jcp.is = jcp.id * jcp.ih * jcp.iw;
 
     jcp.typesize_in = sizeof(prec_traits_t<data_type::f32>::type);
     jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
@@ -836,14 +842,15 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.ic_block = jcp.oc_block = simd_w;
 
     jcp.ur = jcp.isa == avx2 ? 4 : 3; // Intel AVX support
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
-    int load_blocking {0};
-    int load_blocking_max {0};
-    int bcast_blocking {0};
-    int bcast_blocking_max {0};
-    int reduce_blocking {0};
-    int reduce_blocking_max {0};
+    dim_t load_blocking {0};
+    dim_t load_blocking_max {0};
+    dim_t bcast_blocking {0};
+    dim_t bcast_blocking_max {0};
+    dim_t reduce_blocking {0};
+    dim_t reduce_blocking_max {0};
 
     if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
         jcp.reduce_dim = jcp.ic;
@@ -964,7 +971,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                 !is_data_layout_nxc, jcp.load_dim % load_blocking == 0));
 
         bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
-        const int bcast_blocking_lim = is_data_layout_nxc ? 17 : 9;
+        const dim_t bcast_blocking_lim = is_data_layout_nxc ? 17 : 9;
         const bool no_bcast_tail = jcp.bcast_dim % jcp.bcast_block == 0;
         const bool small_size_for_bcast
                 = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw <= 1024;
@@ -989,7 +996,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                 !is_data_layout_nxc, jcp.bcast_dim % bcast_blocking == 0));
 
         reduce_blocking = is_data_layout_nxc
-                ? rnd_up(nstl::min(jcp.ow, 128), jcp.reduce_block)
+                ? rnd_up(nstl::min<dim_t>(jcp.ow, 128), jcp.reduce_block)
                 : 128; // affects L1$ utilization
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
     } else
@@ -1002,7 +1009,8 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     assert(reduce_blocking);
 
     assert(jcp.bcast_block % jcp.ur == 0);
-    jcp.ur_tail = (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.bcast_block;
+    jcp.ur_tail = static_cast<int>(
+            (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.bcast_block);
 
     jcp.nb_bcast_blocking = bcast_blocking / jcp.bcast_block;
     jcp.nb_bcast_blocking_max = bcast_blocking_max / jcp.bcast_block;

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.hpp
@@ -89,7 +89,7 @@ private:
     ymm_t vtmp = ymm_t(14);
 
     void apply_postops(
-            const int load_loop_blk, const int ur, const int load_dim_tail);
+            const int load_loop_blk, const int ur, const dim_t load_dim_tail);
     void generate_bcast_loop(int load_loop_blk);
     void generate_reduce_loop(int load_loop_blk, int ur);
     void generate_diff_bias_loop(int load_loop_blk);

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -52,7 +52,8 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -101,32 +102,33 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
     const int ndims = dst_d.ndims();
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     auto p = jit_1x1_conv_args_t();
     auto rp = rtus_driver_t<avx2>::call_params_t();
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
     // Begin: declare Variables needed for dw conv.
     data_t *pbuf;
     size_t row_offset;
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     auto jcp_dw = pd()->jcp_dw_;
     std::vector<data_t *> addrs;
     jit_generator_t *dw_jit_ker = nullptr;
@@ -136,23 +138,23 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     const bool is_dst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
 
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os = osb * os_block;
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         od = os / (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
@@ -165,7 +167,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         // binary postop injector may override zero-padded areas, so proper
         // output masking needs to be performed base on exact number of channels
@@ -174,12 +176,13 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 ocb * jcp.oc_block, oc, load_step * jcp.oc_block);
     };
 
-    auto ker_1x1 = [&](int ocb, int icb, int ocb_start, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1 = [&](dim_t ocb, dim_t icb, dim_t ocb_start, dim_t n, dim_t g,
+                           dim_t od, dim_t oh, dim_t ow, dim_t id, dim_t ih,
+                           dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
         p.output_data = jcp.with_dw_conv ? pbuf + (oh % jcp_dw->kh) * row_offset
                                          : &dst[dst_off];
         p.bias_data
@@ -196,7 +199,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
 
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
 
@@ -220,19 +223,20 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
-        int iwork = bcast_start;
+        dim_t iwork = bcast_start;
         while (iwork < bcast_end) {
-            int n {0}, g {0}, bcast_step, od, oh, ow, id, ih, iw;
+            dim_t n {0}, g {0}, od, oh, ow, id, ih, iw;
+            dim_t bcast_step;
             init_bcast(
                     iwork, bcast_end, n, g, bcast_step, od, oh, ow, id, ih, iw);
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                     ker_1x1(ocb, icb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                 }
                 ocb += load_step;
@@ -241,41 +245,42 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw->kh) * row_offset;
 
         const ptrdiff_t wch_stride
                 = static_cast<ptrdiff_t>(is_src_layout_nxc ? 1 : jcp_dw->iw)
                 * jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         const auto ocb_end = ocb_start + load_step;
-        const int dil_h = jcp_dw->dilate_h + 1;
-        const int str_h = jcp_dw->stride_h;
-        const int ch_num = jcp_dw->nb_ch_blocking;
-        const int ow = 0;
-        const int kw = 0;
+        const dim_t dil_h = jcp_dw->dilate_h + 1;
+        const dim_t str_h = jcp_dw->stride_h;
+        const dim_t ch_num = jcp_dw->nb_ch_blocking;
+        const dim_t ow = 0;
+        const dim_t kw = 0;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw->t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw->ih,
-                              (int)(dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
-                                      - jcp_dw->t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw->t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw->ih,
+                              dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
+                                      - jcp_dw->t_pad + 1)
                     - jcp_dw->ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw->ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -287,9 +292,11 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw->ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding
+                    = static_cast<size_t>(nstl::max<dim_t>(0, kh_padding));
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw->nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw->nb_ch) - ch)
                     * jcp_dw->ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -298,7 +305,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
             (*dw_jit_ker)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += wch_stride;
         }
     };
@@ -318,33 +325,34 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, 1);
+                bcast_end, nb_oc, ocb_start, ocb_end, dim_t {1});
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -360,8 +368,8 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
         balance211(work_amount, nthr, ithr, start, end);
         conv_1x1(start, end, 0, jcp.nb_load);
     }
@@ -388,18 +396,18 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
     assert(jcp.stride_w == 1 && jcp.stride_h == 1 && jcp.stride_d == 1);
     const int ndims = diff_dst_d.ndims();
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -408,11 +416,11 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
         auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx2>::call_params_t();
 
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int load_step = 0;
-        for (int icb = 0; icb < jcp.nb_load; icb += load_step) {
+        dim_t load_step = 0;
+        for (dim_t icb = 0; icb < jcp.nb_load; icb += load_step) {
             load_step = step(jcp.nb_load_blocking, jcp.nb_load - icb,
                     jcp.nb_load_blocking_max);
 
@@ -420,9 +428,9 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                     icb * jcp.ic_block, jcp.ic, load_step * jcp.ic_block);
             rp.icb = p.load_dim;
 
-            int bcast_step;
-            for (int iwork = start; iwork < end; iwork += bcast_step) {
-                int n {0}, g {0}, osb {0};
+            dim_t bcast_step;
+            for (dim_t iwork = start; iwork < end; iwork += bcast_step) {
+                dim_t n {0}, g {0}, osb {0};
                 nd_iterator_init(
                         iwork, n, jcp.mb, g, jcp.ngroups, osb, jcp.nb_bcast);
 
@@ -430,23 +438,23 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                         jcp.nb_bcast_blocking_max);
                 bcast_step = nstl::min(bcast_step, end - iwork);
 
-                const int os = osb * os_block;
+                const dim_t os = osb * os_block;
                 p.bcast_dim
                         = this_block_size(os, jcp.os, bcast_step * os_block);
                 rp.os = p.bcast_dim;
 
-                const int od = os / (jcp.oh * jcp.ow);
-                const int os_2d = os % (jcp.oh * jcp.ow);
-                const int oh = os_2d / jcp.ow;
-                const int ow = os_2d % jcp.ow;
-                const int id = od * stride_d;
-                const int ih = oh * stride_h;
-                const int iw = ow * stride_w;
+                const dim_t od = os / (jcp.oh * jcp.ow);
+                const dim_t os_2d = os % (jcp.oh * jcp.ow);
+                const dim_t oh = os_2d / jcp.ow;
+                const dim_t ow = os_2d % jcp.ow;
+                const dim_t id = od * stride_d;
+                const dim_t ih = oh * stride_h;
+                const dim_t iw = ow * stride_w;
                 rp.iw_start = iw;
 
                 const bool is_dsrc_layout_nxc = utils::one_of(jcp.src_tag,
                         format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g * nb_ic + icb;
                 rp.src = diff_src
@@ -457,15 +465,15 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                 } else
                     p.output_data = rp.src;
 
-                for (int ocb = 0; ocb < jcp.nb_reduce;
+                for (dim_t ocb = 0; ocb < jcp.nb_reduce;
                         ocb += jcp.nb_reduce_blocking) {
                     const bool is_ddst_layout_nxc
                             = utils::one_of(jcp.dst_tag, format_tag::nwc,
                                     format_tag::nhwc, format_tag::ndhwc);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g * jcp.oc + ocb * jcp.oc_block
                             : g * nb_oc + ocb;
-                    size_t diff_dst_off = data_blk_off(
+                    dim_t diff_dst_off = data_blk_off(
                             diff_dst_d, n, oc_off_idx, od, oh, ow);
                     p.bcast_data = &diff_dst[diff_dst_off];
 
@@ -553,33 +561,33 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic = jcp.nb_bcast;
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
-    const int bcast_work = div_up(nb_ic, nb_ic_blocking);
+    const dim_t nb_ic = jcp.nb_bcast;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t bcast_work = div_up(nb_ic, nb_ic_blocking);
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
-    const int load_work = div_up(nb_oc, nb_oc_blocking);
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t load_work = div_up(nb_oc, nb_oc_blocking);
 
-    const int sp_dim = jcp.reduce_dim;
-    const int mb_sp_work = jcp.mb * sp_dim;
+    const dim_t sp_dim = jcp.reduce_dim;
+    const dim_t mb_sp_work = jcp.mb * sp_dim;
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     const bool is_src_layout_nxc = utils::one_of(
             jcp.src_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
     const bool is_ddst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
     auto oc_ic_sp_loop
-            = [= COMPAT_THIS_CAPTURE](int sp_start, int sp_end,
+            = [= COMPAT_THIS_CAPTURE](dim_t sp_start, dim_t sp_end,
                       bool first_image, data_t *store_to, size_t store_to_ld,
                       const data_t *diff_dst, const data_t *src, int ithr) {
         auto p = jit_1x1_conv_args_t();
@@ -587,15 +595,15 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
         p.output_stride = store_to_ld * sizeof(float);
 
-        int oc_b_step = 0;
-        for (int oc_b = 0; oc_b < nb_oc_blocking; oc_b += oc_b_step) {
+        dim_t oc_b_step = 0;
+        for (dim_t oc_b = 0; oc_b < nb_oc_blocking; oc_b += oc_b_step) {
             oc_b_step = step(nb_oc_blocking, nb_oc_blocking - oc_b,
                     jcp.nb_load_blocking_max);
             p.load_dim = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, oc_b_step * jcp.oc_block);
 
-            int ic_b_step = 0;
-            for (int ic_b = 0; ic_b < nb_ic_blocking; ic_b += ic_b_step) {
+            dim_t ic_b_step = 0;
+            for (dim_t ic_b = 0; ic_b < nb_ic_blocking; ic_b += ic_b_step) {
                 ic_b_step = step(nb_ic_blocking, nb_ic_blocking - ic_b,
                         jcp.nb_bcast_blocking_max);
                 p.bcast_dim = this_block_size(
@@ -606,8 +614,8 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                         + ic_b * jcp.ic_block * jcp.oc_block;
 
                 /* spatial reduction */
-                int sp_step = 0;
-                for (int sp = sp_start; sp < sp_end; sp += sp_step) {
+                dim_t sp_step = 0;
+                for (dim_t sp = sp_start; sp < sp_end; sp += sp_step) {
                     sp_step = step(jcp.nb_reduce_blocking, sp_end - sp,
                             jcp.nb_reduce_blocking_max);
                     p.reduce_dim = sp_step * jcp.reduce_block;
@@ -623,14 +631,14 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                                           : jcp.oc_block);
 
                     if (pd()->rtus_.reduce_src_) {
-                        const int od = sp / (jcp.oh * jcp.ow);
-                        const int sp_2d = sp % (jcp.oh * jcp.ow);
-                        const int oh = sp_2d / jcp.ow;
-                        const int ow = sp_2d % jcp.ow;
+                        const dim_t od = sp / (jcp.oh * jcp.ow);
+                        const dim_t sp_2d = sp % (jcp.oh * jcp.ow);
+                        const dim_t oh = sp_2d / jcp.ow;
+                        const dim_t ow = sp_2d % jcp.ow;
 
-                        const int id = od * stride_d;
-                        const int ih = oh * stride_h;
-                        const int iw = ow * stride_w;
+                        const dim_t id = od * stride_d;
+                        const dim_t ih = oh * stride_h;
+                        const dim_t iw = ow * stride_w;
                         rp.iw_start = iw;
 
                         rp.ws = rtus_space
@@ -662,23 +670,24 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
     };
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (is_ddst_layout_nxc && ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = nb_ic - 1;
-                const size_t off = pd()->with_groups()
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for_(dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb)
+            {
+                const dim_t z_icb = nb_ic - 1;
+                const dim_t off = pd()->with_groups()
                         ? diff_weights_d.blk_off(g, z_ocb, z_icb)
                         : diff_weights_d.blk_off(z_ocb, z_icb);
                 data_t *z_wei = diff_weights + off + ic_tail * jcp.oc_block;
-                const int zero_work
+                const dim_t zero_work
                         = (nb_ic * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -693,26 +702,26 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
         /* setup: independent work (oc, ic) */
         const int w_job_start = rw->balancer().ithr_job_off(ithr);
-        int g {0}, load_i {0}, bcast_i {0};
+        dim_t g {0}, load_i {0}, bcast_i {0};
         nd_iterator_init(w_job_start, g, jcp.ngroups, load_i, load_work,
                 bcast_i, bcast_work);
 
         /* setup: reduction work (mb, sp) */
-        int mb_sp_start {0}, mb_sp_end {0};
+        dim_t mb_sp_start {0}, mb_sp_end {0};
         balance211(mb_sp_work, rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), mb_sp_start, mb_sp_end);
-        int img_start {0}, sp_start {0};
+        dim_t img_start {0}, sp_start {0};
         nd_iterator_init(mb_sp_start, img_start, jcp.mb, sp_start, sp_dim);
 
         /* independent work */
         for (int iwork = 0; iwork < w_njobs; ++iwork) {
-            const int oc_b = nb_oc_blocking * load_i;
-            const int ic_b = nb_ic_blocking * bcast_i;
+            const dim_t oc_b = nb_oc_blocking * load_i;
+            const dim_t ic_b = nb_ic_blocking * bcast_i;
 
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * nb_oc + oc_b;
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * nb_ic + ic_b;
 
@@ -726,17 +735,19 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 store_to = &diff_weights[off];
                 store_to_ld = rnd_up(jcp.ic, jcp.ic_block) * jcp.oc_block;
             } else {
-                const size_t off = (size_t)iwork * rw->balancer().job_size_;
+                const dim_t off
+                        = static_cast<dim_t>(iwork) * rw->balancer().job_size_;
                 store_to
                         = rw->get_local_ptr(ithr, reducer_wei_scratchpad) + off;
                 store_to_ld = nb_ic_blocking * jcp.ic_block * jcp.oc_block;
             }
 
             /* reduction work */
-            int img = img_start;
-            int sp = sp_start;
-            int sp_step = 0;
-            for (int mb_sp = mb_sp_start; mb_sp < mb_sp_end; mb_sp += sp_step) {
+            dim_t img = img_start;
+            dim_t sp = sp_start;
+            dim_t sp_step = 0;
+            for (dim_t mb_sp = mb_sp_start; mb_sp < mb_sp_end;
+                    mb_sp += sp_step) {
                 sp_step = nstl::min(sp_dim - sp, mb_sp_end - mb_sp);
 
                 const bool first_image = img == img_start;
@@ -780,18 +791,18 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        int img_start {0}, img_end {0};
+        dim_t img_start {0}, img_end {0};
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */
-        int g_start {0}, ocb_start {0};
+        dim_t g_start {0}, ocb_start {0};
         nd_iterator_init(b_job_start, g_start, jcp.ngroups, ocb_start, nb_oc);
 
-        for (int img = img_start; img < img_end; ++img) {
-            int g = g_start, ocb = ocb_start;
+        for (dim_t img = img_start; img < img_end; ++img) {
+            dim_t g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g * nb_oc + ocb;
 
@@ -805,13 +816,13 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] = 0.;
 
-                const int spatial_shift
+                const dim_t spatial_shift
                         = is_ddst_layout_nxc ? jcp.oc : jcp.oc_block;
-                const int max_oc = this_block_size(
+                const dim_t max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
                 for (dim_t hw = 0; hw < jcp.os; ++hw) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += spatial_shift;
                 }
@@ -857,9 +868,9 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* TODO: put this in ker_bias */
         if (is_bias_padded) {
             assert(IMPLICATION(!is_ddst_layout_nxc, jcp.ngroups == 1));
-            const int padded_stride = utils::rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = utils::rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -278,8 +278,8 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw->nb_ch_blocking != 0)
                 --jcp_dw->nb_ch_blocking;
 
-            jcp_dw->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
 
             const auto dat_tag_nxc = utils::pick(ndims() - 3, format_tag::nwc,
                     format_tag::nhwc, format_tag::ndhwc);
@@ -553,34 +553,41 @@ struct jit_avx2_1x1_convolution_bwd_weights_t : public primitive_t {
 
     private:
         void init_balancers() {
-            const int ic_block = jcp_.bcast_block;
-            const int nb_ic = jcp_.nb_bcast;
-            const int nb_ic_blocking = jcp_.nb_bcast_blocking;
-            const int bcast_work = utils::div_up(nb_ic, nb_ic_blocking);
+            const dim_t ic_block = jcp_.bcast_block;
+            const dim_t nb_ic = jcp_.nb_bcast;
+            const dim_t nb_ic_blocking = jcp_.nb_bcast_blocking;
+            const dim_t bcast_work = utils::div_up(nb_ic, nb_ic_blocking);
 
-            const int oc_block = jcp_.load_block;
-            const int nb_oc = jcp_.nb_load;
-            const int nb_oc_blocking = jcp_.nb_load_blocking;
-            const int load_work = utils::div_up(nb_oc, nb_oc_blocking);
+            const dim_t oc_block = jcp_.load_block;
+            const dim_t nb_oc = jcp_.nb_load;
+            const dim_t nb_oc_blocking = jcp_.nb_load_blocking;
+            const dim_t load_work = utils::div_up(nb_oc, nb_oc_blocking);
 
-            const int job_size
+            const dim_t job_size
                     = nb_oc_blocking * nb_ic_blocking * ic_block * oc_block;
-            const int njobs_x = bcast_work;
-            const int njobs_y = jcp_.ngroups * load_work;
+            const dim_t njobs_x = bcast_work;
+            const dim_t njobs_y = jcp_.ngroups * load_work;
 
             const int max_threads = dnnl_get_max_threads();
             const size_t max_buffer_size = (size_t)max_threads * job_size * 8;
 
             if (with_bias()) {
-                reducer_bia_conf_.init(reduce_balancer_t(max_threads, oc_block,
-                        jcp_.ngroups * nb_oc, jcp_.mb, max_buffer_size, true));
+                reducer_bia_conf_.init(reduce_balancer_t(max_threads,
+                        static_cast<int>(oc_block),
+                        static_cast<int>(jcp_.ngroups * nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
 
             reducer_wei_conf_.init(
-                    reduce_balancer_t(max_threads, job_size, njobs_y * njobs_x,
-                            jcp_.mb * jcp_.nb_reduce, max_buffer_size, true),
-                    job_size / nb_oc_blocking, nb_oc_blocking, ic_block,
-                    nb_ic * ic_block * oc_block, nb_oc);
+                    reduce_balancer_t(max_threads, static_cast<int>(job_size),
+                            static_cast<int>(njobs_y * njobs_x),
+                            static_cast<int>(jcp_.mb * jcp_.nb_reduce),
+                            max_buffer_size, true),
+                    static_cast<int>(job_size / nb_oc_blocking),
+                    static_cast<int>(nb_oc_blocking),
+                    static_cast<int>(ic_block),
+                    static_cast<int>(nb_ic * ic_block * oc_block),
+                    static_cast<int>(nb_oc));
         }
     };
 

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -60,7 +60,7 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
 
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r13, r14,
                 r15, preserve_gpr, preserve_vmm,
@@ -77,18 +77,19 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
 
 void jit_avx2_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int dilate_w = jcp.dilate_w + 1;
-    int ic_block = jcp.ic_block;
+    const int kw = static_cast<int>(jcp.kw);
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    int ic_block = static_cast<int>(jcp.ic_block);
     int ic_tail = jcp.ic_tail;
 
     for (int ki = 0; ki < kw; ki++) {
-        int jj_start = div_up(nstl::max(0, pad_l - ki * dilate_w), stride_w);
-        int jj_end = ur_w
-                - div_up(nstl::max(0,
+        int jj_start = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, pad_l - ki * dilate_w), stride_w));
+        int jj_end = static_cast<int>(ur_w
+                - div_up(nstl::max<dim_t>(0,
                                  ki * dilate_w + pad_r - (kw - 1) * dilate_w),
-                        stride_w);
+                        stride_w));
 
         auto compute = [&](int cur_ic_blk) {
             for (int ifm2 = 0; ifm2 < cur_ic_blk; ifm2++) {
@@ -144,8 +145,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::oh_step_nopad(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     Label kw_loop;
 
-    int kw = jcp.kw;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    int ic_blk = static_cast<int>(jcp.ic_block);
 
     xor_(ki_iter, ki_iter);
     L(kw_loop);
@@ -258,8 +259,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::apply_postops(
 
 void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int oc_blk = jcp.oc_block;
+    const int kw = static_cast<int>(jcp.kw);
+    int oc_blk = static_cast<int>(jcp.oc_block);
     int oc_tail = jcp.oc_tail;
 
     if (oc_tail) {
@@ -412,7 +413,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
     if (jcp.ndims == 5) {
         safe_add(aux_reg_inp_d, get_input_offset(0, filter_d_to_input(1)),
                 reg_long_offt);
-        safe_add(aux_reg_ker_d, get_kernel_offset(0, jcp.kw * jcp.kh, 0),
+        safe_add(aux_reg_ker_d,
+                get_kernel_offset(0, static_cast<int>(jcp.kw * jcp.kh), 0),
                 reg_long_offt);
 
         dec(reg_ki);
@@ -467,7 +469,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
     } else {
         Label regular_store;
         Label store_done;
-        const int tail = jcp.oc_without_padding % jcp.oc_block;
+        const int tail = static_cast<int>(
+                jcp.oc_without_padding % jcp.oc_block);
         if (jcp.with_binary && tail) {
             test(reg_ci_flag, FLAG_IC_LAST);
             je(regular_store, T_NEAR);
@@ -490,24 +493,28 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
 inline void jit_avx2_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int n_oi = jcp.ow / ur_w;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int str_w = jcp.stride_w;
+    int n_oi = static_cast<int>(jcp.ow / ur_w);
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t str_w = jcp.stride_w;
 
-    int l_pad = jcp.l_pad;
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, str_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    const dim_t l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            str_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
     if (r_pad1 > 0) n_oi--;
 
     if (l_pad > 0) {
         n_oi--;
         if (n_oi < 0 && r_pad1 > 0)
-            width_blk_step(ur_w, l_pad, r_pad1, oc_blocks); // "lrpad"
+            width_blk_step(ur_w, static_cast<int>(l_pad), r_pad1,
+                    oc_blocks); // "lrpad"
         else
-            width_blk_step(ur_w, l_pad, 0, oc_blocks); // "lpad"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
+            width_blk_step(ur_w, static_cast<int>(l_pad), 0,
+                    oc_blocks); // "lpad"
+        add(reg_input,
+                get_input_offset(0,
+                        filter_w_to_input(0, ur_w, static_cast<int>(l_pad))));
         add(reg_output, get_output_offset(0, ur_w));
     }
 
@@ -616,8 +623,11 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.od = (ndims == 5) ? dst_d.dims()[2] : 1;
     jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[ndims - 2];
     jcp.ow = dst_d.dims()[ndims - 1];
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
+    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2]
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : weights_d.dims()[with_groups + ndims - 2];
     jcp.kw = weights_d.dims()[with_groups + ndims - 1];
 
     jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
@@ -631,9 +641,9 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -660,8 +670,10 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag_OIxio, wei_tag_Oxio);
     jcp.dst_tag = dst_d.mb_stride_relaxed_match(dat_tag_nxc, dat_tag_nCx8c);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     bool is_data_layout_nxc
             = everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
@@ -691,8 +703,9 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     /* Grouped channel offset to support 'non-blocked data' format for
      * convolution sizes with '(input_channel / ngroups) < simd' */
     jcp.nonblk_group_off
-            = one_of(jcp.src_tag, ncw, nchw, ncdhw) && jcp.ngroups > 1 ? jcp.ic
-                                                                       : 1;
+            = one_of(jcp.src_tag, ncw, nchw, ncdhw) && jcp.ngroups > 1
+            ? static_cast<int>(jcp.ic)
+            : 1;
 
     bool ok_to_pad_channels = true && !is_data_layout_nxc && jcp.ngroups == 1;
 
@@ -725,7 +738,7 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(flat,
                     jcp.wei_tag == wei_tag_Oxio
                             && ((tag_is_flat(jcp.src_tag, dat_tag_ncx,
-                                         dat_tag_nxc, jcp.ic)
+                                         dat_tag_nxc, static_cast<int>(jcp.ic))
                                         && jcp.dst_tag == dat_tag_nCx8c)
                                     || (jcp.src_tag == dat_tag_nxc
                                             && jcp.dst_tag == dat_tag_nxc)))
@@ -775,7 +788,7 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
         }
     }
 
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     VDISPATCH_CONV_IC(IMPLICATION(!is_data_layout_nxc, jcp.oc % simd_w == 0),
@@ -796,20 +809,22 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             : (jcp.with_binary ? jcp.oc_without_padding % simd_w : 0);
 
     int r_pad_no_tail = nstl::max(0,
-            calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+            static_cast<int>(calculate_end_padding(jcp.l_pad,
+                    jcp.ow - jcp.ur_w_tail, jcp.iw, jcp.stride_w, ext_kw)));
 
     if (r_pad_no_tail > jcp.ur_w * jcp.stride_w && jcp.ow / jcp.ur_w > 1) {
         /* recalculate ur_w, nb_oc_blocking and ur_w_tail */
-        jcp.ur_w = nstl::min(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
-                nstl::min(jcp.ow, num_avail_regs / 2));
+        jcp.ur_w = static_cast<int>(
+                nstl::min<dim_t>(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
+                        nstl::min<dim_t>(jcp.ow, num_avail_regs / 2)));
         jcp.nb_oc_blocking = (num_avail_regs - jcp.ur_w) / jcp.ur_w;
-        jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+        jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
         /* check again ... */
         r_pad_no_tail = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                        jcp.stride_w, ext_kw));
-        VDISPATCH_CONV_IC((jcp.ur_w >= nstl::max(jcp.l_pad, r_pad_no_tail)),
+                static_cast<int>(calculate_end_padding(jcp.l_pad,
+                        jcp.ow - jcp.ur_w_tail, jcp.iw, jcp.stride_w, ext_kw)));
+        VDISPATCH_CONV_IC(
+                (jcp.ur_w >= nstl::max<dim_t>(jcp.l_pad, r_pad_no_tail)),
                 VERBOSE_UNSUPPORTED_PAD_FEATURE,
                 "width unroll exceeds padding size");
     }
@@ -852,13 +867,13 @@ void jit_avx2_conv_fwd_kernel_f32_t::init_scratchpad(
 
 void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
         int ur_w, int l_overflow, int r_overflow) {
-    int kw = jcp.kw;
-    int ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t ow = jcp.ow;
 
-    int oc_block = jcp.oc_block;
+    int oc_block = static_cast<int>(jcp.oc_block);
     int nb_ic_block = jcp.nb_ic_blocking;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t stride_h = jcp.stride_h;
     int oc_tail = jcp.oc_tail;
     int ic_tail = jcp.ic_tail;
 
@@ -918,14 +933,18 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     L(kh_loop);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow); // 0;
-            int jj_end = get_iw_end(ur_w, ki, r_overflow); // ur_w;
+            const int jj_start = static_cast<int>(
+                    get_iw_start(ki, l_overflow)); // 0;
+            const int jj_end = static_cast<int>(
+                    get_iw_end(ur_w, ki, r_overflow)); // ur_w;
 
             auto compute = [&](int cur_oc_blk) {
                 for (int ofm2 = 0; ofm2 < cur_oc_blk; ofm2++) {
                     for (int jj = jj_start; jj < jj_end; jj += stride_w) {
-                        int aux_output_offset = get_ddst_offset(
-                                0, filter_w_to_ddst(ki, jj, jcp.l_pad), ofm2);
+                        dim_t aux_output_offset = get_ddst_offset(0,
+                                filter_w_to_ddst(
+                                        ki, jj, static_cast<int>(jcp.l_pad)),
+                                ofm2);
                         vbroadcastss(Ymm(nb_ic_block * ur_w + jj / stride_w),
                                 ptr[aux_reg_ddst + aux_output_offset]);
                     }
@@ -962,7 +981,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
             }
         }
 
-        add(aux_reg_kernel, get_kernel_offset(0, 0, stride_h * kw, 0));
+        add(aux_reg_kernel,
+                get_kernel_offset(0, 0, static_cast<int>(stride_h * kw), 0));
         sub(aux_reg_ddst, get_ddst_offset(0, (jcp.dilate_h + 1) * ow, 0));
 
         dec(kj);
@@ -974,7 +994,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     if (jcp.ndims == 5) {
         sub(aux_reg_dst_d,
                 get_ddst_offset(0, (jcp.dilate_d + 1) * jcp.oh * ow, 0));
-        add(aux_reg_ker_d, get_kernel_offset(0, 0, jcp.kw * jcp.kh, 0));
+        add(aux_reg_ker_d,
+                get_kernel_offset(0, 0, static_cast<int>(jcp.kw * jcp.kh), 0));
 
         dec(reg_ki);
         cmp(reg_ki, 0);
@@ -985,8 +1006,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     }
 
     if (one_of(jcp.ndims, 3, 4)) {
-        int ddst_oc_shift = get_ddst_offset(1, 0, 0);
-        int kernel_oc_shift = get_kernel_offset(1, 0, 0, 0);
+        dim_t ddst_oc_shift = get_ddst_offset(1, 0, 0);
+        dim_t kernel_oc_shift = get_kernel_offset(1, 0, 0, 0);
 
         add(aux_reg_ddst_oc_loop, ddst_oc_shift);
         add(aux_reg_kernel_oc_loop, kernel_oc_shift);
@@ -1062,18 +1083,20 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::generate() {
     mov(reg_channel, ptr[param1 + GET_OFF(channel)]);
     mov(reg_channel_work, ptr[param1 + GET_OFF(ch_blocks)]);
 
-    int ddst_shift = get_ddst_offset(0, filter_w_to_ddst(0, jcp.ur_w), 0);
-    int dsrc_shift = get_dsrc_offset(0, jcp.ur_w);
+    dim_t ddst_shift = get_ddst_offset(0, filter_w_to_ddst(0, jcp.ur_w), 0);
+    dim_t dsrc_shift = get_dsrc_offset(0, jcp.ur_w);
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kw = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
 
-    int l_overflow = nstl::max(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w);
-    int r_overflow = nstl::max(
-            0, (ext_kw - 1 - nstl::max(0, jcp.r_pad)) / jcp.stride_w);
-    int r_overflow1 = nstl::max(
-            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w));
+    int r_overflow = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - nstl::max<dim_t>(0, jcp.r_pad)) / jcp.stride_w));
+    int r_overflow1 = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w));
 
-    int n_oi = jcp.iw / jcp.ur_w;
+    int n_oi = static_cast<int>(jcp.iw / jcp.ur_w);
     if (r_overflow1 > 0) n_oi--;
 
     if (jcp.ur_w == jcp.iw) {
@@ -1150,8 +1173,11 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
     jcp.ow = diff_dst_d.dims()[ndims - 1];
 
-    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + ndims - 2];
+    jcp.kd = (ndims == 5) ? weights_d.dims()[with_groups + 2]
+                          : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : weights_d.dims()[with_groups + ndims - 2];
     jcp.kw = weights_d.dims()[with_groups + ndims - 1];
 
     jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
@@ -1193,8 +1219,10 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             = diff_dst_d.mb_stride_relaxed_match(dat_tag_nxc, dat_tag_nCx8c);
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
 
-    jcp.typesize_in = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     bool is_data_layout_nxc
             = everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
@@ -1244,9 +1272,9 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && jcp.src_tag == required_dat_tag && jcp.wei_tag == wei_tag;
     VDISPATCH_CONV_IC(tag_ok, VERBOSE_UNSUPPORTED_TAG);
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
@@ -1261,7 +1289,8 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!kernel_outside_src, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weights and src size mismatch");
 
-    int l_overflow = nstl::max(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w));
 
     const int max_regs = 15; /* Maximum number of registers available for
                                 result accumulation and delta dst data.
@@ -1279,10 +1308,11 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     for (int b = 1; b <= 4; b++) {
         if (jcp.nb_ic % b != 0) continue;
 
-        for (int u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
+        for (int u = static_cast<int>(jcp.stride_w);
+                u * b + u / jcp.stride_w <= max_regs
                 && u < jcp.iw + jcp.stride_w;
                 u += jcp.stride_w) {
-            int ur_w = nstl::min(u, jcp.iw);
+            int ur_w = static_cast<int>(nstl::min<dim_t>(u, jcp.iw));
             /* maximum 1 step with l_overflow so far */
             if (l_overflow * jcp.stride_w > ur_w && ur_w != jcp.iw) continue;
             int nfmas = div_up(ur_w, jcp.stride_w) * b;
@@ -1297,10 +1327,10 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(best_nfmas > 0, VERBOSE_BLOCKING_FAIL,
             "cannot find appropriate blocking");
 
-    jcp.ur_w_tail = jcp.iw % jcp.ur_w;
+    jcp.ur_w_tail = static_cast<int>(jcp.iw % jcp.ur_w);
 
-    int r_overflow_no_tail = nstl::max(
-            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w);
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w));
 
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
@@ -1380,8 +1410,12 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.oh = (ndims == 3) ? 1 : diff_dst_d.dims()[ndims - 2];
     jcp.ow = diff_dst_d.dims()[ndims - 1];
 
-    jcp.kd = (ndims == 5) ? diff_weights_d.dims()[with_groups + 2] : 1;
-    jcp.kh = (ndims == 3) ? 1 : diff_weights_d.dims()[with_groups + ndims - 2];
+    jcp.kd = (ndims == 5)
+            ? diff_weights_d.dims()[with_groups + 2]
+            : 1;
+    jcp.kh = (ndims == 3)
+            ? 1
+            : diff_weights_d.dims()[with_groups + ndims - 2];
     jcp.kw = diff_weights_d.dims()[with_groups + ndims - 1];
 
     jcp.f_pad = (ndims == 5) ? cd.padding[0][0] : 0;
@@ -1421,21 +1455,21 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
 
     const int simd_w = 8;
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
-    jcp.r_pad = nstl::max(0,
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
-    const int max_h_pad = ext_kh;
-    const int max_w_pad = ext_kw;
+    const dim_t max_h_pad = ext_kh;
+    const dim_t max_w_pad = ext_kw;
     const bool boundaries_ok = true && jcp.t_pad < max_h_pad
             && jcp.b_pad < max_h_pad && jcp.l_pad < max_w_pad
             && jcp.r_pad < max_w_pad && jcp.f_pad == 0 && jcp.back_pad == 0;
@@ -1456,7 +1490,7 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(flat,
                     jcp.wei_tag == wei_tag_Oxio
                             && ((tag_is_flat(jcp.src_tag, dat_tag_ncx,
-                                         dat_tag_nxc, jcp.ic)
+                                         dat_tag_nxc, static_cast<int>(jcp.ic))
                                         && jcp.dst_tag == dat_tag_nCx8c)
                                     || (jcp.src_tag == dat_tag_nxc
                                             && jcp.dst_tag == dat_tag_nxc)))
@@ -1487,8 +1521,10 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
     jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     const bool is_src_layout_blocked = jcp.src_tag == dat_tag_nCx8c;
     const bool is_dst_layout_blocked = jcp.dst_tag == dat_tag_nCx8c;
@@ -1526,7 +1562,8 @@ jit_avx2_conv_bwd_weights_kernel_f32_t::od_step_comeback_pointers() {
     L(kd_comeback_loop);
     {
         sub(aux_reg_input, get_input_offset(0, jcp.iw * jcp.ih));
-        sub(aux_reg_kernel, get_kernel_offset(jcp.kw * jcp.kh, 0));
+        sub(aux_reg_kernel,
+                get_kernel_offset(jcp.kw * jcp.kh, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kd_comeback_loop, T_NEAR);
@@ -1548,12 +1585,12 @@ jit_avx2_conv_bwd_weights_kernel_f32_t::oh_step_comeback_pointers() {
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset) {
 
     if (ic_block_step <= 0) return;
 
-    const int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     const int oc_tail = jcp.oc_tail;
 
     if (oc_tail) {
@@ -1584,7 +1621,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
                                 + output_offset]);
 
             for (int i_kw = 0; i_kw < kw; i_kw++) {
-                int i_iw = i_ur * jcp.stride_w + i_kw;
+                const dim_t i_iw = i_ur * jcp.stride_w + i_kw;
                 if (i_iw - pad_l < 0
                         || i_iw > (ur_w - 1) * jcp.stride_w + kw - 1 - pad_r)
                     continue;
@@ -1632,7 +1669,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
-    int ic_block_step;
+    dim_t ic_block_step;
     if (one_of(jcp.src_tag, ncw, nchw, ncdhw)) {
         ic_block_step = jcp.kw >= 5 ? 1 : jcp.ic_block;
     } else if (one_of(jcp.src_tag, nwc, nhwc, ndhwc)) {
@@ -1640,7 +1677,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
         if (jcp.ic_block % ic_block_step != 0) {
             ic_block_step = jcp.ic_block < ic_block_step ? jcp.ic_block : 1;
         }
-        if (jcp.ic < ic_block_step) ic_block_step = jcp.ic;
+        if (jcp.ic < ic_block_step) ic_block_step = static_cast<int>(jcp.ic);
     } else {
         ic_block_step = jcp.kw > 7 ? 1 : jcp.kw > 3 ? 2 : jcp.kw > 1 ? 4 : 8;
     }
@@ -1648,9 +1685,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
     const int max_ur_w = jcp.ow > 56 ? 14 : 28;
 
     if (jcp.ow <= max_ur_w || one_of(jcp.src_tag, nwc, nhwc, ndhwc))
-        compute_oh_step_unroll_ow(ic_block_step, max_ur_w);
+        compute_oh_step_unroll_ow(static_cast<int>(ic_block_step), max_ur_w);
     else
-        compute_oh_step_common(ic_block_step, max_ur_w);
+        compute_oh_step_common(static_cast<int>(ic_block_step), max_ur_w);
 
     if (jcp.ndims == 5) {
         od_step_comeback_pointers();
@@ -1665,9 +1702,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         int ic_block_step, int max_ur_w) {
     UNUSED(max_ur_w);
 
-    const int r_pad = jcp.r_pad;
+    const dim_t r_pad = jcp.r_pad;
     const int ic_tail = jcp.ic_tail;
-    const int ic_block = jcp.ic_block;
+    const int ic_block = static_cast<int>(jcp.ic_block);
     const int ic_block_step_tail = jcp.ic % ic_block_step;
     const size_t inp_icblk_stride = get_input_offset(ic_block_step, 0);
 
@@ -1699,8 +1736,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         Label ic_block_loop;
         L(ic_block_loop);
         {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step, 0, 0, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
             add(reg_kernel, get_kernel_offset(0, ic_block_step));
             add(b_ic, ic_block_step);
@@ -1709,7 +1746,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         }
         add(reg_input,
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_block, 0));
-        add(reg_kernel, get_kernel_offset((jcp.kw - 1), 0));
+        add(reg_kernel, get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop, T_NEAR);
@@ -1726,8 +1763,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         mov(b_ic, ic_tail);
         L(ic_block_loop);
         {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step, 0, 0, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
             add(reg_kernel, get_kernel_offset(0, ic_block_step));
             sub(b_ic, ic_block_step);
@@ -1738,8 +1775,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         L(ic_block_loop_done);
 
         if (ic_block_step_tail) {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step_tail, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step_tail, 0, 0, 0);
             add(reg_input, get_input_offset(ic_block_step_tail, 0));
             add(reg_kernel, get_kernel_offset(0, ic_block_step_tail));
         }
@@ -1748,7 +1785,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_tail, 0));
         add(reg_kernel,
                 get_kernel_offset(0, ic_block - ic_tail)
-                        + get_kernel_offset((jcp.kw - 1), 0));
+                        + get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop_ic_tail, T_NEAR);
@@ -1758,7 +1795,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
 
     if (jcp.ndims == 5) {
         add(aux_reg_input, get_input_offset(0, jcp.ih * jcp.iw));
-        add(aux_reg_kernel, get_kernel_offset(jcp.kh * jcp.kw, 0));
+        add(aux_reg_kernel,
+                get_kernel_offset(jcp.kh * jcp.kw, 0));
         dec(ki);
         cmp(ki, 0);
         jg(kd_loop, T_NEAR);
@@ -1770,15 +1808,15 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         int ic_block_step, int max_ur_w) {
     // TODO: suppport channel tails for nxc format
 
-    const int ic_block = jcp.ic_block;
-    const int stride_w = jcp.stride_w;
+    const int ic_block = static_cast<int>(jcp.ic_block);
+    const int stride_w = static_cast<int>(jcp.stride_w);
     Label kd_loop;
 
-    const int r_pad = jcp.r_pad;
+    const int r_pad = static_cast<int>(jcp.r_pad);
 
-    int ur_w = nstl::min(jcp.ow, max_ur_w);
-    int ur_w_trips = jcp.ow / ur_w;
-    int ur_w_tail = jcp.ow % ur_w;
+    int ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, max_ur_w));
+    int ur_w_trips = static_cast<int>(jcp.ow / ur_w);
+    int ur_w_tail = static_cast<int>(jcp.ow % ur_w);
     if ((ur_w_tail == 0 && r_pad != 0) || r_pad >= ur_w_tail) {
         if (ur_w_trips > 1) {
             ur_w_tail += ur_w;
@@ -1789,9 +1827,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         }
     }
 
-    int input_comeback
+    dim_t input_comeback
             = get_input_offset(0, ur_w_trips * ur_w * stride_w - jcp.l_pad);
-    int output_comeback = get_output_offset(0, ur_w_trips * ur_w);
+    dim_t output_comeback = get_output_offset(0, ur_w_trips * ur_w);
 
     if (jcp.ndims == 5) {
         mov(aux_reg_input, reg_input);
@@ -1851,7 +1889,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         }
         add(reg_input,
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_block, 0));
-        add(reg_kernel, get_kernel_offset((jcp.kw - 1), 0));
+        add(reg_kernel, get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop, T_NEAR);
@@ -1859,7 +1897,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 
     if (jcp.ndims == 5) {
         add(aux_reg_input, get_input_offset(0, jcp.ih * jcp.iw));
-        add(aux_reg_kernel, get_kernel_offset(jcp.kh * jcp.kw, 0));
+        add(aux_reg_kernel,
+                get_kernel_offset(jcp.kh * jcp.kw, 0));
         dec(ki);
         cmp(ki, 0);
         jg(kd_loop, T_NEAR);
@@ -1867,9 +1906,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
-    const int t_pad = jcp.t_pad;
-    const int stride_h = jcp.stride_h;
-    int b_pad = jcp.b_pad;
+    const dim_t t_pad = jcp.t_pad;
+    const dim_t stride_h = jcp.stride_h;
+    dim_t b_pad = jcp.b_pad;
 
     Label oh_tpad_loop, oh_loop, oh_loop_end;
 
@@ -1885,7 +1924,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
         {
             compute_oh_step_disp();
             add(reg_output, get_output_offset(0, jcp.ow));
-            sub(reg_kernel, get_kernel_offset(stride_h * jcp.kw, 0));
+            sub(reg_kernel,
+                    get_kernel_offset(stride_h * jcp.kw, 0));
 
             inc(reg_oj);
             add(reg_ih_count, stride_h);
@@ -1893,14 +1933,15 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
 
             /* the overlap between input and kernel may not reach kernel size.
              * so far we do not support that (until we put constant here) */
-            const int final_inp_ker_overlap = jcp.kh; /* [bwd_w:r2] */
+            const dim_t final_inp_ker_overlap = jcp.kh; /* [bwd_w:r2] */
             cmp(reg_kh, final_inp_ker_overlap);
             jl(oh_tpad_loop, T_NEAR);
         }
 
         if (t_pad % stride_h != 0) {
-            int inp_corr = stride_h - t_pad % stride_h;
-            add(reg_kernel, get_kernel_offset(inp_corr * jcp.kw, 0));
+            const dim_t inp_corr = stride_h - t_pad % stride_h;
+            add(reg_kernel,
+                    get_kernel_offset(inp_corr * jcp.kw, 0));
             add(reg_input, get_input_offset(0, inp_corr * jcp.iw));
         }
     }

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
@@ -98,16 +98,16 @@ private:
         return static_cast<dim_t>(ki) * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
     }
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(int i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
             offset = static_cast<dim_t>(i_ic) * jcp.id * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
@@ -190,8 +190,8 @@ private:
 
     void generate() override;
 
-    inline int get_iw_start(int ki, int l_overflow) const {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    inline dim_t get_iw_start(dim_t ki, dim_t l_overflow) const {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -200,10 +200,10 @@ private:
         return res;
     }
 
-    inline int get_iw_end(int ur_w, int ki, int r_overflow) const {
+    inline dim_t get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) const {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
@@ -215,12 +215,12 @@ private:
         return (oi + pad_l - ki * (jcp.dilate_w + 1)) / jcp.stride_w;
     }
 
-    inline dim_t get_ddst_offset(int i_oc_block, int i_ow, int i_oc) const {
+    inline dim_t get_ddst_offset(int i_oc_block, dim_t i_ow, int i_oc) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block + i_oc;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block
+                    + i_oc;
         } else {
             offset = static_cast<dim_t>(i_oc_block) * jcp.od * jcp.oh * jcp.ow
                             * jcp.oc_block
@@ -293,46 +293,43 @@ private:
 
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset);
     inline void compute_oh_step_disp();
     inline void compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w);
     inline void compute_oh_step_common(int ic_block_step, int max_ur_w);
     inline void compute_oh_loop_common();
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(int i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
             offset = static_cast<dim_t>(i_ic) * jcp.id * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_output_offset(int i_oc_block, int i_ow) const {
+    inline dim_t get_output_offset(dim_t i_oc_block, dim_t i_ow) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block;
         } else {
-            offset = static_cast<dim_t>(i_oc_block) * jcp.od * jcp.oh * jcp.ow
-                            * jcp.oc_block
+            offset = i_oc_block * jcp.od * jcp.oh * jcp.ow * jcp.oc_block
                     + i_ow * jcp.oc_block;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_kernel_offset(int ki, int i_ic) const {
+    inline dim_t get_kernel_offset(dim_t ki, dim_t i_ic) const {
         dim_t block_step_size = static_cast<dim_t>(jcp.ic_block) * jcp.oc_block;
-        dim_t offset = static_cast<dim_t>(ki) * block_step_size
-                + i_ic * jcp.oc_block;
+        dim_t offset = ki * block_step_size + i_ic * jcp.oc_block;
         return sizeof(float) * offset;
     }
     void generate() override;

--- a/src/cpu/x64/jit_avx2_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_convolution.cpp
@@ -57,9 +57,8 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper weights_d(pd()->weights_md(0));
     const memory_desc_wrapper bias_d(pd()->weights_md(1));
 
-    const size_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
-    const size_t work_amount
-            = jcp.mb * jcp.ngroups * ocb_work * jcp.od * jcp.oh;
+    const dim_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
+    const dim_t work_amount = jcp.mb * jcp.ngroups * ocb_work * jcp.od * jcp.oh;
 
     // Lambda captures by copy, the bias logic must stay afront the lambda,
     // otherwise, `bias` will be captured unmodified and lead to a crash inside
@@ -74,61 +73,63 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     }
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
                 format_tag::nChw8c, format_tag::nCdhw8c);
-        int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-        int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+        dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+        dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
         bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
                 format_tag::nChw8c, format_tag::nCdhw8c);
-        int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-        int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
-        int oc_bias_scale = is_oc_physically_blocked ? jcp.oc_block : 1;
+        dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+        dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+        dim_t oc_bias_scale = is_oc_physically_blocked ? jcp.oc_block : 1;
 
-        int icbb = 0;
+        dim_t icbb = 0;
         while (icbb < jcp.nb_ic) {
-            int icb_step = jcp.nb_ic_blocking;
-            int icb_step_rem = jcp.nb_ic - icbb;
+            dim_t icb_step = jcp.nb_ic_blocking;
+            dim_t icb_step_rem = jcp.nb_ic - icbb;
             if (icb_step_rem < jcp.nb_ic_blocking_max) icb_step = icb_step_rem;
 
-            size_t n {0}, g {0}, ocbb {0}, oh {0}, od {0};
+            dim_t n {0}, g {0}, ocbb {0}, oh {0}, od {0};
             nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
                     od, jcp.od, oh, jcp.oh);
-            for (size_t iwork = start; iwork < end; ++iwork) {
-                int ocb = ocbb * jcp.nb_oc_blocking;
-                int ocb_num = jcp.nb_oc_blocking;
+            for (dim_t iwork = start; iwork < end; ++iwork) {
+                dim_t ocb = ocbb * jcp.nb_oc_blocking;
+                dim_t ocb_num = jcp.nb_oc_blocking;
 
-                for (int icb = icbb; icb < icbb + icb_step; ++icb) {
+                for (dim_t icb = icbb; icb < icbb + icb_step; ++icb) {
                     auto par_conv = jit_conv_args_t();
 
-                    const int ij = oh * jcp.stride_h;
-                    const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
-                    const int i_b_overflow
-                            = nstl::max(jcp.ih,
+                    const dim_t ij = oh * jcp.stride_h;
+                    const dim_t i_t_overflow
+                            = nstl::max<dim_t>(0, jcp.t_pad - ij);
+                    const dim_t i_b_overflow
+                            = nstl::max<dim_t>(jcp.ih,
                                       ij + (jcp.kh - 1) * (jcp.dilate_h + 1)
                                               - jcp.t_pad + 1)
                             - jcp.ih;
 
-                    const int dj = od * jcp.stride_d;
-                    const int d_t_overflow = nstl::max(0, jcp.f_pad - dj);
-                    const int d_b_overflow
-                            = nstl::max(jcp.id,
+                    const dim_t dj = od * jcp.stride_d;
+                    const dim_t d_t_overflow
+                            = nstl::max<dim_t>(0, jcp.f_pad - dj);
+                    const dim_t d_b_overflow
+                            = nstl::max<dim_t>(jcp.id,
                                       dj + (jcp.kd - 1) * (jcp.dilate_d + 1)
                                               - jcp.f_pad + 1)
                             - jcp.id;
 
-                    const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
-                    const size_t _ic = g * g_ic_offset + icb * icb_ic_scale;
+                    const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                    const dim_t _ic = g * g_ic_offset + icb * icb_ic_scale;
 
-                    const int ih = nstl::max(ij - jcp.t_pad
+                    const dim_t ih = nstl::max<dim_t>(ij - jcp.t_pad
                                     + div_up(i_t_overflow, (jcp.dilate_h + 1))
                                             * (jcp.dilate_h + 1),
                             0);
 
-                    const int id = nstl::max(dj - jcp.f_pad
+                    const dim_t id = nstl::max<dim_t>(dj - jcp.f_pad
                                     + div_up(d_t_overflow, (jcp.dilate_d + 1))
                                             * (jcp.dilate_d + 1),
                             0);
@@ -137,8 +138,8 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
                     par_conv.dst = &dst[src_blk_off(dst_d, n, _oc, od, oh, 0)];
 
-                    const int wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
-                    const int wd = div_up(d_t_overflow, (jcp.dilate_d + 1));
+                    const dim_t wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
+                    const dim_t wd = div_up(d_t_overflow, (jcp.dilate_d + 1));
                     par_conv.filt = &weights[wht_blk_off(
                             weights_d, g, ocb, icb, wd, wh, 0)];
 
@@ -158,20 +159,20 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                             icb * jcp.ic_block, jcp.ic, jcp.ic_block);
 
                     par_conv.oc_blocks
-                            = nstl::min(ocb + ocb_num, jcp.nb_oc) - ocb;
+                            = nstl::min<dim_t>(ocb + ocb_num, jcp.nb_oc) - ocb;
 
                     if (ocbb == ocb_work - 1) par_conv.oc_flag |= FLAG_OC_LAST;
 
                     par_conv.kw_padding = 0;
-                    const int kh_padding = jcp.kh
+                    const dim_t kh_padding = jcp.kh
                             - div_up(i_t_overflow, (jcp.dilate_h + 1))
                             - div_up(i_b_overflow, (jcp.dilate_h + 1));
-                    par_conv.kh_padding = nstl::max(0, kh_padding);
+                    par_conv.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-                    const int kd_padding = jcp.kd
+                    const dim_t kd_padding = jcp.kd
                             - div_up(d_t_overflow, (jcp.dilate_d + 1))
                             - div_up(d_b_overflow, (jcp.dilate_d + 1));
-                    par_conv.kd_padding = nstl::max(0, kd_padding);
+                    par_conv.kd_padding = nstl::max<dim_t>(0, kd_padding);
 
                     par_conv.post_ops_binary_rhs_arg_vec
                             = post_ops_binary_rhs_arg_vec.data();
@@ -201,10 +202,10 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
 
     const auto &jcp = kernel_->jcp;
 
-    int icb_work = jcp.nb_ic / jcp.nb_ic_blocking;
-    int ih_block_size = jcp.ih;
-    int num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
-    size_t work_amount = jcp.mb * jcp.ngroups * icb_work * num_ih_blocks;
+    dim_t icb_work = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ih_block_size = jcp.ih;
+    dim_t num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
+    dim_t work_amount = jcp.mb * jcp.ngroups * icb_work * num_ih_blocks;
 
     const auto data_size = sizeof(data_t);
     const auto L2 = platform::get_per_core_cache_size(2) / data_size;
@@ -215,88 +216,95 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
             + (size_t)jcp.od * jcp.oh * jcp.ow * oc_chunk
             + (size_t)jcp.kd * jcp.kh * jcp.kw * ic_chunk * oc_chunk;
 
-    if (work_amount < (size_t)2 * jcp.nthr || iter_data_amount > L2) {
+    if (work_amount < 2 * static_cast<dim_t>(jcp.nthr)
+            || iter_data_amount > L2) {
         ih_block_size = 1;
         num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
         work_amount *= num_ih_blocks;
     }
 
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-    int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+    dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+    dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
     bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-    int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+    dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+    dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
 
     const bool is_ddst_layout_nxc = one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-    const int oc_step = is_ddst_layout_nxc ? jcp.nb_oc_blocking : 1;
+    const dim_t oc_step = is_ddst_layout_nxc ? jcp.nb_oc_blocking : 1;
 
     auto ker = [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        size_t n {0}, g {0}, icbb {0}, ihb {0};
+        dim_t n {0}, g {0}, icbb {0}, ihb {0};
         nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, icbb, icb_work, ihb,
                 num_ih_blocks);
-        for (size_t iwork = start; iwork < end; ++iwork) {
-            for_(int oc = 0; oc < jcp.nb_oc; oc += jcp.nb_oc_blocking)
-            for (int id = 0; id < jcp.id; ++id) {
-                int cur_nb_oc = nstl::min(jcp.nb_oc - oc, jcp.nb_oc_blocking);
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+            for_(dim_t oc = 0; oc < jcp.nb_oc; oc += jcp.nb_oc_blocking)
+            for (dim_t id = 0; id < jcp.id; ++id) {
+                const dim_t cur_nb_oc
+                        = nstl::min<dim_t>(jcp.nb_oc - oc, jcp.nb_oc_blocking);
 
                 auto par_conv = jit_conv_args_t();
 
-                int d_t_overflow, d_b_overflow, od;
+                dim_t d_t_overflow, d_b_overflow, od;
                 if (jcp.dilate_d != 0) { // stride == 1
-                    const int dilate_d = jcp.dilate_d + 1;
-                    d_t_overflow
-                            = div_up(nstl::max(0, ext_kd - 1 - id - jcp.f_pad),
-                                    dilate_d);
+                    const dim_t dilate_d = jcp.dilate_d + 1;
+                    d_t_overflow = div_up(
+                            nstl::max<dim_t>(0, ext_kd - 1 - id - jcp.f_pad),
+                            dilate_d);
                     d_b_overflow = div_up(
-                            nstl::max(0, ext_kd - jcp.id + id - jcp.back_pad),
+                            nstl::max<dim_t>(
+                                    0, ext_kd - jcp.id + id - jcp.back_pad),
                             dilate_d);
                     od = id + jcp.f_pad - d_b_overflow * dilate_d;
                 } else {
-                    d_t_overflow = nstl::max(0, jcp.kd - 1 - id - jcp.f_pad);
-                    d_b_overflow = nstl::max(
+                    d_t_overflow
+                            = nstl::max<dim_t>(0, jcp.kd - 1 - id - jcp.f_pad);
+                    d_b_overflow = nstl::max<dim_t>(
                             0, jcp.kd - 1 - (jcp.id - 1 - id) - jcp.back_pad);
                     od = id + jcp.f_pad - d_b_overflow;
                 }
                 par_conv.kd_padding = jcp.kd - d_t_overflow - d_b_overflow;
 
-                int ih_start = ihb * ih_block_size;
-                int ih_end = nstl::min(jcp.ih, ih_start + ih_block_size);
-                for (int ih = ih_start; ih < ih_end; ++ih) {
+                dim_t ih_start = ihb * ih_block_size;
+                dim_t ih_end
+                        = nstl::min<dim_t>(jcp.ih, ih_start + ih_block_size);
+                for (dim_t ih = ih_start; ih < ih_end; ++ih) {
 
-                    int k_lo, oh;
+                    dim_t k_lo, oh;
                     if (jcp.dilate_h != 0) { // stride == 1
-                        const int dilate_h = jcp.dilate_h + 1;
-                        int i_t_overflow = div_up(
-                                nstl::max(0, ext_kh - 1 - ih - jcp.t_pad),
-                                dilate_h);
-                        int i_b_overflow = div_up(
-                                nstl::max(0, ext_kh - jcp.ih + ih - jcp.b_pad),
+                        const dim_t dilate_h = jcp.dilate_h + 1;
+                        dim_t i_t_overflow
+                                = div_up(nstl::max<dim_t>(0,
+                                                 ext_kh - 1 - ih - jcp.t_pad),
+                                        dilate_h);
+                        dim_t i_b_overflow = div_up(
+                                nstl::max<dim_t>(
+                                        0, ext_kh - jcp.ih + ih - jcp.b_pad),
                                 dilate_h);
                         par_conv.kh_padding
                                 = jcp.kh - i_t_overflow - i_b_overflow;
                         k_lo = i_b_overflow;
                         oh = ih + jcp.t_pad - k_lo * dilate_h;
                     } else {
-                        int i_t_overflow = nstl::max(0,
+                        dim_t i_t_overflow = nstl::max<dim_t>(0,
                                 (jcp.kh - 1 - ih - jcp.t_pad) / jcp.stride_h);
-                        int i_b_overflow = nstl::max(0,
+                        dim_t i_b_overflow = nstl::max<dim_t>(0,
                                 (jcp.kh - jcp.ih + ih - jcp.b_pad)
                                         / jcp.stride_h);
-                        int overflow_kh_hi = jcp.kh - 1
+                        dim_t overflow_kh_hi = jcp.kh - 1
                                 - modulo(jcp.ih - 1 + jcp.b_pad - ih,
                                         jcp.stride_h);
-                        int overflow_kh_lo = (ih + jcp.t_pad) % jcp.stride_h;
+                        dim_t overflow_kh_lo = (ih + jcp.t_pad) % jcp.stride_h;
 
                         par_conv.kh_padding = (overflow_kh_hi - overflow_kh_lo)
                                         / jcp.stride_h
@@ -325,8 +333,7 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
                     if (is_ddst_layout_nxc) {
                         par_conv.load_work = this_block_size(
                                 icbb * jcp.nb_ic_blocking * jcp.ic_block,
-                                (size_t)jcp.ic,
-                                jcp.nb_ic_blocking * jcp.ic_block);
+                                jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
                         par_conv.reduce_work
                                 = this_block_size(oc * jcp.oc_block, jcp.oc,
                                         oc_step * jcp.oc_block);
@@ -380,50 +387,52 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
 
     bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-    int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+    dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+    dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
     bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
     bool is_ddst_layout_nxc = !is_oc_physically_blocked;
-    int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-    int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+    dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+    dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
 
     auto ker = [= COMPAT_THIS_CAPTURE](int ithr, int nthr) {
         assert(nthr == rw->balancer().nthr_);
 
-        const int w_job_start = rw->balancer().ithr_job_off(ithr);
+        const dim_t w_job_start = rw->balancer().ithr_job_off(ithr);
         const int w_njobs = rw->balancer().ithr_njobs(ithr);
 
         if (w_njobs == 0) return;
 
         /* reduction dimension */
-        int img_od_start {0}, img_od_end {0}, img {0}, od_s {0};
+        dim_t img_od_start {0}, img_od_end {0};
+        dim_t img {0}, od_s {0};
         balance211(jcp.mb * jcp.od, rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), img_od_start, img_od_end);
 
-        int img_start = img_od_start, img_end = img_od_end;
+        dim_t img_start = img_od_start;
+        dim_t img_end = img_od_end;
         nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
-        const int img_first = img;
+        const dim_t img_first = img;
 
         /* jobs */
-        int g_start {0}, ocb_start {0}, icb_start {0};
+        dim_t g_start {0}, ocb_start {0}, icb_start {0};
         nd_iterator_init(w_job_start, g_start, jcp.ngroups, ocb_start,
                 jcp.nb_oc, icb_start, jcp.nb_ic);
 
         while (img_start < img_end) {
-            int g = g_start, ocb = ocb_start, icb = icb_start;
+            dim_t g = g_start, ocb = ocb_start, icb = icb_start;
 
-            const int work_rem = img_end - img_start;
-            const int od_e
+            const dim_t work_rem = img_end - img_start;
+            const dim_t od_e
                     = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-            const int id_s = od_s * jcp.stride_d;
-            const int idp = jcp.id + jcp.f_pad + jcp.back_pad;
+            const dim_t id_s = od_s * jcp.stride_d;
+            const dim_t idp = jcp.id + jcp.f_pad + jcp.back_pad;
 
             if (id_s < idp - jcp.back_pad - jcp.kd + 1)
                 for (int w_job_loc = 0; w_job_loc < w_njobs; ++w_job_loc) {
-                    const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
-                    const size_t _ic = g * g_ic_offset + icb * icb_ic_scale;
+                    const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                    const dim_t _ic = g * g_ic_offset + icb * icb_ic_scale;
 
                     /* TODO: put dw <-- 0 in kernel */
                     if (img == img_first)
@@ -432,8 +441,8 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
                                         + w_job_loc * rw->balancer().job_size_,
                                 0, rw->balancer().job_size_);
 
-                    for (int od = od_s; od < od_e; ++od) {
-                        const int id = od * jcp.stride_d;
+                    for (dim_t od = od_s; od < od_e; ++od) {
+                        const dim_t id = od * jcp.stride_d;
                         if (id >= jcp.id - jcp.back_pad - jcp.kd + 1) break;
 
                         auto par_conv = jit_conv_args_t();
@@ -466,25 +475,25 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
     auto ker_bias = [=](int ithr, int nthr) {
         assert(nthr == rb->balancer().nthr_);
 
-        const int b_job_start = rb->balancer().ithr_job_off(ithr);
+        const dim_t b_job_start = rb->balancer().ithr_job_off(ithr);
         const int b_njobs = rb->balancer().ithr_njobs(ithr);
 
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        int img_start {0}, img_end {0};
+        dim_t img_start {0}, img_end {0};
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */
-        int g_start {0}, ocb_start {0};
+        dim_t g_start {0}, ocb_start {0};
         nd_iterator_init(
                 b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_oc);
 
-        for (int img = img_start; img < img_end; ++img) {
-            int g = g_start, ocb = ocb_start;
+        for (dim_t img = img_start; img < img_end; ++img) {
+            dim_t g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
 
                 const data_t *d_dst = &diff_dst[diff_dst_d.blk_off(img, _oc)];
                 data_t *d_bias = rb->get_local_ptr(ithr, diff_bias,
@@ -492,15 +501,15 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
                         + b_job_loc * rb->balancer().job_size_;
 
                 if (img == img_start)
-                    for (int o = 0; o < jcp.oc_block; ++o)
+                    for (dim_t o = 0; o < jcp.oc_block; ++o)
                         d_bias[o] = 0.;
 
-                const int max_oc = this_block_size(
+                const dim_t max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
 
-                for (int dhw = 0; dhw < jcp.od * jcp.oh * jcp.ow; ++dhw) {
+                for (dim_t dhw = 0; dhw < jcp.od * jcp.oh * jcp.ow; ++dhw) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
                                                 : jcp.oc_block;
@@ -546,9 +555,9 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
     parallel(1, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         /* TODO: put this in ker_bias */
         if (pd()->with_bias() && (jcp.oc_without_padding % jcp.oc_block != 0)) {
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g)
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g)
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
         }

--- a/src/cpu/x64/jit_avx2_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_convolution.hpp
@@ -307,14 +307,17 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
 
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(max_threads,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_oc, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
 
             reducer_wei_conf_.init(reduce_balancer_t(max_threads,
-                    jcp_.kd * jcp_.kh * jcp_.kw * jcp_.ic_block * jcp_.oc_block,
-                    jcp_.ngroups * jcp_.nb_ic * jcp_.nb_oc, jcp_.mb * jcp_.od,
-                    max_buffer_size, true));
+                    static_cast<int>(jcp_.kd * jcp_.kh * jcp_.kw * jcp_.ic_block
+                            * jcp_.oc_block),
+                    static_cast<int>(jcp_.ngroups * jcp_.nb_ic * jcp_.nb_oc),
+                    static_cast<int>(jcp_.mb * jcp_.od), max_buffer_size,
+                    true));
         }
     };
 

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -56,7 +56,7 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,
@@ -73,7 +73,7 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
     }
 }
 
-void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
+void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(dim_t load_loop_blk) {
     mov(aux1_reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
     mov(aux_reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
 
@@ -90,9 +90,9 @@ void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             if (i + 1 == num_substeps) L(large_tail);
             reduce_loop(load_loop_blk, jcp.ur, i, false);
             if (i < num_substeps - 1) {
@@ -131,44 +131,45 @@ void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
 }
 
 Address jit_avx512_common_1x1_conv_kernel_t::output_ptr(
-        const bool is_out_layout_nxc, const int i_load, const int i_ur) {
+        const bool is_out_layout_nxc, const dim_t i_load, const dim_t i_ur) {
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         auto i_load_shift = is_out_layout_nxc
                 ? jcp.load_block
                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
-        int i_ur_shift = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t i_ur_shift = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
         auto offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_out;
         return EVEX_compress_addr(aux_reg_output_data, offset);
     } else
         return ptr[aux_reg_output_data
-                + (i_load ? reg_output_stride * i_load
+                + (i_load ? reg_output_stride * static_cast<int>(i_load)
                           : 0) // TODO: Xbyak should allow 0 scale
                 + jcp.typesize_out * jcp.load_block * i_ur];
 }
 
 static int vreg_accum_idx(
-        const int load_loop_blk, const int i_load, const int i_ur) {
-    return (i_ur * load_loop_blk + i_load);
+        const dim_t load_loop_blk, const dim_t i_load, const dim_t i_ur) {
+    return static_cast<int>(i_ur * load_loop_blk + i_load);
 }
 
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const bool mask_tail,
-        const F &fun) {
-    for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur,
+        const bool mask_tail, const F &fun) {
+    for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
         const bool mask_flag = mask_tail && i_load + 1 == load_loop_blk;
-        for (int i_ur = 0; i_ur < ur; ++i_ur)
+        for (dim_t i_ur = 0; i_ur < ur; ++i_ur)
             fun(mask_flag, i_load, i_ur);
     }
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const F &fun) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur, const F &fun) {
     iterate(load_loop_blk, ur, false, fun);
 }
 
 void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
-        const bool is_out_layout_nxc, const int load_loop_blk, const int ur) {
+        const bool is_out_layout_nxc, const dim_t load_loop_blk,
+        const dim_t ur) {
     injector_utils::vmm_index_set_t vmm_idxs;
     if (jcp.with_binary) {
         binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
@@ -178,7 +179,8 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
                     EVEX_compress_addr(rsp, reg_dw_binary_output_off));
         }
         iterate(load_loop_blk, ur, mask_tail,
-                [&](const bool mask_flag, const int i_load, const int i_ur) {
+                [&](const bool mask_flag, const dim_t i_load,
+                        const dim_t i_ur) {
             const auto vmm_idx = vreg_accum_idx(load_loop_blk, i_load, i_ur);
             vmm_idxs.emplace(vmm_idx);
             const dim_t oft
@@ -198,7 +200,7 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
         }
     } else {
         iterate(load_loop_blk, ur,
-                [&](const bool, const int i_load, const int i_ur) {
+                [&](const bool, const dim_t i_load, const dim_t i_ur) {
             vmm_idxs.emplace(vreg_accum_idx(load_loop_blk, i_load, i_ur));
         });
         postops_injector_->compute_vector_range(vmm_idxs);
@@ -206,55 +208,55 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
 }
 
 void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
-        int load_loop_blk, int ur, int substep, bool wraparound) {
+        dim_t load_loop_blk, dim_t ur, dim_t substep, bool wraparound) {
     const bool out_layout_nxc = is_out_layout_nxc(jcp);
     const bool load_layout_nxc = is_load_layout_nxc(jcp);
     const bool bcast_layout_nxc = is_bcast_layout_nxc(jcp);
-    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const dim_t reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+    const dim_t load_dim_tail = jcp.load_dim % jcp.load_block;
 
-    auto vreg_load = [ur, load_loop_blk](int i_load) {
-        return Zmm(ur * load_loop_blk + i_load);
+    auto vreg_load = [ur, load_loop_blk](dim_t i_load) {
+        return Zmm(static_cast<int>(ur * load_loop_blk + i_load));
     };
 
-    auto vreg_accum = [load_loop_blk](int i_load, int i_ur) {
+    auto vreg_accum = [load_loop_blk](dim_t i_load, dim_t i_ur) {
         return Zmm(vreg_accum_idx(load_loop_blk, i_load, i_ur));
     };
 
-    auto bias_ptr = [this](int i_load) {
+    auto bias_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_bias_data, jcp.typesize_out * jcp.oc_block * i_load);
     };
 
-    auto bcast_ptr = [&](int i_reduce, int i_ur, bool bcast) {
+    auto bcast_ptr = [&](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
         dim_t offt;
         if (one_of(jcp.prop_kind, forward_training, forward_inference,
                     backward_data)) {
             assert(jcp.reduce_loop_unroll == jcp.reduce_block);
-            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
-                                                    : jcp.reduce_loop_unroll;
+            const dim_t reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
+                                                      : jcp.reduce_loop_unroll;
             offt = (i_reduce == jcp.reduce_loop_unroll)
                     ? (jcp.bcast_dim + i_ur) * reduce_mul
                     : i_ur * reduce_mul + i_reduce;
         } else {
-            int rmul = bcast_layout_nxc ? jcp.ic : jcp.ic_block;
+            const dim_t rmul = bcast_layout_nxc ? jcp.ic : jcp.ic_block;
             offt = static_cast<dim_t>(i_reduce) * rmul + i_ur;
         }
         return EVEX_compress_addr(
                 aux_reg_bcast_data, jcp.typesize_in * offt, bcast);
     };
 
-    auto load_ptr = [&](int i_reduce, int i_load) {
-        int offt;
-        int u0 = i_reduce % jcp.reduce_loop_unroll;
-        int u1 = i_reduce / jcp.reduce_loop_unroll;
-        int lmul = jcp.load_block
+    auto load_ptr = [&](dim_t i_reduce, dim_t i_load) {
+        dim_t offt;
+        const dim_t u0 = i_reduce % jcp.reduce_loop_unroll;
+        const dim_t u1 = i_reduce / jcp.reduce_loop_unroll;
+        const dim_t lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
                                              jcp.reduce_dim, jcp.reduce_block));
-        int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
+        const dim_t rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
         offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
@@ -345,12 +347,12 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block = [&](bool last_block) {
-        const int i_reduce_end = reduce_dim_tail && last_block
+        const dim_t i_reduce_end = reduce_dim_tail && last_block
                 ? reduce_dim_tail
                 : jcp.reduce_loop_unroll;
 
-        for (int i_reduce = 0; i_reduce < i_reduce_end; i_reduce++) {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+        for (dim_t i_reduce = 0; i_reduce < i_reduce_end; i_reduce++) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 auto vreg = vreg_load(i_load);
                 if (i_load + 1 == load_loop_blk && load_dim_tail)
                     vreg = vreg | k_load_dim_mask | T_z;
@@ -358,10 +360,10 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
                 vmovups(vreg, load_ptr(i_reduce, i_load));
             }
 
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 if (jcp.expl_bcast && load_loop_blk > 1)
                     vbroadcastss(vreg_bcast, bcast_ptr(i_reduce, i_ur, false));
-                for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                     auto vreg_acc = vreg_accum(i_load, i_ur);
                     if (i_load + 1 == load_loop_blk && load_dim_tail)
                         vreg_acc = vreg_acc | k_load_dim_mask | T_z;
@@ -430,7 +432,7 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
     if (jcp.prop_kind == backward_weights)
         mov(reg_output_stride, ptr[param1 + GET_OFF(output_stride)]);
 
-    const int load_dim_tail
+    const dim_t load_dim_tail
             = (one_of(jcp.prop_kind, forward_training, forward_inference)
                               ? jcp.oc_without_padding
                               : jcp.load_dim)
@@ -441,7 +443,7 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
         kmovw(k_load_dim_tail_mask, reg_tail_32);
     }
 
-    auto load_loop_body = [&](int load_loop_blk) {
+    auto load_loop_body = [&](dim_t load_loop_blk) {
         if (load_dim_tail)
             kxnorw(k_load_dim_mask, k_load_dim_mask, k_load_dim_mask);
         sub(reg_load_loop_work, load_loop_blk * jcp.load_loop_iter_step);
@@ -453,12 +455,12 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
         }
         bcast_loop(load_loop_blk);
         add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
-        const size_t offst_with_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_with_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc(jcp)
                                 ? 1
                                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim));
-        const size_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc(jcp) ? 1 : jcp.bcast_dim);
         switch (jcp.prop_kind) {
@@ -718,12 +720,12 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     const int BIG_REDUCE_DIM = 1024;
     const int BIG_LOAD_DIM = 256;
 
-    int load_blocking {0};
-    int load_blocking_max {0};
-    int bcast_blocking {0};
-    int bcast_blocking_max {0};
-    int reduce_blocking {0};
-    int reduce_blocking_max {0};
+    dim_t load_blocking {0};
+    dim_t load_blocking_max {0};
+    dim_t bcast_blocking {0};
+    dim_t bcast_blocking_max {0};
+    dim_t reduce_blocking {0};
+    dim_t reduce_blocking_max {0};
 
     jcp.load_grp_count = 1;
 
@@ -735,7 +737,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
-            if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+            if (jcp.with_dw_conv)
+                jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
             jcp.reduce_dim = jcp.ic;
             jcp.reduce_block = jcp.ic_block;
 
@@ -759,12 +762,12 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         jcp.reduce_loop_load_step
                 = jcp.reduce_loop_unroll * jcp.load_block * jcp.typesize_in;
         jcp.load_loop_load_step
-                = (utils::rnd_up(jcp.reduce_dim, jcp.reduce_block))
+                = utils::rnd_up(jcp.reduce_dim, jcp.reduce_block)
                 * jcp.load_block * jcp.typesize_in;
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold;
-        const int spatial
+        const dim_t spatial
                 = (one_of(jcp.prop_kind, forward_training, forward_inference))
                 ? jcp.od * jcp.oh
                 : jcp.id * jcp.ih;
@@ -797,10 +800,10 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
-            int os_tail = jcp.os % max_regs;
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
+            dim_t os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
-                int i_tail = jcp.os % i;
+                const dim_t i_tail = jcp.os % i;
                 if (i_tail > os_tail || i_tail == 0) {
                     jcp.ur = i;
                     os_tail = i_tail;
@@ -824,9 +827,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         else
             jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
-        int nb_load = div_up(jcp.load_dim, jcp.load_block);
+        const dim_t nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+        const dim_t nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+        const dim_t nb_load = div_up(jcp.load_dim, jcp.load_block);
         if (is_data_layout_nxc) {
             reduce_blocking = jcp.reduce_dim;
         } else if (jcp.expl_bcast) {
@@ -844,7 +847,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             else if (spatial > SMALL_SPATIAL
                     && jcp.reduce_dim >= BIG_REDUCE_DIM)
                 reduce_blocking = 8;
-            reduce_blocking = best_divider(nb_reduce, 1, reduce_blocking, true);
+            reduce_blocking = best_divider(
+                    nb_reduce, 1, static_cast<int>(reduce_blocking), true);
             reduce_blocking *= jcp.reduce_block;
         }
 
@@ -853,22 +857,22 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         // 64 * 1024 is chosen due to 1MB L2 16-way cache.
         // 7 is empirical value. It is about half of 16.
         // So we leave about half of the set for other data - weights, dst
-        int way_size = (64 * 1024) / jcp.typesize_in;
+        const dim_t way_size = (64 * 1024) / jcp.typesize_in;
         int max_hits = 7;
         if (!is_data_layout_nxc
                 && jcp.bcast_dim * reduce_blocking
                         > static_cast<dim_t>(way_size) * max_hits) {
-            int nrb = reduce_blocking / simd_w;
+            const dim_t nrb = reduce_blocking / simd_w;
             auto sp = jcp.bcast_dim;
-            int wl = way_size / simd_w;
-            for (int start_off = 0; start_off < jcp.ur; start_off++) {
+            const dim_t wl = way_size / simd_w;
+            for (dim_t start_off = 0; start_off < jcp.ur; start_off++) {
                 for (dim_t off = start_off, hits = 0; off < sp * nrb;
                         off += wl) {
                     if (off % sp >= jcp.ur || ++hits < max_hits) continue;
-                    int max_r_blocking
+                    const dim_t max_r_blocking
                             = simd_w * nstl::max<dim_t>(1, (off + wl) / sp);
                     reduce_blocking
-                            = nstl::min(reduce_blocking, max_r_blocking);
+                            = nstl::min<dim_t>(reduce_blocking, max_r_blocking);
                     break;
                 }
             }
@@ -882,7 +886,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         }
         load_blocking = jcp.load_dim;
 
-        int load_size = jcp.load_dim * jcp.reduce_dim;
+        const dim_t load_size = jcp.load_dim * jcp.reduce_dim;
         auto bcast_size
                 = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
 
@@ -893,20 +897,20 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int n_lgc = jcp.nthr;
             float ratio = (float)load_size / (float)bcast_size;
             int best_lgc = ratio > 1 ? n_lgc : 1;
-            auto calc_job_cost = [&](int lb, int tg, float mem_k) {
-                int bb_size = jcp.mb * div_up(nb_bcast, tg);
+            auto calc_job_cost = [&](dim_t lb, dim_t tg, float mem_k) {
+                const dim_t bb_size = jcp.mb * div_up(nb_bcast, tg);
                 float calc_size = (float)(bb_size * jcp.ur)
-                        * (lb * jcp.load_block) * jcp.reduce_dim;
+                        * (float)(lb * jcp.load_block) * (float)jcp.reduce_dim;
                 float mem_size = (float)(bb_size * jcp.ur + lb * jcp.load_block)
-                        * jcp.reduce_dim;
+                        * (float)jcp.reduce_dim;
                 return calc_koef * calc_size + mem_k * mem_size;
             };
             for (int lgc, ilgc = 0; ilgc < n_lgc; ilgc++) {
                 lgc = ratio > 1 ? n_lgc - ilgc : ilgc + 1;
-                int min_lb = nb_load / lgc;
-                int max_lb = div_up(nb_load, lgc);
-                int min_tg = jcp.nthr / lgc;
-                int max_tg = div_up(jcp.nthr, lgc);
+                const dim_t min_lb = nb_load / lgc;
+                const dim_t max_lb = div_up(nb_load, lgc);
+                const dim_t min_tg = jcp.nthr / lgc;
+                const dim_t max_tg = div_up(jcp.nthr, lgc);
                 // Some heuristic here
                 float mem_koef = (max_tg == 1) ? 1.f : 1.3f;
                 float job_cost = 0.;
@@ -919,7 +923,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 }
 
                 if (job_cost < best_cost) {
-                    best_lgc = lgc;
+                    best_lgc = static_cast<int>(lgc);
                     best_cost = job_cost;
                 }
             }
@@ -941,21 +945,21 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             load_blocking = jcp.load_block;
         }
 
-        auto get_thr_eff = [&](int load_chunk, int nthr) {
-            int lgc = div_up(nb_load, load_chunk);
-            int thr_per_grp = div_up(nthr, lgc);
-            int bcast_per_thr
+        auto get_thr_eff = [&](dim_t load_chunk, int nthr) {
+            const dim_t lgc = div_up(nb_load, load_chunk);
+            const dim_t thr_per_grp = div_up(nthr, lgc);
+            const dim_t bcast_per_thr
                     = div_up(jcp.mb * nb_bcast, thr_per_grp) * jcp.bcast_block;
-            int load_per_thr = load_chunk * simd_w;
-            float data_norm = (bcast_per_thr + load_per_thr) / 2.f;
-            float data_eff
-                    = (bcast_per_thr * load_per_thr) / (data_norm * data_norm);
-            float thr_eff_over_grp
-                    = (float)nstl::max(1, nthr / lgc) / div_up(nthr, lgc);
-            float thr_eff_in_grp = ((float)jcp.mb * nb_bcast)
-                    / rnd_up(jcp.mb * nb_bcast, thr_per_grp);
+            const dim_t load_per_thr = load_chunk * simd_w;
+            float data_norm = (float)(bcast_per_thr + load_per_thr) / 2.f;
+            float data_eff = (float)(bcast_per_thr * load_per_thr)
+                    / (data_norm * data_norm);
+            float thr_eff_over_grp = (float)nstl::max<dim_t>(1, nthr / lgc)
+                    / (float)div_up(nthr, lgc);
+            float thr_eff_in_grp = ((float)jcp.mb * (float)nb_bcast)
+                    / (float)rnd_up(jcp.mb * nb_bcast, thr_per_grp);
             float thr_eff = thr_eff_over_grp * thr_eff_in_grp;
-            float load_eff = (float)nb_load / rnd_up(nb_load, lgc);
+            float load_eff = (float)nb_load / (float)rnd_up(nb_load, lgc);
             float overall_eff = data_eff + thr_eff + load_eff;
             return overall_eff;
         };
@@ -965,13 +969,13 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int best_lgc = 1;
             float eff;
 
-            for (int load_chunk = 1; load_chunk <= nb_load; load_chunk++) {
-                int lgc = div_up(nb_load, load_chunk);
+            for (dim_t load_chunk = 1; load_chunk <= nb_load; load_chunk++) {
+                const dim_t lgc = div_up(nb_load, load_chunk);
                 if (lgc > nthr) continue;
                 eff = get_thr_eff(load_chunk, nthr);
                 if (eff > best_eff) {
                     best_eff = eff;
-                    best_lgc = lgc;
+                    best_lgc = static_cast<int>(lgc);
                 }
             }
             return best_lgc;
@@ -988,7 +992,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int overall_lgc = jcp.load_grp_count;
             int lgc = 1;
             int best_nthr = jcp.nthr;
-            int end_nthr = with_groups ? jcp.ngroups : 1;
+            const int end_nthr
+                    = with_groups ? static_cast<int>(jcp.ngroups) : 1;
             for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
                 lgc = get_load_chunk(nthr);
                 thr_eff = get_thr_eff(lgc, nthr);
@@ -1010,15 +1015,15 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
         bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
-        int space_for_bcast = (L2_capacity - /* kernel_size - */
+        dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
                 2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
                 - 3 * 1024);
         if (jcp.reduce_dim * jcp.bcast_dim > static_cast<dim_t>(L2_capacity))
             space_for_bcast /= 2;
 
-        int bcast_in_cache
-                = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-        bcast_blocking = nstl::min(
+        const dim_t bcast_in_cache = nstl::max<dim_t>(
+                jcp.bcast_block, space_for_bcast / reduce_blocking);
+        bcast_blocking = nstl::min<dim_t>(
                 bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
         // NHWC perf
         if (is_data_layout_nxc) bcast_blocking = jcp.bcast_block;
@@ -1048,14 +1053,14 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 !(is_data_layout_nxc && jcp.load_dim <= jcp.load_block)) {
             // if reduce_block is big then generated JIT code may be big
             // for small values of ur because reduce_loop_unroll = reduce_block
-            jcp.ur = jcp.bcast_block / 2;
+            jcp.ur = static_cast<int>(jcp.bcast_block / 2);
             jcp.expl_bcast = true;
         } else {
-            jcp.ur = jcp.bcast_block;
+            jcp.ur = static_cast<int>(jcp.bcast_block);
             jcp.expl_bcast = false;
         }
 
-        jcp.ur_tail = jcp.bcast_dim % jcp.bcast_block;
+        jcp.ur_tail = static_cast<int>(jcp.bcast_dim % jcp.bcast_block);
         jcp.reduce_loop_unroll = jcp.reduce_block;
         jcp.reduce_loop_bcast_step = static_cast<dim_t>(jcp.typesize_in)
                 * jcp.reduce_loop_unroll
@@ -1089,12 +1094,13 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         assert(IMPLICATION(
                 !is_data_layout_nxc, jcp.load_dim % load_blocking == 0));
 
-        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int min_bcast_blocking = 5;
+        const dim_t max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        const dim_t min_bcast_blocking = 5;
 
         bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
-        bcast_blocking = best_divider(
-                bcast_blocking, min_bcast_blocking, max_bcast_blocking, false);
+        bcast_blocking = best_divider(bcast_blocking,
+                static_cast<int>(min_bcast_blocking),
+                static_cast<int>(max_bcast_blocking), false);
         bcast_blocking *= jcp.bcast_block;
         bcast_blocking_max = bcast_blocking;
         assert(IMPLICATION(
@@ -1103,17 +1109,19 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         // for reduction balance
         if (is_data_layout_nxc && jcp.reduce_dim >= BIG_SPATIAL * BIG_SPATIAL
                 && jcp.load_dim >= BIG_LOAD_DIM / 2) {
-            reduce_blocking = rnd_up(nstl::min(jcp.ow, 256), jcp.reduce_block);
-        } else {
-            int max_reduce_blocking
-                    = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
-            int min_reduce_blocking = nstl::min(
-                    L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
-            reduce_blocking = best_divider(jcp.reduce_dim, min_reduce_blocking,
-                    max_reduce_blocking, true);
             reduce_blocking
-                    = nstl::max(rnd_dn(reduce_blocking, jcp.reduce_block),
-                            jcp.reduce_block);
+                    = rnd_up(nstl::min<dim_t>(jcp.ow, 256), jcp.reduce_block);
+        } else {
+            const dim_t max_reduce_blocking
+                    = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
+            const dim_t min_reduce_blocking = nstl::min<dim_t>(
+                    L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
+            reduce_blocking = best_divider(jcp.reduce_dim,
+                    static_cast<int>(min_reduce_blocking),
+                    static_cast<int>(max_reduce_blocking), true);
+            reduce_blocking = nstl::max<dim_t>(
+                    rnd_dn(reduce_blocking, jcp.reduce_block),
+                    jcp.reduce_block);
         }
 
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
@@ -1164,16 +1172,17 @@ void jit_avx512_common_1x1_conv_kernel_t::init_scratchpad(
                     || (jcp.prop_kind == backward_weights // nxc layout
                             && jcp.oc % jcp.oc_block != 0))) {
 
-        const size_t nelems_padded_bias
+        const dim_t nelems_padded_bias
                 = jcp.ngroups * utils::rnd_up(jcp.oc, jcp.oc_block);
-        scratchpad.book(
-                key_conv_padded_bias, nelems_padded_bias, jcp.typesize_out);
+        scratchpad.book(key_conv_padded_bias,
+                static_cast<size_t>(nelems_padded_bias), jcp.typesize_out);
     }
 
     if (jcp.prop_kind == backward_weights) {
-        const size_t wei_size = (size_t)jcp.ngroups
-                * rnd_up(jcp.oc, jcp.oc_block) * rnd_up(jcp.ic, jcp.ic_block);
-        scratchpad.book(key_conv_wei_reduction, wei_size * (jcp.nthr_mb - 1),
+        const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+                * rnd_up(jcp.ic, jcp.ic_block);
+        scratchpad.book(key_conv_wei_reduction,
+                static_cast<size_t>(wei_size * (jcp.nthr_mb - 1)),
                 jcp.typesize_out);
         if (dnnl_thr_syncable() && jcp.nthr_mb > 1) {
             scratchpad.book<simple_barrier::ctx_t>(
@@ -1190,11 +1199,11 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
         /* simplification... fortunately it doesn't hurt much */
         return;
     }
-    const int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    const int nb_load = div_up(jcp.load_dim, jcp.load_block);
-    const int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const dim_t nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    const dim_t nb_load = div_up(jcp.load_dim, jcp.load_block);
+    const dim_t nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
 
-    jcp.nthr_g = jcp.ngroups;
+    jcp.nthr_g = static_cast<int>(jcp.ngroups);
     const int nthr = nthreads / jcp.nthr_g;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -1226,12 +1235,15 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
     auto best_mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, jcp.mb * nb_reduce);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, jcp.mb * nb_reduce));
     for (nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, nb_load);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, nb_load));
         for (nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, nb_bcast);
+            nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, nb_bcast));
             auto mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
                 best_mem_cost = mem_cost;
@@ -1242,7 +1254,7 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
         }
     }
     if (jcp.nthr_mb > nthreads / 2 && jcp.nthr_mb < nthreads)
-        jcp.nthr_mb = nstl::min(jcp.mb, nthreads);
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(jcp.mb, nthreads));
 
     jcp.nthr = jcp.nthr_mb * jcp.nthr_g * jcp.nthr_oc_b * jcp.nthr_ic_b;
     assert(jcp.nthr <= nthreads);

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
@@ -87,24 +87,26 @@ private:
     constexpr static int reg_dw_binary_output_off = 3 * reg64_size_;
     constexpr static int stack_space_needed = 4 * reg64_size_;
 
-    void bcast_loop(int load_loop_blk);
-    void reduce_loop(int load_loop_blk, int ur, int substep, bool wraparound);
+    void bcast_loop(dim_t load_loop_blk);
+    void reduce_loop(
+            dim_t load_loop_blk, dim_t ur, dim_t substep, bool wraparound);
 
     inline size_t get_output_offset(const bool is_out_layout_nxc,
-            const int i_load, const int i_ur, bool ignore_dw_conv = false) {
-        const size_t i_load_shift = is_out_layout_nxc
+            const dim_t i_load, const dim_t i_ur,
+            bool ignore_dw_conv = false) {
+        const dim_t i_load_shift = is_out_layout_nxc
                 ? jcp.load_block
                 : (!ignore_dw_conv && jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim)
                         * jcp.load_block;
-        const size_t i_ur_shift
+        const dim_t i_ur_shift
                 = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
         return jcp.typesize_out * (i_load * i_load_shift + i_ur * i_ur_shift);
     }
 
     Xbyak::Address output_ptr(
-            const bool out_layout_nxc, const int i_load, const int i_ur);
-    void apply_postops(const bool is_out_layout_nxc, const int load_loop_blk,
-            const int ur);
+            const bool out_layout_nxc, const dim_t i_load, const dim_t i_ur);
+    void apply_postops(const bool is_out_layout_nxc, const dim_t load_loop_blk,
+            const dim_t ur);
     void generate() override;
     static void balance(jit_1x1_conv_conf_t &jcp);
 };

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -55,7 +55,8 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_
             ? binary_injector::prepare_binary_args(
                       pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -102,11 +103,11 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
             : nullptr;
 
     const int ndims = src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -115,18 +116,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
     const bool is_dst_layout_nxc = utils::one_of(
@@ -138,23 +139,23 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
     memory_tracking::grantor_t dw_scratchpad(
             scratchpad, memory_tracking::names::prefix_fusion);
     dst_data_t *pbuf;
-    size_t row_offset;
-    const int nb_buffer = jcp.nb_load_blocking;
+    dim_t row_offset;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<dst_data_t *> addrs;
     // End
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh, dim_t &ow,
+                              dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
-        bcast_step = step(
-                nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
-        bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+        bcast_step = step(nb_bcast_blocking, nb_bcast - osb,
+                nb_bcast_blocking_max);
+        bcast_step = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -167,16 +168,16 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
-        const auto max_oc
-                = nstl::min(ocb_end * jcp.oc_block, jcp.oc_without_padding);
+        const auto max_oc = nstl::min<dim_t>(
+                ocb_end * jcp.oc_block, jcp.oc_without_padding);
         p.load_dim = this_block_size(
                 ocb * jcp.oc_block, max_oc, load_step * jcp.oc_block);
     };
 
-    auto init_reduce = [&](int icb) {
-        const int nb_ic_blocking_step
+    auto init_reduce = [&](dim_t icb) {
+        const dim_t nb_ic_blocking_step
                 = nstl::min(icb + nb_ic_blocking, nb_ic) - icb;
         p.first_last_flag = 0 | (icb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (icb + nb_ic_blocking_step >= nb_ic ? FLAG_REDUCE_LAST : 0);
@@ -186,12 +187,13 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int icb, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1
+            = [&](dim_t ocb, dim_t ocb_start, dim_t icb, dim_t n, dim_t g, dim_t od,
+                      dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
 
         p.output_data = jcp.with_dw_conv
                 ? pbuf + (oh % pd()->dw_conv_pd_->jcp_.kh) * row_offset
@@ -203,7 +205,7 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         p.load_data
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
         if (pd()->rtus_.reduce_src_) {
@@ -224,21 +226,22 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
 
         if (jcp.loop_order == loop_rlb) {
-            for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+            for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                 init_reduce(icb);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    int iwork = bcast_start;
+                    dim_t iwork = bcast_start;
                     while (iwork < bcast_end) {
-                        int n {0}, g {0}, bcast_step {0}, od {0}, oh {0},
-                                ow {0}, id {0}, ih {0}, iw {0};
+                        dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0},
+                                ih {0}, iw {0};
+                        dim_t bcast_step {0};
                         init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh,
                                 ow, id, ih, iw);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
@@ -249,17 +252,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 }
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -269,17 +273,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_rbl) {
-            for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+            for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                 init_reduce(icb);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    int ocb = ocb_start;
+                    dim_t ocb = ocb_start;
                     while (ocb < ocb_end) {
-                        int load_step;
+                        dim_t load_step;
                         init_load(ocb, ocb_end, load_step);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -289,17 +294,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 }
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                        id {0}, ih {0}, iw {0};
+                dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                        iw {0};
+                dim_t bcast_step {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -313,9 +319,11 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
+    auto ker_dw
+            = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
 
         for (int i = 0; i < jcp_dw.kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw.kh) * row_offset;
@@ -323,31 +331,32 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         const auto ocb_end = ocb_start + load_step;
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw.iw)
                 * jcp_dw.nb_ch_blocking * jcp_dw.ch_block;
-        const int dil_h = jcp_dw.dilate_h + 1;
-        const int str_h = jcp_dw.stride_h;
-        const int ch_num = jcp_dw.nb_ch_blocking;
-        const int ow = 0;
-        const int kw = 0;
+        const dim_t dil_h = jcp_dw.dilate_h + 1;
+        const dim_t str_h = jcp_dw.stride_h;
+        const dim_t ch_num = jcp_dw.nb_ch_blocking;
+        const dim_t ow = 0;
+        const dim_t kw = 0;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end;
+                ch += jcp_dw.nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw.t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw.ih,
-                              (int)(dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
-                                      - jcp_dw.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw.t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw.ih,
+                              dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
+                                      - jcp_dw.t_pad + 1)
                     - jcp_dw.ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw.ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -359,9 +368,11 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw.ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding
+                    = static_cast<size_t>(nstl::max<dim_t>(0, kh_padding));
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw.nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw.nb_ch) - ch)
                     * jcp_dw.ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -381,43 +392,48 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 = dw_scratchpad.get<dst_data_t>(key_fusion_inout_buffer);
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
 
-        const auto dw_conv_buffer_size_
-                = (size_t)jcp_dw.kh * jcp.ow * nb_buffer * jcp.oc_block;
-        pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size_;
-        row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
+        const dim_t dw_conv_buffer_size
+                = jcp_dw.kh * jcp.ow * nb_buffer * jcp.oc_block;
+        pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size;
+        row_offset = dw_conv_buffer_size / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        balance2D(nthr, ithr,
+                jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start, bcast_end,
+                nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw.oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw.kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_range
+                        = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw.kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
                 oh_1x1 = oh_1x1_end;
-                ker_dw(n, g * nb_oc + ocb_start, load_step, oh_dw);
+                ker_dw(n, static_cast<int>(g * nb_oc + ocb_start), load_step,
+                        oh_dw);
 
                 bcast_iter += nb_bcast_blocking;
             }
@@ -429,10 +445,11 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         conv_dw();
     } else {
 
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
-        balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                ocb_start, ocb_end, jcp.load_grp_count);
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
+                jcp.nb_load, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         conv_1x1(bcast_start, bcast_end, ocb_start, ocb_end);
     }
@@ -464,18 +481,18 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
 
     assert(jcp.stride_w == 1 && jcp.stride_h == 1 && jcp.stride_d == 1);
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -484,27 +501,29 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
         auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-        int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
-        balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                icb_start, icb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+        balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
+                jcp.nb_load, icb_start, icb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         bool reduce_outer
                 = (jcp.loop_order == loop_rbl || jcp.loop_order == loop_rlb);
-        int nboc_outer = reduce_outer ? nb_oc : 1;
-        int ocb_outer_step = reduce_outer ? nb_oc_blocking : 1;
+        const dim_t nboc_outer = reduce_outer ? nb_oc : 1;
+        const dim_t ocb_outer_step = reduce_outer ? nb_oc_blocking : 1;
 
-        int nboc_inner = reduce_outer ? 1 : nb_oc;
-        int ocb_inner_step = reduce_outer ? 1 : nb_oc_blocking;
-        const int max_ic = nstl::min(icb_end * jcp.ic_block, jcp.ic);
+        const dim_t nboc_inner = reduce_outer ? 1 : nb_oc;
+        const dim_t ocb_inner_step = reduce_outer ? 1 : nb_oc_blocking;
+        const dim_t max_ic
+                = nstl::min<dim_t>(icb_end * jcp.ic_block, jcp.ic);
 
-        for (int ocb_outer = 0; ocb_outer < nboc_outer;
+        for (dim_t ocb_outer = 0; ocb_outer < nboc_outer;
                 ocb_outer += ocb_outer_step) {
-            size_t cur_ocb_outer
+            dim_t cur_ocb_outer
                     = nstl::min(ocb_outer + ocb_outer_step, nboc_outer)
                     - ocb_outer;
 
-            int load_step = 0;
-            for (int icb = icb_start; icb < icb_end; icb += load_step) {
+            dim_t load_step = 0;
+            for (dim_t icb = icb_start; icb < icb_end; icb += load_step) {
                 load_step = step(jcp.nb_load_blocking, jcp.nb_load - icb,
                         jcp.nb_load_blocking_max);
 
@@ -512,34 +531,36 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
                         icb * jcp.ic_block, max_ic, load_step * jcp.ic_block);
                 rp.icb = p.load_dim;
 
-                int bcast_step;
-                for (int iwork = bcast_start; iwork < bcast_end;
+                dim_t bcast_step;
+                for (dim_t iwork = bcast_start; iwork < bcast_end;
                         iwork += bcast_step) {
-                    int n {0}, g {0}, osb {0};
+                    dim_t n {0}, g {0}, osb {0};
                     nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb,
                             jcp.nb_bcast);
 
-                    bcast_step = step(jcp.nb_bcast_blocking, jcp.nb_bcast - osb,
+                    bcast_step = step(jcp.nb_bcast_blocking,
+                            jcp.nb_bcast - osb,
                             jcp.nb_bcast_blocking_max);
-                    bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+                    bcast_step
+                            = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-                    const int os = osb * os_block;
+                    const dim_t os = osb * os_block;
                     p.bcast_dim = this_block_size(
                             os, jcp.os, bcast_step * os_block);
                     rp.os = p.bcast_dim;
 
-                    const int od = os / (jcp.oh * jcp.ow);
-                    const int os_2d = os % (jcp.oh * jcp.ow);
-                    const int oh = os_2d / jcp.ow;
-                    const int ow = os_2d % jcp.ow;
-                    const int id = od * stride_d;
-                    const int ih = oh * stride_h;
-                    const int iw = ow * stride_w;
+                    const dim_t od = os / (jcp.oh * jcp.ow);
+                    const dim_t os_2d = os % (jcp.oh * jcp.ow);
+                    const dim_t oh = os_2d / jcp.ow;
+                    const dim_t ow = os_2d % jcp.ow;
+                    const dim_t id = od * stride_d;
+                    const dim_t ih = oh * stride_h;
+                    const dim_t iw = ow * stride_w;
                     rp.iw_start = iw;
                     const bool is_dsrc_layout_nxc
                             = utils::one_of(jcp.src_tag, format_tag::nwc,
                                     format_tag::nhwc, format_tag::ndhwc);
-                    const int ic_off_idx = is_dsrc_layout_nxc
+                    const dim_t ic_off_idx = is_dsrc_layout_nxc
                             ? g * jcp.ic + icb * jcp.ic_block
                             : g * nb_ic + icb;
                     rp.src = diff_src
@@ -552,23 +573,23 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
                     } else
                         p.output_data = rp.src;
 
-                    for (int ocb_inner = 0; ocb_inner < nboc_inner;
+                    for (dim_t ocb_inner = 0; ocb_inner < nboc_inner;
                             ocb_inner += ocb_inner_step) {
-                        int cur_ocb_inner
+                        const dim_t cur_ocb_inner
                                 = nstl::min(ocb_inner + ocb_inner_step,
                                           nboc_inner)
                                 - ocb_inner;
 
-                        int ocb = reduce_outer ? ocb_outer : ocb_inner;
-                        int nb_oc_blocking_step
+                        const dim_t ocb = reduce_outer ? ocb_outer : ocb_inner;
+                        const dim_t nb_oc_blocking_step
                                 = reduce_outer ? cur_ocb_outer : cur_ocb_inner;
                         const bool is_ddst_layout_nxc
                                 = utils::one_of(jcp.dst_tag, format_tag::nwc,
                                         format_tag::nhwc, format_tag::ndhwc);
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + ocb * jcp.oc_block
                                 : g * nb_oc + ocb;
-                        size_t diff_dst_off = data_blk_off(
+                        dim_t diff_dst_off = data_blk_off(
                                 diff_dst_d, n, oc_off_idx, od, oh, ow);
                         p.bcast_data = &diff_dst[diff_dst_off];
 
@@ -643,7 +664,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
     auto wei_reduction = scratchpad.get<data_t>(key_conv_wei_reduction);
 
     const int ndims = src_d.ndims();
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block);
 
     simple_barrier::ctx_t *reduction_barrier
@@ -660,19 +681,19 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic = jcp.nb_bcast;
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t nb_ic = jcp.nb_bcast;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
 
-    const int sp_nb = jcp.nb_reduce;
-    const int mb_sp_work = jcp.mb * sp_nb;
+    const dim_t sp_nb = jcp.nb_reduce;
+    const dim_t mb_sp_work = jcp.mb * sp_nb;
 
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -683,22 +704,22 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (is_ddst_layout_nxc && ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = nb_ic - 1;
-                const size_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
+                const dim_t z_icb = nb_ic - 1;
+                const dim_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
                         + ic_tail * jcp.oc_block;
                 data_t *z_wei = diff_weights + off;
-                const int zero_work
+                const dim_t zero_work
                         = (nb_ic * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -714,30 +735,31 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* reduction dimension */
-        int mb_sp_b_start {0}, mb_sp_b_end {0};
+        dim_t mb_sp_b_start {0}, mb_sp_b_end {0};
         balance211(
                 mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start, mb_sp_b_end);
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
-        balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
-        balance211(
-                jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start,
+                oc_b_end);
+        balance211(jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
+                ic_b_end);
 
-        const int g_work = g_end - g_start;
-        const int oc_b_work = oc_b_end - oc_b_start;
-        const int ic_b_work = ic_b_end - ic_b_start;
+        const dim_t g_work = g_end - g_start;
+        const dim_t oc_b_work = oc_b_end - oc_b_start;
+        const dim_t ic_b_work = ic_b_end - ic_b_start;
         const bool cache_aliasing
                 = (jcp.ic * jcp.ngroups * sizeof(float)) % 1024 == 0;
-        int reduce_step = jcp.nb_reduce_blocking;
-        int reduce_step_max = jcp.nb_reduce_blocking_max;
+        dim_t reduce_step = jcp.nb_reduce_blocking;
+        dim_t reduce_step_max = jcp.nb_reduce_blocking_max;
         if (is_src_layout_nxc && cache_aliasing) {
             // Experiments show 4 is a magic number with the tested shapes.
             // TODO: maybe tune for shapes with sp_dim%4 != 0
-            reduce_step = nstl::min(4, reduce_step);
+            reduce_step = nstl::min<dim_t>(4, reduce_step);
             reduce_step_max = reduce_step;
         }
 
@@ -745,19 +767,19 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 ? diff_weights
                 : wei_reduction + (ithr_mb - 1) * wei_size;
 
-        int sp_b_step = 0;
-        for (int mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
+        dim_t sp_b_step = 0;
+        for (dim_t mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
                 mb_sp_b += sp_b_step) {
-            int img {0}, sp_b {0};
+            dim_t img {0}, sp_b {0};
             nd_iterator_init(mb_sp_b, img, jcp.mb, sp_b, sp_nb);
             sp_b_step = step(reduce_step,
                     nstl::min(sp_nb - sp_b, mb_sp_b_end - mb_sp_b),
                     reduce_step_max);
 
-            for (int g = g_start; g < g_end; ++g) {
-                int load_step = 0;
-                int bcast_step = 0;
-                for (int ic_b = ic_b_start; ic_b < ic_b_end;
+            for (dim_t g = g_start; g < g_end; ++g) {
+                dim_t load_step = 0;
+                dim_t bcast_step = 0;
+                for (dim_t ic_b = ic_b_start; ic_b < ic_b_end;
                         ic_b += bcast_step) {
                     if (is_src_layout_nxc && cache_aliasing) {
                         bcast_step = ic_b_work;
@@ -766,28 +788,28 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                 jcp.nb_bcast_blocking_max);
                     }
 
-                    for (int oc_b = oc_b_start; oc_b < oc_b_end;
+                    for (dim_t oc_b = oc_b_start; oc_b < oc_b_end;
                             oc_b += load_step) {
                         load_step = step(nb_oc_blocking, oc_b_end - oc_b,
                                 jcp.nb_load_blocking_max);
-                        const int _ic_b = g * nb_ic + ic_b;
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t _ic_b = g * nb_ic + ic_b;
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + oc_b * jcp.oc_block
                                 : g * nb_oc + oc_b;
 
                         data_t *store_to;
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         store_to = diff_wei + off;
 
-                        const int ic_off_idx
+                        const dim_t ic_off_idx
                                 = (is_src_layout_nxc ? jcp.ic_block : 1)
                                 * _ic_b;
                         const data_t *diff_src
                                 = &src[src_d.blk_off(img, ic_off_idx)];
 
-                        int sp_b_end = sp_b + sp_b_step;
+                        const dim_t sp_b_end = sp_b + sp_b_step;
                         const data_t *pdiff_dst = &diff_dst[diff_dst_d.blk_off(
                                 img, oc_off_idx)];
                         const data_t *local_src = diff_src;
@@ -814,17 +836,17 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                                             : 0)
                                 | (sp_b_end == sp_nb ? FLAG_SP_LAST : 0);
 
-                        int sp = sp_b * jcp.reduce_block;
-                        int oc_mult
+                        dim_t sp = sp_b * jcp.reduce_block;
+                        dim_t oc_mult
                                 = is_ddst_layout_nxc ? jcp.oc : jcp.oc_block;
                         p.load_data = pdiff_dst + sp * oc_mult;
 
                         if (pd()->rtus_.reduce_src_) {
-                            const int oh = sp / jcp.ow;
-                            const int ow = sp % jcp.ow;
+                            const dim_t oh = sp / jcp.ow;
+                            const dim_t ow = sp % jcp.ow;
 
-                            const int ih = oh * stride_h;
-                            const int iw = ow * stride_w;
+                            const dim_t ih = oh * stride_h;
+                            const dim_t iw = ow * stride_w;
                             rp.iw_start = iw;
 
                             rp.ws = rtus_space
@@ -842,7 +864,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
                             p.bcast_data = rp.ws;
                         } else {
-                            int ic_mult
+                            dim_t ic_mult
                                     = is_src_layout_nxc ? jcp.ic : jcp.ic_block;
                             p.bcast_data = local_src + sp * ic_mult;
                         }
@@ -860,29 +882,30 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* diff_weights[:] += sum(wei_reduction[thr_mb][:]) */
         if (dnnl_thr_syncable() && jcp.nthr_mb > 1) {
             simple_barrier::barrier(reduction_barrier, jcp.nthr);
-            const int work = g_work * oc_b_work * ic_b_work;
-            int start {0}, end {0};
+            const dim_t work = g_work * oc_b_work * ic_b_work;
+            dim_t start {0}, end {0};
             balance211(work, jcp.nthr_mb, ithr_mb, start, end);
             if (start == end) return;
 
             for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-                int w = start;
-                int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                dim_t w = start;
+                dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
                 nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
                         oc_b_work, sub_ic_b_start, ic_b_work);
                 while (w < end) {
-                    const int g = g_start + sub_g_start;
-                    const int oc_b = oc_b_start + sub_oc_b_start;
-                    const int ic_b = ic_b_start + sub_ic_b_start;
-                    const int ic_to_accumulate
-                            = nstl::min(end - w, ic_b_work - sub_ic_b_start)
-                            * jcp.ic_block;
-                    const int acc_size
-                            = this_block_size(ic_b * jcp.ic_block,
-                                      jcp.ic_without_padding, ic_to_accumulate)
-                            * jcp.oc_block;
+                    const dim_t g = g_start + sub_g_start;
+                    const dim_t oc_b = oc_b_start + sub_oc_b_start;
+                    const dim_t ic_b = ic_b_start + sub_ic_b_start;
+                    const int ic_to_accumulate = static_cast<int>(
+                            nstl::min<dim_t>(
+                                    end - w, ic_b_work - sub_ic_b_start)
+                            * jcp.ic_block);
+                    const int acc_size = static_cast<int>(
+                            this_block_size(ic_b * jcp.ic_block,
+                                    jcp.ic_without_padding, ic_to_accumulate)
+                            * jcp.oc_block);
 
-                    const size_t off
+                    const dim_t off
                             = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                     data_t *d = diff_weights + off;
                     data_t *s = wei_reduction + (thr_mb - 1) * wei_size + off;
@@ -908,7 +931,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* reduction dimension */
         int img_start {0}, img_end {0};
 
-        balance211(jcp.mb, rb->balancer().nthr_per_group_,
+        balance211(static_cast<int>(jcp.mb), rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */
@@ -916,10 +939,10 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         nd_iterator_init(
                 b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_load);
 
-        for (int img = img_start; img < img_end; ++img) {
+        for (dim_t img = img_start; img < img_end; ++img) {
             int g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g * jcp.nb_load + ocb;
                 const data_t *d_dst
@@ -928,8 +951,8 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 data_t *d_bias = rb->get_local_ptr(ithr, diff_bias,
                                          reducer_bia_scratchpad)
                         + b_job_loc * rb->balancer().job_size_;
-                const int sp_shift = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
-                                                        : jcp.oc_block;
+                const dim_t sp_shift = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
+                                                          : jcp.oc_block;
                 const auto max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
                 if (img == img_start)
@@ -938,7 +961,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
                 for (dim_t os = 0; os < jcp.os; ++os) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += sp_shift;
                 }
@@ -974,11 +997,12 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 int g_start {0}, oc_b_start {0}, ic_b_start {0};
                 int g_end {0}, oc_b_end {0}, ic_b_end {0};
 
-                balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
-                balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start,
-                        oc_b_end);
-                balance211(jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
-                        ic_b_end);
+                balance211(static_cast<int>(jcp.ngroups), jcp.nthr_g, ithr_g,
+                        g_start, g_end);
+                balance211(static_cast<int>(jcp.nb_load), jcp.nthr_oc_b,
+                        ithr_oc_b, oc_b_start, oc_b_end);
+                balance211(static_cast<int>(jcp.nb_bcast), jcp.nthr_ic_b,
+                        ithr_ic_b, ic_b_start, ic_b_end);
 
                 const int g_work = g_end - g_start;
                 const int oc_b_work = oc_b_end - oc_b_start;
@@ -998,16 +1022,17 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                         const int g = g_start + sub_g_start;
                         const int oc_b = oc_b_start + sub_oc_b_start;
                         const int ic_b = ic_b_start + sub_ic_b_start;
-                        const int ic_to_accumulate
-                                = nstl::min(end - w, ic_b_work - sub_ic_b_start)
-                                * jcp.ic_block;
-                        const int acc_size
-                                = this_block_size(ic_b * jcp.ic_block,
-                                          jcp.ic_without_padding,
-                                          ic_to_accumulate)
-                                * jcp.oc_block;
+                        const int ic_to_accumulate = static_cast<int>(
+                                nstl::min<dim_t>(
+                                        end - w, ic_b_work - sub_ic_b_start)
+                                * jcp.ic_block);
+                        const int acc_size = static_cast<int>(
+                                this_block_size(ic_b * jcp.ic_block,
+                                        jcp.ic_without_padding,
+                                        ic_to_accumulate)
+                                * jcp.oc_block);
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         data_t *d = diff_weights + off;
                         data_t *s
@@ -1037,9 +1062,9 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* TODO: put this in ker_bias */
         if (is_bias_padded) {
             assert(IMPLICATION(!is_ddst_layout_nxc, jcp.ngroups == 1));
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -293,11 +293,11 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);
 
-            size_t dw_conv_buffer_size_ = (size_t)nthr * jcp_dw.kh * jcp_dw.iw
-                    * jcp_dw.dw_conv_buffer_oc;
-            assert(dw_conv_buffer_size_);
+            const dim_t dw_conv_buffer_size = static_cast<dim_t>(nthr)
+                    * jcp_dw.kh * jcp_dw.iw * jcp_dw.dw_conv_buffer_oc;
+            assert(dw_conv_buffer_size);
             dw_scratchpad.book(memory_tracking::names::key_fusion_inout_buffer,
-                    dw_conv_buffer_size_,
+                    static_cast<size_t>(dw_conv_buffer_size),
                     types::data_type_size(dw_conv_pd_->src_md()->data_type));
 
             jit_uni_dw_conv_fwd_kernel_t<avx512_core,
@@ -554,11 +554,14 @@ struct jit_avx512_common_1x1_convolution_bwd_weights_t : public primitive_t {
 
     private:
         void init_balancers() {
-            const size_t max_buffer_size = jcp_.nthr * 3 * 5 * 5 * 16 * 16;
+            const dim_t max_buffer_size
+                    = static_cast<dim_t>(jcp_.nthr) * 3 * 5 * 5 * 16 * 16;
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(jcp_.nthr,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_load, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_load),
+                        static_cast<int>(jcp_.mb),
+                        static_cast<size_t>(max_buffer_size), true));
             }
         }
     };

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -102,7 +102,7 @@ jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_args_static_params {
@@ -208,7 +208,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::store_output(int ur_w) {
     L(no_update_label);
     if (jcp.with_bias) {
         for (int k = 0; k < jcp.nb_oc_blocking; k++) {
-            int bias_offset = jcp.typesize_out * k * jcp.oc_block;
+            const dim_t bias_offset = jcp.typesize_out * k * jcp.oc_block;
             for (int j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 // mask only needed for last oc_block
@@ -251,16 +251,16 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::store_output(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     const bool is_source_layout_nxc = is_src_layout_nxc();
     const bool icb_loop_in_compute_function = is_source_layout_nxc;
     const int ic_tail = jcp.ic_tail;
     const int oc_tail = jcp.oc == jcp.oc_without_padding ? jcp.oc_tail : 0;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_oc_block = jcp.nb_oc_blocking;
+    dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
     Label kh_label, kd_label;
     std::vector<Label> ic_tail_jmp(kw);
 
@@ -268,14 +268,15 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
     // assert if it is extended in future to catch unpadded_oc_tail.
     assert(IMPLICATION(oc_tail, nb_oc_block == 1));
 
-    int num_ker_loads = ic_block * nb_oc_block * kw;
-    int ker_pipeline_depth
-            = oc_tail || ic_tail ? 1 : nstl::min(4, num_ker_loads);
+    const dim_t num_ker_loads = ic_block * nb_oc_block * kw;
+    int ker_pipeline_depth = oc_tail || ic_tail
+            ? 1
+            : static_cast<int>(nstl::min<dim_t>(4, num_ker_loads));
     assert(ker_reg_base_idx + ker_pipeline_depth <= 32);
     assert(oc_block >= ker_pipeline_depth);
 
-    int inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
-                                       : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
+                                         : (!jcp.is_1stconv ? ic_block : 1);
 
     if (one_of(jcp.ndims, 3, 4)) {
         mov(aux_reg_inp, reg_inp);
@@ -322,7 +323,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                         je(ic_tail_jmp[ki], T_NEAR);
                     }
                 }
-                int aux_kernel_offset = 0;
+                dim_t aux_kernel_offset = 0;
                 if (step == 0) {
                     for (int i = 0; i < ker_pipeline_depth; i++) {
                         aux_kernel_offset = get_kernel_offset(ki, ic, 0, i);
@@ -331,7 +332,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                                         aux_reg_ker, aux_kernel_offset));
                     }
                 } else if (step < num_ker_loads - ker_pipeline_depth + 1) {
-                    int load_offset = ker_pipeline_depth - 1;
+                    const dim_t load_offset = ker_pipeline_depth - 1;
                     int ker_load_reg_idx
                             = (step + load_offset) % ker_pipeline_depth;
                     aux_kernel_offset
@@ -341,10 +342,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                 }
 
                 Vmm vmm_kernel = vmm_ker(step % ker_pipeline_depth);
-                int j_start = get_ow_start(ki, pad_l);
-                int j_end = get_ow_end(ur_w, ki, pad_r);
-                for (int j = j_start; j < j_end; j++) {
-                    size_t aux_input_offset
+                const dim_t j_start = get_ow_start(ki, pad_l);
+                const dim_t j_end = get_ow_end(ur_w, ki, pad_r);
+                for (dim_t j = j_start; j < j_end; j++) {
+                    const dim_t aux_input_offset
                             = get_input_offset(ki, ic, j, pad_l);
                     auto addr = EVEX_compress_addr_safe(
                             aux_reg_inp, aux_input_offset, reg_long_offt, true);
@@ -354,9 +355,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
             }
             L(ic_tail_jmp[ki]);
         }
-        int ker_shift = jcp.typesize_in * kw * oc_block * ic_block;
+        const dim_t ker_shift = jcp.typesize_in * kw * oc_block * ic_block;
         add(aux_reg_ker, ker_shift);
-        int inp_shift = jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mul;
+        const dim_t inp_shift
+                = jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mul;
         add(aux_reg_inp, inp_shift);
         dec(reg_kj);
         cmp(reg_kj, 0);
@@ -364,10 +366,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
     }
 
     if (jcp.ndims == 5) {
-        int inp_shift
+        const dim_t inp_shift
                 = typesize * (jcp.dilate_d + 1) * jcp.ih * jcp.iw * inp_mul;
         add(aux_reg_inp_d, inp_shift);
-        int ker_shift
+        const dim_t ker_shift
                 = typesize * jcp.kw * jcp.kh * jcp.oc_block * jcp.ic_block;
         add(aux_reg_ker_d, ker_shift);
 
@@ -382,23 +384,23 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
-        int ur_w, int pad_l, int pad_r) {
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_oc_block = jcp.nb_oc_blocking;
+        int ur_w, dim_t pad_l, dim_t pad_r) {
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
     const bool is_source_layout_nxc = is_src_layout_nxc();
     const bool icb_loop_in_compute_function = is_source_layout_nxc;
     const int ic_tail = jcp.ic_tail;
 
     Label kh_label, kd_label;
     std::vector<Label> ic_tail_jmp(kw);
-    int shift_kernel_ptr
+    dim_t shift_kernel_ptr
             = jcp.typesize_in * jcp.kw * jcp.oc_block * jcp.ic_block;
-    int inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
-                                       : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
+                                         : (!jcp.is_1stconv ? ic_block : 1);
 
-    int shift_input_ptr
+    dim_t shift_input_ptr
             = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mul;
 
     if (one_of(jcp.ndims, 3, 4)) {
@@ -435,8 +437,8 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_ow_start(ki, pad_l);
-            int jj_end = get_ow_end(ur_w, ki, pad_r);
+            const dim_t jj_start = get_ow_start(ki, pad_l);
+            const dim_t jj_end = get_ow_end(ur_w, ki, pad_r);
             for (int ic = 0; ic < ic_block; ic++) {
                 if (ic_tail && ic >= ic_tail) {
                     // if src has only tails to compute, skip early
@@ -448,8 +450,8 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                     }
                 }
                 if (jcp.kernel_kind == expl_bcast) {
-                    for (int jj = jj_start; jj < jj_end; jj++) {
-                        size_t aux_input_offset
+                    for (dim_t jj = jj_start; jj < jj_end; jj++) {
+                        dim_t aux_input_offset
                                 = get_input_offset(ki, ic, jj, pad_l);
                         vbroadcastss(vmm_inp(jj, nb_oc_block),
                                 EVEX_compress_addr_safe(aux_reg_inp,
@@ -457,7 +459,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                     }
                 }
                 for (int ii = 0; ii < nb_oc_block; ii++) {
-                    int aux_kernel_offset = jcp.typesize_in
+                    dim_t aux_kernel_offset = jcp.typesize_in
                             * (ii * jcp.nb_ic * jcp.kh * jcp.kw * jcp.kd
                                             * ic_block * oc_block
                                     + ki * ic_block * oc_block + ic * oc_block);
@@ -465,12 +467,12 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                         vmovups(vmm_wei,
                                 EVEX_compress_addr(
                                         aux_reg_ker, aux_kernel_offset));
-                    for (int jj = jj_start; jj < jj_end; jj++)
+                    for (dim_t jj = jj_start; jj < jj_end; jj++)
                         if (jcp.kernel_kind == expl_bcast)
                             vfmadd231ps(vmm_out(jj, ii),
                                     vmm_inp(jj, nb_oc_block), vmm_wei);
                         else {
-                            size_t aux_input_offset
+                            dim_t aux_input_offset
                                     = get_input_offset(ki, ic, jj, pad_l);
                             vfmadd231ps(vmm_out(jj, ii), vmm_wei,
                                     EVEX_compress_addr_safe(aux_reg_inp,
@@ -491,7 +493,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
     if (jcp.ndims == 5) {
         add(aux_reg_inp_d,
                 typesize * (jcp.dilate_d + 1) * jcp.ih * jcp.iw * inp_mul);
-        const int ker_shift
+        const dim_t ker_shift
                 = typesize * jcp.kw * jcp.kh * jcp.oc_block * jcp.ic_block;
         add(aux_reg_ker_d, ker_shift);
 
@@ -506,7 +508,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     if (jcp.ndims == 5) push(reg_oi);
 
     prepare_output(ur_w);
@@ -548,7 +550,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
     if (generate_icb_loop) {
         assert(is_src_layout_nxc());
-        const int inp_shift = jcp.ic_block * jcp.typesize_in;
+        const dim_t inp_shift = jcp.ic_block * jcp.typesize_in;
         add(reg_inp, inp_shift);
         const size_t ker_shift = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.ic_block
                 * jcp.oc_block * jcp.typesize_in;
@@ -567,22 +569,23 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int ow_block = jcp.ow_block;
-    int nb_ow = jcp.nb_ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    dim_t ow_block = jcp.ow_block;
+    dim_t nb_ow = jcp.nb_ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
-    int inp_mult = is_src_layout_nxc() ? jcp.ngroups * jcp.ic
-                                       : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    int inp_shift_pad = jcp.typesize_in * (ur_w * stride_w - l_pad) * inp_mult;
-    int inp_shift = jcp.typesize_in * ur_w * stride_w * inp_mult;
-    int inp_shift_pad_second_block = -1 * jcp.typesize_in * l_pad * inp_mult;
-    int out_shift = jcp.typesize_out * ur_w
+    dim_t inp_mult = is_src_layout_nxc() ? jcp.ngroups * jcp.ic
+                                         : (jcp.is_1stconv ? 1 : jcp.ic_block);
+    dim_t inp_shift_pad
+            = jcp.typesize_in * (ur_w * stride_w - l_pad) * inp_mult;
+    dim_t inp_shift = jcp.typesize_in * ur_w * stride_w * inp_mult;
+    dim_t inp_shift_pad_second_block = -1 * jcp.typesize_in * l_pad * inp_mult;
+    dim_t out_shift = jcp.typesize_out * ur_w
             * (is_dst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block);
 
     preamble();
@@ -612,9 +615,9 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
             kmovw(postops_mask, reg_tail_32);
         }
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+    const dim_t r_pad = nstl::max<dim_t>(0, jcp.r_pad);
+    dim_t n_oi = ow / ur_w;
+    const dim_t r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
             calculate_extended_filter_size(kw, jcp.dilate_w));
 
     if (!is_ow_threading_on(jcp)) {
@@ -666,14 +669,15 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
         Label oi_loop_label, oi_loop_start_label, oi_loop_end_label;
 
         assert(ow_block % ur_w == 0);
-        int n_oi_not_last_ow_block = ow_block / ur_w;
+        int n_oi_not_last_ow_block = static_cast<int>(ow_block / ur_w);
         // to simplify code (and general regs usage),
         // size of ow block must be >= 2 * ur_w
         assert(n_oi_not_last_ow_block > 1);
         int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
         int n_oi_first_ow_block = n_oi_not_last_ow_block;
 
-        int n_oi_last_ow_block = (ow - ow_block * (nb_ow - 1)) / ur_w;
+        int n_oi_last_ow_block
+                = static_cast<int>((ow - ow_block * (nb_ow - 1)) / ur_w);
 
         // prepare right padding
         bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
@@ -828,9 +832,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -987,11 +991,11 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.typesize_out = typesize;
 
     if (jcp.is_1stconv) {
-        jcp.ur_w = nstl::min(jcp.ow, regs);
+        jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
     } else {
         // avx512_core guard - just to avoid possible regression for other archs
         if (mayiuse(avx512_core)) {
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
         } else {
             for (int ur_w = regs; ur_w > 0; --ur_w) {
                 if (jcp.ow % ur_w == 0) {
@@ -1001,15 +1005,15 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             }
         }
         if ((ndims == 5 && jcp.ur_w <= 8) || (jcp.ur_w <= 1)) {
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
         }
     }
     // TODO (Tanya): currently applied to Segnet convolutions only.
     // Need to try for other topologies
     if (jcp.ow > 150 && jcp.ur_w < regs / 2) jcp.ur_w = regs;
 
-    int n_oi = (jcp.ow / jcp.ur_w);
-    int r_pad = calculate_end_padding(
+    dim_t n_oi = jcp.ow / jcp.ur_w;
+    dim_t r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ur_w * n_oi, jcp.iw, jcp.stride_w, ext_kw);
     if (jcp.l_pad > 0 && r_pad > 0) n_oi--;
 
@@ -1018,12 +1022,12 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && ((jcp.l_pad <= 0 && n_oi > 0) || (jcp.l_pad > 0 && n_oi > 1));
     if (large_code_size) {
         const int max_code_size = 24 * 1024;
-        const int num_ops_per_reg = 6 + jcp.ic_block * jcp.kw;
+        const dim_t num_ops_per_reg = 6 + jcp.ic_block * jcp.kw;
         int mult = 1;
         if (jcp.l_pad > 0) mult += 1;
         if (r_pad > 0) mult += 1;
         for (int ur_w = jcp.ur_w; ur_w > regs / 2; --ur_w) {
-            if (ur_w * mult * num_ops_per_reg * 9.0 < max_code_size) {
+            if ((double)(ur_w * mult * num_ops_per_reg) * 9.0 < max_code_size) {
                 jcp.ur_w = ur_w;
                 break;
             }
@@ -1032,10 +1036,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     /* Grouped channel offset to support 'non-blocked data' format for
      * convolution sizes with '(input_channel / ngroups) < simd' */
-    jcp.nonblk_group_off
-            = (jcp.ngroups > 1 && one_of(jcp.src_tag, ncw, nchw, ncdhw))
-            ? jcp.ic
-            : 1;
+    jcp.nonblk_group_off = static_cast<int>(
+            (jcp.ngroups > 1 && one_of(jcp.src_tag, ncw, nchw, ncdhw)) ? jcp.ic
+                                                                       : 1);
 
     jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
@@ -1046,39 +1049,39 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.ow_block = jcp.ow;
 
-    auto get_thr_eff = [&](int nb_oc_blocking, int ow_block, int nthr) {
-        int nb_ow = div_up(jcp.ow, ow_block);
-        int nb_oc_chunks = div_up(jcp.nb_oc, nb_oc_blocking);
-        int work_amount = jcp.mb * jcp.oh * nb_oc_chunks * nb_ow;
-        float disbalance = (float)jcp.ow / rnd_up(jcp.ow, ow_block);
-        float thr_eff
-                = disbalance * (float)work_amount / rnd_up(work_amount, nthr);
+    auto get_thr_eff = [&](int nb_oc_blocking, dim_t ow_block, int nthr) {
+        const dim_t nb_ow = div_up(jcp.ow, ow_block);
+        const dim_t nb_oc_chunks = div_up(jcp.nb_oc, nb_oc_blocking);
+        const dim_t work_amount = jcp.mb * jcp.oh * nb_oc_chunks * nb_ow;
+        float disbalance = (float)jcp.ow / (float)rnd_up(jcp.ow, ow_block);
+        float thr_eff = disbalance * (float)work_amount
+                / (float)rnd_up(work_amount, nthr);
         return thr_eff;
     };
 
     auto get_ow_block = [&](int nb_oc_blocking, int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+        dim_t res_ow_block = jcp.ow;
         float eff = get_thr_eff(nb_oc_blocking, res_ow_block, nthr);
         if (!is_ow_threading_applicable()) return res_ow_block;
 
         int L2_part = (platform::get_per_core_cache_size(2) * 7 / 8) / typesize;
-        int size_src_chunk = jcp.ic_block * ur_w * jcp.kh;
-        int size_dst_chunk = jcp.oc_block * nb_oc_blocking * ur_w;
-        int size_wei_chunk = jcp.oc_block * nb_oc_blocking * jcp.ic_block
-                * jcp.kw * jcp.kh;
-        int nurw_cache = (L2_part - 2 * size_wei_chunk)
+        const dim_t size_src_chunk = jcp.ic_block * ur_w * jcp.kh;
+        const dim_t size_dst_chunk = jcp.oc_block * nb_oc_blocking * ur_w;
+        const dim_t size_wei_chunk = jcp.oc_block * nb_oc_blocking
+                * jcp.ic_block * jcp.kw * jcp.kh;
+        const dim_t nurw_cache = (L2_part - 2 * size_wei_chunk)
                 / (2 * size_dst_chunk + 2 * size_src_chunk);
         // current design of generate() requires ow_block >= 2 * ur_w
-        int ow_block_cache = ur_w * nstl::max(2, nurw_cache);
+        const dim_t ow_block_cache = ur_w * nstl::max<dim_t>(2, nurw_cache);
 
-        int ow_block_thr = ow_block_cache;
+        dim_t ow_block_thr = ow_block_cache;
         eff = get_thr_eff(nb_oc_blocking, ow_block_thr, nthr);
 
-        int max_nb_ow = div_up(jcp.ow, 2 * ur_w);
-        int start_nb_ow = div_up(jcp.ow, ow_block_thr);
-        for (int nb_ow = start_nb_ow; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, 2 * ur_w);
+        const dim_t start_nb_ow = div_up(jcp.ow, ow_block_thr);
+        for (dim_t nb_ow = start_nb_ow; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             float eff_threshold = 0.9f;
             if (ow_block < nb_oc_blocking * jcp.oc_block && eff > eff_threshold)
                 break;
@@ -1092,7 +1095,8 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             eff_threshold = 0.98f;
             if (eff > eff_threshold) break;
         }
-        res_ow_block = nstl::min(jcp.ow, nstl::max(2 * ur_w, ow_block_thr));
+        res_ow_block = static_cast<int>(nstl::min<dim_t>(
+                jcp.ow, nstl::max<dim_t>(2 * ur_w, ow_block_thr)));
         eff = get_thr_eff(nb_oc_blocking, res_ow_block, nthr);
         return res_ow_block;
     };
@@ -1100,9 +1104,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const size_t L1_cache_size = platform::get_per_core_cache_size(1);
     if (mayiuse(avx512_core)) {
         int try_nb_oc_blocking = 2;
-        unsigned int ker_inp_size = typesize * div_up(jcp.iw, jcp.stride_w)
+        const size_t ker_inp_size = typesize * div_up(jcp.iw, jcp.stride_w)
                 * jcp.ic_block * jcp.kh * jcp.kd;
-        unsigned int ker_out_size
+        const size_t ker_out_size
                 = typesize * jcp.ow * jcp.oc_block * try_nb_oc_blocking;
         size_t ker_wei_size = static_cast<size_t>(typesize) * jcp.kh * jcp.kw
                 * jcp.ic_block * jcp.oc_block * try_nb_oc_blocking * jcp.kd;
@@ -1137,19 +1141,21 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                         || (jcp.ow <= 147 && jcp.oc <= 96))));
 
         if (jcp.mb == 1) {
-            unsigned int inp_size = jcp.mb * div_up(jcp.ih, jcp.stride_h)
+            const size_t inp_size = jcp.mb * div_up(jcp.ih, jcp.stride_h)
                     * div_up(jcp.iw, jcp.stride_w) * jcp.ic;
-            unsigned int wei_size = jcp.ic * jcp.oc * jcp.kh * jcp.kw;
+            const size_t wei_size = jcp.ic * jcp.oc * jcp.kh * jcp.kw;
 
             // Estimate whether we need to limit the number of threads
             // and calculate this number. Includes some heuristic.
-            int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-            int work_amount = jcp.mb * jcp.ngroups * oc_chunks * jcp.oh;
-            int job_size_min = work_amount / nthreads;
-            int job_size_max = div_up(work_amount, nthreads);
-            int ch_max = rnd_up(jcp.oh, job_size_max);
-            int ch_min = (job_size_min == 0) ? jcp.oh
-                                             : rnd_up(jcp.oh, job_size_min);
+            const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+            const dim_t work_amount = jcp.mb * jcp.ngroups * oc_chunks * jcp.oh;
+            const int job_size_min = static_cast<int>(work_amount / nthreads);
+            const int job_size_max
+                    = static_cast<int>(div_up(work_amount, nthreads));
+            const dim_t ch_max = rnd_up(jcp.oh, job_size_max);
+            const dim_t ch_min = (job_size_min == 0)
+                    ? jcp.oh
+                    : rnd_up(jcp.oh, job_size_min);
             bool not_aligned_max = ch_max % jcp.oh != 0 && ch_max / jcp.oh < 2
                     && (jcp.oh != 8 || ch_max / jcp.oh > 1);
             bool not_aligned_min = ch_min % jcp.oh != 0 && ch_min / jcp.oh < 2
@@ -1176,7 +1182,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         const int max_nb_oc = 5;
         if (embd_bcast_condition) {
             jcp.kernel_kind = embd_bcast;
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
             jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
             const unsigned int L1_cache_size
                     = platform::get_per_core_cache_size(1);
@@ -1185,7 +1191,8 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     && IMPLICATION(jcp.is_1stconv, jcp.mb == 1)
                     && IMPLICATION(jcp.mb == 1, jcp.ur_w < jcp.ow)) {
                 jcp.nb_oc_blocking = try_nb_oc_blocking;
-                jcp.ur_w = nstl::min(jcp.ow, 31 / (jcp.nb_oc_blocking + 1));
+                jcp.ur_w = static_cast<int>(nstl::min<dim_t>(
+                        jcp.ow, 31 / (jcp.nb_oc_blocking + 1)));
             }
         } else {
             jcp.kernel_kind = expl_bcast;
@@ -1194,14 +1201,17 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     || expl_bcast_condition) {
                 float best_thr_eff = 0.f;
                 int best_nb_oc_blocking = 1;
-                for (int i = nstl::min(jcp.nb_oc, max_nb_oc); i > 0; i--) {
+                for (int i = static_cast<int>(
+                             nstl::min<dim_t>(jcp.nb_oc, max_nb_oc));
+                        i > 0; i--) {
                     if (jcp.nb_oc % i == 0) {
                         if (expl_bcast_condition) {
                             best_nb_oc_blocking = i;
                             break;
                         } else {
-                            int ur_w = nstl::min(jcp.ow, 31 / (i + 1));
-                            int ow_block = get_ow_block(i, ur_w, jcp.nthr);
+                            int ur_w = static_cast<int>(
+                                    nstl::min<dim_t>(jcp.ow, 31 / (i + 1)));
+                            dim_t ow_block = get_ow_block(i, ur_w, jcp.nthr);
                             float thr_eff = get_thr_eff(i, ow_block, jcp.nthr);
                             if (thr_eff > 1.05f * best_thr_eff) {
                                 best_nb_oc_blocking = i;
@@ -1211,12 +1221,13 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     }
                 }
                 jcp.nb_oc_blocking = best_nb_oc_blocking;
-                jcp.ur_w = nstl::min(jcp.ow, 31 / (jcp.nb_oc_blocking + 1));
+                jcp.ur_w = static_cast<int>(nstl::min<dim_t>(
+                        jcp.ow, 31 / (jcp.nb_oc_blocking + 1)));
             }
         }
     }
 
-    jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+    jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
 
     bool args_ok = true && jcp.l_pad <= jcp.ur_w
             && jcp.ic <= src_d.padded_dims()[1]
@@ -1226,9 +1237,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(args_ok, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weight and src size mismatch");
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(r_pad_no_tail <= jcp.ur_w,
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -1255,10 +1266,10 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     if (thr_eff < eff_threshold && jcp.ngroups < jcp.nthr
             && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        dim_t ow_block = jcp.ow_block;
         float best_thr_eff = -1.0f;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        const int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
             ow_block = get_ow_block(jcp.nb_oc_blocking, jcp.ur_w, nthr);
             eff = get_thr_eff(jcp.nb_oc_blocking, ow_block, nthr);
@@ -1275,10 +1286,11 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const int L2_size = platform::get_per_core_cache_size(2) / typesize;
     // Source and output data needs to fit in L2,
     // leaving some space for weights and prefetching.
-    int h_L2 = int(((0.6f * L2_size) / jcp.simd_w
-                           - nstl::min(0, jcp.kh - jcp.stride_h) * jcp.iw)
-            / (jcp.stride_h * jcp.iw + jcp.ow));
-    jcp.h_blocking = nstl::max(1, nstl::min(jcp.oh, h_L2));
+    int h_L2 = int(((0.6f * (float)L2_size) / (float)jcp.simd_w
+                           - (float)(nstl::min<dim_t>(0, jcp.kh - jcp.stride_h)
+                                   * jcp.iw))
+            / (float)(jcp.stride_h * jcp.iw + jcp.ow));
+    jcp.h_blocking = nstl::max<dim_t>(1, nstl::min<dim_t>(jcp.oh, h_L2));
 
     if (is_data_layout_nxc) {
         // TODO: improve L2 blocking for large IC
@@ -1286,7 +1298,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         if (jcp.nb_ic > nb_ic_theshold_L2 && jcp.nb_ic < 2 * nb_ic_theshold_L2)
             jcp.nb_ic_L2 = div_up(jcp.nb_ic, 2);
         else
-            jcp.nb_ic_L2 = nstl::min(nb_ic_theshold_L2, jcp.nb_ic);
+            jcp.nb_ic_L2 = nstl::min<dim_t>(nb_ic_theshold_L2, jcp.nb_ic);
     }
 
     // A rough check on code size
@@ -1295,9 +1307,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         const int max_code_size = 256 * 1024; // default size of jit generator
         int mult = 1 + (jcp.l_pad > 0) + (r_pad > 0);
         const float max_instruction_size = 15;
-        float ur_fac
-                = (float)jcp.kw * jcp.ic_block * jcp.nb_oc_blocking * jcp.ur_w;
-        float code_size = mult * ur_fac * max_instruction_size;
+        float ur_fac = (float)jcp.kw * (float)jcp.ic_block
+                * (float)jcp.nb_oc_blocking * (float)jcp.ur_w;
+        float code_size = (float)mult * ur_fac * max_instruction_size;
         VDISPATCH_CONV_IC(
                 code_size <= max_code_size, "code size limit exceeded");
     }
@@ -1358,23 +1370,23 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::store_output(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
-        int ur_w, int l_overflow, int r_overflow) {
+        int ur_w, dim_t l_overflow, dim_t r_overflow) {
     Label kh_label, kd_label;
-    int kw = jcp.kw;
-    int ow = jcp.ow;
+    dim_t kw = jcp.kw;
+    dim_t ow = jcp.ow;
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    dim_t stride_w = jcp.stride_w;
+    dim_t stride_h = jcp.stride_h;
 
     int ker_pipeline_depth = 4;
     assert(ker_reg_base_idx + ker_pipeline_depth <= 32);
     assert(oc_block >= ker_pipeline_depth);
 
-    int num_ker_loads = oc_block * kw;
+    const int num_ker_loads = static_cast<int>(oc_block * kw);
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
-    int oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
     const bool ocb_loop_in_compute_function = ddst_layout_nxc;
 
     const int ic_tail = jcp.ic_tail;
@@ -1428,7 +1440,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
                 }
                 if (step == 0) {
                     for (int i = 0; i < ker_pipeline_depth; i++) {
-                        int aux_kernel_offset = typesize
+                        dim_t aux_kernel_offset = typesize
                                 * ((oc + i) * oc_block
                                         + ki * ic_block * oc_block);
                         vmovups(vmm_ker(i),
@@ -1439,7 +1451,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
                     int load_offset = ker_pipeline_depth - 1;
                     int ker_load_reg_idx
                             = (step + load_offset) % ker_pipeline_depth;
-                    int aux_kernel_offset = typesize
+                    dim_t aux_kernel_offset = typesize
                             * ((oc + load_offset) * oc_block
                                     + ki * ic_block * oc_block);
                     vmovups(vmm_ker(ker_load_reg_idx),
@@ -1448,24 +1460,24 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
 
                 auto vmm_kernel = vmm_ker(step % ker_pipeline_depth);
 
-                int jj_start = get_iw_start(ki, l_overflow);
-                int jj_end = get_iw_end(ur_w, ki, r_overflow);
-                const int dil_w = jcp.dilate_w + 1;
-                const int ref_jj_start
-                        = nstl::max(0, l_overflow - (kw - 1 - ki) * dil_w);
-                const int ref_jj_end
-                        = ur_w - nstl::max(0, r_overflow - ki * dil_w);
+                const dim_t jj_start = get_iw_start(ki, l_overflow);
+                const dim_t jj_end = get_iw_end(ur_w, ki, r_overflow);
+                const dim_t dil_w = jcp.dilate_w + 1;
+                const dim_t ref_jj_start = nstl::max<dim_t>(
+                        0, l_overflow - (kw - 1 - ki) * dil_w);
+                const dim_t ref_jj_end
+                        = ur_w - nstl::max<dim_t>(0, r_overflow - ki * dil_w);
                 assert(IMPLICATION(stride_w == 1,
                         jj_start == ref_jj_start && jj_end == ref_jj_end));
                 UNUSED(dil_w);
                 UNUSED(ref_jj_start);
                 UNUSED(ref_jj_end);
 
-                for (int jj = jj_start; jj < jj_end; jj += stride_w) {
+                for (dim_t jj = jj_start; jj < jj_end; jj += stride_w) {
                     assert((jj + jcp.l_pad - ki * (jcp.dilate_w + 1)) % stride_w
                             == 0);
-                    int aux_dst_offset = get_dst_offset(jj, oc, ki);
-                    vfmadd231ps(vmm_out(jj, 0), vmm_kernel,
+                    dim_t aux_dst_offset = get_dst_offset(jj, oc, ki);
+                    vfmadd231ps(vmm_out(static_cast<int>(jj), 0), vmm_kernel,
                             EVEX_compress_addr(
                                     aux_reg_dst, aux_dst_offset, true));
                 }
@@ -1474,9 +1486,9 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
             L(oc_tail_jmp[ki]);
         }
 
-        const int ker_shift = typesize * stride_h * kw * oc_block * ic_block;
+        const dim_t ker_shift = typesize * stride_h * kw * oc_block * ic_block;
         add(aux_reg_ker, ker_shift);
-        const int ddst_shift = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
+        const dim_t ddst_shift = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
         sub(aux_reg_dst, ddst_shift);
 
         dec(reg_kj);
@@ -1484,10 +1496,10 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
         jg(kh_label, T_NEAR);
     }
     if (jcp.ndims == 5) {
-        const int depth_ddst_shift
+        const dim_t depth_ddst_shift
                 = typesize * (jcp.dilate_d + 1) * jcp.oh * ow * oc_mult;
         sub(aux_reg_dst_d, depth_ddst_shift);
-        const int depth_ker_shift = typesize * jcp.stride_d * jcp.kw * jcp.kh
+        const dim_t depth_ker_shift = typesize * jcp.stride_d * jcp.kw * jcp.kh
                 * oc_block * ic_block;
         add(aux_reg_ker_d, depth_ker_shift);
 
@@ -1502,29 +1514,29 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
-        Vmm>::compute_loop_fma_core(int ur_w, int l_overflow, int r_overflow,
-        int k_offset) {
-    int kw = jcp.kw;
-    int ow = jcp.ow;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_ic_block = jcp.nb_ic_blocking;
+        Vmm>::compute_loop_fma_core(int ur_w, dim_t l_overflow,
+        dim_t r_overflow, int k_offset) {
+    dim_t kw = jcp.kw;
+    dim_t ow = jcp.ow;
+    dim_t stride_w = jcp.stride_w;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_ic_block = jcp.nb_ic_blocking;
     Label kh_label, kd_label;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
-    int shift_ker_ptr = typesize * kw * oc_block * ic_block;
-    int oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
-    int shift_dst_ptr = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
+    dim_t shift_ker_ptr = typesize * kw * oc_block * ic_block;
+    dim_t oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t shift_dst_ptr = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
 
     const int oc_tail = jcp.oc_tail;
     const int max_filter_size = 20;
     Label oc_tail_jmp[max_filter_size];
 
-    auto kernel_offset = [this](int icb, int oc, int ki) {
-        int blk_idx = icb * jcp.kh * jcp.kw * jcp.kd + ki;
-        int blk_offset = blk_idx * jcp.oc_block * jcp.ic_block;
-        int oc_offset = oc * jcp.oc_block;
+    auto kernel_offset = [this](dim_t icb, dim_t oc, dim_t ki) -> dim_t {
+        const dim_t blk_idx = icb * jcp.kh * jcp.kw * jcp.kd + ki;
+        const dim_t blk_offset = blk_idx * jcp.oc_block * jcp.ic_block;
+        const dim_t oc_offset = oc * jcp.oc_block;
         return typesize * (blk_offset + oc_offset);
     };
 
@@ -1562,8 +1574,8 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow);
-            int jj_end = get_iw_end(ur_w, ki, r_overflow);
+            const dim_t jj_start = get_iw_start(ki, l_overflow);
+            const dim_t jj_end = get_iw_end(ur_w, ki, r_overflow);
             for (int oc = 0; oc < oc_block; oc++) {
                 if (oc_tail && oc >= oc_tail) {
                     // if src has only tails to compute, skip early
@@ -1575,25 +1587,27 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
                     }
                 }
                 if (jcp.kernel_kind == expl_bcast) {
-                    for (int jj = jj_start; jj < jj_end; jj++) {
-                        int aux_output_offset = get_dst_offset(jj, oc, ki);
-                        vbroadcastss(vmm_inp(jj, nb_ic_block),
+                    for (dim_t jj = jj_start; jj < jj_end; jj++) {
+                        dim_t aux_output_offset = get_dst_offset(jj, oc, ki);
+                        vbroadcastss(vmm_inp(static_cast<int>(jj), nb_ic_block),
                                 ptr[aux_reg_dst + aux_output_offset]);
                     }
                 }
                 for (int ii = 0; ii < nb_ic_block; ii++) {
-                    int aux_kernel_offset
+                    dim_t aux_kernel_offset
                             = kernel_offset(ii, oc, ki + k_offset);
                     if (jj_end - jj_start > 0)
                         vmovups(vmm_wei,
                                 EVEX_compress_addr(
                                         aux_reg_ker, aux_kernel_offset));
-                    for (int jj = jj_start; jj < jj_end; jj += stride_w)
+                    for (dim_t jj = jj_start; jj < jj_end; jj += stride_w)
                         if (jcp.kernel_kind == expl_bcast)
-                            vfmadd231ps(vmm_out(jj, ii),
-                                    vmm_inp(jj, nb_ic_block), vmm_wei);
+                            vfmadd231ps(vmm_out(static_cast<int>(jj), ii),
+                                    vmm_inp(static_cast<int>(jj), nb_ic_block),
+                                    vmm_wei);
                         else
-                            vfmadd231ps(vmm_out(jj, ii), vmm_wei,
+                            vfmadd231ps(vmm_out(static_cast<int>(jj), ii),
+                                    vmm_wei,
                                     EVEX_compress_addr(aux_reg_dst,
                                             get_dst_offset(jj, oc, ki), true));
                 }
@@ -1623,7 +1637,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
 
 template <typename Vmm>
 inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
-        int ur_w, int l_overflow, int r_overflow, int k_offset) {
+        int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset) {
     if (jcp.ndims == 5) push(reg_oi);
 
     prepare_output(ur_w);
@@ -1655,7 +1669,7 @@ inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
 
     if (generate_ocb_loop) {
         add(reg_dst, jcp.oc_block * typesize);
-        const int ker_shift = jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw
+        const dim_t ker_shift = jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw
                 * jcp.ic_block * jcp.oc_block * typesize;
         add(reg_ker, ker_shift);
         sub(reg_channel, jcp.oc_block);
@@ -1672,20 +1686,20 @@ inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int kw = jcp.kw;
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
     int ur_w = jcp.ur_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_iw = jcp.nb_iw;
-    int iw_block = jcp.iw_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_iw = jcp.nb_iw;
+    const dim_t iw_block = jcp.iw_block;
     int ur_w_tail = jcp.ur_w_tail;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    int dilate_w = static_cast<int>(jcp.dilate_w) + 1;
+    int stride_w = static_cast<int>(jcp.stride_w);
 
-    int dst_shift = jcp.typesize_in * (ur_w / stride_w)
+    dim_t dst_shift = jcp.typesize_in * (ur_w / stride_w)
             * (is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block);
-    int src_shift = jcp.typesize_out * ur_w
+    dim_t src_shift = jcp.typesize_out * ur_w
             * (is_dsrc_layout_nxc() ? jcp.ngroups * jcp.ic : ic_block);
 
     preamble();
@@ -1710,15 +1724,16 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
         L(masking_done);
     }
 
-    int l_overflow = nstl::max(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
-    int r_overflow = nstl::max(
-            0, ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad)) / stride_w);
-    int r_overflow_no_tail = nstl::max(0,
-            ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad + ur_w_tail))
-                    / stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w));
+    int r_overflow = static_cast<int>(nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad)) / stride_w));
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad + ur_w_tail))
+                    / stride_w));
 
     int body_l_overflow = 0, body_r_overflow = 0;
-    int n_oi = iw / ur_w;
+    int n_oi = static_cast<int>(iw / ur_w);
     int head_n_oi = 0, body_n_oi = 0, pretail_n_oi = 0, tail_n_oi = 0;
     int head_thread = 0, pretail_thread = 0, tail_thread = 0;
     bool threaded = is_iw_threading_on(jcp);
@@ -1746,12 +1761,12 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
         // Setup for threaded code generation, and jump into the correct
         // portion of code for execution.
         head_thread = 0;
-        tail_thread = nb_iw - 1;
+        tail_thread = static_cast<int>(nb_iw - 1);
         pretail_thread = tail_thread;
 
-        int base_n_oi = iw_block / ur_w;
+        int base_n_oi = static_cast<int>(iw_block / ur_w);
         head_n_oi = l_overflow > 0 ? base_n_oi - 1 : base_n_oi;
-        tail_n_oi = (iw - iw_block * (nb_iw - 1)) / ur_w;
+        tail_n_oi = static_cast<int>((iw - iw_block * (nb_iw - 1)) / ur_w);
         pretail_n_oi = tail_n_oi;
         if (r_overflow_no_tail > 0) {
             if (tail_n_oi > 0) {
@@ -1920,9 +1935,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -2033,11 +2048,11 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ur_w = jcp.stride_w;
+    jcp.ur_w = static_cast<int>(jcp.stride_w);
 
     int regs = 28;
     if (jcp.iw <= regs)
-        jcp.ur_w = jcp.iw;
+        jcp.ur_w = static_cast<int>(jcp.iw);
     else {
         for (int ur_w = regs; ur_w > 0; --ur_w)
             if (ur_w % jcp.stride_w == 0) {
@@ -2045,13 +2060,13 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 break;
             }
     }
-    int l_overflow = nstl::max(
-            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
-    int r_overflow_no_tail = nstl::max(0,
+    int l_overflow = static_cast<int>(nstl::max<dim_t>(
+            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w));
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.iw % jcp.ur_w))
-                    / jcp.stride_w);
-    int n_oi = jcp.iw / jcp.ur_w;
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.iw % jcp.ur_w))
+                    / jcp.stride_w));
+    dim_t n_oi = jcp.iw / jcp.ur_w;
     if (r_overflow_no_tail > 0) n_oi--;
 
     jcp.typesize_in = typesize;
@@ -2065,12 +2080,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             && (r_overflow_no_tail > 0) && (l_overflow > 0);
     if (large_code_size) {
         const int max_code_size = 24 * 1024;
-        const int num_ops_per_reg = 6 + jcp.oc_block * jcp.kw;
+        const dim_t num_ops_per_reg = 6 + jcp.oc_block * jcp.kw;
         int mult = 1;
         if (l_overflow > 0) mult += 1;
         if (r_overflow_no_tail > 0) mult += 1;
         for (int ur_w = jcp.ur_w; ur_w > regs / 2; --ur_w) {
-            if ((ur_w / jcp.stride_w) * mult * num_ops_per_reg * 9.2
+            if ((double)((ur_w / jcp.stride_w) * mult * num_ops_per_reg) * 9.2
                     < max_code_size) {
                 if (ur_w % jcp.stride_w == 0) {
                     jcp.ur_w = ur_w;
@@ -2098,13 +2113,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
     if (mayiuse(avx512_core)) {
         int try_nb_ic_blocking = 2;
-        unsigned int ker_inp_size = typesize * jcp.iw * jcp.ic_block
+        const size_t ker_inp_size = typesize * jcp.iw * jcp.ic_block
                 * try_nb_ic_blocking * jcp.kh;
-        unsigned int ker_out_size = typesize * jcp.ow * jcp.oc_block;
-        unsigned int ker_wei_size = typesize * jcp.kh * jcp.kw * jcp.ic_block
+        const size_t ker_out_size = typesize * jcp.ow * jcp.oc_block;
+        const size_t ker_wei_size = typesize * jcp.kh * jcp.kw * jcp.ic_block
                 * jcp.oc_block * try_nb_ic_blocking;
-        unsigned int ker_total_size
-                = ker_inp_size + ker_out_size + ker_wei_size;
+        size_t ker_total_size = ker_inp_size + ker_out_size + ker_wei_size;
         bool use_expl_bcast
                 = !(jcp.kw == 1 || (jcp.kw == 5 && jcp.iw < 8)
                           || (jcp.kw < 5
@@ -2114,7 +2128,7 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 || jcp.stride_h > 1 || jcp.stride_d > 1;
         if (use_expl_bcast && !jcp.large_w_filter) {
             jcp.kernel_kind = embd_bcast;
-            jcp.ur_w = nstl::min(jcp.iw, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.iw, regs));
             jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
             if (!(jcp.kw > 3
                         || (jcp.kw == 3 && ker_total_size < L1_cache_size
@@ -2123,13 +2137,14 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 if (jcp.nb_ic % try_nb_ic_blocking == 0) {
                     jcp.nb_ic_blocking = try_nb_ic_blocking;
                     jcp.ur_w = 31 / (jcp.nb_ic_blocking + 1);
-                    if (jcp.iw < jcp.ur_w) jcp.ur_w = jcp.iw;
+                    if (jcp.iw < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.iw);
                 }
         } else {
             jcp.kernel_kind = expl_bcast;
             jcp.nb_oc_blocking = 1;
             jcp.nb_ic_blocking = jcp.large_w_filter ? 2 : 4;
-            if (jcp.nb_ic < jcp.nb_ic_blocking) jcp.nb_ic_blocking = jcp.nb_ic;
+            if (jcp.nb_ic < jcp.nb_ic_blocking)
+                jcp.nb_ic_blocking = static_cast<int>(jcp.nb_ic);
             if (jcp.nb_ic % jcp.nb_ic_blocking != 0)
                 for (int i = jcp.nb_ic_blocking; i > 0; i--)
                     if (jcp.nb_ic % i == 0) {
@@ -2137,34 +2152,35 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                         break;
                     }
             jcp.ur_w = 31 / (jcp.nb_ic_blocking + 1);
-            if (jcp.iw < jcp.ur_w) jcp.ur_w = jcp.iw;
+            if (jcp.iw < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.iw);
         }
     }
     jcp.ur_w_tail = jcp.iw % jcp.ur_w;
 
     auto is_iw_threading_applicable = [&]() { return one_of(jcp.ndims, 3, 4); };
 
-    auto get_thr_eff = [&](int nb_ic_blocking, int iw_block, int nthr) {
+    auto get_thr_eff = [&](int nb_ic_blocking, dim_t iw_block, int nthr) {
         // Cost heuristic for threading overhead. Determined using OMP.
         const float iw_block_cost = 32.0;
 
-        int nb_iw = div_up(jcp.iw, iw_block);
-        int nb_ic_chunks = div_up(jcp.nb_ic, nb_ic_blocking);
-        int work_amount = jcp.mb * jcp.ih * nb_ic_chunks * nb_iw;
-        float disbalance = (float)jcp.iw / rnd_up(jcp.iw, iw_block);
-        float block_overhead = nstl::max(0.0f, 1.0f - iw_block_cost / iw_block);
+        const dim_t nb_iw = div_up(jcp.iw, iw_block);
+        const dim_t nb_ic_chunks = div_up(jcp.nb_ic, nb_ic_blocking);
+        const dim_t work_amount = jcp.mb * jcp.ih * nb_ic_chunks * nb_iw;
+        float disbalance = (float)jcp.iw / (float)rnd_up(jcp.iw, iw_block);
+        float block_overhead
+                = nstl::max(0.0f, 1.0f - iw_block_cost / (float)iw_block);
         float thr_eff = block_overhead * disbalance
-                * ((float)work_amount / rnd_up(work_amount, nthr));
+                * ((float)work_amount / (float)rnd_up(work_amount, nthr));
         return thr_eff;
     };
 
     auto get_iw_block
             = [&](int nb_ic_blocking, int ur_w, float &eff, int nthr) {
-        int res_iw_block = jcp.iw;
+        int res_iw_block = static_cast<int>(jcp.iw);
         if (!is_iw_threading_applicable()) return res_iw_block;
 
-        int max_nb_iw = div_up(jcp.iw, 2 * ur_w);
-        int iw_block_thr;
+        const dim_t max_nb_iw = div_up(jcp.iw, 2 * ur_w);
+        dim_t iw_block_thr;
 
         if (jcp.ndims == 3) {
             // Blocking optimization to prevent data from leaving cache This
@@ -2174,14 +2190,15 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             // the height dimension.
             int L2_part
                     = (platform::get_per_core_cache_size(2) * 7 / 8) / typesize;
-            int size_diff_src_chunk = jcp.ic_block * nb_ic_blocking * ur_w;
-            int size_diff_dst_chunk = jcp.oc_block * ur_w;
-            int size_wei_chunk
+            const dim_t size_diff_src_chunk
+                    = jcp.ic_block * nb_ic_blocking * ur_w;
+            const dim_t size_diff_dst_chunk = jcp.oc_block * ur_w;
+            const dim_t size_wei_chunk
                     = jcp.ic_block * nb_ic_blocking * jcp.oc_block * jcp.kw;
-            int nurw_cache = (L2_part - 2 * size_wei_chunk)
+            const dim_t nurw_cache = (L2_part - 2 * size_wei_chunk)
                     / (2 * size_diff_dst_chunk + 2 * size_diff_src_chunk);
             // current design of generate() requires iw_block >= 2 * ur_w
-            int iw_block_cache = ur_w * nstl::max(2, nurw_cache);
+            const dim_t iw_block_cache = ur_w * nstl::max<dim_t>(2, nurw_cache);
 
             iw_block_thr = iw_block_cache;
         } else
@@ -2189,12 +2206,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         eff = get_thr_eff(nb_ic_blocking, iw_block_thr, nthr);
 
         // Search for most efficient threading over iw_blocks.
-        int start_nb_iw = div_up(jcp.iw, iw_block_thr);
-        for (int nb_iw = start_nb_iw; nb_iw <= max_nb_iw; nb_iw++) {
+        const dim_t start_nb_iw = div_up(jcp.iw, iw_block_thr);
+        for (dim_t nb_iw = start_nb_iw; nb_iw <= max_nb_iw; nb_iw++) {
             float eff_threshold = 0.98f;
             if (eff > eff_threshold) break;
-            int iw_block
-                    = nstl::min(rnd_up(div_up(jcp.iw, nb_iw), ur_w), jcp.iw);
+            const dim_t iw_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.iw, nb_iw), ur_w), jcp.iw);
             if (div_up(jcp.iw, iw_block) != nb_iw) continue;
             float thr_eff = get_thr_eff(nb_ic_blocking, iw_block, nthr);
             if (iw_block >= 2 * ur_w && thr_eff > eff) {
@@ -2202,7 +2219,8 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 eff = thr_eff;
             }
         }
-        res_iw_block = nstl::min(jcp.iw, nstl::max(2 * ur_w, iw_block_thr));
+        res_iw_block = static_cast<int>(nstl::min<dim_t>(
+                jcp.iw, nstl::max<dim_t>(2 * ur_w, iw_block_thr)));
         return res_iw_block;
     };
 
@@ -2223,8 +2241,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     size_t total_size = jcp.ngroups * (wei_size + out_size + inp_size);
 
     if (jcp.ngroups < jcp.nthr && (total_size < L1_cache_size)) {
-        int iw_block = jcp.iw_block;
-        int end_nthr = with_groups ? jcp.ngroups : ndims - 2;
+        int iw_block = static_cast<int>(jcp.iw_block);
+        const int end_nthr
+                = with_groups ? static_cast<int>(jcp.ngroups) : ndims - 2;
         float eff = -1.0f;
         float best_thr_eff = -1.0f;
         // When thr_eff equals zero (cannot get the proper effciency)
@@ -2252,10 +2271,10 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             !(l_overflow * jcp.stride_w > jcp.ur_w && !jcp.large_w_filter),
             VERBOSE_BAD_PARAM, "stride, unroll width");
 
-    r_overflow_no_tail = nstl::max(0,
+    r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.ur_w_tail))
-                    / jcp.stride_w);
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.ur_w_tail))
+                    / jcp.stride_w));
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
             || r_overflow_no_tail * jcp.stride_w > jcp.ur_w
@@ -2275,7 +2294,7 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         if (jcp.nb_oc > nb_oc_theshold_L2 && jcp.nb_oc < 2 * nb_oc_theshold_L2)
             jcp.nb_oc_L2 = div_up(jcp.nb_oc, 2);
         else
-            jcp.nb_oc_L2 = nstl::min(nb_oc_theshold_L2, jcp.nb_oc);
+            jcp.nb_oc_L2 = nstl::min<dim_t>(nb_oc_theshold_L2, jcp.nb_oc);
     }
 
     bool args_ok = true && jcp.ic <= diff_src_d.padded_dims()[1]
@@ -2291,9 +2310,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         const int max_code_size = 256 * 1024; // default size of jit generator
         int mult = 1 + (l_overflow > 0) + (r_overflow_no_tail > 0);
         const float max_instruction_size = 15;
-        float ur_fac
-                = (float)jcp.kw * jcp.oc_block * jcp.nb_ic_blocking * jcp.ur_w;
-        float code_size = mult * ur_fac * max_instruction_size;
+        float ur_fac = (float)jcp.kw * (float)jcp.oc_block
+                * (float)jcp.nb_ic_blocking * (float)jcp.ur_w;
+        float code_size = (float)mult * ur_fac * max_instruction_size;
         VDISPATCH_CONV_IC(!(code_size > max_code_size && !jcp.large_w_filter),
                 "code size limit exceeded");
     }
@@ -2319,10 +2338,10 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     mov(kj, reg_kd_count);
     L(kd_comeback_label);
     {
-        int inp_mult = is_src_layout_nxc()
+        const dim_t inp_mult = is_src_layout_nxc()
                 ? jcp.ngroups * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
-        int iw = jcp.iw;
+        const dim_t iw = jcp.iw;
         sub(reg_input,
                 jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * iw * inp_mult);
         sub(reg_kernel,
@@ -2340,11 +2359,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     mov(kj, reg_kh);
     L(kh_comeback_label);
     {
-        int kw = jcp.is_hw_transp ? 1 : jcp.kw;
-        int inp_mult = is_src_layout_nxc()
+        const dim_t kw = jcp.is_hw_transp ? 1 : jcp.kw;
+        const dim_t inp_mult = is_src_layout_nxc()
                 ? jcp.ngroups * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
-        int iw = jcp.is_hw_transp ? 1 : jcp.iw;
+        const dim_t iw = jcp.is_hw_transp ? 1 : jcp.iw;
         sub(reg_input, jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mult);
         sub(reg_kernel, jcp.typesize_out * kw * jcp.ic_block * jcp.oc_block);
         dec(kj);
@@ -2354,15 +2373,16 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset, bool input_wraparound) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset,
+        bool input_wraparound) {
 
-    int kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
-    int iw = jcp.is_hw_transp ? jcp.tr_iw : jcp.iw;
-    int kw_tr_mult = jcp.is_hw_transp ? jcp.kw : 1;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    auto get_ker_offt = [&](int i_kw, int i_ic) {
+    const dim_t kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
+    const dim_t iw = jcp.is_hw_transp ? jcp.tr_iw : jcp.iw;
+    const dim_t kw_tr_mult = jcp.is_hw_transp ? jcp.kw : 1;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    auto get_ker_offt = [&](dim_t i_kw, dim_t i_ic) {
         return typesize * (i_kw * kw_tr_mult * ic_block + i_ic) * jcp.oc_block
                 + kernel_offset;
     };
@@ -2370,11 +2390,13 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
         for (int i_ic = 0; i_ic < ic_block_step; i_ic++)
             vmovups(Zmm(i_kw * ic_block_step + i_ic),
                     EVEX_compress_addr(reg_kernel, get_ker_offt(i_kw, i_ic)));
-    const int out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
+    const dim_t out_mult
+            = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
     const int oc_tail = jcp.oc_tail;
 
     for (int i_ur = 0; i_ur < ur_w; i_ur++) {
-        const int ddst_pipeline_start_idx = ic_block_step * kw;
+        const int ddst_pipeline_start_idx
+                = static_cast<int>(ic_block_step * kw);
         static constexpr int ddst_pipeline_len = 4;
         auto get_ddst_reg_idx = [ddst_pipeline_start_idx](int ur_idx) {
             return ddst_pipeline_start_idx + (ur_idx) % ddst_pipeline_len;
@@ -2402,7 +2424,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
         }
 
         for (int i_kw = 0; i_kw < kw; i_kw++) {
-            int i_iw = get_iw_idx(i_ur, i_kw, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, i_kw, pad_l);
             if (i_iw < 0 || i_iw > get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r
                     || get_iw_idx(i_ur, i_kw, jcp.l_pad) >= iw)
                 continue;
@@ -2423,29 +2445,30 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_fma_expl(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int input_offset, int kernel_offset,
-                int output_offset, bool input_wraparound) {
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+        compute_ic_block_step_fma_expl(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+                dim_t output_offset, bool input_wraparound) {
+    dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
     const int oc_tail = jcp.oc_tail;
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const int max_regs = 32;
-    const int ddst_pipeline_start_idx = 2 * ic_block_step * kw;
+    const int ddst_pipeline_start_idx
+            = static_cast<int>(2 * ic_block_step * kw);
     const int ddst_pipeline_len
             = ddst_layout_nxc ? 1 : max_regs - ddst_pipeline_start_idx;
-    const int iw_last_value = get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r;
+    const dim_t iw_last_value = get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r;
     assert(jcp.stride_w == 1 && jcp.dilate_w == 0 && ddst_pipeline_len > 0
             && jcp.kernel_kind == expl_bcast);
 
-    const int out_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    const dim_t out_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
     auto get_diff_wei_reg_idx = [ic_block_step](int i_kw, int i_ic) {
         return i_kw * ic_block_step + i_ic;
     };
-    auto get_src_reg_idx = [&](int i_iw, int i_ic) {
-        return kw * ic_block_step + ((i_iw + pad_l) % kw) * ic_block_step
-                + i_ic;
+    auto get_src_reg_idx = [&](dim_t i_iw, int i_ic) {
+        return static_cast<int>(kw * ic_block_step
+                + ((i_iw + pad_l) % kw) * ic_block_step + i_ic);
     };
     auto get_diff_dst_reg_idx
             = [ddst_pipeline_start_idx, ddst_pipeline_len](int i_ur) {
@@ -2469,7 +2492,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
             }
 
             for (int i_kw = 0; i_kw < kw; i_kw++) {
-                int i_iw = get_iw_idx(0, i_kw, pad_l);
+                dim_t i_iw = get_iw_idx(0, i_kw, pad_l);
                 if (i_iw < 0 || i_iw > iw_last_value) continue;
 
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
@@ -2490,7 +2513,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
                 vmovups(zmm_ddst, addr_out);
             }
 
-            int i_iw = get_iw_idx(i_ur, kw - 1, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, kw - 1, pad_l);
             if (i_iw >= 0 && i_iw <= iw_last_value) {
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
                     auto addr_inp = EVEX_compress_addr_safe(reg_input,
@@ -2501,7 +2524,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
             }
         }
         for (int i_kw = 0; i_kw < kw; i_kw++) {
-            int i_iw = get_iw_idx(i_ur, i_kw, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, i_kw, pad_l);
             if (i_iw < 0 || i_iw > iw_last_value) continue;
             for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
                 vfmadd231ps(Zmm(get_diff_wei_reg_idx(i_kw, i_ic)),
@@ -2529,8 +2552,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset, bool input_wraparound) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset,
+        bool input_wraparound) {
     if (jcp.kernel_kind == expl_bcast)
         compute_ic_block_step_fma_expl(ur_w, pad_l, pad_r, ic_block_step,
                 input_offset, kernel_offset, output_offset, input_wraparound);
@@ -2545,15 +2569,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
 
     Label kh_label, kd_label;
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
     const bool src_layout_nxc = is_src_layout_nxc();
-    int inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
-                                 : (!jcp.is_1stconv ? ic_block : 1);
-    int iw = jcp.iw;
+    dim_t inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
+                                   : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t iw = jcp.iw;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    dim_t l_pad = jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2594,7 +2618,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
         L(icb_block_label_end);
 
-        const int input_icb_shift = jcp.typesize_in * ic_block;
+        const dim_t input_icb_shift = jcp.typesize_in * ic_block;
         const size_t kernel_icb_shift = (size_t)jcp.typesize_out * jcp.kd
                 * jcp.kh * jcp.kw * ic_block * oc_block;
 
@@ -2662,19 +2686,19 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w) {
     Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
     const bool src_layout_nxc = is_src_layout_nxc();
-    int inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
-                                 : (!jcp.is_1stconv ? jcp.ic_block : 1);
+    dim_t inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
+                                   : (!jcp.is_1stconv ? jcp.ic_block : 1);
     const int ic_tail = jcp.ic_tail;
     UNUSED(max_ur_w);
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
 
-    int inp_icb_sp_stride = jcp.is_hw_transp ? 1 : jcp.iw;
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t inp_icb_sp_stride = jcp.is_hw_transp ? 1 : jcp.iw;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    dim_t l_pad = jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2703,7 +2727,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         mov(b_ic, ic_block);
         L(ic_block_label);
         {
-            compute_ic_block_step(ow, l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(
+                    static_cast<int>(ow), l_pad, r_pad, ic_block_step, 0, 0, 0);
             size_t inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
                     ? (size_t)jcp.ih * jcp.iw * jcp.id
                     : 1;
@@ -2718,7 +2743,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
         L(icb_block_label_end);
 
-        const int input_shift = jcp.typesize_in * (jcp.dilate_h + 1)
+        const dim_t input_shift = jcp.typesize_in * (jcp.dilate_h + 1)
                 * inp_icb_sp_stride * inp_mul;
 
         if (generate_icb_loop || ic_tail) {
@@ -2761,8 +2786,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
                 if (ic_tail % ic_block_step) {
                     cmp(reg_icb, 0);
                     jle(skip_ic_tail, T_NEAR);
-                    compute_ic_block_step(
-                            ow, l_pad, r_pad, ic_tail % ic_block_step, 0, 0, 0);
+                    compute_ic_block_step(static_cast<int>(ow), l_pad, r_pad,
+                            ic_tail % ic_block_step, 0, 0, 0);
                 }
                 L(skip_ic_tail);
             }
@@ -2807,16 +2832,16 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
     Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
 
     const bool src_layout_nxc = is_src_layout_nxc();
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    int r_pad = max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int ow = static_cast<int>(jcp.is_hw_transp ? jcp.oh : jcp.ow);
+    int r_pad = static_cast<int>(max<dim_t>(0, jcp.r_pad));
+    int l_pad = static_cast<int>(jcp.l_pad);
 
-    int ur_w = min(ow, max_ur_w);
-    int ur_w_trips = ow / ur_w;
-    int ur_w_tail = ow % ur_w;
+    int ur_w = static_cast<int>(min<dim_t>(ow, max_ur_w));
+    dim_t ur_w_trips = ow / ur_w;
+    dim_t ur_w_tail = ow % ur_w;
     if ((ur_w_tail == 0 && r_pad != 0) || (r_pad > 0 && r_pad >= ur_w_tail)) {
         if (ur_w_trips > 1) {
             ur_w_tail += ur_w;
@@ -2828,26 +2853,27 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
     }
 
     assert(l_pad <= max_ur_w);
-    int inp_mult = src_layout_nxc
+    dim_t inp_mult = src_layout_nxc
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : ic_block * (jcp.is_hw_transp ? jcp.iw : 1));
-    int out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
-    int input_comeback
-            = max((ur_w_trips * ur_w * jcp.stride_w - l_pad), 0) * inp_mult;
-    int output_comeback = ur_w_trips * ur_w * out_mult;
+    dim_t out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t input_comeback
+            = max<dim_t>(ur_w_trips * ur_w * jcp.stride_w - l_pad, 0)
+            * inp_mult;
+    dim_t output_comeback = ur_w_trips * ur_w * out_mult;
     const int ic_tail = jcp.ic_tail;
     const bool generate_icb_loop = jcp.nb_ic_blocking_max > 1;
 
     auto ic_loop = [&](int ic_block_step) {
         Label ow_block_label, ic_block_inner_label;
-        int ur_w_blocks = ur_w_trips;
+        int ur_w_blocks = static_cast<int>(ur_w_trips);
 
-        int l_pad_tail = max(l_pad - ur_w, 0);
+        dim_t l_pad_tail = max<dim_t>(l_pad - ur_w, 0);
         L(ic_block_inner_label);
         if (l_pad != 0) {
             ur_w_blocks--;
             compute_ic_block_step(ur_w, l_pad, 0, ic_block_step, 0, 0, 0);
-            int iw_offset = ur_w * jcp.stride_w - l_pad;
+            dim_t iw_offset = ur_w * jcp.stride_w - l_pad;
             if (iw_offset > 0)
                 add(reg_input, jcp.typesize_in * iw_offset * inp_mult);
             add(reg_output, jcp.typesize_in * ur_w * out_mult);
@@ -2868,13 +2894,13 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
                 inc(reg_ur_w_trips);
                 cmp(reg_ur_w_trips, ur_w_blocks);
                 jl(ow_block_label, T_NEAR);
-                l_pad_tail = max(l_pad_tail - ur_w, 0);
+                l_pad_tail = max<dim_t>(l_pad_tail - ur_w, 0);
             }
         }
 
         if (ur_w_tail > 0)
-            compute_ic_block_step(
-                    ur_w_tail, l_pad_tail, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(ur_w_tail), l_pad_tail,
+                    r_pad, ic_block_step, 0, 0, 0);
 
         sub(reg_output, jcp.typesize_in * output_comeback);
     };
@@ -2908,7 +2934,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
         {
             ic_loop(ic_block_step);
             sub(reg_input, jcp.typesize_in * input_comeback);
-            int inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
+            dim_t inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
                     ? jcp.ih * jcp.iw * jcp.id
                     : 1;
             size_t input_offset
@@ -2922,7 +2948,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
         }
         L(ic_block_label_end);
 
-        const int input_shift
+        const dim_t input_shift
                 = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mult;
 
         if (generate_icb_loop || ic_tail) {
@@ -3012,14 +3038,14 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_disp() {
     if (jcp.is_1stconv) {
         bool large_code = jcp.kw >= 7 && (jcp.l_pad > 0 || jcp.t_pad > 0);
         ic_block_step = (jcp.kw * jcp.ic_block <= 28 && !large_code)
-                ? jcp.ic_block
+                ? static_cast<int>(jcp.ic_block)
                 : 1;
     }
 
     bool too_large_to_unroll = (jcp.kw > 1 || jcp.kh > 1 || jcp.kd > 1)
             && (jcp.stride_w > 1 || jcp.stride_h > 1 || jcp.stride_d > 1);
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
     if (jcp.ndims == 5) {
         /* NOTE: reg_kd_count = aux_reg_input = r12. The following order of
          * 'movs' must be guaranteed. */
@@ -3076,11 +3102,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
                             + ic1 * jcp.oc_block * jcp.typesize_out],
                     zero);
         add(reg_tmp, jcp.ic_block * jcp.oc_block * jcp.typesize_out);
-        cmp(reg_tmp, kernel_block_bytes);
+        cmp(reg_tmp, static_cast<uint32_t>(kernel_block_bytes));
         jnz(zeroing_loop);
     }
     if (generate_icb_loop) {
-        add(reg_kernel, kernel_block_bytes);
+        add(reg_kernel, static_cast<uint32_t>(kernel_block_bytes));
         sub(reg_icb, jcp.ic_block);
         cmp(reg_icb, 0);
         jg(icb_block_label, T_NEAR);
@@ -3111,7 +3137,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_2d() {
         if (oc_tail) zmm_out = zmm_out | k_oc_mask | T_z;
         vmovups(zmm_out, ptr[reg_output + reg_tmp]);
         vaddps(Zmm(0), Zmm(0), Zmm(1));
-        const int oc_stride
+        const dim_t oc_stride
                 = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
         add(reg_tmp, jcp.typesize_out * oc_stride);
         dec(reg_oi);
@@ -3159,7 +3185,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_3d() {
         if (oc_tail) zmm_out = zmm_out | k_oc_mask | T_z;
         vmovups(zmm_out, ptr[reg_output + reg_tmp]);
         vaddps(Zmm(1), Zmm(1), Zmm(0));
-        add(reg_tmp, oc_mult * jcp.typesize_out);
+        add(reg_tmp, static_cast<uint32_t>(oc_mult * jcp.typesize_out));
         cmp(reg_tmp, reg_oi);
         jl(bias_loop);
     }
@@ -3171,27 +3197,27 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_3d() {
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         compute_oh_loop_common() {
     assert(one_of(jcp.harness, harness_mb_reduction, harness_3d_reduction));
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    dim_t b_pad = jcp.b_pad;
+    dim_t t_pad = jcp.t_pad;
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
-    const int inp_mult = is_src_layout_nxc()
+    dim_t dilate_h = jcp.dilate_h + 1;
+    dim_t stride_h = jcp.stride_h;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
-    int iw = jcp.is_hw_transp ? 1 : jcp.iw;
+    dim_t iw = jcp.is_hw_transp ? 1 : jcp.iw;
     Label oh_label, oh_label_end, oh_tpad_label, oh_tpad_tail_label,
             oh_bpad_label, oh_bpad_label_end, oh_dilate_label_shift,
             oh_dilate_label_noshift, oh_dilate_label_end;
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    int oh = jcp.is_hw_transp ? jcp.ow : jcp.oh;
-    int kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
-    int kh = jcp.is_hw_transp ? jcp.tr_kh : jcp.kh;
-    int ih = jcp.is_hw_transp ? jcp.tr_ih : jcp.ih;
-    int ihp = jcp.is_hw_transp ? jcp.tr_ih : jcp.ihp;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t oh = jcp.is_hw_transp ? jcp.ow : jcp.oh;
+    dim_t kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
+    dim_t kh = jcp.is_hw_transp ? jcp.tr_kh : jcp.kh;
+    dim_t ih = jcp.is_hw_transp ? jcp.tr_ih : jcp.ih;
+    dim_t ihp = jcp.is_hw_transp ? jcp.tr_ih : jcp.ihp;
 
     assert(IMPLICATION(jcp.is_hw_transp,
             everyone_is(1, oh, stride_h, dilate_h)
@@ -3201,10 +3227,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
     xor_(reg_oj, reg_oj);
     /* Compute 'top' edge */
     if (t_pad > 0) {
-        const int kh_range = 1 + (kh - 1) * dilate_h;
-        const int overflow = nstl::max(0, kh - div_up(t_pad + ih, dilate_h));
-        const int underflow = div_up(t_pad, dilate_h);
-        const int initial_inp_ker_overlap = kh - overflow - underflow;
+        const dim_t kh_range = 1 + (kh - 1) * dilate_h;
+        const dim_t overflow
+                = nstl::max<dim_t>(0, kh - div_up(t_pad + ih, dilate_h));
+        const dim_t underflow = div_up(t_pad, dilate_h);
+        const dim_t initial_inp_ker_overlap = kh - overflow - underflow;
         mov(reg_kh, initial_inp_ker_overlap);
         add(reg_kernel,
                 jcp.typesize_out * underflow * kw * jcp.ic_block
@@ -3212,8 +3239,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         // generate loop to process kernel while it remains within t_pad + ih
         if (kh_range < t_pad + ih) {
             if (is_dilated) {
-                const int tail = t_pad % dilate_h;
-                const int shift = tail == 0 ? 0 : dilate_h - tail;
+                const int tail = static_cast<int>(t_pad % dilate_h);
+                const int shift
+                        = tail == 0 ? 0 : static_cast<int>(dilate_h - tail);
                 mov(reg_tmp, shift);
                 if (tail != 0)
                     add(reg_input, jcp.typesize_in * shift * iw * inp_mult);
@@ -3249,8 +3277,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
                 inc(reg_oj);
 
                 // final number of kernel elements that overlap with input
-                const int final_inp_ker_overlap
-                        = nstl::min(kh, div_up(ih, dilate_h));
+                const int final_inp_ker_overlap = static_cast<int>(
+                        nstl::min<dim_t>(kh, div_up(ih, dilate_h)));
                 cmp(reg_kh, final_inp_ker_overlap);
                 jl(oh_tpad_label, T_NEAR);
             }
@@ -3284,7 +3312,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
             // kernel has moved beyond padding (adjust for stride effects)
             if (t_pad % stride_h != 0) {
                 assert(!is_dilated);
-                int inp_corr = stride_h - t_pad % stride_h;
+                const dim_t inp_corr = stride_h - t_pad % stride_h;
                 add(reg_kernel,
                         jcp.typesize_out * inp_corr * kw * jcp.ic_block
                                 * jcp.oc_block);
@@ -3299,9 +3327,10 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
     }
 
-    const int oj_end_value = nstl::min(oh,
+    const int oj_end_value = static_cast<int>(nstl::min<dim_t>(oh,
             utils::div_up(
-                    nstl::max(0, ihp - b_pad - (kh - 1) * dilate_h), stride_h));
+                    nstl::max<dim_t>(0, ihp - b_pad - (kh - 1) * dilate_h),
+                    stride_h)));
     cmp(reg_oj, oj_end_value);
     jge(oh_label_end, T_NEAR);
 
@@ -3359,16 +3388,17 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         compute_oh_loop_partial() {
     assert(jcp.harness == harness_2d_reduction);
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    const int inp_mult = is_src_layout_nxc()
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
-    const int input_bottom_padding_overlap = div_up(
-            nstl::max(0, jcp.ih + jcp.t_pad - (jcp.kh - 1)), jcp.stride_h);
-    const int bottom_pad_input_correction
+    const dim_t input_bottom_padding_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.ih + jcp.t_pad - (jcp.kh - 1)),
+                    jcp.stride_h);
+    const dim_t bottom_pad_input_correction
             = jcp.ih + jcp.t_pad - input_bottom_padding_overlap * jcp.stride_h;
 
     const size_t filter_shift = jcp.typesize_out * jcp.kw * ic_block * oc_block;
@@ -3417,11 +3447,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_kernel, filter_shift * jcp.stride_h);
+        sub(reg_kernel, static_cast<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3429,13 +3459,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_kernel, filter_shift * inp_corr);
-                add(reg_input, input_shift * inp_corr);
+                dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                add(reg_kernel, static_cast<uint32_t>(filter_shift * inp_corr));
+                add(reg_input, static_cast<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
-            sub(reg_kernel, (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+            sub(reg_kernel,
+                    static_cast<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Set filter element count for outside the t_pad region */
@@ -3473,11 +3505,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     }
 
     /* Compute middle block */
-    add(reg_input, input_shift * jcp.stride_h);
+    add(reg_input, static_cast<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_output, output_shift);
+    add(reg_output, static_cast<uint32_t>(output_shift));
     inc(reg_oj);
     cmp(reg_oj, ptr[param + GET_OFF(os_index_end)]);
     jl(loop_begin_label, T_NEAR);
@@ -3488,19 +3520,20 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         compute_od_loop_partial() {
     assert(jcp.harness == harness_3d_reduction);
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    const int inp_mult = is_src_layout_nxc()
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    const int input_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
-    const int back_pad_input_correction
+    dim_t iw = jcp.iw;
+    dim_t ow = jcp.ow;
+    const dim_t input_backpad_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d);
+    const dim_t back_pad_input_correction
             = jcp.id + jcp.f_pad - input_backpad_overlap * jcp.stride_d;
 
     const size_t filter_shift
@@ -3549,11 +3582,12 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         jge(fpad_end_label, T_NEAR);
 
         /* Fpad steps */
-        sub(reg_kernel, filter_shift * jcp.stride_d);
+        sub(reg_kernel, static_cast<uint32_t>(filter_shift * jcp.stride_d));
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const int inp_ker_overlap
+                = static_cast<int>(nstl::min<dim_t>(jcp.kd, jcp.id));
         cmp(reg_kd_count, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3561,13 +3595,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int inp_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
-                add(reg_kernel, filter_shift * inp_corr);
-                add(reg_input_d, input_shift * inp_corr);
+                const dim_t inp_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                add(reg_kernel, static_cast<uint32_t>(filter_shift * inp_corr));
+                add(reg_input_d, static_cast<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
-            sub(reg_kernel, (jcp.f_pad - jcp.od * jcp.stride_d) * filter_shift);
+            sub(reg_kernel,
+                    static_cast<uint32_t>((jcp.f_pad - jcp.od * jcp.stride_d)
+                            * filter_shift));
         }
 
         /* Set filter element count for outside the f_pad region */
@@ -3605,11 +3641,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     }
 
     /* Compute middle block */
-    add(reg_input_d, input_shift * jcp.stride_d);
+    add(reg_input_d, static_cast<uint32_t>(input_shift * jcp.stride_d));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_output_d, output_shift);
+    add(reg_output_d, static_cast<uint32_t>(output_shift));
     inc(reg_d_index);
     cmp(reg_d_index, ptr[param + GET_OFF(os_index_end)]);
     jl(d_loop_label, T_NEAR);
@@ -3667,33 +3703,33 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
     MAYBE_UNUSED(ddst_reg_count);
     assert(ker_reg_count + src_reg_count + ddst_reg_count <= 32);
 
-    auto dwei_offset = [&](int i_kw, int i_ic) {
-        const int oc_block_size = sizeof(float);
-        const int ic_block_size = jcp.oc_block * oc_block_size;
-        const int kw_block_size = jcp.ic_block * ic_block_size;
-        const int kh_block_size = jcp.kw * kw_block_size;
-        const int kd_block_size = jcp.kh * kh_block_size;
-        const int icb_block_size = jcp.kd * kd_block_size;
+    auto dwei_offset = [&](dim_t i_kw, dim_t i_ic) {
+        const dim_t oc_block_size = sizeof(float);
+        const dim_t ic_block_size = jcp.oc_block * oc_block_size;
+        const dim_t kw_block_size = jcp.ic_block * ic_block_size;
+        const dim_t kh_block_size = jcp.kw * kw_block_size;
+        const dim_t kd_block_size = jcp.kh * kh_block_size;
+        const dim_t icb_block_size = jcp.kd * kd_block_size;
 
-        int icb = i_ic / jcp.ic_block;
+        const dim_t icb = i_ic / jcp.ic_block;
         i_ic = i_ic % jcp.ic_block;
 
         return icb * icb_block_size + i_kw * kw_block_size
                 + i_ic * ic_block_size;
     };
 
-    auto src_offset = [&](int i_ic, int i_iw) {
+    auto src_offset = [&](int i_ic, dim_t i_iw) -> dim_t {
         const int ic_block_size = sizeof(float);
-        const int g_block_size = jcp.ic * ic_block_size;
-        const int iw_block_size = jcp.ngroups * g_block_size;
+        const dim_t g_block_size = jcp.ic * ic_block_size;
+        const dim_t iw_block_size = jcp.ngroups * g_block_size;
 
         return i_iw * iw_block_size + i_ic * ic_block_size;
     };
 
     auto ddst_offset = [&](int i_ow) {
         const int oc_block_size = sizeof(float);
-        const int g_block_size = jcp.oc * oc_block_size;
-        const int ow_block_size = jcp.ngroups * g_block_size;
+        const dim_t g_block_size = jcp.oc * oc_block_size;
+        const dim_t ow_block_size = jcp.ngroups * g_block_size;
 
         return i_ow * ow_block_size;
     };
@@ -3762,7 +3798,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
                 }
             }
             for (int i_ic = 0; i_ic < ur_ic; i_ic++) {
-                int ker_offset = dwei_offset(i_kw, i_ic);
+                const dim_t ker_offset = dwei_offset(i_kw, i_ic);
                 vaddps(get_ker_zmm(i_ic), zword[reg_dwei + ker_offset]);
                 vmovups(zword[reg_dwei + ker_offset], get_ker_zmm(i_ic));
             }
@@ -3773,8 +3809,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
 
     auto kw_loop = [&](int ur_ow, int ur_ic, int is_iw_edge) {
         Label kwb_loop_begin, kwb_loop_end;
-        int kw_tail = jcp.kw % kw_unroll;
-        int kw_iter = jcp.kw / kw_unroll;
+        const int kw_tail = static_cast<int>(jcp.kw % kw_unroll);
+        const int kw_iter = static_cast<int>(jcp.kw / kw_unroll);
 
         if (kw_iter > 0) {
             if (kw_iter > 1) {
@@ -3785,7 +3821,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
 
             if (kw_iter > 1 || kw_tail) {
                 add(reg_iw_base, (jcp.dilate_w + 1) * kw_unroll);
-                add(reg_src, src_offset(0, (jcp.dilate_w + 1) * kw_unroll));
+                add(reg_src,
+                        static_cast<uint32_t>(
+                                src_offset(0, (jcp.dilate_w + 1) * kw_unroll)));
                 add(reg_dwei, dwei_offset(kw_unroll, 0));
             }
 
@@ -3802,8 +3840,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
 
     auto ic_loop = [&](int ur_ow, int is_iw_edge) {
         Label icb_loop_begin, icb_loop_end;
-        int ic_tail = jcp.ic % ic_unroll;
-        int ic_iter = jcp.ic / ic_unroll;
+        const int ic_tail = static_cast<int>(jcp.ic % ic_unroll);
+        const int ic_iter = static_cast<int>(jcp.ic / ic_unroll);
 
         if (ic_iter > 0) {
             if (ic_iter > 1 || ic_tail) {
@@ -3858,7 +3896,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
     auto ic_loop_dispatch = [&](int ur_ow) {
         Label iw_edge_case, ic_end;
 
-        const int iw_overflow_bound = jcp.iw - (ur_ow - 1) * jcp.stride_w
+        const dim_t iw_overflow_bound = jcp.iw - (ur_ow - 1) * jcp.stride_w
                 - (jcp.kw - 1) * (jcp.dilate_w + 1);
         cmp(reg_iw_base, iw_overflow_bound);
         jge(iw_edge_case, T_NEAR);
@@ -3983,9 +4021,9 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -3997,13 +4035,13 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     VDISPATCH_CONV_IC(ok, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -4091,7 +4129,7 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd
@@ -4104,8 +4142,9 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     if (!jcp.is_hw_transp && jcp.kw > 14) return status::unimplemented;
 
     /* setting register strategy */
-    const int unroll_dim = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    for (int ur_w = nstl::min(max_ur_w, unroll_dim); ur_w > 0; --ur_w) {
+    const dim_t unroll_dim = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    for (int ur_w = static_cast<int>(nstl::min<dim_t>(max_ur_w, unroll_dim));
+            ur_w > 0; --ur_w) {
         if (unroll_dim % ur_w == 0) {
             jcp.ur_w = ur_w;
             break;
@@ -4234,7 +4273,7 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
         jcp.ur_ic = 2 - jcp.ic % 2;
         jcp.ur_kw = 1;
         if (jcp.stride_w == jcp.dilate_w + 1) {
-            jcp.ur_kw = jcp.kw;
+            jcp.ur_kw = static_cast<int>(jcp.kw);
             if (jcp.kw > 7) {
                 // Blocking by kw is more effective than by ic in the compute
                 // kernel since neighbor kw operations share src data
@@ -4246,11 +4285,11 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
 
         // Unroll by ow to decrease updates to diff_weights. In practice, this
         // should be approximately 1/4 - 1/2 of the zmm registers
-        jcp.ur_ow = nstl::min(
-                (zmm_regs - jcp.ur_kw * jcp.ur_ic) / (jcp.ur_ic + 1), jcp.ow);
+        jcp.ur_ow = static_cast<int>(nstl::min<dim_t>(
+                (zmm_regs - jcp.ur_kw * jcp.ur_ic) / (jcp.ur_ic + 1), jcp.ow));
 
-        int work_amount_base = jcp.mb * jcp.od * jcp.oh;
-        int ow_iter = div_up(jcp.ow, jcp.ur_ow);
+        int work_amount_base = static_cast<int>(jcp.mb * jcp.od * jcp.oh);
+        int ow_iter = static_cast<int>(div_up(jcp.ow, jcp.ur_ow));
         int nthr_ow = nstl::min(
                 jcp.nthr / math::gcd(work_amount_base, jcp.nthr), ow_iter);
         int ow_block = div_up(ow_iter, nthr_ow) * jcp.ur_ow;
@@ -4260,8 +4299,8 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
 
         // Choose a simple parallelization method. A more advance may need made
         // later
-        int work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow;
-        nthr_mb = nstl::min(jcp.nthr, work_amount);
+        const dim_t work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow;
+        nthr_mb = nstl::min(jcp.nthr, static_cast<int>(work_amount));
         nthr_g = 1;
         nthr_oc_b = 1;
         nthr_ic_b = 1;
@@ -4285,7 +4324,8 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.nb_ic_blocking_max = 1;
     if (is_data_layout_nxc && (jcp.ow > max_ur_w || jcp.ndims == 5)) {
         assert(!jcp.is_hw_transp);
-        jcp.nb_ic_blocking_max = nstl::min(8, div_up(jcp.nb_ic, jcp.nthr_ic_b));
+        jcp.nb_ic_blocking_max = static_cast<int>(
+                nstl::min<dim_t>(8, div_up(jcp.nb_ic, jcp.nthr_ic_b)));
     }
 
     return status::success;
@@ -4325,17 +4365,18 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = nthreads / nthr_g_;
 
-    const int ih = j.is_hw_transp ? j.tr_ih : j.ih;
-    const int oh = j.is_hw_transp ? j.ow : j.oh;
+    const dim_t ih = j.is_hw_transp ? j.tr_ih : j.ih;
+    const dim_t oh = j.is_hw_transp ? j.ow : j.oh;
 
-    int ih_reduce = j.harness == harness_2d_reduction ? ih : 1;
-    int oh_reduce = j.harness == harness_2d_reduction ? oh : 1;
-    int ih_no_reduce = j.harness == harness_2d_reduction ? 1 : ih;
-    int oh_no_reduce = j.harness == harness_2d_reduction ? 1 : oh;
-    int nthr_oh_reduce = nstl::max(1, oh_reduce / min_oh_reduce);
+    const dim_t ih_reduce = j.harness == harness_2d_reduction ? ih : 1;
+    const dim_t oh_reduce = j.harness == harness_2d_reduction ? oh : 1;
+    const dim_t ih_no_reduce = j.harness == harness_2d_reduction ? 1 : ih;
+    const dim_t oh_no_reduce = j.harness == harness_2d_reduction ? 1 : oh;
+    const int nthr_oh_reduce
+            = static_cast<int>(nstl::max<dim_t>(1, oh_reduce / min_oh_reduce));
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
         /* calculate per thread memory cost (read/write). high level optimizer
@@ -4370,12 +4411,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     dim_t best_mem_cost = calc_mem_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, j.mb * j.od * nthr_oh_reduce);
+    const int nthr_mb_max = static_cast<int>(
+            nstl::min<dim_t>(nthr, j.mb * j.od * nthr_oh_reduce));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
 
             dim_t mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -4402,15 +4446,17 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     dim_t best_comp_cost = calc_comp_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
             dim_t mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             dim_t comp_cost = calc_comp_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
             const bool opt1 = comp_cost <= best_comp_cost
-                    && IMPLICATION(
-                            !j.is_hw_transp, mem_cost < 1.1 * best_mem_cost);
+                    && IMPLICATION(!j.is_hw_transp,
+                            (double)mem_cost < 1.1 * (double)best_mem_cost);
             const bool opt2 = 4 * comp_cost <= 3 * best_comp_cost;
 
             if (opt1 || opt2) {
@@ -4423,7 +4469,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     }
 
     if (nthr_mb_ > nthreads / 2 && nthr_mb_ < nthreads)
-        nthr_mb_ = nstl::min(j.mb * j.od * nthr_oh_reduce, nthreads);
+        nthr_mb_ = static_cast<int>(
+                nstl::min<dim_t>(j.mb * j.od * nthr_oh_reduce, nthreads));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= nthreads);

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -86,25 +86,25 @@ private:
     Xbyak::Opmask k_oc_tail_mask = Xbyak::Opmask(2);
     const Xbyak::Opmask postops_mask = Xbyak::Opmask(3);
 
-    inline Vmm vmm_ker(int i_ic) {
+    inline Vmm vmm_ker(dim_t i_ic) {
         assert(i_ic < 4);
-        return Vmm(ker_reg_base_idx + i_ic);
+        return Vmm(static_cast<int>(ker_reg_base_idx + i_ic));
     }
 
-    inline int vmm_out_idx(int i_ur, int i_oc) {
-        const int idx = i_ur * jcp.nb_oc_blocking + i_oc;
+    inline int vmm_out_idx(dim_t i_ur, dim_t i_oc) {
+        const dim_t idx = i_ur * jcp.nb_oc_blocking + i_oc;
         assert(idx < ker_reg_base_idx);
-        return idx;
+        return static_cast<int>(idx);
     }
 
-    inline Vmm vmm_out(int i_ur, int i_oc) {
+    inline Vmm vmm_out(dim_t i_ur, dim_t i_oc) {
         return Vmm(vmm_out_idx(i_ur, i_oc));
     }
 
-    inline Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    inline Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
 
     Xbyak::Reg64 imm_addr64 = r15;
@@ -116,13 +116,13 @@ private:
     inline void prepare_output(int ur_w);
     inline void apply_postops(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop_fma(int ur_w, int pad_l, int pad_r);
-    inline void compute_loop_fma_core(int ur_w, int pad_l, int pad_r);
-    inline void compute_loop(int ur_w, int pad_l, int pad_r);
+    inline void compute_loop_fma(int ur_w, dim_t pad_l, dim_t pad_r);
+    inline void compute_loop_fma_core(int ur_w, dim_t pad_l, dim_t pad_r);
+    inline void compute_loop(int ur_w, dim_t pad_l, dim_t pad_r);
 
     void generate() override;
 
-    inline size_t get_output_offset(int oi, int n_oc_block) {
+    inline size_t get_output_offset(dim_t oi, dim_t n_oc_block) {
         const bool is_nxc_layout = is_dst_layout_nxc();
         size_t ow_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
         size_t ocb_str = is_nxc_layout
@@ -132,35 +132,36 @@ private:
         return jcp.typesize_out * (n_oc_block * ocb_str + oi * ow_str);
     }
 
-    inline size_t get_input_offset(int ki, int ic, int oi, int pad_l) {
+    inline dim_t get_input_offset(dim_t ki, dim_t ic, dim_t oi, dim_t pad_l) {
         const bool is_nxc_layout = is_src_layout_nxc();
-        size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic
-                                      : (!jcp.is_1stconv ? jcp.ic_block : 1);
-        size_t ic_str = !jcp.is_1stconv || is_nxc_layout
+        dim_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic
+                                     : (!jcp.is_1stconv ? jcp.ic_block : 1);
+        dim_t ic_str = !jcp.is_1stconv || is_nxc_layout
                 ? 1
-                : (size_t)jcp.iw * jcp.ih * jcp.id;
-        size_t iw_idx = ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
+                : jcp.iw * jcp.ih * jcp.id;
+        dim_t iw_idx = ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
 
         return jcp.typesize_in * (iw_idx * iw_str + ic * ic_str);
     }
 
-    inline int get_kernel_offset(
-            int ki, int ic, int n_oc_block, int ker_number) {
+    inline dim_t get_kernel_offset(
+            dim_t ki, dim_t ic, dim_t n_oc_block, dim_t ker_number) {
         return jcp.typesize_in * jcp.oc_block
                 * (n_oc_block * jcp.nb_ic * jcp.ic_block * jcp.kh * jcp.kw
                                 * jcp.kd
                         + (ic + ker_number) + ki * jcp.ic_block);
     }
 
-    inline int get_ow_start(int ki, int pad_l) {
+    inline dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
 
-    inline int get_ow_end(int ur_w, int ki, int pad_r) {
+    inline dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
@@ -271,34 +272,34 @@ private:
 
     Xbyak::Opmask k_ic_tail_mask = Xbyak::Opmask(1);
 
-    inline Vmm vmm_ker(int i_ic) {
+    inline Vmm vmm_ker(dim_t i_ic) {
         assert(i_ic < 4);
-        return Vmm(ker_reg_base_idx + i_ic);
+        return Vmm(static_cast<int>(ker_reg_base_idx + i_ic));
     }
-    inline Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    inline Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
-    inline Vmm vmm_out(int i_ur, int i_oc) {
-        int idx = i_ur + i_oc * jcp.ur_w;
+    inline Vmm vmm_out(dim_t i_ur, dim_t i_oc) {
+        const dim_t idx = i_ur + i_oc * jcp.ur_w;
         assert(idx < ker_reg_base_idx);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
 
     Vmm vmm_wei = Vmm(31);
 
     inline void prepare_output(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop_fma(int ur_w, int l_overflow, int r_overflow);
+    inline void compute_loop_fma(int ur_w, dim_t l_overflow, dim_t r_overflow);
     inline void compute_loop_fma_core(
-            int ur_w, int l_overflow, int r_overflow, int k_offset);
+            int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset);
     inline void compute_loop(
-            int ur_w, int l_overflow, int r_overflow, int k_offset = 0);
+            int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset = 0);
     void generate() override;
 
-    inline int get_iw_start(int ki, int l_overflow) {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    inline dim_t get_iw_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -307,10 +308,10 @@ private:
         return res;
     }
 
-    inline int get_iw_end(int ur_w, int ki, int r_overflow) {
+    inline dim_t get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
@@ -318,7 +319,7 @@ private:
         return ur_w - res;
     }
 
-    inline size_t get_diff_src_offset(int iw, int icb) {
+    inline size_t get_diff_src_offset(dim_t iw, dim_t icb) {
         const bool is_nxc_layout = is_dsrc_layout_nxc();
         size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
         size_t icb_str = is_nxc_layout
@@ -328,7 +329,7 @@ private:
         return typesize * (icb * icb_str + iw * iw_str);
     }
 
-    inline ptrdiff_t get_dst_offset(int iw, int oc, int kw) {
+    inline ptrdiff_t get_dst_offset(dim_t iw, dim_t oc, dim_t kw) {
         ptrdiff_t ow
                 = (iw + jcp.l_pad - kw * (jcp.dilate_w + 1)) / jcp.stride_w;
         ptrdiff_t ow_str = is_ddst_layout_nxc()
@@ -460,15 +461,15 @@ private:
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
     inline void compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w);
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound = false);
-    inline void compute_ic_block_step_fma(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound);
-    inline void compute_ic_block_step_fma_expl(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset, bool input_wraparound = false);
+    inline void compute_ic_block_step_fma(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset, bool input_wraparound);
+    inline void compute_ic_block_step_fma_expl(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t input_offset,
+            dim_t kernel_offset, dim_t output_offset, bool input_wraparound);
     inline void compute_oh_step_common(int ic_block_step, int max_ur_w);
     inline void compute_oh_step_disp();
     inline void compute_oh_loop_common();
@@ -486,7 +487,7 @@ private:
     }
 
     inline ptrdiff_t get_full_src_offset(
-            int i_iw, int i_ic, ptrdiff_t input_offset) {
+            dim_t i_iw, int i_ic, ptrdiff_t input_offset) {
         const bool is_nxc_layout = is_src_layout_nxc();
         const size_t w_shift_st = (jcp.is_hw_transp ? jcp.iw : 1)
                 * (jcp.is_1stconv ? 1 : jcp.ic_block);
@@ -499,7 +500,7 @@ private:
         return input_offset + typesize * local_input_offset;
     }
 
-    inline int get_iw_idx(int ow, int kw, int l_pad) const {
+    inline dim_t get_iw_idx(dim_t ow, dim_t kw, dim_t l_pad) const {
         return ow * jcp.stride_w + kw * (jcp.dilate_w + 1) - l_pad;
     }
 

--- a/src/cpu/x64/jit_avx512_common_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.cpp
@@ -118,7 +118,7 @@ inline void jit_conv_ker_pipeline_bwd_w(const jit_conv_ker_t ker,
         const void *bias, int channel, int kh_padding, size_t reduce_work,
         size_t load_work) {
     jit_conv_ker_pipeline(ker, p, src, dst, filt, bias, channel, kh_padding,
-            reduce_work, load_work);
+            static_cast<int>(reduce_work), static_cast<int>(load_work));
 }
 
 void jit_conv_2d_ker_bwd_w_pipeline(const jit_conv_ker_t ker,
@@ -203,14 +203,14 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
     int nthr = jcp.aligned_threads;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -221,9 +221,10 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t src_c_stride = src_d.blk_off<false, true>(0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic;
+                icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn) {
                 int dummy {0};
@@ -241,20 +242,20 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
             }
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
                 const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-                const int oc_off_idx = is_dst_layout_nxc
+                const dim_t oc_off_idx = is_dst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g_ocb;
                 auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, ow_s);
                 const bool is_src_layout_nxc = jcp.src_tag == format_tag::nwc;
-                const int ic_off_idx = is_src_layout_nxc
+                const dim_t ic_off_idx = is_src_layout_nxc
                         ? g * jcp.ic + icb_l2 * jcp.ic_block
                         : g_icb + icb_l2;
                 auto src_w = src + src_d.blk_off(n, ic_off_idx, iw_s);
@@ -264,16 +265,18 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                         * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                    : nullptr;
 
-                int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
-                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                dim_t icb_end
+                        = nstl::min<dim_t>(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const dim_t oc_work = utils::this_block_size(ocb * jcp.oc_block,
                         jcp.oc_without_padding,
                         jcp.nb_oc_blocking * jcp.oc_block);
 
-                int ic_work = icb_step * jcp.ic_block;
+                dim_t ic_work = icb_step * jcp.ic_block;
 
-                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = static_cast<int>(
+                            nstl::min<dim_t>(icb_step, icb_end - icb));
                     int flags = 0;
                     if (icb == 0) flags |= FLAG_IC_FIRST;
                     if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -282,7 +285,10 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                 jcp.ic, icb_step * jcp.ic_block);
                     }
                     jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv, src_w,
-                            dst_w, wht_w, bias_w, icb, 1, owb, ic_work, oc_work,
+                            dst_w, wht_w, bias_w, static_cast<int>(icb), 1,
+                            static_cast<int>(owb),
+                            static_cast<int>(ic_work),
+                            static_cast<int>(oc_work),
                             post_ops_binary_rhs_arg_vec.data(), dst, flags);
 
                     src_w += src_c_stride;
@@ -329,14 +335,14 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
     int nthr = jcp.aligned_threads;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -350,9 +356,10 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic;
+                icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn)
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -367,49 +374,52 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int work_rem = end - start;
+                dim_t work_rem = end - start;
 
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; //step instead
 
-                for (int oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
-                    int ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
+                for (dim_t oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
+                    dim_t ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
                     const bool is_dst_layout_nxc
                             = jcp.dst_tag == format_tag::nhwc;
-                    const int oc_off_idx = is_dst_layout_nxc
+                    const dim_t oc_off_idx = is_dst_layout_nxc
                             ? g * jcp.oc + ocb * jcp.oc_block
                             : g_ocb;
                     auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, oh_b, ow_s);
                     const bool is_src_layout_nxc
                             = jcp.src_tag == format_tag::nhwc;
-                    const int ic_off_idx = is_src_layout_nxc
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g * jcp.ic + icb_l2 * jcp.ic_block
                             : g_icb + icb_l2;
                     auto src_w = src + src_d.blk_off(n, ic_off_idx, ih_b, iw_s);
                     auto wht_w
                             = weights + wht_blk_off(weights_d, g, ocb, icb_l2);
 
-                    int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                    int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                    dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                    dim_t icb_end = nstl::min<dim_t>(
+                            jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
                     auto bias_w = bias ? bias
                                     + oc_off_idx
                                             * (is_dst_layout_nxc ? 1
                                                                  : jcp.oc_block)
                                        : nullptr;
-                    const int oc_work = utils::this_block_size(
+                    const dim_t oc_work = utils::this_block_size(
                             ocb * jcp.oc_block, jcp.oc_without_padding,
                             jcp.nb_oc_blocking * jcp.oc_block);
-                    int ic_work = icb_step * jcp.ic_block;
-                    for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                        int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                    dim_t ic_work = icb_step * jcp.ic_block;
+                    for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                        int curr_nb_ic = static_cast<int>(
+                                nstl::min<dim_t>(icb_step, icb_end - icb));
                         int flags = 0;
                         if (icb == 0) flags |= FLAG_IC_FIRST;
                         if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -419,18 +429,19 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                         }
                         auto src_c = src_w;
                         auto dst_c = dst_w;
-                        for (int oj = oh_b, ij = ih_b;
-                                oj < min(oh_e, oh_b + jcp.h_blocking);
+                        for (dim_t oj = oh_b, ij = ih_b; oj
+                                < nstl::min<dim_t>(oh_e, oh_b + jcp.h_blocking);
                                 ++oj, ij += jcp.stride_h) {
-                            int dilate_h = jcp.dilate_h + 1;
-                            int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t dilate_h = jcp.dilate_h + 1;
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0, -ij), dilate_h);
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             ij - jcp.ih
                                                     + (jcp.kh - 1) * dilate_h
                                                     + 1),
                                     dilate_h);
-                            int kh_padding = nstl::max(
+                            dim_t kh_padding = nstl::max<dim_t>(
                                     0, jcp.kh - i_t_overflow - i_b_overflow);
 
                             auto aux_src = src_c
@@ -438,8 +449,12 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                             auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
                             jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv,
-                                    aux_src, dst_c, aux_wht, bias_w, icb,
-                                    kh_padding, owb, ic_work, oc_work,
+                                    aux_src, dst_c, aux_wht, bias_w,
+                                    static_cast<int>(icb),
+                                    static_cast<int>(kh_padding),
+                                    static_cast<int>(owb),
+                                    static_cast<int>(ic_work),
+                                    static_cast<int>(oc_work),
                                     post_ops_binary_rhs_arg_vec.data(), dst,
                                     flags);
 
@@ -488,15 +503,15 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -512,9 +527,10 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic;
+                icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn)
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -529,36 +545,38 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; //step instead
 
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
 
-                int dilate_d = jcp.dilate_d + 1;
-                int d_t_overflow = div_up(max(0, -id_s), dilate_d);
-                int d_b_overflow = div_up(
-                        max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+                dim_t dilate_d = jcp.dilate_d + 1;
+                dim_t d_t_overflow = div_up(max<dim_t>(0, -id_s), dilate_d);
+                dim_t d_b_overflow = div_up(
+                        max<dim_t>(
+                                0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
                         dilate_d);
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_t_overflow - d_b_overflow);
+                dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_t_overflow - d_b_overflow);
                 const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-                const int oc_off_idx = is_dst_layout_nxc
+                const dim_t oc_off_idx = is_dst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g_ocb;
                 auto dst_w
                         = dst + dst_d.blk_off(n, oc_off_idx, od_s, oh_s, ow_s);
                 const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-                const int ic_off_idx = is_src_layout_nxc
+                const dim_t ic_off_idx = is_src_layout_nxc
                         ? g * jcp.ic + icb_l2 * jcp.ic_block
                         : g_icb + icb_l2;
                 auto src_w = src
@@ -571,15 +589,17 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                         * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                    : nullptr;
 
-                const int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
-                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                const dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                dim_t icb_end
+                        = nstl::min<dim_t>(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const dim_t oc_work = utils::this_block_size(ocb * jcp.oc_block,
                         jcp.oc_without_padding,
                         jcp.nb_oc_blocking * jcp.oc_block);
 
-                int ic_work = icb_step * jcp.ic_block;
-                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                dim_t ic_work = icb_step * jcp.ic_block;
+                for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = static_cast<int>(
+                            nstl::min<dim_t>(icb_step, icb_end - icb));
                     int flags = 0;
                     if (icb == 0) flags |= FLAG_IC_FIRST;
                     if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -589,22 +609,27 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                     }
                     auto src_c = src_w;
                     auto dst_c = dst_w;
-                    for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                    for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                             ++oj, ij += jcp.stride_h) {
-                        int dilate_h = jcp.dilate_h + 1;
-                        int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                        int i_b_overflow = div_up(
-                                max(0,
+                        dim_t dilate_h = jcp.dilate_h + 1;
+                        dim_t i_t_overflow
+                                = div_up(max<dim_t>(0, -ij), dilate_h);
+                        dim_t i_b_overflow = div_up(
+                                max<dim_t>(0,
                                         ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                 + 1),
                                 dilate_h);
-                        int kh_padding = nstl::max(
+                        dim_t kh_padding = nstl::max<dim_t>(
                                 0, jcp.kh - i_t_overflow - i_b_overflow);
                         jit_conv_3d_ker_pipeline_ow_thr(jit_ker, par_conv,
                                 src_c + i_t_overflow * dilate_h * src_h_stride,
                                 dst_c, wht_w + i_t_overflow * wht_h_stride,
-                                bias_w, icb, kh_padding, kd_padding, owb,
-                                ic_work, oc_work,
+                                bias_w, static_cast<int>(icb),
+                                static_cast<int>(kh_padding),
+                                static_cast<int>(kd_padding),
+                                static_cast<int>(owb),
+                                static_cast<int>(ic_work),
+                                static_cast<int>(oc_work),
                                 post_ops_binary_rhs_arg_vec.data(), dst, flags);
 
                         src_c += src_h_stride * jcp.stride_h;
@@ -650,14 +675,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -668,9 +693,10 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         size_t diff_dst_c_stride = diff_dst_d.blk_off<false, true>(0, 1);
         size_t wht_oc_stride = wht_blk_off(weights_d, 0, 1);
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc;
+                ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, iwb {0};
+            dim_t n {0}, gg {0}, icc {0}, iwb {0};
             if (jcp.loop_order == loop_cwgn) {
                 int dummy {0};
                 nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
@@ -687,42 +713,47 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
             }
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
-                int iw_s = iwb * jcp.iw_block;
-                int ow_s = iw_s / jcp.stride_w;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
+                dim_t iw_s = iwb * jcp.iw_block;
+                dim_t ow_s = iw_s / jcp.stride_w;
 
                 const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w
                         = diff_src + diff_src_d.blk_off(n, ic_off_idx, iw_s);
                 const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w
                         = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, ow_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc = nstl::min<dim_t>(
+                            ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
 
                     jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src_w,
-                            diff_dst_w, wht_w, nullptr, ocb, 1, iwb,
-                            reduce_work, load_work);
+                            diff_dst_w, wht_w, nullptr, static_cast<int>(ocb),
+                            1, static_cast<int>(iwb),
+                            static_cast<int>(reduce_work),
+                            static_cast<int>(load_work));
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
                 }
@@ -762,14 +793,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -785,9 +816,10 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
 
         bool is_fast_path = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc;
+                ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
+            dim_t n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
 
             if (jcp.loop_order == loop_cwgn) {
                 nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
@@ -802,62 +834,66 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
 
-                int work_rem = end - start;
-                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_e
+                        = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     ih_e = ih_s + 1; //step instead
-                int iw_s = iwb * jcp.iw_block;
-                int ow_s = iw_s / jcp.stride_w;
+                dim_t iw_s = iwb * jcp.iw_block;
+                dim_t ow_s = iw_s / jcp.stride_w;
                 const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nhwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w
                         = diff_src + diff_src_d.blk_off(n, ic_off_idx, 0, iw_s);
                 const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w
                         = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, 0, ow_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc = nstl::min<dim_t>(
+                            ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
-                    for (int ij = ih_s; ij < ih_e; ++ij) {
-                        int oj, k_len, k_lo;
+                    for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                        dim_t oj, k_len, k_lo;
                         if (is_fast_path) { // dilate == 0 && stride == 1
-                            int i_t_overflow
-                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                            int i_b_overflow
-                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            dim_t i_t_overflow = max<dim_t>(
+                                    0, jcp.kh - 1 - ij - jcp.t_pad);
+                            dim_t i_b_overflow = max<dim_t>(
+                                    0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                             k_len = jcp.kh - i_t_overflow - i_b_overflow;
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow;
                         } else if (jcp.dilate_h != 0) { // stride == 1
-                            int dilate_h = jcp.dilate_h + 1;
+                            dim_t dilate_h = jcp.dilate_h + 1;
                             // Note: use div_up to account for "holes" in filter
-                            int i_t_overflow
-                                    = div_up(max(0,
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0,
                                                      (jcp.kh - 1) * dilate_h
                                                              - ij - jcp.t_pad),
                                             dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             (jcp.kh - 1) * dilate_h + 1 - jcp.ih
                                                     + ij - jcp.b_pad),
                                     dilate_h);
@@ -865,16 +901,16 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                         } else { // dilate == 0
-                            int i_t_overflow = max(0,
+                            dim_t i_t_overflow = max<dim_t>(0,
                                     (jcp.kh - 1 - ij - jcp.t_pad)
                                             / jcp.stride_h);
-                            int i_b_overflow = max(0,
+                            dim_t i_b_overflow = max<dim_t>(0,
                                     (jcp.kh - jcp.ih + ij - jcp.b_pad)
                                             / jcp.stride_h);
-                            int overflow_kh_hi = jcp.kh - 1
+                            dim_t overflow_kh_hi = jcp.kh - 1
                                     - modulo(jcp.ih - 1 + jcp.b_pad - ij,
                                             jcp.stride_h);
-                            int overflow_kh_lo
+                            dim_t overflow_kh_lo
                                     = (ij + jcp.t_pad) % jcp.stride_h;
 
                             k_len = (overflow_kh_hi - overflow_kh_lo)
@@ -887,8 +923,11 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                         jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
-                                k_len, iwb, reduce_work, load_work);
+                                wht_w + k_lo * wht_h_stride, nullptr,
+                                static_cast<int>(ocb),
+                                static_cast<int>(k_len), static_cast<int>(iwb),
+                                static_cast<int>(reduce_work),
+                                static_cast<int>(load_work));
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -926,14 +965,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -953,9 +992,10 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         bool is_fast_path_d = jcp.dilate_d == 0 && jcp.stride_d == 1;
         bool is_fast_path_h = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc;
+                ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
+            dim_t n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
             // Input width threading is not currently implemented for 3d, so it
             // is not included in the iterator.
             if (jcp.loop_order == loop_cwgn)
@@ -971,31 +1011,35 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
 
-                int work_rem = end - start;
-                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_e
+                        = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     ih_e = ih_s + 1; //step instead
-                int d_len = 0, d_lo = 0, d_oj = 0;
+                dim_t d_len = 0;
+                dim_t d_lo = 0, d_oj = 0;
                 if (is_fast_path_d) { // dilate == 0 && stride == 1
-                    int d_t_overflow = max(0, jcp.kd - 1 - id_s - jcp.f_pad);
-                    int d_b_overflow
-                            = max(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
+                    dim_t d_t_overflow
+                            = max<dim_t>(0, jcp.kd - 1 - id_s - jcp.f_pad);
+                    dim_t d_b_overflow = max<dim_t>(
+                            0, jcp.kd - jcp.id + id_s - jcp.back_pad);
                     d_len = jcp.kd - d_t_overflow - d_b_overflow;
                     d_lo = d_b_overflow;
                     d_oj = id_s + jcp.f_pad - d_b_overflow;
                 } else if (jcp.dilate_d != 0) { // stride == 1
-                    int dilate_d = jcp.dilate_d + 1;
+                    dim_t dilate_d = jcp.dilate_d + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int d_t_overflow = div_up(
-                            max(0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
+                    dim_t d_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
                             dilate_d);
-                    int d_b_overflow = div_up(
-                            max(0,
+                    dim_t d_b_overflow = div_up(
+                            max<dim_t>(0,
                                     (jcp.kd - 1) * dilate_d + 1 - jcp.id + id_s
                                             - jcp.back_pad),
                             dilate_d);
@@ -1003,15 +1047,15 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                     d_lo = d_b_overflow;
                     d_oj = id_s + jcp.f_pad - d_b_overflow * dilate_d;
                 } else { // dilate == 0
-                    int d_t_overflow = max(
+                    dim_t d_t_overflow = max<dim_t>(
                             0, (jcp.kd - 1 - id_s - jcp.f_pad) / jcp.stride_d);
-                    int d_b_overflow = max(0,
+                    dim_t d_b_overflow = max<dim_t>(0,
                             (jcp.kd - jcp.id + id_s - jcp.back_pad)
                                     / jcp.stride_d);
-                    int overflow_kd_hi = jcp.kd - 1
+                    dim_t overflow_kd_hi = jcp.kd - 1
                             - modulo(jcp.id - 1 + jcp.back_pad - id_s,
                                     jcp.stride_d);
-                    int overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
+                    dim_t overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
 
                     d_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                             - d_t_overflow - d_b_overflow;
@@ -1021,14 +1065,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
 
                 const bool is_dsrc_layout_nxc
                         = jcp.src_tag == format_tag::ndhwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w = diff_src + diff_src_d.blk_off(n, ic_off_idx)
                         + id_s * diff_src_d_stride;
                 const bool is_ddst_layout_nxc
                         = jcp.dst_tag == format_tag::ndhwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w = diff_dst + diff_dst_d.blk_off(n, oc_off_idx)
@@ -1036,37 +1080,41 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb)
                         + d_lo * wht_d_stride;
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc = nstl::min<dim_t>(
+                            ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
-                    for (int ij = ih_s; ij < ih_e; ++ij) {
-                        int oj, k_len, k_lo;
+                    for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                        dim_t oj, k_lo;
+                        dim_t k_len;
                         if (is_fast_path_h) { // dilate == 0 && stride == 1
-                            int i_t_overflow
-                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                            int i_b_overflow
-                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            dim_t i_t_overflow = max<dim_t>(
+                                    0, jcp.kh - 1 - ij - jcp.t_pad);
+                            dim_t i_b_overflow = max<dim_t>(
+                                    0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                             k_len = jcp.kh - i_t_overflow - i_b_overflow;
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow;
                         } else if (jcp.dilate_h != 0) { // stride == 1
-                            int dilate_h = jcp.dilate_h + 1;
+                            dim_t dilate_h = jcp.dilate_h + 1;
                             // Note: use div_up to account for "holes" in filter
-                            int i_t_overflow
-                                    = div_up(max(0,
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0,
                                                      (jcp.kh - 1) * dilate_h
                                                              - ij - jcp.t_pad),
                                             dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             (jcp.kh - 1) * dilate_h + 1 - jcp.ih
                                                     + ij - jcp.b_pad),
                                     dilate_h);
@@ -1074,16 +1122,16 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                         } else { // dilate == 0
-                            int i_t_overflow = max(0,
+                            dim_t i_t_overflow = max<dim_t>(0,
                                     (jcp.kh - 1 - ij - jcp.t_pad)
                                             / jcp.stride_h);
-                            int i_b_overflow = max(0,
+                            dim_t i_b_overflow = max<dim_t>(0,
                                     (jcp.kh - jcp.ih + ij - jcp.b_pad)
                                             / jcp.stride_h);
-                            int overflow_kh_hi = jcp.kh - 1
+                            dim_t overflow_kh_hi = jcp.kh - 1
                                     - modulo(jcp.ih - 1 + jcp.b_pad - ij,
                                             jcp.stride_h);
-                            int overflow_kh_lo
+                            dim_t overflow_kh_lo
                                     = (ij + jcp.t_pad) % jcp.stride_h;
 
                             k_len = (overflow_kh_hi - overflow_kh_lo)
@@ -1097,8 +1145,12 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                         jit_conv_3d_ker_pipeline(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
-                                k_len, d_len, reduce_work, load_work);
+                                wht_w + k_lo * wht_h_stride, nullptr,
+                                static_cast<int>(ocb),
+                                static_cast<int>(k_len),
+                                static_cast<int>(d_len),
+                                static_cast<int>(reduce_work),
+                                static_cast<int>(load_work));
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -1212,21 +1264,23 @@ struct jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 key_conv_wei_bia_reduction_bctx);
 
         /* reduction dimension */
-        int oh_reduce = jcp.harness == harness_2d_reduction ? jcp.oh : 1;
-        balance211(jcp.mb * jcp.od * oh_reduce, self->nthr_mb_, ithr_mb,
-                img_start, img_end);
+        int oh_reduce = static_cast<int>(
+                jcp.harness == harness_2d_reduction ? jcp.oh : 1);
+        balance211(static_cast<int>(jcp.mb * jcp.od * oh_reduce),
+                self->nthr_mb_, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(static_cast<int>(jcp.ngroups), self->nthr_g_, ithr_g,
+                g_start, g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(static_cast<int>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(static_cast<int>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         ic_b_work = ic_b_end - ic_b_start;
     }
 };
@@ -1238,25 +1292,25 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         const {
     const auto &jcp = kernel_->jcp;
 
-    const int wei_size
+    const dim_t wei_size
             = jcp.ngroups * jcp.oc * jcp.ic * jcp.kh * jcp.kw * jcp.kd;
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
             : ti->wei_bia_reduction + (ti->ithr_mb - 1) * wei_size;
 
-    auto diff_weights_offset
-            = [&](int g, int i_kd, int i_kh, int i_kw, int i_ic, int i_oc) {
-        const int oc_block_size = 1;
-        const int ic_block_size = jcp.oc_block * oc_block_size;
-        const int kw_block_size = jcp.ic_block * ic_block_size;
-        const int kh_block_size = jcp.kw * kw_block_size;
-        const int kd_block_size = jcp.kh * kh_block_size;
-        const int icb_block_size = jcp.kd * kd_block_size;
-        const int ocb_block_size = jcp.nb_ic * icb_block_size;
-        const int g_block_size = jcp.nb_oc * ocb_block_size;
+    auto diff_weights_offset = [&](dim_t g, dim_t i_kd, dim_t i_kh, dim_t i_kw,
+                                       dim_t i_ic, dim_t i_oc) {
+        const dim_t oc_block_size = 1;
+        const dim_t ic_block_size = jcp.oc_block * oc_block_size;
+        const dim_t kw_block_size = jcp.ic_block * ic_block_size;
+        const dim_t kh_block_size = jcp.kw * kw_block_size;
+        const dim_t kd_block_size = jcp.kh * kh_block_size;
+        const dim_t icb_block_size = jcp.kd * kd_block_size;
+        const dim_t ocb_block_size = jcp.nb_ic * icb_block_size;
+        const dim_t g_block_size = jcp.nb_oc * ocb_block_size;
 
-        int icb = i_ic / jcp.ic_block;
-        int ocb = i_oc / jcp.oc_block;
+        dim_t icb = i_ic / jcp.ic_block;
+        dim_t ocb = i_oc / jcp.oc_block;
         i_ic = i_ic % jcp.ic_block;
         i_oc = i_oc % jcp.oc_block;
 
@@ -1265,27 +1319,27 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 + i_kw * kw_block_size + i_ic * ic_block_size
                 + i_oc * oc_block_size;
     };
-    auto src_offset
-            = [&](int g, int i_mb, int i_id, int i_ih, int i_ic, int i_iw) {
-        const int ic_block_size = 1;
-        const int g_block_size = jcp.ic * ic_block_size;
-        const int iw_block_size = jcp.ngroups * g_block_size;
-        const int ih_block_size = jcp.iw * iw_block_size;
-        const int id_block_size = jcp.ih * ih_block_size;
-        const int mb_block_size = jcp.id * id_block_size;
+    auto src_offset = [&](dim_t g, dim_t i_mb, dim_t i_id, dim_t i_ih,
+                              dim_t i_ic, dim_t i_iw) {
+        const dim_t ic_block_size = 1;
+        const dim_t g_block_size = jcp.ic * ic_block_size;
+        const dim_t iw_block_size = jcp.ngroups * g_block_size;
+        const dim_t ih_block_size = jcp.iw * iw_block_size;
+        const dim_t id_block_size = jcp.ih * ih_block_size;
+        const dim_t mb_block_size = jcp.id * id_block_size;
 
         return g * g_block_size + i_mb * mb_block_size + i_id * id_block_size
                 + i_ih * ih_block_size + i_iw * iw_block_size
                 + i_ic * ic_block_size;
     };
-    auto diff_dst_offset
-            = [&](int g, int i_mb, int i_od, int i_oh, int i_ow, int i_oc) {
-        const int oc_block_size = 1;
-        const int g_block_size = jcp.oc * oc_block_size;
-        const int ow_block_size = jcp.ngroups * g_block_size;
-        const int oh_block_size = jcp.ow * ow_block_size;
-        const int od_block_size = jcp.oh * oh_block_size;
-        const int mb_block_size = jcp.od * od_block_size;
+    auto diff_dst_offset = [&](dim_t g, dim_t i_mb, dim_t i_od, dim_t i_oh,
+                                   dim_t i_ow, dim_t i_oc) {
+        const dim_t oc_block_size = 1;
+        const dim_t g_block_size = jcp.oc * oc_block_size;
+        const dim_t ow_block_size = jcp.ngroups * g_block_size;
+        const dim_t oh_block_size = jcp.ow * ow_block_size;
+        const dim_t od_block_size = jcp.oh * oh_block_size;
+        const dim_t mb_block_size = jcp.od * od_block_size;
 
         return g * g_block_size + i_mb * mb_block_size + i_od * od_block_size
                 + i_oh * oh_block_size + i_ow * ow_block_size
@@ -1297,47 +1351,47 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             diff_wei[i] = 0;
     };
 
-    int kd_step = jcp.dilate_d + 1;
-    int kh_step = jcp.dilate_h + 1;
-    int stride_d = jcp.stride_d;
-    int stride_h = jcp.stride_h;
-    int f_pad = jcp.f_pad;
-    int t_pad = jcp.t_pad;
+    dim_t kd_step = jcp.dilate_d + 1;
+    dim_t kh_step = jcp.dilate_h + 1;
+    dim_t stride_d = jcp.stride_d;
+    dim_t stride_h = jcp.stride_h;
+    dim_t f_pad = jcp.f_pad;
+    dim_t t_pad = jcp.t_pad;
 
     dim_t work_amount
             = static_cast<dim_t>(jcp.mb) * jcp.od * jcp.oh * jcp.nb_ow;
     dim_t i_work {0}, i_work_end {0};
     balance211(work_amount, jcp.nthr_mb, ti->ithr_mb, i_work, i_work_end);
 
-    int i_mb {0}, i_od {0}, i_oh {0}, i_owb {0};
+    dim_t i_mb {0}, i_od {0}, i_oh {0}, i_owb {0};
     nd_iterator_init(
             i_work, i_mb, jcp.mb, i_od, jcp.od, i_oh, jcp.oh, i_owb, jcp.nb_ow);
 
     zero_diff_weights();
     while (i_work < i_work_end) {
-        int kd_start = div_up(
-                nstl::max(0, jcp.f_pad - jcp.stride_d * i_od), kd_step);
-        int kd_end = nstl::min(
+        dim_t kd_start = div_up(
+                nstl::max<dim_t>(0, jcp.f_pad - jcp.stride_d * i_od), kd_step);
+        dim_t kd_end = nstl::min<dim_t>(
                 jcp.kd - 1, (jcp.id - 1 + f_pad - stride_d * i_od) / kd_step);
-        int i_id_base = stride_d * i_od - f_pad;
-        int kh_start = div_up(
-                nstl::max(0, jcp.t_pad - jcp.stride_h * i_oh), +kh_step);
-        int kh_end = nstl::min(
+        dim_t i_id_base = stride_d * i_od - f_pad;
+        dim_t kh_start = div_up(
+                nstl::max<dim_t>(0, jcp.t_pad - jcp.stride_h * i_oh), kh_step);
+        dim_t kh_end = nstl::min<dim_t>(
                 jcp.kh - 1, (jcp.ih - 1 + t_pad - stride_h * i_oh) / kh_step);
-        int i_ih_base = jcp.stride_h * i_oh + -jcp.t_pad;
-        int i_ow_base = i_owb * jcp.ow_block;
-        int i_ow_end = nstl::min(jcp.ow, i_ow_base + jcp.ow_block);
+        dim_t i_ih_base = jcp.stride_h * i_oh + -jcp.t_pad;
+        dim_t i_ow_base = i_owb * jcp.ow_block;
+        dim_t i_ow_end = nstl::min<dim_t>(jcp.ow, i_ow_base + jcp.ow_block);
 
         // The kernel is small so these loops produce measurable overhead. Since
         // these are simple loops, the compiler will likely make the loops just
         // as well as we can with the jitted assembly, so there is not
         // necessarily a reason to move these loops into assembly. Avoid placing
         // computationally heavy operations within the loops.
-        for_(int i_ow = i_ow_base; i_ow < i_ow_end; i_ow += jcp.ur_ow)
-        for_(int i_oc = 0; i_oc < jcp.oc; i_oc += jcp.oc_block)
-        for_(int g = 0; g < jcp.ngroups; g++)
-        for_(int i_kd = kd_start; i_kd <= kd_end; i_kd++)
-        for (int i_kh = kh_start; i_kh <= kh_end; i_kh++) {
+        for_(dim_t i_ow = i_ow_base; i_ow < i_ow_end; i_ow += jcp.ur_ow)
+        for_(dim_t i_oc = 0; i_oc < jcp.oc; i_oc += jcp.oc_block)
+        for_(dim_t g = 0; g < jcp.ngroups; g++)
+        for_(dim_t i_kd = kd_start; i_kd <= kd_end; i_kd++)
+        for (dim_t i_kh = kh_start; i_kh <= kh_end; i_kh++) {
             // Some Optimization Observations: It may be
             // worthwhile to move the kd and kh loops below the
             // icb loop in the kernel to further amortize the
@@ -1349,16 +1403,18 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             // The compiler seems to do a good job at optimizing these
             // computations. The offset functions likely need to be located
             // so that they will be inlined.
-            int i_iw = i_ow * jcp.stride_w - jcp.l_pad;
-            int i_id = i_id_base + i_kd * kd_step;
-            int i_ih = i_ih_base + i_kh * kh_step;
-            int ddst_offset = diff_dst_offset(g, i_mb, i_od, i_oh, i_ow, i_oc);
-            int s_off_base = src_offset(g, i_mb, i_id, i_ih, 0, i_iw);
-            int dwei_off_base = diff_weights_offset(g, i_kd, i_kh, 0, 0, i_oc);
+            dim_t i_iw = i_ow * jcp.stride_w - jcp.l_pad;
+            dim_t i_id = i_id_base + i_kd * kd_step;
+            dim_t i_ih = i_ih_base + i_kh * kh_step;
+            dim_t ddst_offset
+                    = diff_dst_offset(g, i_mb, i_od, i_oh, i_ow, i_oc);
+            dim_t s_off_base = src_offset(g, i_mb, i_id, i_ih, 0, i_iw);
+            dim_t dwei_off_base
+                    = diff_weights_offset(g, i_kd, i_kh, 0, 0, i_oc);
             // ensure all parameters are 64bit, to comply with windows kernel
             // param access where the params from 5th are passed using stack.
             (*kernel_)(&diff_wei[dwei_off_base], &ti->src[s_off_base],
-                    &ti->diff_dst[ddst_offset], (dim_t)i_iw, (dim_t)i_ow);
+                    &ti->diff_dst[ddst_offset], i_iw, i_ow);
         }
         nd_iterator_step(
                 i_mb, jcp.mb, i_od, jcp.od, i_oh, jcp.oh, i_owb, jcp.nb_ow);
@@ -1377,9 +1433,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw * jcp.kd;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1396,25 +1452,28 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     for (int img = ti->img_start; img < ti->img_end; ++img) {
         auto p = jit_conv_args_t();
 
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
         const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
-                    oc_b * jcp.oc_block, max_oc, jcp.oc_block);
+            const dim_t oc_to_compute
+                    = this_block_size(oc_b * jcp.oc_block, max_oc,
+                            jcp.oc_block);
 
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
 
@@ -1439,9 +1498,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1451,10 +1510,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             : ti->wei_bia_reduction + (nthr_mb_ - 1) * wei_size
                     + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
 
-    int img {0}, oh_s {0};
-    int img_start = ti->img_start, img_end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t img_start = ti->img_start, img_end = ti->img_end;
     nd_iterator_init(img_start, img, jcp.mb, oh_s, jcp.oh);
-    const int img_first = img;
+    const dim_t img_first = img;
 
     int ic_b_step = jcp.nb_ic_blocking_max;
     int icb_work = ti->ic_b_end - ti->ic_b_start;
@@ -1463,35 +1522,39 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     while (img_start < img_end) {
         auto p = jit_conv_args_t();
 
-        int work_rem = img_end - img_start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        const int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        const int kh_top_overflow = nstl::max(0, -ih_s);
-        const int kh_bottom_overflow = nstl::max(0, ih_s - jcp.ih + jcp.kh);
-        int kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
-        int kh_padding_offset = nstl::min(jcp.kh - 1, kh_top_overflow) * jcp.kw
-                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        dim_t work_rem = img_end - img_start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        const dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        const dim_t kh_top_overflow = nstl::max<dim_t>(0, -ih_s);
+        const dim_t kh_bottom_overflow
+                = nstl::max<dim_t>(0, ih_s - jcp.ih + jcp.kh);
+        dim_t kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
+        dim_t kh_padding_offset = nstl::min<dim_t>(jcp.kh - 1, kh_top_overflow)
+                * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
         auto src_h = ti->src + src_d.blk_off(img, 0, ih_s + kh_top_overflow);
         auto diff_dst_h = ti->diff_dst + diff_dst_d.blk_off(img, 0, oh_s);
 
         const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
         const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
-                    oc_b * jcp.oc_block, max_oc, jcp.oc_block);
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t oc_to_compute
+                    = this_block_size(oc_b * jcp.oc_block, max_oc,
+                            jcp.oc_block);
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
             auto src = src_h + src_d.blk_off(0, ic_off_idx);
@@ -1499,9 +1562,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             p.flags = ic_b == 0 ? 0 : 1;
             jit_conv_2d_ker_bwd_w_pipeline(jit_ker, p, src, diff_dst,
                     diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
-                    diff_bia + _oc * jcp.oc_block, (img == img_first), oh_s,
-                    oh_e, kh_padding, kh_padding_offset, ic_to_compute,
-                    oc_to_compute);
+                    diff_bia + _oc * jcp.oc_block, (img == img_first),
+                    static_cast<int>(oh_s),
+                    static_cast<int>(oh_e), static_cast<int>(kh_padding),
+                    kh_padding_offset, ic_to_compute, oc_to_compute);
         }
         nd_iterator_jump(img_start, img_end, img, jcp.mb, oh_s, jcp.oh);
     }
@@ -1518,9 +1582,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw * jcp.kd;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1531,17 +1595,17 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
 
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-    const int inp_mult = is_src_layout_nxc
+    const dim_t inp_mult = is_src_layout_nxc
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int input_step = jcp.ih * jcp.iw * inp_mult;
+    const dim_t input_step = jcp.ih * jcp.iw * inp_mult;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-    const int output_step = jcp.ow * jcp.oh
+    const dim_t output_step = jcp.ow * jcp.oh
             * (is_ddst_layout_nxc ? jcp.ngroups * jcp.oc : jcp.oc_block);
-    int img {0}, od_s {0};
-    int img_start = ti->img_start, img_end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t img_start = ti->img_start, img_end = ti->img_end;
     nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
-    const int img_first = img;
+    const dim_t img_first = img;
 
     int ic_b_step = jcp.nb_ic_blocking_max;
     int icb_work = ti->ic_b_end - ti->ic_b_start;
@@ -1551,35 +1615,38 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     while (img_start < img_end) {
         auto p = jit_conv_args_t();
 
-        int work_rem = img_end - img_start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        const int id_s = od_s * jcp.stride_d;
-        const int ik_overlap = nstl::max(0, id_s - jcp.f_pad);
-        const int kd_front_pad = nstl::max(0, jcp.f_pad - id_s);
-        const int kd_back_pad
-                = nstl::max(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
-        int kd_pad_off = nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw
-                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        dim_t work_rem = img_end - img_start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        const dim_t id_s = od_s * jcp.stride_d;
+        const dim_t ik_overlap = nstl::max<dim_t>(0, id_s - jcp.f_pad);
+        const dim_t kd_front_pad = nstl::max<dim_t>(0, jcp.f_pad - id_s);
+        const dim_t kd_back_pad
+                = nstl::max<dim_t>(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
+        dim_t kd_pad_off = nstl::min<dim_t>(jcp.kd - 1, kd_front_pad) * jcp.kh
+                * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
 
         for_(int g = ti->g_start; g < ti->g_end; ++g)
         for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
 
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
-                    oc_b * jcp.oc_block, max_oc, jcp.oc_block);
+            const dim_t oc_to_compute
+                    = this_block_size(oc_b * jcp.oc_block, max_oc,
+                            jcp.oc_block);
 
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
             auto src = &ti->src[src_d.blk_off(img, ic_off_idx)
@@ -1590,9 +1657,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             p.flags = ic_b == 0 ? 0 : 1;
             jit_conv_3d_ker_bwd_w_pipeline(jit_ker, p, src, dst,
                     diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
-                    diff_bia_ptr, (img == img_first), od_s, od_e,
-                    jcp.kd - kd_front_pad - kd_back_pad, kd_pad_off,
-                    ic_to_compute, oc_to_compute);
+                    diff_bia_ptr, (img == img_first), static_cast<int>(od_s),
+                    static_cast<int>(od_e),
+                    static_cast<int>(jcp.kd - kd_front_pad - kd_back_pad),
+                    kd_pad_off, ic_to_compute, oc_to_compute);
         }
         nd_iterator_jump(img_start, img_end, img, jcp.mb, od_s, jcp.od);
     }
@@ -1605,34 +1673,36 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw;
 
     /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
     if (dnnl_thr_syncable())
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work = ti->ic_b_work * jcp.kh;
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t ic_b_kh_work = ti->ic_b_work * jcp.kh;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
-    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
-    if (start == end) return;
+    int bal_start {0}, bal_end {0};
+    balance211(static_cast<int>(work), nthr_mb_, ti->ithr_mb, bal_start,
+            bal_end);
+    if (bal_start == bal_end) return;
 
     for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = bal_start, end = bal_end;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
-            const int kh = sub_ic_b_kh_start % jcp.kh;
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b
+                    = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
+            const dim_t kh = sub_ic_b_kh_start % jcp.kh;
 
-            const int acc_size
-                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
+            const dim_t acc_size = nstl::min<dim_t>(end - w,
+                                           ic_b_kh_work - sub_ic_b_kh_start)
                     * jcp.kw * jcp.ic_block * jcp.oc_block;
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kh);
@@ -1642,7 +1712,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             diff_weights_data_t *s
                     = ti->wei_bia_reduction + (thr_mb - 1) * wei_size + off;
 
-            acc_ker_->accumulate(d, s, acc_size);
+            acc_ker_->accumulate(d, s, static_cast<int>(acc_size));
 
             nd_iterator_jump(w, end, sub_g_start, ti->g_work, sub_oc_b_start,
                     ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
@@ -1658,33 +1728,35 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
     if (dnnl_thr_syncable())
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work = ti->ic_b_work * jcp.kd;
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t ic_b_kh_work = ti->ic_b_work * jcp.kd;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
-    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
-    if (start == end) return;
+    int bal_start {0}, bal_end {0};
+    balance211(static_cast<int>(work), nthr_mb_, ti->ithr_mb, bal_start,
+            bal_end);
+    if (bal_start == bal_end) return;
 
     for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = bal_start, end = bal_end;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
-            const int kd = sub_ic_b_kh_start % jcp.kd;
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b
+                    = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
+            const dim_t kd = sub_ic_b_kh_start % jcp.kd;
 
-            const int acc_size
-                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
+            const dim_t acc_size = nstl::min<dim_t>(end - w,
+                                           ic_b_kh_work - sub_ic_b_kh_start)
                     * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.kh;
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kd);
@@ -1692,7 +1764,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     = (diff_weights_data_t *)ti->diff_weights + off;
             diff_weights_data_t *s
                     = ti->wei_bia_reduction + (thr_mb - 1) * wei_size + off;
-            acc_ker_->accumulate(d, s, acc_size);
+            acc_ker_->accumulate(d, s, static_cast<int>(acc_size));
 
             nd_iterator_jump(w, end, sub_g_start, ti->g_work, sub_oc_b_start,
                     ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
@@ -1721,22 +1793,22 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     /* reduction dimension */
     int img_start {0}, img_end {0};
-    balance211(jcp.mb, rb->balancer().nthr_per_group_,
+    balance211(static_cast<int>(jcp.mb), rb->balancer().nthr_per_group_,
             rb->balancer().id_in_group(ti->ithr), img_start, img_end);
 
     /* jobs */
     int g_start {0}, ocb_start {0};
     nd_iterator_init(b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_oc);
-    for (int img = img_start; img < img_end; ++img) {
+    for (dim_t img = img_start; img < img_end; ++img) {
         int g = g_start, ocb = ocb_start;
         for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-            const size_t _oc = g * jcp.nb_oc + ocb;
-            const int max_oc
+            const dim_t _oc = g * jcp.nb_oc + ocb;
+            const dim_t max_oc
                     = this_block_size(ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
 
             const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                     format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : _oc;
             const diff_dst_data_t *d_dst
@@ -1751,7 +1823,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     d_bias[o] = 0;
             for (int hw = 0; hw < jcp.oh * jcp.ow * jcp.od; ++hw) {
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < max_oc; ++o)
+                for (dim_t o = 0; o < max_oc; ++o)
                     d_bias[o] += d_dst[o];
                 d_dst += is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
                                             : jcp.oc_block;
@@ -1773,7 +1845,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const size_t wei_size = (size_t)jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
-    const int bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
     const diff_weights_data_t *diff_bias_ws
             = ti->wei_bia_reduction + (size_t)(nthr_mb_ - 1) * wei_size;
 
@@ -1781,7 +1853,8 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     if (ti->ithr == 0) {
         for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-            acc_ker_->accumulate(ti->diff_bias, diff_bias_ws, bia_size);
+            acc_ker_->accumulate(
+                    ti->diff_bias, diff_bias_ws, static_cast<int>(bia_size));
             diff_bias_ws += bia_size;
         }
     }
@@ -1910,8 +1983,8 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                                              key_conv_padded_bias);
             auto diff_bias_in
                     = CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
             for (int g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);

--- a/src/cpu/x64/jit_avx512_common_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.hpp
@@ -232,8 +232,9 @@ struct jit_avx512_common_convolution_bwd_weights_t : public primitive_t {
             const size_t max_buffer_size = jcp_.nthr * 3 * 5 * 5 * 16 * 16;
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(jcp_.nthr,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_oc, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
         }
     };

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -50,7 +50,7 @@ jit_avx512_core_amx_1x1_fwd_kernel_t::jit_avx512_core_amx_1x1_fwd_kernel_t(
         const auto &rhs_addr_cache_reg = bin_injector_helper_reg_3;
         static constexpr bool preserve_gpr = false;
         static constexpr bool preserve_vmm = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {31, rhs_addr_reg,
@@ -90,25 +90,25 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::init_runtime_counters() {
     is_buffer_empty_ = true;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_h_shift() const {
-    return (size_t)jcp.ow * jcp.ngroups * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_h_shift() const {
+    return jcp.ow * jcp.ngroups * jcp.oc_without_padding;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_w_shift() const {
-    return (size_t)jcp.ngroups * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_w_shift() const {
+    return jcp.ngroups * jcp.oc_without_padding;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::inp_offset(
-        int h, int w, int icb) const {
-    return (size_t)jcp.typesize_in
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::inp_offset(
+        dim_t h, dim_t w, dim_t icb) const {
+    return jcp.typesize_in
             * (h * jcp.iw * jcp.ngroups * jcp.ic_without_padding
                     + w * jcp.ngroups * jcp.ic_without_padding
                     + icb * jcp.ic_block_int_np);
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
-        int h, int w, int ocb) const {
-    return (size_t)jcp.typesize_out
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
+        dim_t h, dim_t w, dim_t ocb) const {
+    return jcp.typesize_out
             * (h * jcp.ow * jcp.ngroups * jcp.oc_without_padding
                     + w * jcp.ngroups * jcp.oc_without_padding
                     + ocb * jcp.oc_block);
@@ -117,9 +117,9 @@ size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
 void jit_avx512_core_amx_1x1_fwd_kernel_t::update_buffer_pointers() {
     auto buffer_offset
             = [this](bool shift) { return ((buf_count_ + shift) % 2); };
-    int wsp_shift = jcp.typesize_acc * (jcp.wsp_buffer_size / 2);
+    dim_t wsp_shift = jcp.typesize_acc * (jcp.wsp_buffer_size / 2);
 
-    int postop_shift = wsp_shift * buffer_offset(true);
+    dim_t postop_shift = wsp_shift * buffer_offset(true);
 
     mov(reg_postop, wsp_ptr);
     add(reg_postop, postop_shift);
@@ -149,7 +149,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::interleave_store() {
                             {bin_injector_helper_reg_1,
                                     bin_injector_helper_reg_2,
                                     bin_injector_helper_reg_3});
-            const int wsp_row_offset = jcp.typesize_acc
+            const dim_t wsp_row_offset = jcp.typesize_acc
                     * (osb * jcp.nb_oc_blocking * jcp.max_width * jcp.oc_block
                             + ocb * jcp.max_width * jcp.oc_block
                             + row * jcp.oc_block);
@@ -164,7 +164,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::interleave_store() {
         if (row_count_ == exp_row_count) {
             int oh = ((jcp.nb_os_blocking * jcp.tile_width) / jcp.ow);
             int ow = ((jcp.nb_os_blocking * jcp.tile_width) % jcp.ow);
-            size_t out_offset = jcp.typesize_out
+            dim_t out_offset = jcp.typesize_out
                     * (oh * out_h_shift() + ow * out_w_shift());
             add(out_ptr, out_offset);
             row_count_ = 0;
@@ -292,7 +292,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
     }
 
     if (jcp.src_zero_point) {
-        const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
         const Zmm zmm_zp_m = zmm_mask(zmm_zp, mask_flag);
         vpmulld(zmm_zp_m, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -321,7 +321,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
         for (int j = 0; j < jcp.tile_width; j++) {
-            const int scale_offset
+            const dim_t scale_offset
                     = jcp.is_oc_scale * (sizeof(float) * ocb * jcp.oc_block);
             const Zmm zmm_r = zmm_out(j);
             const Zmm zmm_r_msk = zmm_mask(zmm_r, mask_flag);
@@ -333,7 +333,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
         for (int j = 0; j < jcp.tile_width; j++) {
@@ -446,12 +446,12 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
     if (jcp.src_zero_point) {
-        const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
         const Zmm zmm_zp_m = zmm_mask(zmm_zp, mask_flag);
         vpmulld(zmm_zp_m, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -468,7 +468,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        int scale_offset
+        const dim_t scale_offset
                 = jcp.is_oc_scale * (sizeof(float) * ocb * jcp.oc_block);
         const Zmm zmm_out_msk = zmm_mask(zmm_out, mask_flag);
         vmulps(zmm_out_msk, zmm_out,
@@ -517,7 +517,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_bf16(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        const int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         const auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
         for (int j = 0; j < jcp.tile_width; j++) {
@@ -583,7 +583,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_bf16(
         }
     }
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         if (jcp.bia_dt == data_type::bf16) {
             vpmovzxwd(zmm_mask(zmm_bias, mask_flag), bias_addr);
@@ -634,7 +634,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output(
         bool do_store, bool has_tail) {
 
     auto store_output_subblock = [&](int ocb, int osb) {
-        const int wsp_offset = jcp.typesize_acc
+        const dim_t wsp_offset = jcp.typesize_acc
                 * (osb * jcp.nb_oc_blocking * jcp.max_width * jcp.oc_block
                         + ocb * jcp.max_width * jcp.oc_block);
         tilestored(ptr[wsp_ptr + stride_seq + wsp_offset],
@@ -713,12 +713,13 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
         }
     };
 
-    auto tileloadd_nt = [this](const Tmm &t1, int offset) {
-        int ab_size = jcp.nb_os2_blocking * jcp.nb_os_blocking * jcp.tile_width
+    auto tileloadd_nt = [this](const Tmm &t1, dim_t offset) {
+        const dim_t ab_size = jcp.nb_os2_blocking * jcp.nb_os_blocking
+                * jcp.tile_width
                 * (jcp.nb_ic_int * jcp.ic_block_int_np
                         + jcp.nb_oc_blocking * jcp.oc_block);
-        int c_size = (jcp.nb_ic_int * jcp.ic_block_int_np * jcp.nb_oc_blocking
-                * jcp.oc_block);
+        const dim_t c_size = (jcp.nb_ic_int * jcp.ic_block_int_np
+                * jcp.nb_oc_blocking * jcp.oc_block);
         // If the size of  src + wei used in the kernel cannot fit into L1 cache,
         // use non-temporal load of weights to help keep src in L1 cache
         if (static_cast<size_t>(jcp.typesize_in * (ab_size + c_size))
@@ -730,19 +731,20 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     auto compute_block = [&](int icb, int os_b) {
         for (int osb = 0; osb < os_b; osb++) {
-            int ih = ((osb * jcp.tile_width) / jcp.ow) * jcp.stride_h;
-            int iw = ((osb * jcp.tile_width) % jcp.ow) * jcp.stride_w;
+            dim_t ih = ((osb * jcp.tile_width) / jcp.ow) * jcp.stride_h;
+            dim_t iw = ((osb * jcp.tile_width) % jcp.ow) * jcp.stride_w;
             tileloadd(Tmm(get_inp_tensor(osb)),
                     ptr[inp_ptr + stride_nhwc + inp_offset(ih, iw, icb)]);
         }
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-            const int wei_offset = jcp.typesize_in
+            const dim_t wei_offset = jcp.typesize_in
                     * (ocb
                                     * utils::rnd_up(jcp.ic_without_padding,
                                             jcp.ic_block_int)
                                     * jcp.oc_block
                             + icb * jcp.ic_block_int_np * jcp.oc_block);
-            tileloadd_nt(Tmm(get_wei_tensor(ocb)), wei_offset);
+            tileloadd_nt(
+                    Tmm(get_wei_tensor(ocb)), static_cast<int>(wei_offset));
             for (int osb = 0; osb < os_b; osb++) {
                 tdpbxxd(Tmm(get_out_tensor(osb, ocb)), Tmm(get_inp_tensor(osb)),
                         Tmm(get_wei_tensor(ocb)));
@@ -765,7 +767,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
         mov(reg_tilebuff, ptr[param1 + GET_OFF(src_prf)]);
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++)
             for (int osb = 0; osb < os_b; osb++) {
-                const int wsp_offset = jcp.typesize_acc
+                const dim_t wsp_offset = jcp.typesize_acc
                         * (osb * jcp.nb_oc_blocking * jcp.max_width
                                         * jcp.oc_block
                                 + ocb * jcp.max_width * jcp.oc_block);
@@ -788,7 +790,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     auto compute_icb_loop = [&](int os_b = 1) {
         int shift = (get_ic_tail() && os_b == 1) ? 1 : 0;
-        int nb_ic_int = jcp.nb_ic_int - shift;
+        const int nb_ic_int = static_cast<int>(jcp.nb_ic_int - shift);
 
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
@@ -814,7 +816,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     Label label_last_os, label_compute_done, label_tail, label_done;
 
-    int stride_nhwc_ = jcp.typesize_in * jcp.ngroups * jcp.ic_without_padding
+    dim_t stride_nhwc_ = jcp.typesize_in * jcp.ngroups * jcp.ic_without_padding
             * jcp.stride_w;
     mov(stride_nhwc, stride_nhwc_);
 
@@ -851,19 +853,19 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::osb_loop(int nb_os) {
         int oh = (((osi + 1) * jcp.nb_os_blocking * jcp.tile_width) / jcp.ow);
         int ow = (((osi + 1) * jcp.nb_os_blocking * jcp.tile_width) % jcp.ow);
         if (do_store) {
-            size_t out_offset = jcp.typesize_out
+            dim_t out_offset = jcp.typesize_out
                     * (oh * out_h_shift() + ow * out_w_shift());
             add(out_ptr, out_offset);
         }
 
-        int ih = oh * jcp.stride_h;
-        int iw = ow * jcp.stride_w;
+        dim_t ih = oh * jcp.stride_h;
+        dim_t iw = ow * jcp.stride_w;
         add(inp_ptr, inp_offset(ih, iw, 0));
     }
 }
 
 int jit_avx512_core_amx_1x1_fwd_kernel_t::get_ic_tail() const {
-    return (jcp.ic_without_padding % jcp.ic_block_int_np);
+    return static_cast<int>(jcp.ic_without_padding % jcp.ic_block_int_np);
 }
 
 void jit_avx512_core_amx_1x1_fwd_kernel_t::generate() {
@@ -952,12 +954,12 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                 tc_configure_tile(buff, get_out_tensor(s, i), Cr, Cc);
             }
 
-        buff->palette_id = amx::get_target_palette();
+        buff->palette_id = static_cast<uint8_t>(amx::get_target_palette());
     };
 
-    int Ac = jcp.typesize_in
+    int Ac = static_cast<int>(jcp.typesize_in
             * ((jcp.nb_ic_int == 1 && get_ic_tail()) ? get_ic_tail()
-                                                     : jcp.ic_block_int_np);
+                                                     : jcp.ic_block_int_np));
 
     cfg_tiles((palette_config_t *)tcfg_buff, Ac);
     if (jcp.nb_ic_int > 1 && get_ic_tail()) {
@@ -1193,15 +1195,19 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                     p, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
-    jcp.nb_ic = jcp.ic / jcp.ic_block;
-    jcp.nb_oc = jcp.oc / jcp.oc_block;
-    jcp.nb_ic_int = div_up(jcp.ic_without_padding, jcp.ic_block_int_np);
+    jcp.nb_ic = static_cast<int>(jcp.ic / jcp.ic_block);
+    jcp.nb_oc = static_cast<int>(jcp.oc / jcp.oc_block);
+    jcp.nb_ic_int = static_cast<int>(
+            div_up(jcp.ic_without_padding, jcp.ic_block_int_np));
 
     jcp.max_width = amx::get_max_rows(amx::get_target_palette());
     VDISPATCH_CONV_IC(jcp.max_width > 0, VERBOSE_BAD_PARAM, "max_width = 0");
@@ -1209,8 +1215,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const int size_treshold = 32;
     const int min_width
             = 1; // TODO: Possible optimizations: do not use small values
-    const int spatial = jcp.od * jcp.oh;
-    const int os = jcp.od * jcp.oh * jcp.ow;
+    const dim_t spatial = jcp.od * jcp.oh;
+    const dim_t os = jcp.od * jcp.oh * jcp.ow;
 
     jcp.tile_width = 1;
     for (int s_size = jcp.max_width; s_size >= min_width; s_size--) {
@@ -1221,8 +1227,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         }
     }
     if (jcp.tile_width == 1) {
-        jcp.tile_width = nstl::min(jcp.max_width, os);
-        jcp.tile_tail = os % jcp.max_width;
+        jcp.tile_width = static_cast<int>(nstl::min<dim_t>(jcp.max_width, os));
+        jcp.tile_tail = static_cast<int>(os % jcp.max_width);
         for (int i = jcp.max_width; i >= min_width; i--) {
             int i_tail = os % i;
             if (i_tail > jcp.tile_tail || i_tail == 0) {
@@ -1255,7 +1261,7 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_oc_blocking = (jcp.nb_oc % 2 == 0) ? 2 : 1;
     jcp.nb_ic_blocking = 1;
     jcp.nb_os_blocking = (os / jcp.tile_width > 2) ? 2 : 1;
-    jcp.nb_os = os / jcp.tile_width;
+    jcp.nb_os = static_cast<int>(os / jcp.tile_width);
     jcp.nb_os2_blocking = (jcp.nb_os_blocking > 1)
             ? (jcp.nb_os % jcp.nb_os_blocking == 0) ? 2 : 1
             : 1;
@@ -1265,7 +1271,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     int ops_tile_store
             = jcp.nb_oc_blocking * jcp.nb_os_blocking * jcp.tile_width;
-    int avaliable_ops = jcp.nb_ic_int * jcp.nb_oc_blocking * jcp.nb_os_blocking;
+    const dim_t avaliable_ops
+            = jcp.nb_ic_int * jcp.nb_oc_blocking * jcp.nb_os_blocking;
     jcp.per_one_pstore
             = (avaliable_ops) ? ops_tile_store / avaliable_ops + 1 : 0;
     if (jcp.per_one_pstore > 12) jcp.per_one_pstore = 0;

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
@@ -122,10 +122,10 @@ private:
     int get_wei_tensor(int i) const;
     int get_ic_tail() const;
 
-    size_t out_h_shift() const;
-    size_t out_w_shift() const;
-    size_t inp_offset(int ih, int iw, int icb) const;
-    size_t out_row_offset(int h, int w, int ocb) const;
+    dim_t out_h_shift() const;
+    dim_t out_w_shift() const;
+    dim_t inp_offset(dim_t ih, dim_t iw, dim_t icb) const;
+    dim_t out_row_offset(dim_t h, dim_t w, dim_t ocb) const;
 
     void prepare_output();
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
@@ -121,17 +121,16 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             utils::rnd_up(jcp.ic_without_padding, jcp.ic_block_int)
             * jcp.oc_block * jcp.nb_oc_blocking);
 
-    int nb_os = (jcp.tile_tail) ? jcp.nb_os + 1 : jcp.nb_os;
-    int os_step = jcp.nb_os2_blocking * jcp.nb_os_blocking;
-    int os_chunks = div_up(nb_os, os_step);
+    const dim_t nb_os = (jcp.tile_tail) ? jcp.nb_os + 1 : jcp.nb_os;
+    const dim_t os_step = jcp.nb_os2_blocking * jcp.nb_os_blocking;
+    const dim_t os_chunks = div_up(nb_os, os_step);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
 
-    const size_t work_amount
-            = (size_t)jcp.mb * jcp.ngroups * os_chunks * oc_chunks;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * os_chunks * oc_chunks;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -153,19 +152,20 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, _osb {0}, _ocb {0};
+        dim_t mb {0}, g {0}, _osb {0}, _ocb {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, _osb, os_chunks,
                 _ocb, oc_chunks);
 
         while (start < end) {
-            int osb = _osb * os_step;
-            int ocb = _ocb * jcp.nb_oc_blocking;
+            const dim_t osb = _osb * os_step;
+            const dim_t ocb = _ocb * jcp.nb_oc_blocking;
             auto bias_w = bias
                     ? bias + (bias_d.blk_off(ocb * jcp.oc_block) * bia_dt_size)
                     : nullptr;
 
-            int oc = g * jcp.oc_without_padding + ocb * jcp.oc_block;
-            int ic = g * jcp.ic_without_padding;
+            const dim_t oc = g * jcp.oc_without_padding
+                    + ocb * jcp.oc_block;
+            const dim_t ic = g * jcp.ic_without_padding;
 
             p.acc_s32 = wsp + ithr * jcp.wsp_buffer_size;
             p.src_prf = wsp_tile + ithr * (jcp.wsp_buffer_size / 2);
@@ -191,18 +191,18 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             const bool is_overflow = (osb + os_step >= nb_os);
             if (is_overflow
                     && (os_chunks > 1 || (os_chunks == 1 && is_ic_tail))) {
-                int step = (check_last_sp) ? 1 : jcp.nb_os_blocking;
-                for (int osi = 0; osi < nb_os - osb; osi += step) {
-                    int osb_i = osi + osb;
-                    int od {0}, oh {0}, ow {0};
+                const dim_t step = (check_last_sp) ? 1 : jcp.nb_os_blocking;
+                for (dim_t osi = 0; osi < nb_os - osb; osi += step) {
+                    const dim_t osb_i = osi + osb;
+                    dim_t od {0}, oh {0}, ow {0};
                     nd_iterator_init(osb_i * jcp.tile_width, od, jcp.od, oh,
                             jcp.oh, ow, jcp.ow);
                     size_t dst_offset = md_blk_off(dst_d, mb, oc, od, oh, ow);
                     p.dst = dst + dst_dt_size * dst_offset;
 
-                    int id = od * jcp.stride_d;
-                    int ih = oh * jcp.stride_h;
-                    int iw = ow * jcp.stride_w;
+                    const dim_t id = od * jcp.stride_d;
+                    const dim_t ih = oh * jcp.stride_h;
+                    const dim_t iw = ow * jcp.stride_w;
                     size_t inp_offset = md_blk_off(src_d, mb, ic, id, ih, iw);
                     p.src = src + src_dt_size * inp_offset;
 
@@ -213,15 +213,15 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
                     (*kernel_)(&p);
                 }
             } else {
-                int od {0}, oh {0}, ow {0};
+                dim_t od {0}, oh {0}, ow {0};
                 nd_iterator_init(osb * jcp.tile_width, od, jcp.od, oh, jcp.oh,
                         ow, jcp.ow);
                 size_t dst_offset = md_blk_off(dst_d, mb, oc, od, oh, ow);
                 p.dst = dst + dst_dt_size * dst_offset;
 
-                int id = od * jcp.stride_d;
-                int ih = oh * jcp.stride_h;
-                int iw = ow * jcp.stride_w;
+                const dim_t id = od * jcp.stride_d;
+                const dim_t ih = oh * jcp.stride_h;
+                const dim_t iw = ow * jcp.stride_w;
                 size_t inp_offset = md_blk_off(src_d, mb, ic, id, ih, iw);
                 p.src = src + src_dt_size * inp_offset;
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -42,7 +42,7 @@ using namespace dnnl::impl::data_type;
 using namespace dnnl::impl::utils;
 using namespace Xbyak;
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(int ur_w) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(dim_t ur_w) {
     for (int oc = 0; oc < jcp.nb_oc_blocking; oc++)
         for (int ur = 0; ur < ur_w; ur++) {
             const Zmm zmm = zmm_out(ur, oc);
@@ -51,22 +51,22 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(int ur_w) {
 }
 
 void jit_avx512_core_amx_compute_zp_pbuff_t::store_output(
-        int ur_w, bool last_oc_block_flag) {
+        dim_t ur_w, bool last_oc_block_flag) {
     assert(jcp.is_nspc);
 
-    const int nb_oc_block = jcp.nb_oc_blocking;
-    const int oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t oc_block = jcp.oc_block;
 
     const auto src_zp_addr = EVEX_compress_addr(reg_src_zero_point, 0, true);
 
     /* write out register to output_addr */
     for (int oc = 0; oc < nb_oc_block; oc++) {
         const bool mask_flag = last_oc_block_flag && oc == nb_oc_block - 1;
-        for (int ur = 0; ur < ur_w; ur++) {
-            const int output_offset = sizeof(int32_t)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
+            const dim_t output_offset = sizeof(int32_t)
                     * (oc * oc_block
                             + ur * jcp.oc_without_padding * jcp.ngroups);
-            const Zmm zmm_dst = zmm_out(ur, oc);
+            const Zmm zmm_dst = zmm_out(static_cast<int>(ur), oc);
             const Zmm m_zmm_dst = mask_flag ? zmm_dst | ktail_mask : zmm_dst;
             // multiply dst by src_zero_point
             vpmulld(m_zmm_dst, zmm_dst, src_zp_addr);
@@ -75,13 +75,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::store_output(
     }
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool padded) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag, bool padded) {
 
-    const int kw = jcp.kw;
-    const int ic_block = jcp.ic_block_int_np;
-    const int oc_block = jcp.oc_block;
-    const int nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block_int_np;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
 
     const bool ic_tail
             = (jcp.ic_without_padding % (jcp.ic_block / ic_inner_block)) > 0;
@@ -90,24 +90,23 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
 
     /* Skip the last loads of input
             if (ic%16)/ic_sub_step < ic_block/ic_sub_step */
-    const int icb = (last_ic_block_flag == ic_block_t::last_ic_block)
+    const dim_t icb = (last_ic_block_flag == ic_block_t::last_ic_block)
             ? div_up((jcp.ic_without_padding % jcp.ic_block_int),
                       ic_inner_block)
             : ic_block / ic_inner_block;
 
-    auto get_filter_offset = [this, oc_block](int ocb, int ic, int ki) {
-        size_t w_step = jcp.is_relo ? jcp.kh : 1;
-        size_t kw_offset = static_cast<size_t>(ki) * w_step
-                * jcp.ic_block_int_np * jcp.oc_block;
-        size_t oc_subblock_step = static_cast<size_t>(jcp.kd) * jcp.kh * jcp.kw
-                * jcp.ic_block_int_np * jcp.oc_block;
-        size_t offset = kw_offset
-                + static_cast<size_t>(ocb) * jcp.nb_ic_int * oc_subblock_step
-                + static_cast<size_t>(ic) * oc_block * ic_inner_block;
-        return sizeof(char) * offset;
+    auto get_filter_offset = [this, oc_block](dim_t ocb, dim_t ic, dim_t ki) {
+        const dim_t w_step = jcp.is_relo ? jcp.kh : 1;
+        const dim_t kw_offset
+                = ki * w_step * jcp.ic_block_int_np * jcp.oc_block;
+        const dim_t oc_subblock_step
+                = jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
+        return static_cast<dim_t>(sizeof(char))
+                * (kw_offset + ocb * jcp.nb_ic_int * oc_subblock_step
+                        + ic * oc_block * ic_inner_block);
     };
     auto compute_fma = [this, masked_write, icb](const Zmm zmm_accum,
-                               const int ic, const Address addr) {
+                               const dim_t ic, const Address addr) {
         if (jcp.is_relo) {
             vmovups(zmm_permb, ptr[reg_scratch]); // get permute index table
             const Zmm r_zmm = masked_write && ic == icb - 1
@@ -130,18 +129,19 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
     }
     if (jcp.is_relo) mov(reg_scratch, permb_idx_label);
 
-    for (int ki = 0; ki < kw; ki++) {
-        const int ur_start = get_ow_start(ki, pad_l);
-        const int ur_end = get_ow_end(ur_w, ki, pad_r);
-        for (int ur = 0; ur < ur_w; ur++) {
+    for (dim_t ki = 0; ki < kw; ki++) {
+        const dim_t ur_start = get_ow_start(ki, pad_l);
+        const dim_t ur_end = get_ow_end(ur_w, ki, pad_r);
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             // Calculate zero_point padding as:
             // accum = is_padding ? src_zero_point_s32 * conv(1, wei_s8) : 0)
             if (ur < ur_start || ur >= ur_end || padded) {
                 for (int oc = 0; oc < nb_oc_block; oc++) {
-                    const Zmm zmm_accum = zmm_out(ur, oc);
-                    for (int ic = 0; ic < icb; ic++) {
-                        const auto addr_filt = EVEX_compress_addr(
-                                aux_reg_filt, get_filter_offset(oc, ic, ki));
+                    const Zmm zmm_accum = zmm_out(static_cast<int>(ur), oc);
+                    for (dim_t ic = 0; ic < icb; ic++) {
+                        const auto addr_filt = EVEX_compress_addr(aux_reg_filt,
+                                static_cast<int>(
+                                        get_filter_offset(oc, ic, ki)));
                         compute_fma(zmm_accum, ic, addr_filt);
                     }
                 }
@@ -150,14 +150,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
     }
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(dim_t ur_w, dim_t pad_l,
+        dim_t pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
 
     Label kh_label, skip_kh_loop;
-    const size_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
-    const size_t shift_wei_h_step = sizeof(char)
-            * static_cast<size_t>(wei_h_step) * jcp.ic_block_int_np
-            * jcp.oc_block;
+    const dim_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
+    const dim_t shift_wei_h_step
+            = sizeof(char) * wei_h_step * jcp.ic_block_int_np * jcp.oc_block;
 
     // Compute zero_point compensation for the padded region. Total compute
     // area is 'overflow * kw' where 'overflow' indicates the overlap
@@ -201,14 +200,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(int ur_w, int pad_l,
     if (handle_h_pad && jcp.ndims > 3) compute_kh_loop(GET_OFF(b_overflow));
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(dim_t ur_w, dim_t pad_l,
+        dim_t pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
 
     Label kd_label, skip_kd_loop;
-    const size_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
-    const size_t shift_wei_h_step = sizeof(char)
-            * static_cast<size_t>(wei_h_step) * jcp.ic_block_int_np
-            * jcp.oc_block;
+    const dim_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
+    const dim_t shift_wei_h_step
+            = sizeof(char) * wei_h_step * jcp.ic_block_int_np * jcp.oc_block;
 
     // Compute zero_point compensation for the padded region. Total compute
     // area is 'overflow * kh * kw' where 'overflow' indicates the overlap
@@ -270,7 +268,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(int ur_w, int pad_l,
 }
 
 void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool handle_h_pad) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, bool handle_h_pad) {
 
     Label icb_label;
     const size_t nb_ic = jcp.nb_ic_int;
@@ -308,15 +306,16 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        const size_t shift_wei_icb_step = static_cast<size_t>(jcp.kd) * jcp.kh
-                * jcp.kw * jcp.oc_block * jcp.ic_block_int_np;
-        add(reg_filt, sizeof(char) * shift_wei_icb_step);
+        const dim_t shift_wei_icb_step
+                = jcp.kd * jcp.kh * jcp.kw * jcp.oc_block * jcp.ic_block_int_np;
+        add(reg_filt, static_cast<uint32_t>(sizeof(char) * shift_wei_icb_step));
 
         dec(reg_icb);
         cmp(reg_icb, 0);
         jg(icb_label, T_NEAR);
 
-        sub(reg_filt, sizeof(char) * shift_wei_icb_step * nb_ic);
+        sub(reg_filt,
+                static_cast<int>(sizeof(char) * shift_wei_icb_step * nb_ic));
     }
 
     if (jcp.oc_without_padding != jcp.oc) {
@@ -340,36 +339,41 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
 void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
         const bool h_padding) {
 
-    auto ur_w_shift = [&](const int ur_w) {
-        return sizeof(int32_t) * (ur_w * jcp.oc_without_padding * jcp.ngroups);
+    auto ur_w_shift = [&](const dim_t ur_w) {
+        return static_cast<dim_t>(sizeof(int32_t))
+                * (ur_w * jcp.oc_without_padding * jcp.ngroups);
     };
 
     const int max_ur_w = jit_avx512_core_amx_compute_zp_pbuff_t::max_regs_ur
             / (jcp.nb_oc_blocking);
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int l_pad = jcp.l_pad;
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t l_pad = jcp.l_pad;
 
-    const int l_pad_output = jcp.l_pad_output;
-    const int r_pad_output = jcp.r_pad_output;
+    const dim_t l_pad_output = jcp.l_pad_output;
+    const dim_t r_pad_output = jcp.r_pad_output;
 
     // a single middle element (if required) containing only height padding
-    const int no_pad = nstl::max(0, jcp.ow - l_pad_output - r_pad_output);
+    const dim_t no_pad
+            = nstl::max<dim_t>(0, jcp.ow - l_pad_output - r_pad_output);
 
-    const int ow_start = nstl::max(jcp.ow - r_pad_output, l_pad_output);
-    const int r_pad_start = nstl::min(jcp.ow_pad - l_pad_output, r_pad_output);
+    const dim_t ow_start
+            = nstl::max<dim_t>(jcp.ow - r_pad_output, l_pad_output);
+    const dim_t r_pad_start
+            = nstl::min(jcp.ow_pad - l_pad_output, r_pad_output);
 
-    int ow = 0;
-    int cur_l_pad_output = l_pad_output;
+    dim_t ow = 0;
+    dim_t cur_l_pad_output = l_pad_output;
     while (cur_l_pad_output > 0) {
-        const int ur_w = nstl::min(cur_l_pad_output, max_ur_w);
+        const dim_t ur_w
+                = nstl::min(cur_l_pad_output, static_cast<dim_t>(max_ur_w));
         ow += ur_w;
-        const int cur_r_pad = calculate_end_padding(
+        const dim_t cur_r_pad = calculate_end_padding(
                 jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, l_pad, cur_r_pad, h_padding);
         add(reg_zp_pbuff, ur_w_shift(ur_w));
 
-        l_pad = nstl::max(l_pad - ur_w * jcp.stride_w, 0);
-        cur_l_pad_output = nstl::max(cur_l_pad_output - ur_w, 0);
+        l_pad = nstl::max<dim_t>(l_pad - ur_w * jcp.stride_w, 0);
+        cur_l_pad_output = nstl::max<dim_t>(cur_l_pad_output - ur_w, 0);
     }
 
     if (no_pad > 0) {
@@ -380,16 +384,17 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
     assert(ow + no_pad == ow_start);
 
     ow = ow_start;
-    int cur_r_pad_output = r_pad_start;
+    dim_t cur_r_pad_output = r_pad_start;
     while (cur_r_pad_output > 0 && ow < jcp.ow) {
-        const int ur_w = nstl::min(cur_r_pad_output, max_ur_w);
+        const dim_t ur_w
+                = nstl::min(cur_r_pad_output, static_cast<dim_t>(max_ur_w));
         ow += ur_w;
-        const int cur_r_pad = calculate_end_padding(
+        const dim_t cur_r_pad = calculate_end_padding(
                 jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, 0, cur_r_pad, h_padding);
         add(reg_zp_pbuff, ur_w_shift(ur_w));
 
-        cur_r_pad_output = nstl::max(cur_r_pad_output - ur_w, 0);
+        cur_r_pad_output = nstl::max<dim_t>(cur_r_pad_output - ur_w, 0);
     }
 }
 
@@ -407,8 +412,8 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::generate() {
 
     if (jcp.oc_without_padding != jcp.oc) {
         const Reg32 reg_tmp = reg_scratch.cvt32();
-        const int tail_size = jcp.oc_without_padding % jcp.oc_block;
-        const int mask = (1 << tail_size) - 1;
+        const dim_t tail_size = jcp.oc_without_padding % jcp.oc_block;
+        const int mask = (1 << static_cast<int>(tail_size)) - 1;
         mov(reg_tmp, mask);
         kmovw(ktail_mask, reg_tmp);
         mov(reg_oc_blocks, ptr[param1 + GET_OFF(oc_blocks)]);
@@ -455,7 +460,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::generate() {
             db(select_src2_bit | permb_idx_table[i]);
 
         // write zero-mask (permb) for ic_tail in VNNI format '..16o4i'
-        const int ic_tail_size
+        const dim_t ic_tail_size
                 = jcp.ic_without_padding % (jcp.ic_block / ic_inner_block);
         if (jcp.ic_without_padding != jcp.ic && ic_tail_size > 0) {
             align(64);
@@ -493,45 +498,48 @@ void jit_avx512_core_amx_copy_to_wbuffer_t::generate() {
         vmovdqu8(zmm_idx, ptr[reg_tmp]);
 
     const int vnni_width = is_bf16 ? 2 : 4;
-    const int r = jcp.kh * jcp.kw * jcp.ic_without_padding;
-    const int nb_r = div_up(r, vnni_width);
-    const int rtail = (r % vnni_width) * jcp.oc_block;
+    const dim_t r = jcp.kh * jcp.kw * jcp.ic_without_padding;
+    const dim_t nb_r = div_up(r, vnni_width);
+    const dim_t rtail = (r % vnni_width) * jcp.oc_block;
     if (rtail > 0) {
         uint64_t mask = (UINT64_C(1) << rtail) - 1;
         mov(reg_tmp, mask);
         kmovq(kmask_load, reg_tmp);
     }
-    const int nb_z = rnd_up(nb_r, jcp.ic_block);
+    const dim_t nb_z = rnd_up(nb_r, jcp.ic_block);
     if (nb_r < nb_z) vpxord(zmm_zero, zmm_zero, zmm_zero);
 
-    const int tile_size = jcp.ic_block_int * jcp.oc_block * jcp.typesize_in;
-    const int ocb_src_step = r * jcp.oc_block * jcp.typesize_in;
-    const int ocb_dst_step = rnd_up(ocb_src_step, tile_size);
+    const dim_t tile_size = jcp.ic_block_int * jcp.oc_block * jcp.typesize_in;
+    const dim_t ocb_src_step = r * jcp.oc_block * jcp.typesize_in;
+    const dim_t ocb_dst_step = rnd_up(ocb_src_step, tile_size);
 
     // reorder from ~Owhi16o -> ~OR16oVr with r := whi and V := vnni_width
-    for (int g = 0; g < jcp.ngroups; g++) {
-        for (int ocb = 0; ocb < jcp.nb_oc; ocb++) {
-            int offset = 0;
-            int rb = 0;
+    for (dim_t g = 0; g < jcp.ngroups; g++) {
+        for (dim_t ocb = 0; ocb < jcp.nb_oc; ocb++) {
+            dim_t offset = 0;
+            dim_t rb = 0;
             for (; rb < nb_r; offset += 64, rb++) {
                 auto zmm_src_tmp = (rtail > 0 && rb == nb_r - 1)
                         ? zmm_src | kmask_load | T_z
                         : zmm_src;
                 if (is_bf16) {
-                    vmovdqu16(zmm_src_tmp, ptr[reg_src + offset]);
+                    vmovdqu16(zmm_src_tmp,
+                            ptr[reg_src + static_cast<int>(offset)]);
                     vpermw(zmm_dst, zmm_idx, zmm_src);
-                    vmovdqu16(ptr[reg_dst + offset], zmm_dst);
+                    vmovdqu16(ptr[reg_dst + static_cast<int>(offset)], zmm_dst);
                 } else {
-                    vmovdqu8(zmm_src_tmp, ptr[reg_src + offset]);
+                    vmovdqu8(zmm_src_tmp,
+                            ptr[reg_src + static_cast<int>(offset)]);
                     vpermb(zmm_dst, zmm_idx, zmm_src);
-                    vmovdqu8(ptr[reg_dst + offset], zmm_dst);
+                    vmovdqu8(ptr[reg_dst + static_cast<int>(offset)], zmm_dst);
                 }
             }
             for (; rb < nb_z; offset += 64, rb++) {
                 if (is_bf16)
-                    vmovdqu16(ptr[reg_dst + offset], zmm_zero);
+                    vmovdqu16(
+                            ptr[reg_dst + static_cast<int>(offset)], zmm_zero);
                 else
-                    vmovdqu8(ptr[reg_dst + offset], zmm_zero);
+                    vmovdqu8(ptr[reg_dst + static_cast<int>(offset)], zmm_zero);
             }
             add(reg_src, ocb_src_step);
             add(reg_dst, ocb_dst_step);
@@ -556,92 +564,107 @@ void jit_avx512_core_amx_copy_to_wbuffer_t::generate() {
 }
 
 void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_body(
-        int lpad, int iw_len, int icb) {
+        dim_t lpad, dim_t iw_len, dim_t icb) {
 
     const bool is_bf16 = jcp.src_dt == data_type::bf16;
-    int iwp_idx = 0;
+    dim_t iwp_idx = 0;
     // there are min(gen_kw, jcp.stride_w) continuous sets of input
     // data (for each stride idx), they are placed one by one
     // without additional padding
     const bool are_sets_interleaved
             = IMPLICATION(jcp.dilate_w != 0, jcp.stride_w == 1);
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
-    const int num_sets = are_sets_interleaved ? jcp.n_stride_sets : jcp.kw;
-    for (int set_idx = 0; set_idx < num_sets; set_idx++) {
-        int set_width_padded = !jcp.is_pbuffer_strided
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t num_sets = are_sets_interleaved ? jcp.n_stride_sets : jcp.kw;
+    for (dim_t set_idx = 0; set_idx < num_sets; set_idx++) {
+        dim_t set_width_padded = !jcp.is_pbuffer_strided
                 ? (jcp.ow_block - 1) * jcp.stride_w + gen_kw
                 : are_sets_interleaved ? jcp.ow_block - 1 + gen_kw / num_sets
                         + (set_idx < gen_kw % num_sets ? 1 : 0)
                                        : jcp.ow_block;
-        for (int set_shift = 0; set_shift < set_width_padded;
+        for (dim_t set_shift = 0; set_shift < set_width_padded;
                 set_shift++, iwp_idx++) {
-            int iw_idx = set_idx * (jcp.dilate_w + 1)
+            dim_t iw_idx = set_idx * (jcp.dilate_w + 1)
                     + set_shift * (jcp.is_pbuffer_strided ? jcp.stride_w : 1)
                     - lpad;
-            size_t out_base_offset
-                    = (size_t)jcp.typesize_in * iwp_idx * jcp.ic_block_int_np;
+            const dim_t out_base_offset
+                    = jcp.typesize_in * iwp_idx * jcp.ic_block_int_np;
             if (iw_idx < 0 || iw_idx >= iw_len) {
                 // left or right padding
-                vmovups(ptr[reg_aux_out_ptr + out_base_offset], zmm_zero);
+                vmovups(ptr[reg_aux_out_ptr
+                                + static_cast<int>(out_base_offset)],
+                        zmm_zero);
             } else if (jcp.is_nspc) {
-                size_t inp_w_offset = (size_t)jcp.typesize_in * iw_idx
+                const dim_t inp_w_offset = jcp.typesize_in * iw_idx
                         * jcp.ngroups * jcp.ic_without_padding;
-                int ic = icb * jcp.ic_block_int_np;
+                const dim_t ic = icb * jcp.ic_block_int_np;
                 // TODO: use Xmm or Ymm moves for better small ic efficiency
                 auto zmm_tmp_mask
                         = ic + jcp.ic_block_int <= jcp.ic_without_padding
                         ? zmm_tmp
                         : zmm_tmp | ktail_mask | T_z;
                 if (is_bf16) {
-                    vmovdqu16(
-                            zmm_tmp_mask, ptr[reg_aux_inp_ptr + inp_w_offset]);
-                    vmovdqu16(ptr[reg_aux_out_ptr + out_base_offset], zmm_tmp);
+                    vmovdqu16(zmm_tmp_mask,
+                            ptr[reg_aux_inp_ptr
+                                    + static_cast<int>(inp_w_offset)]);
+                    vmovdqu16(ptr[reg_aux_out_ptr
+                                      + static_cast<int>(out_base_offset)],
+                            zmm_tmp);
                 } else {
-                    vmovdqu8(zmm_tmp_mask, ptr[reg_aux_inp_ptr + inp_w_offset]);
-                    vmovdqu8(ptr[reg_aux_out_ptr + out_base_offset], zmm_tmp);
+                    vmovdqu8(zmm_tmp_mask,
+                            ptr[reg_aux_inp_ptr
+                                    + static_cast<int>(inp_w_offset)]);
+                    vmovdqu8(ptr[reg_aux_out_ptr
+                                     + static_cast<int>(out_base_offset)],
+                            zmm_tmp);
                 }
             } else {
                 assert(is_bf16);
-                size_t inp_w_offset
-                        = (size_t)jcp.typesize_in * iw_idx * jcp.ic_block;
-                for (int j = 0; j < jcp.ic_block_int_np / jcp.ic_block; j++) {
-                    int ic = icb * jcp.ic_block_int_np + j * jcp.ic_block;
-                    size_t inp_c_w_offset = (size_t)jcp.typesize_in * j * jcp.ih
+                const dim_t inp_w_offset
+                        = jcp.typesize_in * iw_idx * jcp.ic_block;
+                for (dim_t j = 0; j < jcp.ic_block_int_np / jcp.ic_block; j++) {
+                    const dim_t ic
+                            = icb * jcp.ic_block_int_np + j * jcp.ic_block;
+                    const dim_t inp_c_w_offset = jcp.typesize_in * j * jcp.ih
                                     * jcp.iw * jcp.ic_block
                             + inp_w_offset;
                     if (ic + jcp.ic_block <= jcp.ic) {
-                        vmovdqu16(
-                                ymm_tmp, ptr[reg_aux_inp_ptr + inp_c_w_offset]);
+                        vmovdqu16(ymm_tmp,
+                                ptr[reg_aux_inp_ptr
+                                        + static_cast<int>(inp_c_w_offset)]);
                     } else {
                         vpxord(ymm_tmp, ymm_tmp, ymm_tmp);
                     }
-                    size_t out_offset = out_base_offset
-                            + (size_t)jcp.typesize_in * j * jcp.ic_block;
-                    vmovdqu16(ptr[reg_aux_out_ptr + out_offset], ymm_tmp);
+                    const dim_t out_offset = out_base_offset
+                            + jcp.typesize_in * j * jcp.ic_block;
+                    vmovdqu16(
+                            ptr[reg_aux_out_ptr + static_cast<int>(out_offset)],
+                            ymm_tmp);
                 }
             }
         }
     }
 }
 
-void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(int icb) {
+void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(dim_t icb) {
     if (jcp.nb_ow == 1) {
         copy_row_body(jcp.l_pad, jcp.iw, icb);
     } else {
-        auto get_iw_len_required = [&](int cur_ow_block, int cur_lpad) {
+        auto get_iw_len_required
+                = [&](dim_t cur_ow_block, dim_t cur_lpad) -> dim_t {
             return (cur_ow_block - 1) * jcp.stride_w
                     + (jcp.kw - 1) * (jcp.dilate_w + 1) + 1 - cur_lpad;
         };
 
-        auto get_iw_len_limited = [&](int owb, int cur_ow_block, int cur_lpad) {
+        auto get_iw_len_limited
+                = [&](dim_t owb, dim_t cur_ow_block, dim_t cur_lpad) -> dim_t {
             auto len_req = get_iw_len_required(cur_ow_block, cur_lpad);
             if (owb < 0) return len_req;
-            int ow_block_start = nstl::max(
+            const dim_t ow_block_start = nstl::max<dim_t>(
                     0, owb * jcp.ow_block * jcp.stride_w - jcp.l_pad);
-            return nstl::min(jcp.iw - ow_block_start, len_req);
+            return nstl::min<dim_t>(jcp.iw - ow_block_start, len_req);
         };
 
-        int general_owb_cases = jcp.nb_ow;
+        dim_t general_owb_cases = jcp.nb_ow;
         Xbyak::Label copy_row_done_label;
         bool special_first_block_case = jcp.l_pad > 0;
         if (special_first_block_case) {
@@ -665,8 +688,9 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(int icb) {
             Xbyak::Label skip_last_block_case_label;
             cmp(reg_owb, jcp.nb_ow - 1);
             jne(skip_last_block_case_label, T_NEAR);
-            int ow_block_tail = jcp.ow % jcp.ow_block;
-            int cur_ow_block = ow_block_tail > 0 ? ow_block_tail : jcp.ow_block;
+            dim_t ow_block_tail = jcp.ow % jcp.ow_block;
+            dim_t cur_ow_block
+                    = ow_block_tail > 0 ? ow_block_tail : jcp.ow_block;
             copy_row_body(
                     0, get_iw_len_limited(jcp.nb_ow - 1, cur_ow_block, 0), icb);
             jmp(copy_row_done_label, T_NEAR);
@@ -704,7 +728,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
             == 64);
     assert(jcp.is_nspc);
 
-    auto load_mask = [this](int tail, Opmask kmask) {
+    auto load_mask = [this](dim_t tail, Opmask kmask) {
         uint64_t mask = (UINT64_C(1) << tail) - 1;
         mov(reg_tmp, mask);
         kmovq(kmask, reg_tmp);
@@ -713,25 +737,26 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
     const bool is_f32 = jcp.src_dt == data_type::f32;
     const bool is_xf16 = one_of(jcp.src_dt, data_type::bf16, data_type::f16);
 
-    const int inp_w_step
+    const dim_t inp_w_step
             = jcp.ngroups * jcp.ic_without_padding * jcp.typesize_in;
-    const int inp_h_step = jcp.iw * inp_w_step;
-    const int out_h_step = jcp.ic_without_padding * jcp.typesize_in;
-    const int out_w_step = jcp.kh * out_h_step;
-    const int tail_size = jcp.ic_without_padding % jcp.ic_block_int;
+    const dim_t inp_h_step = jcp.iw * inp_w_step;
+    const dim_t out_h_step = jcp.ic_without_padding * jcp.typesize_in;
+    const dim_t out_w_step = jcp.kh * out_h_step;
+    const dim_t tail_size = jcp.ic_without_padding % jcp.ic_block_int;
     if (tail_size > 0) load_mask(tail_size, ktail_mask);
 
     auto zero_it = [this, is_f32, is_xf16](reg64_t tmp_out_ptr) {
-        for (int ic = 0; ic < jcp.ic_without_padding; ic += jcp.ic_block_int) {
-            const int offset = ic * jcp.typesize_in;
+        for (dim_t ic = 0; ic < jcp.ic_without_padding;
+                ic += jcp.ic_block_int) {
+            const dim_t offset = ic * jcp.typesize_in;
             const bool masked = ic + jcp.ic_block_int > jcp.ic_without_padding;
             Zmm zmm = masked ? zmm_zero | ktail_mask : zmm_zero;
             if (is_f32)
-                vmovdqu32(ptr[tmp_out_ptr + offset], zmm);
+                vmovdqu32(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm);
             else if (is_xf16)
-                vmovdqu16(ptr[tmp_out_ptr + offset], zmm);
+                vmovdqu16(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm);
             else
-                vmovdqu8(ptr[tmp_out_ptr + offset], zmm);
+                vmovdqu8(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm);
         }
     };
 
@@ -890,7 +915,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
         // retrieve output pointer
         mov(reg_out_ptr, reg_save_out_ptr);
         // calculate the shift
-        imul(reg_tmp, reg_kwp, out_w_step);
+        imul(reg_tmp, reg_kwp, static_cast<int>(out_w_step));
         // shift past the body
         add(reg_out_ptr, reg_tmp);
         // skip if no right overflow
@@ -920,7 +945,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
     // For int8, it is sufficient to zero-pad the weights only
     if (is_f32 || is_xf16) {
         // shift forward to align h index to end of needed buffer
-        imul(reg_tmp, reg_kht, out_h_step);
+        imul(reg_tmp, reg_kht, static_cast<int>(out_h_step));
         add(reg_out_ptr, reg_tmp);
         // shift backward to align w index to end of needed buffer
         sub(reg_out_ptr, out_w_step);
@@ -956,7 +981,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
     vpxord(zmm_zero, zmm_zero, zmm_zero);
 
     if (jcp.is_nspc && jcp.ic_without_padding % jcp.ic_block_int) {
-        int tail_size = jcp.ic_without_padding % jcp.ic_block_int;
+        int tail_size
+                = static_cast<int>(jcp.ic_without_padding % jcp.ic_block_int);
         uint64_t mask = (UINT64_C(1) << tail_size) - 1;
         mov(reg_tmp, mask);
         kmovq(ktail_mask, reg_tmp);
@@ -993,7 +1019,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
                 vmovups(ptr[reg_aux_out_ptr
                                 + jcp.typesize_in * iw * jcp.ic_block_int_np],
                         zmm_zero);
-            int out_h_offset = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
             add(reg_aux_out_ptr, out_h_offset);
 
             dec(reg_kh_over);
@@ -1008,12 +1035,12 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
         L(kh_label);
         {
             copy_row(icb);
-            size_t inp_h_offset = !jcp.is_nspc
-                    ? (size_t)jcp.typesize_in * jcp.iw * jcp.ic_block
-                    : (size_t)jcp.typesize_in * jcp.iw * jcp.ngroups
+            const dim_t inp_h_offset = !jcp.is_nspc
+                    ? jcp.typesize_in * jcp.iw * jcp.ic_block
+                    : jcp.typesize_in * jcp.iw * jcp.ngroups
                             * jcp.ic_without_padding;
-            size_t out_h_offset
-                    = (size_t)jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
 
             add(reg_aux_inp_ptr, inp_h_offset);
             add(reg_aux_out_ptr, out_h_offset);
@@ -1034,20 +1061,21 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
                 vmovups(ptr[reg_aux_out_ptr
                                 + jcp.typesize_in * iw * jcp.ic_block_int_np],
                         zmm_zero);
-            int out_h_offset = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
             add(reg_aux_out_ptr, out_h_offset);
 
             dec(reg_khc);
             jnz(kh_bover_label, T_NEAR);
         }
-        size_t out_d_offset = (size_t)jcp.typesize_in
+        const dim_t out_d_offset = jcp.typesize_in
                 * (jcp.ihp * jcp.iwp * jcp.ic_block_int_np + jcp.ic_block_int);
         L(no_kh_bover_label);
         if (is_3d) {
-            size_t inp_d_offset = !jcp.is_nspc
-                    ? (size_t)jcp.typesize_in * jcp.ih * jcp.iw * jcp.ic_block
+            const dim_t inp_d_offset = !jcp.is_nspc
+                    ? jcp.typesize_in * jcp.ih * jcp.iw * jcp.ic_block
                             * (jcp.dilate_d + 1)
-                    : (size_t)jcp.typesize_in * jcp.ih * jcp.iw * jcp.ngroups
+                    : jcp.typesize_in * jcp.ih * jcp.iw * jcp.ngroups
                             * jcp.ic_without_padding * (jcp.dilate_d + 1);
             pop(reg_aux_out_ptr);
             pop(reg_aux_inp_ptr);
@@ -1058,11 +1086,11 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
             L(no_kd_label);
         }
         // End IC Loop
-        size_t inp_cb_offset = !jcp.is_nspc
-                ? (size_t)jcp.typesize_in * (jcp.ic_block_int_np / jcp.ic_block)
+        const dim_t inp_cb_offset = !jcp.is_nspc
+                ? jcp.typesize_in * (jcp.ic_block_int_np / jcp.ic_block)
                         * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
-                : (size_t)jcp.typesize_in * jcp.ic_block_int_np;
-        size_t out_cb_offset = (size_t)jcp.kd * out_d_offset;
+                : jcp.typesize_in * jcp.ic_block_int_np;
+        const dim_t out_cb_offset = jcp.kd * out_d_offset;
 
         add(reg_inp_ptr, inp_cb_offset);
         add(reg_out_ptr, out_cb_offset);
@@ -1082,7 +1110,7 @@ jit_avx512_core_amx_fwd_kernel_t::jit_avx512_core_amx_fwd_kernel_t(
         const auto &rhs_addr_cache_reg = bin_injector_helper_reg_3;
         static constexpr bool preserve_gpr = false;
         static constexpr bool preserve_vmm = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {
@@ -1135,10 +1163,10 @@ int jit_avx512_core_amx_fwd_kernel_t::get_out_tensor(
     const int C_LAST = 4;
     assert(0 <= C_BASE && C_BASE < C_LAST && C_LAST <= jcp.max_tiles);
     MAYBE_UNUSED(C_LAST);
-    const int tile = C_BASE
+    const int tile = static_cast<int>(C_BASE
             + (jcp.nb_oh_blocking > 1
                             ? h * jcp.nb_oh_blocking + i
-                            : (int)is_h_tail * jcp.nb_oc_blocking + i);
+                            : (int)is_h_tail * jcp.nb_oc_blocking + i));
     assert(C_BASE <= tile && tile < C_LAST);
     return tile;
 }
@@ -1163,99 +1191,95 @@ int jit_avx512_core_amx_fwd_kernel_t::get_wei_tensor(int i) const {
 }
 
 // Shifts and offsets
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_icb_step() const {
-    return (size_t)jcp.kd * get_inp_d_step();
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_icb_step() const {
+    return jcp.kd * get_inp_d_step();
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_icb_step() const {
-    return (size_t)jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw
-            * jcp.ic_block_int_np * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_icb_step() const {
+    return jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np
+            * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_d_step() const {
-    return (size_t)jcp.typesize_in
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_d_step() const {
+    return jcp.typesize_in
             * (jcp.ihp * jcp.iwp * jcp.ic_block_int_np + jcp.ic_block_int);
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_h_step() const {
-    return (size_t)jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np
-            * (jcp.dilate_h + 1);
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_h_step() const {
+    return jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np * (jcp.dilate_h + 1);
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_d_step() const {
-    return (size_t)jcp.typesize_in * jcp.kh * jcp.kw * jcp.ic_block_int_np
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_d_step() const {
+    return jcp.typesize_in * jcp.kh * jcp.kw * jcp.ic_block_int_np
             * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_h_step() const {
-    return (size_t)jcp.typesize_in * jcp.kw * jcp.ic_block_int_np
-            * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_h_step() const {
+    return jcp.typesize_in * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_ocb_offset(
-        int ohb, int ocb, size_t typesize) const {
-    size_t el_offset = jcp.is_nspc
-            ? (size_t)ocb * jcp.oc_block
-                    + (size_t)ohb * jcp.ow * jcp.ngroups
-                            * jcp.oc_without_padding
-            : (size_t)ocb * jcp.oh * jcp.ow * jcp.oc_block
-                    + (size_t)ohb * jcp.ow * jcp.oc_block;
-    return (size_t)typesize * el_offset;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_ocb_offset(
+        dim_t ohb, dim_t ocb, dim_t typesize) const {
+    dim_t el_offset = jcp.is_nspc ? ocb * jcp.oc_block
+                    + ohb * jcp.ow * jcp.ngroups * jcp.oc_without_padding
+                                  : ocb * jcp.oh * jcp.ow * jcp.oc_block
+                    + ohb * jcp.ow * jcp.oc_block;
+    return typesize * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_row_offset(
-        int ohb, int ocb, int j, size_t typesize) const {
-    size_t offset_w = jcp.is_nspc
-            ? (size_t)typesize * j * jcp.ngroups * jcp.oc_without_padding
-            : (size_t)typesize * j * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_row_offset(
+        dim_t ohb, dim_t ocb, dim_t j, dim_t typesize) const {
+    const dim_t offset_w = jcp.is_nspc
+            ? typesize * j * jcp.ngroups * jcp.oc_without_padding
+            : typesize * j * jcp.oc_block;
     return get_out_ocb_offset(ohb, ocb, typesize) + offset_w;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_shift(
-        int width, size_t typesize) const {
-    return jcp.is_nspc
-            ? (size_t)typesize * width * jcp.ngroups * jcp.oc_without_padding
-            : (size_t)typesize * width * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_shift(
+        dim_t width, dim_t typesize) const {
+    return jcp.is_nspc ? typesize * width * jcp.ngroups * jcp.oc_without_padding
+                       : typesize * width * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_ocb_offset(
-        int ohb, int ocb) const {
-    size_t el_offset = (size_t)ocb * prv_width_ * jcp.oc_block
-            + (size_t)ohb * jcp.nb_oc_blocking * jcp.full_tile_width
-                    * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_ocb_offset(
+        dim_t ohb, dim_t ocb) const {
+    dim_t el_offset = ocb * prv_width_ * jcp.oc_block
+            + ohb * jcp.nb_oc_blocking * jcp.full_tile_width * jcp.oc_block;
     return jcp.typesize_acc * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_row_offset(
-        int ohb, int ocb, int j) const {
-    return get_wsp_ocb_offset(ohb, ocb)
-            + (size_t)jcp.typesize_acc * j * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_row_offset(
+        dim_t ohb, dim_t ocb, dim_t j) const {
+    return get_wsp_ocb_offset(ohb, ocb) + jcp.typesize_acc * j * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_shift() const {
-    return (size_t)jcp.typesize_acc * jcp.nb_oh_blocking * jcp.full_tile_width
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_shift() const {
+    return jcp.typesize_acc * jcp.nb_oh_blocking * jcp.full_tile_width
             * jcp.oc_block * jcp.nb_oc_blocking;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_offset(int ocb, int kw) const {
-    size_t el_offset = (size_t)kw * jcp.ic_block_int_np * jcp.oc_block;
-    size_t raw_oc_subblock_step
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_offset(
+        dim_t ocb, dim_t kw) const {
+    dim_t el_offset = kw * jcp.ic_block_int_np * jcp.oc_block;
+    dim_t raw_oc_subblock_step
             = jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
-    size_t oc_subblock_step = jcp.is_relo
+    dim_t oc_subblock_step = jcp.is_relo
             ? rnd_up(raw_oc_subblock_step, jcp.ic_block_int * jcp.oc_block)
             : raw_oc_subblock_step;
-    el_offset += (size_t)ocb * jcp.nb_ic_int * oc_subblock_step;
+    el_offset += ocb * jcp.nb_ic_int * oc_subblock_step;
     return jcp.typesize_in * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_shift() const {
-    size_t w_step = (jcp.is_relo ? jcp.stride_w * jcp.kh
-                                    : jcp.is_pbuffer_strided ? 1
-                                                             : jcp.stride_w)
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_shift() const {
+    const dim_t w_step
+            = (jcp.is_relo                             ? jcp.stride_w * jcp.kh
+                              : jcp.is_pbuffer_strided ? 1
+                                                       : jcp.stride_w)
             * jcp.ic_block_int_np;
-    return (size_t)jcp.typesize_in * jcp.tile_width * w_step;
+    return jcp.typesize_in * jcp.tile_width * w_step;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(int ohb, int kw) const {
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(
+        dim_t ohb, dim_t kw) const {
     if (jcp.is_relo)
         return ohb * jcp.iwp * jcp.kh * jcp.ic_block_int_np * jcp.typesize_in;
     // calculate offset by height dimension
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_stride_h = nstl::min(jcp.stride_h, gen_kh);
-    size_t el_offset = (size_t)ohb * jcp.oh_per_tile * gen_stride_h * jcp.iwp
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_stride_h = nstl::min<dim_t>(jcp.stride_h, gen_kh);
+    dim_t el_offset = ohb * jcp.oh_per_tile * gen_stride_h * jcp.iwp
             * jcp.ic_block_int_np;
 
     // add offset by width dimension
     if (IMPLICATION(jcp.is_pbuffer_strided, jcp.stride_w == 1)) {
-        el_offset += (size_t)kw * (jcp.dilate_w + 1) * jcp.ic_block_int_np;
+        el_offset += kw * (jcp.dilate_w + 1) * jcp.ic_block_int_np;
     } else if (jcp.dilate_w > 0) {
-        el_offset += (size_t)kw * jcp.ow_block * jcp.ic_block_int_np;
+        el_offset += kw * jcp.ow_block * jcp.ic_block_int_np;
     } else {
         // dilate_w == 0 && stride_w > 1
         // there are min(jcp.kw, jcp.stride_w) continuous sets of input data
@@ -1263,35 +1287,36 @@ size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(int ohb, int kw) const {
         // padding
 
         // calculate set idx for current kw value
-        int set_idx = kw % jcp.stride_w;
+        const dim_t set_idx = kw % jcp.stride_w;
         // calculate shift within set for current kw value
-        int set_shift = kw / jcp.stride_w;
+        const dim_t set_shift = kw / jcp.stride_w;
 
         // calculate the beginning of the current set along width, each set
         // with index set_i contains number of elements along width equal to
         // jcp.ow - 1 + jcp.kw / jcp.stride_w
         //     + (set_i < jcp.kw % jcp.stride_w)
-        size_t set_start = (jcp.ow_block - 1 + jcp.kw / jcp.stride_w) * set_idx
-                + nstl::min(set_idx, jcp.kw % jcp.stride_w);
+        const dim_t set_start
+                = (jcp.ow_block - 1 + jcp.kw / jcp.stride_w) * set_idx
+                + nstl::min<dim_t>(set_idx, jcp.kw % jcp.stride_w);
         el_offset += (set_start + set_shift) * jcp.ic_block_int_np;
     }
     return jcp.typesize_in * el_offset;
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::get_zp_comp_offset(
-        int ocb, int zp_h, int zp_w) const {
-    const size_t ocb_offset = (size_t)ocb * jcp.oc_block;
-    const size_t sp_offset = (size_t)(zp_h * jcp.ow_pad + zp_w) * jcp.ngroups
-            * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_zp_comp_offset(
+        dim_t ocb, dim_t zp_h, dim_t zp_w) const {
+    const dim_t ocb_offset = ocb * jcp.oc_block;
+    const dim_t sp_offset
+            = (zp_h * jcp.ow_pad + zp_w) * jcp.ngroups * jcp.oc_without_padding;
     return (ocb_offset + sp_offset) * sizeof(int32_t);
 }
 
-int jit_avx512_core_amx_fwd_kernel_t::get_zp_index_offset(
-        int index, int mid, int s_pad_output, int e_pad_output) {
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_zp_index_offset(
+        dim_t index, dim_t mid, dim_t s_pad_output, dim_t e_pad_output) {
     using namespace nstl;
-    const int mid_end = e_pad_output - 1;
-    int zp_mid = nstl::min(mid, nstl::max(0, index - mid_end));
-    int zp_pad_offset
+    const dim_t mid_end = e_pad_output - 1;
+    const dim_t zp_mid = nstl::min(mid, nstl::max<dim_t>(0, index - mid_end));
+    const dim_t zp_pad_offset
             = accum_with_upper_bound(index, s_pad_output, e_pad_output);
     return zp_pad_offset + zp_mid;
 }
@@ -1314,41 +1339,41 @@ void jit_avx512_core_amx_fwd_kernel_t::init_runtime_counters(
     is_buffer_empty_ = true;
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_block(
-        const int block_size, const int pad_output) {
-    return (size_t)(pad_output >= block_size ? block_size : 0)
+dim_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_block(
+        const dim_t block_size, const dim_t pad_output) {
+    return (pad_output >= block_size ? block_size : 0)
             + (pad_output % block_size);
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_blocked_dims(
-        const int dim_size, const int block_size, const int s_pad_output,
-        const int e_pad_output) {
+dim_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_blocked_dims(
+        const dim_t dim_size, const dim_t block_size, const dim_t s_pad_output,
+        const dim_t e_pad_output) {
     using namespace nstl;
 
     // start padding (s_pad)
-    int s_pad_limit = reduce_to_block(block_size, s_pad_output);
-    int s_pad_area_blk = rnd_up(s_pad_limit, block_size);
+    const dim_t s_pad_limit = reduce_to_block(block_size, s_pad_output);
+    const dim_t s_pad_area_blk = rnd_up(s_pad_limit, block_size);
 
     // middle (no padding)
-    int no_pad_area = nstl::max(
+    const dim_t no_pad_area = nstl::max<dim_t>(
             0, dim_size - rnd_up(s_pad_output, block_size) - e_pad_output);
-    int no_pad_limit = (no_pad_area >= block_size ? block_size : 0);
+    const dim_t no_pad_limit = (no_pad_area >= block_size ? block_size : 0);
 
     // end padding (e_pad)
-    int no_pad_area_shift = no_pad_area % block_size;
-    int e_pad_area_overlap
+    const dim_t no_pad_area_shift = no_pad_area % block_size;
+    const dim_t e_pad_area_overlap
             = no_pad_area_shift == 0 ? 0 : block_size - no_pad_area_shift;
     // middle and end padding shift
-    int e_pad_shift_limit
+    const dim_t e_pad_shift_limit
             = no_pad_area_shift + min(e_pad_output, e_pad_area_overlap);
-    int e_pad_area_blk = nstl::max(0, e_pad_output - e_pad_area_overlap);
+    const dim_t e_pad_area_blk
+            = nstl::max<dim_t>(0, e_pad_output - e_pad_area_overlap);
     // full end padding block
-    int e_pad_limit = reduce_to_block(block_size, e_pad_area_blk);
+    const dim_t e_pad_limit = reduce_to_block(block_size, e_pad_area_blk);
 
     // calculate reduced size of s_pad, middle and e_pad blocks.
-    return min((size_t)dim_size,
-            (size_t)s_pad_area_blk + no_pad_limit + e_pad_shift_limit
-                    + e_pad_limit);
+    return min(dim_size,
+            s_pad_area_blk + no_pad_limit + e_pad_shift_limit + e_pad_limit);
 }
 
 Ymm jit_avx512_core_amx_fwd_kernel_t::ymm_mask(
@@ -1406,7 +1431,7 @@ void jit_avx512_core_amx_fwd_kernel_t::apply_sum(const Zmm &zmm_out,
 
 void jit_avx512_core_amx_fwd_kernel_t::apply_postops(const Zmm &zmm_out,
         const float *p_sum_scale, const int32_t *p_sum_zp,
-        const Xbyak::Address &addr, const size_t off, const bool mask_flag) {
+        const Xbyak::Address &addr, const dim_t off, const bool mask_flag) {
     if (jcp.with_eltwise || jcp.with_binary
             || (jcp.with_sum && p_sum_scale != nullptr)) {
         apply_sum(zmm_out, p_sum_scale, p_sum_zp, addr, mask_flag);
@@ -1433,7 +1458,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_ymm_bf16(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
-        const Zmm &zmm_out, int ocb, int h, int w) {
+        const Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w) {
     const bool mask_flag = jcp.is_nspc && jcp.oc_without_padding != jcp.oc
             && ocb == (jcp.nb_oc_blocking - 1);
 
@@ -1454,7 +1479,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
         }
     }
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         if (jcp.bia_dt == data_type::bf16) {
             vpmovzxwd(zmm_mask(zmm_bias, mask_flag), bias_addr);
@@ -1476,10 +1501,10 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
-        const Zmm &zmm_out, int ocb, int h, int w, const bool compute_zp,
-        const int zp_h, const int zp_w) {
-    const int nb_oc_block = jcp.nb_oc_blocking;
-    const int oc_block = jcp.oc_block;
+        const Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w, const bool compute_zp,
+        const dim_t zp_h, const dim_t zp_w) {
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t oc_block = jcp.oc_block;
     const bool mask_flag = true && jcp.oc_without_padding != jcp.oc
             && ocb == (nb_oc_block - 1);
 
@@ -1504,7 +1529,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
     }
 
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
@@ -1514,13 +1539,13 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
         const Zmm m_zmm_zp = zmm_mask(zmm_zp, mask_flag);
         vmovups(m_zmm_zp,
                 EVEX_compress_addr(reg_zero_point_pbuff,
-                        get_zp_comp_offset(ocb, zp_h, zp_w)));
+                        static_cast<int>(get_zp_comp_offset(ocb, zp_h, zp_w))));
         const Zmm m_zmm_out = zmm_mask(zmm_out, mask_flag);
         vpaddd(m_zmm_out, zmm_out, zmm_zp);
     }
     if (jcp.src_zero_point) {
         // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-        int zp_offset = sizeof(int32_t) * ocb * oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * oc_block;
         const Zmm m_zmm_zp = zmm_mask(zmm_zp, mask_flag);
         vpmulld(m_zmm_zp, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -1540,10 +1565,11 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        const int scale_offset
+        const dim_t scale_offset
                 = jcp.is_oc_scale * (sizeof(float) * ocb * oc_block);
         vmulps(zmm_out_msk, zmm_out,
-                EVEX_compress_addr(reg_ptr_wei_scales, scale_offset,
+                EVEX_compress_addr(reg_ptr_wei_scales,
+                        static_cast<int>(scale_offset),
                         /* bcast = */ !jcp.is_oc_scale));
     }
 
@@ -1581,8 +1607,8 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector(const Zmm &zmm_out,
-        int ocb, int h, int w, const bool compute_zp, const int zp_h,
-        const int zp_w) {
+        dim_t ocb, dim_t h, dim_t w, const bool compute_zp, const dim_t zp_h,
+        const dim_t zp_w) {
     /*
     Output:
               jcp.is_nspc              !jcp.is_nspc
@@ -1597,23 +1623,25 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector(const Zmm &zmm_out,
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
-        bool do_store, const bool handle_h_blk, const int t_pad_output,
-        const int b_pad_output, const int l_pad_output, const int r_pad_output,
-        const bool is_last_oh_block, const bool zp_3d_pad) {
-    auto store_output_block
-            = [&](int width, int tail, bool do_store, bool is_last_h = false) {
+void jit_avx512_core_amx_fwd_kernel_t::store_output(dim_t width, int tail,
+        bool do_store, const bool handle_h_blk, const dim_t t_pad_output,
+        const dim_t b_pad_output, const dim_t l_pad_output,
+        const dim_t r_pad_output, const bool is_last_oh_block,
+        const bool zp_3d_pad) {
+    auto store_output_block = [&](dim_t width, int tail, bool do_store,
+                                      bool is_last_h = false) {
         // Calculate the number of oh blocks; it may differ on last call
-        const int last_h_blks
-                = div_up(jcp.oh, jcp.oh_per_tile) % jcp.nb_oh_blocking;
-        const int h_blks = is_last_h && last_h_blks != 0 ? last_h_blks
-                                                         : jcp.nb_oh_blocking;
+        const int last_h_blks = static_cast<int>(
+                div_up(jcp.oh, jcp.oh_per_tile) % jcp.nb_oh_blocking);
+        const int h_blks = is_last_h && last_h_blks != 0
+                ? last_h_blks
+                : static_cast<int>(jcp.nb_oh_blocking);
         // Calculate the number of oh rows per tile; it may differ on last call
         const int h_tail = is_last_h && jcp.oh % jcp.oh_per_tile != 0
                 ? (h_blks - 1) * jcp.oh_per_tile + jcp.oh % jcp.oh_per_tile
                 : h_blks * jcp.oh_per_tile;
-        const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
-        const int owp = gen_kw + jcp.ow - 1;
+        const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+        const dim_t owp = gen_kw + jcp.ow - 1;
 
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
@@ -1644,17 +1672,17 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
 
             for (int tw = 0; tw < width && do_store; tw++) {
                 // height
-                const int oh_index = ohb * jcp.oh_per_tile + tw / owp;
+                const dim_t oh_index = ohb * jcp.oh_per_tile + tw / owp;
                 const bool zp_h_pad
                         = oh_index < t_pad_output || oh_index >= b_pad_output;
-                const int zp_h = get_zp_index_offset(
-                        oh_index, (int)jcp.oh_mid, t_pad_output, b_pad_output);
+                const dim_t zp_h = get_zp_index_offset(
+                        oh_index, jcp.oh_mid, t_pad_output, b_pad_output);
                 // width
-                const int ow_index = tw % owp;
+                const dim_t ow_index = tw % owp;
                 const bool zp_w_pad
                         = ow_index < l_pad_output || ow_index >= r_pad_output;
-                const int zp_w = get_zp_index_offset(
-                        ow_index, (int)jcp.ow_mid, l_pad_output, r_pad_output);
+                const dim_t zp_w = get_zp_index_offset(
+                        ow_index, jcp.ow_mid, l_pad_output, r_pad_output);
 
                 const bool compute_zp = jcp.req_zero_point_buffer
                         && (zp_3d_pad || zp_w_pad || zp_h_pad);
@@ -1694,17 +1722,20 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
         }
     }
     if (do_store) {
-        add(reg_out_ptr, get_out_shift(width, jcp.typesize_out));
+        add(reg_out_ptr,
+                static_cast<int>(get_out_shift(width, jcp.typesize_out)));
         if (jcp.req_zero_point_buffer) {
-            const size_t sp_shift
+            const dim_t sp_shift
                     = accum_with_upper_bound(width, l_pad_output, r_pad_output);
-            add(reg_zero_point_pbuff, get_out_shift(sp_shift, sizeof(int32_t)));
+            add(reg_zero_point_pbuff,
+                    static_cast<int>(get_out_shift(sp_shift, sizeof(int32_t))));
         }
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
-        int const t_pad_output, int const b_pad_output, const bool zp_3d_pad) {
+void jit_avx512_core_amx_fwd_kernel_t::interleave_store(dim_t width,
+        dim_t const t_pad_output, dim_t const b_pad_output,
+        const bool zp_3d_pad) {
     for (int c = 0;
             c < jcp.per_one_pstore && !is_store_done_ && !is_buffer_empty_;
             c++) {
@@ -1719,20 +1750,20 @@ void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
                         {bin_injector_helper_reg_1, bin_injector_helper_reg_2});
 
         // height
-        const int oh_index = ohb;
+        const dim_t oh_index = ohb;
         const bool zp_h_pad
                 = oh_index < t_pad_output || oh_index >= b_pad_output;
-        const int zp_h = get_zp_index_offset(
-                oh_index, (int)jcp.oh_mid, t_pad_output, b_pad_output);
+        const dim_t zp_h = get_zp_index_offset(
+                oh_index, jcp.oh_mid, t_pad_output, b_pad_output);
         // width
-        const int l_pad_output
+        const dim_t l_pad_output
                 = w_padding.empty() ? 0 : w_padding.front().l_pad_output;
-        const int r_pad_output
+        const dim_t r_pad_output
                 = w_padding.empty() ? jcp.ow : w_padding.front().r_pad_output;
 
         const bool zp_w_pad = tw < l_pad_output || tw >= r_pad_output;
-        const int zp_w = get_zp_index_offset(
-                tw, (int)jcp.ow_mid, l_pad_output, r_pad_output);
+        const dim_t zp_w = get_zp_index_offset(
+                tw, jcp.ow_mid, l_pad_output, r_pad_output);
 
         const bool compute_zp = jcp.req_zero_point_buffer
                 && (zp_3d_pad || zp_w_pad || zp_h_pad);
@@ -1744,25 +1775,29 @@ void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
 
         if (row_count_
                 == prv_width_ * jcp.nb_oc_blocking * jcp.nb_oh_blocking) {
-            add(reg_out_ptr, get_out_shift(prv_width_, jcp.typesize_out));
+            add(reg_out_ptr,
+                    static_cast<int>(
+                            get_out_shift(prv_width_, jcp.typesize_out)));
             if (jcp.req_zero_point_buffer) {
-                const size_t sp_shift = accum_with_upper_bound(
+                const dim_t sp_shift = accum_with_upper_bound(
                         prv_width_, l_pad_output, r_pad_output);
                 add(reg_zero_point_pbuff,
-                        get_out_shift(sp_shift, sizeof(int32_t)));
+                        static_cast<int>(
+                                get_out_shift(sp_shift, sizeof(int32_t))));
                 if (!w_padding.empty()) w_padding.pop();
             }
             row_count_ = 0;
             is_store_done_ = true;
-            prv_width_ = width;
+            prv_width_ = static_cast<int>(width);
         }
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
-        bool do_store, const bool handle_h_blk, const int t_pad_output,
-        const int b_pad_output, const int l_pad_output, const int r_pad_output,
-        const bool zp_3d_pad, const bool is_last_oh_block) {
+void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(dim_t width,
+        bool do_store, const bool handle_h_blk, const dim_t t_pad_output,
+        const dim_t b_pad_output, const dim_t l_pad_output,
+        const dim_t r_pad_output, const bool zp_3d_pad,
+        const bool is_last_oh_block) {
     const bool tail = width == jcp.tile_tail;
 
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
@@ -1796,13 +1831,14 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
 
     // reduced lowering path
     if (jcp.is_relo) {
-        const int nreduce = jcp.nreduce;
-        const int stride = jcp.ic_block_int; // ie 64 (32) for int8 (bf16)
+        const dim_t nreduce = jcp.nreduce;
+        const int stride = static_cast<int>(
+                jcp.ic_block_int); // ie 64 (32) for int8 (bf16)
 
         push(reg_inp_ptr);
         push(reg_wei_ptr);
 
-        for (int ireduce = 0; ireduce < nreduce; ireduce += stride) {
+        for (dim_t ireduce = 0; ireduce < nreduce; ireduce += stride) {
             for (int ohb = 0; ohb < jcp.nb_oh_blocking; ohb++) {
                 tileloadd(Tmm(get_inp_tensor(ohb, tail)),
                         ptr[reg_inp_ptr + get_inp_offset(ohb, 0)
@@ -1821,7 +1857,9 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
             }
             if (ireduce + stride < nreduce) {
                 add(reg_inp_ptr, stride * jcp.typesize_in);
-                add(reg_wei_ptr, stride * jcp.oc_block * jcp.typesize_in);
+                add(reg_wei_ptr,
+                        static_cast<int>(
+                                stride * jcp.oc_block * jcp.typesize_in));
             }
         }
         pop(reg_wei_ptr);
@@ -1835,21 +1873,21 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
         return;
     }
 
-    auto wei_offset = [&](int icb, int ocb, int kd, int kh, int kw) {
-        return (size_t)icb * get_wei_icb_step() + kd * get_wei_d_step()
+    auto wei_offset = [&](dim_t icb, dim_t ocb, dim_t kd, dim_t kh, dim_t kw) {
+        return icb * get_wei_icb_step() + kd * get_wei_d_step()
                 + kh * get_wei_h_step() + get_wei_offset(ocb, kw);
     };
 
-    auto inp_offset = [&](int icb, int ohb, int kd, int kh, int kw) {
-        return (size_t)icb * get_inp_icb_step() + kd * get_inp_d_step()
+    auto inp_offset = [&](dim_t icb, dim_t ohb, dim_t kd, dim_t kh, dim_t kw) {
+        return icb * get_inp_icb_step() + kd * get_inp_d_step()
                 + kh * get_inp_h_step() + get_inp_offset(ohb, kw);
     };
 
     auto safe_tileloadd
-            = [this](const Tmm &t1, const Xbyak::Reg64 &reg_ptr, size_t offset,
+            = [this](const Tmm &t1, const Xbyak::Reg64 &reg_ptr, dim_t offset,
                       const Xbyak::Reg64 &reg_stride) {
         if (offset <= INT32_MAX) {
-            tileloadd(t1, ptr[reg_ptr + offset + reg_stride]);
+            tileloadd(t1, ptr[reg_ptr + static_cast<int>(offset) + reg_stride]);
         } else {
             safe_add(reg_ptr, offset, reg_tmp);
             tileloadd(t1, ptr[reg_ptr + reg_stride]);
@@ -1864,24 +1902,24 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
         Label kd_skip_compute;
         if (check_kd_padding) mov(reg_kd, ptr[param1 + GET_OFF(kd_padding)]);
 
-        for (int kd = 0; kd < jcp.kd; kd++) {
+        for (dim_t kd = 0; kd < jcp.kd; kd++) {
             if (check_kd_padding) {
                 dec(reg_kd);
                 jl(kd_skip_compute, T_NEAR);
                 push(reg_kd);
             }
-            for (int kh = 0; kh < jcp.kh; kh++) {
-                for (int set_idx = 0; set_idx < jcp.n_stride_sets;
+            for (dim_t kh = 0; kh < jcp.kh; kh++) {
+                for (dim_t set_idx = 0; set_idx < jcp.n_stride_sets;
                         set_idx++) { // used to optimize input memory reuse in L1$
-                    for (int kw = set_idx; kw < jcp.kw; kw += jcp.kw_step) {
+                    for (dim_t kw = set_idx; kw < jcp.kw; kw += jcp.kw_step) {
                         for (int ohb = 0; ohb < jcp.nb_oh_blocking; ohb++) {
-                            const size_t inp_off
+                            const dim_t inp_off
                                     = inp_offset(icb, ohb, kd, kh, kw);
                             safe_tileloadd(Tmm(get_inp_tensor(ohb, tail)),
                                     reg_inp_ptr, inp_off, reg_inp_stride);
                         }
                         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-                            const size_t wei_off
+                            const dim_t wei_off
                                     = wei_offset(icb, ocb, kd, kh, kw);
                             safe_tileloadd(Tmm(get_wei_tensor(ocb)),
                                     reg_wei_ptr, wei_off, reg_wei_stride);
@@ -1908,15 +1946,15 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
     add(reg_inp_ptr, get_inp_shift());
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
-        bool do_store, const int l_pad_output, const int r_pad_output,
+void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(dim_t width,
+        bool do_store, const dim_t l_pad_output, const dim_t r_pad_output,
         const bool zp_3d_pad) {
     if (jcp.req_zero_point_buffer
             && (jcp.t_pad_output > 0 || jcp.b_pad_output > 0)) {
-        const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
-        const size_t height_limit = reduce_to_blocked_dims(
+        const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+        const dim_t height_limit = reduce_to_blocked_dims(
                 jcp.oh, oh_step_size, jcp.t_pad_output, jcp.b_pad_output);
-        const int ur_h = div_up(height_limit, oh_step_size);
+        const int ur_h = static_cast<int>(div_up(height_limit, oh_step_size));
         assert(6 >= ur_h);
 
         // Use a jump-table to execute the corresponding block
@@ -1939,8 +1977,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
         const bool local_is_buffer_empty = is_buffer_empty_;
 
         // Unroll ow_block with regards to l_pad_output and r_pad_output
-        int cur_t_pad = reduce_to_block(oh_step_size, jcp.t_pad_output);
-        int cur_b_pad = height_limit
+        dim_t cur_t_pad = reduce_to_block(oh_step_size, jcp.t_pad_output);
+        dim_t cur_b_pad = height_limit
                 - reduce_to_block(oh_step_size, jcp.b_pad_output);
         for (int u = 0; u < ur_h; u++) {
             bool last = u == ur_h - 1;
@@ -1953,8 +1991,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
             is_buffer_empty_ = local_is_buffer_empty;
             compute_icb_loop(width, do_store, false, cur_t_pad, cur_b_pad,
                     l_pad_output, r_pad_output, zp_3d_pad, last);
-            cur_t_pad = nstl::max(0, cur_t_pad - oh_step_size);
-            cur_b_pad = nstl::max(0, cur_b_pad - oh_step_size);
+            cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step_size);
+            cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step_size);
             if (!last) jmp(h_blk_end_label, T_NEAR);
         }
         L(h_blk_end_label);
@@ -1964,8 +2002,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(int width,
-        bool do_store, const int l_pad_output, const int r_pad_output) {
+void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(dim_t width,
+        bool do_store, const dim_t l_pad_output, const dim_t r_pad_output) {
     if (jcp.req_zero_point_buffer && (jcp.f_pad > 0 || jcp.back_pad > 0)) {
         Label compute_3d_zp_label, zp_d_end_label;
         mov(reg_kd, ptr[param1 + GET_OFF(kd_padding)]);
@@ -1995,18 +2033,21 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(int width,
 
 void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
     auto compute_ow_loop_body
-            = [this](bool last_owb, int num_tile_blocks, const int l_pad_output,
-                      const int r_pad_output) {
-        int cur_l_pad_output = l_pad_output;
-        int cur_r_pad_output = r_pad_output;
-        int gen_tile_tail = last_owb && jcp.tile_tail > 0 ? jcp.tile_tail
-                                                          : jcp.tile_width;
+            = [this](bool last_owb, int num_tile_blocks,
+                      const dim_t l_pad_output, const dim_t r_pad_output) {
+        dim_t cur_l_pad_output = l_pad_output;
+        dim_t cur_r_pad_output = r_pad_output;
+        const dim_t gen_tile_tail = last_owb && jcp.tile_tail > 0
+                ? jcp.tile_tail
+                : jcp.tile_width;
         init_runtime_counters(last_owb && num_tile_blocks == 1);
         for (int owb = 0; owb < num_tile_blocks - 1; owb++) {
             dispatch_zp_3d_compute(
                     jcp.tile_width, false, cur_l_pad_output, cur_r_pad_output);
-            cur_l_pad_output = nstl::max(0, cur_l_pad_output - jcp.tile_width);
-            cur_r_pad_output = nstl::max(0, cur_r_pad_output - jcp.tile_width);
+            cur_l_pad_output
+                    = nstl::max<dim_t>(0, cur_l_pad_output - jcp.tile_width);
+            cur_r_pad_output
+                    = nstl::max<dim_t>(0, cur_r_pad_output - jcp.tile_width);
         }
         dispatch_zp_3d_compute(
                 gen_tile_tail, true, cur_l_pad_output, cur_r_pad_output);
@@ -2014,23 +2055,24 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
 
     assert(jcp.nb_ow > 0);
     if (jcp.nb_ow == 1) {
-        const int ow_r_pad_start
-                = nstl::max(jcp.ow - jcp.r_pad_output, jcp.l_pad_output);
-        compute_ow_loop_body(
-                true, jcp.ow_blocks, jcp.l_pad_output, ow_r_pad_start);
+        const dim_t ow_r_pad_start
+                = nstl::max<dim_t>(jcp.ow - jcp.r_pad_output, jcp.l_pad_output);
+        compute_ow_loop_body(true, static_cast<int>(jcp.ow_blocks),
+                jcp.l_pad_output, ow_r_pad_start);
     } else if (jcp.req_zero_point_buffer
             && (jcp.l_pad_output > 0 || jcp.r_pad_output > 0)) {
 
-        const size_t zp_addr_shift
+        const dim_t zp_addr_shift
                 = jcp.ngroups * jcp.oc_without_padding * sizeof(int32_t);
-        const int ow_step_size = jcp.ow_block;
-        const int ow_blocks_per_call = div_up(ow_step_size, jcp.tile_width);
+        const int ow_step_size = static_cast<int>(jcp.ow_block);
+        const int ow_blocks_per_call
+                = static_cast<int>(div_up(ow_step_size, jcp.tile_width));
         const int last_owb_tile_blocks = jcp.ow_blocks % ow_blocks_per_call == 0
                 ? ow_blocks_per_call
                 : jcp.ow_blocks % ow_blocks_per_call;
-        const int width_limit = reduce_to_blocked_dims(
+        const dim_t width_limit = reduce_to_blocked_dims(
                 jcp.ow, ow_step_size, jcp.l_pad_output, jcp.r_pad_output);
-        const int ur_w = div_up(width_limit, ow_step_size);
+        const int ur_w = static_cast<int>(div_up(width_limit, ow_step_size));
         assert(6 >= ur_w);
         // Use a jump-table to execute the corresponding block
         Label w_blk_label[6], w_blk_end_label, jmp_table_label;
@@ -2046,21 +2088,23 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
         }
 
         // Unroll ow_block with regards to l_pad_output and r_pad_output
-        int cur_l_pad = reduce_to_block(ow_step_size, jcp.l_pad_output);
-        int cur_r_pad
+        dim_t cur_l_pad = reduce_to_block(ow_step_size, jcp.l_pad_output);
+        dim_t cur_r_pad
                 = width_limit - reduce_to_block(ow_step_size, jcp.r_pad_output);
-        int zp_offset = 0;
+        dim_t zp_offset = 0;
         for (int u = 0; u < ur_w; u++) {
             const bool last = u == ur_w - 1;
             L(w_blk_label[u]);
-            if (u > 0) add(reg_zero_point_pbuff, zp_offset * zp_addr_shift);
+            if (u > 0)
+                add(reg_zero_point_pbuff,
+                        static_cast<int>(zp_offset * zp_addr_shift));
             compute_ow_loop_body(last,
                     last ? last_owb_tile_blocks : ow_blocks_per_call, cur_l_pad,
                     cur_r_pad);
             zp_offset += accum_with_upper_bound(
                     ow_step_size, cur_l_pad, cur_r_pad);
-            cur_l_pad = nstl::max(0, cur_l_pad - ow_step_size);
-            cur_r_pad = nstl::max(0, cur_r_pad - ow_step_size);
+            cur_l_pad = nstl::max<dim_t>(0, cur_l_pad - ow_step_size);
+            cur_r_pad = nstl::max<dim_t>(0, cur_r_pad - ow_step_size);
             if (!last) jmp(w_blk_end_label, T_NEAR);
         }
         L(w_blk_end_label);
@@ -2068,7 +2112,8 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
     } else {
         assert(jcp.oh_per_tile == 1);
         Label label_done;
-        int ow_blocks_per_call = utils::div_up(jcp.ow_block, jcp.tile_width);
+        int ow_blocks_per_call
+                = static_cast<int>(utils::div_up(jcp.ow_block, jcp.tile_width));
         int last_owb_tile_blocks = jcp.ow_blocks % ow_blocks_per_call;
         if (last_owb_tile_blocks == 0 && jcp.tile_tail > 0)
             last_owb_tile_blocks = ow_blocks_per_call;
@@ -2102,11 +2147,11 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
 
-    const int fac = jcp.is_relo      ? jcp.stride_w * jcp.kh
+    const dim_t fac = jcp.is_relo    ? jcp.stride_w * jcp.kh
             : jcp.is_pbuffer_strided ? 1
                                      : jcp.stride_w;
-    const int inp_stride = fac * jcp.ic_block_int_np * jcp.typesize_in;
-    const int wei_stride = jcp.oc_block * jcp.typesize_acc;
+    const dim_t inp_stride = fac * jcp.ic_block_int_np * jcp.typesize_in;
+    const dim_t wei_stride = jcp.oc_block * jcp.typesize_acc;
     mov(reg_inp_stride, inp_stride);
     mov(reg_wei_stride, wei_stride);
 
@@ -2115,8 +2160,8 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
         // loads / stores with block index
         // ocb = occ * jcp.nb_oc_blocking + (jcp.nb_oc_blocking - 1)
         // TODO: use masked loads / stores for the last occ only
-        int current_block_size = jcp.oc_block;
-        int mask = (1 << current_block_size) - 1;
+        dim_t current_block_size = jcp.oc_block;
+        int mask = (1 << static_cast<int>(current_block_size)) - 1;
         Xbyak::Reg32 regw_tmp = reg_tmp.cvt32();
         mov(regw_tmp, mask);
         kmovw(ktail_mask, regw_tmp);
@@ -2126,7 +2171,7 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
         jne(mask_is_set, T_NEAR);
         // Reset the mask
         current_block_size = jcp.oc_without_padding % jcp.oc_block;
-        mask = (1 << current_block_size) - 1;
+        mask = (1 << static_cast<int>(current_block_size)) - 1;
         mov(regw_tmp, mask);
         kmovw(ktail_mask, regw_tmp);
 
@@ -2143,11 +2188,12 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
 void jit_avx512_core_amx_fwd_kernel_t::tile_configure(char *tcfg_buff) {
     const int vnni_width = jcp.src_dt == data_type::bf16 ? 2 : 4;
     // Input tile dimensions
-    const int a_col = jcp.is_relo ? jcp.ic_block_int
-                                  : jcp.ic_block_int_np * jcp.kw_per_tile;
+    const int a_col = static_cast<int>(jcp.is_relo
+                    ? jcp.ic_block_int
+                    : jcp.ic_block_int_np * jcp.kw_per_tile);
     // Weights tile dimensions
-    const int b_col = jcp.oc_block * vnni_width;
-    const int b_row = a_col / vnni_width;
+    const dim_t b_col = jcp.oc_block * vnni_width;
+    const dim_t b_row = a_col / vnni_width;
     // Accumulator tile dimensions
     const int c_col = 16;
 
@@ -2181,7 +2227,8 @@ void jit_avx512_core_amx_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                     c_col * jcp.typesize_acc);
     }
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::set_oh_blk_limits(jit_conv_conf_t &jcp) {
@@ -2196,31 +2243,33 @@ void jit_avx512_core_amx_fwd_kernel_t::set_oh_blk_limits(jit_conv_conf_t &jcp) {
     if (jcp.req_zero_point_buffer && calculate_oh_limits) {
 
         int limit_idx = 0;
-        const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+        const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
 
         // full t_pad output block
-        const int t_pad_blk_end = rnd_dn(jcp.t_pad_output, oh_step_size);
+        const dim_t t_pad_blk_end = rnd_dn(jcp.t_pad_output, oh_step_size);
         if (jcp.t_pad_output >= oh_step_size) {
             jcp.h_blk_limits[limit_idx++] = t_pad_blk_end;
         }
         // t_pad output overlap with no padding
-        const int t_pad_shift = jcp.t_pad_output % oh_step_size;
+        const dim_t t_pad_shift = jcp.t_pad_output % oh_step_size;
         if (t_pad_shift != 0) {
             jcp.h_blk_limits[limit_idx++] = t_pad_blk_end + t_pad_shift;
         }
-        const int t_pad_next_blk = rnd_up(jcp.t_pad_output, oh_step_size);
-        const int oh_blk_tail = jcp.oh % oh_step_size;
-        const int b_pad_no_tail = nstl::max(0, jcp.b_pad_output - oh_blk_tail);
-        const int b_pad_start
-                = nstl::max(jcp.t_pad_output, jcp.oh - jcp.b_pad_output);
-        const int b_pad_blk_start = rnd_dn(b_pad_start, oh_step_size);
+        const dim_t t_pad_next_blk = rnd_up(jcp.t_pad_output, oh_step_size);
+        const dim_t oh_blk_tail = jcp.oh % oh_step_size;
+        const dim_t b_pad_no_tail
+                = nstl::max<dim_t>(0, jcp.b_pad_output - oh_blk_tail);
+        const dim_t b_pad_start
+                = nstl::max<dim_t>(jcp.t_pad_output, jcp.oh - jcp.b_pad_output);
+        const dim_t b_pad_blk_start = rnd_dn(b_pad_start, oh_step_size);
         // middle block without padding
-        const int mid_blk = nstl::max(0, b_pad_blk_start - t_pad_next_blk);
+        const dim_t mid_blk
+                = nstl::max<dim_t>(0, b_pad_blk_start - t_pad_next_blk);
         if (mid_blk >= oh_step_size) {
             jcp.h_blk_limits[limit_idx++] = b_pad_blk_start;
         }
         // no padding with b_pad overlap
-        const int b_pad_shift = b_pad_no_tail % oh_step_size;
+        const dim_t b_pad_shift = b_pad_no_tail % oh_step_size;
         if (b_pad_shift != 0) {
             jcp.h_blk_limits[limit_idx++] = rnd_up(b_pad_start, oh_step_size);
         }
@@ -2241,7 +2290,7 @@ void jit_avx512_core_amx_fwd_kernel_t::set_ow_blk_limits(jit_conv_conf_t &jcp) {
     const bool calculate_ow_limits
             = jcp.nb_ow > 1 && (jcp.l_pad_output > 0 || jcp.r_pad_output > 0);
     if (jcp.req_zero_point_buffer && calculate_ow_limits) {
-        const int ow_step_size = jcp.ow_block;
+        const int ow_step_size = static_cast<int>(jcp.ow_block);
 
         // l_pad
         const int l_pad_limit
@@ -2251,16 +2300,16 @@ void jit_avx512_core_amx_fwd_kernel_t::set_ow_blk_limits(jit_conv_conf_t &jcp) {
         jcp.l_pad_blk = div_up(l_pad_limit, ow_step_size);
 
         // middle (area without padding)
-        const int no_pad_area
-                = nstl::max(0, jcp.ow - l_pad_area_blk - jcp.r_pad_output);
+        const int no_pad_area = static_cast<int>(nstl::max<dim_t>(
+                0, jcp.ow - l_pad_area_blk - jcp.r_pad_output));
         jcp.no_pad_w_blk = no_pad_area >= ow_step_size ? 1 : 0;
 
         // r_pad
         const int no_pad_area_shift = no_pad_area % ow_step_size;
         const int r_pad_area_overlap
                 = no_pad_area_shift == 0 ? 0 : ow_step_size - no_pad_area_shift;
-        const int r_pad_area
-                = nstl::max(0, jcp.r_pad_output - r_pad_area_overlap);
+        const int r_pad_area = static_cast<int>(
+                nstl::max<dim_t>(0, jcp.r_pad_output - r_pad_area_overlap));
         const int r_pad_limit = (r_pad_area >= ow_step_size ? ow_step_size : 0)
                 + (r_pad_area % ow_step_size);
         jcp.r_pad_blk = (r_pad_area_overlap > 0 ? 1 : 0)
@@ -2336,9 +2385,9 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = !is_1d ? cd.dilates[ndims - 4] : 0;
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, gen_kd);
     jcp.b_pad = calculate_end_padding(
@@ -2459,7 +2508,8 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             args_ok, VERBOSE_BLOCKING_FAIL, "bad blocking dimensions");
 
     const int vnni_width = is_bf16_convolution ? 2 : 4;
-    jcp.ic_block_int = jcp.ic_block * vnni_width; // 32 for bf16, 64 for int8
+    jcp.ic_block_int = jcp.ic_block * vnni_width;
+    // 32 for bf16, 64 for int8
 
     // fallback to non-amx impl when accumulation is too small
     const dim_t total_k = static_cast<dim_t>(jcp.ic_without_padding) * jcp.kd
@@ -2470,7 +2520,7 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // small-ic parameters
     jcp.ic_block_int_np = jcp.is_nspc
-            ? nstl::min(jcp.ic_block_int, jcp.ic_without_padding)
+            ? nstl::min<dim_t>(jcp.ic_block_int, jcp.ic_without_padding)
             : jcp.ic_block_int;
     bool is_small_ic = jcp.ic_block_int_np < jcp.ic_block_int;
 
@@ -2586,10 +2636,13 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -2613,19 +2666,20 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const bool ok_to_pack_tile = !jcp.is_relo
             && (utils::everyone_is(1, jcp.kh, jcp.kw)
                     || utils::everyone_is(1, jcp.stride_h, jcp.stride_w));
-    const int max_oh_per_tile
-            = 1 + (jcp.full_tile_width - jcp.ow) / (jcp.ow + gen_kw - 1);
+    const int max_oh_per_tile = static_cast<int>(
+            1 + (jcp.full_tile_width - jcp.ow) / (jcp.ow + gen_kw - 1));
     jcp.oh_per_tile = ok_to_pack_tile
-            ? nstl::min(jcp.oh, nstl::max(1, max_oh_per_tile))
+            ? static_cast<int>(
+                      nstl::min<dim_t>(jcp.oh, nstl::max(1, max_oh_per_tile)))
             : 1;
-    jcp.tile_width = nstl::min<int>(
-            jcp.full_tile_width, calculate_tile_width(jcp.oh_per_tile));
+    jcp.tile_width = static_cast<int>(nstl::min<dim_t>(
+            jcp.full_tile_width, calculate_tile_width(jcp.oh_per_tile)));
     jcp.ow_blocks = utils::div_up(jcp.ow, jcp.tile_width);
 
     // Prefer to use a single tile width when possible
     // (eg ow28 => 2 tiles of 14 vs 1 of 16 and 1 of 12)
     if (jcp.oh_per_tile == 1 && jcp.ow % jcp.ow_blocks == 0)
-        jcp.tile_width = jcp.ow / jcp.ow_blocks;
+        jcp.tile_width = static_cast<int>(jcp.ow / jcp.ow_blocks);
     jcp.tile_tail = jcp.oh_per_tile == 1 ? jcp.ow % jcp.tile_width : 0;
 
     jcp.nb_oc_blocking = (jcp.nb_oc % 2 == 0) ? 2 : 1;
@@ -2643,20 +2697,23 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // TODO: tune oh blocking
     const int oh_blk_size_param = jcp.is_relo ? 1 : 10;
-    const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+    const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
     const int oh_blk_size = rnd_up(oh_blk_size_param, oh_step_size);
-    jcp.oh_blk_size = rnd_up(nstl::min(jcp.oh, oh_blk_size), oh_step_size);
+    jcp.oh_blk_size
+            = rnd_up(nstl::min<dim_t>(jcp.oh, oh_blk_size), oh_step_size);
     // Here ihp means the input buffer height including padding (ie the number
     // of input rows required for computation of jcp.oh_blk_size output rows.
     // If an input row doesn't participate in the computation of any output row,
     // it isn't copied to the buffer at all (eg jcp.stride_h > gen_kh).
     jcp.ihp = jcp.is_relo
             ? jcp.oh_blk_size
-            : (jcp.oh_blk_size - 1) * nstl::min(jcp.stride_h, gen_kh) + gen_kh;
+            : (jcp.oh_blk_size - 1) * nstl::min<dim_t>(jcp.stride_h, gen_kh)
+                    + gen_kh;
 
     // TODO: tune ow blocking
     const int ow_blocks_per_call = jcp.is_relo ? 10 : 2;
-    jcp.ow_block = nstl::min(jcp.ow, jcp.tile_width * ow_blocks_per_call);
+    jcp.ow_block
+            = nstl::min<dim_t>(jcp.ow, jcp.tile_width * ow_blocks_per_call);
     jcp.nb_ow = utils::div_up(jcp.ow, jcp.ow_block);
     // iwp includes all width elements that are really used in calculation
     // including left and right zero padding
@@ -2669,9 +2726,9 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // Number of ops per tile store
     int ops_tile_store = jcp.tile_width;
     // Number of ops per accumulation tile
-    int avaliable_ops = jcp.is_relo
-            ? utils::div_up(jcp.nreduce, jcp.ic_block_int)
-            : jcp.nb_ic_int * jcp.kh * (jcp.kw / jcp.kw_per_tile);
+    const int avaliable_ops = static_cast<int>(jcp.is_relo
+                    ? utils::div_up(jcp.nreduce, jcp.ic_block_int)
+                    : jcp.nb_ic_int * jcp.kh * (jcp.kw / jcp.kw_per_tile));
     // Number of vectors to store per tile operation
     // NOTE: set to zero to turn off interleave store (mostly for debugging)
     jcp.per_one_pstore = utils::div_up(ops_tile_store, avaliable_ops);
@@ -2701,24 +2758,25 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.with_dst_scales = !attr.scales_.get(DNNL_ARG_DST).has_default_values();
 
     // Note: currently unsupported, results in seg-fault
-    const int l_pad_output
-            = nstl::min(jcp.ow, div_up(nstl::max(0, jcp.l_pad), jcp.stride_w));
+    const dim_t l_pad_output = nstl::min<dim_t>(
+            jcp.ow, div_up(nstl::max<dim_t>(0, jcp.l_pad), jcp.stride_w));
     VDISPATCH_CONV_IC(!(!jcp.is_relo && (l_pad_output > jcp.ow_block)),
             VERBOSE_BLOCKING_FAIL, "bad padding dimensions for blocking");
 
     // Relevant to 'zero_point padding buffer' (pbuff) jit kernel
     if (jcp.req_zero_point_buffer) {
         auto calculate_output_padding_dims
-                = [](int o_dim, int s_pad, int e_pad, int &s_pad_output,
-                          int &e_pad_output, bool &o_mid, int &o_pad,
-                          int stride, bool req_mid_area) {
-            s_pad_output
-                    = nstl::min(o_dim, div_up(nstl::max(0, s_pad), stride));
-            e_pad_output
-                    = nstl::min(o_dim, div_up(nstl::max(0, e_pad), stride));
+                = [](dim_t o_dim, dim_t s_pad, dim_t e_pad, dim_t &s_pad_output,
+                          dim_t &e_pad_output, bool &o_mid, dim_t &o_pad,
+                          dim_t stride, bool req_mid_area) {
+            s_pad_output = nstl::min<dim_t>(
+                    o_dim, div_up(nstl::max<dim_t>(0, s_pad), stride));
+            e_pad_output = nstl::min<dim_t>(
+                    o_dim, div_up(nstl::max<dim_t>(0, e_pad), stride));
             o_mid = (o_dim - s_pad_output - e_pad_output > 0) && req_mid_area;
-            o_pad = nstl::min(o_dim,
-                    nstl::max(1, s_pad_output + e_pad_output + (int)o_mid));
+            o_pad = nstl::min<dim_t>(o_dim,
+                    nstl::max<dim_t>(
+                            1, s_pad_output + e_pad_output + (dim_t)o_mid));
         };
 
         const bool mid_w_area = (jcp.l_pad > 0 || jcp.r_pad > 0)
@@ -2786,7 +2844,7 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_scratchpad(
         scratchpad.book(key_conv_zero_point_pad,
                 (size_t)nthr * jcp.zp_pbuff_size, sizeof(int32_t));
         if (!jcp.zp_pbuff_outer_compute) {
-            const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+            const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
             scratchpad.book<bool>(key_conv_zero_point_flag,
                     (size_t)jcp.nthr * oc_chunks * jcp.ngroups);
         }
@@ -2815,30 +2873,30 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
 
     const bool is_xf16
             = utils::one_of(jcp.ddst_dt, data_type::bf16, data_type::f16);
-    const int inp_w_step
+    const dim_t inp_w_step
             = jcp.ngroups * jcp.oc_without_padding * jcp.typesize_in;
-    const int inp_h_step = jcp.ow * inp_w_step;
-    const int out_w_step = jcp.oc_block_int * jcp.typesize_in;
-    const int out_h_step = jcp.owp * out_w_step;
+    const dim_t inp_h_step = jcp.ow * inp_w_step;
+    const dim_t out_w_step = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t out_h_step = jcp.owp * out_w_step;
 
-    auto zero_it = [this, is_xf16](reg64_t tmp_out_ptr, int offset) {
+    auto zero_it = [this, is_xf16](reg64_t tmp_out_ptr, dim_t offset) {
         // no mask as output is a padded buffer
         if (is_xf16)
-            vmovdqu16(ptr[tmp_out_ptr + offset], zmm_zero);
+            vmovdqu16(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm_zero);
         else
-            vmovdqu8(ptr[tmp_out_ptr + offset], zmm_zero);
+            vmovdqu8(ptr[tmp_out_ptr + static_cast<int>(offset)], zmm_zero);
     };
 
-    auto copy_it = [this, is_masked, is_xf16](reg64_t tmp_inp_ptr, int inp_off,
-                           reg64_t tmp_out_ptr, int out_off) {
+    auto copy_it = [this, is_masked, is_xf16](reg64_t tmp_inp_ptr,
+                           dim_t inp_off, reg64_t tmp_out_ptr, dim_t out_off) {
         Zmm zmm_load = is_masked ? zmm_tmp | ktail_mask | T_z : zmm_tmp;
         Zmm zmm_stor = zmm_tmp; // no mask as output is padded buffer
         if (is_xf16) {
-            vmovdqu16(zmm_load, ptr[tmp_inp_ptr + inp_off]);
-            vmovdqu16(ptr[tmp_out_ptr + out_off], zmm_stor);
+            vmovdqu16(zmm_load, ptr[tmp_inp_ptr + static_cast<int>(inp_off)]);
+            vmovdqu16(ptr[tmp_out_ptr + static_cast<int>(out_off)], zmm_stor);
         } else {
-            vmovdqu8(zmm_load, ptr[tmp_inp_ptr + inp_off]);
-            vmovdqu8(ptr[tmp_out_ptr + out_off], zmm_stor);
+            vmovdqu8(zmm_load, ptr[tmp_inp_ptr + static_cast<int>(inp_off)]);
+            vmovdqu8(ptr[tmp_out_ptr + static_cast<int>(out_off)], zmm_stor);
         }
     };
 
@@ -2851,7 +2909,7 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
         L(label_tov_loop);
         {
             for (int ow = 0; ow < jcp.owp; ow++) {
-                const int offset = ow * out_w_step;
+                const dim_t offset = ow * out_w_step;
                 zero_it(reg_ptr_aux_out, offset);
             }
             add(reg_ptr_aux_out, out_h_step);
@@ -2912,10 +2970,11 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
                     jz(label_kwp_skip, T_NEAR);
                     // Handle Dilation-by-Stride
                     for (int sw = 0; sw < jcp.stride_w - 1; sw++) {
-                        const int offset = sw * out_w_step;
+                        const dim_t offset = sw * out_w_step;
                         zero_it(reg_ptr_aux_out, offset);
                     }
-                    add(reg_ptr_aux_out, (jcp.stride_w - 1) * out_w_step);
+                    add(reg_ptr_aux_out,
+                            static_cast<int>((jcp.stride_w - 1) * out_w_step));
                     if (jcp.stride_w == 2)
                         dec(reg_cnt_tmp);
                     else
@@ -2952,11 +3011,12 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
             // Handle Dilation-by-Stride
             for (int sh = 0; sh < jcp.stride_h - 1; sh++) {
                 for (int ow = 0; ow < jcp.owp; ow++) {
-                    const int offset = sh * out_h_step + ow * out_w_step;
+                    const dim_t offset = sh * out_h_step + ow * out_w_step;
                     zero_it(reg_ptr_aux_out, offset);
                 }
             }
-            add(reg_ptr_aux_out, (jcp.stride_h - 1) * out_h_step);
+            add(reg_ptr_aux_out,
+                    static_cast<int>((jcp.stride_h - 1) * out_h_step));
             if (jcp.stride_h == 2)
                 dec(reg_cnt_khp);
             else
@@ -2978,7 +3038,7 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
         L(label_bov_loop);
         {
             for (int ow = 0; ow < jcp.owp; ow++) {
-                const int offset = ow * out_w_step;
+                const dim_t offset = ow * out_w_step;
                 zero_it(reg_ptr_aux_out, offset);
             }
             add(reg_ptr_aux_out, out_h_step);
@@ -3010,11 +3070,10 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::kd_loop(bool is_masked) {
     copy_row(is_masked);
 
     if (is_3d) {
-        const size_t inp_d_offset = static_cast<size_t>(jcp.typesize_in)
-                * (jcp.dilate_d + 1) * jcp.oh * jcp.ow * jcp.ngroups
-                * jcp.oc_without_padding;
-        const size_t out_d_offset = static_cast<size_t>(jcp.typesize_in)
-                * jcp.ohp * jcp.owp * jcp.oc_block_int;
+        const dim_t inp_d_offset = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.oh
+                * jcp.ow * jcp.ngroups * jcp.oc_without_padding;
+        const dim_t out_d_offset
+                = jcp.typesize_in * jcp.ohp * jcp.owp * jcp.oc_block_int;
         pop(reg_ptr_aux_inp_h);
         pop(reg_ptr_aux_out);
         sub(reg_ptr_aux_inp_h, inp_d_offset);
@@ -3028,10 +3087,10 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::kd_loop(bool is_masked) {
 
 void jit_avx512_core_amx_bwd_data_copy_kernel_t::generate() {
 
-    const int inp_c_step = jcp.oc_block_int * jcp.typesize_in;
-    const int out_c_step = jcp.kd * jcp.ohp * jcp.owp * inp_c_step;
-    const int nb_oc_int_no_tail = jcp.oc_without_padding / jcp.oc_block_int;
-    const int oc_block_int_tail = jcp.oc_without_padding % jcp.oc_block_int;
+    const dim_t inp_c_step = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t out_c_step = jcp.kd * jcp.ohp * jcp.owp * inp_c_step;
+    const dim_t nb_oc_int_no_tail = jcp.oc_without_padding / jcp.oc_block_int;
+    const dim_t oc_block_int_tail = jcp.oc_without_padding % jcp.oc_block_int;
 
     preamble();
 
@@ -3091,7 +3150,7 @@ int jit_avx512_core_amx_bwd_data_kernel_t::get_out_tensor(int h, int i) const {
     const int C_LAST = 4;
     assert(0 <= C_BASE && C_BASE < C_LAST && C_LAST <= jcp.max_tiles);
     MAYBE_UNUSED(C_LAST);
-    const int tile = C_BASE + h * jcp.nb_ih_blocking + i;
+    const int tile = static_cast<int>(C_BASE + h * jcp.nb_ih_blocking + i);
     assert(C_BASE <= tile && tile < C_LAST);
     return tile;
 }
@@ -3118,85 +3177,80 @@ int jit_avx512_core_amx_bwd_data_kernel_t::get_wei_tensor(int i) const {
 // - inp is a padded buffer ~ [nb_oc_int][kd][ohp][owp]{32c,64c}
 // - weights is user buffer ~ OIdhw16o16i{2o,4o}
 // - output is tiled buffer ~ [NBIH][NBIC][tile_width][16c]
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_ocb_step() const {
-    return (size_t)jcp.typesize_in * jcp.kd * jcp.ohp * jcp.owp
-            * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_ocb_step() const {
+    return jcp.typesize_in * jcp.kd * jcp.ohp * jcp.owp * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_shift() const {
-    return (size_t)jcp.typesize_in * jcp.tile_width * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_shift() const {
+    return jcp.typesize_in * jcp.tile_width * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_d_step() const {
-    return static_cast<size_t>(jcp.typesize_in) * jcp.ohp * jcp.owp
-            * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_d_step() const {
+    return jcp.typesize_in * jcp.ohp * jcp.owp * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_offset(
-        int ihb, int kh, int kw) const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_offset(
+        dim_t ihb, dim_t kh, dim_t kw) const {
     // calculate offset by src height dimension
-    size_t sp_offset = (size_t)ihb * jcp.owp;
+    dim_t sp_offset = ihb * jcp.owp;
     // add offset by kernel height dimension
-    sp_offset += (size_t)(jcp.kh - 1 - kh) * (jcp.dilate_h + 1) * jcp.owp;
+    sp_offset += (jcp.kh - 1 - kh) * (jcp.dilate_h + 1) * jcp.owp;
     // add offset by kernel width dimension
-    sp_offset += (size_t)(jcp.kw - 1 - kw) * (jcp.dilate_w + 1);
+    sp_offset += (jcp.kw - 1 - kw) * (jcp.dilate_w + 1);
     return jcp.typesize_in * sp_offset * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_kh_step() const {
-    return (size_t)jcp.typesize_in * jcp.kw * jcp.oc_block_int * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_kh_step() const {
+    return jcp.typesize_in * jcp.kw * jcp.oc_block_int * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_ocb_step() const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_ocb_step() const {
     const bool is_deconv = jcp.prop_kind != prop_kind::backward_data;
-    return (size_t)jcp.typesize_in * (is_deconv ? 1 : jcp.nb_ic) * jcp.kd
-            * jcp.kh * jcp.kw * jcp.oc_block_int * jcp.ic_block;
+    return jcp.typesize_in * (is_deconv ? 1 : jcp.nb_ic) * jcp.kd * jcp.kh
+            * jcp.kw * jcp.oc_block_int * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_offset(
-        int icb, int kh, int kw) const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_offset(
+        dim_t icb, dim_t kh, dim_t kw) const {
     const bool is_deconv = jcp.prop_kind != prop_kind::backward_data;
-    const size_t wei_kw_stride = jcp.oc_block_int * jcp.ic_block;
-    const size_t wei_kh_stride = jcp.kw * wei_kw_stride;
-    const size_t wei_kd_stride = jcp.kh * wei_kh_stride;
-    const size_t wei_icb_stride
+    const dim_t wei_kw_stride = jcp.oc_block_int * jcp.ic_block;
+    const dim_t wei_kh_stride = jcp.kw * wei_kw_stride;
+    const dim_t wei_kd_stride = jcp.kh * wei_kh_stride;
+    const dim_t wei_icb_stride
             = (is_deconv ? jcp.nb_oc_int : 1) * jcp.kd * wei_kd_stride;
     return jcp.typesize_in
             * (icb * wei_icb_stride + kh * wei_kh_stride + kw * wei_kw_stride);
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_d_step() const {
-    const size_t wei_kd_stride
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_d_step() const {
+    const dim_t wei_kd_stride
             = jcp.kh * jcp.kw * jcp.oc_block_int * jcp.ic_block;
     // step through 'kd' weight elements by `stride_d`
-    return static_cast<size_t>(jcp.typesize_in) * jcp.stride_d * wei_kd_stride;
+    return jcp.typesize_in * jcp.stride_d * wei_kd_stride;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_icb_offset(
-        int ihb, int icb) const {
-    size_t el_offset = jcp.is_nspc
-            ? (size_t)icb * jcp.ic_block
-                    + (size_t)ihb * jcp.iw * jcp.ngroups
-                            * jcp.ic_without_padding
-            : (size_t)icb * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
-                    + (size_t)ihb * jcp.iw * jcp.ic_block;
-    return (size_t)jcp.typesize_out * el_offset;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_icb_offset(
+        dim_t ihb, dim_t icb) const {
+    dim_t el_offset = jcp.is_nspc
+            ? icb * jcp.ic_block
+                    + ihb * jcp.iw * jcp.ngroups * jcp.ic_without_padding
+            : icb * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
+                    + ihb * jcp.iw * jcp.ic_block;
+    return jcp.typesize_out * el_offset;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_row_offset(
-        int ihb, int icb, int j) const {
-    size_t offset_w = jcp.is_nspc ? (size_t)jcp.typesize_out * j * jcp.ngroups
-                    * jcp.ic_without_padding
-                                  : (size_t)jcp.typesize_out * j * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_row_offset(
+        dim_t ihb, dim_t icb, dim_t j) const {
+    const dim_t offset_w = jcp.is_nspc
+            ? jcp.typesize_out * j * jcp.ngroups * jcp.ic_without_padding
+            : jcp.typesize_out * j * jcp.ic_block;
     return get_out_icb_offset(ihb, icb) + offset_w;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_shift(int width) const {
-    return jcp.is_nspc ? (size_t)jcp.typesize_out * width * jcp.ngroups
-                    * jcp.ic_without_padding
-                       : (size_t)jcp.typesize_out * width * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_shift(dim_t width) const {
+    return jcp.is_nspc
+            ? jcp.typesize_out * width * jcp.ngroups * jcp.ic_without_padding
+            : jcp.typesize_out * width * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_icb_offset(
-        int ihb, int icb) const {
-    size_t el_offset = (size_t)icb * prv_width_ * jcp.ic_block
-            + (size_t)ihb * jcp.nb_ic_blocking * jcp.full_tile_width
-                    * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_icb_offset(
+        dim_t ihb, dim_t icb) const {
+    dim_t el_offset = icb * prv_width_ * jcp.ic_block
+            + ihb * jcp.nb_ic_blocking * jcp.full_tile_width * jcp.ic_block;
     return jcp.typesize_acc * el_offset;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_row_offset(
-        int ihb, int icb, int j) const {
-    return get_wsp_icb_offset(ihb, icb)
-            + (size_t)jcp.typesize_acc * j * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_row_offset(
+        dim_t ihb, dim_t icb, dim_t j) const {
+    return get_wsp_icb_offset(ihb, icb) + jcp.typesize_acc * j * jcp.ic_block;
 }
 
 // Code generation
@@ -3258,7 +3312,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::cvt2ps(data_type_t type_in,
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
-        const Zmm &zmm_out, int icb, int h, int w) {
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
     const bool mask_flag = jcp.is_nspc && jcp.ic_without_padding != jcp.ic
             && icb == (jcp.nb_ic_blocking - 1);
 
@@ -3284,7 +3338,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
     const int sum_idx = p.find(primitive_kind::sum);
     if (sum_idx != -1) load_and_add(jcp.dsrc_dt, zmm_prev_dst, zmm_out, addr);
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * icb * jcp.ic_block;
+        const dim_t bias_offset = jcp.typesize_bia * icb * jcp.ic_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         load_and_add(jcp.bia_dt, zmm_bias, zmm_out, bias_addr);
     }
@@ -3310,9 +3364,9 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
-        const Zmm &zmm_out, int icb, int h, int w) {
-    const int nb_ic_block = jcp.nb_ic_blocking;
-    const int ic_block = jcp.ic_block;
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
+    const dim_t nb_ic_block = jcp.nb_ic_blocking;
+    const dim_t ic_block = jcp.ic_block;
     const bool mask_flag = true && jcp.ic_without_padding != jcp.ic
             && icb == (nb_ic_block - 1);
 
@@ -3336,7 +3390,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
     }
 
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * icb * ic_block;
+        const dim_t bias_offset = jcp.typesize_bia * icb * ic_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
@@ -3353,10 +3407,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        const int scale_offset
+        const dim_t scale_offset
                 = jcp.is_ic_scale * (sizeof(float) * icb * ic_block);
         vmulps(zmm_out_msk, zmm_out,
-                EVEX_compress_addr(reg_ptr_wei_scales, scale_offset,
+                EVEX_compress_addr(reg_ptr_wei_scales,
+                        static_cast<int>(scale_offset),
                         /* bcast = */ !jcp.is_ic_scale));
     }
 
@@ -3402,7 +3457,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector(
-        const Zmm &zmm_out, int icb, int h, int w) {
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
     /*
     Output:
               jcp.is_nspc                 !jcp.is_nspc
@@ -3418,22 +3473,24 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output(
-        int width, bool do_store) {
+        dim_t width, bool do_store) {
     auto store_output_block
-            = [this](int width, bool do_store, bool is_last_ih_blks) {
+            = [this](dim_t width, bool do_store, bool is_last_ih_blks) {
         // Calculate the number of ih blocks; it may differ on last call
-        const int n_ih_blks = is_last_ih_blks ? jcp.ih % jcp.nb_ih_blocking
-                                              : jcp.nb_ih_blocking;
-        for (int icb = 0; icb < jcp.nb_ic_blocking; icb++) {
-            for (int ihb = 0; ihb < n_ih_blks; ihb++) {
+        const int n_ih_blks = is_last_ih_blks
+                ? static_cast<int>(jcp.ih % jcp.nb_ih_blocking)
+                : static_cast<int>(jcp.nb_ih_blocking);
+        for (dim_t icb = 0; icb < jcp.nb_ic_blocking; icb++) {
+            for (dim_t ihb = 0; ihb < n_ih_blks; ihb++) {
                 /* Formats: Workspace: [NBIH][NBIC][W][16OC] */
                 tilestored(ptr[reg_wsp_ptr + reg_wei_stride
                                    + get_wsp_icb_offset(ihb, icb)],
-                        Tmm(get_out_tensor(ihb, icb)));
+                        Tmm(get_out_tensor(
+                                static_cast<int>(ihb), static_cast<int>(icb))));
                 is_buffer_empty_ = false;
                 is_store_done_ = false;
-                for (int tw = 0; tw < width && do_store; tw++) {
-                    Zmm zmm_out = Zmm(tw);
+                for (dim_t tw = 0; tw < width && do_store; tw++) {
+                    Zmm zmm_out = Zmm(static_cast<int>(tw));
                     vmovups(zmm_out,
                             ptr[reg_wsp_ptr
                                     + get_wsp_row_offset(ihb, icb, tw)]);
@@ -3460,7 +3517,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output(
     if (do_store) add(reg_out_ptr, get_out_shift(width));
 }
 
-void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(int width) {
+void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(dim_t width) {
     for (int c = 0;
             c < jcp.per_one_pstore && !is_store_done_ && !is_buffer_empty_;
             c++) {
@@ -3483,7 +3540,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(int width) {
 
             row_count_ = 0;
             is_store_done_ = true;
-            prv_width_ = width;
+            prv_width_ = static_cast<int>(width);
         }
     }
 }
@@ -3492,8 +3549,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::skipped_interleave_store() {
 
     if (is_store_done_save_ || is_buffer_empty_) return;
 
-    const int store_count
-            = prv_width_save_ * jcp.nb_ic_blocking * jcp.nb_ih_blocking;
+    const int store_count = static_cast<int>(
+            prv_width_save_ * jcp.nb_ic_blocking * jcp.nb_ih_blocking);
     for (int row_count = 0; row_count < store_count; row_count++) {
         // row_count = ihb * ICB * TW + icb * TW + tw
         int tw = row_count % prv_width_save_;
@@ -3509,7 +3566,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::skipped_interleave_store() {
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
-        int width, bool do_interleave_store) {
+        dim_t width, bool do_interleave_store) {
 
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
         switch (jcp.ddst_dt) {
@@ -3522,11 +3579,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
         }
     };
 
-    for (int ocb = 0; ocb < jcp.nb_oc_int; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp.nb_oc_int; ocb++) {
         // reverse order through spatial components of weights so that
         // input buffer is accessed in a monotonically increasing fashion
-        for (int kh = jcp.kh - 1; kh >= 0; kh--) {
-            for (int kw = jcp.kw - 1; kw >= 0; kw--) {
+        for (dim_t kh = jcp.kh - 1; kh >= 0; kh--) {
+            for (dim_t kw = jcp.kw - 1; kw >= 0; kw--) {
                 for (int ihb = 0; ihb < jcp.nb_ih_blocking; ihb++) {
                     tileloadd(Tmm(get_inp_tensor(ihb)),
                             ptr[reg_inp_ptr + get_inp_offset(ihb, kh, kw)
@@ -3553,7 +3610,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_kd_loop(
-        int width, bool do_store, bool handle_skipped_stores) {
+        dim_t width, bool do_store, bool handle_skipped_stores) {
 
     Label skip_compute_kd_label, kd_loop_label, end_kd_compute_label;
 
@@ -3635,10 +3692,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_iw_loop() {
     };
 
     if (jcp.nb_iw == 1) {
-        compute_iw_loop_body(true, jcp.iw_blocks);
+        compute_iw_loop_body(true, static_cast<int>(jcp.iw_blocks));
     } else {
         Label label_done;
-        int iw_blocks_per_call = div_up(jcp.iw_block, jcp.tile_width);
+        int iw_blocks_per_call
+                = static_cast<int>(div_up(jcp.iw_block, jcp.tile_width));
         int last_iwb_tile_blocks = jcp.iw_blocks % iw_blocks_per_call;
         if (last_iwb_tile_blocks == 0 && jcp.tile_tail > 0)
             last_iwb_tile_blocks = iw_blocks_per_call;
@@ -3672,8 +3730,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
 
     mov(reg_last_h, ptr[param1 + GET_OFF(last_h)]);
 
-    const int inp_stride = jcp.oc_block_int * jcp.typesize_in;
-    const int wei_stride = jcp.ic_block * jcp.typesize_acc;
+    const dim_t inp_stride = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t wei_stride = jcp.ic_block * jcp.typesize_acc;
     mov(reg_inp_stride, inp_stride);
     mov(reg_wei_stride, wei_stride);
 
@@ -3682,8 +3740,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
         // loads / stores with block index
         // icb = icc * jcp.nb_ic_blocking + (jcp.nb_ic_blocking - 1)
         // TODO: use masked loads / stores for the last icc only
-        int current_block_size = jcp.ic_block;
-        int mask = (1 << current_block_size) - 1;
+        dim_t current_block_size = jcp.ic_block;
+        int mask = (1 << static_cast<int>(current_block_size)) - 1;
         Xbyak::Reg32 regw_tmp = reg_tmp.cvt32();
         mov(regw_tmp, mask);
         kmovw(ktail_mask, regw_tmp);
@@ -3693,7 +3751,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
         jne(mask_is_set, T_NEAR);
         // Reset the mask
         current_block_size = jcp.ic_without_padding % jcp.ic_block;
-        mask = (1 << current_block_size) - 1;
+        mask = (1 << static_cast<int>(current_block_size)) - 1;
         mov(regw_tmp, mask);
         kmovw(ktail_mask, regw_tmp);
 
@@ -3739,13 +3797,13 @@ void jit_avx512_core_amx_bwd_data_kernel_t::tile_configure(char *tcfg_buff) {
             = utils::one_of(jcp.ddst_dt, data_type::bf16, data_type::f16) ? 2
                                                                           : 4;
     // Input tile dimensions
-    const int a_col = jcp.oc_block_int;
+    const int a_col = static_cast<int>(jcp.oc_block_int);
     const int a_row = jcp.tile_width;
     // Weights tile dimensions
-    const int b_col = jcp.ic_block * vnni_width;
-    const int b_row = a_col / vnni_width;
+    const dim_t b_col = jcp.ic_block * vnni_width;
+    const dim_t b_row = a_col / vnni_width;
     // Accumulator tile dimensions
-    const int c_col = jcp.ic_block;
+    const dim_t c_col = jcp.ic_block;
     const int c_row = a_row;
 
     for (size_t i = 0; i < 64; i++)
@@ -3765,7 +3823,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::tile_configure(char *tcfg_buff) {
                     get_out_tensor(h, i), c_row, c_col * jcp.typesize_acc);
     }
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
@@ -3847,9 +3906,9 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!(jcp.dilate_d != 0 && jcp.stride_d != 1),
             "unsupported stride/dilation values");
 
-    const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, gen_kd);
     jcp.b_pad = calculate_end_padding(
@@ -3928,7 +3987,8 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
             args_ok, VERBOSE_BLOCKING_FAIL, "bad blocking dimensions");
 
     const int vnni_width = is_xf16 ? 2 : 4;
-    jcp.oc_block_int = jcp.oc_block * vnni_width; // 32 for xf16, 64 for int8
+    jcp.oc_block_int = jcp.oc_block * vnni_width;
+    // 32 for xf16, 64 for int8
 
     VDISPATCH_CONV_IC(attr.set_default_formats(&diff_src_md) == status::success,
             VERBOSE_UNSUPPORTED_ATTR);
@@ -3972,10 +4032,13 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -3988,12 +4051,14 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!(jcp.max_tiles != 8 || jcp.full_tile_width != 16),
             VERBOSE_BLOCKING_FAIL, "bad blocking parameters");
 
-    jcp.tile_width = nstl::min(jcp.full_tile_width, jcp.iw);
+    jcp.tile_width
+            = static_cast<int>(nstl::min<dim_t>(jcp.full_tile_width, jcp.iw));
     jcp.iw_blocks = div_up(jcp.iw, jcp.tile_width);
 
     // Prefer to use a single tile width when possible
     // (eg iw28 => 2 tiles of 14 vs 1 of 16 and 1 of 12)
-    if (jcp.iw % jcp.iw_blocks == 0) jcp.tile_width = jcp.iw / jcp.iw_blocks;
+    if (jcp.iw % jcp.iw_blocks == 0)
+        jcp.tile_width = static_cast<int>(jcp.iw / jcp.iw_blocks);
     jcp.tile_tail = jcp.iw % jcp.tile_width;
 
     jcp.nb_ic_blocking = (jcp.nb_ic % 2 == 0) ? 2 : 1;
@@ -4006,8 +4071,9 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // TODO: tune ih blocking
     const int ih_blk_size_tmp = 10;
-    const int ih_step = jcp.nb_ih_blocking;
-    jcp.ih_blk_size = rnd_up(nstl::min(jcp.ih, ih_blk_size_tmp), ih_step);
+    const dim_t ih_step = jcp.nb_ih_blocking;
+    jcp.ih_blk_size
+            = rnd_up(nstl::min<dim_t>(jcp.ih, ih_blk_size_tmp), ih_step);
     // ohp includes all elements that are really used in calculation,
     // including zero-padded "dilate-by-strides" and top and bottom overflow
     jcp.ohp = jcp.ih_blk_size + gen_kh - 1;
@@ -4023,7 +4089,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // Number of ops per tile store
     int ops_tile_store = jcp.tile_width;
     // Number of ops per accumulation tile
-    int avaliable_ops = jcp.nb_oc_int * jcp.kh * jcp.kw;
+    const int avaliable_ops = static_cast<int>(jcp.nb_oc_int * jcp.kh * jcp.kw);
     // Number of vectors to store per tile operation
     // NOTE: set to zero to turn off interleave store (mostly for debugging)
     jcp.per_one_pstore = div_up(ops_tile_store, avaliable_ops);
@@ -4100,14 +4166,14 @@ int jit_avx512_core_amx_bwd_weights_kernel_t::get_ddst_tensor(int ocb) const {
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::tile_configure(char *tcfg_buff) {
     // Input tile dimensions
-    const int a_col = jcp.ur_w;
-    const int a_row = jcp.ic_block;
+    const dim_t a_col = jcp.ur_w;
+    const dim_t a_row = jcp.ic_block;
     // Weights tile dimensions
-    const int b_col = jcp.oc_block * 2;
-    const int b_row = a_col / 2;
+    const dim_t b_col = jcp.oc_block * 2;
+    const dim_t b_row = a_col / 2;
     // Accumulator tile dimensions
-    const int c_col = jcp.oc_block;
-    const int c_row = a_row;
+    const dim_t c_col = jcp.oc_block;
+    const dim_t c_row = a_row;
 
     for (size_t i = 0; i < 64; i++)
         tcfg_buff[i] = 0;
@@ -4125,7 +4191,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::tile_configure(char *tcfg_buff) {
             tc_configure_tile((palette_config_t *)tcfg_buff,
                     get_wei_tensor(ocb, icb), c_row, c_col * jcp.typesize_out);
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::od_step_comeback_pointers() {
@@ -4169,9 +4236,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
     auto ddst_row_size = get_ddst_offset(0, 1);
     auto row_size = src_row_size + ddst_row_size;
 
-    int h_block_size = jcp.oh;
+    int h_block_size = static_cast<int>(jcp.oh);
     int h_last_block_size = h_block_size;
-    int min_h_block_size = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+    int min_h_block_size = static_cast<int>(
+            nstl::max<dim_t>(1, nstl::max(jcp.b_pad, jcp.t_pad)));
     auto working_set_size = row_size * h_block_size;
 
     if (working_set_size > full_spat_max_working_set_size) {
@@ -4263,7 +4331,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
         int oh_block_size = (is_last_block) ? h_last_block_size : h_block_size;
         // NB: this is correct because we only support t_pad = kh / 2 and thus
         // ih == oh
-        int ih_block_size = oh_block_size
+        const dim_t ih_block_size = oh_block_size
                 + (!is_first_block + !is_last_block) * jcp.t_pad;
 
         L(kh_loop);
@@ -4332,8 +4400,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
 
             L(kh_loop_work);
 
-            mul_by_const(reg_ihs, reg_tmp, get_src_offset(0, 0, 1));
-            mul_by_const(reg_ohs, reg_tmp, get_ddst_offset(0, 1));
+            mul_by_const(reg_ihs, reg_tmp,
+                    static_cast<int>(get_src_offset(0, 0, 1)));
+            mul_by_const(
+                    reg_ohs, reg_tmp, static_cast<int>(get_ddst_offset(0, 1)));
 
             add(reg_src, reg_ihs);
             add(reg_ddst, reg_ohs);
@@ -4422,12 +4492,12 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
         add(reg_src, first_src_block_step);
         add(reg_ddst, ddst_block_step);
 
-        int num_innermost_iters
+        const dim_t num_innermost_iters
                 = (jcp.oh - h_last_block_size) / h_block_size - 1;
         if (num_innermost_iters > 0) {
             Label h_block_loop;
 
-            mov(reg_tmp_w, num_innermost_iters);
+            mov(reg_tmp_w, static_cast<int>(num_innermost_iters));
             kmovw(reg_h_block, reg_tmp_w);
             L(h_block_loop);
             {
@@ -4450,9 +4520,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
 void jit_avx512_core_amx_bwd_weights_kernel_t::compute_ic_loop(
         int ic_block, int nb_ic_blocking, int nb_oc_blocking) {
     assert(jcp.ur_w % 2 == 0);
-    const int str_w = jcp.stride_w;
+    const dim_t str_w = jcp.stride_w;
     assert(jcp.tr_iw % str_w == 0);
-    const int src_stride_w_shift = jcp.tr_iw / str_w;
+    const dim_t src_stride_w_shift = jcp.tr_iw / str_w;
 
     mov(reg_b_stride, 64);
     mov(reg_a_stride, jcp.tr_iw * jcp.typesize_in);
@@ -4467,7 +4537,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_ic_loop(
                                     + get_full_kernel_offset(
                                             ocb, icb, 0, i_kw)]);
 
-            int src_offset_l = (i_kw * (jcp.dilate_w + 1)) / str_w
+            const dim_t src_offset_l = (i_kw * (jcp.dilate_w + 1)) / str_w
                     + s * src_stride_w_shift;
 
             for (int ur_w_b = 0; ur_w_b < jcp.ur_w_blocks; ur_w_b++) {
@@ -4531,7 +4601,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_diff_bias_row(
     };
 
     Label ow_loop, ow_tail;
-    int niters = jcp.tr_ow / 2;
+    int niters = static_cast<int>(jcp.tr_ow / 2);
     if (niters > 0) {
         mov(reg_tmp, jcp.tr_ow / 2);
         L(ow_loop);
@@ -4569,7 +4639,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::maybe_compute_diff_bias(
         Label bias_loop, skip_label_local;
 
         mov(reg_ddst, ptr[param + GET_OFF(dst)]);
-        add(reg_ddst, jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
+        add(reg_ddst,
+                static_cast<int>(
+                        jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size));
 
         switch (jcp.harness) {
             case harness_2d_reduction:
@@ -4611,7 +4683,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_step_common(
         int nb_ic_blocking, int nb_oc_blocking) {
     Label kh_label, ic_block_label, ow_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    const int ic_block = static_cast<int>(jcp.ic_block);
     int ic_tail = jcp.ic_tail;
 
     auto ic_loop = [&](int nb_ic_blocking, int nb_oc_blocking) {
@@ -4740,12 +4812,12 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::maybe_zero_kernel(
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
         int nb_ic_blocking, int nb_oc_blocking, bool is_partial) {
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    int b_pad = static_cast<int>(jcp.b_pad);
+    int t_pad = static_cast<int>(jcp.t_pad);
 
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t stride_h = jcp.stride_h;
     auto filter_step_size = get_kernel_offset(0, jcp.kw);
     auto src_step_size = get_src_offset(0, 0, 1);
     auto ddst_step_size = get_ddst_offset(0, 1);
@@ -4755,17 +4827,19 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             oh_dilate_label_end, oh_dilate_setup_label_shift,
             oh_dilate_setup_label_noshift, oh_dilate_setup_label_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int oh_body_end
-            = div_up(nstl::max(0, t_pad + jcp.ih - ext_kh + 1), stride_h);
+    int ext_kh = static_cast<int>(
+            calculate_extended_filter_size(jcp.kh, jcp.dilate_h));
+    int oh_body_end = static_cast<int>(
+            div_up(nstl::max<dim_t>(0, t_pad + jcp.ih - ext_kh + 1), stride_h));
     int oh_head_end
             = nstl::min(div_up(nstl::max(0, t_pad), stride_h), oh_body_end);
     int oh_head_overflow_end = div_up(nstl::max(0, t_pad), stride_h);
-    int oh_tail_end = jcp.oh;
+    int oh_tail_end = static_cast<int>(jcp.oh);
 
-    int body_src_start_offset = (stride_h - (t_pad % stride_h)) % stride_h;
-    int ih_body_end
-            = nstl::max(-t_pad + oh_body_end * stride_h, body_src_start_offset);
+    const dim_t body_src_start_offset
+            = (stride_h - (t_pad % stride_h)) % stride_h;
+    const dim_t ih_body_end = nstl::max<dim_t>(
+            -t_pad + oh_body_end * stride_h, body_src_start_offset);
 
     if (is_partial)
         mov(reg_oj, ptr[param + GET_OFF(os_index_begin)]);
@@ -4778,17 +4852,20 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             cmp(reg_oj, oh_head_overflow_end);
             jge(oh_tpad_tail_label_end, T_NEAR);
         }
-        const int overflow = nstl::max(
-                0, jcp.kh - div_up(nstl::max(0, t_pad + jcp.ih), dilate_h));
-        const int underflow = div_up(nstl::max(0, t_pad), dilate_h);
-        const int initial_kh = jcp.kh - overflow - underflow;
+        const int overflow = static_cast<int>(nstl::max<dim_t>(0,
+                jcp.kh
+                        - div_up(nstl::max<dim_t>(0, t_pad + jcp.ih),
+                                dilate_h)));
+        const int underflow = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, t_pad), dilate_h));
+        const dim_t initial_kh = jcp.kh - overflow - underflow;
 
         // Setup reg_kh, reg_kernel, and reg_src
         mov(reg_kh, initial_kh);
         add(reg_kernel, filter_step_size * underflow);
         if (is_dilated) {
-            const int tail = t_pad % dilate_h;
-            const int shift = tail == 0 ? 0 : dilate_h - tail;
+            const dim_t tail = t_pad % dilate_h;
+            const dim_t shift = tail == 0 ? 0 : dilate_h - tail;
             mov(reg_ih_shift, shift);
             if (!is_partial) mov(ptr[rsp + ih_dilate_offset], reg_ih_shift);
             add(reg_src, src_step_size * shift);
@@ -5002,15 +5079,17 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         int nb_ic_blocking, int nb_oc_blocking, bool is_partial) {
     assert(jcp.harness == harness_3d_reduction);
 
-    const int src_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
+    const int src_backpad_overlap = static_cast<int>(
+            div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d));
 
     const auto filter_shift = get_kernel_offset(0, jcp.kh * jcp.kw);
     const auto src_shift = get_src_offset(0, 0, jcp.ih);
     const auto ddst_shift = get_ddst_offset(0, jcp.oh);
 
-    const int kd_front_pad = nstl::max(0, jcp.f_pad);
-    const int kd_back_pad = nstl::max(0, jcp.kd - jcp.f_pad - jcp.id);
+    const int kd_front_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.f_pad));
+    const int kd_back_pad = static_cast<int>(
+            nstl::max<dim_t>(0, jcp.kd - jcp.f_pad - jcp.id));
 
     Label d_loop_label, loop_end_label, common_block_label, fpad_end_label,
             backpad_end_label, backpad_label;
@@ -5024,9 +5103,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         mov(reg_d_index, ptr[param + GET_OFF(os_index_begin)]);
         mov(reg_kd_count, ptr[param + GET_OFF(kd_padding)]);
     } else {
-        const int kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
-        const int kd_offset = get_kernel_offset(
-                0, nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw);
+        const dim_t kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
+        const dim_t kd_offset = get_kernel_offset(0,
+                static_cast<int>(nstl::min<dim_t>(jcp.kd - 1, kd_front_pad))
+                        * jcp.kh * jcp.kw);
         add(reg_kernel, kd_offset);
         xor_(reg_d_index, reg_d_index);
         mov(reg_kd_count, kd_padding);
@@ -5058,7 +5138,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
     /* Compute 'front' edge */
     if (jcp.f_pad > 0) {
         /* Check if within fpad region */
-        cmp(reg_d_index, div_up(nstl::max(0, jcp.f_pad), jcp.stride_d));
+        cmp(reg_d_index,
+                static_cast<int>(
+                        div_up(nstl::max<dim_t>(0, jcp.f_pad), jcp.stride_d)));
         jge(fpad_end_label, T_NEAR);
 
         /* Fpad steps */
@@ -5066,7 +5148,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with src */
-        const int src_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const dim_t src_ker_overlap = nstl::min<dim_t>(jcp.kd, jcp.id);
         cmp(reg_kd_count, src_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -5074,7 +5156,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                const dim_t src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
                 add(reg_kernel, filter_shift * src_corr);
                 add(reg_src_d, src_shift * src_corr);
             }
@@ -5272,9 +5354,9 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -5294,13 +5376,13 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
 
     jcp.transform_to_vnni = diff_weights_d.data_type() == data_type::bf16;
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -5372,12 +5454,14 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
             CHECK(memory_desc_init_by_tag(diff_bias_md, format_tag::x));
     }
     jcp.bia_dt = jcp.with_bias ? diff_bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd;
@@ -5389,8 +5473,8 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ic_tail = jcp.ic % jcp.ic_block;
-    jcp.oc_tail = jcp.oc % jcp.oc_block;
+    jcp.ic_tail = static_cast<int>(jcp.ic % jcp.ic_block);
+    jcp.oc_tail = static_cast<int>(jcp.oc % jcp.oc_block);
 
     jcp.nb_oc_blocking = (jcp.nb_oc > 1) ? 2 : 1;
     jcp.nb_ic_blocking = (jcp.nb_ic > 1) ? 2 : 1;
@@ -5410,21 +5494,22 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     // TODO: Find more shapes (especially 3D with large spatials) for which
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
-    int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    const dim_t optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
 
     jcp.global_transpose = dnnl_thr_syncable();
     jcp.spatial_blk_size = optimal_blk_size;
 
     const int tr_round = 32; // To load full tile register
-    int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
-    jcp.tr_iw = rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
-            * jcp.stride_w;
+    const dim_t tr_pad
+            = rnd_up(nstl::max<dim_t>(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    jcp.tr_iw = (rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
+            * jcp.stride_w);
 
     jcp.tr_src_num_guard_elems = tr_pad; // upper bound
     jcp.tr_ow = rnd_up(jcp.ow, 2);
 
     if (jcp.tr_ow <= max_ur_w) {
-        jcp.ur_w = jcp.tr_ow;
+        jcp.ur_w = static_cast<int>(jcp.tr_ow);
         jcp.ur_w_blocks = 1;
     } else {
         jcp.ur_w = 1;
@@ -5588,7 +5673,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = max_threads / nthr_g_;
 
     auto calc_mem_cost
@@ -5615,9 +5700,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         dim_t wei_size
                 = (dim_t)j.oc * j.ic * j.kd * j.kh * j.kw * wei_type_size;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
+        float wei_compensation_scale
+                = 0.5f * (float)(dst_size + src_size) / (float)wei_size;
         float oi_channels_ratio = (float)(j.nb_oc / j.nb_oc_blocking)
-                / (j.nb_ic / j.nb_ic_blocking);
+                / (float)(j.nb_ic / j.nb_ic_blocking);
         auto get_src_coef = [oi_channels_ratio, wei_compensation_scale]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
             if (wei_compensation_scale < 1.0f) src_coef *= 4.0f;
@@ -5637,23 +5723,29 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         const float dst_coef = get_dst_coef();
         const float wei_coef = get_wei_coef();
 
-        float src_v = src_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.mb
-                * (j.ic_block * j.nb_ic_blocking) * j.id * j.ih * j.tr_iw
-                / j.nthr_mb_work / j.stride_d / j.stride_h / j.stride_w;
-        float wei_v = wei_coef * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_oc / j.nb_oc_blocking),
-                        (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
-                * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.kh * j.kw
-                * j.kd * (j.ic_block * j.nb_ic_blocking)
-                * (j.oc_block * j.nb_oc_blocking);
-        float dst_v = dst_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_oc / j.nb_oc_blocking),
-                        (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
-                * j.mb * (j.oc_block * j.nb_oc_blocking) * j.od * j.oh * j.tr_ow
-                / j.nthr_mb_work;
+        float src_v = src_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.mb
+                        * (j.ic_block * j.nb_ic_blocking) * j.id * j.ih
+                        * j.tr_iw)
+                / (float)(j.nthr_mb_work * j.stride_d * j.stride_h
+                        * j.stride_w);
+        float wei_v = wei_coef
+                * (float)(div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_oc / j.nb_oc_blocking),
+                                (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
+                        * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.kh
+                        * j.kw * j.kd * (j.ic_block * j.nb_ic_blocking)
+                        * (j.oc_block * j.nb_oc_blocking));
+        float dst_v = dst_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_oc / j.nb_oc_blocking),
+                                (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
+                        * j.mb * (j.oc_block * j.nb_oc_blocking) * j.od * j.oh
+                        * j.tr_ow)
+                / (float)j.nthr_mb_work;
 
         return src_v + dst_v + wei_v;
     };
@@ -5662,14 +5754,15 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
 
     /* find the best thread distribution with lowest memory cost */
 
-    const int nthr_mb_max = nstl::min(nthr, j.nthr_mb_work);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, j.nthr_mb_work));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par,
-                (j.nb_oc / j.nb_oc_blocking)); // Amount of nb_oc_blocks
+        const int nthr_oc_b_max = static_cast<int>(nstl::min<dim_t>(nthr_par,
+                (j.nb_oc / j.nb_oc_blocking))); // Amount of nb_oc_blocks
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(
-                    nthr_par / nthr_oc_b, (j.nb_ic / j.nb_ic_blocking));
+            int nthr_ic_b = static_cast<int>(nstl::min<dim_t>(
+                    nthr_par / nthr_oc_b, (j.nb_ic / j.nb_ic_blocking)));
 
             float mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -5682,7 +5775,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
     }
 
     if (nthr_mb_ > nthr / 2 && nthr_mb_ < nthr)
-        nthr_mb_ = nstl::min(j.nthr_mb_work, nthr);
+        nthr_mb_ = static_cast<int>(nstl::min<dim_t>(j.nthr_mb_work, nthr));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= max_threads);
@@ -5691,7 +5784,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
 // start of diff_bias kernel
 dim_t jit_avx512_core_amx_bwd_bias_kernel_t::get_ddst_offset(
         dim_t w_idx, dim_t hd_idx) const {
-    int ow_per_oc = data_type_vnni_granularity(jcp.ddst_dt);
+    const int ow_per_oc
+            = static_cast<int>(data_type_vnni_granularity(jcp.ddst_dt));
     if (ow_per_oc == 0) {
         assert(!"Invalid vnni granularity.");
         return 0;
@@ -5806,7 +5900,9 @@ void jit_avx512_core_amx_bwd_bias_kernel_t::compute_diff_bias(
 
         // pointer to diff_dst
         mov(reg_ddst, ptr[param + GET_OFF(dst)]);
-        add(reg_ddst, jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
+        add(reg_ddst,
+                static_cast<int>(
+                        jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size));
 
         // number of rows
         mov(reg_oj, reg_nrows);

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -80,31 +80,35 @@ private:
     const Xbyak::Opmask kmask_ic_block = Xbyak::Opmask(1);
     const Xbyak::Opmask ktail_mask = Xbyak::Opmask(2);
 
-    void prepare_output(int ur_w);
-    void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void prepare_output(dim_t ur_w);
+    void store_output(dim_t ur_w, bool last_oc_block_flag);
+    void compute_ker(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool padded);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag,
-            bool handle_h_pad);
-    void kd_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag,
-            bool handle_h_pad);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool handle_h_pad);
+    void kh_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag, bool handle_h_pad);
+    void kd_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag, bool handle_h_pad);
+    void icb_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r, bool handle_h_pad);
     void unroll_width(const bool h_padding);
 
     void generate() override;
 
     Xbyak::Zmm zmm_out(int i_ur, int i_oc) const {
-        int idx = i_ur * jcp.nb_oc_blocking + i_oc;
+        const int idx = i_ur * jcp.nb_oc_blocking + i_oc;
         assert(idx < max_regs_ur);
         return Xbyak::Zmm(idx);
     }
-    int get_ow_start(int ki, int pad_l) const {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) const {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) const {
-        int filter_overlap = pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
-        return ur_w - utils::div_up(nstl::max(0, filter_overlap), jcp.stride_w);
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) const {
+        const dim_t filter_overlap
+                = pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
+        return ur_w
+                - utils::div_up(
+                        nstl::max<dim_t>(0, filter_overlap), jcp.stride_w);
     }
 };
 
@@ -184,8 +188,8 @@ private:
     const Xbyak::Zmm &zmm_zero = zmm1;
 
     void generate() override;
-    void copy_row(int icb);
-    void copy_row_body(int lpad, int iw_len, int icb);
+    void copy_row(dim_t icb);
+    void copy_row_body(dim_t lpad, dim_t iw_len, dim_t icb);
     void copy_row_reduced_lowering();
 };
 
@@ -204,11 +208,11 @@ struct jit_avx512_core_amx_fwd_kernel_t : public jit_generator_t {
     static status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp, const primitive_attr_t &attr);
 
-    inline int accum_with_upper_bound(
-            int upper_bound, int lower_value, int upper_value) {
-        return nstl::min(upper_bound,
-                nstl::min(upper_bound, lower_value)
-                        + nstl::max(0, upper_bound - upper_value));
+    inline dim_t accum_with_upper_bound(
+            dim_t upper_bound, dim_t lower_value, dim_t upper_value) {
+        return nstl::min<dim_t>(upper_bound,
+                nstl::min<dim_t>(upper_bound, lower_value)
+                        + nstl::max<dim_t>(0, upper_bound - upper_value));
     }
 
     /*  Calculate and store the limits relevant to 'ow_block'. These limits
@@ -291,9 +295,10 @@ private:
     bool is_buffer_empty_ = true;
 
     struct w_pad_output_t {
-        int l_pad_output;
-        int r_pad_output;
-        w_pad_output_t(int l_, int r_) : l_pad_output(l_), r_pad_output(r_) {}
+        dim_t l_pad_output;
+        dim_t r_pad_output;
+        w_pad_output_t(dim_t l_, dim_t r_)
+            : l_pad_output(l_), r_pad_output(r_) {}
     };
     std::queue<w_pad_output_t> w_padding;
 
@@ -346,24 +351,25 @@ private:
     const Xbyak::Reg64 bin_injector_helper_reg_3 = r11;
 
     // AUX: Steps, shifts and offsets
-    size_t get_inp_icb_step() const;
-    size_t get_wei_icb_step() const;
-    size_t get_inp_d_step() const;
-    size_t get_inp_h_step() const;
-    size_t get_wei_d_step() const;
-    size_t get_wei_h_step() const;
-    size_t get_out_ocb_offset(int ohb, int ocb, size_t typesize) const;
-    size_t get_out_row_offset(int ohb, int ocb, int j, size_t typesize) const;
-    size_t get_out_shift(int width, size_t typesize) const;
-    size_t get_wsp_ocb_offset(int ohb, int ocb) const;
-    size_t get_wsp_row_offset(int ohb, int ocb, int j) const;
-    size_t get_wsp_shift() const;
-    size_t get_wei_offset(int ocb, int kw) const;
-    size_t get_inp_shift() const;
-    size_t get_inp_offset(int ohb, int kw) const;
-    size_t get_zp_comp_offset(int ocb, int zp_h, int zp_w) const;
-    int get_zp_index_offset(
-            int index, int mid, int s_pad_output, int e_pad_output);
+    dim_t get_inp_icb_step() const;
+    dim_t get_wei_icb_step() const;
+    dim_t get_inp_d_step() const;
+    dim_t get_inp_h_step() const;
+    dim_t get_wei_d_step() const;
+    dim_t get_wei_h_step() const;
+    dim_t get_out_ocb_offset(dim_t ohb, dim_t ocb, dim_t typesize) const;
+    dim_t get_out_row_offset(
+            dim_t ohb, dim_t ocb, dim_t j, dim_t typesize) const;
+    dim_t get_out_shift(dim_t width, dim_t typesize) const;
+    dim_t get_wsp_ocb_offset(dim_t ohb, dim_t ocb) const;
+    dim_t get_wsp_row_offset(dim_t ohb, dim_t ocb, dim_t j) const;
+    dim_t get_wsp_shift() const;
+    dim_t get_wei_offset(dim_t ocb, dim_t kw) const;
+    dim_t get_inp_shift() const;
+    dim_t get_inp_offset(dim_t ohb, dim_t kw) const;
+    dim_t get_zp_comp_offset(dim_t ocb, dim_t zp_h, dim_t zp_w) const;
+    dim_t get_zp_index_offset(
+            dim_t index, dim_t mid, dim_t s_pad_output, dim_t e_pad_output);
 
     int get_out_tensor(int h, int i, bool is_h_tail = false) const;
     int get_inp_tensor(int h, bool is_h_tail = false) const;
@@ -371,9 +377,9 @@ private:
 
     void prepare_output(int tail);
     void init_runtime_counters(bool start_with_last_tile_block);
-    size_t reduce_to_block(const int block_size, const int pad_output);
-    size_t reduce_to_blocked_dims(const int dim_size, const int block_size,
-            const int s_pad_output, const int e_pad_output);
+    dim_t reduce_to_block(const dim_t block_size, const dim_t pad_output);
+    dim_t reduce_to_blocked_dims(const dim_t dim_size, const dim_t block_size,
+            const dim_t s_pad_output, const dim_t e_pad_output);
     void cvt2ps(data_type_t type_in, const Xbyak::Zmm &ymm_in,
             const Xbyak::Operand &op, bool mask_flag = false);
     Xbyak::Zmm zmm_out(const int idx) const {
@@ -393,31 +399,31 @@ private:
             const bool mask_flag);
     void apply_postops(const Xbyak::Zmm &zmm_out, const float *p_sum_scale,
             const int32_t *p_sum_zp, const Xbyak::Address &addr,
-            const size_t off, const bool mask_flag);
+            const dim_t off, const bool mask_flag);
     inline void store_output_ymm_bf16(
             const int idx, const Xbyak::Address &addr, const bool mask_flag);
     void store_output_vector_bf16(
-            const Xbyak::Zmm &zmm_out, int ocb, int h, int w);
-    void store_output_vector_int8(const Xbyak::Zmm &zmm_out, int ocb, int h,
-            int w, const bool compute_zp, const int zp_h, const int zp_w);
-    void store_output_vector(const Xbyak::Zmm &zmm_out, int ocb, int h, int w,
-            const bool compute_zp = false, const int zp_h = 0,
-            const int zp_w = 0);
-    void store_output(int width, int tail, bool do_store,
-            const bool handle_h_block, const int t_pad_output,
-            const int b_pad_output, const int l_pad_output,
-            const int r_pad_output, const bool is_last_oh_block,
+            const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w);
+    void store_output_vector_int8(const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h,
+            dim_t w, const bool compute_zp, const dim_t zp_h, const dim_t zp_w);
+    void store_output_vector(const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h,
+            dim_t w, const bool compute_zp = false, const dim_t zp_h = 0,
+            const dim_t zp_w = 0);
+    void store_output(dim_t width, int tail, bool do_store,
+            const bool handle_h_block, const dim_t t_pad_output,
+            const dim_t b_pad_output, const dim_t l_pad_output,
+            const dim_t r_pad_output, const bool is_last_oh_block,
             const bool zp_3d_pad = false);
-    void interleave_store(int width, int const t_pad_output,
-            int const b_pad_output, const bool zp_3d_pad = false);
-    void compute_icb_loop(int width, bool do_store, const bool handle_h_block,
-            const int t_pad_output, const int b_pad_output,
-            const int l_pad_output, const int r_pad_output,
+    void interleave_store(dim_t width, dim_t const t_pad_output,
+            dim_t const b_pad_output, const bool zp_3d_pad = false);
+    void compute_icb_loop(dim_t width, bool do_store, const bool handle_h_block,
+            const dim_t t_pad_output, const dim_t b_pad_output,
+            const dim_t l_pad_output, const dim_t r_pad_output,
             const bool zp_3d_pad, const bool is_last_oh_block = false);
-    void dispatch_icb_loop(int width, bool do_store, const int l_pad_output,
-            const int r_pad_output, const bool zp_3d_pad);
-    void dispatch_zp_3d_compute(int width, bool do_store,
-            const int l_pad_output, const int r_pad_output);
+    void dispatch_icb_loop(dim_t width, bool do_store, const dim_t l_pad_output,
+            const dim_t r_pad_output, const bool zp_3d_pad);
+    void dispatch_zp_3d_compute(dim_t width, bool do_store,
+            const dim_t l_pad_output, const dim_t r_pad_output);
     void compute_ow_loop();
 
     void generate() override;
@@ -560,27 +566,27 @@ private:
     const Xbyak::Zmm zmm_sum_zp = zmm28;
 
     // AUX: Steps, shifts and offsets
-    size_t get_inp_ocb_step() const;
-    size_t get_inp_offset(int ihb, int kh, int kw) const;
-    size_t get_inp_shift() const;
-    size_t get_inp_d_step() const;
-    size_t get_out_icb_offset(int ihb, int icb) const;
-    size_t get_out_row_offset(int ihb, int icb, int j) const;
-    size_t get_out_shift(int width) const;
-    size_t get_wei_kh_step() const;
-    size_t get_wei_ocb_step() const;
-    size_t get_wei_offset(int icb, int kh, int kw) const;
-    size_t get_wei_d_step() const;
-    size_t get_wsp_icb_offset(int ihb, int icb) const;
-    size_t get_wsp_row_offset(int ihb, int icb, int j) const;
-    size_t get_wsp_shift() const;
+    dim_t get_inp_ocb_step() const;
+    dim_t get_inp_offset(dim_t ihb, dim_t kh, dim_t kw) const;
+    dim_t get_inp_shift() const;
+    dim_t get_inp_d_step() const;
+    dim_t get_out_icb_offset(dim_t ihb, dim_t icb) const;
+    dim_t get_out_row_offset(dim_t ihb, dim_t icb, dim_t j) const;
+    dim_t get_out_shift(dim_t width) const;
+    dim_t get_wei_kh_step() const;
+    dim_t get_wei_ocb_step() const;
+    dim_t get_wei_offset(dim_t icb, dim_t kh, dim_t kw) const;
+    dim_t get_wei_d_step() const;
+    dim_t get_wsp_icb_offset(dim_t ihb, dim_t icb) const;
+    dim_t get_wsp_row_offset(dim_t ihb, dim_t icb, dim_t j) const;
+    dim_t get_wsp_shift() const;
 
     int get_out_tensor(int h, int i) const;
     int get_inp_tensor(int h) const;
     int get_wei_tensor(int i) const;
 
     inline bool gaps_in_store() const {
-        const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+        const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
         return gen_kd < jcp.stride_d || jcp.dilate_d > 0;
     }
 
@@ -596,16 +602,17 @@ private:
             const Xbyak::Zmm &zmm_in, bool mask_flag, bool store = false);
 
     void store_output_vector_xf16(
-            const Xbyak::Zmm &zmm_out, int icb, int ihb, int iw);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ihb, dim_t iw);
     void store_output_vector_int8(
-            const Xbyak::Zmm &zmm_out, int icb, int ihb, int iw);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ihb, dim_t iw);
     void store_output_vector(
-            const Xbyak::Zmm &zmm_out, int icb, int ih, int iw);
-    void store_output(int width, bool do_store);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ih, dim_t iw);
+    void store_output(dim_t width, bool do_store);
     void skipped_interleave_store();
-    void interleave_store(int width);
-    void compute_ocb_loop(int width, bool do_interleave_store);
-    void compute_kd_loop(int width, bool do_store, bool handle_skipped_stores);
+    void interleave_store(dim_t width);
+    void compute_ocb_loop(dim_t width, bool do_interleave_store);
+    void compute_kd_loop(
+            dim_t width, bool do_store, bool handle_skipped_stores);
     void compute_iw_loop();
 
     void generate() override;
@@ -722,7 +729,7 @@ private:
         return jcp.typesize_in * (w_off + jcp.tr_ow * jcp.oc_block * hd_idx);
     }
 
-    inline dim_t get_kernel_offset(int ic_idx, dim_t ksp_idx) const {
+    inline dim_t get_kernel_offset(dim_t ic_idx, dim_t ksp_idx) const {
         return jcp.typesize_out * jcp.oc_block
                 * (ksp_idx * jcp.ic_block + ic_idx);
     }

--- a/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
@@ -47,40 +47,43 @@ struct spatial_features_3d_t {
         , init_overflow_(0)
         , end_overflow_(0) {}
 
-    inline int get_init_overflow(const int in) const {
+    inline dim_t get_init_overflow(const dim_t in) const {
         if (is_fast_path_)
-            return nstl::max(0, filter_size_ - 1 - in - init_pad_);
+            return nstl::max<dim_t>(0, filter_size_ - 1 - in - init_pad_);
         if (dilate_ != 1)
             return div_up(
-                    nstl::max(0, (filter_size_ - 1) * dilate_ - in - init_pad_),
+                    nstl::max<dim_t>(
+                            0, (filter_size_ - 1) * dilate_ - in - init_pad_),
                     dilate_);
-        return nstl::max(0, (filter_size_ - 1 - in - init_pad_) / stride_);
+        return nstl::max<dim_t>(
+                0, (filter_size_ - 1 - in - init_pad_) / stride_);
     }
 
-    inline int get_end_overflow(const int in) const {
+    inline dim_t get_end_overflow(const dim_t in) const {
         if (is_fast_path_)
-            return nstl::max(0, filter_size_ - input_size_ + in - end_pad_);
+            return nstl::max<dim_t>(
+                    0, filter_size_ - input_size_ + in - end_pad_);
         if (dilate_ != 1)
-            return div_up(nstl::max(0,
+            return div_up(nstl::max<dim_t>(0,
                                   (filter_size_ - 1) * dilate_ + 1 - input_size_
                                           + in - end_pad_),
                     dilate_);
-        return nstl::max(
+        return nstl::max<dim_t>(
                 0, (filter_size_ - input_size_ + in - end_pad_) / stride_);
     }
 
-    void update_params(const int in) {
+    void update_params(const dim_t in) {
 
         init_overflow_ = get_init_overflow(in);
         end_overflow_ = get_end_overflow(in);
 
         // overflow_kd_hi
-        const int overflow_filter_hi_ = compute_extended_features_
+        const dim_t overflow_filter_hi_ = compute_extended_features_
                 ? filter_size_ - 1
                         - nstl::modulo(input_size_ - 1 + end_pad_ - in, stride_)
                 : 0;
         // overflow_kd_lo
-        const int overflow_filter_lo_
+        const dim_t overflow_filter_lo_
                 = compute_extended_features_ ? (in + init_pad_) % stride_ : 0;
 
         filter_ = compute_extended_features_
@@ -96,30 +99,30 @@ struct spatial_features_3d_t {
                 : in + init_pad_ - end_overflow_ * dilate_;
     }
 
-    inline int get_filter_padding() const {
+    inline dim_t get_filter_padding() const {
         return filter_ - init_overflow_ - end_overflow_;
     }
 
-    inline int get_lower_offset() const { return lower_offset_; }
+    inline dim_t get_lower_offset() const { return lower_offset_; }
 
-    inline int get_output_offset() const { return output_offset_; }
+    inline dim_t get_output_offset() const { return output_offset_; }
 
 private:
-    int input_size_;
-    int filter_size_;
-    int dilate_;
-    int stride_;
-    int init_pad_; // f_pad
-    int end_pad_; // back_pad
+    dim_t input_size_;
+    dim_t filter_size_;
+    dim_t dilate_;
+    dim_t stride_;
+    dim_t init_pad_; // f_pad
+    dim_t end_pad_; // back_pad
     bool is_fast_path_; // 'dilate_ == 1 && stride_ == 1'
     bool compute_extended_features_; // eq. '(!is_fast_path_) && dilate_ == 1'
 
-    int filter_;
-    int lower_offset_; // d_lo
-    int output_offset_; // d_oj
+    dim_t filter_;
+    dim_t lower_offset_; // d_lo
+    dim_t output_offset_; // d_oj
 
-    int init_overflow_; // d_t_overflow
-    int end_overflow_; // d_b_overflow
+    dim_t init_overflow_; // d_t_overflow
+    dim_t end_overflow_; // d_b_overflow
 };
 
 } // namespace amx_utils

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -48,7 +48,7 @@ using namespace nstl;
 
 template <typename T>
 static inline T accum_with_upper_bound(T ub, T lv, T uv) {
-    return nstl::min(ub, nstl::min(ub, lv) + nstl::max(0, ub - uv));
+    return nstl::min<T>(ub, nstl::min<T>(ub, lv) + nstl::max<T>(0, ub - uv));
 }
 
 void jit_avx512_core_amx_convolution_fwd_t::prepare_padded_bias(
@@ -123,18 +123,19 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             ? reinterpret_cast<int32_t *>(w + offset)
             : nullptr;
 
-    const int t_pad_output = jcp.t_pad_output;
-    const int b_pad_output = jcp.b_pad_output;
-    const int b_pad_start = nstl::max(jcp.oh - b_pad_output, t_pad_output);
-    const int zp_buff_b_pad_start
-            = nstl::max(jcp.oh_pad - b_pad_output, t_pad_output);
+    const dim_t t_pad_output = jcp.t_pad_output;
+    const dim_t b_pad_output = jcp.b_pad_output;
+    const int b_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.oh - b_pad_output, t_pad_output));
+    const dim_t zp_buff_b_pad_start
+            = nstl::max<dim_t>(jcp.oh_pad - b_pad_output, t_pad_output);
 
-    const int ngroups = jcp.ngroups;
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
-    const int work_amount
+    const dim_t ngroups = jcp.ngroups;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * oh_chunks * jcp.nb_ow * oc_chunks;
-    const int zp_pbuff_size = jcp.zp_pbuff_size;
+    const dim_t zp_pbuff_size = jcp.zp_pbuff_size;
 
     // reorder weights from (g)Owhi16o to (g)OR16r16o4r, where r := whi
     auto p = jit_conv_args_t();
@@ -156,27 +157,29 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
     if (req_zero_point_buffer && zp_pbuff_outer_compute) {
         const size_t wei_oc_step = (size_t)jcp.kh * jcp.kw * jcp.ic_block_int_np
                 * jcp.nb_oc_blocking * jcp.oc_block;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
-        const int oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
         parallel_nd(ngroups, oc_chunks, oh_work,
                 [= COMPAT_THIS_CAPTURE](dim_t g, dim_t occ, dim_t oh) {
             auto p = jit_conv_args_t();
 
-            const int oh_ = oh >= zp_buff_b_pad_start
+            const dim_t oh_ = oh >= zp_buff_b_pad_start
                     ? b_pad_start + oh - zp_buff_b_pad_start
                     : oh;
-            const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-            const int t_overflow
-                    = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-            const int b_overflow = nstl::min(jcp.kh,
-                    div_up(nstl::max(0, ih + gen_kh - jcp.ih), dilate_h));
+            const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+            const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+            const int b_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kh,
+                    div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                            dilate_h)));
             p.t_overflow = t_overflow;
             p.b_overflow = b_overflow;
-            p.kh_padding = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+            p.kh_padding
+                    = nstl::max<dim_t>(0, jcp.kh - t_overflow - b_overflow);
 
-            const int ocb
+            const dim_t ocb
                     = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
             const size_t ch_offset = dst_d.blk_off(0, ocb);
             const size_t sp_offset = oh * jcp.ow_pad * sp_stride;
@@ -194,7 +197,7 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
     // input data reuse and parallelize input data reorders
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        balance211(static_cast<int>(work_amount), nthr, ithr, start, end);
         int32_t *local_zp_pbuff = req_zero_point_buffer
                 ? (zp_pbuff_outer_compute
                                   ? zero_point_pbuff
@@ -205,7 +208,7 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 : nullptr;
         if (zp_pbuff_parallel_block) {
             PRAGMA_OMP_SIMD()
-            for (int oc = 0; oc < oc_chunks * ngroups; oc++)
+            for (dim_t oc = 0; oc < oc_chunks * ngroups; oc++)
                 zp_flags[oc] = true;
         }
 
@@ -225,31 +228,32 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        const int oh_work = jcp.oh_pad;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
         const size_t wei_oc_step = (size_t)jcp.kh * jcp.kw * jcp.ic_block_int_np
                 * jcp.nb_oc_blocking * jcp.oc_block;
         size_t oc_stride = dst_d.blk_off(0, 1);
-        const int owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
+        const dim_t owb_limit
+                = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
 
-        int mb {0}, g {0}, ohc {0}, owb {0}, occ {0};
+        dim_t mb {0}, g {0}, ohc {0}, owb {0}, occ {0};
         // need "inner" oh blocks w.r.t. ow blocks to allow pbuffer reuse
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, owb, jcp.nb_ow, ohc,
                 oh_chunks, occ, oc_chunks);
-        int last_copied_mb = -1;
-        int last_copied_ohc = -1;
-        int last_copied_owb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_ohc = -1;
+        dim_t last_copied_owb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + src_dt_size * ithr * jcp.inp_buffer_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            int oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
-            int ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
+            dim_t oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
+            dim_t ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
             const char *bias_w = bias
                     ? bias + (bias_d.blk_off(oc) * bia_dt_size)
                     : nullptr;
@@ -258,8 +262,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             p.src_zero_point = src_zero_points;
             p.dst_zero_point = dst_zero_points;
 
-            int oh_s = ohc * jcp.oh_blk_size;
-            int oh_e = nstl::min(jcp.oh, oh_s + jcp.oh_blk_size);
+            dim_t oh_s = ohc * jcp.oh_blk_size;
+            dim_t oh_e = nstl::min<dim_t>(jcp.oh, oh_s + jcp.oh_blk_size);
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_ohc == ohc && last_copied_owb == owb
                     && last_copied_g == g;
@@ -270,11 +274,12 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                     ? zp_flags[g * oc_chunks + occ] // already computed?
                     : false;
 
-            int cur_t_pad = nstl::max(0, t_pad_output - oh_s);
-            int cur_b_pad = nstl::max(
-                    nstl::max(0, jcp.oh - b_pad_output - oh_s), cur_t_pad);
-            size_t zp_oh
-                    = accum_with_upper_bound(oh_s, t_pad_output, b_pad_start);
+            dim_t cur_t_pad = nstl::max<dim_t>(0, t_pad_output - oh_s);
+            dim_t cur_b_pad = nstl::max<dim_t>(
+                    nstl::max<dim_t>(0, jcp.oh - b_pad_output - oh_s),
+                    cur_t_pad);
+            size_t zp_oh = accum_with_upper_bound<dim_t>(
+                    oh_s, t_pad_output, b_pad_start);
 
             int limit_idx = 0;
             constexpr int limit_size = 5;
@@ -288,19 +293,20 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 assert(!zp_pbuff_outer_compute);
                 zp_flags[g * oc_chunks + occ] = false;
                 for (int oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
-                    const int oh_ = oh_pad >= zp_buff_b_pad_start
+                    const dim_t oh_ = oh_pad >= zp_buff_b_pad_start
                             ? b_pad_start + oh_pad - zp_buff_b_pad_start
                             : oh_pad;
-                    const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-                    const int t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-                    const int b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0, ih + gen_kh - jcp.ih),
-                                    dilate_h));
+                    const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+                    const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+                    const int b_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh,
+                            div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                                    dilate_h)));
                     p.t_overflow = t_overflow;
                     p.b_overflow = b_overflow;
-                    p.kh_padding
-                            = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+                    p.kh_padding = nstl::max<dim_t>(
+                            0, jcp.kh - t_overflow - b_overflow);
 
                     const size_t ch_offset = dst_d.blk_off(0, oc);
                     const size_t sp_offset = oh_pad * jcp.ow_pad * sp_stride;
@@ -314,50 +320,51 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 }
             }
 
-            int oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
-            for (int oh = oh_s; oh < oh_e; oh += oh_step) {
-                const int inp_buffer_h_step
+            dim_t oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
+            for (dim_t oh = oh_s; oh < oh_e; oh += oh_step) {
+                const dim_t inp_buffer_h_step
                         = jcp.stride_h * jcp.ic_without_padding;
                 assert(jcp.is_nspc);
                 assert(jcp.stride_h <= jcp.kh);
 
-                int ow = owb * jcp.ow_block;
+                dim_t ow = owb * jcp.ow_block;
 
                 char *inp_buffer_oh
                         = inp_buffer + src_dt_size * oh * inp_buffer_h_step;
 
                 if (!is_inp_buffer_relevant) {
                     // prepare padded input buffer
-                    const int icb = g * jcp.ic;
+                    const dim_t icb = g * jcp.ic;
                     size_t inp_offset = src_d.blk_off(mb, icb);
-                    const int iw_step = jcp.ngroups * jcp.ic_without_padding;
+                    const dim_t iw_step = jcp.ngroups * jcp.ic_without_padding;
                     const char *psrc = src + src_dt_size * inp_offset;
                     // calculate overlap...
-                    const int ih_overlap = has_inp_buffer_overlap
-                            * nstl::max(0, jcp.kh - oh_step * jcp.stride_h);
-                    const int kh_eff = jcp.kh - ih_overlap;
+                    const dim_t ih_overlap = has_inp_buffer_overlap
+                            * nstl::max<dim_t>(
+                                    0, jcp.kh - oh_step * jcp.stride_h);
+                    const dim_t kh_eff = jcp.kh - ih_overlap;
                     // prepare padded input buffer
                     char *pdst = inp_buffer_oh
                             + src_dt_size * ih_overlap * jcp.ic_without_padding;
                     for (int doh = 0; doh < oh_step; doh++) {
-                        const int ih_s = (doh + oh) * jcp.stride_h - jcp.t_pad
+                        const dim_t ih_s = (doh + oh) * jcp.stride_h - jcp.t_pad
                                 + ih_overlap;
-                        const int ih_e = ih_s + kh_eff;
-                        const int ih = nstl::max(0, ih_s);
-                        p.t_overflow = nstl::max(0, -ih_s);
-                        p.b_overflow = nstl::min<int>(
-                                kh_eff, nstl::max(0, ih_e - jcp.ih));
-                        p.kh_padding = nstl::max<int>(
-                                0, (kh_eff - p.t_overflow - p.b_overflow));
-                        p.kh_offset = kh_eff;
+                        const dim_t ih_e = ih_s + kh_eff;
+                        const dim_t ih = nstl::max<dim_t>(0, ih_s);
+                        p.t_overflow = nstl::max<dim_t>(0, -ih_s);
+                        p.b_overflow = nstl::min<dim_t>(
+                                kh_eff, nstl::max<dim_t>(0, ih_e - jcp.ih));
+                        p.kh_padding = static_cast<int>(nstl::max<dim_t>(
+                                0, kh_eff - p.t_overflow - p.b_overflow));
+                        p.kh_offset = static_cast<int>(kh_eff);
 
-                        const int iw_s = ow * jcp.stride_w - jcp.l_pad;
-                        const int iw_e = iw_s + jcp.iwp;
-                        const int iw = nstl::max(0, iw_s);
-                        p.f_overflow = nstl::max(0, -iw_s);
-                        p.back_overflow = nstl::max(0, iw_e - jcp.iw);
-                        p.kw_padding = nstl::max<int>(
-                                0, jcp.iwp - p.f_overflow - p.back_overflow);
+                        const dim_t iw_s = ow * jcp.stride_w - jcp.l_pad;
+                        const dim_t iw_e = iw_s + jcp.iwp;
+                        const dim_t iw = nstl::max<dim_t>(0, iw_s);
+                        p.f_overflow = nstl::max<dim_t>(0, -iw_s);
+                        p.back_overflow = nstl::max<dim_t>(0, iw_e - jcp.iw);
+                        p.kw_padding = static_cast<int>(nstl::max<dim_t>(
+                                0, jcp.iwp - p.f_overflow - p.back_overflow));
 
                         p.src = psrc
                                 + src_dt_size * (ih * jcp.iw + iw) * iw_step;
@@ -395,8 +402,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                     limit_idx++;
                 p.ohb = limit_idx;
                 p.last_h = (oh + oh_step <= oh_e);
-                const int zp_owb = nstl::min(jcp.l_pad_blk, owb)
-                        + nstl::max(0, owb - owb_limit);
+                const dim_t zp_owb = nstl::min<dim_t>(jcp.l_pad_blk, owb)
+                        + nstl::max<dim_t>(0, owb - owb_limit);
                 p.owb = req_zero_point_buffer ? zp_owb : owb;
 
                 p.oc_blocks = occ * jcp.nb_oc_blocking;
@@ -410,8 +417,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 if (req_zero_point_buffer) {
                     zp_oh += accum_with_upper_bound(
                             oh_step, cur_t_pad, cur_b_pad);
-                    cur_t_pad = nstl::max(0, cur_t_pad - oh_step);
-                    cur_b_pad = nstl::max(0, cur_b_pad - oh_step);
+                    cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step);
+                    cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step);
                 }
             }
             last_copied_mb = mb;
@@ -494,24 +501,25 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             ? reinterpret_cast<int32_t *>(&w[offset])
             : nullptr;
 
-    const int f_pad_output = jcp.f_pad_output;
-    const int back_pad_output = jcp.back_pad_output;
-    const int back_pad_start
-            = nstl::max(jcp.od - back_pad_output, f_pad_output);
-    const int zp_buff_back_pad_start
-            = nstl::max(jcp.od_pad - back_pad_output, f_pad_output);
-    const int t_pad_output = jcp.t_pad_output;
-    const int b_pad_output = jcp.b_pad_output;
-    const int b_pad_start = nstl::max(jcp.oh - b_pad_output, t_pad_output);
-    const int zp_buff_b_pad_start
-            = nstl::max(jcp.oh_pad - b_pad_output, t_pad_output);
+    const dim_t f_pad_output = jcp.f_pad_output;
+    const dim_t back_pad_output = jcp.back_pad_output;
+    const int back_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.od - back_pad_output, f_pad_output));
+    const dim_t zp_buff_back_pad_start
+            = nstl::max<dim_t>(jcp.od_pad - back_pad_output, f_pad_output);
+    const dim_t t_pad_output = jcp.t_pad_output;
+    const dim_t b_pad_output = jcp.b_pad_output;
+    const int b_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.oh - b_pad_output, t_pad_output));
+    const dim_t zp_buff_b_pad_start
+            = nstl::max<dim_t>(jcp.oh_pad - b_pad_output, t_pad_output);
 
-    const int ngroups = jcp.ngroups;
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
-    const size_t work_amount = (size_t)jcp.mb * jcp.ngroups * jcp.od * oh_chunks
-            * jcp.nb_ow * oc_chunks;
-    const int zp_pbuff_size = jcp.zp_pbuff_size;
+    const dim_t ngroups = jcp.ngroups;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
+    const dim_t work_amount
+            = jcp.mb * jcp.ngroups * jcp.od * oh_chunks * jcp.nb_ow * oc_chunks;
+    const dim_t zp_pbuff_size = jcp.zp_pbuff_size;
 
     // init zero_point padding buffer
     const bool req_zero_point_buffer = jcp.req_zero_point_buffer;
@@ -519,42 +527,46 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
     const bool zp_pbuff_parallel_block
             = req_zero_point_buffer && !zp_pbuff_outer_compute;
     if (req_zero_point_buffer && zp_pbuff_outer_compute) {
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_d = jcp.dilate_d + 1;
-        const int gen_kd = (jcp.kd - 1) * dilate_d + 1;
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
-        const int od_work = jcp.od_pad;
-        const int oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_d = jcp.dilate_d + 1;
+        const dim_t gen_kd = (jcp.kd - 1) * dilate_d + 1;
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t od_work = jcp.od_pad;
+        const dim_t oh_work = jcp.oh_pad;
         parallel_nd(ngroups, oc_chunks, od_work, oh_work,
                 [= COMPAT_THIS_CAPTURE](
                         dim_t g, dim_t occ, dim_t od, dim_t oh) {
             auto p = jit_conv_args_t();
 
-            const int od_ = od >= zp_buff_back_pad_start
+            const dim_t od_ = od >= zp_buff_back_pad_start
                     ? back_pad_start + od - zp_buff_back_pad_start
                     : od;
-            const int id = od_ * jcp.stride_d - jcp.f_pad;
-            const int f_overflow
-                    = nstl::min(jcp.kd, div_up(max(0, -id), dilate_d));
-            const int back_overflow = nstl::min(jcp.kd,
-                    div_up(nstl::max(0, id + gen_kd - jcp.id), dilate_d));
+            const dim_t id = od_ * jcp.stride_d - jcp.f_pad;
+            const int f_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd, div_up(max<dim_t>(0, -id), dilate_d)));
+            const int back_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kd,
+                    div_up(nstl::max<dim_t>(0, id + gen_kd - jcp.id),
+                            dilate_d)));
             p.f_overflow = f_overflow;
             p.back_overflow = back_overflow;
-            p.kd_padding = nstl::max(0, jcp.kd - f_overflow - back_overflow);
-            const int oh_ = oh >= zp_buff_b_pad_start
+            p.kd_padding
+                    = nstl::max<dim_t>(0, jcp.kd - f_overflow - back_overflow);
+            const dim_t oh_ = oh >= zp_buff_b_pad_start
                     ? b_pad_start + oh - zp_buff_b_pad_start
                     : oh;
-            const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-            const int t_overflow
-                    = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-            const int b_overflow = nstl::min(jcp.kh,
-                    div_up(nstl::max(0, ih + gen_kh - jcp.ih), dilate_h));
+            const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+            const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+            const int b_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kh,
+                    div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                            dilate_h)));
             p.t_overflow = t_overflow;
             p.b_overflow = b_overflow;
-            p.kh_padding = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+            p.kh_padding
+                    = nstl::max<dim_t>(0, jcp.kh - t_overflow - b_overflow);
 
-            const int ocb
+            const dim_t ocb
                     = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
             const size_t ch_offset = dst_d.blk_off(0, ocb);
             auto sp_offset = (od * jcp.oh_pad + oh) * jcp.ow_pad * sp_stride;
@@ -571,7 +583,7 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
     // TODO: implement 2D parallelization driver (g * spatial x oc) to increase
     // input data reuse and parallelize input data reorders
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
         int32_t *local_zp_pbuff = req_zero_point_buffer
                 ? (zp_pbuff_outer_compute
@@ -583,7 +595,7 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 : nullptr;
         if (zp_pbuff_parallel_block) {
             PRAGMA_OMP_SIMD()
-            for (int oc = 0; oc < oc_chunks * ngroups; oc++)
+            for (dim_t oc = 0; oc < oc_chunks * ngroups; oc++)
                 zp_flags[oc] = true;
         }
 
@@ -604,30 +616,31 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        const int oh_work = jcp.oh_pad;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_d = jcp.dilate_d + 1;
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_d = jcp.dilate_d + 1;
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
         size_t oc_stride = dst_d.blk_off(0, 1);
-        const int owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
+        const dim_t owb_limit
+                = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
 
-        int mb {0}, g {0}, odc {0}, ohc {0}, owb {0}, occ {0};
+        dim_t mb {0}, g {0}, odc {0}, ohc {0}, owb {0}, occ {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, odc, jcp.od, ohc,
                 oh_chunks, owb, jcp.nb_ow, occ, oc_chunks);
-        int last_copied_mb = -1;
-        int last_copied_odc = -1;
-        int last_copied_ohc = -1;
-        int last_copied_owb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_odc = -1;
+        dim_t last_copied_ohc = -1;
+        dim_t last_copied_owb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + src_dt_size * ithr * jcp.inp_buffer_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            int oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
-            int ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
+            dim_t oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
+            int ocb = static_cast<int>(jcp.is_nspc ? oc : oc / jcp.oc_block);
             const char *bias_w = bias
                     ? bias + (bias_d.blk_off(oc) * bia_dt_size)
                     : nullptr;
@@ -637,8 +650,8 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             p.dst_zero_point = dst_zero_points;
 
             const size_t inp_src_d_stride = mem_blk_off(src_d, 0, 0, 1, 0, 0);
-            int oh_s = ohc * jcp.oh_blk_size;
-            int oh_e = nstl::min(jcp.oh, oh_s + jcp.oh_blk_size);
+            dim_t oh_s = ohc * jcp.oh_blk_size;
+            dim_t oh_e = nstl::min<dim_t>(jcp.oh, oh_s + jcp.oh_blk_size);
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_odc == odc && last_copied_ohc == ohc
                     && last_copied_owb == owb && last_copied_g == g;
@@ -646,14 +659,15 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                     ? zp_flags[g * oc_chunks + occ] // already computed?
                     : false;
 
-            int cur_t_pad = nstl::max(0, t_pad_output - oh_s);
-            int cur_b_pad = nstl::max(
-                    nstl::max(0, jcp.oh - b_pad_output - oh_s), cur_t_pad);
+            dim_t cur_t_pad = nstl::max<dim_t>(0, t_pad_output - oh_s);
+            dim_t cur_b_pad = nstl::max<dim_t>(
+                    nstl::max<dim_t>(0, jcp.oh - b_pad_output - oh_s),
+                    cur_t_pad);
             const size_t zp_od = odc >= back_pad_start
                     ? odc - back_pad_start + zp_buff_back_pad_start
-                    : nstl::min(f_pad_output, odc);
-            size_t zp_oh
-                    = accum_with_upper_bound(oh_s, t_pad_output, b_pad_start);
+                    : nstl::min<dim_t>(f_pad_output, odc);
+            size_t zp_oh = accum_with_upper_bound<dim_t>(
+                    oh_s, t_pad_output, b_pad_start);
 
             int limit_idx = 0;
             constexpr int limit_size = 5;
@@ -667,20 +681,21 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 assert(pd()->ndims() != 5);
                 assert(!zp_pbuff_outer_compute);
                 zp_flags[g * oc_chunks + occ] = false;
-                for (int oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
-                    const int oh_ = oh_pad >= zp_buff_b_pad_start
+                for (dim_t oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
+                    const dim_t oh_ = oh_pad >= zp_buff_b_pad_start
                             ? b_pad_start + oh_pad - zp_buff_b_pad_start
                             : oh_pad;
-                    const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-                    const int t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-                    const int b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0, ih + gen_kh - jcp.ih),
-                                    dilate_h));
+                    const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+                    const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+                    const int b_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh,
+                            div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                                    dilate_h)));
                     p.t_overflow = t_overflow;
                     p.b_overflow = b_overflow;
-                    p.kh_padding
-                            = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+                    p.kh_padding = nstl::max<dim_t>(
+                            0, jcp.kh - t_overflow - b_overflow);
 
                     const size_t ch_offset = dst_d.blk_off(0, oc);
                     const size_t sp_offset = oh_pad * jcp.ow_pad * sp_stride;
@@ -695,38 +710,43 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 }
             }
 
-            const int id_s = odc * jcp.stride_d - jcp.f_pad;
-            const int d_f_overflow
-                    = nstl::min(jcp.kd, div_up(max(0, -id_s), dilate_d));
-            const int d_back_overflow = nstl::min(jcp.kd,
-                    div_up(max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
-                            dilate_d));
-            p.kd_padding
-                    = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+            const dim_t id_s = odc * jcp.stride_d - jcp.f_pad;
+            const int d_f_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd, div_up(max<dim_t>(0, -id_s), dilate_d)));
+            const int d_back_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd,
+                    div_up(max<dim_t>(0,
+                                   id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+                            dilate_d)));
+            p.kd_padding = nstl::max<dim_t>(
+                    0, jcp.kd - d_f_overflow - d_back_overflow);
 
-            int oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
-            for (int oh = oh_s; oh < oh_e; oh += oh_step) {
-                const int gen_kh = ((jcp.kh - 1) * (jcp.dilate_h + 1) + 1);
-                const int gen_stride_h = nstl::min(jcp.stride_h, gen_kh);
+            dim_t oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
+            for (dim_t oh = oh_s; oh < oh_e; oh += oh_step) {
+                const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                const int gen_stride_h = static_cast<int>(
+                        nstl::min<dim_t>(jcp.stride_h, gen_kh));
                 if (!is_inp_buffer_relevant) {
-                    const int iw = nstl::max(
+                    const dim_t iw = nstl::max<dim_t>(
                             0, owb * jcp.ow_block * jcp.stride_w - jcp.l_pad);
 
                     assert(IMPLICATION(
                             jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-                    const int icb = g * (jcp.is_nspc ? jcp.ic : jcp.nb_ic);
+                    const dim_t icb = g * (jcp.is_nspc ? jcp.ic : jcp.nb_ic);
 
                     // generalized kh including dilation
                     // the current implementation of copy routine is not
                     // optimal for small jcp.oh_blk_size as it copies
                     // dilation rows to buffer
                     const bool continuous_copy = gen_kh >= jcp.stride_h;
-                    int current_oh_block = nstl::min(oh_e - oh, oh_step);
-                    int num_copy_calls = continuous_copy ? 1 : current_oh_block;
+                    dim_t current_oh_block
+                            = nstl::min<dim_t>(oh_e - oh, oh_step);
+                    dim_t num_copy_calls
+                            = continuous_copy ? 1 : current_oh_block;
                     for (int ohi = 0; ohi < num_copy_calls; ohi++) {
-                        int ih_copy_start
+                        dim_t ih_copy_start
                                 = (oh + ohi) * jcp.stride_h - jcp.t_pad;
-                        int ih_copy_end = ih_copy_start + gen_kh;
+                        dim_t ih_copy_end = ih_copy_start + gen_kh;
                         if (continuous_copy) {
                             ih_copy_end
                                     += jcp.stride_h * (current_oh_block - 1);
@@ -737,21 +757,23 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                                 //     (oh - 1) * str_h - t_pad + kh
                                 ih_copy_start += gen_kh - jcp.stride_h;
                         }
-                        int ih_zero_top = nstl::max(0, -ih_copy_start);
-                        int ih_zero_bottom = nstl::max(0, ih_copy_end - jcp.ih);
+                        dim_t ih_zero_top = nstl::max<dim_t>(0, -ih_copy_start);
+                        dim_t ih_zero_bottom
+                                = nstl::max<dim_t>(0, ih_copy_end - jcp.ih);
                         // how many real data rows to copy (including padding)
-                        int rows_to_copy = ih_copy_end - ih_copy_start;
-                        p.kh_padding = max(0, rows_to_copy);
-                        p.t_overflow = ih_zero_top;
-                        p.b_overflow = ih_zero_bottom;
-                        p.owb = owb;
-                        int ih = nstl::max(ih_copy_start, 0);
+                        dim_t rows_to_copy = ih_copy_end - ih_copy_start;
+                        p.kh_padding = static_cast<int>(
+                                nstl::max<dim_t>(0, rows_to_copy));
+                        p.t_overflow = static_cast<int>(ih_zero_top);
+                        p.b_overflow = static_cast<int>(ih_zero_bottom);
+                        p.owb = static_cast<int>(owb);
+                        dim_t ih = nstl::max<dim_t>(ih_copy_start, 0);
                         size_t inp_offset
                                 = mem_blk_off(src_d, mb, icb, id_s, ih, iw)
                                 + d_f_overflow * dilate_d * inp_src_d_stride;
                         p.src = src + src_dt_size * inp_offset;
                         // inp_buffer has physical padding
-                        int ih_buf = continuous_copy
+                        dim_t ih_buf = continuous_copy
                                 ? ih_copy_start + jcp.t_pad
                                         - oh_s * jcp.stride_h
                                 : gen_stride_h * (oh + ohi - oh_s);
@@ -762,8 +784,8 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                         kernel_->copy_to_pbuffer()(&p);
                     }
                 }
-                int ih_buf = gen_stride_h * (oh - oh_s);
-                int ow = owb * jcp.ow_block;
+                dim_t ih_buf = gen_stride_h * (oh - oh_s);
+                dim_t ow = owb * jcp.ow_block;
                 p.src = inp_buffer
                         + src_dt_size * ih_buf * jcp.iwp * jcp.ic_block_int_np;
 
@@ -795,9 +817,9 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 assert(limit_idx < 6);
                 p.ohb = limit_idx;
                 p.last_h = (oh + oh_step <= oh_e);
-                const int zp_owb = nstl::min(jcp.l_pad_blk, owb)
-                        + nstl::max(0, owb - owb_limit);
-                p.owb = req_zero_point_buffer ? zp_owb : owb;
+                const dim_t zp_owb = nstl::min<dim_t>(jcp.l_pad_blk, owb)
+                        + nstl::max<dim_t>(0, owb - owb_limit);
+                p.owb = static_cast<int>(req_zero_point_buffer ? zp_owb : owb);
 
                 p.oc_blocks = occ * jcp.nb_oc_blocking;
 
@@ -808,10 +830,10 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 (*kernel_)(&p);
 
                 if (req_zero_point_buffer) {
-                    zp_oh += accum_with_upper_bound(
+                    zp_oh += accum_with_upper_bound<dim_t>(
                             oh_step, cur_t_pad, cur_b_pad);
-                    cur_t_pad = nstl::max(0, cur_t_pad - oh_step);
-                    cur_b_pad = nstl::max(0, cur_b_pad - oh_step);
+                    cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step);
+                    cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step);
                 }
             }
             last_copied_mb = mb;
@@ -864,9 +886,9 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
     auto global_tcfg = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_tilecfg);
 
-    const int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-    const int ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
-    const int work_amount
+    const dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    const dim_t ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * jcp.id * ih_chunks * jcp.nb_iw * ic_chunks;
 
     const bool is_1d = jcp.ndims == 3;
@@ -874,7 +896,7 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        balance211(static_cast<int>(work_amount), nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
 
@@ -895,84 +917,100 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
+        dim_t mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, id_s, jcp.id, ihc,
                 ih_chunks, iwb, jcp.nb_iw, icc, ic_chunks);
-        int last_copied_mb = -1;
-        int last_copied_id = -1;
-        int last_copied_ihc = -1;
-        int last_copied_iwb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_id = -1;
+        dim_t last_copied_ihc = -1;
+        dim_t last_copied_iwb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer = inp_p_buffer
                     + ithr * jcp.inp_buffer_size * diff_dst_dt_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-            int ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
-            int icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
+            dim_t ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
+            dim_t icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            const int ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
+            const dim_t ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
 
-            const int ih_b = ihc * jcp.ih_blk_size;
-            const int ih_e = nstl::min(jcp.ih, ih_b + jcp.ih_blk_size);
-            const int iw = iwb * jcp.iw_block;
+            const dim_t ih_b = ihc * jcp.ih_blk_size;
+            const dim_t ih_e = nstl::min<dim_t>(jcp.ih, ih_b + jcp.ih_blk_size);
+            const dim_t iw = iwb * jcp.iw_block;
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_id == id_s && last_copied_ihc == ihc
                     && last_copied_iwb == iwb && last_copied_g == g;
 
             sfd.update_params(id_s);
             p.kd_padding = sfd.get_filter_padding();
-            const int d_lo = sfd.get_lower_offset();
-            const int d_oj = sfd.get_output_offset();
+            const dim_t d_lo = sfd.get_lower_offset();
+            const dim_t d_oj = sfd.get_output_offset();
 
-            int ih_step = jcp.nb_ih_blocking;
-            for (int ih = ih_b; ih < ih_e; ih += ih_step) {
+            dim_t ih_step = jcp.nb_ih_blocking;
+            for (dim_t ih = ih_b; ih < ih_e; ih += ih_step) {
                 if (!is_inp_buffer_relevant) {
-                    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-                    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+                    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
                     // dox: x-index dilated by strides (dox = ox * stride_x)
-                    const int doh = ih + jcp.t_pad - (gen_kh - 1);
-                    const int dow = iw + jcp.l_pad - (gen_kw - 1);
-                    const int doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
-                    const int doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
-                    const int dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
+                    const dim_t doh = ih + jcp.t_pad - (gen_kh - 1);
+                    const dim_t dow = iw + jcp.l_pad - (gen_kw - 1);
+                    const dim_t doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
+                    const dim_t doh_l = (jcp.oh - 1) * jcp.stride_h;
+                    const dim_t dow_l = (jcp.ow - 1) * jcp.stride_w;
 
                     // dox_{s,f}: start and finish indices for copy kernel
-                    const int doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
-                    const int doh_f = doh + (ih_step - 1) + (gen_kh - 1);
-                    const int delta_h = doh_f - doh_s + 1;
-                    const int doh_t_overflow = 0 < doh_s && doh_s < doh_l
-                            ? nstl::additive_inverse_modulo(doh_s, jcp.stride_h)
-                            : nstl::max(0, -doh_s);
-                    const int doh_b_overflow = 0 < doh_f && doh_f < doh_l
-                            ? nstl::modulo(doh_f, jcp.stride_h)
-                            : nstl::max(0, nstl::min(delta_h, doh_f - doh_l));
-                    int dow_s = dow;
-                    int dow_f = dow + jcp.owp - 1;
-                    const int delta_w = dow_f - dow_s + 1;
-                    const int dow_l_overflow = 0 < dow_s && dow_s < dow_l
-                            ? nstl::additive_inverse_modulo(dow_s, jcp.stride_w)
-                            : nstl::max(0, -dow_s);
-                    const int dow_r_overflow = 0 < dow_f && dow_f < dow_l
-                            ? nstl::modulo(dow_f, jcp.stride_w)
-                            : nstl::max(0, nstl::min(delta_w, dow_f - dow_l));
-                    const int oh_s
-                            = utils::div_up(nstl::max(0, doh_s), jcp.stride_h);
-                    const int ow_s
-                            = utils::div_up(nstl::max(0, dow_s), jcp.stride_w);
+                    const dim_t doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
+                    const dim_t doh_f = doh + (ih_step - 1) + (gen_kh - 1);
+                    const dim_t delta_h = doh_f - doh_s + 1;
+                    const int doh_t_overflow
+                            = static_cast<int>(0 < doh_s && doh_s < doh_l
+                                            ? nstl::additive_inverse_modulo(
+                                                      static_cast<dim_t>(doh_s),
+                                                      jcp.stride_h)
+                                            : nstl::max<dim_t>(0, -doh_s));
+                    const int doh_b_overflow = static_cast<int>(
+                            0 < doh_f && doh_f < doh_l
+                                    ? nstl::modulo(static_cast<dim_t>(doh_f),
+                                              jcp.stride_h)
+                                    : nstl::max<dim_t>(0,
+                                              nstl::min<dim_t>(
+                                                      delta_h, doh_f - doh_l)));
+                    dim_t dow_s = dow;
+                    dim_t dow_f = dow + jcp.owp - 1;
+                    const dim_t delta_w = dow_f - dow_s + 1;
+                    const int dow_l_overflow
+                            = static_cast<int>(0 < dow_s && dow_s < dow_l
+                                            ? nstl::additive_inverse_modulo(
+                                                      static_cast<dim_t>(dow_s),
+                                                      jcp.stride_w)
+                                            : nstl::max<dim_t>(0, -dow_s));
+                    const int dow_r_overflow = static_cast<int>(
+                            0 < dow_f && dow_f < dow_l
+                                    ? nstl::modulo(static_cast<dim_t>(dow_f),
+                                              jcp.stride_w)
+                                    : nstl::max<dim_t>(0,
+                                              nstl::min<dim_t>(
+                                                      delta_w, dow_f - dow_l)));
+                    const dim_t oh_s = utils::div_up(
+                            nstl::max<dim_t>(0, doh_s), jcp.stride_h);
+                    const dim_t ow_s = utils::div_up(
+                            nstl::max<dim_t>(0, dow_s), jcp.stride_w);
                     // how many real data rows to copy (including padding)
-                    p.t_overflow = nstl::min(delta_h, doh_t_overflow);
-                    p.b_overflow = nstl::min<size_t>(
-                            delta_h - p.t_overflow, doh_b_overflow);
-                    p.kh_padding = nstl::max<size_t>(
-                            0, delta_h - p.t_overflow - p.b_overflow);
-                    p.l_overflow = nstl::min(delta_w, dow_l_overflow);
-                    p.kw_padding = nstl::max<size_t>(
-                            0, delta_w - dow_l_overflow - dow_r_overflow);
-                    p.r_overflow = nstl::min<size_t>(
-                            delta_w - dow_l_overflow, dow_r_overflow);
+                    p.t_overflow = static_cast<int>(
+                            nstl::min<dim_t>(delta_h, doh_t_overflow));
+                    p.b_overflow = static_cast<int>(nstl::min<dim_t>(
+                            delta_h - p.t_overflow, doh_b_overflow));
+                    p.kh_padding = static_cast<int>(nstl::max<dim_t>(
+                            0, delta_h - p.t_overflow - p.b_overflow));
+                    p.l_overflow = static_cast<int>(
+                            nstl::min<dim_t>(delta_w, dow_l_overflow));
+                    p.kw_padding = static_cast<int>(nstl::max<dim_t>(
+                            0, delta_w - dow_l_overflow - dow_r_overflow));
+                    p.r_overflow = static_cast<int>(nstl::min<dim_t>(
+                            delta_w - dow_l_overflow, dow_r_overflow));
                     size_t inp_offset = is_1d
                             ? diff_dst_d.blk_off(mb, ocb, ow_s)
                             : is_3d
@@ -1049,8 +1087,11 @@ status_t jit_avx512_core_amx_convolution_bwd_weights_t::init(engine_t *engine) {
     }
     if (j.transform_to_vnni) {
         CHECK(safe_ptr_assign(diff_wei_trans_kernel_,
-                new jit_diff_wei_trans_to_vnni_t(j.wei_dt, j.kd, j.kh, j.kw,
-                        j.ic_block, j.oc_block, j.nb_ic)));
+                new jit_diff_wei_trans_to_vnni_t(j.wei_dt,
+                        static_cast<int>(j.kd), static_cast<int>(j.kh),
+                        static_cast<int>(j.kw), static_cast<int>(j.ic_block),
+                        static_cast<int>(j.oc_block),
+                        static_cast<int>(j.nb_ic))));
         CHECK(diff_wei_trans_kernel_->create_kernel());
     }
     return status::success;
@@ -1134,21 +1175,22 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
         ithr_but_ic = (ithr_mb * self->nthr_g_ + ithr_g) * self->nthr_oc_b_
                 + ithr_oc_b;
 
-        int work_amount = jcp.nthr_mb_work;
+        int work_amount = static_cast<int>(jcp.nthr_mb_work);
         /* reduction dimension */
         balance211(work_amount, self->nthr_mb_, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(static_cast<int>(jcp.ngroups), self->nthr_g_, ithr_g,
+                g_start, g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(static_cast<int>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(static_cast<int>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         if (jcp.transform_to_vnni) {
             if (ic_b_start % 2 != 0) ic_b_start++;
             if (ic_b_end != jcp.nb_ic && ic_b_end % 2 != 0) ic_b_end++;
@@ -1158,7 +1200,7 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
 };
 
 size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_src_buf_number(
-        const thread_info_t *ti, int g, int ic) const {
+        const thread_info_t *ti, dim_t g, dim_t ic) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_ic * jcp.ngroups + g * jcp.nb_ic + ic
@@ -1166,7 +1208,7 @@ size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_src_buf_number(
 }
 
 size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_diff_dst_buf_number(
-        const thread_info_t *ti, int g, int oc) const {
+        const thread_info_t *ti, dim_t g, dim_t oc) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_oc * jcp.ngroups + g * jcp.nb_oc + oc
@@ -1174,27 +1216,29 @@ size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_diff_dst_buf_number(
 }
 
 void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
-        src_data_t *tr_src, const src_data_t *src_base, int spatial_start,
-        dim_t spatial_start_offset, int icb_start, dim_t chb_stride,
-        int row_count) const {
+        src_data_t *tr_src, const src_data_t *src_base, dim_t spatial_start,
+        dim_t spatial_start_offset, dim_t icb_start, dim_t chb_stride,
+        dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int src_stride = jcp.iw * jcp.ngroups * jcp.ic;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
-    int work_rest = row_count;
-    int max_spatial_work = jcp.id * jcp.ih;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    dim_t work_rest = row_count;
+    const dim_t max_spatial_work = jcp.id * jcp.ih;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *src = src_base + spatial_start_offset;
-    int icb = 0;
-    const int ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
+    dim_t icb = 0;
+    const dim_t ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = src;
             ctx.tr_src = tr_src;
             assert(icb_start + icb < jcp.nb_ic);
-            ctx.ch_work = (icb_start + icb + 1) == jcp.nb_ic ? ic_tail_work
-                                                             : jcp.ic_block;
+            ctx.ch_work = static_cast<int>((icb_start + icb + 1) == jcp.nb_ic
+                            ? ic_tail_work
+                            : jcp.ic_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_kernel_)(&ctx);
@@ -1202,7 +1246,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
             tr_src += tr_src_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         icb++;
         src = src_base + icb * chb_stride;
     }
@@ -1210,25 +1254,27 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
 
 void jit_avx512_core_amx_convolution_bwd_weights_t::trans_dst_nxc(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst_base,
-        int spatial_start, dim_t spatial_start_offset, int ocb_start,
-        dim_t chb_stride, int row_count) const {
+        dim_t spatial_start, dim_t spatial_start_offset, dim_t ocb_start,
+        dim_t chb_stride, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
-    int work_rest = row_count;
-    int max_spatial_work = jcp.od * jcp.oh;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    const dim_t diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    dim_t work_rest = row_count;
+    const dim_t max_spatial_work = jcp.od * jcp.oh;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *diff_dst = diff_dst_base + spatial_start_offset;
-    int ocb = 0;
-    const int oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
+    dim_t ocb = 0;
+    const dim_t oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = diff_dst;
             ctx.tr_src = tr_diff_dst;
             assert(ocb_start + ocb < jcp.nb_oc);
-            ctx.ch_work = (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
-                                                             : jcp.oc_block;
+            ctx.ch_work = static_cast<int>((ocb_start + ocb + 1) == jcp.nb_oc
+                            ? oc_tail_work
+                            : jcp.oc_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_dst_kernel_)(&ctx);
@@ -1236,7 +1282,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_dst_nxc(
             tr_diff_dst += tr_diff_dst_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         ocb++;
         diff_dst = diff_dst_base + ocb * chb_stride;
     }
@@ -1249,10 +1295,10 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_hblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_hblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1272,7 +1318,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * adj
@@ -1280,23 +1326,23 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                 + oj * tr_row_size;
     };
 
-    int img {0}, oh_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     nd_iterator_init(start, img, jcp.mb, oh_s, jcp.oh);
 
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        int ih_s = nstl::max(0, -jcp.t_pad + oh_s * jcp.stride_h);
-        const int ih_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        dim_t ih_s = nstl::max<dim_t>(0, -jcp.t_pad + oh_s * jcp.stride_h);
+        const dim_t ih_e = nstl::min<dim_t>(
                 jcp.ih, -jcp.t_pad + (oh_e - 1) * jcp.stride_h + ext_kh);
 
-        auto tr_src_off = [&](int g, int ic, int ih_end, int ij) {
+        auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ih_end, dim_t ij) {
             const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
             // Aligned to buffer end to use guard elements
@@ -1308,24 +1354,25 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             using simple_barrier::barrier;
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][ih][16][~iw~] <- src[nb_ic][ih][iw][16] */
-            int j {0};
-            int work_amount = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
-            int tr_start {0}, tr_end {0};
+            dim_t j {0};
+            dim_t work_amount = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
+            dim_t tr_start {0}, tr_end {0};
             balance211(
                     work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start, tr_end);
 
-            int g {0}, ic_b {0};
+            dim_t g {0}, ic_b {0};
             nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work, j,
                     ih_e - ih_s);
 
             if (nthr_oc_b_ > 1)
                 barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int ic_b_ = ic_b + ti->ic_b_start;
-                int j_s = j + ih_s;
-                int j_e = j_s + nstl::min(tr_end - tr_start, ih_e - j_s);
-                const int ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t ic_b_ = ic_b + ti->ic_b_start;
+                dim_t j_s = j + ih_s;
+                dim_t j_e
+                        = j_s + nstl::min<dim_t>(tr_end - tr_start, ih_e - j_s);
+                const dim_t ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
                 const src_data_t *src
                         = &ti->src[src_d.blk_off(img, ic_off_idx, j_s)];
                 src_data_t *tr_src
@@ -1345,18 +1392,19 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                     work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start, tr_end);
 
             g = 0;
-            int oc_b = 0;
+            dim_t oc_b = 0;
             nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work, j,
                     oh_e - oh_s);
 
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int oc_b_ = oc_b + ti->oc_b_start;
-                int j_s = j + oh_s;
-                int j_e = j_s + nstl::min(tr_end - tr_start, oh_e - j_s);
-                const int oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t oc_b_ = oc_b + ti->oc_b_start;
+                dim_t j_s = j + oh_s;
+                dim_t j_e
+                        = j_s + nstl::min<dim_t>(tr_end - tr_start, oh_e - j_s);
+                const dim_t oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
                 const diff_dst_data_t *diff_dst
                         = &ti->diff_dst[diff_dst_d.blk_off(
                                 img, oc_off_idx, j_s)];
@@ -1371,31 +1419,35 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
         }
-        int height_block = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
+        dim_t height_block
+                = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
 
-        for_(int ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+        for_(dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                 oc_b += jcp.nb_oc_blocking)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int ohb_e = nstl::min(ohb_s + height_block, oh_e);
-            const int ihb_s = nstl::max(0, -jcp.t_pad + ohb_s * jcp.stride_h);
-            const int ihb_e = nstl::min(
+            const dim_t ohb_e = nstl::min<dim_t>(ohb_s + height_block, oh_e);
+            const dim_t ihb_s
+                    = nstl::max<dim_t>(0, -jcp.t_pad + ohb_s * jcp.stride_h);
+            const dim_t ihb_e = nstl::min<dim_t>(
                     jcp.ih, -jcp.t_pad + (ohb_e - 1) * jcp.stride_h + ext_kh);
             assert(IMPLICATION(jcp.global_transpose,
                     oh_s == ohb_s && oh_e == ohb_e && ih_s == ihb_s
                             && ih_e == ihb_e));
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
@@ -1403,8 +1455,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                 src_data_t *tr_src
                         = &ti->tr_src[tr_src_off(0, 0, ihb_e, ihb_s)];
 
-                for (int icb = 0; icb < nb_ic_blocks; icb++) {
-                    const int ic_off_idx
+                for (dim_t icb = 0; icb < nb_ic_blocks; icb++) {
+                    const dim_t ic_off_idx
                             = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
                     const src_data_t *src
                             = (src_data_t *)&ti->src[src_d.blk_off(
@@ -1422,8 +1474,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             if (!jcp.global_transpose) {
                 diff_dst_data_t *tr_diff_dst
                         = &ti->tr_diff_dst[tr_diff_dst_off(0, 0, 0)];
-                for (int ocb = 0; ocb < nb_oc_blocks; ocb++) {
-                    const int oc_off_idx
+                for (dim_t ocb = 0; ocb < nb_oc_blocks; ocb++) {
+                    const dim_t oc_off_idx
                             = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
                     const diff_dst_data_t *diff_dst
                             = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1445,10 +1497,10 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                     + oc_b * jcp.oc_block;
             p.channel = (start == ti->img_start) && (ohb_s == oh_s);
 
-            p.reduce_work = ic_to_compute;
-            p.load_work = oc_to_compute; // it's only for mask
-            p.os_index_begin = ohb_s;
-            p.os_index_end = ohb_e;
+            p.reduce_work = static_cast<int>(ic_to_compute);
+            p.load_work = static_cast<int>(oc_to_compute); // it's only for mask
+            p.os_index_begin = static_cast<int>(ohb_s);
+            p.os_index_end = static_cast<int>(ohb_e);
             p.flags = 0 | (ic_b == 0 ? FLAG_IC_FIRST : 0);
             p.last_ic_block = (nb_ic_blocks == jcp.nb_ic_blocking) ? 0 : 1;
             p.last_oc_block = (nb_oc_blocks == jcp.nb_oc_blocking) ? 0 : 1;
@@ -1466,10 +1518,10 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_dblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_dblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1489,7 +1541,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od) {
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         const size_t tr_3d_size = tr_row_size * jcp.oh;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
@@ -1497,22 +1549,22 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size;
     };
-    int img {0}, od_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     nd_iterator_init(start, img, jcp.mb, od_s, jcp.od);
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        int id_s = nstl::max(0, -jcp.f_pad + od_s * jcp.stride_d);
-        const int id_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        dim_t id_s = nstl::max<dim_t>(0, -jcp.f_pad + od_s * jcp.stride_d);
+        const dim_t id_e = nstl::min<dim_t>(
                 jcp.id, -jcp.f_pad + (od_e - 1) * jcp.stride_d + ext_kd);
 
-        auto tr_src_off_3d = [&](int g, int ic, int id_end, int id) {
+        auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id_end, dim_t id) {
             const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             const size_t tr_3d_size = tr_row_size * jcp.ih;
             int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
@@ -1525,15 +1577,15 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             using simple_barrier::barrier;
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][id][16][~iw~] <- src[nb_ic][id][iw][16] */
-            int d {0};
+            dim_t d {0};
 
-            int work_amount = ti->g_work * ti->ic_b_work * (id_e - id_s);
+            dim_t work_amount = ti->g_work * ti->ic_b_work * (id_e - id_s);
 
-            int tr_start {0}, tr_end {0};
+            dim_t tr_start {0}, tr_end {0};
             balance211(
                     work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start, tr_end);
 
-            int g {0}, ic_b {0};
+            dim_t g {0}, ic_b {0};
 
             nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work, d,
                     id_e - id_s);
@@ -1541,12 +1593,13 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (nthr_oc_b_ > 1)
                 barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int ic_b_ = ic_b + ti->ic_b_start;
-                int d_s = d + id_s;
-                int d_e = d_s + nstl::min(tr_end - tr_start, id_e - d_s);
+                dim_t g_ = g + ti->g_start;
+                dim_t ic_b_ = ic_b + ti->ic_b_start;
+                dim_t d_s = d + id_s;
+                dim_t d_e
+                        = d_s + nstl::min<dim_t>(tr_end - tr_start, id_e - d_s);
 
-                const int ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
+                const dim_t ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
                 const src_data_t *src
                         = &ti->src[src_d.blk_off(img, ic_off_idx, d_s)];
                 src_data_t *tr_src
@@ -1568,7 +1621,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                     work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start, tr_end);
 
             g = 0;
-            int oc_b = 0;
+            dim_t oc_b = 0;
 
             nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work, d,
                     od_e - od_s);
@@ -1576,11 +1629,12 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int oc_b_ = oc_b + ti->oc_b_start;
-                int d_s = d + od_s;
-                int d_e = d_s + nstl::min(tr_end - tr_start, od_e - d_s);
-                const int oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t oc_b_ = oc_b + ti->oc_b_start;
+                dim_t d_s = d + od_s;
+                dim_t d_e
+                        = d_s + nstl::min<dim_t>(tr_end - tr_start, od_e - d_s);
+                const dim_t oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
 
                 const diff_dst_data_t *diff_dst
                         = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1598,40 +1652,43 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
         }
 
-        int depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
+        dim_t depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
 
-        for_(int odb_s = od_s; odb_s < od_e; odb_s += depth_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+        for_(dim_t odb_s = od_s; odb_s < od_e; odb_s += depth_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                 oc_b += jcp.nb_oc_blocking)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int odb_e = nstl::min(odb_s + depth_block, od_e);
-            const int idb_s = nstl::max(0, -jcp.f_pad + odb_s * jcp.stride_d);
-            const int idb_e = nstl::min(
+            const dim_t odb_e = nstl::min<dim_t>(odb_s + depth_block, od_e);
+            const dim_t idb_s
+                    = nstl::max<dim_t>(0, -jcp.f_pad + odb_s * jcp.stride_d);
+            const dim_t idb_e = nstl::min<dim_t>(
                     jcp.id, -jcp.f_pad + (odb_e - 1) * jcp.stride_d + ext_kd);
-            const int kdb_front_pad
-                    = nstl::max(0, jcp.f_pad - odb_s * jcp.stride_d);
+            const dim_t kdb_front_pad
+                    = nstl::max<dim_t>(0, jcp.f_pad - odb_s * jcp.stride_d);
             // Assumes kd_back_pad = 0 when kernel is dilated
-            const int kdb_back_pad = nstl::max(
+            const dim_t kdb_back_pad = nstl::max<dim_t>(
                     0, odb_s * jcp.stride_d + jcp.kd - jcp.f_pad - jcp.id);
-            const int kdb_pad_off = nstl::min(jcp.kd - 1, kdb_front_pad)
-                    * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
-                    * jcp.typesize_out;
+            const dim_t kdb_pad_off
+                    = nstl::min<dim_t>(jcp.kd - 1, kdb_front_pad) * jcp.kh
+                    * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
             assert(IMPLICATION(jcp.global_transpose,
                     od_s == odb_s && od_e == odb_e && id_s == idb_s
                             && id_e == idb_e));
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
@@ -1639,8 +1696,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 src_data_t *tr_src
                         = &ti->tr_src[tr_src_off_3d(0, 0, idb_e, idb_s)];
 
-                for (int icb = 0; icb < nb_ic_blocks; icb++) {
-                    const int ic_off_idx
+                for (dim_t icb = 0; icb < nb_ic_blocks; icb++) {
+                    const dim_t ic_off_idx
                             = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
                     const src_data_t *src
                             = (src_data_t *)&ti->src[src_d.blk_off(
@@ -1658,8 +1715,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (!jcp.global_transpose) {
                 diff_dst_data_t *tr_diff_dst
                         = &ti->tr_diff_dst[tr_diff_dst_off_3d(0, 0, 0)];
-                for (int ocb = 0; ocb < nb_oc_blocks; ocb++) {
-                    const int oc_off_idx
+                for (dim_t ocb = 0; ocb < nb_oc_blocks; ocb++) {
+                    const dim_t oc_off_idx
                             = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
                     const diff_dst_data_t *diff_dst
                             = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1704,9 +1761,9 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1726,23 +1783,24 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_src_off = [&](int g, int ic, int nb_ic_block, int ij) {
+    auto tr_src_off = [&](dim_t g, dim_t ic, dim_t nb_ic_block, dim_t ij) {
         const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size * adj
                 + ij * tr_row_size + nb_ic_block * jcp.tr_src_buf_size;
     };
 
-    auto tr_src_off_3d = [&](int g, int ic, int nb_ic_block, int id, int ij) {
+    auto tr_src_off_3d
+            = [&](dim_t g, dim_t ic, dim_t nb_ic_block, dim_t id, dim_t ij) {
         const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         const size_t tr_3d_size = tr_row_size * jcp.ih;
-        int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
+        dim_t adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size * adj
                 + id * tr_3d_size + ij * tr_row_size
                 + nb_ic_block * jcp.tr_src_buf_size;
     };
 
-    auto tr_diff_dst_off = [&](int g, int oc, int nb_oc_block, int oj) {
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t nb_oc_block, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
@@ -1751,26 +1809,26 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
     };
 
     auto tr_diff_dst_off_3d
-            = [&](int g, int oc, int nb_oc_block, int od, int oj) {
+            = [&](dim_t g, dim_t oc, dim_t nb_oc_block, dim_t od, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         const size_t tr_3d_size = tr_row_size * jcp.oh;
-        int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
+        dim_t adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 * adj
                 + od * tr_3d_size + oj * tr_row_size
                 + nb_oc_block * jcp.tr_src_buf_size;
     };
 
-    auto uker_trans
-            = [&](int img, int g = 0, int ic_b = 0, int nb_ic_block = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.ih * jcp.id;
-        int ic;
-        int icb_start = ic_b;
+    auto uker_trans = [&](dim_t img, dim_t g = 0, dim_t ic_b = 0,
+                              dim_t nb_ic_block = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.ih * jcp.id;
+        dim_t ic;
+        dim_t icb_start = ic_b;
         if (jcp.global_transpose) {
-            const int work_amount = ti->ic_b_work * jcp.ih * jcp.id;
+            const dim_t work_amount = ti->ic_b_work * jcp.ih * jcp.id;
 
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, start, end);
             my_work = end - start;
 
@@ -1792,7 +1850,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
         const bool need_local_gwork = jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) ic = gg * jcp.ic + ic_b * jcp.ic_block;
             src_data_t *tr_src = (jcp.ndims == 5)
                     ? &ti->tr_src[tr_src_off_3d(gg, ic_b, nb_ic_block, d, j)]
@@ -1803,23 +1861,23 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
             dim_t sp_start_offset = (jcp.ndims == 5) ? src_d.blk_off(0, 0, d, j)
                                                      : src_d.blk_off(0, 0, j);
             dim_t ch_shift = src_d.blk_off(0, jcp.ic_block);
-            int sp_start_idx = d * jcp.ih + j;
+            dim_t sp_start_idx = d * jcp.ih + j;
             trans_src_nxc(tr_src, src, sp_start_idx, sp_start_offset, icb_start,
                     ch_shift, my_work);
         }
     };
 
-    auto diff_dst_trans
-            = [&](int img, int g = 0, int oc_b = 0, int nb_oc_block = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.oh * jcp.od;
-        int oc;
-        int ocb_start = oc_b;
+    auto diff_dst_trans = [&](dim_t img, dim_t g = 0, dim_t oc_b = 0,
+                                  dim_t nb_oc_block = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.oh * jcp.od;
+        dim_t oc;
+        dim_t ocb_start = oc_b;
 
         if (jcp.global_transpose) {
-            const size_t work_amount = ti->oc_b_work * jcp.oh * jcp.od;
+            const dim_t work_amount = ti->oc_b_work * jcp.oh * jcp.od;
 
-            size_t start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, start, end);
             my_work = end - start;
 
@@ -1841,7 +1899,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
         const bool need_local_gwork = jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) oc = gg * jcp.oc + oc_b * jcp.oc_block;
             diff_dst_data_t *tr_diff_dst = (jcp.ndims == 5)
                     ? &ti->tr_diff_dst[tr_diff_dst_off_3d(
@@ -1855,7 +1913,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                     ? diff_dst_d.blk_off(0, 0, d, j)
                     : diff_dst_d.blk_off(0, 0, j);
             dim_t ch_shift = diff_dst_d.blk_off(0, jcp.oc_block);
-            int sp_start_idx = d * jcp.oh + j;
+            dim_t sp_start_idx = d * jcp.oh + j;
             trans_dst_nxc(tr_diff_dst, diff_dst, sp_start_idx, sp_start_offset,
                     ocb_start, ch_shift, my_work);
         }
@@ -1884,22 +1942,24 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                 oc_b += jcp.nb_oc_blocking)
         for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
 
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
             if (!jcp.global_transpose) {
-                for (int nib = 0; nib < nb_ic_blocks; nib++)
+                for (dim_t nib = 0; nib < nb_ic_blocks; nib++)
                     uker_trans(img, g, ic_b + nib, nib);
             }
             if (jcp.ndims == 5) {
@@ -1981,7 +2041,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1);
 
     const bool is_bf16_out = diff_weights_d.data_type() == data_type::bf16;
@@ -1993,8 +2053,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
             if (jcp.transform_to_vnni) {
                 store_in_vnni_format(ti);
             } else {
-                for_(int g = ti->g_start; g < ti->g_end; g++)
-                for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
+                for_(dim_t g = ti->g_start; g < ti->g_end; g++)
+                for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
                     const size_t acc_size = (size_t)ti->ic_b_work * jcp.kh
                             * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1)
                             * jcp.ic_block * jcp.oc_block;
@@ -2007,12 +2067,12 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
             }
         }
         if (is_bf16_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
-                int result_start_idx = g * jcp.oc_without_padding
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
+                dim_t result_start_idx = g * jcp.oc_without_padding
                         + ti->oc_b_start * jcp.oc_block;
-                int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
                 bfloat16_t *diff_bias
@@ -2028,26 +2088,26 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
     if (jcp.global_transpose)
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work
+    const dim_t ic_b_kh_work
             = ti->ic_b_work * ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, nthr_mb_, ti->ithr_mb, start, end);
     if (!jcp.transform_to_vnni && start == end) return;
 
     const int _start_nthr_mb = 1;
     for (int thr_mb = _start_nthr_mb; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = start;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start
                     + sub_ic_b_kh_start / ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-            const int kX
+            const dim_t kX
                     = sub_ic_b_kh_start % ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
 
             const size_t acc_size = (size_t)jcp.kw * jcp.ic_block * jcp.oc_block
@@ -2086,18 +2146,18 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
                 float *bias_reduced = is_bf16_bias ? ti->bia_reduction
                                                    : (float *)(ti->diff_bias);
                 int thr_mb_buffer_idx = is_bf16_bias ? thr_mb : thr_mb - 1;
-                int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+                dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
                 float *bias_to_reduce
                         = ti->bia_reduction + thr_mb_buffer_idx * bias_buf_size;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
-                int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 if (is_bf16_bias && thr_mb == nthr_mb_ - 1) {
                     // the last iteration for bfloat16 requires conversion and
                     // store to diff_weights array
-                    int diff_bias_idx = g * jcp.oc_without_padding
+                    dim_t diff_bias_idx = g * jcp.oc_without_padding
                             + ti->oc_b_start * jcp.oc_block;
                     add_floats_and_cvt_to_bfloat16(
                             (bfloat16_t *)(ti->diff_bias) + diff_bias_idx,
@@ -2132,7 +2192,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::prepare_scratchpad_data(
     for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
         src_data_t *ts
                 = &tr_src[ithr * jcp.tr_src_buf_size * jcp.nb_ic_blocking];
-        for (int i = 0; i < jcp.tr_src_num_guard_elems; ++i)
+        for (dim_t i = 0; i < jcp.tr_src_num_guard_elems; ++i)
             ts[i] = 0;
     }
 
@@ -2228,9 +2288,9 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::execute_backward_weights(
                     = ctx.get_scratchpad_grantor().template get<const float>(
                             key_conv_padded_bias);
             auto diff_bias_in = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -260,15 +260,16 @@ private:
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    size_t tr_src_buf_number(const thread_info_t *ti, int g, int ic) const;
-    size_t tr_diff_dst_buf_number(const thread_info_t *ti, int g, int oc) const;
+    size_t tr_src_buf_number(const thread_info_t *ti, dim_t g, dim_t ic) const;
+    size_t tr_diff_dst_buf_number(
+            const thread_info_t *ti, dim_t g, dim_t oc) const;
     void trans_src_nxc(src_data_t *tr_src, const src_data_t *src_base,
-            int spatial_start, dim_t spatial_start_offset, int icb_start,
-            dim_t chb_stride, int my_work) const;
+            dim_t spatial_start, dim_t spatial_start_offset, dim_t icb_start,
+            dim_t chb_stride, dim_t my_work) const;
     void trans_dst_nxc(diff_dst_data_t *tr_diff_dst,
-            const diff_dst_data_t *diff_dst_base, int spatial_start,
-            dim_t spatial_start_offset, int ocb_start, dim_t chb_stride,
-            int my_work) const;
+            const diff_dst_data_t *diff_dst_base, dim_t spatial_start,
+            dim_t spatial_start_offset, dim_t ocb_start, dim_t chb_stride,
+            dim_t my_work) const;
 
     int nthr_ = 0, nthr_mb_ = 0, nthr_g_ = 0, nthr_oc_b_ = 0, nthr_ic_b_ = 0;
 
@@ -280,7 +281,8 @@ private:
     std::unique_ptr<jit_trans_src_t> trans_kernel_;
     std::unique_ptr<jit_trans_dst_t> trans_dst_kernel_;
 
-    inline dim_t wei_offset_int(int g, int oc_b, int ic_b, int kX) const {
+    inline dim_t wei_offset_int(
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kX) const {
         const auto &jcp = kernel_->jcp;
         const dim_t const_extra_offset = jcp.kw * jcp.ic_block * jcp.oc_block;
         dim_t extra_offset = (jcp.ndims == 5) ? kX * jcp.kh * const_extra_offset
@@ -289,9 +291,10 @@ private:
                 * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
                 + extra_offset;
     }
-    inline dim_t wei_offset_ext(int g, int oc_b, int ic_b, int kX) const {
+    inline dim_t wei_offset_ext(
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kX) const {
         const auto &jcp = kernel_->jcp;
-        const int nb_ic = utils::div_up(jcp.ic, 2 * jcp.ic_block);
+        const dim_t nb_ic = utils::div_up(jcp.ic, 2 * jcp.ic_block);
         const dim_t const_extra_offset
                 = static_cast<dim_t>(jcp.kw) * jcp.ic_block * jcp.oc_block * 2;
         dim_t extra_offset = (jcp.ndims == 5) ? kX * jcp.kh * const_extra_offset

--- a/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
@@ -75,7 +75,7 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
 
     const dim_t wei_g_shift = wht_blk_off(weights_d, 1, 0);
     const dim_t wei_ic_shift = wht_blk_off(weights_d, 0, jcp.nb_ic_blocking);
-    const size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
+    const dim_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
     auto inp_p_buffer = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_inp_buffer);
@@ -84,9 +84,9 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
     auto global_tcfg = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_tilecfg);
 
-    const int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-    const int ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
-    const int work_amount
+    const dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    const dim_t ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * jcp.id * ih_chunks * jcp.nb_iw * ic_chunks;
 
     const bool is_1d = jcp.ndims == 3;
@@ -108,7 +108,7 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
     });
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -130,88 +130,90 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
+        dim_t mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, id_s, jcp.id, ihc,
                 ih_chunks, iwb, jcp.nb_iw, icc, ic_chunks);
-        int last_copied_mb = -1;
-        int last_copied_id = -1;
-        int last_copied_ihc = -1;
-        int last_copied_iwb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_id = -1;
+        dim_t last_copied_ihc = -1;
+        dim_t last_copied_iwb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + ithr * jcp.inp_buffer_size * src_dt_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-            int ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
-            int icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
+            dim_t ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
+            dim_t icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            const int ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
+            const dim_t ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
             auto bias_w = bias_ptr
                     ? bias_ptr + (bias_d.blk_off(ic) * bia_dt_size)
                     : nullptr;
 
-            const int ih_b = ihc * jcp.ih_blk_size;
-            const int ih_e = nstl::min(jcp.ih, ih_b + jcp.ih_blk_size);
-            const int iw = iwb * jcp.iw_block;
+            const dim_t ih_b = ihc * jcp.ih_blk_size;
+            const dim_t ih_e = nstl::min<dim_t>(jcp.ih, ih_b + jcp.ih_blk_size);
+            const dim_t iw = iwb * jcp.iw_block;
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_id == id_s && last_copied_ihc == ihc
                     && last_copied_iwb == iwb && last_copied_g == g;
 
             sfd.update_params(id_s);
             p.kd_padding = sfd.get_filter_padding();
-            const int d_lo = sfd.get_lower_offset();
-            const int d_oj = sfd.get_output_offset();
+            const dim_t d_lo = sfd.get_lower_offset();
+            const dim_t d_oj = sfd.get_output_offset();
 
-            int ih_step = jcp.nb_ih_blocking;
-            for (int ih = ih_b; ih < ih_e; ih += ih_step) {
+            const dim_t ih_step = jcp.nb_ih_blocking;
+            for (dim_t ih = ih_b; ih < ih_e; ih += ih_step) {
                 if (!is_inp_buffer_relevant) {
-                    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-                    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+                    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
                     // dox: x-index dilated by strides (dox = ox * stride_x)
-                    const int doh = ih + jcp.t_pad - (gen_kh - 1);
-                    const int dow = iw + jcp.l_pad - (gen_kw - 1);
-                    const int doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
-                    const int doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
-                    const int dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
+                    const dim_t doh = ih + jcp.t_pad - (gen_kh - 1);
+                    const dim_t dow = iw + jcp.l_pad - (gen_kw - 1);
+                    const dim_t doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
+                    const dim_t doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
+                    const dim_t dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
 
                     // dox_{s,f}: start and finish indices for copy kernel
-                    const int doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
-                    const int doh_f = doh + (ih_step - 1) + (gen_kh - 1);
-                    const int delta_h = doh_f - doh_s + 1;
-                    const int doh_t_overflow = 0 < doh_s && doh_s < doh_l
+                    const dim_t doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
+                    const dim_t doh_f = doh + (ih_step - 1) + (gen_kh - 1);
+                    const dim_t delta_h = doh_f - doh_s + 1;
+                    const dim_t doh_t_overflow = 0 < doh_s && doh_s < doh_l
                             ? nstl::additive_inverse_modulo(doh_s, jcp.stride_h)
-                            : nstl::max(0, -doh_s);
-                    const int doh_b_overflow = 0 < doh_f && doh_f < doh_l
+                            : nstl::max<dim_t>(0, -doh_s);
+                    const dim_t doh_b_overflow = 0 < doh_f && doh_f < doh_l
                             ? nstl::modulo(doh_f, jcp.stride_h)
-                            : nstl::max(0, nstl::min(delta_h, doh_f - doh_l));
-                    int dow_s = dow;
-                    int dow_f = dow + jcp.owp - 1;
-                    const int delta_w = dow_f - dow_s + 1;
-                    const int dow_l_overflow = 0 < dow_s && dow_s < dow_l
+                            : nstl::max<dim_t>(0,
+                                      nstl::min<dim_t>(delta_h, doh_f - doh_l));
+                    dim_t dow_s = dow;
+                    dim_t dow_f = dow + jcp.owp - 1;
+                    const dim_t delta_w = dow_f - dow_s + 1;
+                    const dim_t dow_l_overflow = 0 < dow_s && dow_s < dow_l
                             ? nstl::additive_inverse_modulo(dow_s, jcp.stride_w)
-                            : nstl::max(0, -dow_s);
-                    const int dow_r_overflow = 0 < dow_f && dow_f < dow_l
+                            : nstl::max<dim_t>(0, -dow_s);
+                    const dim_t dow_r_overflow = 0 < dow_f && dow_f < dow_l
                             ? nstl::modulo(dow_f, jcp.stride_w)
-                            : nstl::max(0, nstl::min(delta_w, dow_f - dow_l));
-                    const int oh_s
-                            = utils::div_up(nstl::max(0, doh_s), jcp.stride_h);
-                    const int ow_s
-                            = utils::div_up(nstl::max(0, dow_s), jcp.stride_w);
+                            : nstl::max<dim_t>(0,
+                                      nstl::min<dim_t>(delta_w, dow_f - dow_l));
+                    const dim_t oh_s = utils::div_up(
+                            nstl::max<dim_t>(0, doh_s), jcp.stride_h);
+                    const dim_t ow_s = utils::div_up(
+                            nstl::max<dim_t>(0, dow_s), jcp.stride_w);
                     // how many real data rows to copy (including padding)
-                    p.t_overflow = nstl::min(delta_h, doh_t_overflow);
-                    p.b_overflow = nstl::min<size_t>(
+                    p.t_overflow = nstl::min<dim_t>(delta_h, doh_t_overflow);
+                    p.b_overflow = nstl::min<dim_t>(
                             delta_h - p.t_overflow, doh_b_overflow);
-                    p.kh_padding = nstl::max<size_t>(
+                    p.kh_padding = nstl::max<dim_t>(
                             0, delta_h - p.t_overflow - p.b_overflow);
-                    p.l_overflow = nstl::min(delta_w, dow_l_overflow);
-                    p.kw_padding = nstl::max<size_t>(
+                    p.l_overflow = nstl::min<dim_t>(delta_w, dow_l_overflow);
+                    p.kw_padding = nstl::max<dim_t>(
                             0, delta_w - dow_l_overflow - dow_r_overflow);
-                    p.r_overflow = nstl::min<size_t>(
+                    p.r_overflow = nstl::min<dim_t>(
                             delta_w - dow_l_overflow, dow_r_overflow);
-                    size_t inp_offset = is_1d ? src_d.blk_off(mb, ocb, ow_s)
+                    dim_t inp_offset = is_1d ? src_d.blk_off(mb, ocb, ow_s)
                             : is_3d ? src_d.blk_off(mb, ocb, d_oj, oh_s, ow_s)
                                     : src_d.blk_off(mb, ocb, oh_s, ow_s);
                     p.src = src + src_dt_size * inp_offset;
@@ -222,9 +224,9 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
                     kernel_->bwd_data_copy_kernel()(&p);
                 }
 
-                size_t dst_offset = is_1d ? dst_d.blk_off(mb, icb, iw)
-                        : is_3d           ? dst_d.blk_off(mb, icb, id_s, ih, iw)
-                                          : dst_d.blk_off(mb, icb, ih, iw);
+                dim_t dst_offset = is_1d ? dst_d.blk_off(mb, icb, iw)
+                        : is_3d          ? dst_d.blk_off(mb, icb, id_s, ih, iw)
+                                         : dst_d.blk_off(mb, icb, ih, iw);
                 p.dst = inp_buffer
                         + (size_t)(ih - ih_b) * jcp.owp * jcp.oc_block_int
                                 * src_dt_size;

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -51,7 +51,7 @@ jit_avx512_core_bf16_1x1_conv_kernel_t::jit_avx512_core_bf16_1x1_conv_kernel_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const dim_t tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,
@@ -92,7 +92,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const int num_substeps = static_cast<int>(jcp.bcast_block / jcp.ur);
         assert(num_substeps > 0 && num_substeps < 10);
         for (int i = 0; i < num_substeps; i++) {
             if (i + 1 == num_substeps) L(long_tail);
@@ -151,11 +151,11 @@ Address jit_avx512_core_bf16_1x1_conv_kernel_t::output_ptr(
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        int i_load_shift = is_output_layout_nxc
+        dim_t i_load_shift = is_output_layout_nxc
                 ? jcp.load_block
                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
-        int i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offset = (i_load * i_load_shift + i_ur * i_ur_shift)
+        dim_t i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_out;
         return EVEX_compress_addr(aux_reg_output_data, offset);
     } else
@@ -194,7 +194,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::apply_postops(
             iterate(load_loop_blk, ur, mask_tail,
                     [&](const bool mask_flag, const int i_load,
                             const int i_ur) {
-                const int aux_output_l_off
+                const dim_t aux_output_l_off
                         = get_output_offset(i_load, i_ur, true);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -254,8 +254,9 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
         int load_loop_blk, int ur, int substep, bool wraparound) {
     const bool load_layout_nxc = is_load_layout_nxc();
     const bool bcast_layout_nxc = is_bcast_layout_nxc();
-    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const int reduce_dim_tail
+            = static_cast<int>(jcp.reduce_dim % jcp.reduce_block);
+    const int load_dim_tail = static_cast<int>(jcp.load_dim % jcp.load_block);
 
     auto vreg_load = [ur, load_loop_blk](int i_load) {
         int idx = ur * load_loop_blk + i_load;
@@ -275,22 +276,22 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto bcast_ptr
-            = [this, bcast_layout_nxc](int i_reduce, int i_ur, bool bcast) {
+            = [this, bcast_layout_nxc](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
-        int offt;
+        dim_t offt;
         if (one_of(jcp.prop_kind, forward_training, forward_inference,
                     backward_data)) {
             assert(jcp.reduce_loop_unroll == jcp.reduce_block);
-            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
-                                                    : jcp.reduce_loop_unroll;
+            const dim_t reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
+                                                      : jcp.reduce_loop_unroll;
             offt = (i_reduce == jcp.reduce_loop_unroll)
                     ? (jcp.bcast_dim + i_ur) * reduce_mul
                     : i_ur * reduce_mul + i_reduce;
         } else {
             if (jcp.uses_permw_transposition) {
-                int rmul = bcast_layout_nxc ? jcp.ngroups * jcp.ic
-                                            : jcp.ic_block;
+                dim_t rmul = bcast_layout_nxc ? jcp.ngroups * jcp.ic
+                                              : jcp.ic_block;
                 offt = i_reduce * rmul + i_ur;
             } else {
                 offt = (i_reduce / 2) * 2 * jcp.ic_block + 2 * i_ur;
@@ -303,22 +304,22 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     auto load_ptr = [this, load_layout_nxc](int i_reduce, int i_load) {
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
-        int lmul = jcp.load_block
+        dim_t lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
                                              jcp.reduce_dim, jcp.reduce_block));
-        int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offt = i_load * lmul + u0 * rmul;
+        dim_t rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
     };
 
     auto store_buffer_ptr = [this](int i_load, int i_ur) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        int i_load_shift
+        dim_t i_load_shift
                 = jcp.load_block * (is_output_layout_nxc ? 1 : jcp.bcast_dim);
-        int i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offset = (i_load * i_load_shift + i_ur * i_ur_shift)
+        dim_t i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_acc;
         return EVEX_compress_addr(aux_reg_store_buf, offset);
     };
@@ -540,11 +541,12 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block_bwd_w = [&](bool is_tail) {
-        int n_reduce_tail = jcp.reduce_dim % jcp.reduce_loop_unroll;
-        int n_reduce
+        const int n_reduce_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_loop_unroll);
+        const int n_reduce
                 = is_tail && n_reduce_tail > 0 && !jcp.uses_permw_transposition
                 ? n_reduce_tail
-                : jcp.reduce_loop_unroll;
+                : static_cast<int>(jcp.reduce_loop_unroll);
         int bcast_count = 0;
         int pipeline_length_max = 1;
         if (isa_has_bf16(jcp.isa)) {
@@ -557,7 +559,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
             assert(regs_for_pipeline_total >= regs_for_pipeline_iter);
             pipeline_length_max = nstl::min(
                     regs_for_pipeline_total / regs_for_pipeline_iter,
-                    n_reduce / 2);
+                    static_cast<int>(n_reduce / 2));
         }
 
         const int pipeline = saturate(1, 4, pipeline_length_max);
@@ -743,9 +745,11 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block_fwd_bwd_d = [&](bool is_tail) {
-        int n_reduce_tail = jcp.reduce_dim % jcp.reduce_loop_unroll;
-        int n_reduce = is_tail && n_reduce_tail > 0 ? n_reduce_tail
-                                                    : jcp.reduce_loop_unroll;
+        const int n_reduce_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_loop_unroll);
+        const int n_reduce = is_tail && n_reduce_tail > 0
+                ? n_reduce_tail
+                : static_cast<int>(jcp.reduce_loop_unroll);
         const int reduce_step = 2;
         for (int i_reduce = 0; i_reduce < n_reduce; i_reduce += 2) {
             if (isa_has_bf16(jcp.isa)) {
@@ -972,7 +976,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::compute_diff_bias(
     test(reg_reduce_pos_flag, FLAG_REDUCE_FIRST); // If FLAG_REDUCE_FIRST
     jnz(skip_reading, T_NEAR);
 
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(jcp.load_dim % jcp.load_block);
     for (int i_load = 0; i_load < load_loop_blk; i_load++) {
         bool mask_flag = load_dim_tail && i_load + 1 == load_loop_blk;
         auto vacc = vreg_acc(i_load);
@@ -1013,11 +1017,11 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::generate() {
     mov(reg_trans_tmp.cvt32(), 0xffff0000);
     kmovd(half_mask_hi, reg_trans_tmp.cvt32());
 
-    const int load_dim_tail
-            = (one_of(jcp.prop_kind, forward_training, forward_inference)
-                              ? jcp.oc_without_padding
-                              : jcp.load_dim)
-            % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(
+            (one_of(jcp.prop_kind, forward_training, forward_inference)
+                            ? jcp.oc_without_padding
+                            : jcp.load_dim)
+            % jcp.load_block);
     if (load_dim_tail) {
         mov(reg_trans_tmp.cvt32(), (1 << load_dim_tail) - 1);
         kmovw(k_load_dim_tail_mask, reg_trans_tmp.cvt32());
@@ -1076,12 +1080,12 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::generate() {
         mov(reg_load_loop_work, ptr[rsp + reg_load_loop_work_off]);
 
         add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
-        const size_t off_with_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t off_with_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc()
                                 ? 1
                                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim));
-        const size_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out * (is_out_layout_nxc() ? 1 : jcp.bcast_dim);
         switch (jcp.prop_kind) {
             case forward_training:
@@ -1245,7 +1249,9 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             ? pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.data_type,
                       data_type::undef, cd.diff_bias_desc.data_type)
             : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     jcp.os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
     jcp.is = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw;
@@ -1343,15 +1349,20 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
     jcp.typesize_acc = sizeof(float);
     if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
-        jcp.typesize_in = types::data_type_size(src_d.data_type());
-        jcp.typesize_out = types::data_type_size(dst_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
+        jcp.typesize_out
+                = static_cast<int>(types::data_type_size(dst_d.data_type()));
         jcp.dst_dt = dst_d.data_type();
     } else if (jcp.prop_kind == backward_data) {
-        jcp.typesize_in = types::data_type_size(dst_d.data_type());
-        jcp.typesize_out = types::data_type_size(src_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(dst_d.data_type()));
+        jcp.typesize_out
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
         jcp.dst_dt = src_d.data_type();
     } else if (jcp.prop_kind == backward_weights) {
-        jcp.typesize_in = types::data_type_size(src_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
         jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
         jcp.dst_dt = weights_d.data_type();
     }
@@ -1388,7 +1399,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 backward_data)) {
         jcp.nthr = nthreads;
         if (one_of(jcp.prop_kind, forward_inference, forward_training)) {
-            if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+            if (jcp.with_dw_conv)
+                jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
             jcp.reduce_dim = jcp.ic;
             jcp.reduce_block = jcp.ic_block;
 
@@ -1416,11 +1428,12 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold, ur_step;
-        const int spatial
+        const dim_t spatial
                 = (one_of(jcp.prop_kind, forward_training, forward_inference))
                 ? jcp.od * jcp.oh
                 : jcp.id * jcp.ih;
-        const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+        const int reduce_dim_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_block);
         if (reduce_dim_tail % 2 == 0 // cannot expl_bcast odd tail
                 && (8 * jcp.mb) / jcp.nthr >= 1) {
             max_regs = 9;
@@ -1454,10 +1467,10 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
-            int os_tail = jcp.os % max_regs;
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
+            int os_tail = static_cast<int>(jcp.os % max_regs);
             for (int i = max_regs; i >= min_regs; i -= ur_step) {
-                int i_tail = jcp.os % i;
+                int i_tail = static_cast<int>(jcp.os % i);
                 if (i_tail > os_tail || i_tail == 0) {
                     jcp.ur = i;
                     os_tail = i_tail;
@@ -1467,7 +1480,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         }
 
         jcp.bcast_block = jcp.ur;
-        jcp.ur_tail = (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur;
+        jcp.ur_tail = static_cast<int>(
+                (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur);
 
         jcp.bcast_loop_output_step
                 = jcp.ur * (is_data_layout_nxc ? jcp.load_dim : jcp.load_block);
@@ -1483,22 +1497,26 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         else
             jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
-        int nb_load = div_up(jcp.load_dim, jcp.load_block);
+        int nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+        int nb_reduce
+                = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
+        int nb_load = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
 
         if (is_data_layout_nxc
                 || (jcp.prop_kind == backward_data && reduce_src)) {
-            reduce_blocking = jcp.reduce_dim;
+            reduce_blocking = static_cast<int>(jcp.reduce_dim);
         } else {
             if (jcp.expl_bcast) {
                 if (jcp.load_dim <= BIG_LOAD_DIM && spatial > SMALL_SPATIAL
                         && spatial < BIG_SPATIAL)
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 160);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 160));
                 else if (spatial > SMALL_SPATIAL)
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 1024);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 1024));
                 else
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 512);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 512));
             } else {
                 reduce_blocking = nb_reduce;
                 if (spatial <= SMALL_SPATIAL
@@ -1520,14 +1538,15 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             int max_hits = 7;
             if (jcp.bcast_dim * reduce_blocking > way_size * max_hits) {
                 int nrb = reduce_blocking / simd_w;
-                int sp = jcp.bcast_dim;
-                int wl = way_size / simd_w;
+                dim_t sp = jcp.bcast_dim;
+                dim_t wl = way_size / simd_w;
                 for (int start_off = 0; start_off < jcp.ur; start_off++) {
-                    for (int off = start_off, hits = 0; off < sp * nrb;
+                    for (dim_t off = start_off, hits = 0; off < sp * nrb;
                             off += wl) {
                         if (off % sp >= jcp.ur || ++hits < max_hits) continue;
-                        int max_r_blocking
-                                = simd_w * nstl::max(1, (off + wl) / sp);
+                        int max_r_blocking = simd_w
+                                * static_cast<int>(
+                                        nstl::max<dim_t>(1, (off + wl) / sp));
                         reduce_blocking
                                 = nstl::min(reduce_blocking, max_r_blocking);
                         break;
@@ -1535,10 +1554,10 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 }
             }
         }
-        load_blocking = jcp.load_dim;
+        load_blocking = static_cast<int>(jcp.load_dim);
 
-        int load_size = jcp.load_dim * jcp.reduce_dim;
-        auto bcast_size
+        dim_t load_size = jcp.load_dim * jcp.reduce_dim;
+        const dim_t bcast_size
                 = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
 
         if (jcp.nthr <= 28 && jcp.mb < jcp.nthr
@@ -1549,11 +1568,11 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             float ratio = (float)load_size / (float)bcast_size;
             int best_lgc = ratio > 1 ? n_lgc : 1;
             auto calc_job_cost = [&](int lb, int tg, float mem_k) {
-                int bb_size = jcp.mb * div_up(nb_bcast, tg);
+                dim_t bb_size = jcp.mb * div_up(nb_bcast, tg);
                 float calc_size = (float)(bb_size * jcp.ur)
-                        * (lb * jcp.load_block) * jcp.reduce_dim;
+                        * (float)(lb * jcp.load_block) * (float)jcp.reduce_dim;
                 float mem_size = (float)(bb_size * jcp.ur + lb * jcp.load_block)
-                        * jcp.reduce_dim;
+                        * (float)jcp.reduce_dim;
                 return calc_koef * calc_size + mem_k * mem_size;
             };
             for (int lgc, ilgc = 0; ilgc < n_lgc; ilgc++) {
@@ -1579,8 +1598,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 }
             }
             jcp.load_grp_count = best_lgc;
-            load_blocking
-                    = div_up(nb_load, jcp.load_grp_count) * jcp.load_block;
+            load_blocking = static_cast<int>(
+                    div_up(nb_load, jcp.load_grp_count) * jcp.load_block);
         } else {
             jcp.load_grp_count
                     = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
@@ -1593,24 +1612,27 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         } else if (jcp.bcast_dim <= 49 && jcp.mb <= jcp.nthr
                 && jcp.load_dim > 512 && jcp.load_dim / jcp.reduce_dim >= 4) {
             jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2);
-            load_blocking = jcp.load_block;
+            load_blocking = static_cast<int>(jcp.load_block);
         }
 
-        bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                                 div_up(jcp.nthr, jcp.load_grp_count))
-                * jcp.bcast_block;
-        bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
-        bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                           div_up(jcp.nthr, jcp.load_grp_count))
+                        * jcp.bcast_block);
+        bcast_blocking = static_cast<int>(
+                nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
+        bcast_blocking
+                = static_cast<int>(rnd_up(bcast_blocking, jcp.bcast_block));
 
-        int space_for_bcast = (L2_capacity - /* kernel_size - */
+        dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
                 2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
                 - 3 * 1024);
         if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
 
-        int bcast_in_cache
-                = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-        bcast_blocking = nstl::min(
-                bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+        const dim_t bcast_in_cache = nstl::max<dim_t>(
+                jcp.bcast_block, space_for_bcast / reduce_blocking);
+        bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+                bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
         load_blocking_max = load_blocking;
         bcast_blocking_max = bcast_blocking * 3 / 2;
@@ -1629,7 +1651,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 && IMPLICATION(ndims == 5, jcp.oc <= 64);
 
         if (jcp.uses_permw_transposition) {
-            int rdim = nstl::min<dim_t>(256, jcp.reduce_dim);
+            int rdim = static_cast<int>(nstl::min<dim_t>(256, jcp.reduce_dim));
             jcp.reduce_block = best_divider(jcp.reduce_dim, 7, rdim, true, 2);
         } else
             jcp.reduce_block = best_divider(jcp.reduce_dim, 8, 16, true, 2);
@@ -1648,8 +1670,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.bcast_dim = jcp.ic;
         jcp.bcast_block = jcp.ic_block;
 
-        jcp.ur = jcp.bcast_block;
-        jcp.ur_tail = jcp.bcast_dim % jcp.bcast_block;
+        jcp.ur = static_cast<int>(jcp.bcast_block);
+        jcp.ur_tail = static_cast<int>(jcp.bcast_dim % jcp.bcast_block);
         // TODO: try to enable jcp.expl_bcast version
         jcp.expl_bcast = false;
 
@@ -1681,16 +1703,18 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         /* --- */
         balance(jcp, jcp.nthr);
 
-        load_blocking = div_up(jcp.load_dim, jcp.load_block);
+        load_blocking = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
         load_blocking = best_divider(load_blocking, 16, load_blocking, false);
         load_blocking *= jcp.load_block;
 
         load_blocking_max = load_blocking;
 
-        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        int max_bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         int min_bcast_blocking = 5;
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         bcast_blocking = best_divider(
                 bcast_blocking, min_bcast_blocking, max_bcast_blocking, false);
         bcast_blocking *= jcp.bcast_block;
@@ -1701,14 +1725,14 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         }
 
         // for reduction balance
-        int max_reduce_blocking
-                = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
-        int min_reduce_blocking
-                = nstl::min(L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
+        int max_reduce_blocking = static_cast<int>(
+                nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim));
+        int min_reduce_blocking = static_cast<int>(nstl::min<dim_t>(
+                L1_capacity / jcp.ur, nstl::max<dim_t>(jcp.iw, jcp.ih)));
         reduce_blocking = best_divider(
                 jcp.reduce_dim, min_reduce_blocking, max_reduce_blocking, true);
-        reduce_blocking = nstl::max(
-                rnd_dn(reduce_blocking, jcp.reduce_block), jcp.reduce_block);
+        reduce_blocking = static_cast<int>(nstl::max<dim_t>(
+                rnd_dn(reduce_blocking, jcp.reduce_block), jcp.reduce_block));
 
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
     } else
@@ -1758,7 +1782,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             && jcp.typesize_in * bcast_size < 8192 && jcp.ngroups < jcp.nthr
             && jcp.nb_bcast * jcp.nb_load < jcp.nthr;
     if (is_adjust_thread) {
-        int nthr = nstl::max(jcp.nb_bcast, jcp.nb_load);
+        int nthr = static_cast<int>(nstl::max(jcp.nb_bcast, jcp.nb_load));
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 
@@ -1855,11 +1879,13 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
         /* simplification... fortunately it doesn't hurt much */
         return;
     }
-    const int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    const int nb_load = div_up(jcp.load_dim, jcp.load_block);
-    const int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const int nb_bcast
+            = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    const int nb_load = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
+    const int nb_reduce
+            = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
-    jcp.nthr_g = jcp.ngroups;
+    jcp.nthr_g = static_cast<int>(jcp.ngroups);
     const int nthr = nthreads / jcp.nthr_g;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -1877,7 +1903,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
 
         if (jcp.prop_kind == backward_weights) {
             int mult = (jcp.stride_h == 1 && jcp.stride_w == 1)
-                    ? nstl::max(1, (jcp.oc / jcp.ic))
+                    ? static_cast<int>(nstl::max<dim_t>(1, (jcp.oc / jcp.ic)))
                     : 1;
             output_koeff = 4 * mult;
         }
@@ -1899,7 +1925,8 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
     auto best_mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, jcp.mb * nb_reduce);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, jcp.mb * nb_reduce));
     for (nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
         const int nthr_oc_b_max = nstl::min(nthr_par, nb_load);
@@ -1915,7 +1942,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
         }
     }
     if (jcp.nthr_mb > nthreads / 2 && jcp.nthr_mb < nthreads)
-        jcp.nthr_mb = nstl::min(jcp.mb, nthreads);
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(jcp.mb, nthreads));
 
     jcp.nthr = jcp.nthr_mb * jcp.nthr_g * jcp.nthr_oc_b * jcp.nthr_ic_b;
     assert(jcp.nthr <= nthreads);

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
@@ -182,14 +182,14 @@ private:
         return ymm;
     }
 
-    inline size_t get_output_offset(
+    inline dim_t get_output_offset(
             const int i_load, const int i_ur, bool ignore_dw_conv) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        const size_t i_load_shift = is_output_layout_nxc
+        const dim_t i_load_shift = is_output_layout_nxc
                 ? jcp.load_block
                 : (!ignore_dw_conv && jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim)
                         * jcp.load_block;
-        const size_t i_ur_shift
+        const dim_t i_ur_shift
                 = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
         return jcp.typesize_out * (i_load * i_load_shift + i_ur * i_ur_shift);
     }

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -44,7 +44,7 @@ namespace {
  * not used here ?*/
 template <typename T, typename U>
 void balance2D(U nthr, U ithr, T ny, T &ny_start, T &ny_end, T nx, T &nx_start,
-        T &nx_end, T nx_divider) {
+        T &nx_end, U nx_divider) {
     const T grp_size = utils::div_up(nthr, nx_divider);
     const T grp_count = utils::div_up(nthr, grp_size);
 
@@ -77,7 +77,8 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_ != nullptr
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -145,26 +146,27 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     float *store_buffer = scratchpad.template get<float>(key_conv_store_wsp);
 
     const int ndims = src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast
+            = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -172,7 +174,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     dst_data_t *pbuf; //bf16->bf16 fusion
     size_t row_offset;
     const auto jcp_dw = pd()->jcp_dw_;
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<decltype(pbuf)> addrs;
     const bool is_dst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
@@ -181,23 +183,23 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
     auto start_off = dst_d.off_l(0);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh, dim_t &ow,
+                              dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
-        bcast_step = step(
-                nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
+        bcast_step = step(nb_bcast_blocking, nb_bcast - osb,
+                nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -210,16 +212,16 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
-        const auto max_oc
-                = nstl::min(ocb_end * jcp.oc_block, jcp.oc_without_padding);
+        const auto max_oc = nstl::min<dim_t>(
+                ocb_end * jcp.oc_block, jcp.oc_without_padding);
         p.load_dim = this_block_size(
                 ocb * jcp.oc_block, max_oc, load_step * jcp.oc_block);
     };
 
-    auto init_reduce = [&](int icb) {
-        const int nb_ic_blocking_step
+    auto init_reduce = [&](dim_t icb) {
+        const dim_t nb_ic_blocking_step
                 = nstl::min(icb + nb_ic_blocking, nb_ic) - icb;
         p.first_last_flag = 0 | (icb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (icb + nb_ic_blocking_step >= nb_ic ? FLAG_REDUCE_LAST : 0);
@@ -229,12 +231,13 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int icb, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1
+            = [&](dim_t ocb, dim_t ocb_start, dim_t icb, dim_t n, dim_t g, dim_t od,
+                      dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
 
         void *output_data = jcp.with_dw_conv
                 ? (void *)(pbuf + (oh % jcp_dw->kh) * row_offset)
@@ -247,7 +250,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
 
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
         if (pd()->rtus_.reduce_src_) {
@@ -278,21 +281,23 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic;
+                            icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -302,17 +307,19 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                        id {0}, ih {0}, iw {0};
+                dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                        iw {0};
+                dim_t bcast_step {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic;
+                            icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -326,8 +333,9 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
 
         for (int i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw->kh) * row_offset;
@@ -336,22 +344,23 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw->iw)
                 * jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
 
-        const int dil_h = jcp_dw->dilate_h + 1;
-        const int str_h = jcp_dw->stride_h;
-        const int ch_num = jcp_dw->nb_ch_blocking;
+        const dim_t dil_h = jcp_dw->dilate_h + 1;
+        const dim_t str_h = jcp_dw->stride_h;
+        const dim_t ch_num = jcp_dw->nb_ch_blocking;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end;
+                ch += jcp_dw->nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw->t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw->ih,
-                              (int)(dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
-                                      - jcp_dw->t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw->t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw->ih,
+                              dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
+                                      - jcp_dw->t_pad + 1)
                     - jcp_dw->ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
+            const int kh = static_cast<int>(div_up(i_t_overflow, dil_h));
+            const dim_t kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             const int ow = 0;
@@ -360,7 +369,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw->ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -373,9 +382,11 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw->ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding
+                    = static_cast<size_t>(nstl::max<dim_t>(0, kh_padding));
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw->nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw->nb_ch) - ch)
                     * jcp_dw->ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -402,33 +413,36 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        balance2D(nthr, ithr,
+                jcp.mb * jcp.ngroups * jcp_dw->oh,
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end,
+                jcp.load_grp_count);
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -444,10 +458,10 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
-        balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                ocb_start, ocb_end, jcp.load_grp_count);
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
+                jcp.nb_load, ocb_start, ocb_end, jcp.load_grp_count);
 
         conv_1x1(bcast_start, bcast_end, ocb_start, ocb_end);
     }
@@ -491,13 +505,13 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
             : nullptr;
     float *store_buffer = scratchpad.template get<float>(key_conv_store_wsp);
     const int ndims = diff_src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -505,26 +519,27 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
-    balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-            icb_start, icb_end, jcp.load_grp_count);
+    dim_t bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+    balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
+            jcp.nb_load, icb_start, icb_end, jcp.load_grp_count);
 
-    auto init_bcast = [&](int iwork, int &n, int &g, int &bcast_step, int &od,
-                              int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast
+            = [&](dim_t iwork, dim_t &n, dim_t &g, dim_t &bcast_step, dim_t &od,
+                      dim_t &oh, dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, jcp.nb_bcast);
         bcast_step = step(jcp.nb_bcast_blocking, jcp.nb_bcast - osb,
                 jcp.nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
         id = od * stride_d;
@@ -536,17 +551,18 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int icb, int &load_step) {
+    auto init_load = [&](dim_t icb, dim_t &load_step) {
         load_step = step(
                 jcp.nb_load_blocking, icb_end - icb, jcp.nb_load_blocking_max);
-        const int max_ic = nstl::min(icb_end * jcp.ic_block, jcp.ic);
+        const dim_t max_ic
+                = nstl::min<dim_t>(icb_end * jcp.ic_block, jcp.ic);
         p.load_dim = this_block_size(
                 icb * jcp.ic_block, max_ic, load_step * jcp.ic_block);
         rp.icb = p.load_dim;
     };
 
-    auto init_reduce = [&](int ocb) {
-        const int nb_oc_blocking_step
+    auto init_reduce = [&](dim_t ocb) {
+        const dim_t nb_oc_blocking_step
                 = nstl::min(ocb + nb_oc_blocking, nb_oc) - ocb;
         p.first_last_flag = 0 | (ocb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (ocb + nb_oc_blocking_step >= nb_oc ? FLAG_REDUCE_LAST : 0);
@@ -555,14 +571,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
                 ocb * jcp.oc_block, jcp.oc, nb_oc_blocking_step * jcp.oc_block);
     };
 
-    auto inner_ker = [&](int icb, int ocb, int n, int g, int od, int oh, int ow,
-                             int id, int ih, int iw) {
+    auto inner_ker = [&](dim_t icb, dim_t ocb, dim_t n, dim_t g, dim_t od, dim_t oh,
+                             dim_t ow, dim_t id, dim_t ih, dim_t iw) {
         const bool is_dsrc_layout_nxc = utils::one_of(jcp.src_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-        const int ic_off_idx = is_dsrc_layout_nxc
+        const dim_t ic_off_idx = is_dsrc_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
-        const size_t diff_src_off
+        const dim_t diff_src_off
                 = data_blk_off(diff_src_d, n, ic_off_idx, id, ih, iw);
 
         rp.src = diff_src + diff_src_off;
@@ -577,7 +593,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
 
         const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-        const int oc_off_idx = is_ddst_layout_nxc
+        const dim_t oc_off_idx = is_ddst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
         p.bcast_data = diff_dst
@@ -596,15 +612,16 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     };
 
     if (jcp.loop_order == loop_lbr) {
-        int icb = icb_start;
+        dim_t icb = icb_start;
         while (icb < icb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(icb, load_step);
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, n, g, bcast_step, od, oh, ow, id, ih, iw);
-                for (int ocb = 0; ocb < nb_oc; ocb += nb_oc_blocking) {
+                for (dim_t ocb = 0; ocb < nb_oc; ocb += nb_oc_blocking) {
                     init_reduce(ocb);
                     inner_ker(icb, ocb, n, g, od, oh, ow, id, ih, iw);
                 }
@@ -652,13 +669,13 @@ jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::init(
             CHECK(tr_reorder_->create_kernel());
         }
         if (is_src_layout_nxc) {
-            int ic = pd()->jcp_.ic * pd()->jcp_.ngroups;
+            int ic = static_cast<int>(pd()->jcp_.ic * pd()->jcp_.ngroups);
             CHECK(safe_ptr_assign(tr_reorder_nhwc_src_,
                     new jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t(ic)));
             CHECK(tr_reorder_nhwc_src_->create_kernel());
         }
         if (is_ddst_layout_nxc) {
-            int oc = pd()->jcp_.oc * pd()->jcp_.ngroups;
+            int oc = static_cast<int>(pd()->jcp_.oc * pd()->jcp_.ngroups);
             CHECK(safe_ptr_assign(tr_reorder_nhwc_ddst_,
                     new jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t(oc)));
             CHECK(tr_reorder_nhwc_ddst_->create_kernel());
@@ -700,7 +717,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             : nullptr;
 
     const int ndims = src_d.ndims();
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block);
     const int n_wei_buffers
             = jcp.dst_dt == data_type::bf16 ? jcp.nthr_mb : jcp.nthr_mb - 1;
@@ -715,18 +732,18 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
 
-    const int sp_nb = jcp.nb_reduce;
-    const int mb_sp_work = jcp.mb * sp_nb;
+    const dim_t sp_nb = jcp.nb_reduce;
+    const dim_t mb_sp_work = jcp.mb * sp_nb;
 
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -735,22 +752,22 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = jcp.nb_bcast - 1;
-                const size_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
+                const dim_t z_icb = jcp.nb_bcast - 1;
+                const dim_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
                         + ic_tail * jcp.oc_block;
                 diff_wei_data_t *z_wei = diff_weights + off;
-                const int zero_work
+                const dim_t zero_work
                         = (jcp.nb_bcast * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -766,18 +783,21 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* reduction dimension */
-        int mb_sp_b_start {0}, mb_sp_b_end {0};
+        dim_t mb_sp_b_start {0}, mb_sp_b_end {0};
         balance211(
                 mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start, mb_sp_b_end);
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0};
+        dim_t oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0};
+        dim_t oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
-        balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
-        balance211(
-                jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start,
+                oc_b_end);
+        balance211(jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
+                ic_b_end);
 
         float *diff_wei;
         if (diff_weights_type == data_type::bf16) {
@@ -790,7 +810,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
         float *diff_bia = nullptr;
         if (jcp.with_bias) {
-            const int bias_size = jcp.ngroups * jcp.nb_load * jcp.oc_block;
+            const dim_t bias_size = jcp.ngroups * jcp.nb_load * jcp.oc_block;
             if (jcp.bia_dt == data_type::bf16) {
                 diff_bia = bia_reduction + (ithr_mb)*bias_size;
             } else {
@@ -800,42 +820,42 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
         }
 
-        int sp_b_step = 0;
-        for (int mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
+        dim_t sp_b_step = 0;
+        for (dim_t mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
                 mb_sp_b += sp_b_step) {
-            int img {0}, sp_b {0};
+            dim_t img {0}, sp_b {0};
             nd_iterator_init(mb_sp_b, img, jcp.mb, sp_b, sp_nb);
             sp_b_step = step(jcp.nb_reduce_blocking,
                     nstl::min(sp_nb - sp_b, mb_sp_b_end - mb_sp_b),
                     jcp.nb_reduce_blocking_max);
 
-            for (int g = g_start; g < g_end; ++g) {
-                int load_step = 0;
-                int bcast_step = 0;
-                for (int ic_b = ic_b_start; ic_b < ic_b_end;
+            for (dim_t g = g_start; g < g_end; ++g) {
+                dim_t load_step = 0;
+                dim_t bcast_step = 0;
+                for (dim_t ic_b = ic_b_start; ic_b < ic_b_end;
                         ic_b += bcast_step) {
                     bcast_step = step(nb_ic_blocking, ic_b_end - ic_b,
                             jcp.nb_bcast_blocking_max);
-                    for (int oc_b = oc_b_start; oc_b < oc_b_end;
+                    for (dim_t oc_b = oc_b_start; oc_b < oc_b_end;
                             oc_b += load_step) {
                         load_step = step(nb_oc_blocking, oc_b_end - oc_b,
                                 jcp.nb_load_blocking_max);
 
                         float *store_to;
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         store_to = diff_wei + off;
 
                         const bool is_src_layout_nxc
                                 = utils::one_of(jcp.src_tag, format_tag::nwc,
                                         format_tag::nhwc, format_tag::ndhwc);
-                        const int ic_off_idx = is_src_layout_nxc
+                        const dim_t ic_off_idx = is_src_layout_nxc
                                 ? g * jcp.ic + ic_b * jcp.ic_block
                                 : g * nb_oc + ic_b;
                         const src_data_t *diff_src
                                 = &src[src_d.blk_off(img, ic_off_idx)];
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + oc_b * jcp.oc_block
                                 : g * nb_oc + oc_b;
                         const diff_dst_data_t *pdiff_dst
@@ -870,17 +890,18 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                                             : 0)
                                 | (ic_b == 0 ? FLAG_COMPUTE_BIAS : 0);
 
-                        int sp = sp_b * jcp.reduce_block;
-                        int oc_mult = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
-                                                         : jcp.oc_block;
+                        dim_t sp = sp_b * jcp.reduce_block;
+                        dim_t oc_mult = is_ddst_layout_nxc
+                                ? jcp.ngroups * jcp.oc
+                                : jcp.oc_block;
                         p.load_data = pdiff_dst + sp * oc_mult;
 
                         if (pd()->rtus_.reduce_src_) {
-                            const int oh = sp / jcp.ow;
-                            const int ow = sp % jcp.ow;
+                            const dim_t oh = sp / jcp.ow;
+                            const dim_t ow = sp % jcp.ow;
 
-                            const int ih = oh * stride_h;
-                            const int iw = ow * stride_w;
+                            const dim_t ih = oh * stride_h;
+                            const dim_t iw = ow * stride_w;
                             rp.iw_start = iw;
 
                             rp.ws = rtus_space
@@ -898,7 +919,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
                             p.bcast_data = rp.ws;
                         } else {
-                            int ic_mult = is_src_layout_nxc
+                            dim_t ic_mult = is_src_layout_nxc
                                     ? jcp.ngroups * jcp.ic
                                     : jcp.ic_block;
                             p.bcast_data = local_src + sp * ic_mult;
@@ -906,22 +927,23 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                         if (!jcp.uses_permw_transposition) {
                             bf16_support::jit_call_t ptr;
                             ptr.nelems = p.reduce_dim;
-                            int thr_src_block_size = rnd_up(jcp.reduce_dim, 2)
+                            dim_t thr_src_block_size = rnd_up(jcp.reduce_dim, 2)
                                     * jcp.ic_block * jcp.nb_bcast_blocking_max;
                             src_data_t *tr_src
                                     = &tr_src_buffer[ithr * thr_src_block_size];
-                            for (int bs = 0; bs < bcast_step; bs++) {
-                                size_t src_off = bs * jcp.ic_block
+                            for (dim_t bs = 0; bs < bcast_step; bs++) {
+                                dim_t src_off = bs * jcp.ic_block
                                         * (is_src_layout_nxc ? 1
                                                              : jcp.reduce_dim);
-                                size_t src_tr_off = bs
+                                dim_t src_tr_off = bs
                                         * rnd_up(jcp.reduce_dim, 2)
                                         * jcp.ic_block;
                                 src_data_t *curr_inp = &(
                                         (src_data_t *)p.bcast_data)[src_off];
                                 src_data_t *curr_out = &tr_src[src_tr_off];
-                                int ch_work = nstl::min<int>(
-                                        p.bcast_dim - bs * jcp.bcast_block, 16);
+                                int ch_work = static_cast<int>(nstl::min<dim_t>(
+                                        p.bcast_dim - bs * jcp.bcast_block,
+                                        16));
                                 assert(ch_work <= 16);
                                 ptr.mask = (1 << ch_work) - 1;
                                 ptr.inp = (void *)curr_inp;
@@ -933,14 +955,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                             }
 
                             p.bcast_data = (void *)tr_src;
-                            int thr_dst_block_size = rnd_up(jcp.reduce_dim, 2)
+                            dim_t thr_dst_block_size = rnd_up(jcp.reduce_dim, 2)
                                     * jcp.oc_block * jcp.nb_load_blocking_max;
                             diff_dst_data_t *tr_diff_dst = &tr_diff_buffer[ithr
                                     * thr_dst_block_size];
-                            for (int ls = 0; ls < load_step; ls++) {
-                                size_t ddst_off = ls * jcp.oc_block
+                            for (dim_t ls = 0; ls < load_step; ls++) {
+                                dim_t ddst_off = ls * jcp.oc_block
                                         * (is_ddst_layout_nxc ? 1 : jcp.os);
-                                size_t ddst_tr_off = ls
+                                dim_t ddst_tr_off = ls
                                         * rnd_up(jcp.reduce_dim, 2)
                                         * jcp.oc_block;
                                 diff_dst_data_t *curr_inp
@@ -948,8 +970,8 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                                         p.load_data)[ddst_off];
                                 diff_dst_data_t *curr_out
                                         = &tr_diff_dst[ddst_tr_off];
-                                int ch_work = nstl::min<int>(
-                                        p.load_dim - ls * jcp.load_block, 16);
+                                int ch_work = static_cast<int>(nstl::min<dim_t>(
+                                        p.load_dim - ls * jcp.load_block, 16));
                                 ptr.mask = (1 << ch_work) - 1;
                                 ptr.inp = (void *)curr_inp;
                                 ptr.out = (void *)curr_out;
@@ -983,17 +1005,18 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
-        balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
-        balance211(
-                jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start,
+                oc_b_end);
+        balance211(jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
+                ic_b_end);
 
-        const int g_work = g_end - g_start;
-        const int oc_b_work = oc_b_end - oc_b_start;
-        const int ic_b_work = ic_b_end - ic_b_start;
+        const dim_t g_work = g_end - g_start;
+        const dim_t oc_b_work = oc_b_end - oc_b_start;
+        const dim_t ic_b_work = ic_b_end - ic_b_start;
 
         const int _start_nthr_mb = 1;
         const bool is_bf16_out = diff_weights_type == data_type::bf16;
@@ -1003,24 +1026,25 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         if (jcp.nthr_mb > _start_nthr_mb) {
             if (dnnl_thr_syncable())
                 simple_barrier::barrier(reduction_barrier, jcp.nthr);
-            const int work = g_work * oc_b_work * ic_b_work;
-            int start {0}, end {0};
+            const dim_t work = g_work * oc_b_work * ic_b_work;
+            dim_t start {0}, end {0};
             balance211(work, jcp.nthr_mb, ithr_mb, start, end);
             if (start == end) return;
 
             for (int thr_mb = _start_nthr_mb; thr_mb < jcp.nthr_mb; ++thr_mb) {
-                int w = start;
-                int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                dim_t w = start;
+                dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
                 nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
                         oc_b_work, sub_ic_b_start, ic_b_work);
                 while (w < end) {
-                    const int g = g_start + sub_g_start;
-                    const int oc_b = oc_b_start + sub_oc_b_start;
-                    const int ic_b = ic_b_start + sub_ic_b_start;
-                    const int ic_to_accumulate
-                            = nstl::min(end - w, ic_b_work - sub_ic_b_start)
+                    const dim_t g = g_start + sub_g_start;
+                    const dim_t oc_b = oc_b_start + sub_oc_b_start;
+                    const dim_t ic_b = ic_b_start + sub_ic_b_start;
+                    const dim_t ic_to_accumulate
+                            = nstl::min<dim_t>(
+                                    end - w, ic_b_work - sub_ic_b_start)
                             * jcp.ic_block;
-                    const int acc_size
+                    const size_t acc_size
                             = this_block_size(ic_b * jcp.ic_block,
                                       jcp.ic_without_padding, ic_to_accumulate)
                             * jcp.oc_block;
@@ -1051,12 +1075,12 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
                 if (jcp.with_bias && ithr_ic_b == 0 && ic_b_work > 0
                         && ithr_mb == 0) {
-                    for (int g = g_start; g < g_end; g++) {
+                    for (dim_t g = g_start; g < g_end; g++) {
                         float *bias_reduced
                                 = is_bf16_bias ? bia_reduction : diff_bias;
                         int thr_mb_buffer_idx
                                 = is_bf16_bias ? thr_mb : thr_mb - 1;
-                        int bias_buf_size
+                        dim_t bias_buf_size
                                 = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
                         float *bias_to_reduce = bia_reduction
                                 + thr_mb_buffer_idx * bias_buf_size;
@@ -1064,12 +1088,12 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                 = this_block_size(oc_b_start * jcp.oc_block,
                                         jcp.oc_without_padding,
                                         (oc_b_end - oc_b_start) * jcp.oc_block);
-                        int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                        dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                                 + oc_b_start * jcp.oc_block;
                         if (is_bf16_bias && thr_mb == jcp.nthr_mb - 1) {
                             // the last iteration for bfloat16 requires conversion and
                             // store to diff_weights array
-                            int diff_bias_idx = g * jcp.oc_without_padding
+                            dim_t diff_bias_idx = g * jcp.oc_without_padding
                                     + oc_b_start * jcp.oc_block;
                             bfloat16_t *diff_bias_result
                                     = CTX_OUT_MEM(
@@ -1087,10 +1111,11 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
         } else {
             if (is_bf16_out) {
-                const auto ic_work = nstl::min(jcp.ic, ic_b_end * jcp.ic_block)
+                const dim_t ic_work
+                        = nstl::min<dim_t>(jcp.ic, ic_b_end * jcp.ic_block)
                         - ic_b_start * jcp.ic_block;
-                for_(int g = g_start; g < g_end; g++)
-                for (int oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
+                for_(dim_t g = g_start; g < g_end; g++)
+                for (dim_t oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
                     const size_t acc_size = (size_t)ic_work * jcp.oc_block;
                     const size_t off
                             = wht_blk_off(diff_weights_d, g, oc_b, ic_b_start);
@@ -1101,13 +1126,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
 
             if (is_bf16_bias && ithr_ic_b == 0 && ic_b_work > 0) {
-                for (int g = g_start; g < g_end; g++) {
-                    int result_start_idx = g * jcp.oc_without_padding
+                for (dim_t g = g_start; g < g_end; g++) {
+                    dim_t result_start_idx = g * jcp.oc_without_padding
                             + oc_b_start * jcp.oc_block;
-                    int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                    dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                             + oc_b_start * jcp.oc_block;
-                    const size_t acc_size = nstl::min(jcp.oc_without_padding,
-                                                    oc_b_end * jcp.oc_block)
+                    const size_t acc_size
+                            = nstl::min<dim_t>(jcp.oc_without_padding,
+                                      oc_b_end * jcp.oc_block)
                             - oc_b_start * jcp.oc_block;
                     bfloat16_t *diff_bias_result
                             = CTX_OUT_MEM(bfloat16_t *, DNNL_ARG_DIFF_BIAS)

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -301,7 +301,8 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
                 --jcp_dw->nb_ch_blocking;
 
             jcp_dw->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+                    = static_cast<int>(
+                            jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
 
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -89,8 +89,8 @@ inline bool is_iw_threading_on(const jit_conv_conf_t &jcp) {
 }
 inline bool is_1stconv(const jit_conv_conf_t &jcp) {
     const bool no_big_offt = nstl::max<size_t>(jcp.ic, jcp.oc)
-                    * nstl::max(jcp.typesize_in, jcp.typesize_out) * jcp.id
-                    * jcp.ih * jcp.iw
+                    * nstl::max<dim_t>(jcp.typesize_in, jcp.typesize_out)
+                    * jcp.id * jcp.ih * jcp.iw
             < INT_MAX;
     return jcp.ic < 16 && jcp.ngroups == 1 && no_big_offt;
 }
@@ -106,8 +106,8 @@ jit_avx512_core_bf16_fwd_kernel_vmm_t<
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t oc_block_tail = jcp.oc_block % isa_simd_width_;
-        const size_t tail_size = oc_block_tail
+        const dim_t oc_block_tail = jcp.oc_block % isa_simd_width_;
+        const dim_t tail_size = oc_block_tail
                 ? oc_block_tail
                 : jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
@@ -199,7 +199,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w) {
             if (mask_tail || oc_blk_is_smaller_than_vmm) {
                 Label postops_no_tail;
                 if (mask_tail) {
-                    test(byte[param1 + GET_OFF(load_work)], jcp.oc_block - 1);
+                    test(byte[param1 + GET_OFF(load_work)],
+                            static_cast<uint32_t>(jcp.oc_block - 1));
                     jz(postops_no_tail, T_NEAR);
                 }
                 postops_injector_->compute_vector_range(
@@ -251,7 +252,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::store_dst(int ur_w) {
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
         for (int k = 0; k < jcp.nb_oc_blocking; k++) {
-            int bias_offset = jcp.typesize_bia * k * jcp.oc_block;
+            dim_t bias_offset = jcp.typesize_bia * k * jcp.oc_block;
             for (int j = 0; j < ur_w; j++) {
                 // mask only needed for last oc_block
                 bool mask_flag = oc_tail && k + 1 == jcp.nb_oc_blocking;
@@ -359,7 +360,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::store_dst(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     Label kh_label, kd_label;
     const int ic_tail = jcp.ic_tail;
     const int ic_step = 2;
@@ -376,12 +377,12 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     dim_t max_src_offset = 0;
     if (jcp.is_1stconv || ic_tail) {
         for (int ki = 0; ki < jcp.kw; ki++) {
-            int ow_fst = get_ow_start(ki, pad_l);
-            int ow_last = get_ow_end(ur_w, ki, pad_r) - 1;
+            dim_t ow_fst = get_ow_start(ki, pad_l);
+            dim_t ow_last = get_ow_end(ur_w, ki, pad_r) - 1;
             if (ow_fst > ow_last) continue;
-            int ic_last = rnd_up(nstl::min(jcp.ic_block,
-                                         nstl::max(jcp.ic, ic_tail)),
-                                  ic_step)
+            dim_t ic_last = rnd_up(nstl::min<dim_t>(jcp.ic_block,
+                                           nstl::max<dim_t>(jcp.ic, ic_tail)),
+                                    ic_step)
                     - ic_step;
 
             dim_t src_offset = get_src_offset(
@@ -397,7 +398,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
         mov(reg_kj, ptr[param1 + GET_OFF(kd_padding)]);
         if ((jcp.dilate_d >= jcp.id)
                 || (jcp.kd - 1) * (jcp.dilate_d + 1)
-                        < nstl::max(jcp.f_pad, jcp.back_pad)) {
+                        < nstl::max<dim_t>(jcp.f_pad, jcp.back_pad)) {
             cmp(reg_kj, 0);
             je(skip_compute_loop, T_NEAR);
         }
@@ -405,7 +406,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     mov(reg_kj, reg_kh);
     if ((jcp.dilate_h >= jcp.ih)
             || (jcp.kh - 1) * (jcp.dilate_h + 1)
-                    < nstl::max(jcp.t_pad, jcp.b_pad)) {
+                    < nstl::max<dim_t>(jcp.t_pad, jcp.b_pad)) {
         cmp(reg_kj, 0);
         je(skip_compute_loop, T_NEAR);
     }
@@ -432,20 +433,21 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     L(kh_label);
     {
         for (int ki = 0; ki < jcp.kw; ki++) {
-            int ow_start = get_ow_start(ki, pad_l);
-            int ow_end = get_ow_end(ur_w, ki, pad_r);
-            for (int ic = 0;
-                    ic < rnd_up(nstl::min(jcp.ic_block, jcp.ic), ic_step);
+            dim_t ow_start = get_ow_start(ki, pad_l);
+            dim_t ow_end = get_ow_end(ur_w, ki, pad_r);
+            for (int ic = 0; ic
+                    < rnd_up(nstl::min<dim_t>(jcp.ic_block, jcp.ic), ic_step);
                     ic += ic_step) {
                 if (ic_tail && ic == rnd_up(ic_tail, ic_step)) {
                     // insert this check at most once per icb, no more.
                     cmp(reg_ic, ic_tail);
                     je(ic_tail_jmp[ki], T_NEAR);
                 }
-                for (int oi = ow_start; oi < ow_end; oi++) {
+                for (dim_t oi = ow_start; oi < ow_end; oi++) {
                     dim_t src_offset = get_src_offset(
                             ic, filter_w_to_src(ki, oi, pad_l));
-                    auto vmm_in = vmm_src(oi, jcp.nb_oc_blocking);
+                    auto vmm_in
+                            = vmm_src(static_cast<int>(oi), jcp.nb_oc_blocking);
                     const auto addr_base = EVEX_compress_addr_safe(
                             aux_reg_src, src_offset, reg_long_offt);
                     const bool tail_load
@@ -520,9 +522,10 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
                     vmovups(vmm_wei,
                             EVEX_compress_addr_safe(
                                     aux_reg_ker, wei_off, reg_long_offt));
-                    for (int oi = ow_start; oi < ow_end; oi++) {
-                        auto acc = vmm_dst(oi, kk);
-                        auto src = vmm_src(oi, jcp.nb_oc_blocking);
+                    for (dim_t oi = ow_start; oi < ow_end; oi++) {
+                        auto acc = vmm_dst(static_cast<int>(oi), kk);
+                        auto src = vmm_src(
+                                static_cast<int>(oi), jcp.nb_oc_blocking);
                         if (isa_has_bf16(jcp.isa)) {
                             vdpbf16ps(acc, vmm_wei, src);
                         } else
@@ -555,7 +558,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
     // End of IC Loop
     dim_t src_step = get_src_offset(jcp.ic_block, 0);
-    const size_t ker_step = get_kernel_offset(0, jcp.ic_block, 0);
+    const dim_t ker_step = get_kernel_offset(0, jcp.ic_block, 0);
     safe_add(reg_src, src_step, reg_long_offt);
     safe_add(reg_ker, ker_step, reg_long_offt);
 
@@ -572,15 +575,15 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int ow_block = jcp.ow_block;
-    int nb_ow = jcp.nb_ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    dim_t iw = jcp.iw;
+    dim_t ow = jcp.ow;
+    int ow_block = static_cast<int>(jcp.ow_block);
+    dim_t nb_ow = jcp.nb_ow;
+    dim_t kw = jcp.kw;
+    dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    dim_t stride_w = jcp.stride_w;
 
     auto src_shift = get_src_offset(0, filter_w_to_src(0, ur_w));
     auto dst_shift = get_dst_offset(ur_w, 0);
@@ -622,7 +625,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
             kxnord(k_oc_tail_mask_extended, k_oc_tail_mask_extended,
                     k_oc_tail_mask_extended);
 
-        test(byte[param1 + GET_OFF(load_work)], jcp.oc_block - 1);
+        test(byte[param1 + GET_OFF(load_work)],
+                static_cast<uint32_t>(jcp.oc_block - 1));
         jz(done, T_NEAR);
         auto reg_tail_32 = reg_oc.cvt32();
         mov(reg_tail_32, (1 << jcp.oc_tail) - 1);
@@ -652,9 +656,9 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
     mov(reg_ker, ptr[param1 + GET_OFF(filt)]);
     mov(reg_kh, ptr[param1 + GET_OFF(kh_padding)]);
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+    dim_t r_pad = nstl::max<dim_t>(0, jcp.r_pad);
+    dim_t n_oi = ow / ur_w;
+    dim_t r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
             calculate_extended_filter_size(kw, jcp.dilate_w));
 
     if (!is_ow_threading_on(jcp)) {
@@ -714,7 +718,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
         int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
         int n_oi_first_ow_block = n_oi_not_last_ow_block;
 
-        int n_oi_last_ow_block = (ow - ow_block * (nb_ow - 1)) / ur_w;
+        int n_oi_last_ow_block
+                = static_cast<int>((ow - ow_block * (nb_ow - 1)) / ur_w);
 
         // prepare right padding
         bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
@@ -879,15 +884,19 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1054,7 +1063,7 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
 
     jcp.kernel_kind = expl_bcast;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--) {
         int ur_w = regs / (jcp.nb_oc_blocking + 1);
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
@@ -1064,27 +1073,27 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     }
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
-    jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
+    jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
 
     jcp.ow_block = jcp.ow;
     if (is_ow_threading_available(jcp)) {
         const int L1_part = platform::get_per_core_cache_size(1) * 5 / 8;
-        int size_src_chunk = jcp.typesize_in * jcp.ic_block * jcp.ur_w;
-        int size_dst_chunk = jcp.typesize_out * jcp.oc_block
+        dim_t size_src_chunk = jcp.typesize_in * jcp.ic_block * jcp.ur_w;
+        dim_t size_dst_chunk = jcp.typesize_out * jcp.oc_block
                 * jcp.nb_oc_blocking * jcp.ur_w;
-        int size_wei_chunk = jcp.typesize_in * jcp.oc_block * jcp.ic_block
+        dim_t size_wei_chunk = jcp.typesize_in * jcp.oc_block * jcp.ic_block
                 * jcp.nb_oc_blocking * jcp.kw;
-        int nurw = (L1_part - size_wei_chunk)
+        dim_t nurw = (L1_part - size_wei_chunk)
                 / (size_dst_chunk + size_src_chunk);
         // current design of generate() requires ow_block >= 2 * ur_w
-        jcp.ow_block = jcp.ur_w * nstl::max(2, nurw);
+        jcp.ow_block = jcp.ur_w * nstl::max<dim_t>(2, nurw);
     }
     jcp.nb_ow = div_up(jcp.ow, jcp.ow_block);
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(!(jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w),
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -1104,10 +1113,11 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     size_t total_size = jcp.ngroups * (wei_size + inp_size + out_size);
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
-    // The factor for 1d=1, 2d=2, 3d=4;
+    // The factor for 1d=1, 2d=2, 3d=4; a small fixed code-generation
+    // constant, not a tensor-scale value.
     int factor = nstl::max(1, (2 * (ndims - 3)));
     if (jcp.ngroups < jcp.nthr && total_size < L1_cache_size / factor) {
-        jcp.nthr = nstl::min(jcp.nthr, 4);
+        jcp.nthr = static_cast<int>(nstl::min<dim_t>(jcp.nthr, 4));
     }
 
     pick_loop_order(jcp);
@@ -1233,11 +1243,11 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::store_output(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int l_overflow, int r_overflow) {
-    int kw = jcp.kw;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+        int ur_w, dim_t l_overflow, dim_t r_overflow) {
+    dim_t kw = jcp.kw;
+    dim_t dilate_w = jcp.dilate_w + 1;
+    dim_t stride_w = jcp.stride_w;
+    dim_t stride_h = jcp.stride_h;
     const int oc_tail = jcp.oc_tail;
     Label kh_label, skip_compute_label;
 
@@ -1277,29 +1287,29 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow);
-            int jj_end = get_iw_end(ur_w, ki, r_overflow);
-            const int ref_jj_start
-                    = nstl::max(0, l_overflow - (kw - 1 - ki) * dilate_w);
-            const int ref_jj_end
-                    = ur_w - nstl::max(0, r_overflow - ki * dilate_w);
+            dim_t jj_start = get_iw_start(ki, l_overflow);
+            dim_t jj_end = get_iw_end(ur_w, ki, r_overflow);
+            const dim_t ref_jj_start = nstl::max<dim_t>(
+                    0, l_overflow - (kw - 1 - ki) * dilate_w);
+            const dim_t ref_jj_end
+                    = ur_w - nstl::max<dim_t>(0, r_overflow - ki * dilate_w);
             assert(IMPLICATION(stride_w == 1,
                     jj_start == ref_jj_start && jj_end == ref_jj_end));
             UNUSED(ref_jj_start);
             UNUSED(ref_jj_end);
             const int oc_step = 2;
-            for (int oc = 0;
-                    oc < rnd_up(nstl::min(jcp.oc_block, jcp.oc), oc_step);
+            for (int oc = 0; oc
+                    < rnd_up(nstl::min<dim_t>(jcp.oc_block, jcp.oc), oc_step);
                     oc += oc_step) {
                 if (oc_tail && oc == rnd_up(oc_tail, oc_step)) {
                     cmp(reg_oc, oc_tail);
                     je(oc_tail_jmp[ki], T_NEAR);
                 }
-                for (int jj = jj_start; jj < jj_end; jj += stride_w) {
+                for (dim_t jj = jj_start; jj < jj_end; jj += stride_w) {
                     assert((jj + jcp.l_pad - ki * dilate_w) % stride_w == 0);
-                    int ow_idx = (jj + jcp.l_pad - ki * dilate_w) / stride_w;
+                    dim_t ow_idx = (jj + jcp.l_pad - ki * dilate_w) / stride_w;
                     auto aux_ddst_offset = get_diff_dst_offset(ow_idx, oc);
-                    auto ddst = vmm_ddst(jj / stride_w);
+                    auto ddst = vmm_ddst(static_cast<int>(jj / stride_w));
                     const bool tail_load = oc_tail && oc == rnd_dn(oc_tail, 2);
                     const bool need_single_load = oc + 1 == oc_tail;
 
@@ -1323,9 +1333,9 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
                     vmovups(vmm_wei,
                             EVEX_compress_addr(aux_reg_ker, aux_kernel_offset));
 
-                    for (int jj = jj_start; jj < jj_end; jj += stride_w) {
-                        auto ddst = vmm_ddst(jj / stride_w);
-                        auto acc = vmm_dsrc(jj, kk);
+                    for (dim_t jj = jj_start; jj < jj_end; jj += stride_w) {
+                        auto ddst = vmm_ddst(static_cast<int>(jj / stride_w));
+                        auto acc = vmm_dsrc(static_cast<int>(jj), kk);
 
                         if (isa_has_bf16(jcp.isa)) {
                             vdpbf16ps(acc, vmm_wei, ddst);
@@ -1374,14 +1384,14 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int kw = jcp.kw;
+    const dim_t iw = jcp.iw;
+    const int kw = static_cast<int>(jcp.kw);
     int ur_w = jcp.ur_w;
-    int nb_iw = jcp.nb_iw;
-    int iw_block = jcp.iw_block;
+    dim_t nb_iw = jcp.nb_iw;
+    int iw_block = static_cast<int>(jcp.iw_block);
     int ur_w_tail = jcp.ur_w_tail;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dst_shift = get_diff_dst_offset(ur_w / stride_w, 0);
     const auto src_shift = get_diff_src_offset(ur_w, 0);
@@ -1407,7 +1417,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
             kxnord(k_ic_tail_mask_extended, k_ic_tail_mask_extended,
                     k_ic_tail_mask_extended);
 
-        test(byte[param1 + GET_OFF(load_work)], jcp.ic_block - 1);
+        test(byte[param1 + GET_OFF(load_work)],
+                static_cast<uint32_t>(jcp.ic_block - 1));
         jz(done, T_NEAR);
         Reg32 reg_tail_32 = reg_ic.cvt32();
         mov(reg_tail_32, (1 << jcp.ic_tail) - 1);
@@ -1425,15 +1436,16 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
 
     mov(reg_kh, ptr[param + GET_OFF(kh_padding)]);
 
-    int l_overflow = nstl::max(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
-    int r_overflow = nstl::max(
-            0, ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad)) / stride_w);
-    int r_overflow1 = nstl::max(0,
-            ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad + ur_w_tail))
+    dim_t l_overflow
+            = nstl::max<dim_t>(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
+    dim_t r_overflow = nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad)) / stride_w);
+    dim_t r_overflow1 = nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad + ur_w_tail))
                     / stride_w);
 
     int body_l_overflow = 0, body_r_overflow = 0;
-    int n_oi = iw / ur_w;
+    int n_oi = static_cast<int>(iw / ur_w);
     int head_n_oi = 0, body_n_oi = 0, pretail_n_oi = 0, tail_n_oi = 0;
     int head_thread = 0, pretail_thread = 0, tail_thread = 0;
     bool threaded = is_iw_threading_on(jcp);
@@ -1445,8 +1457,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
     if (n_oi < 0) {
         // l_overflow and r_overflow1 are handled in the same compute_loop.
         // Perform one iteration of body handling l_overflow and r_overflow1.
-        body_l_overflow = l_overflow;
-        body_r_overflow = r_overflow1;
+        body_l_overflow = static_cast<int>(l_overflow);
+        body_r_overflow = static_cast<int>(r_overflow1);
         n_oi = 1;
         l_overflow = 0;
         r_overflow1 = 0;
@@ -1458,12 +1470,12 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
         // Setup for threaded code generation, and jump into the correct
         // portion of code for execution.
         head_thread = 0;
-        tail_thread = nb_iw - 1;
+        tail_thread = static_cast<int>(nb_iw - 1);
         pretail_thread = tail_thread;
 
-        int base_n_oi = iw_block / ur_w;
+        int base_n_oi = static_cast<int>(iw_block / ur_w);
         head_n_oi = l_overflow > 0 ? base_n_oi - 1 : base_n_oi;
-        tail_n_oi = (iw - iw_block * (nb_iw - 1)) / ur_w;
+        tail_n_oi = static_cast<int>((iw - iw_block * (nb_iw - 1)) / ur_w);
         pretail_n_oi = tail_n_oi;
         if (r_overflow1 > 0) {
             if (tail_n_oi > 0) {
@@ -1485,8 +1497,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
         // n_oi is used to determine how much control flow in the body portion
         // of the code needs generated. As such, n_oi needs to be set to the
         // maximum number of iterations it will be used the body code section.
-        n_oi = nstl::max(body_n_oi, head_n_oi);
-        n_oi = nstl::max(n_oi, pretail_n_oi);
+        n_oi = static_cast<int>(nstl::max<dim_t>(body_n_oi, head_n_oi));
+        n_oi = static_cast<int>(nstl::max<dim_t>(n_oi, pretail_n_oi));
 
         assert(iw_block % ur_w == 0);
         mov(reg_iwb, ptr[param1 + GET_OFF(iwb)]);
@@ -1623,9 +1635,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(dilate_ok, VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1738,7 +1750,7 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ur_w = jcp.stride_w;
+    jcp.ur_w = static_cast<int>(jcp.stride_w);
 
     /* Maximum number of registers available for result accumulation and delta
        dst data. One additional register is reserved for weights data. */
@@ -1746,11 +1758,13 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
             = isa_has_bf16(jcp.isa) ? 31 : 26; /* In case of cpx emulation
                                                   additional 5 registers are
                                                   reserved */
-    int l_overflow = nstl::max(
+    const dim_t l_overflow = nstl::max<dim_t>(
             0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
 
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
 
     /* Find the best blocking with maximum number of compute instructions
        per ur_w * nb_ic_blocking compute loops. Number of required registers
@@ -1767,10 +1781,10 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
         for (int b = 1; b <= max_ic_blocks; b++) {
             if (jcp.nb_ic % b != 0) continue;
 
-            for (int u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
+            for (dim_t u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
                     && u < jcp.iw + jcp.stride_w;
                     u += jcp.stride_w) {
-                int ur_w = nstl::min(u, jcp.iw);
+                const int ur_w = static_cast<int>(nstl::min<dim_t>(u, jcp.iw));
                 /* maximum 1 step with l_overflow so far */
                 if (l_overflow * jcp.stride_w > ur_w && ur_w != jcp.iw)
                     continue;
@@ -1790,23 +1804,24 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.ur_w_tail = jcp.iw % jcp.ur_w;
 
     if (is_iw_threading_available(jcp)) {
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-        int work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih;
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih;
 
         auto efficiency = [](dim_t size, dim_t block) {
             // avoid msvc warning 'potential divide by zero'
             if (size <= 0 || block == 0) return 0.f;
-            return (float)size / rnd_up(size, block);
+            return (float)size / (float)rnd_up(size, block);
         };
 
         float no_iw_block_eff = efficiency(work_units, jcp.nthr);
 
         // current design of generate() requires iw_block >= 2 * ur_w
         const int min_iw_block = jcp.ur_w * 2;
-        int iw_threads = jcp.nthr / math::gcd(work_units, jcp.nthr);
-        int iw_block = nstl::max(min_iw_block,
-                rnd_up(jcp.iw, jcp.ur_w * iw_threads) / iw_threads);
-        int nb_iw = div_up(jcp.iw, iw_block);
+        int iw_threads
+                = jcp.nthr / math::gcd(static_cast<int>(work_units), jcp.nthr);
+        int iw_block = static_cast<int>(nstl::max<dim_t>(min_iw_block,
+                rnd_up(jcp.iw, jcp.ur_w * iw_threads) / iw_threads));
+        const int nb_iw = static_cast<int>(div_up(jcp.iw, iw_block));
 
         float block_eff = efficiency(jcp.iw, iw_block);
         work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih * nb_iw;
@@ -1815,7 +1830,8 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
         const int iw_thread_min_size = 16 * 128;
         const float iw_block_cost = 20.0;
-        float block_overhead = nstl::max(0.0f, 1.0f - iw_block_cost / iw_block);
+        float block_overhead
+                = nstl::max(0.0f, 1.0f - iw_block_cost / (float)iw_block);
 
         bool iw_thread_useful = no_iw_block_eff < block_overhead * iw_block_eff
                 && jcp.ic_block * jcp.iw > iw_thread_min_size;
@@ -1829,9 +1845,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(l_overflow * jcp.stride_w <= jcp.ur_w,
             VERBOSE_BLOCKING_FAIL, "failing boundary conditions");
 
-    int r_overflow_no_tail = nstl::max(0,
+    const dim_t r_overflow_no_tail = nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.ur_w_tail))
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.ur_w_tail))
                     / jcp.stride_w);
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
@@ -1858,9 +1874,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
     //The factor for 1d: 1, 2d: 2, 3d: 4;
-    int factor = nstl::max(1, (2 * (ndims - 3)));
+    const int factor = static_cast<int>(nstl::max<dim_t>(1, 2 * (ndims - 3)));
     if (jcp.ngroups < jcp.nthr && total_size < L1_cache_size / factor) {
-        jcp.nthr = nstl::min(jcp.nthr, 4);
+        jcp.nthr = static_cast<int>(nstl::min<dim_t>(jcp.nthr, 4));
     }
 
     pick_loop_order(jcp);
@@ -1899,18 +1915,18 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_extern(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_extern(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!is_src_layout_nxc() && !is_ddst_layout_nxc());
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     bool no_src_pad = jcp.is_1stconv && !jcp.transpose_src;
     static constexpr int ddst_zmm_base_idx = 24;
     const int num_ddst_zmm_regs = !isa_has_bf16(jcp.isa) ? 2 : 4;
     const int zmm_src_reg = ddst_zmm_base_idx + num_ddst_zmm_regs;
 
-    auto zmm_ker = [ic_block_step](int i_kw, int i_ic) {
-        return Zmm(i_kw * ic_block_step + i_ic);
+    auto zmm_ker = [ic_block_step](dim_t i_kw, dim_t i_ic) {
+        return Zmm(static_cast<int>(i_kw * ic_block_step + i_ic));
     };
     auto zmm_ddst = [num_ddst_zmm_regs](int i_iw) {
         // TODO: move reg calc to global member funcs
@@ -1922,8 +1938,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         return EVEX_compress_addr(reg_kernel, local_offset + kernel_offset);
     };
     auto src_addr
-            = [this, src_offset](int i_iw, int i_ic, ptrdiff_t extra_offset = 0,
-                      bool vnni_bcast = false) {
+            = [this, src_offset](dim_t i_iw, int i_ic,
+                      ptrdiff_t extra_offset = 0, bool vnni_bcast = false) {
         auto local_offset = get_src_offset(i_ic, i_iw);
         return EVEX_compress_addr(
                 reg_src, local_offset + src_offset + extra_offset, vnni_bcast);
@@ -1942,22 +1958,23 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     assert(ur_w % 2 == 0);
     auto steps = ur_w / 2;
 
-    const int str_w = jcp.stride_w;
+    const dim_t str_w = jcp.stride_w;
     const int underflow_boundary = -1;
-    int i_iw_shift = jcp.tr_ow - ur_w - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
-    const int overflow_boundary = jcp.iw - 1 - i_iw_shift;
+    const dim_t i_iw_shift
+            = jcp.tr_ow - ur_w - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
+    const dim_t overflow_boundary = jcp.iw - 1 - i_iw_shift;
 
     for (int s = 0; s < str_w; s++) {
         const int kw_start = s;
         assert(jcp.tr_iw % str_w == 0);
-        const int src_stride_w_shift = jcp.tr_iw / str_w;
+        const int src_stride_w_shift = static_cast<int>(jcp.tr_iw / str_w);
         for (int i_ur = 0; i_ur < steps; i_ur++) {
             auto zmm = zmm_ddst(i_ur);
             vmovdqu16(zmm, ddst_addr(i_ur));
 
             for (int i_kw = kw_start; i_kw < kw; i_kw += str_w) {
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
-                    int i_iw = 2 * i_ur + (i_kw * (jcp.dilate_w + 1)) / str_w
+                    dim_t i_iw = 2 * i_ur + (i_kw * (jcp.dilate_w + 1)) / str_w
                             + s * src_stride_w_shift;
                     bool underflow = false;
                     bool overflow = false;
@@ -2011,7 +2028,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         interleave_w_reorder_size(int ur_w) const {
     const int reorder_block = 16;
-    return rnd_up(jcp.stride_w * (ur_w - 1) + jcp.kw, reorder_block);
+    return static_cast<int>(
+            rnd_up(jcp.stride_w * (ur_w - 1) + jcp.kw, reorder_block));
 }
 int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         interleave_w_reorder_bytes(int ur_w) {
@@ -2022,12 +2040,12 @@ int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::interleave_stack_size(
     return ic_block_step * interleave_w_reorder_bytes(ur_w);
 }
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_interleave(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_interleave(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     // Only supports nchw format src
     assert(jcp.is_1stconv && !jcp.transpose_src);
-    int kw = jcp.kw;
+    const dim_t kw = jcp.kw;
     static constexpr int ddst_zmm_base_idx = 24;
     static constexpr int in_zmm_base_idx = 24;
     const int num_ddst_zmm_regs = !isa_has_bf16(jcp.isa) ? 2 : 4;
@@ -2060,9 +2078,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         return EVEX_compress_addr(reg_kernel, local_offset + kernel_offset);
     };
     auto src_addr
-            = [this, reorder_bytes](int i_iw, int i_ic,
+            = [this, reorder_bytes](dim_t i_iw, int i_ic,
                       ptrdiff_t extra_offset = 0, bool vnni_bcast = false) {
-        int local_offset = i_ic * reorder_bytes + 2 * jcp.typesize_in * i_iw;
+        const dim_t local_offset
+                = i_ic * reorder_bytes + 2 * jcp.typesize_in * i_iw;
         return EVEX_compress_addr(rsp, local_offset, vnni_bcast);
     };
     auto ddst_addr = [this, ddst_offset](int i_ur) {
@@ -2071,14 +2090,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
                 reg_ddst, get_ddst_offset(ow_scale * i_ur) + ddst_offset);
     };
     auto load_src_to_stack
-            = [&](int i_iw, int i_ic, Opmask mask, bool mask_empty,
+            = [&](dim_t i_iw, int i_ic, Opmask mask, bool mask_empty,
                       Opmask stride_mask, bool stride_mask_empty) {
         auto local_offset = get_src_offset(i_ic, i_iw);
-        int stack_offset
+        const dim_t stack_offset
                 = i_ic * reorder_bytes + 2 * jcp.typesize_in * (i_iw + pad_l);
 
-        auto zmm = zmm_in(i_iw, i_ic, false);
-        auto zmm_stride = zmm_in(i_iw, i_ic, true);
+        auto zmm = zmm_in(static_cast<int>(i_iw), i_ic, false);
+        auto zmm_stride = zmm_in(static_cast<int>(i_iw), i_ic, true);
         auto base_addr
                 = EVEX_compress_addr(reg_src, local_offset + src_offset, false);
         auto stride_addr = EVEX_compress_addr(reg_src,
@@ -2101,19 +2120,21 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     assert(ur_w % 2 == 0);
     auto steps = ur_w / 2;
 
-    const int str_w = jcp.stride_w;
-    int i_iw_shift = str_w * (jcp.tr_ow - ur_w)
+    const dim_t str_w = jcp.stride_w;
+    const dim_t i_iw_shift = str_w * (jcp.tr_ow - ur_w)
             - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
-    const int overflow_boundary
+    const dim_t overflow_boundary
             = is_tail ? jcp.iw - i_iw_shift : str_w * (ur_w - 1) + kw - pad_l;
 
     // Calculate padding required by the data reorder using 32 byte loads
-    int reorder_overflow = reorder_size - pad_l - overflow_boundary;
-    int reorder_stride_overflow = reorder_overflow + str_w;
-    reorder_overflow = nstl::max(0, reorder_overflow);
-    reorder_stride_overflow = nstl::max(0, reorder_stride_overflow);
-    int reorder_pad_r = reorder_overflow % reorder_block;
-    int reorder_stride_pad_r = reorder_stride_overflow % reorder_block;
+    dim_t reorder_overflow = reorder_size - pad_l - overflow_boundary;
+    dim_t reorder_stride_overflow = reorder_overflow + str_w;
+    reorder_overflow = nstl::max<dim_t>(0, reorder_overflow);
+    reorder_stride_overflow = nstl::max<dim_t>(0, reorder_stride_overflow);
+    const int reorder_pad_r
+            = static_cast<int>(reorder_overflow % reorder_block);
+    int reorder_stride_pad_r
+            = static_cast<int>(reorder_stride_overflow % reorder_block);
     if (reorder_stride_overflow >= reorder_size && reorder_stride_pad_r == 0) {
         assert(reorder_stride_overflow == reorder_size);
         reorder_stride_pad_r = reorder_block;
@@ -2133,18 +2154,21 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         // Overflow and underflow happen in different data reorder rounds
         kxnorw(overflow_stride_mask, overflow_stride_mask,
                 overflow_stride_mask);
-        kshiftlw(underflow_mask, overflow_stride_mask, pad_l);
+        kshiftlw(underflow_mask, overflow_stride_mask,
+                static_cast<uint8_t>(pad_l));
         kshiftlw(underflow_stride_mask, overflow_stride_mask,
-                pad_l >= str_w ? pad_l - str_w : 0);
-        kshiftrw(overflow_mask, overflow_stride_mask, reorder_pad_r);
+                static_cast<uint8_t>(pad_l >= str_w ? pad_l - str_w : 0));
+        kshiftrw(overflow_mask, overflow_stride_mask,
+                static_cast<uint8_t>(reorder_pad_r));
         kshiftrw(overflow_stride_mask, overflow_stride_mask,
-                reorder_stride_pad_r);
+                static_cast<uint8_t>(reorder_stride_pad_r));
     } else if (reorder_size - reorder_overflow > reorder_block) {
         // Overflow and underflow happen in the same round for loading the data
         // at the stride offset.
         kxnorw(overflow_mask, overflow_mask, overflow_mask);
-        kshiftlw(underflow_mask, overflow_mask, pad_l);
-        kshiftrw(overflow_mask, overflow_mask, reorder_pad_r);
+        kshiftlw(underflow_mask, overflow_mask, static_cast<uint8_t>(pad_l));
+        kshiftrw(overflow_mask, overflow_mask,
+                static_cast<uint8_t>(reorder_pad_r));
         mov(reg_tmp.cvt32(), pad_l_mask_strided & pad_r_mask_strided);
         kmovw(underflow_stride_mask, reg_tmp.cvt32());
     } else {
@@ -2156,9 +2180,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     }
 
     // Load and reorder data to the stack
-    int reorder_start = -pad_l;
-    int reorder_end = reorder_size - pad_l;
-    for (int i_iw = reorder_start; i_iw < reorder_end; i_iw += reorder_block) {
+    const dim_t reorder_start = -pad_l;
+    const dim_t reorder_end = reorder_size - pad_l;
+    for (dim_t i_iw = reorder_start; i_iw < reorder_end;
+            i_iw += reorder_block) {
         for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
             Opmask mask, stride_mask;
             bool mask_empty, stride_mask_empty;
@@ -2222,7 +2247,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
         for (int i_kw = 0; i_kw < kw; i_kw++) {
             for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
-                int i_iw = 2 * i_ur * str_w + i_kw;
+                const dim_t i_iw = 2 * i_ur * str_w + i_kw;
                 auto acc = zmm_ker(i_kw, i_ic);
                 auto ddst = zmm_ddst(i_ur);
 
@@ -2260,7 +2285,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         convert_src_to_vnni_format(
-                int ur_w, int pad_l, int pad_r, int src_offset) {
+                int ur_w, dim_t pad_l, dim_t pad_r, dim_t src_offset) {
     Reg64 reg_trans_tmp = r11;
     const int ic_tail = jcp.ic_tail;
     mov(EVEX_compress_addr(rsp, trans_tmp_offset), reg_trans_tmp);
@@ -2281,7 +2306,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     for (int src_count = 0;
             sizeof_cacheline * src_count < permw_stack_size(ur_w);
             src_count++) {
-        int i_ur = nstl::min(src_count, ur_w - 2);
+        const int i_ur
+                = static_cast<int>(nstl::min<dim_t>(src_count, ur_w - 2));
         int i_kw = src_count - i_ur;
         int buffer_offset = permw_buffer_start + src_count * 64;
         auto bcast_values = Zmm(src_count % max_regs);
@@ -2350,15 +2376,16 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_vpermw_expl(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_vpermw_expl(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!jcp.is_1stconv); // This method does not support nchw data
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     int src_count = 0;
-    int ic_block_step_idx = src_offset / (jcp.typesize_in * ic_block_step);
+    const int ic_block_step_idx
+            = static_cast<int>(src_offset / (jcp.typesize_in * ic_block_step));
     const int max_regs = (!isa_has_bf16(jcp.isa)) ? 26 : 31;
-    int src_pl_len = kw;
+    const int src_pl_len = kw;
     const int diff_dst_pl_start_reg_idx = ic_block_step * (kw + src_pl_len);
     const int diff_dst_pl_len = max_regs - diff_dst_pl_start_reg_idx;
 
@@ -2408,8 +2435,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     int src_count_last = 0;
     for (int i_ur = 0; i_ur < ur_w; i_ur += 2) {
         if (i_ur == 0) {
-            for (int dst_count = 0;
-                    dst_count < nstl::min(diff_dst_pl_len, div_up(ur_w, 2));
+            for (int dst_count = 0; dst_count
+                    < nstl::min<dim_t>(diff_dst_pl_len, div_up(ur_w, 2));
                     dst_count++) {
                 load_dst(dst_count);
             }
@@ -2476,18 +2503,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_vpermw(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_vpermw(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!jcp.is_1stconv); // This method does not support nchw data
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
 
     int dst_count = 0;
 
-    int ic_block_step_idx = src_offset / (jcp.typesize_in * ic_block_step);
+    const int ic_block_step_idx
+            = static_cast<int>(src_offset / (jcp.typesize_in * ic_block_step));
 
-    int pipeline_length = (isa_has_bf16(jcp.isa))
-            ? nstl::max(1, nstl::min(4, ur_w / 2))
+    const int pipeline_length = isa_has_bf16(jcp.isa)
+            ? static_cast<int>(
+                      nstl::max<dim_t>(1, nstl::min<dim_t>(4, ur_w / 2)))
             : 1;
     may_be_set_oc_tail_mask();
 
@@ -2610,7 +2639,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_diff_bias_row(
     };
 
     Label ow_loop, ow_tail;
-    int niters = jcp.tr_ow / 2;
+    int niters = static_cast<int>(jcp.tr_ow / 2);
     if (niters > 0) {
         mov(reg_tmp, jcp.tr_ow / 2);
         L(ow_loop);
@@ -2679,8 +2708,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int src_offset,
-        int kernel_offset, int ddst_offset, bool is_tail) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step, dim_t src_offset,
+        dim_t kernel_offset, dim_t ddst_offset, bool is_tail) {
 
     if (jcp.uses_permw_transposition)
         if (jcp.kernel_kind == expl_bcast)
@@ -2700,7 +2729,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
         int &ur_w, int &ur_w_tail, int &ur_w_trips) const {
     if (jcp.tr_ow <= max_ur_w) {
-        ur_w = jcp.tr_ow;
+        ur_w = static_cast<int>(jcp.tr_ow);
         ur_w_tail = 0;
         ur_w_trips = 1;
         return;
@@ -2709,14 +2738,15 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
     int r_pad = 0;
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        r_pad = nstl::max(0,
-                calculate_end_padding(
-                        jcp.l_pad, jcp.tr_ow, jcp.tr_iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(jcp.l_pad, jcp.tr_ow, jcp.tr_iw,
+                        jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
     ur_w = max_ur_w;
-    ur_w_trips = jcp.tr_ow / ur_w;
+    ur_w_trips = static_cast<int>(jcp.tr_ow / ur_w);
     ur_w_tail = jcp.tr_ow % ur_w;
     if ((ur_w_tail == 0 && jcp.r_pad != 0) || r_pad >= ur_w_tail) {
         if (ur_w_trips > 1) {
@@ -2728,7 +2758,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
                                               : ur_w_tail / 2 + 1;
             ur_w_tail = ur_w_tail_total - ur_w;
             if (l_pad > ur_w / 2) {
-                ur_w = (l_pad % 2 == 0) ? l_pad : l_pad + 1;
+                ur_w = static_cast<int>((l_pad % 2 == 0) ? l_pad : l_pad + 1);
                 ur_w_tail = ur_w_tail_total - ur_w;
             } else if (r_pad > ur_w_tail) {
                 ur_w_tail = (r_pad % 2 == 0) ? r_pad : r_pad + 1;
@@ -2742,9 +2772,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow_icblock(int ic_block_step) {
     Label kh_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     int r_pad = 0;
     int ur_w, ur_w_tail, ur_w_trips;
     get_ur_w(ur_w, ur_w_tail, ur_w_trips);
@@ -2752,12 +2782,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2787,7 +2819,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         const int ic_tail_loop_work = rnd_up(ic_tail, ic_block_step);
         for (int i_b_ic = 0; i_b_ic < jcp.ic_block; i_b_ic += ic_block_step) {
-            const int src_offset = get_src_offset(i_b_ic, 0);
+            const dim_t src_offset = get_src_offset(i_b_ic, 0);
             compute_ic_block_step(ur_w, l_pad, r_pad, ic_block_step, src_offset,
                     get_kernel_offset(i_b_ic, 0), 0, true);
             if (generate_icb_loop || ic_tail) sub(reg_icb, ic_block_step);
@@ -2843,9 +2875,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow(int ic_block_step) {
     Label kh_label, ic_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     const int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
 
     int r_pad = 0;
     int ur_w, ur_w_tail, ur_w_trips;
@@ -2854,12 +2886,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2886,7 +2920,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         xor_(b_ic, b_ic);
         if (jcp.uses_permw_transposition) {
-            convert_src_to_vnni_format(ow, l_pad, r_pad, 0);
+            convert_src_to_vnni_format(static_cast<int>(ow), l_pad, r_pad, 0);
             xor_(b_ic, b_ic);
         }
 
@@ -2975,18 +3009,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         int ic_block_step) {
     Label kh_label, ic_block_label, ow_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     int r_pad = 0;
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     int ur_w, ur_w_trips, ur_w_tail;
     get_ur_w(ur_w, ur_w_tail, ur_w_trips);
@@ -3113,7 +3149,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         auto src_icbstep_shift = get_src_offset(1, 0);
 
         auto ic_loop = [&](int ic_block_step) {
-            int ic_work = ic_block;
+            dim_t ic_work = ic_block;
             Label ow_block_label, ic_block_label_padl, ic_block_label_general,
                     ic_block_label_tail;
             int ur_w_blocks = ur_w_trips;
@@ -3254,12 +3290,12 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         compute_oh_step_disp() {
-    int ic_block_step = jcp.ic_block_step;
+    const int ic_block_step = static_cast<int>(jcp.ic_block_step);
 
     bool too_large_to_unroll = (jcp.kw > 1 || jcp.kh > 1 || jcp.kd > 1)
             && (jcp.stride_w > 1 || jcp.stride_h > 1 || jcp.stride_d > 1);
 
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     if (jcp.ndims == 5) {
         /* NOTE: reg_kd_count = aux_reg_src = r12. The following order of
          * 'movs' must be guaranteed. */
@@ -3336,12 +3372,12 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
             vmovups(ptr[reg_kernel + reg_tmp + get_kernel_offset(ic1, 0)],
                     zero);
         add(reg_tmp, get_kernel_offset(jcp.ic_block, 0));
-        cmp(reg_tmp, kernel_block_bytes);
+        cmp(reg_tmp, static_cast<uint32_t>(kernel_block_bytes));
         jnz(zeroing_loop);
     }
 
     if (generate_icb_loop) {
-        add(reg_kernel, kernel_block_bytes);
+        add(reg_kernel, static_cast<uint32_t>(kernel_block_bytes));
         sub(reg_icb, jcp.ic_block);
         cmp(reg_icb, 0);
         jg(icb_block_label, T_NEAR);
@@ -3354,11 +3390,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_loop_common(bool is_partial) {
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    dim_t b_pad = jcp.b_pad;
+    dim_t t_pad = jcp.t_pad;
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
+    dim_t dilate_h = jcp.dilate_h + 1;
+    dim_t stride_h = jcp.stride_h;
     auto filter_step_size = get_kernel_offset(0, jcp.kw);
     auto src_step_size = get_src_offset(0, 0, 1);
     auto ddst_step_size = get_ddst_offset(0, 1);
@@ -3368,15 +3404,17 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             oh_dilate_label_end, oh_dilate_setup_label_shift,
             oh_dilate_setup_label_noshift, oh_dilate_setup_label_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int oh_body_end = div_up(t_pad + jcp.ih - ext_kh + 1, stride_h);
-    int oh_head_end = nstl::min(div_up(t_pad, stride_h), oh_body_end);
-    int oh_head_overflow_end = div_up(t_pad, stride_h);
-    int oh_tail_end = jcp.oh;
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t oh_body_end = div_up(t_pad + jcp.ih - ext_kh + 1, stride_h);
+    const dim_t oh_head_end
+            = nstl::min<dim_t>(div_up(t_pad, stride_h), oh_body_end);
+    const dim_t oh_head_overflow_end = div_up(t_pad, stride_h);
+    const dim_t oh_tail_end = jcp.oh;
 
-    int body_src_start_offset = (stride_h - (t_pad % stride_h)) % stride_h;
-    int ih_body_end
-            = nstl::max(-t_pad + oh_body_end * stride_h, body_src_start_offset);
+    const dim_t body_src_start_offset
+            = (stride_h - (t_pad % stride_h)) % stride_h;
+    const dim_t ih_body_end = nstl::max<dim_t>(
+            -t_pad + oh_body_end * stride_h, body_src_start_offset);
 
     if (is_partial)
         mov(reg_oj, ptr[param + GET_OFF(os_index_begin)]);
@@ -3389,17 +3427,17 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             cmp(reg_oj, oh_head_overflow_end);
             jge(oh_tpad_tail_label_end, T_NEAR);
         }
-        const int overflow
-                = nstl::max(0, jcp.kh - div_up(t_pad + jcp.ih, dilate_h));
-        const int underflow = div_up(t_pad, dilate_h);
-        const int initial_kh = jcp.kh - overflow - underflow;
+        const dim_t overflow = nstl::max<dim_t>(
+                0, jcp.kh - div_up(t_pad + jcp.ih, dilate_h));
+        const dim_t underflow = div_up(t_pad, dilate_h);
+        const dim_t initial_kh = jcp.kh - overflow - underflow;
 
         // Setup reg_kh, reg_kernel, and reg_src
         mov(reg_kh, initial_kh);
         add(reg_kernel, filter_step_size * underflow);
         if (is_dilated) {
-            const int tail = t_pad % dilate_h;
-            const int shift = tail == 0 ? 0 : dilate_h - tail;
+            const int tail = static_cast<int>(t_pad % dilate_h);
+            const int shift = tail == 0 ? 0 : static_cast<int>(dilate_h - tail);
             mov(reg_ih_shift, shift);
             if (!is_partial) mov(ptr[rsp + ih_dilate_shift], reg_ih_shift);
             add(reg_src, src_step_size * shift);
@@ -3556,7 +3594,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         }
         if (is_partial) {
             lea(reg_oj_setup,
-                    ptr[reg_oj - nstl::max(oh_body_end, oh_head_overflow_end)]);
+                    ptr[reg_oj
+                            - nstl::max<dim_t>(
+                                    oh_body_end, oh_head_overflow_end)]);
             if (stride_h == 1 && !is_dilated) {
                 sub(reg_kh, reg_oj_setup);
             } else {
@@ -3613,8 +3653,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_od_loop_common(bool is_partial) {
     assert(jcp.harness == harness_3d_reduction);
 
-    const int src_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
+    const dim_t src_backpad_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d);
 
     const auto filter_shift
             = get_kernel_offset(0, static_cast<dim_t>(jcp.kh) * jcp.kw);
@@ -3622,8 +3663,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
     const auto ddst_shift = get_ddst_offset(0, jcp.oh);
     const dim_t src_common_shift = src_shift * jcp.stride_d;
 
-    const int kd_front_pad = nstl::max(0, jcp.f_pad);
-    const int kd_back_pad = nstl::max(0, jcp.kd - jcp.f_pad - jcp.id);
+    const dim_t kd_front_pad = nstl::max<dim_t>(0, jcp.f_pad);
+    const dim_t kd_back_pad = nstl::max<dim_t>(0, jcp.kd - jcp.f_pad - jcp.id);
 
     Label d_loop_label, loop_end_label, common_block_label, fpad_end_label,
             backpad_end_label, backpad_label;
@@ -3637,10 +3678,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         mov(reg_d_index, ptr[param + GET_OFF(os_index_begin)]);
         mov(reg_kd_count, ptr[param + GET_OFF(kd_padding)]);
     } else {
-        const int kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
-        const int kd_offset = get_kernel_offset(0,
-                nstl::min(jcp.kd - 1, kd_front_pad) * static_cast<dim_t>(jcp.kh)
-                        * jcp.kw);
+        const dim_t kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
+        const dim_t kd_offset = get_kernel_offset(0,
+                nstl::min<dim_t>(jcp.kd - 1, kd_front_pad)
+                        * static_cast<dim_t>(jcp.kh) * jcp.kw);
         add(reg_kernel, kd_offset);
         xor_(reg_d_index, reg_d_index);
         mov(reg_kd_count, kd_padding);
@@ -3680,7 +3721,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with src */
-        const int src_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const dim_t src_ker_overlap = nstl::min<dim_t>(jcp.kd, jcp.id);
         cmp(reg_kd_count, src_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3688,7 +3729,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                const dim_t src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
                 add(reg_kernel, filter_shift * src_corr);
                 // for src, subtract src_common_shift that gets added later.
                 add(reg_src_d, src_shift * src_corr - src_common_shift);
@@ -3759,9 +3800,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     auto ddst_row_size = get_ddst_offset(0, 1);
     auto row_size = src_row_size + ddst_row_size;
 
-    int h_block_size = jcp.oh;
-    int h_last_block_size = h_block_size;
-    int min_h_block_size = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+    dim_t h_block_size = jcp.oh;
+    dim_t h_last_block_size = h_block_size;
+    const dim_t min_h_block_size
+            = nstl::max<dim_t>(1, nstl::max<dim_t>(jcp.b_pad, jcp.t_pad));
     auto working_set_size = row_size * h_block_size;
 
     if (working_set_size > full_spat_max_working_set_size) {
@@ -3769,7 +3811,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
         while (working_set_size > full_spat_opt_working_set_size
                 && h_block_size >= min_h_block_size) {
-            for (int i = 2; i <= h_block_size; i++)
+            for (dim_t i = 2; i <= h_block_size; i++)
                 if (i == h_block_size)
                     h_block_size = h_block_size / 2;
                 else if (h_block_size % i == 0) {
@@ -3778,7 +3820,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
                 }
             working_set_size = row_size * h_block_size;
         }
-        h_block_size = nstl::max(min_h_block_size, h_block_size);
+        h_block_size = nstl::max<dim_t>(min_h_block_size, h_block_size);
         h_last_block_size = jcp.oh % h_block_size;
         if (h_last_block_size < jcp.b_pad) h_last_block_size += h_block_size;
     }
@@ -3846,10 +3888,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         };
 
         if (full_w_unroll) {
-            emit_step(pad_ow, true);
+            emit_step(static_cast<int>(pad_ow), true);
         } else {
             Label w_loop;
-            int num_w_iters = pad_ow / def_step_size;
+            int num_w_iters = static_cast<int>(pad_ow / def_step_size);
             mov(reg_i, num_w_iters);
             L(w_loop);
             {
@@ -3892,10 +3934,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         xor_(reg_kh, reg_kh);
         Label kh_loop, kh_loop_end;
 
-        int oh_block_size = (is_last_block) ? h_last_block_size : h_block_size;
+        const dim_t oh_block_size
+                = (is_last_block) ? h_last_block_size : h_block_size;
         // NB: this is correct because we only support t_pad = kh / 2 and thus
         // ih == oh
-        int ih_block_size = oh_block_size
+        const dim_t ih_block_size = oh_block_size
                 + (!is_first_block + !is_last_block) * jcp.t_pad;
 
         L(kh_loop);
@@ -3962,8 +4005,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
             L(kh_loop_work);
 
-            mul_by_const(reg_ihs, reg_tmp, get_src_offset(0, 0, 1));
-            mul_by_const(reg_ohs, reg_tmp, get_ddst_offset(0, 1));
+            mul_by_const(reg_ihs, reg_tmp,
+                    static_cast<int>(get_src_offset(0, 0, 1)));
+            mul_by_const(
+                    reg_ohs, reg_tmp, static_cast<int>(get_ddst_offset(0, 1)));
 
             add(reg_src, reg_ihs);
             add(reg_ddst, reg_ohs);
@@ -4046,8 +4091,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         add(reg_src, first_src_block_step);
         add(reg_ddst, ddst_block_step);
 
-        int num_innermost_iters
-                = (jcp.oh - h_last_block_size) / h_block_size - 1;
+        const int num_innermost_iters = static_cast<int>(
+                (jcp.oh - h_last_block_size) / h_block_size - 1);
         if (num_innermost_iters > 0) {
             Label h_block_loop;
 
@@ -4129,10 +4174,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::setup_stack_space() {
             || jcp.uses_permw_transposition) {
         int ur_w, ur_w_tail, ur_w_trips;
         get_ur_w(ur_w, ur_w_tail, ur_w_trips);
-        ur_w = nstl::max(ur_w, ur_w_tail);
+        ur_w = static_cast<int>(nstl::max<dim_t>(ur_w, ur_w_tail));
         ic_block_step_stack_size = jcp.uses_permw_transposition
-                ? permw_stack_size(ur_w)
-                : interleave_stack_size(ur_w, jcp.ic_block_step);
+                ? static_cast<int>(permw_stack_size(ur_w))
+                : interleave_stack_size(
+                          ur_w, static_cast<int>(jcp.ic_block_step));
     } else
         ic_block_step_stack_size = extern_ic_block_step_stack_size;
 
@@ -4230,9 +4276,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -4243,13 +4289,13 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             && IMPLICATION(jcp.dilate_h != 0, ext_kh <= jcp.ih);
     VDISPATCH_CONV_IC(ok, "dilation / stride values do not match");
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -4329,14 +4375,16 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             CHECK(memory_desc_init_by_tag(diff_bias_md, x));
     }
     jcp.bia_dt = jcp.with_bias ? diff_bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd
@@ -4360,8 +4408,10 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
                     data_type::bf16);
     VDISPATCH_CONV_IC(ok, VERBOSE_UNSUPPORTED_DT_CFG);
 
-    jcp.ic_tail = is_data_layout_nxc ? jcp.ic % jcp.ic_block : 0;
-    jcp.oc_tail = is_data_layout_nxc ? jcp.oc % jcp.oc_block : 0;
+    jcp.ic_tail
+            = is_data_layout_nxc ? static_cast<int>(jcp.ic % jcp.ic_block) : 0;
+    jcp.oc_tail
+            = is_data_layout_nxc ? static_cast<int>(jcp.oc % jcp.oc_block) : 0;
 
     if (jcp.is_1stconv) {
         jcp.ic_block_step = 24 / jcp.kw;
@@ -4381,7 +4431,7 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             && jcp.kw == 1 && jcp.ic_block_step > 4;
     // Threshold is based on performance measurements
     const bool apply_permw_nxc = is_data_layout_nxc && ndims == 3
-            && nstl::max(jcp.ic, jcp.oc) <= 32;
+            && nstl::max<dim_t>(jcp.ic, jcp.oc) <= 32;
     jcp.uses_permw_transposition
             = is_permw_applicable && (apply_permw_blocked || apply_permw_nxc);
 
@@ -4437,7 +4487,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
     bool use_spatial_blocking = jcp.is_1stconv && !nt_stores_ok && blocking_ok;
-    int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    int optimal_blk_size = static_cast<int>(is_3d ? jcp.od
+                    : is_2d                       ? jcp.oh
+                                                  : jcp.ow);
     if (use_spatial_blocking) {
         // Default value, works best most of the times
         // TODO: For 3D shapes with intermediate sizes especially the ones not
@@ -4491,7 +4543,8 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     // padding. Because elements are read two at a time, we may need r_pad + 1
     // padding on the right. As such, the shared padding is the max of l_pad and
     // r_pad + 1, rounded as necessary for the transpose data format.
-    int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    const dim_t tr_pad
+            = rnd_up(nstl::max<dim_t>(jcp.l_pad, jcp.r_pad + 1), tr_round);
     jcp.tr_iw = jcp.transpose_src
             ? rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
                     * jcp.stride_w
@@ -4517,7 +4570,7 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     const auto out_row_size
             = static_cast<size_t>(jcp.oc_block) * jcp.tr_ow * jcp.typesize_in;
     const auto full_spat_min_h_block_size
-            = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+            = nstl::max<dim_t>(1, nstl::max<dim_t>(jcp.b_pad, jcp.t_pad));
     const auto full_spat_working_set_size
             = (inp_row_size + out_row_size) * full_spat_min_h_block_size;
     bool use_full_spat_loop = isa_has_bf16(jcp.isa) && jcp.ndims < 5
@@ -4572,7 +4625,8 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.nb_ic_blocking_max = 1;
     if (is_data_layout_nxc && jcp.uses_permw_transposition
             && (jcp.ow > max_ur_w || jcp.ndims == 5))
-        jcp.nb_ic_blocking_max = nstl::min(8, div_up(jcp.nb_ic, jcp.nthr_ic_b));
+        jcp.nb_ic_blocking_max = static_cast<int>(
+                nstl::min<dim_t>(8, div_up(jcp.nb_ic, jcp.nthr_ic_b)));
     return status::success;
 }
 
@@ -4656,7 +4710,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = max_threads / nthr_g_;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -4682,8 +4736,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         dim_t wei_size
                 = (dim_t)j.oc * j.ic * j.kd * j.kh * j.kw * wei_type_size;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
-        float oi_channels_ratio = (float)j.nb_oc / j.nb_ic;
+        float wei_compensation_scale
+                = 0.5f * (float)(dst_size + src_size) / (float)wei_size;
+        float oi_channels_ratio = (float)j.nb_oc / (float)j.nb_ic;
         auto get_src_coef = [oi_channels_ratio, wei_compensation_scale]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
             if (wei_compensation_scale < 1.0f) src_coef *= 4.0f;
@@ -4703,16 +4758,24 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         const float dst_coef = get_dst_coef();
         const float wei_coef = get_wei_coef();
 
-        float src_v = src_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_ic, nthr_ic_b) * j.mb
-                * j.ic_block * j.id * j.ih * j.tr_iw / j.nthr_mb_work
-                / j.stride_d / j.stride_h / j.stride_w;
-        float wei_v = wei_coef * div_up(j.ngroups, nthr_g_)
-                * div_up(j.nb_oc, nthr_oc_b) * div_up(j.nb_ic, nthr_ic_b) * j.kh
-                * j.kw * j.kd * j.ic_block * j.oc_block;
-        float dst_v = dst_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_oc, nthr_oc_b) * j.mb
-                * j.oc_block * j.od * j.oh * j.tr_ow / j.nthr_mb_work;
+        float src_v = src_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_ic, nthr_ic_b) * j.mb * j.ic_block * j.id
+                        * j.ih * j.tr_iw)
+                / (float)(j.nthr_mb_work * j.stride_d * j.stride_h
+                        * j.stride_w);
+        float wei_v = wei_coef
+                * (float)(div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_oc, nthr_oc_b)
+                        * div_up(j.nb_ic, nthr_ic_b) * j.kh * j.kw * j.kd
+                        * j.ic_block * j.oc_block);
+        float dst_v = dst_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_oc, nthr_oc_b) * j.mb * j.oc_block * j.od
+                        * j.oh * j.tr_ow)
+                / (float)j.nthr_mb_work;
 
         return src_v + dst_v + wei_v;
     };
@@ -4720,12 +4783,15 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
     float best_mem_cost = calc_mem_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
 
     /* find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, j.nthr_mb_work);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, j.nthr_mb_work));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
 
             float mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -4738,7 +4804,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
     }
 
     if (nthr_mb_ > nthr / 2 && nthr_mb_ < nthr)
-        nthr_mb_ = nstl::min(j.nthr_mb_work, nthr);
+        nthr_mb_ = static_cast<int>(nstl::min<dim_t>(j.nthr_mb_work, nthr));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= max_threads);

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -134,11 +134,11 @@ private:
     inline void prepare_dst(int ur_w);
     void apply_postops(int ur_w);
     inline void store_dst(int ur_w);
-    inline void compute_loop(int ur_w, int pad_l, int pad_r);
+    inline void compute_loop(int ur_w, dim_t pad_l, dim_t pad_r);
 
     void generate() override;
 
-    inline dim_t get_dst_offset(dim_t sp_idx, int ocb) {
+    inline dim_t get_dst_offset(dim_t sp_idx, dim_t ocb) {
         const bool is_layout_nxc = is_dst_layout_nxc();
         dim_t sp_str = is_layout_nxc ? static_cast<dim_t>(jcp.ngroups) * jcp.oc
                                      : jcp.oc_block;
@@ -147,20 +147,20 @@ private:
         return jcp.typesize_out * (ocb_str * ocb + sp_str * sp_idx);
     }
 
-    inline dim_t filter_w_to_src(int kw, int ow = 0, int pad_l = 0) {
-        return static_cast<dim_t>(kw) * (jcp.dilate_w + 1) + ow * jcp.stride_w
-                - pad_l;
+    inline dim_t filter_w_to_src(
+            dim_t kw, dim_t ow = 0, dim_t pad_l = 0) {
+        return kw * (jcp.dilate_w + 1) + ow * jcp.stride_w - pad_l;
     }
-    inline dim_t filter_h_to_src(int kh) {
-        return static_cast<dim_t>(kh) * (jcp.dilate_h + 1) * jcp.iw;
+    inline dim_t filter_h_to_src(dim_t kh) {
+        return kh * (jcp.dilate_h + 1) * jcp.iw;
     }
-    inline dim_t filter_d_to_src(int kd) {
-        return static_cast<dim_t>(kd) * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
+    inline dim_t filter_d_to_src(dim_t kd) {
+        return kd * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
     }
 
     inline dim_t get_src_offset(dim_t ic_idx, dim_t isp) {
-        int icb = ic_idx / jcp.ic_block;
-        int ic = ic_idx % jcp.ic_block;
+        dim_t icb = ic_idx / jcp.ic_block;
+        dim_t ic = ic_idx % jcp.ic_block;
         dim_t isp_str = is_src_layout_nxc()
                 ? static_cast<dim_t>(jcp.ngroups) * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
@@ -174,12 +174,12 @@ private:
     }
 
     inline dim_t get_kernel_offset(
-            int ocb, int ic_idx, int kw, int kh = 0, int kd = 0) {
-        int scale = 2; //bf16 vnni is used
-        int rnd_ic_block = utils::rnd_up(jcp.ic_block, scale);
-        int icb = ic_idx / jcp.ic_block;
-        int ic = ic_idx % jcp.ic_block;
-        dim_t ksp_str = static_cast<dim_t>(rnd_ic_block) * jcp.oc_block;
+            dim_t ocb, dim_t ic_idx, dim_t kw, dim_t kh = 0, dim_t kd = 0) {
+        const dim_t scale = 2; //bf16 vnni is used
+        dim_t rnd_ic_block = utils::rnd_up(jcp.ic_block, scale);
+        dim_t icb = ic_idx / jcp.ic_block;
+        dim_t ic = ic_idx % jcp.ic_block;
+        dim_t ksp_str = rnd_ic_block * jcp.oc_block;
         dim_t ksp_idx
                 = static_cast<dim_t>(kd) * jcp.kh * jcp.kw + kh * jcp.kw + kw;
 
@@ -191,15 +191,16 @@ private:
                 * (ocb * ocb_str + icb * icb_str + ksp_idx * ksp_str + ic_off);
     }
 
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
 
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
@@ -354,11 +355,11 @@ private:
 
     inline void prepare_output(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop(int ur_w, int l_overflow, int r_overflow);
+    inline void compute_loop(int ur_w, dim_t l_overflow, dim_t r_overflow);
     void generate() override;
 
-    int get_iw_start(int ki, int l_overflow) {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    dim_t get_iw_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -367,10 +368,10 @@ private:
         return res;
     }
 
-    int get_iw_end(int ur_w, int ki, int r_overflow) {
+    dim_t get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
@@ -378,39 +379,39 @@ private:
         return ur_w - res;
     }
 
-    inline int filter_h_to_dst(int kh) {
+    inline dim_t filter_h_to_dst(dim_t kh) {
         return kh * (jcp.dilate_h + 1) * jcp.ow;
     }
-    inline int filter_d_to_dst(int kd) {
+    inline dim_t filter_d_to_dst(dim_t kd) {
         return kd * (jcp.dilate_d + 1) * jcp.ow * jcp.oh;
     }
 
-    inline size_t get_diff_src_offset(int iw_idx, int n_ic_block) {
+    inline dim_t get_diff_src_offset(dim_t iw_idx, dim_t n_ic_block) {
         const bool is_nxc_layout = is_dsrc_layout_nxc();
-        size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
-        size_t icb_str = jcp.ic_block
-                * (is_nxc_layout ? 1 : (size_t)jcp.id * jcp.ih * jcp.iw);
+        dim_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
+        dim_t icb_str
+                = jcp.ic_block * (is_nxc_layout ? 1 : jcp.id * jcp.ih * jcp.iw);
         return jcp.typesize_out * (iw_str * iw_idx + icb_str * n_ic_block);
     }
 
-    inline size_t get_diff_dst_offset(
-            int osp_idx, int oc_within_block_idx, int oc_block_idx = 0) {
+    inline dim_t get_diff_dst_offset(
+            dim_t osp_idx, dim_t oc_within_block_idx, dim_t oc_block_idx = 0) {
         const bool is_nxc_layout = is_ddst_layout_nxc();
-        size_t osp_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
-        size_t ocb_str = jcp.oc_block
-                * (is_nxc_layout ? 1 : (size_t)jcp.od * jcp.oh * jcp.ow);
+        dim_t osp_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
+        dim_t ocb_str
+                = jcp.oc_block * (is_nxc_layout ? 1 : jcp.od * jcp.oh * jcp.ow);
         return jcp.typesize_in
                 * (osp_str * osp_idx + ocb_str * oc_block_idx
                         + oc_within_block_idx);
     }
 
-    inline size_t get_kernel_offset(
-            int icb, int oc_idx, int kw, int kh = 0, int kd = 0) {
+    inline dim_t get_kernel_offset(
+            dim_t icb, dim_t oc_idx, dim_t kw, dim_t kh = 0, dim_t kd = 0) {
         int scale = 2; //bf16 vnni is used
-        int ocb = oc_idx / jcp.oc_block;
-        int oc = oc_idx % jcp.oc_block;
-        size_t ksp_str = jcp.ic_block * jcp.oc_block;
-        size_t ksp_idx = kd * jcp.kh * jcp.kw + kh * jcp.kw + kw;
+        dim_t ocb = oc_idx / jcp.oc_block;
+        dim_t oc = oc_idx % jcp.oc_block;
+        dim_t ksp_str = jcp.ic_block * jcp.oc_block;
+        dim_t ksp_idx = kd * jcp.kh * jcp.kw + kh * jcp.kw + kw;
 
         size_t icb_str = jcp.kd * jcp.kh * jcp.kw * ksp_str;
         size_t ocb_str = jcp.nb_ic * icb_str;
@@ -569,18 +570,18 @@ private:
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
     inline void compute_oh_step_unroll_ow(int ic_block_step);
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_extern(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_interleave(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_vpermw(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_extern(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_interleave(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t src_offset,
+            dim_t kernel_offset, dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_vpermw(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
     inline void compute_oh_step_common(int ic_block_step);
     inline void compute_oh_step_disp();
     inline void compute_loop();
@@ -591,12 +592,12 @@ private:
     void compute_diff_bias_row(bool is_partial = true);
     void maybe_compute_diff_bias();
     void convert_src_to_vnni_format(
-            int ur_w, int pad_l, int pad_r, int src_offset);
+            int ur_w, dim_t pad_l, dim_t pad_r, dim_t src_offset);
     void may_be_set_oc_tail_mask();
     void may_be_reset_oc_tail_mask();
-    inline void compute_ic_block_step_vpermw_expl(int ur_w, int pad_l,
-            int pad_r, int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_vpermw_expl(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t src_offset,
+            dim_t kernel_offset, dim_t ddst_offset, bool is_tail = false);
     inline bool is_src_layout_nxc() const {
         return jcp.uses_permw_transposition
                 && utils::one_of(jcp.src_tag, format_tag::ndhwc,
@@ -613,26 +614,26 @@ private:
     static void balance(const jit_conv_conf_t &j, int &nthr, int &nthr_mb,
             int &nthr_g, int &nthr_oc_b, int &nthr_ic_b);
 
-    void get_w_positions(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw,
+    void get_w_positions(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw,
             int &iw_0, int &iw_1) const {
         auto get_w_position = [&](int idx) {
-            int iw = i_ur + idx;
+            dim_t iw = i_ur + idx;
             if (iw >= ur_w) return -1;
             iw += i_kw;
             if (iw - pad_l < 0 || iw > (ur_w - 1) + (jcp.kw - 1) - pad_r)
                 return -1;
-            return iw - pad_l;
+            return static_cast<int>(iw - pad_l);
         };
         iw_0 = get_w_position(0);
         iw_1 = get_w_position(1);
     }
-    bool check_borders(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw) {
+    bool check_borders(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw) {
         int iw_1, iw_2;
         get_w_positions(ur_w, pad_l, pad_r, i_ur, i_kw, iw_1, iw_2);
 
         return (iw_1 == -1 && iw_2 == -1) ? false : true;
     }
-    bool get_load_mask(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw,
+    bool get_load_mask(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw,
             Xbyak::Opmask &load_mask) {
         int iw_1, iw_2;
         get_w_positions(ur_w, pad_l, pad_r, i_ur, i_kw, iw_1, iw_2);
@@ -650,10 +651,10 @@ private:
         return rt;
     }
 
-    inline dim_t filter_w_to_src(int kw, int ow = 0, int pad_l = 0) const {
-        int stride_w = jcp.transpose_src ? 1 : jcp.stride_w;
-        return static_cast<dim_t>(kw) * (jcp.dilate_w + 1) + ow * stride_w
-                - pad_l;
+    inline dim_t filter_w_to_src(
+            dim_t kw, dim_t ow = 0, dim_t pad_l = 0) const {
+        const dim_t stride_w = jcp.transpose_src ? 1 : jcp.stride_w;
+        return kw * (jcp.dilate_w + 1) + ow * stride_w - pad_l;
     }
     inline dim_t filter_h_to_src(int kh) const {
         return static_cast<dim_t>(kh) * (jcp.dilate_h + 1);
@@ -690,8 +691,8 @@ private:
     }
 
     inline dim_t get_ddst_offset(dim_t w_idx, dim_t hd_idx = 0) {
-        int ow_per_oc = jcp.transpose_dst ? 2 : 1;
-        int ch_mult
+        const dim_t ow_per_oc = jcp.transpose_dst ? 2 : 1;
+        dim_t ch_mult
                 = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
         dim_t hd_off = jcp.tr_ow * ch_mult * hd_idx;
         dim_t w_off
@@ -699,7 +700,7 @@ private:
         return jcp.typesize_in * (w_off + hd_off);
     }
 
-    inline dim_t get_kernel_offset(int ic_idx, dim_t ksp_idx) const {
+    inline dim_t get_kernel_offset(dim_t ic_idx, dim_t ksp_idx) const {
         // Only the ic_idx index inside the block is supported,
         // ic_idx == jcp.ic_block is considered as a shift inside one block
         // and not as moving to the next ic block.
@@ -721,7 +722,7 @@ private:
     inline int interleave_w_reorder_size(int ur_w) const;
     inline int interleave_w_reorder_bytes(int ur_w);
     inline int interleave_stack_size(int ur_w, int ic_block_step);
-    inline int permw_stack_size(int ur_w) const {
+    inline dim_t permw_stack_size(dim_t ur_w) const {
         return (ur_w + jcp.kw - 1) * sizeof_cacheline;
     }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -71,10 +71,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount
             = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks * jcp.nb_ow;
 
@@ -84,14 +84,14 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
         balance211(work_amount, nthr, ithr, start, end);
         auto par_conv = jit_conv_args_t();
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn) {
-            int dummy {0};
+            dim_t dummy {0};
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
                     nb_groups, n, jcp.mb, dummy, 1);
         } else if (jcp.loop_order == loop_gncw) {
-            int dummy {0};
+            dim_t dummy {0};
             nd_iterator_init(start, gg, nb_groups, n, jcp.mb, occ, oc_chunks,
                     owb, jcp.nb_ow, dummy, 1);
         } else if (jcp.loop_order == loop_nhwcg) {
@@ -101,13 +101,13 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w
@@ -117,7 +117,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::nwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, iw_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb);
 
@@ -135,11 +135,11 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
             (*kernel_)(&par_conv);
 
             if (jcp.loop_order == loop_cwgn) {
-                int dummy {0};
+                dim_t dummy {0};
                 nd_iterator_jump(start, end, occ, oc_chunks, owb, jcp.nb_ow, gg,
                         nb_groups, n, jcp.mb, dummy, 1);
             } else if (jcp.loop_order == loop_gncw) {
-                int dummy {0};
+                dim_t dummy {0};
                 nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, occ,
                         oc_chunks, owb, jcp.nb_ow, dummy, 1);
             } else if (jcp.loop_order == loop_nhwcg) {
@@ -172,10 +172,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks
             * jcp.oh * jcp.nb_ow;
 
@@ -191,7 +191,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
         size_t dst_h_stride = dst_d.blk_off<false, true>(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -207,18 +207,18 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
 
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) oh_e = oh_s + 1; //step instead
 
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w = dst
@@ -228,19 +228,20 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, ih_s, iw_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-            for (int oj = oh_s, ij = ih_s; oj < oh_e;
+            for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                     ++oj, ij += jcp.stride_h) {
-                int dilate_h = jcp.dilate_h + 1;
-                int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                int i_b_overflow = div_up(
-                        max(0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+                dim_t dilate_h = jcp.dilate_h + 1;
+                dim_t i_t_overflow = div_up(max<dim_t>(0, -ij), dilate_h);
+                dim_t i_b_overflow = div_up(
+                        max<dim_t>(
+                                0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h);
-                int kh_padding
-                        = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+                dim_t kh_padding = nstl::max<dim_t>(
+                        0, jcp.kh - i_t_overflow - i_b_overflow);
                 auto aux_src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
@@ -298,10 +299,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks
             * jcp.od * jcp.oh * jcp.nb_ow;
 
@@ -319,7 +320,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, gg {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -335,25 +336,26 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
 
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) oh_e = oh_s + 1; //step instead
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
-            int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-            int dilate_d = jcp.dilate_d + 1;
-            int d_t_overflow = div_up(max(0, -id_s), dilate_d);
-            int d_b_overflow = div_up(
-                    max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+            dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+            dim_t dilate_d = jcp.dilate_d + 1;
+            dim_t d_t_overflow = div_up(max<dim_t>(0, -id_s), dilate_d);
+            dim_t d_b_overflow = div_up(
+                    max<dim_t>(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
                     dilate_d);
-            int kd_padding = nstl::max(0, jcp.kd - d_t_overflow - d_b_overflow);
+            dim_t kd_padding
+                    = nstl::max<dim_t>(0, jcp.kd - d_t_overflow - d_b_overflow);
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w = dst
@@ -364,21 +366,22 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, id_s, ih_s, iw_s)
                     + d_t_overflow * dilate_d * src_d_stride;
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0)
                     + d_t_overflow * wht_d_stride;
 
-            for (int oj = oh_s, ij = ih_s; oj < oh_e;
+            for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                     ++oj, ij += jcp.stride_h) {
-                int dilate_h = jcp.dilate_h + 1;
-                int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                int i_b_overflow = div_up(
-                        max(0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+                dim_t dilate_h = jcp.dilate_h + 1;
+                dim_t i_t_overflow = div_up(max<dim_t>(0, -ij), dilate_h);
+                dim_t i_b_overflow = div_up(
+                        max<dim_t>(
+                                0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h);
-                int kh_padding
-                        = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+                dim_t kh_padding = nstl::max<dim_t>(
+                        0, jcp.kh - i_t_overflow - i_b_overflow);
                 auto aux_src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
@@ -430,12 +433,12 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
     const auto &jcp = pd()->jcp_;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t start {0}, end {0};
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
         // TODO: experiment with g_blocking for perf fine tuning
-        int g_blocking = 1;
-        int nb_groups = jcp.ngroups / g_blocking;
-        int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
+        dim_t g_blocking = 1;
+        dim_t nb_groups = jcp.ngroups / g_blocking;
+        dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto par_conv = jit_conv_args_t();
@@ -449,7 +452,7 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
         bool is_fast_path_d = jcp.dilate_d == 0 && jcp.stride_d == 1;
         bool is_fast_path_h = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        int n {0}, gg {0}, icc {0}, id_s {0}, ih_s {0};
+        dim_t n {0}, gg {0}, icc {0}, id_s {0}, ih_s {0};
         if (jcp.loop_order == loop_cgn)
             nd_iterator_init(start, icc, ic_chunks, gg, nb_groups, n, jcp.mb,
                     id_s, jcp.id, ih_s, jcp.ih);
@@ -463,28 +466,30 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int icb = icc * jcp.nb_ic_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+            dim_t icb = icc * jcp.nb_ic_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) ih_e = ih_s + 1; //step instead
 
-            int od_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t od_s = 0, kd_len = 0, kd_lo = 0;
             if (is_fast_path_d) {
-                int d_t_overflow = max(0, jcp.kd - 1 - id_s - jcp.f_pad);
-                int d_b_overflow
-                        = max(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
+                dim_t d_t_overflow
+                        = max<dim_t>(0, jcp.kd - 1 - id_s - jcp.f_pad);
+                dim_t d_b_overflow
+                        = max<dim_t>(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
                 kd_len = jcp.kd - d_t_overflow - d_b_overflow;
                 kd_lo = d_b_overflow;
                 od_s = id_s + jcp.f_pad - d_b_overflow;
             } else if (jcp.dilate_d != 0) { // stride == 1
-                int dilate_d = jcp.dilate_d + 1;
+                dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
-                int d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
+                dim_t d_t_overflow = div_up(
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
                         dilate_d);
-                int d_b_overflow
-                        = div_up(max(0,
+                dim_t d_b_overflow
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.id
                                                  + id_s - jcp.back_pad),
                                 dilate_d);
@@ -492,14 +497,14 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
                 kd_lo = d_b_overflow;
                 od_s = id_s + jcp.f_pad - d_b_overflow * dilate_d;
             } else { // dilate == 0
-                int d_t_overflow = max(
+                dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - 1 - id_s - jcp.f_pad) / jcp.stride_d);
-                int d_b_overflow = max(0,
+                dim_t d_b_overflow = max<dim_t>(0,
                         (jcp.kd - jcp.id + id_s - jcp.back_pad) / jcp.stride_d);
-                int overflow_kd_hi = jcp.kd - 1
+                dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(
                                 jcp.id - 1 + jcp.back_pad - id_s, jcp.stride_d);
-                int overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
+                dim_t overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_b_overflow;
@@ -509,32 +514,36 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
             assert(kd_len >= 0);
 
             const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-            const int ic_idx = is_dsrc_layout_nxc
+            const dim_t ic_idx = is_dsrc_layout_nxc
                     ? g * jcp.ic + icb * jcp.ic_block
                     : g * jcp.nb_ic + icb;
             auto diff_src_w = diff_src
                     + jcp.typesize_out * diff_src_d.blk_off(n, ic_idx, id_s);
             const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-            const int oc_idx = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
+            const dim_t oc_idx
+                    = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
             auto diff_dst_w = diff_dst + diff_dst_d.blk_off(n, oc_idx, od_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, 0, icb, kd_lo);
 
-            for (int ij = ih_s; ij < ih_e; ++ij) {
-                int oj, kh_len, kh_lo;
+            for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                dim_t oj, kh_len, kh_lo;
                 if (is_fast_path_h) { // dilate == 0 && stride == 1
-                    int i_t_overflow = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                    int i_b_overflow = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                    dim_t i_t_overflow
+                            = max<dim_t>(0, jcp.kh - 1 - ij - jcp.t_pad);
+                    dim_t i_b_overflow
+                            = max<dim_t>(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                     kh_len = jcp.kh - i_t_overflow - i_b_overflow;
                     kh_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow;
                 } else if (jcp.dilate_h != 0) { // stride == 1
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int i_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
+                    dim_t i_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
                             dilate_h);
-                    int i_b_overflow
-                            = div_up(max(0,
+                    dim_t i_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.ih + ij - jcp.b_pad),
                                     dilate_h);
@@ -542,13 +551,13 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
                     kh_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                 } else { // dilate == 0
-                    int i_t_overflow = max(
+                    dim_t i_t_overflow = max<dim_t>(
                             0, (jcp.kh - 1 - ij - jcp.t_pad) / jcp.stride_h);
-                    int i_b_overflow = max(0,
+                    dim_t i_b_overflow = max<dim_t>(0,
                             (jcp.kh - jcp.ih + ij - jcp.b_pad) / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.ih - 1 + jcp.b_pad - ij, jcp.stride_h);
-                    int overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - i_t_overflow - i_b_overflow;
@@ -598,12 +607,12 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
     const auto &jcp = pd()->jcp_;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t start {0}, end {0};
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
         // TODO: experiment with g_blocking for perf fine tuning
-        int g_blocking = 1;
-        int nb_groups = jcp.ngroups / g_blocking;
-        int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
+        dim_t g_blocking = 1;
+        dim_t nb_groups = jcp.ngroups / g_blocking;
+        dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto par_conv = jit_conv_args_t();
@@ -616,7 +625,7 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
 
         bool is_fast_path = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        int n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
+        dim_t n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
                     nb_groups, n, jcp.mb, ih_s, jcp.ih);
@@ -630,22 +639,23 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int icb = icc * jcp.nb_ic_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+            dim_t icb = icc * jcp.nb_ic_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) ih_e = ih_s + 1; //step instead
-            int iw_s = iwb * jcp.iw_block;
-            int ow_s = iw_s / jcp.stride_w;
+            dim_t iw_s = iwb * jcp.iw_block;
+            dim_t ow_s = iw_s / jcp.stride_w;
 
             auto diff_src_w = diff_src;
             auto diff_dst_w = diff_dst;
             const bool is_ddst_layout_nxc = utils::one_of(
                     jcp.dst_tag, format_tag::nwc, format_tag::nhwc);
-            const int oc_idx = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
+            const dim_t oc_idx
+                    = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
             const bool is_dsrc_layout_nxc = utils::one_of(
                     jcp.src_tag, format_tag::nwc, format_tag::nhwc);
-            const int ic_idx = is_dsrc_layout_nxc
+            const dim_t ic_idx = is_dsrc_layout_nxc
                     ? g * jcp.ic + icb * jcp.ic_block
                     : g * jcp.nb_ic + icb;
             if (jcp.ndims == 3) {
@@ -659,22 +669,25 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
             }
             auto wht_w = weights + wht_blk_off(weights_d, g, 0, icb);
 
-            for (int ij = ih_s; ij < ih_e; ++ij) {
-                int oj, k_len, k_lo;
+            for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                dim_t oj, k_len, k_lo;
                 if (is_fast_path) { // dilate == 0 && stride == 1
-                    int i_t_overflow = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                    int i_b_overflow = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                    dim_t i_t_overflow
+                            = max<dim_t>(0, jcp.kh - 1 - ij - jcp.t_pad);
+                    dim_t i_b_overflow
+                            = max<dim_t>(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                     k_len = jcp.kh - i_t_overflow - i_b_overflow;
                     k_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow;
                 } else if (jcp.dilate_h != 0) { // stride == 1
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int i_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
+                    dim_t i_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
                             dilate_h);
-                    int i_b_overflow
-                            = div_up(max(0,
+                    dim_t i_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.ih + ij - jcp.b_pad),
                                     dilate_h);
@@ -682,13 +695,13 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
                     k_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                 } else { // dilate == 0
-                    int i_t_overflow = max(
+                    dim_t i_t_overflow = max<dim_t>(
                             0, (jcp.kh - 1 - ij - jcp.t_pad) / jcp.stride_h);
-                    int i_b_overflow = max(0,
+                    dim_t i_b_overflow = max<dim_t>(0,
                             (jcp.kh - jcp.ih + ij - jcp.b_pad) / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.ih - 1 + jcp.b_pad - ij, jcp.stride_h);
-                    int overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
 
                     k_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h + 1
                             - i_t_overflow - i_b_overflow;
@@ -842,34 +855,35 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t ::thread_info_t {
         ithr_but_ic = (ithr_mb * self->nthr_g_ + ithr_g) * self->nthr_oc_b_
                 + ithr_oc_b;
 
-        int work_amount = jcp.nthr_mb_work;
+        int work_amount = static_cast<int>(jcp.nthr_mb_work);
         /* reduction dimension */
         balance211(work_amount, self->nthr_mb_, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
 
         /* independent dimensions */
-        balance211(jcp.ngroups, self->nthr_g_, ithr_g, g_start, g_end);
+        balance211(static_cast<int>(jcp.ngroups), self->nthr_g_, ithr_g,
+                g_start, g_end);
         g_work = g_end - g_start;
 
-        balance211(
-                jcp.nb_oc, self->nthr_oc_b_, ithr_oc_b, oc_b_start, oc_b_end);
+        balance211(static_cast<int>(jcp.nb_oc), self->nthr_oc_b_, ithr_oc_b,
+                oc_b_start, oc_b_end);
         oc_b_work = oc_b_end - oc_b_start;
 
-        balance211(
-                jcp.nb_ic, self->nthr_ic_b_, ithr_ic_b, ic_b_start, ic_b_end);
+        balance211(static_cast<int>(jcp.nb_ic), self->nthr_ic_b_, ithr_ic_b,
+                ic_b_start, ic_b_end);
         ic_b_work = ic_b_end - ic_b_start;
     }
 };
 
 size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_src_buf_number(
-        const thread_info_t *ti, int g, int ic) const {
+        const thread_info_t *ti, dim_t g, dim_t ic) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_ic * jcp.ngroups + g * jcp.nb_ic + ic
             : ti->ithr;
 }
 size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_diff_dst_buf_number(
-        const thread_info_t *ti, int g, int oc) const {
+        const thread_info_t *ti, dim_t g, dim_t oc) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_oc * jcp.ngroups + g * jcp.nb_oc + oc
@@ -877,7 +891,7 @@ size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_diff_dst_buf_number(
 }
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
-        src_data_t *tr_src, const src_data_t *src, int row_count) const {
+        src_data_t *tr_src, const src_data_t *src, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     const int pf_depth = 2;
     struct {
@@ -886,14 +900,14 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
     } pf_circ_buf_src[pf_depth];
 
     assert(jcp.ic_block == 16 || jcp.is_1stconv);
-    const int src_stride = jcp.iw * jcp.ic_block;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ic_block;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
     for (int iwork = 0; iwork < row_count + pf_depth - 1; iwork++) {
         pf_circ_buf_src[iwork % pf_depth] = {src, tr_src};
 
         if (iwork >= pf_depth - 1) {
-            int old_idx = (iwork - pf_depth + 1) % pf_depth;
+            dim_t old_idx = (iwork - pf_depth + 1) % pf_depth;
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = pf_circ_buf_src[old_idx].src;
             ctx.tr_src = pf_circ_buf_src[old_idx].tr_src;
@@ -907,27 +921,29 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
 }
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
-        src_data_t *tr_src, const src_data_t *src_base, int spatial_start,
-        dim_t spatial_start_offset, int icb_start, dim_t chb_stride,
-        int row_count) const {
+        src_data_t *tr_src, const src_data_t *src_base, dim_t spatial_start,
+        dim_t spatial_start_offset, dim_t icb_start, dim_t chb_stride,
+        dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int src_stride = jcp.iw * jcp.ngroups * jcp.ic;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
-    int work_rest = row_count;
-    int max_spatial_work = jcp.id * jcp.ih;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    dim_t work_rest = row_count;
+    dim_t max_spatial_work = jcp.id * jcp.ih;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *src = src_base + spatial_start_offset;
-    int icb = 0;
-    const int ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
+    dim_t icb = 0;
+    const dim_t ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = src;
             ctx.tr_src = tr_src;
             assert(icb_start + icb < jcp.nb_ic);
-            ctx.ch_work = (icb_start + icb + 1) == jcp.nb_ic ? ic_tail_work
-                                                             : jcp.ic_block;
+            ctx.ch_work = static_cast<int>((icb_start + icb + 1) == jcp.nb_ic
+                            ? ic_tail_work
+                            : jcp.ic_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_kernel_)(&ctx);
@@ -935,7 +951,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
             tr_src += tr_src_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         icb++;
         src = src_base + icb * chb_stride;
     }
@@ -943,7 +959,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst,
-        int row_count) const {
+        dim_t row_count) const {
 
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     const int pf_depth = 2;
@@ -953,15 +969,15 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
     } pf_circ_buf_dst[pf_depth];
 
     assert(jcp.ic_block == 16 || jcp.is_1stconv);
-    const int diff_dst_stride = jcp.ow * jcp.oc_block;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    const dim_t diff_dst_stride = jcp.ow * jcp.oc_block;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
 
     for (int iwork = 0; iwork < row_count + pf_depth - 1; iwork++) {
         pf_circ_buf_dst[iwork % pf_depth]
                 = {(diff_dst_data_t *)diff_dst, tr_diff_dst};
 
         if (iwork >= pf_depth - 1) {
-            int old_idx = (iwork - pf_depth + 1) % pf_depth;
+            dim_t old_idx = (iwork - pf_depth + 1) % pf_depth;
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = pf_circ_buf_dst[old_idx].diff_dst;
             ctx.tr_src = pf_circ_buf_dst[old_idx].tr_diff_dst;
@@ -976,25 +992,27 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_dst_nxc(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst_base,
-        int spatial_start, dim_t spatial_start_offset, int ocb_start,
-        dim_t chb_stride, int row_count) const {
+        dim_t spatial_start, dim_t spatial_start_offset, dim_t ocb_start,
+        dim_t chb_stride, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
-    int work_rest = row_count;
-    int max_spatial_work = jcp.od * jcp.oh;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    const dim_t diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    dim_t work_rest = row_count;
+    dim_t max_spatial_work = jcp.od * jcp.oh;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *diff_dst = diff_dst_base + spatial_start_offset;
-    int ocb = 0;
-    const int oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
+    dim_t ocb = 0;
+    const dim_t oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
     while (work_rest > 0) {
         for (int iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = diff_dst;
             ctx.tr_src = tr_diff_dst;
             assert(ocb_start + ocb < jcp.nb_oc);
-            ctx.ch_work = (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
-                                                             : jcp.oc_block;
+            ctx.ch_work = static_cast<int>((ocb_start + ocb + 1) == jcp.nb_oc
+                            ? oc_tail_work
+                            : jcp.oc_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_dst_kernel_)(&ctx);
@@ -1002,7 +1020,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_dst_nxc(
             tr_diff_dst += tr_diff_dst_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         ocb++;
         diff_dst = diff_dst_base + ocb * chb_stride;
     }
@@ -1017,10 +1035,10 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_hblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_hblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1040,30 +1058,30 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + oj * tr_row_size;
     };
 
-    int img {0}, oh_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     nd_iterator_init(start, img, jcp.mb, oh_s, jcp.oh);
 
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        int ih_s = nstl::max(0, -jcp.t_pad + oh_s * jcp.stride_h);
-        const int ih_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        dim_t ih_s = nstl::max<dim_t>(0, -jcp.t_pad + oh_s * jcp.stride_h);
+        const dim_t ih_e = nstl::min<dim_t>(
                 jcp.ih, -jcp.t_pad + (oh_e - 1) * jcp.stride_h + ext_kh);
 
-        auto tr_src_off = [&](int g, int ic, int ih_end, int ij) {
-            const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ih_end, dim_t ij) {
+            const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             // Aligned to buffer end to use guard elements
             return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                     + (jcp.ih - ih_end + ij) * tr_row_size;
@@ -1074,25 +1092,26 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][ih][16][~iw~] <- src[nb_ic][ih][iw][16] */
             if (jcp.transpose_src) {
-                int j {0};
-                const int work_amount
+                dim_t j {0};
+                const dim_t work_amount
                         = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start,
                         tr_end);
 
-                int g {0}, ic_b {0};
+                dim_t g {0}, ic_b {0};
                 nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work,
                         j, ih_e - ih_s);
 
                 if (nthr_oc_b_ > 1)
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int ic_b_ = ic_b + ti->ic_b_start;
-                    int j_s = j + ih_s;
-                    int j_e = j_s + nstl::min(tr_end - tr_start, ih_e - j_s);
-                    const int ic_off_idx = is_src_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t ic_b_ = ic_b + ti->ic_b_start;
+                    dim_t j_s = j + ih_s;
+                    dim_t j_e = j_s
+                            + nstl::min<dim_t>(tr_end - tr_start, ih_e - j_s);
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g_ * jcp.ic + ic_b_ * jcp.ic_block
                             : g_ * jcp.nb_ic + ic_b_;
                     const src_data_t *src
@@ -1112,25 +1131,26 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             }
             if (jcp.transpose_dst) {
-                int j {0};
-                const int work_amount
+                dim_t j {0};
+                const dim_t work_amount
                         = ti->g_work * ti->oc_b_work * (oh_e - oh_s);
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start,
                         tr_end);
 
-                int g {0}, oc_b {0};
+                dim_t g {0}, oc_b {0};
                 nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work,
                         j, oh_e - oh_s);
 
                 if (nthr_ic_b_ > 1)
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int oc_b_ = oc_b + ti->oc_b_start;
-                    int j_s = j + oh_s;
-                    int j_e = j_s + nstl::min(tr_end - tr_start, oh_e - j_s);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t oc_b_ = oc_b + ti->oc_b_start;
+                    dim_t j_s = j + oh_s;
+                    dim_t j_e = j_s
+                            + nstl::min<dim_t>(tr_end - tr_start, oh_e - j_s);
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g_ * jcp.oc + oc_b_ * jcp.oc_block
                             : g_ * jcp.nb_oc + oc_b_;
                     const diff_dst_data_t *diff_dst
@@ -1152,34 +1172,36 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             }
         }
-        int height_block = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
+        dim_t height_block
+                = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
         int ic_b_step
                 = jcp.uses_permw_transposition ? jcp.nb_ic_blocking_max : 1;
         int icb_work = ti->ic_b_end - ti->ic_b_start;
         if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
             ic_b_step = utils::div_up(icb_work, 2);
 
-        for_(int ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for_(dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int ohb_e = nstl::min(ohb_s + height_block, oh_e);
-            const int ihb_s = nstl::max(0, -jcp.t_pad + ohb_s * jcp.stride_h);
-            const int ihb_e = nstl::min(
+            const dim_t ohb_e = nstl::min<dim_t>(ohb_s + height_block, oh_e);
+            const dim_t ihb_s
+                    = nstl::max<dim_t>(0, -jcp.t_pad + ohb_s * jcp.stride_h);
+            const dim_t ihb_e = nstl::min<dim_t>(
                     jcp.ih, -jcp.t_pad + (ohb_e - 1) * jcp.stride_h + ext_kh);
             assert(IMPLICATION(jcp.global_transpose,
                     oh_s == ohb_s && oh_e == ohb_e && ih_s == ihb_s
                             && ih_e == ihb_e));
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
 
             if (jcp.transpose_src) {
@@ -1249,10 +1271,10 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
     const auto &jcp = kernel_->jcp;
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_dblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_dblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1272,31 +1294,31 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od) {
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od) {
         assert(IMPLICATION(is_ddst_layout_nxc, jcp.transpose_dst));
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
-        const size_t tr_3d_size = tr_row_size * jcp.oh;
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.oh;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size;
     };
-    int img {0}, od_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     nd_iterator_init(start, img, jcp.mb, od_s, jcp.od);
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        int id_s = nstl::max(0, -jcp.f_pad + od_s * jcp.stride_d);
-        const int id_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        dim_t id_s = nstl::max<dim_t>(0, -jcp.f_pad + od_s * jcp.stride_d);
+        const dim_t id_e = nstl::min<dim_t>(
                 jcp.id, -jcp.f_pad + (od_e - 1) * jcp.stride_d + ext_kd);
 
-        auto tr_src_off_3d = [&](int g, int ic, int id_end, int id) {
-            const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
-            const size_t tr_3d_size = tr_row_size * jcp.ih;
+        auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id_end, dim_t id) {
+            const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+            const dim_t tr_3d_size = tr_row_size * jcp.ih;
             // Aligned to buffer end to use guard elements
             return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                     + (jcp.id - id_end + id) * tr_3d_size;
@@ -1307,16 +1329,16 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][id][16][~iw~] <- src[nb_ic][id][iw][16] */
             if (jcp.transpose_src) {
-                int d {0};
+                dim_t d {0};
 
-                const int work_amount
+                const dim_t work_amount
                         = ti->g_work * ti->ic_b_work * (id_e - id_s);
 
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start,
                         tr_end);
 
-                int g {0}, ic_b {0};
+                dim_t g {0}, ic_b {0};
 
                 nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work,
                         d, id_e - id_s);
@@ -1324,12 +1346,13 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                 if (nthr_oc_b_ > 1)
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int ic_b_ = ic_b + ti->ic_b_start;
-                    int d_s = d + id_s;
-                    int d_e = d_s + nstl::min(tr_end - tr_start, id_e - d_s);
+                    dim_t g_ = g + ti->g_start;
+                    dim_t ic_b_ = ic_b + ti->ic_b_start;
+                    dim_t d_s = d + id_s;
+                    dim_t d_e = d_s
+                            + nstl::min<dim_t>(tr_end - tr_start, id_e - d_s);
 
-                    const int ic_off_idx = is_src_layout_nxc
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g_ * jcp.ic + ic_b_ * jcp.ic_block
                             : g_ * jcp.nb_ic + ic_b_;
                     const src_data_t *src
@@ -1350,16 +1373,16 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             }
             if (jcp.transpose_dst) {
-                int d {0};
+                dim_t d {0};
 
-                const int work_amount
+                const dim_t work_amount
                         = ti->g_work * ti->oc_b_work * (od_e - od_s);
 
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start,
                         tr_end);
 
-                int g {0}, oc_b {0};
+                dim_t g {0}, oc_b {0};
 
                 nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work,
                         d, od_e - od_s);
@@ -1367,11 +1390,12 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                 if (nthr_ic_b_ > 1)
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int oc_b_ = oc_b + ti->oc_b_start;
-                    int d_s = d + od_s;
-                    int d_e = d_s + nstl::min(tr_end - tr_start, od_e - d_s);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t oc_b_ = oc_b + ti->oc_b_start;
+                    dim_t d_s = d + od_s;
+                    dim_t d_e = d_s
+                            + nstl::min<dim_t>(tr_end - tr_start, od_e - d_s);
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g_ * jcp.oc + oc_b_ * jcp.oc_block
                             : g_ * jcp.nb_oc + oc_b_;
 
@@ -1396,37 +1420,38 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
             }
         }
 
-        int depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
+        dim_t depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
 
-        for_(int odb_s = od_s; odb_s < od_e; odb_s += depth_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end; ++ic_b) {
-            const int odb_e = nstl::min(odb_s + depth_block, od_e);
-            const int idb_s = nstl::max(0, -jcp.f_pad + odb_s * jcp.stride_d);
-            const int idb_e = nstl::min(
+        for_(dim_t odb_s = od_s; odb_s < od_e; odb_s += depth_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end; ++ic_b) {
+            const dim_t odb_e = nstl::min<dim_t>(odb_s + depth_block, od_e);
+            const dim_t idb_s
+                    = nstl::max<dim_t>(0, -jcp.f_pad + odb_s * jcp.stride_d);
+            const dim_t idb_e = nstl::min<dim_t>(
                     jcp.id, -jcp.f_pad + (odb_e - 1) * jcp.stride_d + ext_kd);
-            const int kdb_front_pad
-                    = nstl::max(0, jcp.f_pad - odb_s * jcp.stride_d);
+            const dim_t kdb_front_pad
+                    = nstl::max<dim_t>(0, jcp.f_pad - odb_s * jcp.stride_d);
             // Assumes kd_back_pad = 0 when kernel is dilated
-            const int kdb_back_pad = nstl::max(
+            const dim_t kdb_back_pad = nstl::max<dim_t>(
                     0, odb_s * jcp.stride_d + jcp.kd - jcp.f_pad - jcp.id);
-            const int kdb_pad_off = nstl::min(jcp.kd - 1, kdb_front_pad)
-                    * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
-                    * jcp.typesize_out;
+            const dim_t kdb_pad_off
+                    = nstl::min<dim_t>(jcp.kd - 1, kdb_front_pad) * jcp.kh
+                    * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
             assert(IMPLICATION(jcp.global_transpose,
                     od_s == odb_s && od_e == odb_e && id_s == idb_s
                             && id_e == idb_e));
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
             if (jcp.transpose_src) {
                 if (!jcp.global_transpose) {
@@ -1504,7 +1529,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
     const size_t wei_size = static_cast<size_t>(jcp.ngroups) * jcp.nb_oc
             * jcp.oc_block * jcp.nb_ic * jcp.ic_block * jcp.kh * jcp.kw
             * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1524,45 +1549,45 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_src_off = [&](int g, int ic, int ij) {
+    auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ij) {
         assert(IMPLICATION(is_src_layout_nxc, jcp.transpose_src));
-        const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                 + ij * tr_row_size;
     };
 
-    auto tr_src_off_3d = [&](int g, int ic, int id, int ij) {
+    auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id, dim_t ij) {
         assert(IMPLICATION(is_ddst_layout_nxc, jcp.transpose_dst));
-        const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
-        const size_t tr_3d_size = tr_row_size * jcp.ih;
+        const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.ih;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                 + id * tr_3d_size + ij * tr_row_size;
     };
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + oj * tr_row_size;
     };
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
-        const size_t tr_3d_size = tr_row_size * jcp.oh;
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.oh;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size + oj * tr_row_size;
     };
 
-    auto uker_trans = [&](int img, int g = 0, int ic_b = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.ih * jcp.id;
+    auto uker_trans = [&](dim_t img, dim_t g = 0, dim_t ic_b = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.ih * jcp.id;
         dim_t ic;
-        int icb_start = ic_b;
+        dim_t icb_start = ic_b;
         if (jcp.global_transpose) {
-            const int work_amount = is_src_layout_nxc
+            const dim_t work_amount = is_src_layout_nxc
                     ? ti->ic_b_work * jcp.ih * jcp.id
                     : ti->g_work * ti->ic_b_work * jcp.ih * jcp.id;
 
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, start, end);
             my_work = end - start;
 
@@ -1596,7 +1621,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         const bool need_local_gwork = is_src_layout_nxc && jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork)
                 ic = static_cast<dim_t>(gg) * jcp.ic
                         + static_cast<dim_t>(ic_b) * jcp.ic_block;
@@ -1614,7 +1639,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                         ? src_d.blk_off(0, 0, d, j)
                         : src_d.blk_off(0, 0, j);
                 dim_t ch_shift = src_d.blk_off(0, jcp.ic_block);
-                int sp_start_idx = d * jcp.ih + j;
+                dim_t sp_start_idx = d * jcp.ih + j;
                 trans_src_nxc(tr_src, src, sp_start_idx, sp_start_offset,
                         icb_start, ch_shift, my_work);
             } else
@@ -1622,18 +1647,18 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         }
     };
 
-    auto diff_dst_trans = [&](int img, int g = 0, int oc_b = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.oh * jcp.od;
-        int oc;
-        int ocb_start = oc_b;
+    auto diff_dst_trans = [&](dim_t img, dim_t g = 0, dim_t oc_b = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.oh * jcp.od;
+        dim_t oc;
+        dim_t ocb_start = oc_b;
 
         if (jcp.global_transpose) {
-            const size_t work_amount = is_ddst_layout_nxc
+            const dim_t work_amount = is_ddst_layout_nxc
                     ? ti->oc_b_work * jcp.oh * jcp.od
                     : ti->g_work * ti->oc_b_work * jcp.oh * jcp.od;
 
-            size_t start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, start, end);
             my_work = end - start;
 
@@ -1666,7 +1691,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                 = is_ddst_layout_nxc && jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) oc = gg * jcp.oc + oc_b * jcp.oc_block;
             diff_dst_data_t *tr_diff_dst = (jcp.ndims == 5)
                     ? &ti->tr_diff_dst[tr_diff_dst_off_3d(gg, oc_b, d, j)]
@@ -1682,7 +1707,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                         ? diff_dst_d.blk_off(0, 0, d, j)
                         : diff_dst_d.blk_off(0, 0, j);
                 dim_t ch_shift = diff_dst_d.blk_off(0, jcp.oc_block);
-                int sp_start_idx = d * jcp.oh + j;
+                dim_t sp_start_idx = d * jcp.oh + j;
                 trans_dst_nxc(tr_diff_dst, diff_dst, sp_start_idx,
                         sp_start_offset, ocb_start, ch_shift, my_work);
             } else
@@ -1716,19 +1741,19 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         int icb_work = ti->ic_b_end - ti->ic_b_start;
         if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
             ic_b_step = utils::div_up(icb_work, 2);
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
             if (jcp.transpose_src) {
                 if (!jcp.global_transpose) {
@@ -1798,8 +1823,8 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
     if (nthr_mb_ == 1) {
         if (is_bf16_out) {
             // reduction is not required, only conversion
-            for_(int g = ti->g_start; g < ti->g_end; g++)
-            for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
+            for_(dim_t g = ti->g_start; g < ti->g_end; g++)
+            for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
                 const size_t acc_size = (size_t)ti->ic_b_work * jcp.kh * jcp.kw
                         * ((jcp.ndims == 5) ? jcp.kd : 1) * jcp.ic_block
                         * jcp.oc_block;
@@ -1811,12 +1836,12 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
         }
 
         if (is_bf16_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
-                int result_start_idx = g * jcp.oc_without_padding
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
+                dim_t result_start_idx = g * jcp.oc_without_padding
                         + ti->oc_b_start * jcp.oc_block;
-                int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
                 bfloat16_t *diff_bias
@@ -1832,31 +1857,32 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
     if (jcp.global_transpose)
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work
+    const dim_t ic_b_kh_work
             = ti->ic_b_work * ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, nthr_mb_, ti->ithr_mb, start, end);
     if (start == end) return;
 
     const int _start_nthr_mb = 1;
     for (int thr_mb = _start_nthr_mb; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = start;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start
                     + sub_ic_b_kh_start / ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-            const int kX
+            const dim_t kX
                     = sub_ic_b_kh_start % ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
 
             const size_t acc_size = (size_t)jcp.kw * jcp.ic_block * jcp.oc_block
                     * ((jcp.ndims == 5) ? jcp.kh : 1)
-                    * nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start);
+                    * nstl::min<dim_t>(
+                            end - w, ic_b_kh_work - sub_ic_b_kh_start);
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kX);
 
@@ -1882,22 +1908,22 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
         }
         if (jcp.with_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0
                 && ti->ithr_mb == 0 && ti->img_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
                 float *bias_reduced = is_bf16_bias ? ti->bia_reduction
                                                    : (float *)(ti->diff_bias);
                 int thr_mb_buffer_idx = is_bf16_bias ? thr_mb : thr_mb - 1;
-                int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+                dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
                 float *bias_to_reduce
                         = ti->bia_reduction + thr_mb_buffer_idx * bias_buf_size;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
-                int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 if (is_bf16_bias && thr_mb == nthr_mb_ - 1) {
                     // the last iteration for bfloat16 requires conversion and
                     // store to diff_weights array
-                    int diff_bias_idx = g * jcp.oc_without_padding
+                    dim_t diff_bias_idx = g * jcp.oc_without_padding
                             + ti->oc_b_start * jcp.oc_block;
                     add_floats_and_cvt_to_bfloat16(
                             (bfloat16_t *)(ti->diff_bias) + diff_bias_idx,
@@ -1926,7 +1952,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::prepare_scratchpad_data(
         // buffers sharing padding
         for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
             src_data_t *ts = &tr_src[ithr * jcp.tr_src_buf_size];
-            for (int i = 0; i < jcp.tr_src_num_guard_elems; ++i)
+            for (dim_t i = 0; i < jcp.tr_src_num_guard_elems; ++i)
                 ts[i] = 0;
         }
 
@@ -2007,9 +2033,9 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::execute_backward_weights(
                     = ctx.get_scratchpad_grantor().template get<const float>(
                             key_conv_padded_bias);
             auto diff_bias_in = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
@@ -254,19 +254,20 @@ private:
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    size_t tr_src_buf_number(const thread_info_t *ti, int g, int ic) const;
-    size_t tr_diff_dst_buf_number(const thread_info_t *ti, int g, int oc) const;
+    size_t tr_src_buf_number(const thread_info_t *ti, dim_t g, dim_t ic) const;
+    size_t tr_diff_dst_buf_number(
+            const thread_info_t *ti, dim_t g, dim_t oc) const;
     void trans_src(
-            src_data_t *tr_src1, const src_data_t *src1, int my_work) const;
+            src_data_t *tr_src1, const src_data_t *src1, dim_t my_work) const;
     void trans_dst(diff_dst_data_t *tr_diff_dst1,
-            const diff_dst_data_t *diff_dst1, int my_work) const;
+            const diff_dst_data_t *diff_dst1, dim_t my_work) const;
     void trans_src_nxc(src_data_t *tr_src, const src_data_t *src_base,
-            int spatial_start, dim_t spatial_start_offset, int icb_start,
-            dim_t chb_stride, int my_work) const;
+            dim_t spatial_start, dim_t spatial_start_offset, dim_t icb_start,
+            dim_t chb_stride, dim_t my_work) const;
     void trans_dst_nxc(diff_dst_data_t *tr_diff_dst,
-            const diff_dst_data_t *diff_dst_base, int spatial_start,
-            dim_t spatial_start_offset, int ocb_start, dim_t chb_stride,
-            int my_work) const;
+            const diff_dst_data_t *diff_dst_base, dim_t spatial_start,
+            dim_t spatial_start_offset, dim_t ocb_start, dim_t chb_stride,
+            dim_t my_work) const;
 
     int nthr_ = 0, nthr_mb_ = 0, nthr_g_ = 0, nthr_oc_b_ = 0, nthr_ic_b_ = 0;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -42,7 +42,7 @@ jit_avx512_dw_conv_fwd_kernel_bf16_t::jit_avx512_dw_conv_fwd_kernel_bf16_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         static constexpr bool use_exact_tail_scalar_bcast = true;
-        const size_t tail_size = jcp.oc_without_padding
+        const dim_t tail_size = jcp.oc_without_padding
                 % (cpu_isa_traits_t<avx512_core>::vlen / sizeof(float));
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,
@@ -88,14 +88,14 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::load_src(
                     = mask_flag ? zmm_acc | ktail_mask | T_z : zmm_acc;
 
             if (this->jcp.with_bias) {
-                int b_off = ch * ch_blk;
+                const dim_t b_off = ch * ch_blk;
                 uni_vmovups(
                         zmm_acc_msk, vmmword[reg_bias + b_off * sizeof(float)]);
             } else {
                 uni_vpxor(zmm_acc, zmm_acc, zmm_acc);
             }
             if (this->jcp.with_sum) {
-                int o_off = ch * ocb_stride + ow * ow_stride;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                 if (jcp.dst_dt == data_type::bf16) {
                     const Zmm zmm_prev_dst_msk = mask_flag
                             ? zmm_prev_dst | ktail_mask | T_z
@@ -116,10 +116,10 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::load_src(
 void jit_avx512_dw_conv_fwd_kernel_bf16_t::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r,
         bool last_ch_block_flag) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -144,20 +144,21 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::apply_filter_unrolled(
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
             const bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
             for (int kw = 0; kw < jcp.kw; kw++) {
-                int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
+                const dim_t ker_off
+                        = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
                 const Zmm zmm_ker_reg_msk = mask_flag
                         ? zmm_ker_reg | ktail_mask | T_z
                         : zmm_ker_reg;
                 vpmovzxwd(zmm_ker_reg_msk,
                         ptr[aux_reg_kernel + ker_off * jcp.typesize_in]);
-                int ow_start = get_ow_start(kw, pad_l);
-                int ow_end = get_ow_end(ur_w, kw, pad_r);
-                for (int ow = ow_start; ow < ow_end; ow++) {
+                const dim_t ow_start = get_ow_start(kw, pad_l);
+                const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                for (dim_t ow = ow_start; ow < ow_end; ow++) {
                     const Zmm zmm_src_reg_msk = mask_flag
                             ? zmm_src_reg | ktail_mask | T_z
                             : zmm_src_reg;
-                    Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
-                    int inp_off = ch * icb_stride
+                    Zmm zmm_acc = get_acc_reg(static_cast<int>(ch * ur_w + ow));
+                    const dim_t inp_off = ch * icb_stride
                             + (ow * stride_w - pad_l) * iw_stride
                             + kw * dilate_w * iw_stride;
                     /* zero-extend bf16 to packed 32-bit int */
@@ -312,7 +313,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::store_dst(
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
                 for (int ow = 0; ow < ur_w; ow++) {
-                    int o_off = ch * ocb_stride + ow * ow_stride;
+                    const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                     Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
                     Zmm zmm_dst_msk
                             = mask_flag ? zmm_dst | ktail_mask : zmm_dst;
@@ -353,7 +354,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::store_dst(
                     bool mask_flag
                             = last_ch_block_flag && ch == ur_ch_blocks - 1;
                     for (int ow = 0; ow < ur_w; ow++) {
-                        int o_off = ch * ocb_stride + ow * ow_stride;
+                        const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                         Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
 
                         /* down-convert f32 output to bf16 */
@@ -408,10 +409,10 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
 
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_ch = jcp.oc / jcp.ch_block;
-        const int nb_ch_blocking_tail
-                = jcp.nb_ch - utils::rnd_dn(nb_ch, jcp.nb_ch_blocking);
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int nb_ch = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int nb_ch_blocking_tail = static_cast<int>(
+                jcp.nb_ch - utils::rnd_dn(nb_ch, jcp.nb_ch_blocking));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         push(reg_kernel);
         push(reg_input);
@@ -427,10 +428,11 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, static_cast<uint32_t>(wei_ch_stride));
+                add(reg_input, static_cast<uint32_t>(inp_ch_stride));
+                add(reg_output, static_cast<uint32_t>(out_ch_stride));
+                if (jcp.with_bias)
+                    add(reg_bias, static_cast<uint32_t>(bias_stride));
                 sub(reg_ch_blocks, ch_step);
                 cmp(reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -458,46 +460,46 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
 
 void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int n_oi = static_cast<int>(ow / ur_w);
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
     if (r_pad1 > 0) n_oi--;
     xor_(reg_oi, reg_oi);
     if (ow == ur_w) {
-        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
+        compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad);
     } else {
         if (n_oi == 0) {
-            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
+            compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, static_cast<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
         } else {
             if (l_pad > 0) {
-                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
+                compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, static_cast<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -505,8 +507,8 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, static_cast<uint32_t>(inp_shift));
+                    add(reg_output, static_cast<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -515,8 +517,8 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, static_cast<uint32_t>(inp_shift));
+                add(reg_output, static_cast<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
@@ -563,7 +565,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::generate() {
     if (oc_tail != 0) {
         // Note: is_src_layout_nxc() == true, otherwise channels are padded
         // Prepare masks for tailing
-        const int oc_tail_shift
+        const dim_t oc_tail_shift
                 = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
         static constexpr auto zmm_16b_mask = ((1 << 16) - 1);
 
@@ -597,7 +599,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        loop_ow(jcp.nb_ch);
+        loop_ow(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
@@ -632,14 +634,14 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::load_ddst(
 
 inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
         int ur_ch_blocks, int ur_str_w, bool last_ch_block_flag) {
-    int kw = jcp.kw;
-    int kh = jcp.kh;
-    int ow = jcp.ow;
-    int oh = jcp.oh;
+    const dim_t kw = jcp.kw;
+    const dim_t kh = jcp.kh;
+    const dim_t ow = jcp.ow;
+    const dim_t oh = jcp.oh;
 
-    int ch_blk = jcp.ch_block;
-    int stride_h = jcp.stride_h;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const size_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
@@ -667,7 +669,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 const bool mask_flag
                         = last_ch_block_flag && ch == ur_ch_blocks - 1;
-                int ker_off = ch * kh * kw * ch_blk;
+                const dim_t ker_off = ch * kh * kw * ch_blk;
                 Zmm mm_zmm_ker // mm: maybe masked
                         = mask_flag ? zmm_ker_reg | k_ch_tail_mask | T_z
                                     : zmm_ker_reg;
@@ -693,7 +695,8 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
             }
 
             add(aux1_reg_kernel, ch_blk * stride_w * jcp.typesize_in);
-            sub(aux1_reg_ddst, sp_step * jcp.typesize_in);
+            sub(aux1_reg_ddst,
+                    static_cast<uint32_t>(sp_step * jcp.typesize_in));
 
             sub(iter_kw, stride_w);
             cmp(iter_kw, 0);
@@ -701,7 +704,8 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
         }
 
         add(aux_reg_kernel, kw * ch_blk * stride_h * jcp.typesize_in);
-        sub(aux_reg_ddst, ow * sp_step * jcp.typesize_in);
+        sub(aux_reg_ddst,
+                static_cast<uint32_t>(ow * sp_step * jcp.typesize_in));
 
         sub(iter_kh, stride_h);
         cmp(iter_kh, 0);
@@ -713,10 +717,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
 
 inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::store_dsrc(
         int ur_ch_blocks, int ur_str_w, bool last_ch_block_flag) {
-    int ch_blk = jcp.ch_block;
-    int iw = jcp.iw;
-    int ih = jcp.ih;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t iw = jcp.iw;
+    const dim_t ih = jcp.ih;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dsrc_layout_nxc = is_dsrc_layout_nxc();
     const size_t ch_block_step = ch_blk * (dsrc_layout_nxc ? 1 : ih * iw);
@@ -730,7 +734,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::store_dsrc(
         for (int w = 0; w < ur_str_w; w++) {
             size_t sp_offset = w * stride_w * sp_step;
             size_t ch_offset = ch * ch_block_step;
-            int dsrc_off = sp_offset + ch_offset;
+            const dim_t dsrc_off = sp_offset + ch_offset;
             auto zmm_dsrc = get_acc_reg(ch * ur_str_w + w);
             Zmm mm_zmm_dsrc // mm: maybe masked
                     = mask_flag ? zmm_dsrc | k_ch_tail_mask : zmm_dsrc;
@@ -776,10 +780,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
         assert(is_ddst_layout_nxc() && is_dsrc_layout_nxc());
 
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_oc = jcp.oc / jcp.ch_block;
-        const int ch_block_tail
-                = jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int nb_oc = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int ch_block_tail = static_cast<int>(
+                jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking)));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         const size_t wei_ch_stride
                 = (size_t)jcp.nb_ch_blocking * jcp.kh * jcp.kw * jcp.ch_block;
@@ -800,9 +804,14 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
             {
                 call_compute_body(jcp.nb_ch_blocking, unroll_w);
 
-                add(reg_kernel, wei_ch_stride * jcp.typesize_in);
-                add(reg_dsrc, data_ch_stride * jcp.typesize_out);
-                add(reg_ddst, data_ch_stride * jcp.typesize_in);
+                add(reg_kernel,
+                        static_cast<uint32_t>(wei_ch_stride * jcp.typesize_in));
+                add(reg_dsrc,
+                        static_cast<uint32_t>(
+                                data_ch_stride * jcp.typesize_out));
+                add(reg_ddst,
+                        static_cast<uint32_t>(
+                                data_ch_stride * jcp.typesize_in));
 
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
@@ -842,8 +851,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::unroll_width_body(
 
             ch_loop_body(ur_ch_blocks, unroll_w);
 
-            add(reg_dsrc, jcp.typesize_out * jcp.stride_w * ch_step);
-            add(reg_ddst, jcp.typesize_in * ch_step);
+            add(reg_dsrc,
+                    static_cast<uint32_t>(
+                            jcp.typesize_out * jcp.stride_w * ch_step));
+            add(reg_ddst, static_cast<uint32_t>(jcp.typesize_in * ch_step));
 
             sub(reg_ur_str_w, unroll_w);
             jmp(unroll_w_label);
@@ -874,7 +885,7 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
             const size_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
             kxnorw(k_ch_tail_mask, k_ch_tail_mask,
                     k_ch_tail_mask); // dummy mask all 1's
-            cmp(reg_ch_blocks, channel_step);
+            cmp(reg_ch_blocks, static_cast<uint32_t>(channel_step));
             je(masking_done, T_NEAR);
             // Prepare masks for tail
             Reg32 reg_tmp_32 = reg_tmp.cvt32();
@@ -883,7 +894,7 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
             L(masking_done);
         }
 
-        unroll_width_body(jcp.nb_ch);
+        unroll_width_body(static_cast<int>(jcp.nb_ch));
     } else {
         auto ch_blocks_loop = [&](int ch_blocks) {
             Label skip_loop_label;
@@ -913,7 +924,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter() {
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::load_filter(
         bool is_last_ch) {
     for (int i = 0; i < jcp.kw; ++i) {
-        int off_filter = i * jcp.ch_block;
+        const dim_t off_filter = i * jcp.ch_block;
         Zmm zmm_acc = get_acc_reg(i);
         Zmm m_zmm_acc = is_last_ch ? zmm_acc | k_ch_tail_mask | T_z : zmm_acc;
         vmovups(m_zmm_acc,
@@ -936,14 +947,15 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
         bool is_last_ch) {
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const int right_border = static_cast<int>(jcp.iw - iw_block);
+    const int r_pad = static_cast<int>(jcp.r_pad);
 
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const int cascade_input = static_cast<int>(nstl::min(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const int input_overlap
+            = static_cast<int>(nstl::max<dim_t>(jcp.kw - l_pad, 0));
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
 
     /* LOAD initial input registers, then cascade LOADs and FMAs*/
@@ -971,8 +983,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
             }
         } else {
             for (int c = 0; c < cascade_input; ++c) {
-                int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                int input_sp = overlap + c - pad_offset;
+                const dim_t overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
+                const dim_t input_sp = overlap + c - pad_offset;
                 if (input_sp < 0 || overlap + c + l_pad > right_border)
                     continue;
 
@@ -982,7 +994,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
 
                 size_t input_offset = static_cast<size_t>(
                         input_sp * ch_step * jcp.typesize_in);
-                Zmm zmm_input = get_input_reg(overlap + c);
+                Zmm zmm_input = get_input_reg(static_cast<int>(overlap + c));
                 Zmm m_zmm_input = is_last_ch ? zmm_input | k_ch_tail_mask | T_z
                                              : zmm_input;
                 vpmovzxwd(m_zmm_input, ptr[reg_tmp_input + input_offset]);
@@ -990,7 +1002,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
         }
 
         for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-            int io_overlap = i_kw + (i_ur * jcp.stride_w);
+            const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
             /* Don't apply FMAs that fall into the padded region */
             if (io_overlap - l_pad < 0
@@ -1001,7 +1013,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
                     && (io_overlap - jcp.l_pad + jcp.r_pad > right_border);
             if (over_steps_bdry) continue;
 
-            Zmm zmm_input = get_input_reg(io_overlap - l_pad);
+            Zmm zmm_input = get_input_reg(static_cast<int>(io_overlap - l_pad));
             Zmm zmm_acc = get_acc_reg(i_kw);
             if (isa_has_bf16(jcp.isa))
                 vdpbf16ps(zmm_acc, zmm_input, zmm_out_reg);
@@ -1014,7 +1026,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_bias_step_unroll(
         const int unroll_w, bool is_last_ch) {
 
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t ch_step = is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block;
     for (int i = 0; i < unroll_w; ++i) {
         size_t off_output = static_cast<size_t>(i * ch_step * jcp.typesize_in);
         /* bf16 output data requires conversion to f32 */
@@ -1032,7 +1044,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::store_filter(
     /* bf16: all data is stored as f32. Down-convert to bf16 happens at the
      * reduction phase. */
     for (int i = 0; i < jcp.kw; ++i) {
-        int off_filter = i * jcp.ch_block;
+        const dim_t off_filter = i * jcp.ch_block;
         Zmm zmm_acc = get_acc_reg(i);
         Zmm m_zmm_acc = is_last_ch ? zmm_acc | k_ch_tail_mask : zmm_acc;
         vmovups(vmmword[reg_tmp_filter + off_filter * jcp.typesize_out],
@@ -1051,9 +1063,12 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
     Label oh_label;
     Label ow_blk_label;
 
-    const int unroll_w = nstl::min(max_unroll_w_, jcp.ow);
-    const int unroll_w_trips = jcp.ow / unroll_w;
-    const int tail_w = jcp.ow > max_unroll_w_ ? jcp.ow % max_unroll_w_ : 0;
+    const int unroll_w
+            = static_cast<int>(nstl::min<dim_t>(max_unroll_w_, jcp.ow));
+    const int unroll_w_trips = static_cast<int>(jcp.ow / unroll_w);
+    const int tail_w = jcp.ow > max_unroll_w_
+            ? static_cast<int>(jcp.ow % max_unroll_w_)
+            : 0;
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
     const size_t ch_offset = ch_step * jcp.typesize_in;
@@ -1069,7 +1084,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
         L(ow_blk_label);
         {
             compute_bias_step_unroll(unroll_w, is_last_ch);
-            add(reg_tmp_output, unroll_w * ch_offset);
+            add(reg_tmp_output, static_cast<uint32_t>(unroll_w * ch_offset));
 
             dec(reg_iter_ow_blk);
             cmp(reg_iter_ow_blk, 0);
@@ -1078,7 +1093,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
 
         if (tail_w > 0) {
             compute_bias_step_unroll(tail_w, is_last_ch);
-            add(reg_tmp_output, tail_w * ch_offset);
+            add(reg_tmp_output, static_cast<uint32_t>(tail_w * ch_offset));
         }
 
         inc(reg_oh);
@@ -1209,14 +1224,14 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter_kh_loop() {
     {
         store_filter();
 
-        add(reg_tmp_filter, filter_offset_kw);
+        add(reg_tmp_filter, static_cast<uint32_t>(filter_offset_kw));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
     }
 
     /* Comeback pointers */
-    sub(reg_tmp_filter, filter_offset_kh);
+    sub(reg_tmp_filter, static_cast<uint32_t>(filter_offset_kh));
 }
 
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::deploy_zero_filter() {
@@ -1256,8 +1271,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_kh_step(int unroll_w,
                 unroll_w, l_pad, pad_offset, ow_block, is_last_ch);
         store_filter();
 
-        add(reg_tmp_filter, filter_offset);
-        add(reg_tmp_input, input_offset);
+        add(reg_tmp_filter, static_cast<uint32_t>(filter_offset));
+        add(reg_tmp_input, static_cast<uint32_t>(input_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
@@ -1268,8 +1283,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_kh_step(int unroll_w,
     mov(reg_kh_aux, reg_kh);
     L(kh_comeback_label);
     {
-        sub(reg_tmp_input, input_offset);
-        sub(reg_tmp_filter, filter_offset);
+        sub(reg_tmp_input, static_cast<uint32_t>(input_offset));
+        sub(reg_tmp_filter, static_cast<uint32_t>(filter_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_comeback_label, T_NEAR);
@@ -1313,7 +1328,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
     mov(reg_tmp_input, reg_input_baddr);
     mov(reg_tmp_filter, reg_filter_baddr);
 
-    const int input_bottom_padding_overlap
+    const dim_t input_bottom_padding_overlap
             = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1348,11 +1363,11 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_tmp_filter, filter_shift * jcp.stride_h);
+        sub(reg_tmp_filter, static_cast<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -1360,14 +1375,17 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_tmp_filter, filter_shift * inp_corr);
-                add(reg_tmp_input, input_shift * inp_corr);
+                const dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                add(reg_tmp_filter,
+                        static_cast<uint32_t>(filter_shift * inp_corr));
+                add(reg_tmp_input,
+                        static_cast<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
             sub(reg_tmp_filter,
-                    (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+                    static_cast<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Apply correction: reset value of 'reg_kh' to scenario outside of
@@ -1402,11 +1420,11 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
     }
 
     /* Compute middle block */
-    add(reg_tmp_input, input_shift * jcp.stride_h);
+    add(reg_tmp_input, static_cast<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_tmp_output, output_shift);
+    add(reg_tmp_output, static_cast<uint32_t>(output_shift));
     inc(reg_oh);
     cmp(reg_oh, reg_oh_worksize);
     jl(loop_begin_label, T_NEAR);
@@ -1415,12 +1433,12 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
 }
 
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::calculate_w_unrolling(
-        int &unroll_trips, int &unroll_w, int &unroll_w_tail) {
+        int &unroll_trips, int &unroll_w, int &unroll_w_tail) const {
 
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (do_unroll_w) {
-        unroll_w = nstl::min(block_size_, jcp.ow);
-        unroll_trips = jcp.ow / unroll_w;
+        unroll_w = static_cast<int>(nstl::min<dim_t>(block_size_, jcp.ow));
+        unroll_trips = static_cast<int>(jcp.ow / unroll_w);
         /* calculate tail */
         unroll_w_tail = jcp.ow % unroll_w;
         /* Perform some rebalancing if tail too small*/
@@ -1436,7 +1454,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::calculate_w_unrolling(
             }
         }
     } else {
-        unroll_w_tail = jcp.ow;
+        unroll_w_tail = static_cast<int>(jcp.ow);
     }
 }
 
@@ -1444,7 +1462,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
 
     Label ow_blk_label; // for compute middle block
     int pad_offset = 0;
-    int l_pad = jcp.l_pad;
+    int l_pad = static_cast<int>(jcp.l_pad);
     int unroll_w_tail = 0;
     int unroll_w = 0;
     int unroll_trips = 0;
@@ -1465,8 +1483,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (l_pad && do_unroll_w) {
         compute_h_loop(unroll_w, l_pad, 0, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, static_cast<uint32_t>(data_offset));
+        add(reg_input_baddr, static_cast<uint32_t>(data_offset * jcp.stride_w));
         unroll_trips--;
         pad_offset = l_pad;
         l_pad = 0;
@@ -1481,8 +1499,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
     }
     if (unroll_trips > 0) {
         compute_h_loop(unroll_w, l_pad, pad_offset, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, static_cast<uint32_t>(data_offset));
+        add(reg_input_baddr, static_cast<uint32_t>(data_offset * jcp.stride_w));
     }
     if (do_ow_blk_loop) {
         dec(reg_iter_ow_blk);
@@ -1492,8 +1510,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
 
     /* compute right padded block */
     if (unroll_w_tail) {
-        compute_h_loop(
-                unroll_w_tail, l_pad, pad_offset, jcp.ow - unroll_w_tail);
+        compute_h_loop(unroll_w_tail, l_pad, pad_offset,
+                static_cast<int>(jcp.ow - unroll_w_tail));
     }
 }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
@@ -88,16 +88,17 @@ private:
     Xbyak::Zmm get_acc_reg(int idx);
 
     int get_ow_start(int ki, int pad_l) const {
-        return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+        return static_cast<int>(utils::div_up(
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w));
     }
 
     int get_ow_end(int ur_w, int ki, int pad_r) const {
         return ur_w
-                - utils::div_up(
-                        nstl::max(0,
+                - static_cast<int>(utils::div_up(
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
-                        jcp.stride_w);
+                        jcp.stride_w));
     }
 
     inline bool is_src_layout_nxc() const {
@@ -242,7 +243,8 @@ private:
         return Xbyak::Zmm(idx + idx_start);
     }
     inline Xbyak::Zmm get_input_reg(int idx) const {
-        const int i_idx = idx_start + jcp.kw + idx % jcp.kw;
+        const int i_idx
+                = static_cast<int>(idx_start + jcp.kw + idx % jcp.kw);
         assert(i_idx <= get_max_regs());
         return Xbyak::Zmm(i_idx);
     }
@@ -313,7 +315,7 @@ private:
     void store_bias(bool is_last_ch);
     void compute_bias();
     void calculate_w_unrolling(
-            int &unroll_trips, int &unroll_w, int &unroll_w_tail);
+            int &unroll_trips, int &unroll_w, int &unroll_w_tail) const;
 
     void generate() override;
 

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -39,7 +39,7 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
     : jit_generator_t(jit_name()), jcp(ajcp) {
     const auto simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const auto tail_size = jcp.oc_without_padding % simd_w;
+    const dim_t tail_size = jcp.oc_without_padding % simd_w;
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr auto preserve_gpr = true;
@@ -62,11 +62,12 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
             jcp.src_dt, jcp.dst_dt};
     io_ = utils::make_unique<io::jit_io_multi_dt_helper_t<Xbyak::Zmm>>(this,
             jcp.isa, data_types, io::io_conf_t {},
-            io::io_tail_conf_t {simd_w, tail_size, k_oc_tail_mask, 0, reg_tmp});
+            io::io_tail_conf_t {simd_w, static_cast<std::size_t>(tail_size),
+                    k_oc_tail_mask, 0, reg_tmp});
 }
 
-static bool check_if_tail(const bool is_ch_tail, const int c_tail, const int ch,
-        const int ur_ch_blocks, const int simd_w) {
+static bool check_if_tail(const bool is_ch_tail, const dim_t c_tail,
+        const int ch, const int ur_ch_blocks, const int simd_w) {
     return is_ch_tail && (ch + 1 == ur_ch_blocks) && simd_w > c_tail;
 }
 
@@ -78,7 +79,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const int c_tail = jcp.oc % jcp.ch_block;
+    const dim_t c_tail = jcp.oc % jcp.ch_block;
 
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
         const bool is_tail_load
@@ -91,14 +92,14 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
                 const Zmm zmm_acc_msk = is_tail_load
                         ? zmm_acc | k_oc_tail_mask | T_z
                         : zmm_acc;
-                const int b_off = ch * ch_blk;
+                const dim_t b_off = ch * ch_blk;
                 uni_vmovups(zmm_acc_msk, ptr[reg_bias + b_off * sizeof(float)]);
             } else {
                 uni_vpxor(zmm_acc, zmm_acc, zmm_acc);
             }
 
             if (jcp.with_sum) {
-                const int o_off = ch * ocb_stride + ow * ow_stride;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                 // using ker_zmm as zmm_tmp as it is safe to do so.
                 auto zmm_tmp = get_ker_reg(0);
                 io_->at(jcp.src_dt)
@@ -112,10 +113,10 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
 
 void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r, bool is_ch_tail) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -125,16 +126,16 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             : (jcp.is_fused_conv ? 1 : jcp.ih) * jcp.iw * ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
 
-    auto get_input_spatial_index = [=](int oi, int ki) {
+    auto get_input_spatial_index = [=](dim_t oi, dim_t ki) -> dim_t {
         return (ki * dilate_w + oi * stride_w - pad_l);
     };
 
-    auto get_input_offset = [&](int ii, int ci) {
+    auto get_input_offset = [&](dim_t ii, dim_t ci) -> dim_t {
         return (ci * icb_stride + ii * iw_stride) * jcp.typesize_in;
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise) {
         // find bounds of input spatial indices
         bool first = true;
@@ -142,7 +143,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             int oi_start = get_ow_start(ki, pad_l);
             int oi_end = get_ow_end(ur_w, ki, pad_r);
             for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = get_input_spatial_index(oi, ki);
+                const dim_t ii = get_input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -163,42 +164,44 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             mov(aux_reg_input, ptr[aux_reg_input_buffer_ptr]);
             add(aux_reg_input, reg_iw_offset);
         }
-        const int c_tail = jcp.oc % jcp.ch_block;
+        const dim_t c_tail = jcp.oc % jcp.ch_block;
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
             const bool is_tail_load = check_if_tail(
                     is_ch_tail, c_tail, ch, ur_ch_blocks, simd_w);
             if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= 0) continue;
             if (jcp.is_resrc_depthwise) {
                 // now we can load input once and reuse up to jcp.kw times
-                for (int ii = ii_start; ii <= ii_end; ii++) {
-                    Zmm zmm_src = get_src_reg(ii);
-                    const int inp_off = get_input_offset(ii, ch);
+                for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                    Zmm zmm_src = get_src_reg(static_cast<int>(ii));
+                    const dim_t inp_off = get_input_offset(ii, ch);
                     io_->at(jcp.src_dt)
                             ->load(ptr[aux_reg_input + inp_off], zmm_src,
                                     is_tail_load);
                 }
             }
             for (int kw = 0; kw < jcp.kw; kw++) {
-                const int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
+                const dim_t ker_off
+                        = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
 
                 Zmm zmm_ker = get_ker_reg(0);
                 io_->at(jcp.src_dt)
                         ->load(ptr[aux_reg_kernel + ker_off * jcp.typesize_in],
                                 zmm_ker, is_tail_load);
-                int ow_start = get_ow_start(kw, pad_l);
-                int ow_end = get_ow_end(ur_w, kw, pad_r);
-                for (int ow = ow_start; ow < ow_end; ow++) {
+                const dim_t ow_start = get_ow_start(kw, pad_l);
+                const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                for (dim_t ow = ow_start; ow < ow_end; ow++) {
 
-                    const int ii = get_input_spatial_index(ow, kw);
-                    Zmm zmm_src = jcp.is_resrc_depthwise ? get_src_reg(ii)
-                                                         : get_src_reg(0);
+                    const dim_t ii = get_input_spatial_index(ow, kw);
+                    Zmm zmm_src = jcp.is_resrc_depthwise
+                            ? get_src_reg(static_cast<int>(ii))
+                            : get_src_reg(0);
                     if (!jcp.is_resrc_depthwise) {
-                        const int inp_off = get_input_offset(ii, ch);
+                        const dim_t inp_off = get_input_offset(ii, ch);
                         io_->at(jcp.src_dt)
                                 ->load(ptr[aux_reg_input + inp_off], zmm_src,
                                         is_tail_load);
                     }
-                    Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
+                    Zmm zmm_acc = get_acc_reg(static_cast<int>(ch * ur_w + ow));
                     const Zmm zmm_ker_msk = is_tail_load
                             ? zmm_ker | k_oc_tail_mask | T_z
                             : zmm_ker;
@@ -252,7 +255,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_postops(
             const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
             const auto mask_tail_blocked_layout
                     = jcp.oc_without_padding % jcp.ch_block && !dst_layout_nxc;
-            const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+            const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
             iterate(ur_ch_blocks, ur_w, mask_tail_blocked_layout,
                     [&](const int ch, const int ow,
                             const bool mask_flag_blocked_layout) {
@@ -316,14 +319,14 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::store_dst(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+    const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
 
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
         const bool is_tail_load
                 = check_if_tail(is_ch_tail, c_tail, ch, ur_ch_blocks, simd_w);
         if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= 0) continue;
         for (int ow = 0; ow < ur_w; ow++) {
-            const int o_off = ch * ocb_stride + ow * ow_stride;
+            const dim_t o_off = ch * ocb_stride + ow * ow_stride;
             Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
             io_->at(jcp.dst_dt)
                     ->store(zmm_dst, ptr[reg_output + o_off * jcp.typesize_out],
@@ -364,9 +367,9 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
     mov(aux_reg_ch_blocks, reg_ch_blocks);
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int ch_block_tail = jcp.nb_ch
-                - (utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int ch_block_tail = static_cast<int>(jcp.nb_ch
+                - utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         push(reg_kernel);
         push(reg_input);
@@ -382,10 +385,11 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking, false);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, static_cast<uint32_t>(wei_ch_stride));
+                add(reg_input, static_cast<uint32_t>(inp_ch_stride));
+                add(reg_output, static_cast<uint32_t>(out_ch_stride));
+                if (jcp.with_bias)
+                    add(reg_bias, static_cast<uint32_t>(bias_stride));
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -413,46 +417,46 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
 
 void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int n_oi = static_cast<int>(ow / ur_w);
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
     if (r_pad1 > 0) n_oi--;
     xor_(reg_oi, reg_oi);
     if (ow == ur_w) {
-        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
+        compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad);
     } else {
         if (n_oi == 0) {
-            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
+            compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, static_cast<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
         } else {
             if (l_pad > 0) {
-                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
+                compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, static_cast<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -460,8 +464,8 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, static_cast<uint32_t>(inp_shift));
+                    add(reg_output, static_cast<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -470,8 +474,8 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, static_cast<uint32_t>(inp_shift));
+                add(reg_output, static_cast<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
@@ -518,7 +522,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::generate() {
     if (oc_tail != 0) {
         // Prepare masks for tailing
         // Not using io_->prepare_tail_mask() since mask needs shifting
-        const int oc_tail_shift
+        const dim_t oc_tail_shift
                 = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
         static constexpr auto zmm_full_mask = ((1 << 16) - 1);
         Reg32 reg_tail_32 = reg_tail.cvt32();
@@ -527,7 +531,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        ow_loop(jcp.nb_ch);
+        ow_loop(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
@@ -85,16 +85,17 @@ private:
     }
 
     int get_ow_start(int ki, int pad_l) const {
-        return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+        return static_cast<int>(utils::div_up(
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w));
     }
 
     int get_ow_end(int ur_w, int ki, int pad_r) const {
         return ur_w
-                - utils::div_up(
-                        nstl::max(0,
+                - static_cast<int>(utils::div_up(
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
-                        jcp.stride_w);
+                        jcp.stride_w));
     }
 
     inline bool is_src_layout_nxc() const {

--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -46,16 +46,16 @@ void fp8_conversion_e5m2_t::prepare_table() {
             case 2: index = i + 1; break;
             case 3: index = i - 2; break;
         }
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
     // Data for bf16
     for (size_t i = 0; i < 32; ++i) {
         size_t index = 4 * (i / 2) + (i % 2);
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
     for (size_t i = 32; i < 64; ++i) {
         size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
 
     // Other tables are not needed if fp8 is native
@@ -87,11 +87,11 @@ void fp8_conversion_e4m3_t::prepare_table() {
     host_->L(label_vnni_permute_index_table_);
     for (size_t i = 0; i < 32; ++i) {
         size_t index = 4 * (i / 2) + (i % 2);
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
     for (size_t i = 32; i < 64; ++i) {
         size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
-        host_->db(index);
+        host_->db(static_cast<int>(index));
     }
 
     host_->L(label_table_from_f8_);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -58,8 +58,8 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr unsigned helper_vmm_idx = 31;
-        const size_t oc_block_tail = jcp.oc_block % isa_simd_width_;
-        const size_t tail_size = oc_block_tail
+        const dim_t oc_block_tail = jcp.oc_block % isa_simd_width_;
+        const dim_t tail_size = oc_block_tail
                 ? oc_block_tail
                 : jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
@@ -84,7 +84,7 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
-        int load_loop_blk) {
+        dim_t load_loop_blk) {
     mov(aux1_reg_bcast_data, reg_bcast_data);
     mov(aux_reg_bcast_data, reg_bcast_data);
 
@@ -100,9 +100,9 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             reduce_loop(load_loop_blk, jcp.ur, false);
             if (i < num_substeps - 1) {
                 add(aux1_reg_bcast_data, jcp.bcast_loop_bcast_substep);
@@ -112,7 +112,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
                         jcp.bcast_loop_bcast_step
                                 - (num_substeps - 1)
                                         * jcp.bcast_loop_bcast_substep);
-                int output_offset = jcp.bcast_loop_output_step
+                dim_t output_offset = jcp.bcast_loop_output_step
                         - (num_substeps - 1) * jcp.bcast_loop_output_substep;
 
                 add(aux_reg_output_data, output_offset);
@@ -154,29 +154,29 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::cvt2ps(
 }
 
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur,
+static void iterate(const dim_t load_loop_blk, const dim_t ur,
         const bool last_oc_block_flag, const bool force_masking, const F &f) {
-    for (int i_load = 0; i_load < load_loop_blk; i_load++) {
+    for (dim_t i_load = 0; i_load < load_loop_blk; i_load++) {
         const bool mask_flag = force_masking
                 || (last_oc_block_flag && i_load + 1 == load_loop_blk);
-        for (int i_ur = 0; i_ur < ur; i_ur++)
+        for (dim_t i_ur = 0; i_ur < ur; i_ur++)
             f(mask_flag, i_load, i_ur);
     }
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur,
+static void iterate(const dim_t load_loop_blk, const dim_t ur,
         const bool last_oc_block_flag, const F &f) {
     iterate(load_loop_blk, ur, last_oc_block_flag, false, f);
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const F &f) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur, const F &f) {
     iterate(load_loop_blk, ur, false, false, f);
 }
 
 template <typename Vmm>
 Address jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::output_ptr(
-        const int i_load, const int i_ur) {
-    const size_t ur_stride = jcp.with_dw_conv
+        dim_t i_load, dim_t i_ur) {
+    const dim_t ur_stride = jcp.with_dw_conv
             ? jcp.nb_load_blocking * jcp.oc_block * i_ur
             : jcp.oc_without_padding * jcp.ngroups * i_ur;
 
@@ -186,26 +186,26 @@ Address jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::output_ptr(
 
 template <typename Vmm>
 int jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::vreg_accum_idx(
-        const int load_loop_blk, int i_load, int i_ur) const {
-    return (i_ur * load_loop_blk + i_load);
+        dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const {
+    return static_cast<int>(i_ur * load_loop_blk + i_load);
 }
 
 template <typename Vmm>
 Vmm jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::vreg_accum(
-        const int load_loop_blk, int i_load, int i_ur) const {
+        dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const {
     return Vmm(vreg_accum_idx(load_loop_blk, i_load, i_ur));
 }
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_sum(
-        const int load_loop_blk, const int ur, const bool mask_flag_in,
+        dim_t load_loop_blk, dim_t ur, const bool mask_flag_in,
         const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_sum) {
         const float sum_scale = *p_sum_scale;
         const int32_t sum_zp = *p_sum_zp;
         const auto sum_injector_lam
                 = [this, sum_scale, sum_zp, load_loop_blk](const bool mask_flag,
-                          const int i_load, const int i_ur) {
+                          const dim_t i_load, const dim_t i_ur) {
             const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
             cvt2ps(jcp.sum_dt, vmm_prev_dst, output_ptr(i_load, i_ur),
                     mask_flag);
@@ -229,7 +229,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_sum(
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
-        const int load_loop_blk, const int ur, const bool mask_flag_in,
+        dim_t load_loop_blk, dim_t ur, const bool mask_flag_in,
         const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
 
@@ -243,11 +243,11 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
             const bool oc_blk_is_smaller_than_vmm
                     = jcp.oc_block < isa_simd_width_;
             iterate(load_loop_blk, ur, mask_tail, oc_blk_is_smaller_than_vmm,
-                    [&](const bool mask_flag, const int i_load,
-                            const int i_ur) {
-                const int ur_stride
+                    [&](const bool mask_flag, const dim_t i_load,
+                            const dim_t i_ur) {
+                const dim_t ur_stride
                         = jcp.oc_without_padding * jcp.ngroups * i_ur;
-                const size_t aux_output_l_off = jcp.typesize_out
+                const dim_t aux_output_l_off = jcp.typesize_out
                         * (ur_stride + i_load * jcp.load_block);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -284,7 +284,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
 
         } else {
             iterate(load_loop_blk, ur,
-                    [&](const bool, const int i_load, const int i_ur) {
+                    [&](const bool, const dim_t i_load, const dim_t i_ur) {
                 vmm_idxs.emplace(vreg_accum_idx(load_loop_blk, i_load, i_ur));
             });
             postops_injector_->compute_vector_range(vmm_idxs);
@@ -294,45 +294,45 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
-        int load_loop_blk, int ur, bool wraparound) {
-    auto vreg_load = [ur, load_loop_blk](int i_load) {
-        return Vmm(ur * load_loop_blk + i_load);
+        dim_t load_loop_blk, dim_t ur, bool wraparound) {
+    auto vreg_load = [ur, load_loop_blk](dim_t i_load) {
+        return Vmm(static_cast<int>(ur * load_loop_blk + i_load));
     };
 
-    auto bias_ptr = [this](int i_load) {
+    auto bias_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_bias_data, jcp.typesize_bia * jcp.oc_block * i_load);
     };
 
-    auto comp_ptr = [this](int i_load) {
+    auto comp_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_comp_data, sizeof(int32_t) * jcp.oc_block * i_load);
     };
 
-    auto bcast_ptr = [this](int i_reduce, int i_ur, bool bcast) {
+    auto bcast_ptr = [this](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
         assert(jcp.reduce_loop_unroll == jcp.reduce_block);
 
-        int offt = (jcp.ic_without_padding * i_ur * jcp.ngroups + i_reduce);
+        dim_t offt = jcp.ic_without_padding * i_ur * jcp.ngroups + i_reduce;
 
         return EVEX_compress_addr(
                 aux_reg_bcast_data, jcp.typesize_in * offt, bcast);
     };
 
-    auto load_ptr = [this](int i_reduce, int i_load) {
-        int u0 = i_reduce % jcp.reduce_loop_unroll;
-        int u1 = i_reduce / jcp.reduce_loop_unroll;
+    auto load_ptr = [this](dim_t i_reduce, dim_t i_load) {
+        const dim_t u0 = i_reduce % jcp.reduce_loop_unroll;
+        const dim_t u1 = i_reduce / jcp.reduce_loop_unroll;
 
-        int offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
+        dim_t offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
 
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
     };
 
     auto init = [this, load_loop_blk, ur]() {
-        for (int i_load = 0; i_load < load_loop_blk; ++i_load)
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+        for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load)
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                 vpxord(r, r, r);
             }
@@ -374,7 +374,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             mov(reg_src_zero_point,
                     EVEX_compress_addr(rsp, reg_src_zero_point_off));
         }
-        for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+        for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
             const bool mask_flag = mask_flag_in && i_load == load_loop_blk - 1;
             auto vmm_bias = vmm_tmp;
             auto vmm_comp = vmm_bcast;
@@ -390,7 +390,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             }
             if (jcp.src_zero_point) {
                 // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-                const int zp_offset = sizeof(int32_t) * i_load * jcp.load_block;
+                const dim_t zp_offset
+                        = sizeof(int32_t) * i_load * jcp.load_block;
                 vmovups(vmm_zp,
                         EVEX_compress_addr(reg_zp_compensation, zp_offset));
                 vpmulld(vmm_zp, vmm_zp,
@@ -401,7 +402,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                         = mask_flag ? vmm_zp | k_load_dim_mask | T_z : vmm_zp;
                 vcvtdq2ps(vmm_, vmm_);
             }
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 auto vmm = vreg_accum(load_loop_blk, i_load, i_ur);
                 vcvtdq2ps(vmm, vmm);
                 if (jcp.signed_input) vaddps(vmm, vmm, vmm_comp);
@@ -436,7 +437,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                     mov(reg_wei_scales,
                             EVEX_compress_addr(rsp, reg_wei_scales_off));
 
-                    int scale_offset = jcp.is_oc_scale
+                    const dim_t scale_offset = jcp.is_oc_scale
                             * (sizeof(float) * jcp.oc_block * i_load);
                     vmulps(vmm_k, vmm,
                             EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -461,10 +462,10 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             mov(reg_dst_scales, EVEX_compress_addr(rsp, reg_dst_scales_off));
 
             /* Apply dst scale to accumulator */
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 const bool mask_flag
                         = mask_flag_in && i_load == load_loop_blk - 1;
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     const auto vmm = vreg_accum(load_loop_blk, i_load, i_ur);
                     const Vmm vmm_k
                             = mask_flag ? vmm | k_load_dim_mask | T_z : vmm;
@@ -481,8 +482,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             vcvtdq2ps(vmm_zp, EVEX_compress_addr(reg_dst_zero_point, 0, true));
 
             /* Add dst zero_point to accumulator */
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     vaddps(r, r, vmm_zp);
                 }
@@ -493,8 +494,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
         if (one_of(jcp.dst_dt, u8, s8, s32)) {
             init_saturate_f32(vmm_zero, vmm_saturation,
                     reg_ptr_saturation_ubound, f32, jcp.dst_dt);
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     saturate_cvt_f32(r, vmm_zero, vmm_saturation, jcp.dst_dt);
                 }
@@ -508,8 +509,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
         if (jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa)) {
             // Optimization: use single store instruction for pair
             // of the nearest vectors along LOAD dimension
-            for (int i_ur = 0; i_ur < ur; i_ur++) {
-                int i_load = 0;
+            for (dim_t i_ur = 0; i_ur < ur; i_ur++) {
+                dim_t i_load = 0;
                 for (; i_load < rnd_dn(load_loop_blk, 2); i_load += 2) {
                     auto vmm_dst = vreg_accum(load_loop_blk, i_load, i_ur);
                     auto vmm_dst_next
@@ -530,10 +531,10 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                 }
             }
         } else {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 const bool mask_flag
                         = mask_flag_in && i_load == load_loop_blk - 1;
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     const Vmm r_vmm = mask_flag ? r | k_load_dim_mask : r;
 
@@ -576,28 +577,28 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
     };
 
     auto fma_block = [&](bool last_block) {
-        int reduce_step = 4;
-        int ic_tail_size = jcp.ic_without_padding % reduce_step;
-        int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
+        const dim_t reduce_step = 4;
+        const dim_t ic_tail_size = jcp.ic_without_padding % reduce_step;
+        const dim_t loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
                 ? rnd_up(jcp.ic_without_padding % jcp.ic_block, reduce_step)
                 : jcp.reduce_loop_unroll;
-        for (int i_reduce = 0; i_reduce < loop_unroll;
+        for (dim_t i_reduce = 0; i_reduce < loop_unroll;
                 i_reduce += reduce_step) {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load)
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load)
                 vmovups(vreg_load(i_load), load_ptr(i_reduce, i_load));
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 if (last_block && ic_tail_size != 0
                         && i_reduce == loop_unroll - reduce_step) {
                     Xmm xmm_bcast = Xmm(vmm_bcast.getIdx());
                     load_bytes(xmm_bcast, aux_reg_bcast_data,
                             jcp.ic_without_padding * i_ur + i_reduce,
-                            ic_tail_size);
+                            static_cast<int>(ic_tail_size));
                     vpbroadcastd(vmm_bcast, xmm_bcast);
                 } else {
                     vpbroadcastd(vmm_bcast, bcast_ptr(i_reduce, i_ur, false));
                 }
                 if (jcp.signed_input) vpsubb(vmm_bcast, vmm_bcast, vmm_shift);
-                for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                     compute(vreg_accum(load_loop_blk, i_load, i_ur),
                             vreg_load(i_load), vmm_bcast);
                 }
@@ -665,7 +666,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
 
     preamble();
 
-    const int simd_w = jcp.ic_block;
+    const int simd_w = static_cast<int>(jcp.ic_block);
     xor_(reg_scratch, reg_scratch);
     Reg16 _t = reg_scratch.cvt16();
     mov(_t, 0x1);
@@ -724,11 +725,11 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         kmovb(k_load_dim_tail_mask, reg_tail_32);
     }
 
-    const int load_dim_tail
-            = (one_of(jcp.prop_kind, forward_training, forward_inference)
-                              ? jcp.oc_without_padding
-                              : jcp.load_dim)
-            % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(
+            (one_of(jcp.prop_kind, forward_training, forward_inference)
+                            ? jcp.oc_without_padding
+                            : jcp.load_dim)
+            % jcp.load_block);
     const bool use_extended_mask
             = jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa);
     if (load_dim_tail) {
@@ -782,14 +783,16 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         if (jcp.signed_input) {
             mov(reg_comp_data, EVEX_compress_addr(rsp, reg_comp_data_off));
             add(reg_comp_data,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(EVEX_compress_addr(rsp, reg_comp_data_off), reg_comp_data);
         }
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation,
                     EVEX_compress_addr(rsp, reg_zp_compensation_off));
             add(reg_zp_compensation,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(EVEX_compress_addr(rsp, reg_zp_compensation_off),
                     reg_zp_compensation);
         }
@@ -797,8 +800,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         if (jcp.with_wei_scales) {
             mov(reg_wei_scales, EVEX_compress_addr(rsp, reg_wei_scales_off));
             add(reg_wei_scales,
-                    jcp.is_oc_scale * load_loop_blk * jcp.load_block
-                            * sizeof(float));
+                    static_cast<uint32_t>(jcp.is_oc_scale * load_loop_blk
+                            * jcp.load_block * sizeof(float)));
             mov(EVEX_compress_addr(rsp, reg_wei_scales_off), reg_wei_scales);
         }
         mov(reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
@@ -1066,10 +1069,13 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     const int SMALL_SPATIAL = 7 * 7;
     const int BIG_REDUCE_DIM = 1024;
@@ -1105,9 +1111,9 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             && (jcp.oh <= size_treshold && jcp.ow <= size_treshold)) {
         if (jcp.os <= SMALL_SPATIAL && jcp.oc * jcp.ic < L2_size)
             max_regs = min_regs; // mobilenet_v2 performance improvement
-        jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
     } else {
-        const int spatial = jcp.od * jcp.oh;
+        const dim_t spatial = jcp.od * jcp.oh;
         jcp.ur = 1;
         for (int ur_w = max_regs; ur_w >= min_regs; ur_w--) {
             if ((spatial >= size_treshold && spatial % ur_w == 0)
@@ -1117,10 +1123,10 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
-            int os_tail = jcp.os % max_regs;
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
+            int os_tail = static_cast<int>(jcp.os % max_regs);
             for (int i = max_regs; i >= min_regs; i--) {
-                int i_tail = jcp.os % i;
+                int i_tail = static_cast<int>(jcp.os % i);
                 if (i_tail > os_tail || i_tail == 0) {
                     jcp.ur = i;
                     os_tail = i_tail;
@@ -1129,7 +1135,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             }
         }
     }
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
     jcp.reduce_dim = jcp.ic;
     jcp.reduce_block = jcp.ic_block;
@@ -1160,8 +1167,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-    int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    int nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    int nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     reduce_blocking = nb_reduce;
     if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -1173,7 +1180,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     bool cmp_reduce = reduce_blocking <= jcp.reduce_dim;
     if (cmp_reduce) jcp.loop_order = reduce_src ? loop_rbl : loop_rlb;
-    load_blocking = jcp.load_dim;
+    load_blocking = static_cast<int>(jcp.load_dim);
 
     jcp.load_grp_count = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
     jcp.load_grp_count = best_divider(
@@ -1184,25 +1191,30 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
         jcp.load_grp_count = nstl::max(jcp.load_grp_count, 4);
     } else if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.mb <= jcp.nthr
             && jcp.load_dim > 512 && jcp.load_dim / jcp.reduce_dim >= 4) {
-        jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2); //
-        load_blocking = jcp.load_block;
+        jcp.load_grp_count
+                = static_cast<int>(nstl::max<dim_t>(jcp.load_grp_count, 2)); //
+        load_blocking = static_cast<int>(jcp.load_block);
     }
 
-    bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                             div_up(jcp.nthr, jcp.load_grp_count))
-            * jcp.bcast_block;
-    bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+    bcast_blocking
+            = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                       div_up(jcp.nthr, jcp.load_grp_count))
+                    * jcp.bcast_block);
+    bcast_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
     bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
-    int space_for_bcast = (L2_capacity - /* kernel_size - */
+    const dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
             2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
             - 3 * 1024);
-    if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
+    dim_t space_for_bcast_adjusted = space_for_bcast;
+    if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity)
+        space_for_bcast_adjusted /= 2;
 
-    int bcast_in_cache
-            = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-    bcast_blocking = nstl::min(
-            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+    const dim_t bcast_in_cache = nstl::max<dim_t>(
+            jcp.bcast_block, space_for_bcast_adjusted / reduce_blocking);
+    bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
     load_blocking_max = load_blocking;
     bcast_blocking_max = bcast_blocking * 3 / 2;
@@ -1247,7 +1259,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
     if (jcp.mb == 1 && jcp.nb_load % 4 == 0 && jcp.ic / jcp.oc >= 4
             && jcp.ic * jcp.oc <= L2_size && jcp.nthr <= ncores_per_socket) {
         jcp.nb_load_chunk = 4;
-        jcp.load_grp_count = nstl::max(jcp.nb_load / 4, jcp.load_grp_count);
+        jcp.load_grp_count = static_cast<int>(
+                nstl::max<dim_t>(jcp.nb_load / 4, jcp.load_grp_count));
     }
 
     /* adjust the thread decomposition
@@ -1260,7 +1273,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
     if (jcp.typesize_in * bcast_size < 8192 && jcp.ngroups < jcp.nthr
             && jcp.nb_bcast * jcp.nb_load < jcp.nthr) {
-        int nthr = nstl::max(jcp.nb_load, jcp.nb_bcast);
+        const int nthr
+                = static_cast<int>(nstl::max<dim_t>(jcp.nb_load, jcp.nb_bcast));
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -134,16 +134,16 @@ private:
     }
     inline Vmm_down_t vmm_store() { return Vmm_down_t(ymm_store.getIdx()); }
 
-    void bcast_loop(int load_loop_blk);
-    void reduce_loop(int load_loop_blk, int ur, bool wraparound);
+    void bcast_loop(dim_t load_loop_blk);
+    void reduce_loop(dim_t load_loop_blk, dim_t ur, bool wraparound);
 
-    Xbyak::Address output_ptr(const int i_load, const int i_ur);
-    int vreg_accum_idx(const int load_loop_blk, int i_load, int i_ur) const;
-    Vmm vreg_accum(const int load_loop_blk, int i_load, int i_ur) const;
-    void apply_sum(const int load_loop_blk, const int ur,
+    Xbyak::Address output_ptr(dim_t i_load, dim_t i_ur);
+    int vreg_accum_idx(dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const;
+    Vmm vreg_accum(dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const;
+    void apply_sum(dim_t load_loop_blk, dim_t ur,
             const bool mask_flag_in, const float *p_sum_scale,
             const int32_t *p_sum_zp);
-    void apply_postops(const int load_loop_blk, const int ur,
+    void apply_postops(dim_t load_loop_blk, dim_t ur,
             const bool mask_flag_in, const float *p_sum_scale,
             const int32_t *p_sum_zp);
     void generate() override;
@@ -155,7 +155,7 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel_t {
     jit_avx512_core_x8s8s32x_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.ic_block;
+        const dim_t ch_block = ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -49,7 +49,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const void *src_scales
@@ -110,14 +111,14 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
             ? scratchpad.get<char>(key_conv_rtus_space)
             : nullptr;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     const bool is_2d = pd()->ndims() == 4;
     const bool is_3d = pd()->ndims() == 5;
 
-    const int stride_d = pd()->KSD();
-    const int stride_h = pd()->KSH();
-    const int stride_w = pd()->KSW();
+    const dim_t stride_d = pd()->KSD();
+    const dim_t stride_h = pd()->KSH();
+    const dim_t stride_w = pd()->KSW();
 
     auto offset = weights_d.size() - weights_d.additional_buffer_size();
     char *w = const_cast<char *>(weights);
@@ -139,16 +140,17 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -183,26 +185,26 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
     char *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<char *> addrs;
     // End
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh, dim_t &ow,
+                              dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
-        bcast_step = step(
-                nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
-        bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+        bcast_step = step(nb_bcast_blocking, nb_bcast - osb,
+                nb_bcast_blocking_max);
+        bcast_step = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
-        const int depth_orthogonal_area = jcp.ow * jcp.oh;
+        const dim_t os = osb * os_block;
+        const dim_t depth_orthogonal_area = jcp.ow * jcp.oh;
         od = os / depth_orthogonal_area;
         oh = (os % depth_orthogonal_area) / jcp.ow;
         ow = (os % depth_orthogonal_area) % jcp.ow;
@@ -216,7 +218,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         p.load_dim = this_block_size(ocb * jcp.oc_block, ocb_end * jcp.oc_block,
                 load_step * jcp.oc_block);
@@ -229,17 +231,17 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
     auto init_reduce = [&]() {
         p.reduce_dim = this_block_size(
-                0, jcp.ic_without_padding, jcp.ic_without_padding);
+                dim_t {0}, jcp.ic_without_padding, jcp.ic_without_padding);
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int n, int g, int od, int oh,
-                           int ow, int id, int ih, int iw) {
-        const int icb = 0; // Start from the first IC block
-        const int _ocb = g * nb_oc + ocb;
-        const int _icb = g * nb_ic + icb;
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t n, dim_t g, dim_t od,
+                           dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
+        constexpr dim_t icb = 0; // Start from the first IC block
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g * nb_ic + icb;
 
-        const size_t dst_off = is_3d
+        const dim_t dst_off = is_3d
                 ? dst_d.blk_off(n, _ocb * jcp.oc_block, od, oh, ow)
                 : is_2d ? dst_d.blk_off(n, _ocb * jcp.oc_block, oh, ow)
                         : dst_d.blk_off(n, _ocb * jcp.oc_block, ow);
@@ -288,18 +290,19 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_rlb) {
             init_reduce();
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                    dim_t n, g, od, oh, ow, id, ih, iw;
+                    dim_t bcast_step;
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -308,13 +311,14 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                    dim_t n, g, od, oh, ow, id, ih, iw;
+                    dim_t bcast_step;
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
                     init_reduce();
@@ -325,14 +329,15 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
             }
         } else if (jcp.loop_order == loop_rbl) {
             init_reduce();
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                     ocb += load_step;
@@ -340,14 +345,15 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                 iwork += bcast_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     init_reduce();
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -360,30 +366,32 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
-        int oh_1x1_begin = nstl::max(oh_1x1, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step,
+                              dim_t &dw_oh) {
+        dim_t oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
+        dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1_begin++) % jcp_dw->kh) * row_offset;
 
         const auto ocb_end = ocb_start + load_step;
-        const size_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
+        const dim_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         auto par_conv_dw = jit_conv_args_t();
 
-        par_conv_dw.t_overflow = nstl::min(jcp_dw->kh, nstl::max(0, -oh_1x1));
-        par_conv_dw.b_overflow = nstl::min(
-                jcp_dw->kh, nstl::max(0, oh_1x1 - jcp.oh + jcp_dw->kh));
-        par_conv_dw.kh_padding = nstl::max<int>(0,
+        par_conv_dw.t_overflow
+                = nstl::max<dim_t>(0, nstl::min<dim_t>(jcp_dw->kh, -oh_1x1));
+        par_conv_dw.b_overflow = nstl::max<dim_t>(
+                0, nstl::min<dim_t>(jcp_dw->kh, oh_1x1 - jcp.oh + jcp_dw->kh));
+        par_conv_dw.kh_padding = nstl::max<dim_t>(0,
                 jcp_dw->kh - par_conv_dw.t_overflow - par_conv_dw.b_overflow);
 
-        const size_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
+        const dim_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
                 + dw_oh * jcp_dw->ow * jcp_dw->ngroups;
 
         const auto wht_h_stride = dw_weights_d.blk_off(0, 0, 0, 1);
         const auto wei_stride = (!jcp_dw->signed_input) * par_conv_dw.t_overflow
                 * wht_h_stride;
-        for (int ocb = ocb_start; ocb < ocb_end;
+        for (dim_t ocb = ocb_start; ocb < ocb_end;
                 ocb += jcp_dw->nb_ch_blocking) {
 
             par_conv_dw.src = addrs.data();
@@ -395,7 +403,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                     = weights_dw + dw_weights_d.blk_off(ocb, 0) + wei_stride;
             par_conv_dw.bias
                     = &bias_dw[ocb * jcp_dw->ch_block * dw_bia_dt_size];
-            par_conv_dw.ur_w = (size_t)(jcp_dw->ow);
+            par_conv_dw.ur_w = jcp_dw->ow;
             par_conv_dw.owb = jcp_dw->ow;
             par_conv_dw.oc_blocks = ocb;
             par_conv_dw.compensation = compensation_dw
@@ -414,7 +422,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
             (*kernel_dw_)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += src_ch_stride;
         }
     };
@@ -423,39 +431,42 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         auto jcp_dw = pd()->jcp_dw_;
         auto dw_conv_buffer = dw_scratchpad.get<char>(key_fusion_inout_buffer);
 
-        const auto dw_conv_buffer_size_
-                = (size_t)jcp_dw->kh * jcp.ow * nb_buffer * jcp.oc_block;
+        const dim_t dw_conv_buffer_size_
+                = jcp_dw->kh * jcp.ow * nb_buffer * jcp.oc_block;
         pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size_;
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        balance2D(nthr, ithr,
+                jcp.mb * jcp.ngroups * jcp_dw->oh,
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -471,10 +482,10 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
                 jcp.nb_load / jcp.nb_load_chunk, ocb_start, ocb_end,
-                jcp.load_grp_count);
+                static_cast<dim_t>(jcp.load_grp_count));
         if (jcp.nb_load_chunk > 1) {
             ocb_start *= jcp.nb_load_chunk;
             ocb_end *= jcp.nb_load_chunk;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -266,7 +266,8 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                 --jcp_dw_->nb_ch_blocking;
 
             jcp_dw_->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+                    = static_cast<int>(
+                            jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
             jcp_1x1.bcast_loop_output_step = jcp_1x1.ur
                     * (jcp_1x1.nb_load_blocking * jcp_1x1.oc_block)
                     * jcp_1x1.typesize_out;
@@ -274,7 +275,8 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);
 
-            size_t dw_conv_buffer_size_ = (size_t)nthr * jcp_dw_->kh
+            dim_t dw_conv_buffer_size_ = static_cast<dim_t>(nthr)
+                    * jcp_dw_->kh
                     * jcp_dw_->iw * jcp_dw_->dw_conv_buffer_oc;
             assert(dw_conv_buffer_size_);
             dw_scratchpad.book(memory_tracking::names::key_fusion_inout_buffer,

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -66,10 +66,10 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t block_tail
+        const dim_t block_tail
                 = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
                 % isa_simd_width_;
-        const size_t tail_size = block_tail
+        const dim_t tail_size = block_tail
                 ? block_tail
                 : (jcp.is_depthwise ? jcp.ngroups : jcp.oc_without_padding)
                         % isa_simd_width_;
@@ -94,8 +94,9 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::prepare_output(int ur_w) {
-    int nb_oc_block
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::prepare_output(
+        dim_t ur_w) {
+    const dim_t nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
     for (int k = 0; k < nb_oc_block; k++)
         for (int j = 0; j < ur_w; j++) {
@@ -144,36 +145,36 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::cvt2ps(data_type_t type_in,
 }
 
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w,
+static void iterate(const dim_t nb_oc_block, const dim_t ur_w,
         const bool last_oc_block_flag, const bool force_masking, const F &f) {
-    for (int k = 0; k < nb_oc_block; k++) {
+    for (dim_t k = 0; k < nb_oc_block; k++) {
         const bool mask_flag
                 = force_masking || (last_oc_block_flag && k + 1 == nb_oc_block);
-        for (int j = 0; j < ur_w; j++)
+        for (dim_t j = 0; j < ur_w; j++)
             f(mask_flag, k, j);
     }
 }
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w,
+static void iterate(const dim_t nb_oc_block, const dim_t ur_w,
         const bool last_oc_block_flag, const F &f) {
     iterate(nb_oc_block, ur_w, last_oc_block_flag, false, f);
 }
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w, const F &f) {
+static void iterate(const dim_t nb_oc_block, const dim_t ur_w, const F &f) {
     iterate(nb_oc_block, ur_w, false, false, f);
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_sum(int ur_w,
-        bool last_oc_block_flag, const int nb_oc_block, const int oc_block,
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_sum(dim_t ur_w,
+        bool last_oc_block_flag, const dim_t nb_oc_block, const dim_t oc_block,
         const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_sum) {
         const float sum_scale = *p_sum_scale;
         const int32_t sum_zp = *p_sum_zp;
         const auto sum_injector_lam
                 = [this, oc_block, sum_scale, sum_zp](
-                          const bool mask_flag, const int k, const int j) {
-            int aux_output_offset = jcp.typesize_out
+                          const bool mask_flag, const dim_t k, const dim_t j) {
+            dim_t aux_output_offset = jcp.typesize_out
                     * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
             auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
             Vmm vmm = vmm_out(j, k);
@@ -202,8 +203,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_sum(int ur_w,
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
-        bool last_oc_block_flag, const int nb_oc_block, const int oc_block,
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(dim_t ur_w,
+        bool last_oc_block_flag, const dim_t nb_oc_block, const dim_t oc_block,
         const float *p_sum_scale, const int32_t *p_sum_zp) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         apply_sum(ur_w, last_oc_block_flag, nb_oc_block, oc_block, p_sum_scale,
@@ -215,8 +216,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
             const bool oc_blk_is_smaller_than_vmm = oc_block < isa_simd_width_;
             iterate(nb_oc_block, ur_w, last_oc_block_flag,
                     oc_blk_is_smaller_than_vmm,
-                    [&](const bool mask_flag, const int k, const int j) {
-                const size_t aux_output_l_off = jcp.typesize_out
+                    [&](const bool mask_flag, const dim_t k, const dim_t j) {
+                const dim_t aux_output_l_off = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 const auto vmm_idx = vmm_out_idx(j, k);
@@ -231,7 +232,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
             postops_injector_->compute_vector_range(vmm_idxs, rhs_arg_params);
         } else {
             iterate(nb_oc_block, ur_w,
-                    [&](const bool, const int k, const int j) {
+                    [&](const bool, const dim_t k, const dim_t j) {
                 vmm_idxs.emplace(vmm_out_idx(j, k));
             });
             postops_injector_->compute_vector_range(vmm_idxs);
@@ -241,10 +242,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
-        int ur_w, bool last_oc_block_flag) {
-    int nb_oc_block
+        dim_t ur_w, bool last_oc_block_flag) {
+    const dim_t nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-    int oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
+    const dim_t oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
     if (jcp.signed_input)
@@ -265,23 +266,23 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         p_sum_zp = &p_entry.sum.zero_point;
     }
 
-    for (int k = 0; k < nb_oc_block; k++) {
+    for (dim_t k = 0; k < nb_oc_block; k++) {
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * k * oc_block;
+            const dim_t bias_offset = jcp.typesize_bia * k * oc_block;
             auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
 
             cvt2ps(jcp.bia_dt, vmm_bias, bias_addr, mask_flag);
         }
         if (jcp.signed_input) {
-            int comp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * k * oc_block;
             Vmm vmm_comp_ = vmm_mask(vmm_comp, mask_flag);
             vmovups(vmm_comp_,
                     EVEX_compress_addr(reg_compensation, comp_offset));
         }
         if (jcp.src_zero_point) {
             // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-            int zp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * k * oc_block;
             Vmm vmm_zp_ = vmm_mask(vmm_zp, mask_flag);
             vmovups(vmm_zp_,
                     EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -290,7 +291,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
                             reg_src_zero_point, 0, jcp.zp_src_is_common));
         }
         /* add to zmm_accum: compensation, zero_point, bias and permute */
-        for (int j = 0; j < ur_w; j++) {
+        for (dim_t j = 0; j < ur_w; j++) {
             Vmm vmm = vmm_out(j, k);
             if (jcp.is_fast_depthwise)
                 vpermd(zmm_out(j, k), zmm_permute, zmm_out(j, k));
@@ -326,7 +327,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             if (jcp.with_wei_scales) {
                 mov(reg_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
 
-                int scale_offset
+                const dim_t scale_offset
                         = jcp.is_oc_scale * (sizeof(float) * k * oc_block);
                 vmulps(vmm_k, vmm,
                         EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -352,9 +353,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         mov(reg_dst_scales, ptr[param1 + GET_OFF(dst_scales)]);
 
         /* Apply dst scale to accumulator */
-        for (int k = 0; k < nb_oc_block; k++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
             const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-            for (int j = 0; j < ur_w; j++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 const Vmm vmm_k = vmm_mask(vmm, mask_flag);
                 vmulps(vmm_k, vmm,
@@ -369,8 +370,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         vcvtdq2ps(vmm_zp, EVEX_compress_addr(reg_dst_zero_point, 0, true));
 
         /* Add dst zero_point to accumulator */
-        for (int k = 0; k < nb_oc_block; k++) {
-            for (int j = 0; j < ur_w; j++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 vaddps(vmm, vmm, vmm_zp);
             }
@@ -381,8 +382,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
     if (one_of(jcp.dst_dt, u8, s8, s32)) {
         init_saturate_f32(
                 vmm_zero, vmm_saturation, aux_reg_saturation, f32, jcp.dst_dt);
-        for (int k = 0; k < nb_oc_block; k++) {
-            for (int j = 0; j < ur_w; j++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 saturate_cvt_f32(vmm, vmm_zero, vmm_saturation, jcp.dst_dt);
             }
@@ -396,13 +397,13 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
     if (jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa)) {
         // Optimization: use single store instruction for pair of the
         // nearest vectors along OC dimension
-        for (int j = 0; j < ur_w; j++) {
-            int k = 0;
+        for (dim_t j = 0; j < ur_w; j++) {
+            dim_t k = 0;
             for (; k < rnd_dn(nb_oc_block, 2); k += 2) {
                 Vmm vmm = vmm_out(j, k);
                 Vmm vmm_next = vmm_out(j, k + 1);
 
-                int aux_output_offset = jcp.typesize_out
+                dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -417,7 +418,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             if (nb_oc_block % 2 != 0) {
                 Vmm vmm = vmm_out(j, k);
                 auto vmm_down = Vmm_down_t(vmm.getIdx());
-                int aux_output_offset = jcp.typesize_out
+                dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -429,10 +430,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             }
         }
     } else {
-        for (int k = 0; k < nb_oc_block; k++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
             const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-            for (int j = 0; j < ur_w; j++) {
-                int aux_output_offset = jcp.typesize_out
+            for (dim_t j = 0; j < ur_w; j++) {
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -457,14 +458,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker_dw(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     assert(!"invalid group blocking for depthwise convolution");
 }
 
 template <>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
 
     const bool compute_kernel = IMPLICATION(h_padded, jcp.signed_input);
 
@@ -473,11 +476,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    auto input_spatial_index = [this, pad_l](int oi, int ki) {
+    auto input_spatial_index = [this, pad_l](dim_t oi, dim_t ki) -> dim_t {
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
 
-    auto input_offset2 = [this](int ii, int ci) {
+    auto input_offset2 = [this](dim_t ii, dim_t ci) -> dim_t {
         if (jcp.is_fused_conv)
             return jcp.typesize_in
                     * (ii * jcp.dw_conv_buffer_oc + ci * jcp.ch_block);
@@ -486,11 +489,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
     };
 
     auto input_offset3 = [this, input_offset2, input_spatial_index](
-                                 int oi, int ci, int ki) {
+                                 dim_t oi, dim_t ci, dim_t ki) {
         return jcp.typesize_in * input_offset2(input_spatial_index(oi, ki), ci);
     };
 
-    auto kernel_offset = [this](int ci, int ki) {
+    auto kernel_offset = [this](dim_t ci, dim_t ki) -> dim_t {
         return jcp.typesize_in * ((ci * jcp.kh * jcp.kw + ki) * jcp.ch_block);
     };
 
@@ -504,16 +507,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
         }
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise && !h_padded) {
         // find bounds of input spatial indices
         bool first = true;
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = input_spatial_index(oi, ki);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; oi++) {
+                const dim_t ii = input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -523,13 +526,13 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 
     if (jcp.signed_input) vmovups(zmm_shifted_zero, vmm_shift);
 
-    for (int ci = 0; ci < jcp.nb_ch_blocking; ci++) {
+    for (dim_t ci = 0; ci < jcp.nb_ch_blocking; ci++) {
         const bool mask_flag = last_ic_block_flag != ic_block_t::no_last_block
                 && ci == jcp.nb_ch_blocking - 1;
         if (jcp.is_resrc_depthwise && !h_padded) {
             // now we can load input once and reuse up to jcp.kw times
-            for (int ii = ii_start; ii <= ii_end; ii++) {
-                int aux_input_offset = input_offset2(ii, ci);
+            for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                dim_t aux_input_offset = input_offset2(ii, ci);
                 const Zmm zmm_inp_tmp = zmm_inp(ii, jcp.nb_ch_blocking);
                 const Zmm zmm_inp_msk = mask_flag
                         ? zmm_inp_tmp | ktail_mask | T_z
@@ -546,10 +549,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
                     vpaddb(zmm_inp_tmp, zmm_inp_tmp, vmm_shift);
             }
         }
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int aux_kernel_offset = kernel_offset(ci, ki);
-            const int oi_start = get_ow_start(ki, pad_l);
-            const int oi_end = get_ow_end(ur_w, ki, pad_r);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            dim_t aux_kernel_offset = kernel_offset(ci, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
             if (compute_kernel) {
                 if (jcp.is_fast_depthwise) {
                     vbroadcasti32x4(zmm_wei,
@@ -562,20 +565,20 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 
                 if (h_padded) {
                     assert(jcp.signed_input);
-                    for (int oi = 0; oi < ur_w; oi++)
+                    for (dim_t oi = 0; oi < ur_w; oi++)
                         compute(zmm_out(oi, ci), zmm_wei, zmm_shifted_zero);
                 } else {
                     const Zmm r_zmm_src
                             = mask_flag ? zmm_src | ktail_mask : zmm_src;
-                    int start_ = jcp.signed_input ? 0 : oi_start;
-                    int end_ = jcp.signed_input ? ur_w : oi_end;
-                    for (int oi = start_; oi < end_; oi++) {
+                    const dim_t start_ = jcp.signed_input ? 0 : oi_start;
+                    const dim_t end_ = jcp.signed_input ? ur_w : oi_end;
+                    for (dim_t oi = start_; oi < end_; oi++) {
                         if (oi >= oi_start && oi < oi_end) {
                             if (jcp.is_resrc_depthwise) {
-                                int ii = input_spatial_index(oi, ki);
+                                const dim_t ii = input_spatial_index(oi, ki);
                                 zmm_src = zmm_inp(ii, jcp.nb_ch_blocking);
                             } else {
-                                int aux_input_offset
+                                dim_t aux_input_offset
                                         = input_offset3(oi, ci, ki);
                                 if (jcp.is_fast_depthwise) {
                                     assert(!mask_flag);
@@ -608,8 +611,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
                     if (jcp.is_fast_depthwise)
                         vpermd(zmm_wei, zmm_permute, zmm_wei);
                 } // else: already loaded weights from previous block
-                int zp_offset = 0;
-                for (int oi = 0; oi < ur_w; oi++) {
+                dim_t zp_offset = 0;
+                for (dim_t oi = 0; oi < ur_w; oi++) {
                     if (oi < oi_start || oi >= oi_end || h_padded) {
                         vpmulld(vmm_zp_tmp, zmm_wei,
                                 EVEX_compress_addr(reg_src_zero_point,
@@ -624,8 +627,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
 
@@ -638,22 +642,23 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int ch_block_all = jcp.ch_block * ic_block * oc_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t ch_block_all = jcp.ch_block * ic_block * oc_block;
 
-    int nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
 
-    auto input_offset = [this, stride_w, pad_l](int oi, int ic, int ki) {
+    auto input_offset
+            = [this, stride_w, pad_l](dim_t oi, dim_t ic, dim_t ki) -> dim_t {
         return jcp.typesize_in
                 * ((ki * (jcp.dilate_w + 1) + oi * stride_w - pad_l)
                                 * jcp.ic_without_padding * jcp.ngroups
                         + ic_sub_step * ic);
     };
-    auto kernel_offset
-            = [this, ch_block_all, oc_block](int ii, int ic, int ki) {
+    auto kernel_offset = [this, ch_block_all, oc_block](
+                                 dim_t ii, dim_t ic, dim_t ki) -> dim_t {
         return jcp.typesize_in
                 * ((ii * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
@@ -669,19 +674,19 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
         }
     };
 
-    for (int ki = 0; ki < kw; ki++) {
-        int jj_start = get_ow_start(ki, pad_l);
-        int jj_end = get_ow_end(ur_w, ki, pad_r);
-        int ic_tail_size = jcp.ic_without_padding % ic_sub_step;
-        int _start = jcp.signed_input ? 0 : jj_start;
-        int _end = jcp.signed_input ? ur_w : jj_end;
+    for (dim_t ki = 0; ki < kw; ki++) {
+        const dim_t jj_start = get_ow_start(ki, pad_l);
+        const dim_t jj_end = get_ow_end(ur_w, ki, pad_r);
+        const dim_t ic_tail_size = jcp.ic_without_padding % ic_sub_step;
+        const dim_t _start = jcp.signed_input ? 0 : jj_start;
+        const dim_t _end = jcp.signed_input ? ur_w : jj_end;
         /* Skip the last loads of input
             if (ic%16)/ic_sub_step < ic_block/ic_sub_step */
-        int icb = (last_ic_block_flag != ic_block_t::no_last_block)
-                ? div_up((jcp.ic_without_padding % ic_block), ic_sub_step)
+        const dim_t icb = (last_ic_block_flag != ic_block_t::no_last_block)
+                ? div_up(jcp.ic_without_padding % ic_block, ic_sub_step)
                 : ic_block / ic_sub_step;
         if (compute_kernel) {
-            for (int ic = 0; ic < icb; ic++) {
+            for (dim_t ic = 0; ic < icb; ic++) {
                 if (h_padded) {
                     // fill padded area with shifted value in first iteration
                     if (ic == 0) {
@@ -689,15 +694,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                         vmovups(inp, vmm_shift); // bcast(128)
                     }
                 } else {
-                    for (int jj = _start; jj < _end; jj++) {
-                        int aux_input_offset = input_offset(jj, ic, ki);
+                    for (dim_t jj = _start; jj < _end; jj++) {
+                        dim_t aux_input_offset = input_offset(jj, ic, ki);
                         if (jj >= jj_start && jj < jj_end) {
                             if (last_ic_block_flag == ic_block_t::last_sp_block
                                     && ic_tail_size != 0 && ic == icb - 1) {
                                 Xmm xmm_tmp = Xmm(
                                         vmm_inp(jj, nb_oc_block).getIdx());
                                 load_bytes(xmm_tmp, aux_reg_inp,
-                                        aux_input_offset, ic_tail_size);
+                                        aux_input_offset,
+                                        static_cast<int>(ic_tail_size));
                                 vpbroadcastd(vmm_inp(jj, nb_oc_block), xmm_tmp);
                             } else {
                                 vpbroadcastd(vmm_inp(jj, nb_oc_block),
@@ -717,11 +723,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                         }
                     }
                 }
-                for (int ii = 0; ii < nb_oc_block; ii++) {
-                    int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                for (dim_t ii = 0; ii < nb_oc_block; ii++) {
+                    dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                     vmovups(vmm_wei,
                             EVEX_compress_addr(aux_reg_ker, aux_kernel_offset));
-                    for (int jj = _start; jj < _end; jj++) {
+                    for (dim_t jj = _start; jj < _end; jj++) {
                         Vmm inp = h_padded ? vmm_inp(0, nb_oc_block)
                                            : vmm_inp(jj, nb_oc_block);
                         compute(vmm_out(jj, ii), vmm_wei, inp);
@@ -733,12 +739,12 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
             /* calculate src_zero_point padding as:
              *      (is_padding ? src_zero_point_s32 * conv(1, wei_s8) : 0) */
             Vmm vmm_tmp = vmm_inp(0, nb_oc_block);
-            for (int jj = 0; jj < ur_w; jj++) {
+            for (dim_t jj = 0; jj < ur_w; jj++) {
                 if (jj < jj_start || jj >= jj_end || h_padded) {
-                    for (int ii = 0; ii < nb_oc_block; ii++) {
+                    for (dim_t ii = 0; ii < nb_oc_block; ii++) {
                         vpxord(vmm_zp_tmp, vmm_zp_tmp, vmm_zp_tmp);
-                        for (int ic = 0; ic < icb; ic++) {
-                            int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                        for (dim_t ic = 0; ic < icb; ic++) {
+                            dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                             if (jcp.has_vnni) {
                                 vpdpbusd(vmm_zp_tmp, vmm_zp_one,
                                         EVEX_compress_addr(aux_reg_ker,
@@ -751,7 +757,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                                 vpaddd(vmm_zp_tmp, vmm_zp_tmp, vmm_tmp);
                             }
                         }
-                        int zp_offset = 0;
+                        const dim_t zp_offset = 0;
                         vpmulld(vmm_zp_tmp, vmm_zp_tmp,
                                 EVEX_compress_addr(reg_src_zero_point,
                                         zp_offset, jcp.zp_src_is_common));
@@ -767,16 +773,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::kh_loop(
-        int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag) {
     Label kd_label, kh_label, skip_kd_loop, skip_kh_loop;
     Label f_overflow_label, no_f_overflow_label, d_h_f_overflow_label,
             t_overflow_label, no_t_overflow_label, b_overflow_label,
             no_b_overflow_label, back_overflow_label, no_back_overflow_label,
             d_h_back_overflow_label;
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
-    int shift_input_ptr
+    dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    dim_t shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
+    dim_t shift_input_ptr
             = jcp.typesize_in * jcp.iw * jcp.ic_without_padding * jcp.ngroups;
 
     if (jcp.ndims == 5) {
@@ -917,7 +923,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::kh_loop(
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, bool is_last_sp_block) {
 
     if (jcp.src_zero_point && !jcp.is_depthwise) {
         xor_(reg_scratch, reg_scratch);
@@ -959,9 +965,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        int inp_step = jcp.ic_block;
-        const size_t ker_step = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.oc_block
-                * jcp.ic_block;
+        const dim_t inp_step = jcp.ic_block;
+        const dim_t ker_step = static_cast<dim_t>(jcp.kd) * jcp.kh * jcp.kw
+                * jcp.oc_block * jcp.ic_block;
         add(reg_inp, jcp.typesize_in * inp_step);
         safe_add(reg_ker, jcp.typesize_in * ker_step, reg_ker_long_offt);
 
@@ -999,16 +1005,19 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
     Label permute_index_table;
-    int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
-                                        : jcp.ic_without_padding * jcp.ngroups;
-    const int urw_inp_stride = jcp.ur_w * jcp.stride_w;
-    const int n_urw_l_pad = nstl::min(
-            div_up(nstl::max(0, jcp.l_pad), urw_inp_stride), jcp.ow / jcp.ur_w);
-    const int inp_shift_pad = nstl::max(0,
+    const dim_t in_ic_shift = jcp.is_fused_conv
+            ? jcp.dw_conv_buffer_oc
+            : jcp.ic_without_padding * jcp.ngroups;
+    const dim_t urw_inp_stride = jcp.ur_w * jcp.stride_w;
+    const dim_t n_urw_l_pad = nstl::min<dim_t>(
+            div_up(nstl::max<dim_t>(0, jcp.l_pad), urw_inp_stride),
+            jcp.ow / jcp.ur_w);
+    const dim_t inp_shift_pad = nstl::max<dim_t>(0,
             jcp.typesize_in * (n_urw_l_pad * urw_inp_stride - jcp.l_pad)
                     * in_ic_shift);
-    int inp_shift = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
-    int out_shift = jcp.typesize_out
+    const dim_t inp_shift
+            = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
+    const dim_t out_shift = jcp.typesize_out
             * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups);
     preamble();
 
@@ -1061,10 +1070,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         kmovb(ktail_mask, reg_tail_32);
     }
     if (jcp.ngroups % jcp.ch_block != 0 || jcp.oc_without_padding != jcp.oc) {
-        int tail_size = jcp.is_depthwise
+        const dim_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
-        int mask = (1 << tail_size) - 1;
+        const int mask = (1 << static_cast<int>(tail_size)) - 1;
         mov(reg_oc_blocks, ptr[param1 + GET_OFF(oc_blocks)]);
         Reg32 regw_tmp = reg_oi.cvt32();
         mov(regw_tmp, mask);
@@ -1096,19 +1105,21 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         mov(reg_scratch, permute_index_table);
         vmovdqu32(zmm_permute, ptr[reg_scratch]);
     }
-    const int extended_filter_size
-            = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int r_pad = nstl::max(0, jcp.r_pad);
+    const int extended_filter_size = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
+    const int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     const int ow_with_no_rpad = 1
-            + (jcp.iw + jcp.l_pad + nstl::min(0, jcp.r_pad)
-                      - extended_filter_size)
-                    / jcp.stride_w;
-    const int n_urw_per_ow_block = jcp.ow_block / jcp.ur_w;
-    const int max_safe_iw = nstl::max(
-            0, jcp.iw - div_up(ic_sub_step, jcp.ic_without_padding));
+            + static_cast<int>(
+                    (jcp.iw + jcp.l_pad + nstl::min<dim_t>(0, jcp.r_pad)
+                            - extended_filter_size)
+                    / jcp.stride_w);
+    const int n_urw_per_ow_block = static_cast<int>(jcp.ow_block / jcp.ur_w);
+    const int max_safe_iw = static_cast<int>(nstl::max<dim_t>(
+            0, jcp.iw - div_up(ic_sub_step, jcp.ic_without_padding)));
     const int max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
-            ? jcp.ow
-            : (max_safe_iw + jcp.l_pad - extended_filter_size) / jcp.stride_w;
+            ? static_cast<int>(jcp.ow)
+            : static_cast<int>((max_safe_iw + jcp.l_pad - extended_filter_size)
+                      / jcp.stride_w);
     Label middle_block_label, done_compute;
     std::vector<Label> ow_block_jmp_table;
 
@@ -1161,15 +1172,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         int cur_ow = 0;
 
         // l_pad region:
-        n_l_pad_labels = div_up(n_urw_l_pad, n_urw_per_ow_block);
+        n_l_pad_labels
+                = static_cast<int>(div_up(n_urw_l_pad, n_urw_per_ow_block));
         n_labels = n_l_pad_labels;
         cur_ow += n_urw_l_pad * jcp.ur_w;
 
         // middle_region:
         int n_urw_middle_block_loop = 0;
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
             n_urw_middle_block_loop
                     = nstl::max(0,
@@ -1183,11 +1195,12 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         // r_pad or ic_block_t::last_sp_block
         if (cur_ow + jcp.ur_w <= jcp.ow) {
             if (r_pad_fall_through_n_urw == 0) ++n_labels;
-            const int n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
-            n_labels += nstl::max(0,
+            const int n_urw_r_pad_region
+                    = static_cast<int>((jcp.ow - cur_ow) / jcp.ur_w);
+            n_labels += static_cast<int>(nstl::max<dim_t>(0,
                     div_up(r_pad_fall_through_n_urw + n_urw_r_pad_region,
                             n_urw_per_ow_block)
-                            - 1);
+                            - 1));
         }
 
         if (jcp.ur_w_tail != 0) {
@@ -1211,9 +1224,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
             L(middle_or_rpad_check);
             // harness passes shifted src pointer that does not take
             // left-padding into account. So, we must re-shift here.
-            const int inp_shift_pad_middle_block = -1 * jcp.typesize_in
-                    * nstl::min(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
-                    * in_ic_shift;
+            const int inp_shift_pad_middle_block = static_cast<int>(-1
+                    * jcp.typesize_in
+                    * nstl::min<dim_t>(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
+                    * in_ic_shift);
             add(reg_inp, inp_shift_pad_middle_block);
         }
         if (r_pad_fall_through_n_urw != 0) {
@@ -1256,7 +1270,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
     int label_cntr = 0;
     int cur_l_pad = 0;
     if (jcp.l_pad > 0) {
-        for (cur_l_pad = jcp.l_pad;
+        for (cur_l_pad = static_cast<int>(jcp.l_pad);
                 cur_l_pad > 0 && cur_ow + jcp.ur_w <= jcp.ow;
                 cur_l_pad -= urw_inp_stride) {
             if (jcp.nb_ow > 1 && cur_n_oi == 0) {
@@ -1272,9 +1286,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
             }
 
             cur_ow += jcp.ur_w;
-            int cur_r_pad = nstl::max(0,
+            int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                     calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                            jcp.stride_w, extended_filter_size));
+                            jcp.stride_w, extended_filter_size)));
             icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_out, out_shift);
             dec(reg_oi);
@@ -1294,9 +1308,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
 
     // middle_block
     {
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
             int n_oi_middle_block_loop
                     = nstl::max(0,
@@ -1337,8 +1351,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
                 L(ow_block_jmp_table[label_cntr++]);
             }
             cur_ow += jcp.ur_w;
-            int cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                    jcp.stride_w, extended_filter_size);
+            int cur_r_pad = static_cast<int>(calculate_end_padding(jcp.l_pad,
+                    cur_ow, jcp.iw, jcp.stride_w, extended_filter_size));
             assert(cur_r_pad > 0 || cur_ow > max_safe_ow); // else, why be here?
             icb_loop(jcp.ur_w, 0, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_inp, inp_shift);
@@ -1454,9 +1468,9 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1513,7 +1527,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                 VERBOSE_BLOCKING_FAIL, "bad blocking dimensions");
     }
 
-    jcp.simd_w = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+    jcp.simd_w
+            = static_cast<int>(jcp.is_depthwise ? jcp.ch_block : jcp.ic_block);
 
     const auto &zp = attr.zero_points_;
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
@@ -1666,10 +1681,13 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                     post_ops, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -1686,7 +1704,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // factor smaller than the left padding (special requirement for SSD:fc6),
     // then search for a smaller OC blocking that satisfies both constraints.
     auto is_oc_blocking_ok = [&](int block) {
-        int ur_w = nstl::min(jcp.ow, jcp.max_regs_ur / (block + 1));
+        int ur_w = static_cast<int>(
+                nstl::min<dim_t>(jcp.ow, jcp.max_regs_ur / (block + 1)));
         return jcp.nb_oc % block == 0 && jcp.l_pad <= ur_w
                 && jcp.ow % ur_w != 1;
     };
@@ -1701,8 +1720,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && jcp.stride_w == 1 && jcp.ic % 64 == 0
             && jcp.nthr <= ncores_per_socket)
         max_threading_nb_oc_chunk = 2;
-    jcp.nb_oc_blocking_thr_chunk
-            = nstl::min(max_threading_nb_oc_chunk, jcp.nb_oc);
+    jcp.nb_oc_blocking_thr_chunk = static_cast<int>(
+            nstl::min<dim_t>(max_threading_nb_oc_chunk, jcp.nb_oc));
     for (; jcp.nb_oc_blocking_thr_chunk > 1; jcp.nb_oc_blocking_thr_chunk--) {
         if (is_oc_blocking_ok(jcp.nb_oc_blocking_thr_chunk)) break;
     }
@@ -1718,7 +1737,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && !(jcp.kh == 1 && jcp.kw == 3)
             && !(jcp.kh >= 7 && jcp.oc % 64 == 0)) {
         const int max_nb_oc_blocking = 2;
-        jcp.nb_oc_blocking = nstl::min(max_nb_oc_blocking, jcp.nb_oc);
+        jcp.nb_oc_blocking = static_cast<int>(
+                nstl::min<dim_t>(max_nb_oc_blocking, jcp.nb_oc));
         for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
             if (jcp.nb_oc_blocking_thr_chunk % jcp.nb_oc_blocking == 0
                     && is_oc_blocking_ok(jcp.nb_oc_blocking))
@@ -1726,30 +1746,30 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     }
 
     if (jcp.is_resrc_depthwise)
-        jcp.ur_w = (jcp.max_regs_ur - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        jcp.ur_w = static_cast<int>((jcp.max_regs_ur - jcp.kw + jcp.stride_w)
+                / (jcp.nb_ch_blocking + jcp.stride_w));
     else
-        jcp.ur_w = jcp.max_regs_ur
+        jcp.ur_w = static_cast<int>(jcp.max_regs_ur
                 / (jcp.is_depthwise ? jcp.nb_ch_blocking
-                                    : jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
-    jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+                                    : jcp.nb_oc_blocking + 1));
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
+    jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
 
-    auto get_thr_eff = [&](int nb_ow, int nthr) {
-        int base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
+    auto get_thr_eff = [&](dim_t nb_ow, int nthr) {
+        const dim_t base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
                 * (jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk);
-        auto work_amount = base_work_amount * nb_ow;
-        return float(work_amount) / rnd_up(work_amount, nthr);
+        const dim_t work_amount = base_work_amount * nb_ow;
+        return float(work_amount) / (float)rnd_up(work_amount, nthr);
     };
 
-    auto get_ow_block = [&](int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+    auto get_ow_block = [&](dim_t ur_w, int nthr) {
+        dim_t res_ow_block = jcp.ow;
         float best_thr_eff = get_thr_eff(1, nthr);
         float thr_eff;
-        int max_nb_ow = div_up(jcp.ow, ur_w);
-        for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, ur_w);
+        for (dim_t nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
                     && best_thr_eff > 0.8f)
                 break;
@@ -1782,13 +1802,13 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     if (thr_eff < 0.9f && jcp.ngroups < jcp.nthr
             && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        int ow_block = static_cast<int>(jcp.ow_block);
         float best_thr_eff = -1.0f;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr > end_nthr; nthr--) {
-            ow_block = get_ow_block(jcp.ur_w, nthr);
-            eff = get_thr_eff(div_up(jcp.ow, ow_block), nthr);
+            ow_block = static_cast<int>(get_ow_block(jcp.ur_w, nthr));
+            eff = get_thr_eff(static_cast<int>(div_up(jcp.ow, ow_block)), nthr);
             if (eff > 1.1f * best_thr_eff) {
                 best_thr_eff = eff;
                 jcp.ow_block = ow_block;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -151,54 +151,58 @@ private:
     Xbyak::Zmm zmm_shifted_zero;
     Xbyak::Zmm zmm_permute;
 
-    int vmm_out_idx(int i_ur, int i_oc) {
-        const int nb_x_blocking
+    int vmm_out_idx(dim_t i_ur, dim_t i_oc) {
+        const dim_t nb_x_blocking
                 = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-        const int idx = i_ur * nb_x_blocking + i_oc;
+        const dim_t idx = i_ur * nb_x_blocking + i_oc;
         assert(idx < (jcp.is_depthwise              ? ker_dw_reg_base_idx
                                : jcp.src_zero_point ? ker_zp_reg_base_idx
                                                     : ker_reg_base_idx));
-        return idx;
+        return static_cast<int>(idx);
     }
 
-    Vmm vmm_out(int i_ur, int i_oc) { return Vmm(vmm_out_idx(i_ur, i_oc)); }
-    Xbyak::Zmm zmm_out(int i_ur, int i_oc) {
-        int idx = vmm_out(i_ur, i_oc).getIdx();
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) {
+        return Vmm(vmm_out_idx(i_ur, i_oc));
+    }
+    Xbyak::Zmm zmm_out(dim_t i_ur, dim_t i_oc) {
+        const int idx = vmm_out(i_ur, i_oc).getIdx();
         assert(idx
                 < (jcp.is_depthwise ? ker_dw_reg_base_idx : ker_reg_base_idx));
         return Xbyak::Zmm(idx);
     }
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
-    Xbyak::Zmm zmm_inp(int i_ic, int nb_x_blocking) {
-        const int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Xbyak::Zmm zmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         const int max_idx = jcp.src_zero_point ? ker_zp_reg_base_idx
                                                : ker_dw_reg_base_idx;
         assert(idx < max_idx);
         MAYBE_UNUSED(max_idx);
 
-        return Xbyak::Zmm(idx);
+        return Xbyak::Zmm(static_cast<int>(idx));
     }
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
-                - utils::div_up(
-                        nstl::max(0,
-                                pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
+                - utils::div_up(nstl::max<dim_t>(0,
+                                         pad_r
+                                                 - (jcp.kw - 1 - ki)
+                                                         * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
 
     // bf16 utils
-    int get_src_down_idx(int nb_x_blocking) {
-        int idx = nb_x_blocking * jcp.ur_w;
+    int get_src_down_idx(dim_t nb_x_blocking) {
+        const dim_t idx = nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return idx;
+        return static_cast<int>(idx);
     }
     inline Vmm maybe_mask_vmm(Vmm vmm, bool mask_flag) {
         return mask_flag ? vmm | ktail_mask_extended : vmm;
@@ -218,20 +222,23 @@ private:
                 maybe_mask_vmm_down(vmm_down, mask_flag || jcp.simd_w == 4));
     }
 
-    void prepare_output(int ur_w);
-    void apply_sum(int ur_w, bool last_oc_block_flag, const int nb_oc_block,
-            const int oc_block, const float *p_sum_scale,
+    void prepare_output(dim_t ur_w);
+    void apply_sum(dim_t ur_w, bool last_oc_block_flag, const dim_t nb_oc_block,
+            const dim_t oc_block, const float *p_sum_scale,
             const int32_t *p_sum_zp);
-    void apply_postops(int ur_w, bool last_oc_block_flag, const int nb_oc_block,
-            const int oc_block, const float *p_sum_scale,
+    void apply_postops(dim_t ur_w, bool last_oc_block_flag,
+            const dim_t nb_oc_block, const dim_t oc_block,
+            const float *p_sum_scale,
             const int32_t *p_sum_zp);
-    void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker_dw(int ur_w, int pad_l, int pad_r,
+    void store_output(dim_t ur_w, bool last_oc_block_flag);
+    void compute_ker_dw(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void compute_ker(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded = false);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool is_last_spatial_block);
+    void kh_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag);
+    void icb_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            bool is_last_spatial_block);
     void generate() override;
     void cvt2ps(data_type_t type_in, Vmm ymm_in, const Xbyak::Operand &op,
             bool mask_flag);
@@ -243,7 +250,8 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel_t {
     jit_avx512_core_x8s8s32x_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
@@ -75,8 +75,8 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
 
     size_t extra_data_offset
             = weights_d.size() - weights_d.additional_buffer_size();
-    size_t ch_offset = jcp.is_depthwise ? jcp.nb_ch * jcp.ch_block
-                                        : jcp.ngroups * jcp.oc;
+    const dim_t ch_offset = jcp.is_depthwise ? jcp.nb_ch * jcp.ch_block
+                                             : jcp.ngroups * jcp.oc;
     auto w = const_cast<char *>(weights);
     int32_t *compensation = (jcp.signed_input)
             ? reinterpret_cast<int32_t *>(&w[extra_data_offset])
@@ -86,13 +86,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
                     + (jcp.signed_input ? ch_offset : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
+    const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -108,7 +108,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -129,13 +129,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int gb = gg * jcp.nb_ch_blocking;
-            int g = gb * group_block;
-            int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.nb_ic * jcp.ic_block;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t gb = gg * jcp.nb_ch_blocking;
+            dim_t g = gb * group_block;
+            dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             p.bias = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                           : nullptr;
@@ -234,12 +234,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
+            = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -259,7 +260,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
         size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -276,20 +277,22 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
+            for (dim_t occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb
+                        = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -301,17 +304,17 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
                 auto src_w = src + src_d.blk_off(n, g_ic, ih_s, iw_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(max(0,
+                    dim_t dilate_h = jcp.dilate_h + 1;
+                    dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ij), dilate_h));
+                    dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
@@ -416,8 +419,8 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.nb_ch * jcp.ch_block : 0)
             : nullptr;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [= COMPAT_THIS_CAPTURE](dim_t n, dim_t oh_s, dim_t owb, dim_t gg) {
@@ -426,12 +429,12 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int gb = gg * jcp.nb_ch_blocking;
-        int g = gb * group_block;
+        dim_t gb = gg * jcp.nb_ch_blocking;
+        dim_t g = gb * group_block;
 
-        int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        int ow_s = owb * jcp.ow_block;
-        int iw_s = ow_s * jcp.stride_w;
+        dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        dim_t ow_s = owb * jcp.ow_block;
+        dim_t iw_s = ow_s * jcp.stride_w;
 
         auto bias_w = bias ? bias + (bias_d.blk_off(g) * bia_dt_size) : nullptr;
         int32_t *compensation_w = jcp.signed_input ? compensation + g : nullptr;
@@ -455,12 +458,15 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
                 ? static_cast<const float *>(wei_scales) + jcp.is_oc_scale * g
                 : nullptr;
 
-        int dilate_h = jcp.dilate_h + 1;
-        int i_t_overflow = nstl::min(jcp.kh, div_up(max(0, -ih_s), dilate_h));
-        int i_b_overflow = nstl::min(jcp.kh,
-                div_up(max(0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+        dim_t dilate_h = jcp.dilate_h + 1;
+        dim_t i_t_overflow = nstl::min<dim_t>(
+                jcp.kh, div_up(max<dim_t>(0, -ih_s), dilate_h));
+        dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                div_up(max<dim_t>(
+                               0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h));
-        int kh_padding = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+        dim_t kh_padding
+                = nstl::max<dim_t>(0, jcp.kh - i_t_overflow - i_b_overflow);
 
         size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
                 ? 0
@@ -535,13 +541,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -563,7 +569,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -580,32 +586,34 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
+            for (dim_t occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb
+                        = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-                int dilate_d = jcp.dilate_d + 1;
-                int d_f_overflow
-                        = nstl::min(jcp.kd, div_up(max(0, -id_s), dilate_d));
-                int d_back_overflow = nstl::min(jcp.kd,
-                        div_up(max(0,
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                dim_t dilate_d = jcp.dilate_d + 1;
+                dim_t d_f_overflow = nstl::min<dim_t>(
+                        jcp.kd, div_up(max<dim_t>(0, -id_s), dilate_d));
+                dim_t d_back_overflow = nstl::min<dim_t>(jcp.kd,
+                        div_up(max<dim_t>(0,
                                        id_s - jcp.id + (jcp.kd - 1) * dilate_d
                                                + 1),
                                 dilate_d));
 
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+                dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_f_overflow - d_back_overflow);
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -623,17 +631,17 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
                                           : d_f_overflow)
                                 * wht_d_stride;
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(max(0,
+                    dim_t dilate_h = jcp.dilate_h + 1;
+                    dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ij), dilate_h));
+                    dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -50,7 +50,7 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
     , postops_injector_(nullptr) {
 
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-        const std::size_t tail_size = jcp.is_depthwise
+        const dim_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
 
@@ -59,8 +59,8 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(Xbyak::Xmm(31).getIdx()), this->r14,
-                this->r15, this->r13, preserve_gpr, preserve_vmm,
+                Xbyak::Xmm(31).getIdx(), this->r14, this->r15, this->r13,
+                preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
                 memory_desc_wrapper(dst_md), tail_size, ktail_mask,
                 use_exact_tail_scalar_bcast};
@@ -258,9 +258,9 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride = 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.iw, jcp.ow, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -301,10 +301,13 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_oc = jcp.oc / jcp.oc_block;
@@ -313,18 +316,18 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     /* kernel blocking params */
     const int regs = jcp.has_vnni ? 30 : 28;
     jcp.nb_ch_blocking = 1;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
                 && jcp.l_pad <= regs / (jcp.nb_oc_blocking + 1))
             break;
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    int l_overflow = max(
-            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
+    int l_overflow = static_cast<int>(max<dim_t>(
+            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w));
 
     if (jcp.ow < jcp.ur_w) {
-        jcp.ur_w = jcp.ow;
+        jcp.ur_w = static_cast<int>(jcp.ow);
         jcp.ur_w_tail = 0;
     } else {
         for (; jcp.ur_w >= 1; jcp.ur_w--) {
@@ -337,10 +340,10 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
                are computed in a single call of compute loop */
             bool left_boundary_covered = jcp.ur_w >= l_overflow * jcp.stride_w;
             jcp.ur_w_tail = jcp.ow % jcp.ur_w;
-            int r_overflow_no_tail = max(0,
-                    ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad)
-                            - jcp.ur_w_tail)
-                            / jcp.stride_w);
+            int r_overflow_no_tail = static_cast<int>(max<dim_t>(0,
+                    ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                            - max<dim_t>(0, jcp.r_pad) - jcp.ur_w_tail)
+                            / jcp.stride_w));
             bool right_boundary_covered
                     = jcp.ur_w >= r_overflow_no_tail * jcp.stride_w;
 
@@ -494,7 +497,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
 
     const auto load_zp_src_pad_comp
             = [&](const Vmm &zp_pad_comp_vmm, const Xbyak::Address &comp_addr,
-                      const int ocb) {
+                      const dim_t ocb) {
         const bool is_last_ocb = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
         const bool is_tail = is_last_ocb && get_tail_size() > 0;
         if (is_tail)
@@ -503,16 +506,16 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
             vmovups(zp_pad_comp_vmm, comp_addr);
     };
 
-    const auto get_zp_src_comp_pad_off = [&](int it_kw, int ocb) {
+    const auto get_zp_src_comp_pad_off = [&](dim_t it_kw, dim_t ocb) {
         const auto kw_offset = it_kw * jcp.oc_without_padding * jcp.ngroups;
         const auto oc_offset = ocb * jcp.oc_block;
 
         return (kw_offset + oc_offset) * sizeof(int32_t);
     };
 
-    for (int it_kw = 0; it_kw < jcp.kw; ++it_kw) {
-        const int ow_start = get_ow_start(it_kw, l_overflow);
-        const int ow_end = get_ow_end(ur_w, it_kw, r_overflow);
+    for (dim_t it_kw = 0; it_kw < jcp.kw; ++it_kw) {
+        const dim_t ow_start = get_ow_start(it_kw, l_overflow);
+        const dim_t ow_end = get_ow_end(ur_w, it_kw, r_overflow);
 
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
             Vmm zp_src_comp_pad_vmm; // will be assigned later
@@ -521,7 +524,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
             const auto zp_src_comp_pad_off
                     = get_zp_src_comp_pad_off(it_kw, ocb);
 
-            for (int it_ow = 0; it_ow < ur_w; ++it_ow) {
+            for (dim_t it_ow = 0; it_ow < ur_w; ++it_ow) {
 
                 const bool inside_padded_area = h_padded
                         || !(it_ow >= ow_start && it_ow < ow_end
@@ -550,7 +553,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
     if (jcp.ndims > 3) {
         if (!base_comp_addr_loaded) load_base_zp_src_pad_comp_addr();
 
-        const auto kh_offset = jcp.kw * jcp.oc_without_padding * jcp.ngroups
+        const dim_t kh_offset = jcp.kw * jcp.oc_without_padding * jcp.ngroups
                 * sizeof(int32_t);
 
         add(reg_zp_src_pad_comp, kh_offset);
@@ -569,33 +572,34 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
     const bool signed_input_or_src_zp
             = (jcp.signed_input || jcp.src_zero_point);
 
-    const int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    const int ur_w_stride = signed_input_or_src_zp ? 1 : jcp.stride_w;
+    const dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    const int ur_w_stride
+            = signed_input_or_src_zp ? 1 : static_cast<int>(jcp.stride_w);
 
-    auto src_offset = [this](int oj, int icb, int ki) {
+    auto src_offset = [this](dim_t oj, dim_t icb, dim_t ki) {
         return jcp.typesize_in
                 * (((oj + jcp.l_pad - ki * (jcp.dilate_w + 1)) / jcp.stride_w)
                                 * jcp.ngroups * jcp.ic_without_padding
                         + icb * 4);
     };
 
-    auto kernel_offset = [this, ch_block_all](int ocb, int icb, int ki) {
+    auto kernel_offset = [this, ch_block_all](dim_t ocb, dim_t icb, dim_t ki) {
         return jcp.typesize_in
                 * ((ocb * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
                         + icb * jcp.oc_block * ic_sub_step);
     };
 
-    for (int ki = 0; ki < jcp.kw; ki++) {
-        int jj_start = get_ow_start(ki, l_overflow);
-        int jj_end = get_ow_end(ur_w, ki, r_overflow);
+    for (dim_t ki = 0; ki < jcp.kw; ki++) {
+        dim_t jj_start = get_ow_start(ki, l_overflow);
+        dim_t jj_end = get_ow_end(ur_w, ki, r_overflow);
 
-        int _start = (signed_input_or_src_zp) ? 0 : jj_start;
-        int _end = (signed_input_or_src_zp) ? ur_w : jj_end;
+        dim_t _start = (signed_input_or_src_zp) ? 0 : jj_start;
+        dim_t _end = (signed_input_or_src_zp) ? ur_w : jj_end;
 
-        int tail_size = jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
-                                         : jcp.ic_without_padding % 4;
-        int n_ic_blocks = jcp.is_depthwise
+        dim_t tail_size = jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
+                                           : jcp.ic_without_padding % 4;
+        dim_t n_ic_blocks = jcp.is_depthwise
                 ? 1
                 : (last_ic_block_flag & ~ker_block_t::no_last_block
                                   ? div_up(jcp.ic_without_padding
@@ -603,7 +607,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                                             4)
                                   : jcp.ic_block / 4);
 
-        for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
+        for (dim_t icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded == true) {
                 if (jcp.signed_input) {
                     /* fill padded area with shifted values */
@@ -613,9 +617,9 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                 }
             } else {
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
-                    int aux_src_off = src_offset(jj, icb1, ki);
+                    dim_t aux_src_off = src_offset(jj, icb1, ki);
 
                     if (jj >= jj_start && jj < jj_end
                             && ((jj + jcp.l_pad - ki) % jcp.stride_w == 0)) {
@@ -633,9 +637,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                                 && tail_size != 0 && icb1 == n_ic_blocks - 1) {
                             const Xmm xmm_tmp = Xmm(
                                     vmm_inp(jj, jcp.nb_oc_blocking).getIdx());
-                            for (int r = 0; r < tail_size; ++r)
+                            for (dim_t r = 0; r < tail_size; ++r)
                                 vpinsrb(xmm_tmp, xmm_tmp,
-                                        ptr[aux_reg_src + aux_src_off + r], r);
+                                        ptr[aux_reg_src + aux_src_off + r],
+                                        static_cast<uint8_t>(r));
                             vpbroadcastd(
                                     vmm_inp(jj, jcp.nb_oc_blocking), xmm_tmp);
                         } else {
@@ -657,7 +662,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                 }
             }
             for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-                int aux_filt_off = kernel_offset(ocb, icb1, ki);
+                dim_t aux_filt_off = kernel_offset(ocb, icb1, ki);
 
                 if (_end - _start > 0) {
                     if (jcp.is_depthwise)
@@ -667,7 +672,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                         vmovups(vmm_wei,
                                 EVEX_compress_addr(aux_reg_filt, aux_filt_off));
                 }
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
                     const bool jj_between_start_end
                             = jj >= jj_start && jj < jj_end;
                     const bool ki_applies_to_stride
@@ -696,15 +701,15 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     const bool signed_input_or_src_zp
             = (jcp.signed_input || jcp.src_zero_point);
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_src_ih = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw
+    dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    dim_t shift_src_ih = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw
             * jcp.ngroups * jcp.ic_without_padding;
-    int shift_src_id = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * jcp.iw
+    dim_t shift_src_id = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * jcp.iw
             * jcp.ngroups * jcp.ic_without_padding;
-    const int stride_h = signed_input_or_src_zp ? 1 : jcp.stride_h;
-    int shift_filt_kh = jcp.typesize_in * jcp.kw * ch_block_all * stride_h;
-    const int stride_d = signed_input_or_src_zp ? 1 : jcp.stride_d;
-    int shift_filt_kd
+    const dim_t stride_h = signed_input_or_src_zp ? 1 : jcp.stride_h;
+    dim_t shift_filt_kh = jcp.typesize_in * jcp.kw * ch_block_all * stride_h;
+    const dim_t stride_d = signed_input_or_src_zp ? 1 : jcp.stride_d;
+    dim_t shift_filt_kd
             = jcp.typesize_in * jcp.kw * ch_block_all * jcp.kh * stride_d;
 
     Label kd_loop_label, kh_loop_label, skip_kh_loop, skip_kd_loop;
@@ -744,9 +749,9 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
         if ((signed_input_or_src_zp) || (jcp.dilate_d >= jcp.id)
                 || (jcp.kd < jcp.stride_d)
                 || ((!signed_input_or_src_zp)
-                        && ((min(jcp.f_pad, jcp.back_pad) < 0)
+                        && ((min<dim_t>(jcp.f_pad, jcp.back_pad) < 0)
                                 || ((jcp.kd - 1) * (jcp.dilate_d + 1)
-                                        < nstl::max(
+                                        < nstl::max<dim_t>(
                                                 jcp.f_pad, jcp.back_pad))))) {
             cmp(reg_ki, 0);
             je(skip_kd_loop, T_NEAR);
@@ -782,9 +787,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     if ((signed_input_or_src_zp) || (jcp.dilate_h >= jcp.ih)
             || (jcp.kh < jcp.stride_h)
             || ((!signed_input_or_src_zp)
-                    && ((min(jcp.t_pad, jcp.b_pad) < 0)
+                    && ((min<dim_t>(jcp.t_pad, jcp.b_pad) < 0)
                             || ((jcp.kh - 1) * (jcp.dilate_h + 1)
-                                    < nstl::max(jcp.t_pad, jcp.b_pad))))) {
+                                    < nstl::max<dim_t>(
+                                            jcp.t_pad, jcp.b_pad))))) {
         cmp(reg_kh, 0);
         je(skip_kh_loop, T_NEAR);
     }
@@ -885,14 +891,14 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     }
 }
 template <typename Vmm>
-int jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_tail_size()
+dim_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_tail_size()
         const noexcept {
     return jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
                             : jcp.oc_without_padding % jcp.oc_block;
 }
 
 template <typename Vmm>
-int jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_blocking_size()
+dim_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_blocking_size()
         const noexcept {
     return jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
 }
@@ -948,7 +954,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
 
         const bool is_tail = get_tail_size() > 0;
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-            const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
             const bool is_last_ocb
                     = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
             const auto vmm = is_last_ocb && is_tail
@@ -970,12 +976,12 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
 
         const Vmm vmm_bias = vmm_tmp;
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+            const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
             auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
             cvt2ps(jcp.bia_dt, vmm_bias, bias_addr, mask_flag);
         }
         if (jcp.signed_input) {
-            int comp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
             auto comp_addr = EVEX_compress_addr(reg_compensation, comp_offset);
             cvt2ps(data_type::s32, vmm_comp, comp_addr, mask_flag);
         }
@@ -1010,7 +1016,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
             if (jcp.with_wei_scales) {
                 mov(reg_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
 
-                int scale_offset = jcp.is_oc_scale
+                const dim_t scale_offset = jcp.is_oc_scale
                         * (sizeof(float) * ocb * jcp.oc_block);
                 vmulps(mask_vmm, vmm,
                         EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -1043,7 +1049,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
                     const bool mask_flag
                             = last_oc_block == 1 && k == jcp.nb_oc_blocking - 1;
                     for (int j = 0; j < ur_w; j++) {
-                        int aux_output_offset = jcp.typesize_out
+                        dim_t aux_output_offset = jcp.typesize_out
                                 * (k * jcp.oc_block
                                         + j * jcp.oc_without_padding
                                                 * jcp.ngroups);
@@ -1072,7 +1078,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
                         = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
                 for (int ur = 0; ur < ur_w; ur++) {
                     const int vmm_idx = vmm_out(ur, ocb).getIdx();
-                    const size_t aux_output_offset = jcp.typesize_out
+                    const dim_t aux_output_offset = jcp.typesize_out
                             * (ocb * jcp.oc_block
                                     + ur * jcp.oc_without_padding
                                             * jcp.ngroups);
@@ -1163,7 +1169,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
     for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
         for (int ur = 0; ur < ur_w; ur++) {
-            int aux_dst_off = jcp.typesize_out
+            dim_t aux_dst_off = jcp.typesize_out
                     * (ur * jcp.ngroups * jcp.oc_without_padding
                             + ocb * jcp.oc_block);
             auto addr = EVEX_compress_addr(reg_dst, aux_dst_off);
@@ -1185,9 +1191,9 @@ template <typename Vmm>
 void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::icb_loop(
         int ur_w, int l_overflow, int r_overflow, bool is_last_sp_block) {
 
-    int shift_src_icb = jcp.typesize_in * jcp.ic_block;
-    const size_t shift_filt_icb = (size_t)jcp.typesize_in * jcp.kd * jcp.kh
-            * jcp.kw * jcp.ic_block * jcp.oc_block;
+    dim_t shift_src_icb = jcp.typesize_in * jcp.ic_block;
+    const dim_t shift_filt_icb = jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw
+            * jcp.ic_block * jcp.oc_block;
 
     prepare_output(ur_w);
 
@@ -1262,20 +1268,20 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::icb_loop(
 template <typename Vmm>
 ur_w_blks_params_t
 jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
-    const int n_ur_blocks = jcp.ow / jcp.ur_w;
+    const dim_t n_ur_blocks = jcp.ow / jcp.ur_w;
 
     ur_w_blks_params_t ur_w_blks_params;
-    int num_blks_to_process_sp_carefully = 0;
-    int idx_last_non_zero_l_overflow_blk = -1;
-    int idx_first_non_zero_r_overflow_blk = n_ur_blocks;
+    dim_t num_blks_to_process_sp_carefully = 0;
+    dim_t idx_last_non_zero_l_overflow_blk = -1;
+    dim_t idx_first_non_zero_r_overflow_blk = n_ur_blocks;
 
     static constexpr int src_pixels_loaded_for_bcast = 4;
     const auto ic_mod = jcp.ic_without_padding % src_pixels_loaded_for_bcast;
-    for (int blk_idx = 0; blk_idx < n_ur_blocks; blk_idx++) {
-        const int first_blk_dst_elem = blk_idx * jcp.ur_w;
-        const int last_dst_blk_elem = first_blk_dst_elem + jcp.ur_w - 1;
+    for (dim_t blk_idx = 0; blk_idx < n_ur_blocks; blk_idx++) {
+        const dim_t first_blk_dst_elem = blk_idx * jcp.ur_w;
+        const dim_t last_dst_blk_elem = first_blk_dst_elem + jcp.ur_w - 1;
 
-        const int last_blk_src_idx = nstl::min(
+        const dim_t last_blk_src_idx = nstl::min<dim_t>(
                 jcp.iw - 1, (last_dst_blk_elem + jcp.l_pad) / jcp.stride_w);
         const bool is_out_of_src_pixels_scope
                 = ((jcp.iw - 1 - last_blk_src_idx) * jcp.ic_without_padding
@@ -1284,30 +1290,29 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
 
         const bool process_sp_carefully
                 = (ic_mod != 0) && is_out_of_src_pixels_scope;
-        const int curr_l_overflow = nstl::max(0,
+        const dim_t curr_l_overflow = nstl::max<dim_t>(0,
                 ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad
                         - first_blk_dst_elem)
                         / jcp.stride_w);
-        const int curr_r_overflow = nstl::max(0,
+        const dim_t curr_r_overflow = nstl::max<dim_t>(0,
                 (last_dst_blk_elem + jcp.l_pad) / jcp.stride_w - (jcp.iw - 1));
 
         ur_w_blks_params.blks_params.emplace_back(
                 curr_l_overflow, curr_r_overflow, process_sp_carefully);
 
-        num_blks_to_process_sp_carefully
-                += static_cast<int>(process_sp_carefully);
+        num_blks_to_process_sp_carefully += process_sp_carefully;
         if (curr_l_overflow > 0) idx_last_non_zero_l_overflow_blk = blk_idx;
         if (curr_r_overflow > 0 && idx_first_non_zero_r_overflow_blk > blk_idx)
             idx_first_non_zero_r_overflow_blk = blk_idx;
     }
     idx_first_non_zero_r_overflow_blk
-            = nstl::max(idx_first_non_zero_r_overflow_blk,
+            = nstl::max<dim_t>(idx_first_non_zero_r_overflow_blk,
                     idx_last_non_zero_l_overflow_blk + 1);
     // limit num_r_overflow_blks and num_blks_to_process_last_sp_carefully so that:
-    // n_ur_blocks >= num_l_overflow_blks + max(num_r_overflow_blks, num_blks_to_process_last_sp_carefully)
+    // n_ur_blocks >= num_l_overflow_blks + max<dim_t>(num_r_overflow_blks, num_blks_to_process_last_sp_carefully)
     ur_w_blks_params.num_pre_blks
-            = nstl::max(0, idx_last_non_zero_l_overflow_blk + 1);
-    const int num_r_overflow_blks = idx_first_non_zero_r_overflow_blk
+            = nstl::max<dim_t>(0, idx_last_non_zero_l_overflow_blk + 1);
+    const dim_t num_r_overflow_blks = idx_first_non_zero_r_overflow_blk
                     <= idx_last_non_zero_l_overflow_blk
             ? n_ur_blocks - ur_w_blks_params.num_pre_blks
             : n_ur_blocks - idx_first_non_zero_r_overflow_blk;
@@ -1316,8 +1321,8 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
                     < n_ur_blocks
             ? num_blks_to_process_sp_carefully
             : n_ur_blocks - ur_w_blks_params.num_pre_blks;
-    ur_w_blks_params.num_post_blks
-            = nstl::max(num_r_overflow_blks, num_blks_to_process_sp_carefully);
+    ur_w_blks_params.num_post_blks = nstl::max<dim_t>(
+            num_r_overflow_blks, num_blks_to_process_sp_carefully);
 
     return ur_w_blks_params;
 }
@@ -1335,10 +1340,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
     vpbroadcastw(vmm_one, _t);
 
     if (jcp.ngroups % jcp.ch_block != 0 || jcp.oc_without_padding != jcp.oc) {
-        int tail_size = jcp.is_depthwise
+        const dim_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
-        int mask = (1 << tail_size) - 1;
+        const uint32_t mask = (uint32_t(1) << tail_size) - 1;
         Reg32 regw_tmp = reg_nur_w.cvt32();
         Label skip_tail_mask;
         if (jcp.is_depthwise) {
@@ -1355,26 +1360,26 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
     mov(reg_filt, ptr[param1 + GET_OFF(filt)]);
     mov(reg_dst, ptr[param1 + GET_OFF(dst)]);
 
-    int dst_shift = jcp.typesize_out * jcp.ur_w * jcp.ngroups
+    dim_t dst_shift = jcp.typesize_out * jcp.ur_w * jcp.ngroups
             * jcp.oc_without_padding;
-    int src_shift = jcp.typesize_in * (jcp.ur_w / jcp.stride_w) * jcp.ngroups
+    dim_t src_shift = jcp.typesize_in * (jcp.ur_w / jcp.stride_w) * jcp.ngroups
             * jcp.ic_without_padding;
 
     const auto ur_w_blks_params = get_ur_w_blks_params();
-    const int nur_w = jcp.ow / jcp.ur_w - ur_w_blks_params.num_pre_blks
-            - ur_w_blks_params.num_post_blks;
+    const int nur_w = static_cast<int>(jcp.ow / jcp.ur_w
+            - ur_w_blks_params.num_pre_blks - ur_w_blks_params.num_post_blks);
 
     const auto &blks_params = ur_w_blks_params.blks_params;
     const auto num_pre_blks = ur_w_blks_params.num_pre_blks;
     const auto num_post_blks = ur_w_blks_params.num_post_blks;
 
-    for (int i = 0; i < num_pre_blks; i++) {
+    for (dim_t i = 0; i < num_pre_blks; i++) {
         const bool blk_process_carefully = blks_params[i].process_sp_carefully;
-        const int blk_l_overflow = blks_params[i].l_overflow;
-        const int blk_r_overflow = blks_params[i].r_overflow;
+        const dim_t blk_l_overflow = blks_params[i].l_overflow;
+        const dim_t blk_r_overflow = blks_params[i].r_overflow;
 
-        icb_loop(jcp.ur_w, blk_l_overflow, blk_r_overflow,
-                blk_process_carefully);
+        icb_loop(jcp.ur_w, static_cast<int>(blk_l_overflow),
+                static_cast<int>(blk_r_overflow), blk_process_carefully);
         add(reg_src, src_shift);
         add(reg_dst, dst_shift);
     }
@@ -1399,11 +1404,11 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
         for (size_t i = start_blk_idx; i < blks_params_size; i++) {
             const bool blk_process_carefully
                     = blks_params[i].process_sp_carefully;
-            const int blk_l_overflow = blks_params[i].l_overflow;
-            const int blk_r_overflow = blks_params[i].r_overflow;
+            const dim_t blk_l_overflow = blks_params[i].l_overflow;
+            const dim_t blk_r_overflow = blks_params[i].r_overflow;
 
-            icb_loop(jcp.ur_w, blk_l_overflow, blk_r_overflow,
-                    blk_process_carefully);
+            icb_loop(jcp.ur_w, static_cast<int>(blk_l_overflow),
+                    static_cast<int>(blk_r_overflow), blk_process_carefully);
             add(reg_src, src_shift);
             add(reg_dst, dst_shift);
         }
@@ -1414,14 +1419,14 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
         //              when computing the left-most (in w dim) output pixel
         int l_overflow = 0;
         if (jcp.ur_w == jcp.ow)
-            l_overflow = max(0,
+            l_overflow = static_cast<int>(max<dim_t>(0,
                     ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad)
-                            / jcp.stride_w);
+                            / jcp.stride_w));
         // r_overflow - no/ of spatial elements of weights standing out of src spatial
         //              when computing the right-most (in w dim) output pixel
-        const int r_overflow = max(0,
-                ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad))
-                        / jcp.stride_w);
+        const int r_overflow = static_cast<int>(max<dim_t>(0,
+                ((jcp.kw - 1) * (jcp.dilate_w + 1) - max<dim_t>(0, jcp.r_pad))
+                        / jcp.stride_w));
 
         icb_loop(jcp.ur_w_tail, l_overflow, r_overflow, true);
     }
@@ -1466,8 +1471,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
     const auto post_ops_binary_rhs_arg_vec
             = binary_injector::prepare_binary_args(jcp.post_ops, ctx);
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const void *src_scales
             = CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
@@ -1487,8 +1492,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1504,7 +1509,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0};
+        dim_t n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks);
         else if (jcp.loop_order == loop_cgn)
@@ -1513,9 +1518,9 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
 
             p.dst = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             p.src = src + src_d.blk_off(n, g_ic);
@@ -1587,8 +1592,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     size_t src_h_stride = src_d.blk_off(0, 0, 1);
     size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -1612,8 +1617,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1630,7 +1635,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     oh_s, jcp.oh);
@@ -1641,11 +1646,11 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
-            int work_rem = end - start;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            dim_t work_rem = end - start;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
 
             auto dst_w = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             auto src_w = src + src_d.blk_off(n, g_ic);
@@ -1656,17 +1661,18 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    int o_b_overflow
-                            = div_up(max(0,
+                    dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1674,15 +1680,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    int o_t_overflow = max(
+                    dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    int o_b_overflow = max(0,
+                    dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1690,7 +1696,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                int wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
+                dim_t wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
                 p.src = src_w + ih_max * src_h_stride;
@@ -1700,10 +1706,10 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                 p.compensation = compensation_w;
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
@@ -1772,8 +1778,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     size_t src_d_stride = src_d.blk_off(0, 0, 1);
     size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);
@@ -1800,8 +1806,9 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
+        dim_t start {0}, end {0};
+        const dim_t work_amount
+                = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1818,7 +1825,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     od_s, jcp.od, oh_s, jcp.oh);
@@ -1829,23 +1836,24 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
-            int work_rem = end - start;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-            int input_d_s = 0, kd_len = 0, kd_lo = 0;
-            int d_t_overflow, d_back_overflow;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            dim_t work_rem = end - start;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t input_d_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t d_t_overflow, d_back_overflow;
 
             if (jcp.dilate_d != 0 && jcp.stride_d == 1) {
                 /* dilation */
-                int dilate_d = jcp.dilate_d + 1;
+                dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
                 d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
                         dilate_d);
                 d_back_overflow
-                        = div_up(max(0,
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.od
                                                  + od_s - jcp.back_pad),
                                 dilate_d);
@@ -1853,15 +1861,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 kd_lo = d_back_overflow;
                 input_d_s = od_s + jcp.f_pad - d_back_overflow * dilate_d;
             } else {
-                int d_t_overflow = max(
+                dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - (od_s + 1 + jcp.f_pad)) / jcp.stride_d);
-                int d_back_overflow = max(0,
+                dim_t d_back_overflow = max<dim_t>(0,
                         ((od_s + jcp.kd) - (jcp.od + jcp.back_pad))
                                 / jcp.stride_d);
-                int overflow_kd_hi = jcp.kd - 1
+                dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(jcp.od + jcp.back_pad - (od_s + 1),
                                 jcp.stride_d);
-                int overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
+                dim_t overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_back_overflow;
@@ -1883,17 +1891,18 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    int o_b_overflow
-                            = div_up(max(0,
+                    dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1901,15 +1910,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    int o_t_overflow = max(
+                    dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    int o_b_overflow = max(0,
+                    dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1917,7 +1926,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                int wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
+                dim_t wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
                 p.src = src_w + ih_max * src_h_stride;
@@ -1929,19 +1938,19 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 strides together */
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kd
                                           - (kd_lo
-                                                  + max(0, kd_len - 1)
+                                                  + max<dim_t>(0, kd_len - 1)
                                                           * jcp.stride_d
                                                   + 1));
                 p.back_overflow = kd_lo;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -49,25 +49,25 @@ enum ker_block_t {
 struct ur_w_blks_params_t {
     struct single_ur_w_blk_params_t {
         single_ur_w_blk_params_t(
-                int l_overflow, int r_overflow, bool process_sp_carefully)
+                dim_t l_overflow, dim_t r_overflow, bool process_sp_carefully)
             : l_overflow(l_overflow)
             , r_overflow(r_overflow)
             , process_sp_carefully(process_sp_carefully) {}
 
         // l_overflow - no. of spatial elements of weights standing out of
         // src spatial when computing the 1st output pixel in the current blk
-        int l_overflow;
+        dim_t l_overflow;
         // r_overflow - no. of spatial elements of weights standing out of
         // src spatial when computing the lst output pixel in the current blk
-        int r_overflow;
+        dim_t r_overflow;
         // process_sp_carefully - indicates if loading the last src sp
         // for computation of the last dst sp of the block can't be done
         // by fetching 4 src sp at once
         bool process_sp_carefully;
     };
     std::vector<single_ur_w_blk_params_t> blks_params;
-    int num_pre_blks; // num of blocks with l_overflow>0
-    int num_post_blks; // num of blocks with r_overflow>0 or that need to be
+    dim_t num_pre_blks; // num of blocks with l_overflow>0
+    dim_t num_post_blks; // num of blocks with r_overflow>0 or that need to be
             // processed carefully
 };
 
@@ -141,19 +141,19 @@ private:
     const Vmm vmm_scale_adjust = Vmm(31);
     const Vmm vmm_prev_dst = Vmm(31);
 
-    Vmm vmm_out(int i_ur, int i_oc) {
-        int idx = i_ur * jcp.nb_oc_blocking + i_oc;
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) {
+        const dim_t idx = i_ur * jcp.nb_oc_blocking + i_oc;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) const {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) const {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
 
-    int get_ow_start(int ki, int l_overflow) {
-        int res = (jcp.ow - 1 + jcp.r_pad) % jcp.stride_w
+    dim_t get_ow_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.ow - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -161,18 +161,18 @@ private:
         return res;
     }
 
-    int get_ow_end(int ur_w, int ki, int r_overflow) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.ow, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
         return ur_w - res;
     }
 
-    int get_blocking_size() const noexcept;
-    int get_tail_size() const noexcept;
+    dim_t get_blocking_size() const noexcept;
+    dim_t get_tail_size() const noexcept;
     void prepare_output(int ur_w);
     void store_output(int ur_w, bool last_oc_block);
     void compute(const Vmm &vreg_acc, const Vmm &vreg_wei, const Vmm &vreg_src);
@@ -200,7 +200,8 @@ struct jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t {
             const memory_desc_t &dst_md)
         : kernel_(nullptr) {
 
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<

--- a/src/cpu/x64/jit_avx512_sparse_decompress_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_sparse_decompress_kernel.hpp
@@ -57,7 +57,8 @@ struct jit_avx512_sparse_decompress_kernel_t : public jit_generator_t {
         }
 
         blk_sz_ = a_outter_blk_sz_ * b_blk_sz_ * a_inner_blk_sz_;
-        nblks_to_decompress_ = bgmmc.K_blk * b_blk_sz_ / blk_sz_;
+        nblks_to_decompress_
+                = static_cast<int>(bgmmc.K_blk * b_blk_sz_ / blk_sz_);
     }
 
     void tile_configure(const char *palette) const { (*this)(palette); }

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -38,17 +38,17 @@ using namespace data_type;
 
 namespace {
 struct blk_info_t {
-    int n_lpad_blks;
-    int rpad_blk_start_idx;
+    dim_t n_lpad_blks;
+    dim_t rpad_blk_start_idx;
 };
-blk_info_t get_blocks_info(int sp_i, int sp_o, int k, int stride, int lpad,
-        int rpad, int blk_size) {
+blk_info_t get_blocks_info(dim_t sp_i, dim_t sp_o, dim_t k, dim_t stride,
+        dim_t lpad, dim_t rpad, dim_t blk_size) {
 
-    const int max_blks = div_up(sp_o, blk_size);
-    const int blk_shift = stride * blk_size;
-    const int n_lpad_blks = nstl::min(
+    const dim_t max_blks = div_up(sp_o, blk_size);
+    const dim_t blk_shift = stride * blk_size;
+    const dim_t n_lpad_blks = nstl::min(
             max_blks, div_up(lpad, blk_shift) + 1 /*include zero lpad*/);
-    const int rpad_blk_start_idx = saturate(
+    const dim_t rpad_blk_start_idx = saturate(
             n_lpad_blks, max_blks, (sp_i + lpad - k + 1) / blk_shift);
     return {n_lpad_blks, rpad_blk_start_idx};
 }
@@ -293,8 +293,9 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
     auto &jcp = jcp_;
 
     auto gen_batch_elements
-            = [&jcp](int fpad, int backpad, int tpad, int bpad, int lpad,
-                      int rpad, int &bs, brgemm_batch_element_t *batches) {
+            = [&jcp](dim_t fpad, dim_t backpad, dim_t tpad, dim_t bpad,
+                      dim_t lpad, dim_t rpad, int &bs,
+                      brgemm_batch_element_t *batches) {
         const bool requires_batch_pad
                 = jcp.s8s8_compensation_required || jcp.src_zero_point;
         const size_t src_w_stride = jcp.ngroups * jcp.src_dsz;
@@ -306,19 +307,20 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
         const size_t wei_h_stride = wei_w_stride * jcp.kw;
         const size_t wei_d_stride = wei_h_stride * jcp.kh;
 
-        const int adj_backpad = nstl::max(0, backpad);
-        const int adj_bpad = nstl::max(0, bpad);
+        const dim_t adj_backpad = nstl::max(dim_t(0), backpad);
+        const dim_t adj_bpad = nstl::max(dim_t(0), bpad);
 
-        for_(int kd = 0; kd < jcp.kd; ++kd)
-        for_(int kh = 0; kh < jcp.kh; ++kh)
-        for (int kw = 0; kw < jcp.kw; ++kw) {
+        for_(dim_t kd = 0; kd < jcp.kd; ++kd)
+        for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+        for (dim_t kw = 0; kw < jcp.kw; ++kw) {
             const bool padded_bs = kd < fpad || kd >= jcp.kd - adj_backpad
                     || kh < tpad || kh >= jcp.kh - adj_bpad;
             if (!requires_batch_pad && padded_bs) continue;
             auto &batch = batches[bs];
-            batch.vvpad.top = div_up(nstl::max(0, lpad - kw), jcp.stride_w);
+            batch.vvpad.top
+                    = div_up(nstl::max(dim_t(0), lpad - kw), jcp.stride_w);
             batch.vvpad.bottom = div_up(
-                    nstl::max(0, rpad - jcp.kw + kw + 1), jcp.stride_w);
+                    nstl::max(dim_t(0), rpad - jcp.kw + kw + 1), jcp.stride_w);
             batch.has_s8s8_comp_batch_pad = padded_bs;
             const dim_t offs_A
                     = kd * src_d_stride + kh * src_h_stride + kw * src_w_stride;
@@ -332,17 +334,19 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
         }
     };
 
-    const int w_shift = jcp.ow_block * jcp.stride_w;
-    const int h_shift = jcp.stride_h;
-    const int d_shift = jcp.stride_d;
+    const dim_t w_shift = jcp.ow_block * jcp.stride_w;
+    const dim_t h_shift = jcp.stride_h;
+    const dim_t d_shift = jcp.stride_d;
 
     const auto w_blk_info = get_blocks_info(jcp.iw, jcp.ow, jcp.kw,
             jcp.stride_w, jcp.l_pad, jcp.r_pad, jcp.ow_block);
-    const int rpad_0
+    const dim_t rpad_0
             = (jcp.ow_block - 1) * jcp.stride_w + jcp.kw - (jcp.iw + jcp.l_pad);
-    const int rpad_1 = rpad_0 + (nstl::max(0, -rpad_0) / w_shift + 1) * w_shift;
-    const int n_uniq_rpads
-            = 1 + div_up(nstl::max(0, jcp.r_pad - (rpad_1 - w_shift)), w_shift);
+    const dim_t rpad_1
+            = rpad_0 + (nstl::max(dim_t(0), -rpad_0) / w_shift + 1) * w_shift;
+    const dim_t n_uniq_rpads = 1
+            + div_up(nstl::max(dim_t(0), jcp.r_pad - (rpad_1 - w_shift)),
+                    w_shift);
 
     const auto h_blk_info = get_blocks_info(
             jcp.ih, jcp.oh, jcp.kh, jcp.stride_h, jcp.t_pad, jcp.b_pad, 1);
@@ -350,41 +354,41 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
     const auto d_blk_info = get_blocks_info(
             jcp.id, jcp.od, jcp.kd, jcp.stride_d, jcp.f_pad, jcp.back_pad, 1);
 
-    const int max_bs = jcp.kd * jcp.kh * jcp.kw;
-    const int n_d_uniq_blks
+    const dim_t max_bs = jcp.kd * jcp.kh * jcp.kw;
+    const dim_t n_d_uniq_blks
             = d_blk_info.n_lpad_blks + (jcp.od - d_blk_info.rpad_blk_start_idx);
-    const int n_h_uniq_blks
+    const dim_t n_h_uniq_blks
             = h_blk_info.n_lpad_blks + (jcp.oh - h_blk_info.rpad_blk_start_idx);
-    const int n_w_uniq_lpads = w_blk_info.n_lpad_blks;
-    const int uniq_blks
+    const dim_t n_w_uniq_lpads = w_blk_info.n_lpad_blks;
+    const dim_t uniq_blks
             = n_d_uniq_blks * n_h_uniq_blks * n_w_uniq_lpads * n_uniq_rpads;
 
     bs_.resize(uniq_blks, 0);
     batches_.resize(bs_.size() * max_bs);
     int bi = 0;
 
-    for_(int odb = 0; odb < n_d_uniq_blks; ++odb)
-    for_(int ohb = 0; ohb < n_h_uniq_blks; ++ohb)
-    for_(int owb = 0; owb < n_w_uniq_lpads; ++owb)
-    for (int rpad_i = 0; rpad_i < n_uniq_rpads; ++rpad_i) {
-        const int lpad = jcp.l_pad - owb * w_shift;
-        const int rpad = rpad_i == 0
+    for_(dim_t odb = 0; odb < n_d_uniq_blks; ++odb)
+    for_(dim_t ohb = 0; ohb < n_h_uniq_blks; ++ohb)
+    for_(dim_t owb = 0; owb < n_w_uniq_lpads; ++owb)
+    for (dim_t rpad_i = 0; rpad_i < n_uniq_rpads; ++rpad_i) {
+        const dim_t lpad = jcp.l_pad - owb * w_shift;
+        const dim_t rpad = rpad_i == 0
                 ? rpad_0
                 : nstl::min(jcp.r_pad, rpad_1 + (rpad_i - 1) * w_shift);
 
-        const int tpad = jcp.t_pad - ohb * h_shift;
-        const int oh = ohb < h_blk_info.n_lpad_blks
+        const dim_t tpad = jcp.t_pad - ohb * h_shift;
+        const dim_t oh = ohb < h_blk_info.n_lpad_blks
                 ? ohb
                 : (h_blk_info.rpad_blk_start_idx
                           + (ohb - h_blk_info.n_lpad_blks));
-        const int bpad = oh * h_shift + jcp.kh - (jcp.ih + jcp.t_pad);
+        const dim_t bpad = oh * h_shift + jcp.kh - (jcp.ih + jcp.t_pad);
 
-        const int fpad = jcp.f_pad - odb * d_shift;
-        const int od = odb < d_blk_info.n_lpad_blks
+        const dim_t fpad = jcp.f_pad - odb * d_shift;
+        const dim_t od = odb < d_blk_info.n_lpad_blks
                 ? odb
                 : (d_blk_info.rpad_blk_start_idx
                           + (odb - d_blk_info.n_lpad_blks));
-        const int backpad = od * d_shift + jcp.kd - (jcp.id + jcp.f_pad);
+        const dim_t backpad = od * d_shift + jcp.kd - (jcp.id + jcp.f_pad);
 
         gen_batch_elements(fpad, backpad, tpad, bpad, lpad, rpad, bs_[bi],
                 &batches_[bi * max_bs]);
@@ -399,23 +403,26 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
     auto &jcp = jcp_;
     const bool is_3d = ndims() == 5;
 
-    auto init_bcp = [&](int &idx, const int M, const int N) {
+    auto init_bcp = [&](int &idx, const dim_t M, const dim_t N) {
         const float alpha = 1.f;
         const float beta = 0.f;
-        const int LDA = jcp.ngroups * jcp.stride_w;
-        const int LDC = jcp.ngroups;
-        const int LDD = jcp.ngroups;
+        const dim_t LDA = jcp.ngroups * jcp.stride_w;
+        const dim_t LDC = jcp.ngroups;
+        const dim_t LDD = jcp.ngroups;
 
         brgemm_attr_t brg_attr;
         brg_attr.max_bs = jcp.kw * jcp.kh * jcp.kd;
-        brg_attr.max_top_vpad = nstl::max(0, jcp.l_pad);
-        brg_attr.max_bottom_vpad = nstl::max(0, jcp.r_pad);
-        brg_attr.max_top_bpad = nstl::max(0, nstl::max(jcp.t_pad, jcp.f_pad));
-        brg_attr.max_bottom_bpad
-                = nstl::max(0, nstl::max(jcp.b_pad, jcp.back_pad));
+        brg_attr.max_top_vpad
+                = static_cast<int>(nstl::max(dim_t(0), jcp.l_pad));
+        brg_attr.max_bottom_vpad
+                = static_cast<int>(nstl::max(dim_t(0), jcp.r_pad));
+        brg_attr.max_top_bpad = static_cast<int>(
+                nstl::max(dim_t(0), nstl::max(jcp.t_pad, jcp.f_pad)));
+        brg_attr.max_bottom_bpad = static_cast<int>(
+                nstl::max(dim_t(0), nstl::max(jcp.b_pad, jcp.back_pad)));
         brg_attr.hint_bs_group
                 = is_superset(jcp.isa, avx512_core) && jcp.stride_w == 1
-                ? jcp.kw
+                ? static_cast<int>(jcp.kw)
                 : 1;
 
         // only needed for strd batch_kind
@@ -478,7 +485,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
                     jcp.ow_block = ow_tail_block;
                 else { jcp.ow_block = jcp.ow; }
             } else {
-                const int max_ow_block = is_superset(jcp.isa, avx512_core)
+                const dim_t max_ow_block = is_superset(jcp.isa, avx512_core)
                         ? 6
                         : bcp_0.bd_block2 /*TODO: Tune for avx2*/;
                 jcp.ow_block = nstl::min(max_ow_block, jcp.ow);
@@ -499,7 +506,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
                 else
                     jcp.nb_ch_blocking = jcp.ngroups;
             } else {
-                const int max_ch_block2 = is_superset(jcp.isa, avx512_core)
+                const dim_t max_ch_block2 = is_superset(jcp.isa, avx512_core)
                         ? 4
                         : bcp_0.ld_block2 /*TODO: Tune for avx2*/;
                 jcp.nb_ch_blocking
@@ -508,7 +515,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
             jcp.chb_tail = jcp.ngroups % jcp.nb_ch_blocking;
         }
 
-        const int n_owb_kernels = std::ceil(log2(jcp.nb_ow));
+        const int n_owb_kernels = static_cast<int>(std::ceil(log2(jcp.nb_ow)));
         const int num_kernels = 1 /*full ow*/ + n_owb_kernels
                 + (jcp.chb_tail != 0) + (jcp.nb_ch_blocking != jcp.ngroups)
                 + (jcp.ow_tail != 0);
@@ -607,12 +614,13 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
                       + extra_data_offset + s8_offset)
             : nullptr;
 
-    const int chb_step = jcp.nb_ch_blocking;
-    const int chb_work = div_up(jcp.ngroups, chb_step);
-    const int ow_step = jcp.ow_block;
-    const int work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow * chb_work;
+    const int chb_step = static_cast<int>(jcp.nb_ch_blocking);
+    const int chb_work = div_up(static_cast<int>(jcp.ngroups), chb_step);
+    const int ow_step = static_cast<int>(jcp.ow_block);
+    const int work_amount
+            = static_cast<int>(jcp.mb * jcp.od * jcp.oh * jcp.nb_ow * chb_work);
 
-    const int max_bs = jcp.kd * jcp.kh * jcp.kw;
+    const int max_bs = static_cast<int>(jcp.kd * jcp.kh * jcp.kw);
 
     const size_t src_ch_stride = jcp.src_dsz;
     const size_t src_w_stride = jcp.ngroups * jcp.src_dsz;
@@ -636,16 +644,19 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
             jcp.ih, jcp.oh, jcp.kh, jcp.stride_h, jcp.t_pad, jcp.b_pad, 1);
     const auto d_blk_info = get_blocks_info(
             jcp.id, jcp.od, jcp.kd, jcp.stride_d, jcp.f_pad, jcp.back_pad, 1);
-    const int n_w_blks = w_blk_info.n_lpad_blks;
-    const int n_h_blks = h_blk_info.n_lpad_blks
-            + nstl::max(0, jcp.oh - h_blk_info.rpad_blk_start_idx);
+    const int n_w_blks = static_cast<int>(w_blk_info.n_lpad_blks);
+    const int n_h_blks = static_cast<int>(h_blk_info.n_lpad_blks)
+            + nstl::max(0,
+                    static_cast<int>(jcp.oh - h_blk_info.rpad_blk_start_idx));
 
-    const int w_shift = jcp.ow_block * jcp.stride_w;
-    const int rpad_0
-            = (jcp.ow_block - 1) * jcp.stride_w + jcp.kw - (jcp.iw + jcp.l_pad);
+    const int w_shift = static_cast<int>(jcp.ow_block * jcp.stride_w);
+    const int rpad_0 = static_cast<int>(
+            (jcp.ow_block - 1) * jcp.stride_w + jcp.kw - (jcp.iw + jcp.l_pad));
     const int rpad_1 = rpad_0 + (nstl::max(0, -rpad_0) / w_shift + 1) * w_shift;
-    const int n_rpad_blks
-            = 1 + div_up(nstl::max(0, jcp.r_pad - (rpad_1 - w_shift)), w_shift);
+    const int n_rpad_blks = 1
+            + div_up(nstl::max(0,
+                             static_cast<int>(jcp.r_pad - (rpad_1 - w_shift))),
+                    w_shift);
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         int start {0}, end {0};
@@ -685,8 +696,8 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
 
             // Begin: get number of owb to process and its corresponding ker_idx
             const auto rem_work = end - iwork;
-            const int rem_row_owb
-                    = saturate(1, jcp.nb_ow - owb, rem_work / chb_work);
+            const int rem_row_owb = saturate(
+                    1, static_cast<int>(jcp.nb_ow - owb), rem_work / chb_work);
             int cur_n_owb = 1;
             int ker_idx = 0;
             if (is_n_tail) {
@@ -697,12 +708,12 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
                 ker_idx = jcp.nb_ch_blocking_idx;
             } else if (rem_row_owb == jcp.nb_ow) {
                 ker_idx = 0;
-                cur_n_owb = jcp.nb_ow;
+                cur_n_owb = static_cast<int>(jcp.nb_ow);
             } else {
                 // The ow_tail kernel is processed alone, subtract if it exists.
-                const int log_rem_owb = log2(rem_row_owb
+                const int log_rem_owb = static_cast<int>(log2(rem_row_owb
                         - (owb + rem_row_owb >= jcp.nb_ow)
-                                * (jcp.ow_tail != 0));
+                                * (jcp.ow_tail != 0)));
                 cur_n_owb = (1 << log_rem_owb);
                 ker_idx = log_rem_owb + 1; // add 1 as 0th is full row.
             }
@@ -713,19 +724,31 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
             // Begin: get batch_element idx
             const int ow = owb * ow_step;
 
-            const int id_s = od * jcp.stride_d - jcp.f_pad;
-            const int ih_s = oh * jcp.stride_h - jcp.t_pad;
-            const int iw_s = ow * jcp.stride_w - jcp.l_pad;
+            const int id_s = static_cast<int>(od * jcp.stride_d - jcp.f_pad);
+            const int ih_s = static_cast<int>(oh * jcp.stride_h - jcp.t_pad);
+            const int iw_s = static_cast<int>(ow * jcp.stride_w - jcp.l_pad);
 
-            const int d_bi = nstl::min(od, d_blk_info.n_lpad_blks - 1)
-                    + nstl::max(0, od - d_blk_info.rpad_blk_start_idx + 1);
-            const int h_bi = nstl::min(oh, h_blk_info.n_lpad_blks - 1)
-                    + nstl::max(0, oh - h_blk_info.rpad_blk_start_idx + 1);
-            const int w_bi = nstl::min(owb, w_blk_info.n_lpad_blks - 1);
+            const int d_bi
+                    = nstl::min(
+                              od, static_cast<int>(d_blk_info.n_lpad_blks - 1))
+                    + nstl::max(0,
+                            static_cast<int>(
+                                    od - d_blk_info.rpad_blk_start_idx + 1));
+            const int h_bi
+                    = nstl::min(
+                              oh, static_cast<int>(h_blk_info.n_lpad_blks - 1))
+                    + nstl::max(0,
+                            static_cast<int>(
+                                    oh - h_blk_info.rpad_blk_start_idx + 1));
+            const int w_bi = nstl::min(
+                    owb, static_cast<int>(w_blk_info.n_lpad_blks - 1));
 
             const int ow_e
-                    = nstl::min(ow + cur_n_owb * jcp.ow_block, jcp.ow) - 1;
-            const int rpad = ow_e * jcp.stride_w - jcp.l_pad + jcp.kw - jcp.iw;
+                    = nstl::min(ow + cur_n_owb * static_cast<int>(jcp.ow_block),
+                              static_cast<int>(jcp.ow))
+                    - 1;
+            const int rpad = static_cast<int>(
+                    ow_e * jcp.stride_w - jcp.l_pad + jcp.kw - jcp.iw);
             const int rpad_i
                     = div_up(nstl::max(0, rpad - rpad_1 + w_shift), w_shift);
 

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -104,9 +104,9 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             = ic_chunks_ > 1 || rtus_compute_partial_k;
     const int i_init_begin = req_extra_accum_brgemm ? 0 : 1;
     const int i_init_end = 2;
-    for_(int vM : {jcp_.M, jcp_.M_tail})
-    for_(int vN : {jcp_.N, jcp_.N_tail})
-    for_(int vK : {jcp_.K, jcp_.K_tail})
+    for_(dim_t vM : {jcp_.M, jcp_.M_tail})
+    for_(dim_t vN : {jcp_.N, jcp_.N_tail})
+    for_(dim_t vK : {jcp_.K, jcp_.K_tail})
     for (int i_init = i_init_begin; i_init < i_init_end; i_init++) {
         if (vM == 0 || vN == 0 || vK == 0) continue;
 
@@ -121,7 +121,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                     && jcp_.M_tail > 0 && vM == jcp_.M && is_accum_kernel;
             if (skip_rtus_M_blk) continue;
 
-            const int rtus_k = is_accum_kernel
+            const dim_t rtus_k = is_accum_kernel
                     ? jcp_.rtus_ic_size
                     : jcp_.ic_without_padding - jcp_.rtus_ic_size;
             const bool is_last_m_kernel = vM == jcp_.M_tail || jcp_.nb_os == 1;
@@ -137,7 +137,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     if (need_extra_m_kernel) { // only used for 'reduced_rtus'
         assert(jcp_.K_tail == 0);
         const int rtus_K_kernels = 2;
-        for_(int vN : {jcp_.N, jcp_.N_tail})
+        for_(dim_t vN : {jcp_.N, jcp_.N_tail})
         for (int idx = 0; idx < rtus_K_kernels; idx++) {
             if (vN == 0) continue;
             auto vM = jcp_.M;
@@ -176,7 +176,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
         const auto vM = params.M_;
         const auto vN = params.N_;
         const auto vK = params.K_;
-        const int LDA = params.LDA_;
+        const dim_t LDA = params.LDA_;
 
         const int k_accum_idx = params.k_accum_idx_;
         const bool req_k_accum = one_of(k_accum_idx, 0, 2);
@@ -199,8 +199,8 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
         brgattr.hint_innermost_loop = jcp_.brgemm_bd_loop_innermost
                 ? brgemm_bd_loop_innermost
                 : brgemm_innermost_undef;
-        brgattr.max_top_vpad = jcp_.max_vpad;
-        brgattr.max_bottom_vpad = jcp_.max_vpad;
+        brgattr.max_top_vpad = static_cast<int>(jcp_.max_vpad);
+        brgattr.max_bottom_vpad = static_cast<int>(jcp_.max_vpad);
         brgattr.hint_ununroll_bd_loop = jcp_.ununroll_bd_loop;
 
         // assuming 2x2 decomposition in amx brgemm kernel
@@ -304,8 +304,8 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
 template <cpu_isa_t isa>
 void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
         const char *__restrict src, char *__restrict inp_buffer,
-        uint8_t *__restrict inp_buffer_mask, int g, int n, int icc, int od,
-        int oh, int ow) const {
+        uint8_t *__restrict inp_buffer_mask, int g, int n, dim_t icc, dim_t od,
+        dim_t oh, dim_t ow) const {
     const auto &jcp = pd()->jcp_;
     if (!jcp.is_rtus) return;
     assert(jcp.is_os_blocking);
@@ -332,12 +332,12 @@ void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
 
     const memory_desc_wrapper src_d(pd()->src_md());
 
-    auto call_kernel = [&](int nh, int nw, int od, int oh, int ow) {
+    auto call_kernel = [&](dim_t nh, dim_t nw, dim_t od, dim_t oh, dim_t ow) {
         assert(nh == 0 || (nw == 0 && ow == 0));
         if (utils::everyone_is(0, nh, nw)) return;
-        const int id = od * jcp.stride_d;
-        const int ih = oh * jcp.stride_h;
-        const int iw = ow * jcp.stride_w;
+        const dim_t id = od * jcp.stride_d;
+        const dim_t ih = oh * jcp.stride_h;
+        const dim_t iw = ow * jcp.stride_w;
 
         // Using blk_off to offset batch is motivated input\output striding aligment
         const auto inp_offset = src_d.off_l(0)
@@ -356,11 +356,11 @@ void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
     };
 
     const bool is_os_tail = jcp.os - os < jcp.os_block;
-    int count = is_os_tail ? jcp.M_tail : jcp.M;
+    dim_t count = is_os_tail ? jcp.M_tail : jcp.M;
 
     if (count < OW || ow > 0) {
         // copy to end of row
-        const auto nw = nstl::min(count, OW - ow);
+        const dim_t nw = nstl::min<dim_t>(count, OW - ow);
         call_kernel(0, nw, od, oh, ow);
         count -= nw;
         if (count == 0) return;
@@ -393,7 +393,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
         const brgemm_exec_ctx_t &brgemm_ctx, int ithr,
         brgemm_batch_element_t *const __restrict brg_batch,
         char *const c_buffer, const char *inp_buffer, int g, int n, int ocb,
-        int od, int oh, int ow, int icc, int *last_brg_idx,
+        dim_t od, dim_t oh, dim_t ow, dim_t icc, int *last_brg_idx,
         const int32_t *src_zero_points, int32_t *src_zp_comp,
         const int32_t *dst_zero_points, int32_t *s8s8_compensation,
         const void *src_scales, const void *wei_scales, const void *dst_scales,
@@ -421,15 +421,15 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
             ? brgemm_ctx.wsp_tile + ithr * jcp.amx_buf_size_per_thread
             : nullptr;
 
-    const int id = ndims_pick(od * SD, 0, 0);
-    const int ih = ndims_pick(oh * SH, oh * SH, 0);
-    const int iw = ow * SW;
+    const dim_t id = ndims_pick(od * SD, 0, 0);
+    const dim_t ih = ndims_pick(oh * SH, oh * SH, 0);
+    const dim_t iw = ow * SW;
 
-    const int oc = ocb * jcp.oc_block;
-    const int g_oc = g * jcp.oc + oc;
+    const dim_t oc = ocb * jcp.oc_block;
+    const dim_t g_oc = g * jcp.oc + oc;
 
-    const int icb = icc * jcp.nb_ic_blocking;
-    const int ic = icb * jcp.ic_block;
+    const dim_t icb = icc * jcp.nb_ic_blocking;
+    const dim_t ic = icb * jcp.ic_block;
 
     const bool use_special_m_idx = get_extra_m_kernel_req(jcp) && is_last_os;
     const int kernel_init = static_cast<int>(icc == 0) + 2 * use_special_m_idx;
@@ -475,7 +475,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
 
     const auto bias_w
             = bias ? bias + (bias_d.blk_off(g_oc) * bia_dsz) : nullptr;
-    const auto nb_ic_b = nstl::min(jcp.nb_ic_blocking, jcp.nb_ic - icb)
+    const dim_t nb_ic_b = nstl::min<dim_t>(jcp.nb_ic_blocking, jcp.nb_ic - icb)
             - (is_ic_tail ? 1 : 0);
 
     const auto comp_offset = (g * jcp.nb_oc + ocb) * jcp.oc_block;
@@ -490,15 +490,16 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
 
     const bool wary_tail_read = jcp.extendable_k;
 
-    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
-                                     bool do_postops, bool brgemm_is_ic_tail) {
+    const auto call_brgemm
+            = [&](int brg_idx, dim_t ic_block_s, dim_t n_ic_blocks,
+                      bool do_postops, bool brgemm_is_ic_tail) {
         // NOTE: avoid some costly tile reconfigurations here by keeping track
         //       of the previous brg kernel tile configuration palette
         // TODO: adjust harness to avoid even more tile reconfigurations
         brgemm_palettes_.maybe_tile_configure(is_amx, *last_brg_idx, brg_idx);
 
-        for (int k = 0; k < n_ic_blocks; k++) {
-            const size_t ic_off = jcp.is_reduced_rtus
+        for (dim_t k = 0; k < n_ic_blocks; k++) {
+            const dim_t ic_off = jcp.is_reduced_rtus
                     ? (brgemm_is_ic_tail ? jcp.ic_without_padding
                                               - jcp.rtus_ic_size
                                          : 0)
@@ -533,13 +534,15 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
 
             void *scratch = is_amx ? static_cast<void *>(wsp_tile)
                                    : static_cast<void *>(s8s8_comp_ptr);
-            brgemm_kernel_execute_postops(brg_ker, n_ic_blocks, brg_batch,
+            brgemm_kernel_execute_postops(brg_ker,
+            static_cast<int>(n_ic_blocks), brg_batch,
                     (void *)ptr_C, (void *)ptr_D, post_ops_data, scratch);
         } else {
             void *scratch = is_amx ? static_cast<void *>(wsp_tile)
                                    : static_cast<void *>(s8s8_comp_ptr);
             brgemm_kernel_execute(
-                    brg_ker, n_ic_blocks, brg_batch, (void *)ptr_C, scratch);
+                    brg_ker, static_cast<int>(n_ic_blocks), brg_batch,
+                    (void *)ptr_C, scratch);
         }
     };
 
@@ -578,8 +581,9 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
     const auto &jcp = pd()->jcp_;
     const bool is_amx = brgemm_convolution_utils::is_amx(isa);
 
-    const int os_chunks = div_up(jcp.nb_os, jcp.nb_os_blocking);
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_oc * os_chunks;
+    const dim_t os_chunks = div_up(jcp.nb_os, jcp.nb_os_blocking);
+    const int work_amount = static_cast<int>(
+            jcp.mb * jcp.ngroups * jcp.nb_oc * os_chunks);
 
     parallel(pd()->jcp_.nthr,
             [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
@@ -624,13 +628,13 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
             if (jcp.is_rtus && (last_n != n || last_g != g))
                 std::memset(inp_buffer_mask, 0, jcp.inp_buffer_mask_size);
             const auto osb_start = oss * jcp.nb_os_blocking;
-            const auto osb_range
-                    = nstl::min(jcp.nb_os - osb_start, jcp.nb_os_blocking);
+            const dim_t osb_range = nstl::min<dim_t>(
+                    jcp.nb_os - osb_start, jcp.nb_os_blocking);
             for (int osb = 0; osb < osb_range; osb++) {
-                const int os = (osb_start + osb) * jcp.os_block;
-                const int od = os / (OH * OW);
-                const int oh = (os % (OH * OW)) / OW;
-                const int ow = os % OW;
+                const dim_t os = (osb_start + osb) * jcp.os_block;
+                const dim_t od = os / (OH * OW);
+                const dim_t oh = (os % (OH * OW)) / OW;
+                const dim_t ow = os % OW;
                 const size_t rtus_offset
                         = jcp.is_reduced_rtus ? 0 : src_dsz * os * jcp.LDA;
                 char *inp_buffer_sp
@@ -673,8 +677,8 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
 
     const auto &jcp = pd()->jcp_;
     const bool is_amx = brgemm_convolution_utils::is_amx(isa);
-    const int work_amount
-            = jcp.mb * jcp.ngroups * jcp.nb_oc * OD * OH * jcp.nb_ow;
+    const int work_amount = static_cast<int>(
+            jcp.mb * jcp.ngroups * jcp.nb_oc * OD * OH * jcp.nb_ow);
     parallel(pd()->jcp_.nthr,
             [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         if (ithr >= work_amount) return;
@@ -707,8 +711,8 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
             assert(!"Unknown loop order");
 
         for (auto work = start; work < end; work++) {
-            for (int icc = 0; icc < pd()->ic_chunks_; icc++) {
-                const int ow = owb * jcp.ow_block;
+            for (dim_t icc = 0; icc < pd()->ic_chunks_; icc++) {
+                const dim_t ow = owb * jcp.ow_block;
                 exec_ker(brgemm_ctx, ithr, brg_batch, c_buffer, nullptr, g, n,
                         ocb, od, oh, ow, icc, &last_brg_idx, src_zero_points,
                         src_zp_comp, dst_zero_points, s8s8_compensation,

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -53,8 +53,8 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
         status_t init(engine_t *engine);
 
         struct brgemm_init_params_t {
-            brgemm_init_params_t(int k_accum_idx, int m, int n, int k,
-                    size_t lda, bool wary_tail_read)
+            brgemm_init_params_t(int k_accum_idx, dim_t m, dim_t n, dim_t k,
+                    dim_t lda, bool wary_tail_read)
                 : k_accum_idx_(k_accum_idx)
                 , M_(m)
                 , N_(n)
@@ -62,8 +62,8 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
                 , LDA_(lda)
                 , wary_tail_read_(wary_tail_read) {}
             const int k_accum_idx_; // controls brgemm:beta param
-            const int M_, N_, K_;
-            const size_t LDA_;
+            const dim_t M_, N_, K_;
+            const dim_t LDA_;
             bool wary_tail_read_ {false};
         };
 
@@ -71,7 +71,7 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
         std::forward_list<brgemm_init_params_t> brgemm_init_params_;
 
         bool need_postwork_ {};
-        int ic_chunks_ {};
+        dim_t ic_chunks_ {};
 
         jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
@@ -117,11 +117,11 @@ private:
 
     void maybe_rtus(int ithr, const char *__restrict src,
             char *__restrict inp_buffer, uint8_t *__restrict inp_buffer_mask,
-            int g, int n, int icc, int od, int oh, int ow) const;
+            int g, int n, dim_t icc, dim_t od, dim_t oh, dim_t ow) const;
     void exec_ker(const brgemm_exec_ctx_t &brgemm_ctx, int ithr,
             brgemm_batch_element_t *const __restrict brg_batch,
             char *const c_buffer, const char *inp_buffer, int g, int n, int ocb,
-            int od, int oh, int ow, int icc, int *last_brg_idx,
+            dim_t od, dim_t oh, dim_t ow, dim_t icc, int *last_brg_idx,
             const int32_t *src_zero_points, int32_t *src_zp_comp,
             const int32_t *dst_zero_points, int32_t *s8s8_compensation,
             const void *src_scales, const void *wei_scales,
@@ -192,7 +192,7 @@ private:
 
     const memory_desc_wrapper bias_d;
 
-    int ID, IH, IW, OD, OH, OW, SD, SH, SW;
+    dim_t ID, IH, IW, OD, OH, OW, SD, SH, SW;
     size_t bia_dsz, acc_dsz, src_dsz, wei_dsz;
     // const variables used for address calculations
     dim_t src_w_sz, src_h_sz, src_d_sz, dst_w_sz, dst_h_sz, dst_d_sz;

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -49,7 +49,7 @@ int brgemm_convolution_fwd_t<isa>::pd_t::get_brg_idx(int m,
             ? brg_indices.find({m, is_N_tail, is_K_tail, do_initialization,
                       kd_b, kd_e, kh_b, kh_e})
             : brg_indices.find({m, is_N_tail, is_K_tail, do_initialization, 0,
-                      jcp_.kd, 0, jcp_.kh});
+                      static_cast<int>(jcp_.kd), 0, static_cast<int>(jcp_.kh)});
     if (brg_idx == brg_indices.end()) return -1;
     return brg_idx->second;
 }
@@ -69,12 +69,12 @@ int brgemm_convolution_fwd_t<isa>::pd_t::get_any_brg_idx(
 }
 
 template <cpu_isa_t isa>
-void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(int icc,
-        const char *src_base, const char *wei_base, int n_ic_blocks,
-        int ic_block_s, int iid_b, int iih_b, int iiw_b,
+void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(dim_t icc,
+        const char *src_base, const char *wei_base, dim_t n_ic_blocks,
+        dim_t ic_block_s, dim_t iid_b, dim_t iih_b, dim_t iiw_b,
         const dim_t *const __restrict kw_top_vpads,
-        const dim_t *const __restrict kw_bottom_vpads, int kd_b, int kd_e,
-        int kh_b, int kh_e, int kw_b, int kw_e, int &k_l,
+        const dim_t *const __restrict kw_bottom_vpads, dim_t kd_b, dim_t kd_e,
+        dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e, dim_t &k_l,
         brgemm_batch_element_t *brg_batch) const {
     const char *ptrA {nullptr};
     const char *ptrB {nullptr};
@@ -89,10 +89,10 @@ void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(int icc,
     k_l = (kd_e - kd_b) * (kh_e - kh_b) * (kw_e - kw_b);
     if (k_l == 0) return;
 
-    const int icb = icc * jcp.nb_ic_blocking;
-    const int wei_ic_base = icb * jcp.ic_block;
+    const dim_t icb = icc * jcp.nb_ic_blocking;
+    const dim_t wei_ic_base = icb * jcp.ic_block;
 
-    for (int i_icb = 0; i_icb < n_ic_blocks; i_icb++) {
+    for (dim_t i_icb = 0; i_icb < n_ic_blocks; i_icb++) {
         const auto ic_off = (ic_block_s + i_icb) * jcp.ic_block;
         const auto wei_ic = wei_ic_base + ic_off;
         const auto n_icb_off = i_icb * k_l;
@@ -106,18 +106,18 @@ void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(int icc,
                         || jcp.brg_type == brgemm_static_offs));
 
         auto k = 0;
-        for (int kd = kd_b; kd < kd_e; kd++) {
+        for (dim_t kd = kd_b; kd < kd_e; kd++) {
             const auto id = iid_b + kd * DD;
             const auto src_base_kd = src_base_ic + id * src_d_offset;
             const auto wei_kd = maybe_invert(kd, KD);
             const auto wei_base_kd = wei_base_ic + wei_kd * wei_kd_offset;
-            for (int kh = kh_b; kh < kh_e; kh++) {
+            for (dim_t kh = kh_b; kh < kh_e; kh++) {
                 const auto ih = iih_b + kh * DH;
                 const auto src_base_kh = src_base_kd + ih * adj_src_h_offset;
                 const auto wei_kh = maybe_invert(kh, KH);
                 const auto wei_base_kh = wei_base_kd + wei_kh * wei_kh_offset;
 
-                for (int kw = kw_b; kw < kw_e; kw++) {
+                for (dim_t kw = kw_b; kw < kw_e; kw++) {
                     const auto iw = iiw_b + kw * DW;
                     const auto b_idx = n_icb_off + k;
                     const auto A_addr = src_base_kh + iw * src_iw_offset;
@@ -150,12 +150,12 @@ void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(int icc,
 }
 
 template <cpu_isa_t isa>
-inline void brgemm_convolution_fwd_t<isa>::pd_t::get_A_B(int icc,
-        const char *src_base, const char *wei_base, int ic_block_s, int iid_b,
-        int iih_b, int iiw_b, int kd_b, int kh_b, const void *&ptrA,
-        const void *&ptrB) const {
-    const int icb = icc * jcp_.nb_ic_blocking;
-    const int wei_ic_base = icb * jcp_.ic_block;
+inline void brgemm_convolution_fwd_t<isa>::pd_t::get_A_B(dim_t icc,
+        const char *src_base, const char *wei_base, dim_t ic_block_s,
+        dim_t iid_b, dim_t iih_b, dim_t iiw_b, dim_t kd_b, dim_t kh_b,
+        const void *&ptrA, const void *&ptrB) const {
+    const dim_t icb = icc * jcp_.nb_ic_blocking;
+    const dim_t wei_ic_base = icb * jcp_.ic_block;
 
     // for brgemm_static_offs we need only base A_addr and B_addr
     const auto ic_off = ic_block_s * jcp_.ic_block;
@@ -179,7 +179,7 @@ inline void brgemm_convolution_fwd_t<isa>::pd_t::get_A_B(int icc,
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
+status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(dim_t vM,
         bool is_N_tail, bool is_K_tail, bool do_init, int kd_b, int kd_e,
         int kh_b, int kh_e) {
 
@@ -199,8 +199,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
                                  : vM;
     if (vN == 0 || vK == 0) return status::success;
 
-    auto brg_idx = get_brg_idx(
-            vM, do_init, is_N_tail, is_K_tail, kd_b, kd_e, kh_b, kh_e);
+    int brg_idx = get_brg_idx(static_cast<int>(vM), do_init, is_N_tail,
+            is_K_tail, kd_b, kd_e, kh_b, kh_e);
     // if brgemm_desc_t already created then skip this iteration
     if (brg_idx != -1) return status::success;
 
@@ -223,7 +223,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
                 auto M_mask = (iM >= vM) ? 0 : 1;
                 for (int ww = 0; ww < jcp_.ow_block && ibrgM < sm_size;
                         ww++, ibrgM++, iM += M_mask) {
-                    bd_mask[ibrgM] = M_mask;
+                    bd_mask[ibrgM] = static_cast<char>(M_mask);
                 }
                 for (int kk = 0; kk < jcp_.oskip && ibrgM < sm_size;
                         kk++, ibrgM++) {
@@ -243,14 +243,14 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
     std::vector<brgemm_batch_element_t> stoffs;
     if (jcp_.brg_type == brgemm_static_offs) {
         assert(one_of(jcp_.exec_type, exec_trans, exec_base));
-        const auto kd_f = nstl::min(kd_e, kd_b + KD_BLOCK);
-        const auto kh_f = nstl::min(kh_e, kh_b + KH_BLOCK);
+        const dim_t kd_f = nstl::min<dim_t>(kd_e, kd_b + KD_BLOCK);
+        const dim_t kh_f = nstl::min<dim_t>(kh_e, kh_b + KH_BLOCK);
 
         assert(jcp_.nb_ic % jcp_.nb_ic_blocking == 0);
         const auto nb_ic_blocks = jcp_.nb_ic_blocking;
 
         stoffs.resize(jcp_.max_batch + 1);
-        int k_l {0};
+        dim_t k_l {0};
 
         init_batch(0, nullptr, nullptr, nb_ic_blocks, 0, 0, 0, 0, nullptr,
                 nullptr, kd_b, kd_f, kh_b, kh_f, 0, KW, k_l, stoffs.data());
@@ -308,11 +308,11 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
         brgattr.max_top_vpad = 0;
         brgattr.max_bottom_vpad = 0;
     } else {
-        brgattr.max_top_vpad = jcp_.max_vpad;
-        brgattr.max_bottom_vpad = jcp_.max_vpad;
+        brgattr.max_top_vpad = static_cast<int>(jcp_.max_vpad);
+        brgattr.max_bottom_vpad = static_cast<int>(jcp_.max_vpad);
     }
     brgattr.fpmath_mode = attr()->fpmath_.mode_;
-    brgattr.K_koef = (float)bs / KW;
+    brgattr.K_koef = (float)bs / static_cast<float>(KW);
 
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
 
@@ -327,8 +327,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
 
     brg_idx = brgemm_descriptors_->insert(brg, bd_mask, stoffs);
 
-    const std::array<int, 8> key
-            = {vM, is_N_tail, is_K_tail, do_init, kd_b, kd_e, kh_b, kh_e};
+    const std::array<int, 8> key = {static_cast<int>(vM), is_N_tail, is_K_tail,
+            do_init, kd_b, kd_e, kh_b, kh_e};
     if (brg_indices.find(key) == brg_indices.end()) {
         brg_indices.insert({key, brg_idx});
         brg_indices_c++;
@@ -474,7 +474,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
     if (jcp_.copy_block_only) {
         assert(jcp_.exec_type == exec_trans && "Missing copy kernel");
         const auto iw_block = jit_avx512_core_brgemm_conv_trans_kernel_t::dst_w(
-                jcp_, jcp_.ow_block);
+                jcp_, static_cast<int>(jcp_.ow_block));
         const auto ih_block = get_inp_size(IHP, jcp_.oh_block, KH, SH, DH - 1);
         const auto id_block = get_inp_size(IDP, jcp_.od_block, KD, SD, DD - 1);
 
@@ -508,26 +508,29 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
         assert(KD % KD_BLOCK == 0);
         assert(KH % KH_BLOCK == 0);
 
-        for (int iod = 0; iod < jcp_.od; iod++) {
-            const int iid = iod * SD - FP;
-            const int kd_s = div_up(nstl::max(0, -iid), DD);
-            const int kd_f = KD
-                    - div_up(nstl::max(0, iid - ID + (KD - 1) * DD + 1), DD);
-            for (int ioh = 0; ioh < jcp_.oh; ioh++) {
+        for (dim_t iod = 0; iod < jcp_.od; iod++) {
+            const dim_t iid = iod * SD - FP;
+            const dim_t kd_s = div_up(nstl::max<dim_t>(0, -iid), DD);
+            const dim_t kd_f = KD
+                    - div_up(nstl::max<dim_t>(0, iid - ID + (KD - 1) * DD + 1),
+                            DD);
+            for (dim_t ioh = 0; ioh < jcp_.oh; ioh++) {
 
                 const auto iih = ioh * SH - TP;
                 const auto kh_s = (jcp_.is_os_blocking || jcp_.is_relo_whi())
                         ? 0
-                        : div_up(nstl::max(0, -iih), DH);
+                        : div_up(nstl::max<dim_t>(0, -iih), DH);
                 const auto kh_f = (jcp_.is_relo_whi()) ? 1
                                                        : KH
-                                - div_up(nstl::max(0,
+                                - div_up(nstl::max<dim_t>(0,
                                                  iih - IH + (KH - 1) * DH + 1),
                                         DH);
                 const auto bs = get_bs(kd_s, kd_f, kh_s, kh_f);
                 if (bs <= 0) continue;
 
-                const std::array<int, 4> key = {kd_s, kd_f, kh_s, kh_f};
+                const std::array<int, 4> key
+                        = {static_cast<int>(kd_s), static_cast<int>(kd_f),
+                                static_cast<int>(kh_s), static_cast<int>(kh_f)};
                 if (batchsizes.find(key) == batchsizes.end()) {
                     batchsizes.insert({key, bs_c});
                     bs_c++;
@@ -535,7 +538,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             }
         }
     } else {
-        batchsizes.insert({{0, KD, 0, KH}, bs_c});
+        batchsizes.insert(
+                {{0, static_cast<int>(KD), 0, static_cast<int>(KH)}, bs_c});
         bs_c++;
     }
 
@@ -564,8 +568,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             || jcp_.src_zero_point || jcp_.dst_zero_point;
 
     const auto &Mv = (jcp_.M_tail > 0 && jcp_.M_tail != jcp_.M)
-            ? std::vector<int> {jcp_.M, jcp_.M_tail}
-            : std::vector<int> {jcp_.M};
+            ? std::vector<dim_t> {jcp_.M, jcp_.M_tail}
+            : std::vector<dim_t> {jcp_.M};
 
     std::vector<bool> bv_true {true};
     std::vector<bool> bv_false {false};
@@ -620,7 +624,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                     jcp_, ow, kw_s, kw_full_s, kw_full_f, kw_f);
             for (int kw = kw_s; kw < kw_f; kw++) {
                 brgemm_convolution_utils::get_ow_range(
-                        jcp_, ow, kw, ow_s, ow_f);
+                        jcp_, static_cast<int>(ow), kw, ow_s, ow_f);
                 const auto M = ow_f - ow_s;
                 if (M <= 0) continue;
 
@@ -646,13 +650,13 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
             if (kw_f == jcp_.kw && kw_s == 0) break;
         }
 
-        for (int ow = (jcp_.nb_ow - 1) * jcp_.ow_block; ow >= 0;
+        for (dim_t ow = (jcp_.nb_ow - 1) * jcp_.ow_block; ow >= 0;
                 ow -= jcp_.ow_block) {
-            brgemm_convolution_utils::get_kw_range(
-                    jcp_, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+            brgemm_convolution_utils::get_kw_range(jcp_, static_cast<int>(ow),
+                    kw_s, kw_full_s, kw_full_f, kw_f);
             for (int kw = kw_s; kw < kw_f; kw++) {
                 brgemm_convolution_utils::get_ow_range(
-                        jcp_, ow, kw, ow_s, ow_f);
+                        jcp_, static_cast<int>(ow), kw, ow_s, ow_f);
                 if (ow_f - ow_s <= 0) continue;
 
                 auto M = ow_f - ow_s;
@@ -730,8 +734,8 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernel(
     bcfg->LDD = (is_init && jcp.use_buffer) ? jcp.LDC : jcp.LDD;
     bcfg->dt_c = (!is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt; // inp
     bcfg->dt_d = (is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt; // out
-    bcfg->typesize_C = types::data_type_size(bcfg->dt_c);
-    bcfg->typesize_D = types::data_type_size(bcfg->dt_d);
+    bcfg->typesize_C = static_cast<int>(types::data_type_size(bcfg->dt_c));
+    bcfg->typesize_D = static_cast<int>(types::data_type_size(bcfg->dt_d));
     bcfg->alpha = !is_init && IMPLICATION(jcp.with_sum, jcp.use_buffer);
     bcfg->beta = is_init ? 0 : 1;
     // See the comment in `add_po_kernels` why `*_pd->attr()` is needed so far.
@@ -744,7 +748,7 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernel(
 
 template <cpu_isa_t isa>
 status_t brgemm_convolution_fwd_t<isa>::add_po_kernels(
-        int i_N, int init_bcast_dim, int po_bcast_dim) {
+        int i_N, dim_t init_bcast_dim, dim_t po_bcast_dim) {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
     const auto &brgs = *(_pd->brgemm_descriptors_);
@@ -753,7 +757,7 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernels(
     if (N <= 0) return status::success;
     auto i_K = (jcp.K_tail > 0);
 
-    const auto brg_idx = _pd->get_any_brg_idx(i_N, i_K);
+    const int brg_idx = _pd->get_any_brg_idx(i_N, i_K);
 
     if (init_bcast_dim > 0) {
         if (brgs[brg_idx]) {
@@ -792,7 +796,7 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernels(
 }
 
 template <cpu_isa_t isa>
-int brgemm_convolution_fwd_t<isa>::get_comp_oh(const int oh) const {
+dim_t brgemm_convolution_fwd_t<isa>::get_comp_oh(dim_t oh) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
@@ -800,12 +804,14 @@ int brgemm_convolution_fwd_t<isa>::get_comp_oh(const int oh) const {
             || comp_oh_kh_b.empty())
         return 0;
 
-    const int comp_oh_e = comp_oh_kh_b.size();
-    const int oh_block
-            = jcp.is_os_blocking ? nstl::min(jcp.oh_block, jcp.oh - oh) : 1;
-    for (int comp_oh_b = 0; comp_oh_b < comp_oh_e; comp_oh_b++) {
-        const auto cur_block = nstl::min(oh_block, comp_oh_e - comp_oh_b);
-        for (int i = 0; i < cur_block; i++) {
+    const dim_t comp_oh_e = comp_oh_kh_b.size();
+    const dim_t oh_block = jcp.is_os_blocking
+            ? nstl::min<dim_t>(jcp.oh_block, jcp.oh - oh)
+            : 1;
+    for (dim_t comp_oh_b = 0; comp_oh_b < comp_oh_e; comp_oh_b++) {
+        const auto cur_block
+                = nstl::min<dim_t>(oh_block, comp_oh_e - comp_oh_b);
+        for (dim_t i = 0; i < cur_block; i++) {
             if (oh_kh_b[oh + i] != comp_oh_kh_b[comp_oh_b + i]
                     || oh_kh_e[oh + i] != comp_oh_kh_e[comp_oh_b + i])
                 break;
@@ -816,16 +822,15 @@ int brgemm_convolution_fwd_t<isa>::get_comp_oh(const int oh) const {
 }
 
 template <cpu_isa_t isa>
-int brgemm_convolution_fwd_t<isa>::get_comp_ker_idx(const int kd_b,
-        const int kd_e, const int kh_b, const int kh_e, const int kw_b,
-        const int kw_e, const int oh) const {
+dim_t brgemm_convolution_fwd_t<isa>::get_comp_ker_idx(dim_t kd_b, dim_t kd_e,
+        dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e, dim_t oh) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
     if (!jcp.req_cal_comp_pad) return 0;
 
     assert(kd_e > kd_b && kh_e > kh_b);
-    for (int k = 0; k < jcp.ker_ranges_size; k++) {
+    for (dim_t k = 0; k < jcp.ker_ranges_size; k++) {
         if (kd_b == kd_bs[k] && kd_e == kd_es[k] && kh_b == kh_bs[k]
                 && kh_e == kh_es[k] && kw_b == kw_bs[k] && kw_e == kw_es[k]
                 && oh == comp_oh[k]) {
@@ -837,10 +842,9 @@ int brgemm_convolution_fwd_t<isa>::get_comp_ker_idx(const int kd_b,
 }
 
 template <cpu_isa_t isa>
-inline int brgemm_convolution_fwd_t<isa>::get_comp_offset(const int g,
-        const int ocb, const int oh, const int ow, const int kd_b,
-        const int kd_e, const int kh_b, const int kh_e, const int kw_b,
-        const int kw_e) const {
+inline dim_t brgemm_convolution_fwd_t<isa>::get_comp_offset(dim_t g, dim_t ocb,
+        dim_t oh, dim_t ow, dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e,
+        dim_t kw_b, dim_t kw_e) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
@@ -933,7 +937,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
     int N_begin = 0;
     int N_end = (jcp.N_tail == jcp.N) ? 1 : 2;
 
-    int num_po_kernels = nstl::max(jcp.M, jcp.M_tail);
+    const dim_t num_po_kernels = nstl::max<dim_t>(jcp.M, jcp.M_tail);
     kernels_po_.resize(num_po_kernels * 2 * 2);
 
     if (jcp.exec_type == exec_trans) {
@@ -949,7 +953,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         ajcp.is_nspc = true;
         ajcp.is_bf32 = jcp.is_bf32;
         ajcp.is_tf32 = jcp.is_tf32;
-        ajcp.typesize_in = jcp.src_dsz;
+        ajcp.typesize_in = static_cast<int>(jcp.src_dsz);
         ajcp.ic_block_int = jcp.amx_w;
 
         ajcp.src_dt = jcp.src_dt;
@@ -977,7 +981,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
     if (is_relo_with_relo_weights) {
         jit_brgemm_relo_copy_to_wbuffer_t::cfg_t wjcp;
         wjcp.wei_dt = jcp.wei_dt;
-        wjcp.out_oc_block = jcp.oc_block;
+        wjcp.out_oc_block = static_cast<int>(jcp.oc_block);
         wjcp.inp_oc_block = 16;
         wjcp.rd = _pd->rd;
         wjcp.is_rd_padded_to_block = jcp.is_rd_padded_to_block;
@@ -1049,20 +1053,20 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         // apply post-ops on final iteration by kw to padded areas in ow_block
         int kw_s {0}, kw_full_s {0}, kw_full_f {0}, kw_f {0}, ow_s {0},
                 ow_f {0};
-        for (int ow = 0; ow < OW; ow += jcp.ow_block) {
-            brgemm_convolution_utils::get_kw_range(
-                    jcp, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+        for (dim_t ow = 0; ow < OW; ow += jcp.ow_block) {
+            brgemm_convolution_utils::get_kw_range(jcp, static_cast<int>(ow),
+                    kw_s, kw_full_s, kw_full_f, kw_f);
             bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
             for_(int i_N = 0; i_N < 2; i_N++)
             for (int i_side = 0; i_side < 2; i_side++) {
                 auto M = is_ow_tail ? jcp.M_tail : jcp.M;
                 if (M <= 0) continue;
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, ow, kw_s, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_s, ow_s, ow_f);
                 const auto init_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, ow, kw_f - 1, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_f - 1, ow_s, ow_f);
                 const auto po_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 CHECK(add_po_kernels(i_N, init_bcast_dim, po_bcast_dim));
@@ -1071,10 +1075,10 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
             if (kw_f == jcp.kw && kw_s == 0) break;
         }
 
-        for (int ow = (jcp.nb_ow - 1) * jcp.ow_block; ow >= 0;
+        for (dim_t ow = (jcp.nb_ow - 1) * jcp.ow_block; ow >= 0;
                 ow -= jcp.ow_block) {
-            brgemm_convolution_utils::get_kw_range(
-                    jcp, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+            brgemm_convolution_utils::get_kw_range(jcp, static_cast<int>(ow),
+                    kw_s, kw_full_s, kw_full_f, kw_f);
 
             bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
 
@@ -1083,11 +1087,11 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
                 auto M = is_ow_tail ? jcp.M_tail : jcp.M;
                 if (M <= 0) continue;
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, ow, kw_s, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_s, ow_s, ow_f);
                 const auto init_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, ow, kw_f - 1, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_f - 1, ow_s, ow_f);
                 const auto po_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 CHECK(add_po_kernels(i_N, init_bcast_dim, po_bcast_dim));
@@ -1103,9 +1107,10 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         owb_kw_bottom_vpads.resize(jcp.nb_ow * jcp.kw);
 
         for (int owb = 0; owb < jcp.nb_ow; owb++) {
-            const int ow = owb * jcp.ow_block;
+            const dim_t ow = owb * jcp.ow_block;
             const bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
-            const int ow_b {ow}, ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
+            const dim_t ow_b {ow},
+                    ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
             const auto ow_l = ow_e - ow_b;
             MAYBE_UNUSED(ow_l);
             assert(0 <= ow_l && ow_l <= jcp.ow_block);
@@ -1128,29 +1133,31 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         oh_kh_b.resize(jcp.oh);
         oh_kh_e.resize(jcp.oh);
 
-        for (int ohb = 0; ohb < jcp.nb_oh; ohb++) {
+        for (dim_t ohb = 0; ohb < jcp.nb_oh; ohb++) {
             const auto oh_begin = ohb * jcp.oh_block;
-            const auto oh_end = nstl::min(OH, oh_begin + jcp.oh_block);
-            for (int oh = oh_begin; oh < oh_end; oh++) {
-                const auto iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
-                const auto kh_s_ = div_up(nstl::max(0, -iih), DH);
-                const auto kh_s = ndims_pick(kh_s_, kh_s_, 0);
-                const auto kh_f_ = KH
-                        - div_up(
-                                nstl::max(0, iih - IH + (KH - 1) * DH + 1), DH);
-                const auto kh_f = ndims_pick(kh_f_, kh_f_, 1);
+            const dim_t oh_end = nstl::min<dim_t>(OH, oh_begin + jcp.oh_block);
+            for (dim_t oh = oh_begin; oh < oh_end; oh++) {
+                const dim_t iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
+                const dim_t kh_s_ = div_up(nstl::max<dim_t>(0, -iih), DH);
+                const dim_t kh_s = ndims_pick(kh_s_, kh_s_, 0);
+                const dim_t kh_f_ = KH
+                        - div_up(nstl::max<dim_t>(
+                                         0, iih - IH + (KH - 1) * DH + 1),
+                                DH);
+                const dim_t kh_f = ndims_pick(kh_f_, kh_f_, 1);
                 oh_kh_b[oh] = kh_s;
                 oh_kh_e[oh] = kh_f;
             }
-            for (int oh = oh_begin; oh < oh_end; oh++) {
-                const auto comp_oh_idx
+            for (dim_t oh = oh_begin; oh < oh_end; oh++) {
+                const dim_t comp_oh_idx
                         = get_comp_oh(jcp.is_os_blocking ? oh_begin : oh);
                 if (comp_oh_kh_b.size() - comp_oh_idx >= 0) {
-                    const auto comp_oh_begin
-                            = oh + comp_oh_kh_b.size() - comp_oh_idx;
-                    const auto comp_oh_end
+                    const dim_t comp_oh_begin = oh
+                            + static_cast<int>(comp_oh_kh_b.size())
+                            - comp_oh_idx;
+                    const dim_t comp_oh_end
                             = jcp.is_os_blocking ? oh_end : oh + 1;
-                    for (int comp_oh = comp_oh_begin; comp_oh < comp_oh_end;
+                    for (dim_t comp_oh = comp_oh_begin; comp_oh < comp_oh_end;
                             comp_oh++) {
                         comp_oh_kh_b.push_back(oh_kh_b[comp_oh]);
                         comp_oh_kh_e.push_back(oh_kh_e[comp_oh]);
@@ -1162,25 +1169,27 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
 
     if (jcp.req_cal_comp_pad && jcp.exec_type != exec_vpad) {
         comp_owb.resize(jcp.nb_ow, -1);
-        vector<int> ow_kw_b(jcp.ow, -1);
-        vector<int> ow_kw_e(jcp.ow, -1);
-        vector<int> comp_ow_kw_s(jcp.comp_ow_size, -1);
-        vector<int> comp_ow_kw_f(jcp.comp_ow_size, -1);
+        vector<dim_t> ow_kw_b(jcp.ow, -1);
+        vector<dim_t> ow_kw_e(jcp.ow, -1);
+        vector<dim_t> comp_ow_kw_s(jcp.comp_ow_size, -1);
+        vector<dim_t> comp_ow_kw_f(jcp.comp_ow_size, -1);
         dim_t comp_ow_l = 0;
 
-        for (int ow = 0; ow < OW;) {
+        for (dim_t ow = 0; ow < OW;) {
             assert(comp_ow_l <= jcp.comp_ow_size);
-            const auto iiw = ow * SW - LP;
-            const auto kw_s = div_up(nstl::max(0, -iiw), DW);
-            const auto kw_f = KW
-                    - div_up(nstl::max(0, iiw - IW + (KW - 1) * DW + 1), DW);
+            const dim_t iiw = ow * SW - LP;
+            const dim_t kw_s = div_up(nstl::max<dim_t>(0, -iiw), DW);
+            const dim_t kw_f = KW
+                    - div_up(nstl::max<dim_t>(0, iiw - IW + (KW - 1) * DW + 1),
+                            DW);
 
-            int ow_e = ow;
+            dim_t ow_e = ow;
             while (ow_e < OW) {
-                const auto iiw_e = ow_e * SW - LP;
-                const auto cur_kw_s = div_up(nstl::max(0, -iiw_e), DW);
-                const auto cur_kw_f = KW
-                        - div_up(nstl::max(0, iiw_e - IW + (KW - 1) * DW + 1),
+                const dim_t iiw_e = ow_e * SW - LP;
+                const dim_t cur_kw_s = div_up(nstl::max<dim_t>(0, -iiw_e), DW);
+                const dim_t cur_kw_f = KW
+                        - div_up(nstl::max<dim_t>(
+                                         0, iiw_e - IW + (KW - 1) * DW + 1),
                                 DW);
                 ow_kw_b[ow_e] = kw_s;
                 ow_kw_e[ow_e] = kw_f;
@@ -1196,8 +1205,8 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         }
 
         for (int owb = 0; owb < jcp.nb_ow; owb++) {
-            const auto ow_b = owb * jcp.ow_block;
-            const auto ow_e = nstl::min(ow_b + jcp.ow_block, OW);
+            const dim_t ow_b = owb * jcp.ow_block;
+            const dim_t ow_e = nstl::min<dim_t>(ow_b + jcp.ow_block, OW);
             const auto comp_ow_f = comp_ow_l - (ow_e - ow_b) + 1;
             MAYBE_UNUSED(comp_ow_f);
 
@@ -1207,7 +1216,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
             }
 
             for_(int i = 0; i < comp_ow_f; i++)
-            for (int ow = ow_b; ow <= ow_e; ow++) {
+            for (dim_t ow = ow_b; ow <= ow_e; ow++) {
                 if (ow == ow_e) {
                     comp_owb[owb] = i;
                     break;
@@ -1223,7 +1232,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
 
     // pre-calculate unique kernel combination
     if (jcp.req_cal_comp_pad) {
-        std::set<std::vector<int>> unique_kernels;
+        std::set<std::vector<dim_t>> unique_kernels;
         size_t k = 0;
         kd_bs.resize(jcp.ker_ranges_size);
         kd_es.resize(jcp.ker_ranges_size);
@@ -1233,8 +1242,9 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         kw_es.resize(jcp.ker_ranges_size);
         comp_oh.resize(jcp.ker_ranges_size);
 
-        const auto update_kernels = [&](int kd_b, int kd_e, int kh_b, int kh_e,
-                                            int kw_b, int kw_e, int oh = 0) {
+        const auto update_kernels
+                = [&](dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e,
+                          dim_t kw_b, dim_t kw_e, dim_t oh = 0) {
             unique_kernels.insert({kd_b, kd_e, kh_b, kh_e, kw_b, kw_e, oh});
             if (k == unique_kernels.size()) return;
             kd_bs[k] = kd_b;
@@ -1252,27 +1262,28 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         for_(int ohb = 0; ohb < jcp.nb_oh; ohb++)
         for (int owb = 0; owb < jcp.nb_ow; owb++) {
             auto oh_begin = ohb * jcp.oh_block;
-            auto oh_end = nstl::min(OH, oh_begin + jcp.oh_block);
-            for (int oh = oh_begin; oh < oh_end; oh++) {
+            auto oh_end = nstl::min<dim_t>(OH, oh_begin + jcp.oh_block);
+            for (dim_t oh = oh_begin; oh < oh_end; oh++) {
                 int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
-                const int ow = owb * jcp.ow_block;
-                const int iid = ndims_pick(od * SD - FP, 0, 0);
-                const int kd_s
-                        = ndims_pick(div_up(nstl::max(0, -iid), DD), 0, 0);
-                const int kd_f = ndims_pick(KD
-                                - div_up(nstl::max(0,
+                const dim_t ow = owb * jcp.ow_block;
+                const dim_t iid = ndims_pick(od * SD - FP, 0, 0);
+                const dim_t kd_s = ndims_pick(
+                        div_up(nstl::max<dim_t>(0, -iid), DD), 0, 0);
+                const dim_t kd_f = ndims_pick(KD
+                                - div_up(nstl::max<dim_t>(0,
                                                  iid - ID + (KD - 1) * DD + 1),
                                         DD),
                         1, 1);
-                const int iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
-                const auto kh_s_ = div_up(nstl::max(0, -iih), DH);
+                const dim_t iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
+                const auto kh_s_ = div_up(nstl::max<dim_t>(0, -iih), DH);
                 const auto kh_s = ndims_pick(kh_s_, kh_s_, 0);
                 const auto kh_f_ = KH
-                        - div_up(
-                                nstl::max(0, iih - IH + (KH - 1) * DH + 1), DH);
+                        - div_up(nstl::max<dim_t>(
+                                         0, iih - IH + (KH - 1) * DH + 1),
+                                DH);
                 const auto kh_f = ndims_pick(kh_f_, kh_f_, 1);
-                brgemm_convolution_utils::get_kw_range(
-                        jcp, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+                brgemm_convolution_utils::get_kw_range(jcp,
+                        static_cast<int>(ow), kw_s, kw_full_s, kw_full_f, kw_f);
                 if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s) {
                     if (jcp.exec_type != exec_trans) {
                         update_kernels(kd_s, kd_f, kh_s, kh_f, 0, KW);
@@ -1309,9 +1320,9 @@ struct brgemm_convolution_fwd_t<isa>::brgemm_thread_ctx_t {
     char *__restrict c_buffer {nullptr};
     char *__restrict wsp_tile {nullptr};
     int cur_brg_idx {-1};
-    int g {-1}, n {-1}, ocb {-1};
-    int od {-1}, odb {-1}, oh {-1}, ohb {-1}, owb {-1};
-    int icc {-1};
+    dim_t g {-1}, n {-1}, ocb {-1};
+    dim_t od {-1}, odb {-1}, oh {-1}, ohb {-1}, owb {-1};
+    dim_t icc {-1};
     int32_t src_zp_val {0};
     int32_t *__restrict src_zp_comp_ptr {nullptr};
     const int32_t *__restrict dst_zp_vals {nullptr};
@@ -1448,7 +1459,7 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
         dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int n {0}, g {0}, ocb {0}, odb {0}, ohb {0}, owb {0};
+        dim_t n {0}, g {0}, ocb {0}, odb {0}, ohb {0}, owb {0};
         BRGEMM_CONV_ITERATOR_INIT;
         for (auto work = start; work < end; work++) {
             btc.g = g;
@@ -1474,16 +1485,16 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                             jcp.inp_buffer_mask_size);
             }
             auto od_begin = odb * jcp.od_block;
-            auto od_end = nstl::min(OD, od_begin + jcp.od_block);
+            auto od_end = nstl::min<dim_t>(OD, od_begin + jcp.od_block);
             auto oh_begin = ohb * jcp.oh_block;
             // if is_os_blocking is true then we do only one iteration of loop
             // by oh and process entire oh block in kernel call
             auto oh_end = jcp.is_os_blocking
                     ? oh_begin + 1
-                    : nstl::min(OH, oh_begin + jcp.oh_block);
-            for_(int od = od_begin; od < od_end; od++)
-            for_(int oh = oh_begin; oh < oh_end; oh++)
-            for (int icc = 0; icc < _pd->ic_chunks; icc++) {
+                    : nstl::min<dim_t>(OH, oh_begin + jcp.oh_block);
+            for_(dim_t od = od_begin; od < od_end; od++)
+            for_(dim_t oh = oh_begin; oh < oh_end; oh++)
+            for (dim_t icc = 0; icc < _pd->ic_chunks; icc++) {
                 btc.od = od;
                 btc.oh = oh;
                 btc.icc = icc;
@@ -1546,7 +1557,7 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
         vpad_k = vpad_next_k;
     }
 
-    const int max_ker_sz = adjusted_k.size();
+    const int max_ker_sz = static_cast<int>(adjusted_k.size());
     const auto comp_buffer_ow = jcp.exec_type != exec_vpad ? jcp.ow : 1;
     // TODO: revise the thread distribution here because the work_amount may be
     // insufficient
@@ -1563,7 +1574,7 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
         if (ithr >= work_amount) return;
 
         dim_t start {0}, end {0};
-        int g {0}, ocb {0}, adj_k {0};
+        dim_t g {0}, ocb {0}, adj_k {0};
         balance211(work_amount, nthr, ithr, start, end);
         nd_iterator_init(
                 start, g, jcp.ngroups, ocb, jcp.nb_oc, adj_k, max_ker_sz);
@@ -1573,12 +1584,12 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
                     kh_ee {kh_es[k]}, kw_bb {kw_bs[k]}, kw_ee {kw_es[k]};
             assert(kd_ee > kd_bb && kh_ee > kh_bb && kw_ee > kw_bb);
 
-            const auto kd_b = maybe_invert_range(kd_bb, kd_ee, KD);
-            const auto kd_e = maybe_invert_range(kd_ee, kd_bb, KD);
-            const auto kh_b = maybe_invert_range(kh_bb, kh_ee, KH);
-            const auto kh_e = maybe_invert_range(kh_ee, kh_bb, KH);
-            const auto kw_b = maybe_invert_range(kw_bb, kw_ee, KW);
-            const auto kw_e = maybe_invert_range(kw_ee, kw_bb, KW);
+            const dim_t kd_b = maybe_invert_range(kd_bb, kd_ee, KD);
+            const dim_t kd_e = maybe_invert_range(kd_ee, kd_bb, KD);
+            const dim_t kh_b = maybe_invert_range(kh_bb, kh_ee, KH);
+            const dim_t kh_e = maybe_invert_range(kh_ee, kh_bb, KH);
+            const dim_t kw_b = maybe_invert_range(kw_bb, kw_ee, KW);
+            const dim_t kw_e = maybe_invert_range(kw_ee, kw_bb, KW);
 
             const auto inp_oc_block
                     = is_relo_with_relo_weights ? 16 : jcp.oc_block;
@@ -1634,9 +1645,9 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
 template <cpu_isa_t isa>
 void brgemm_convolution_fwd_t<isa>::perform_outwork(
         const brgemm_thread_ctx_t &btc, char *dst_base, const char *bias_w,
-        int ow, int g_oc, bool is_oc_tail, int ker_ow_s, int ker_ow_f, int kd_l,
-        int kh_l, bool maybe_do_init, bool do_postwork, size_t comp_ker_offs,
-        bool do_post_comp) const {
+        dim_t ow, dim_t g_oc, bool is_oc_tail, dim_t ker_ow_s, dim_t ker_ow_f,
+        dim_t kd_l, dim_t kh_l, bool maybe_do_init, bool do_postwork,
+        size_t comp_ker_offs, bool do_post_comp) const {
 
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
@@ -1670,7 +1681,7 @@ void brgemm_convolution_fwd_t<isa>::perform_outwork(
     }
 
     auto call_outwork_ker = [&](bool is_postwork, bool has_postcomp,
-                                    int ow_pw_s, int ow_pw_l) {
+                                    dim_t ow_pw_s, dim_t ow_pw_l) {
         auto ker_po_idx = get_ker_po_idx(ow_pw_l - 1, is_postwork, is_oc_tail);
         const auto &outwork_ker = kernels_po_[ker_po_idx].get();
         assert(outwork_ker != nullptr
@@ -1724,8 +1735,9 @@ void brgemm_convolution_fwd_t<isa>::perform_outwork(
 template <cpu_isa_t isa>
 inline void brgemm_convolution_fwd_t<isa>::call_brgemm_kernel(
         const brgemm_thread_ctx_t &btc, const brgemm_kernel_t *brg_ker,
-        int batch_size, char *ptr_C, char *ptr_D, const char *bias_w, int g_oc,
-        bool do_postops, size_t comp_ker_offs, bool do_only_comp) const {
+        int batch_size, char *ptr_C, char *ptr_D, const char *bias_w,
+        dim_t g_oc, bool do_postops, size_t comp_ker_offs,
+        bool do_only_comp) const {
 
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
@@ -1883,28 +1895,30 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
     const auto g_ic = btc.g * jcp.ic + ic;
     const auto oh = btc.ohb * jcp.oh_block;
     const auto ow = btc.owb * jcp.ow_block;
-    const auto iw = nstl::max(0, ow * SW - LP);
+    const dim_t iw = nstl::max<dim_t>(0, ow * SW - LP);
 
-    int id_start {0}, id_end {0}, ih_start {0}, ih_end {0};
-    int virt_id_start {0}, virt_id_end {0}, virt_ih_start {0}, virt_ih_end {0};
+    dim_t id_start {0}, id_end {0}, ih_start {0}, ih_end {0};
+    dim_t virt_id_start {0}, virt_id_end {0}, virt_ih_start {0},
+            virt_ih_end {0};
 
-    auto get_start_end = [](int &start, int &end, int &virt_start,
-                                 int &virt_end, int b, int bs, int i, int o,
-                                 int s, int p, int k, int d, bool prev) {
-        const auto o_b = saturate(0, o, b * bs);
-        const auto prev_o_b = saturate(0, o, (b - 1) * bs);
-        const auto virt_cur_start = o_b * s - p;
-        const auto cur_start = saturate(0, i, virt_cur_start);
-        const auto virt_prev_start = prev_o_b * s - p;
-        const auto i_bs = get_inp_size(i, bs, k, s, d);
-        const auto virt_i_bs = calculate_end_padding(
+    auto get_start_end
+            = [](dim_t &start, dim_t &end, dim_t &virt_start, dim_t &virt_end,
+                      dim_t b, dim_t bs, dim_t i, dim_t o, dim_t s, dim_t p,
+                      dim_t k, dim_t d, bool prev) {
+        const dim_t o_b = saturate<dim_t>(0, o, b * bs);
+        const dim_t prev_o_b = saturate<dim_t>(0, o, (b - 1) * bs);
+        const dim_t virt_cur_start = o_b * s - p;
+        const dim_t cur_start = saturate<dim_t>(0, i, virt_cur_start);
+        const dim_t virt_prev_start = prev_o_b * s - p;
+        const dim_t i_bs = get_inp_size(i, bs, k, s, d);
+        const dim_t virt_i_bs = calculate_end_padding(
                 0, bs, 0, s, calculate_extended_filter_size(k, d));
-        const auto virt_prev_end = prev ? virt_prev_start + virt_i_bs : -p;
-        const auto prev_end = prev ? saturate(0, i, virt_prev_end) : 0;
+        const dim_t virt_prev_end = prev ? virt_prev_start + virt_i_bs : -p;
+        const dim_t prev_end = prev ? saturate<dim_t>(0, i, virt_prev_end) : 0;
         virt_start = nstl::max(virt_prev_end, virt_cur_start);
         start = nstl::max(prev_end, cur_start);
         virt_end = virt_cur_start + virt_i_bs;
-        end = saturate(0, i, cur_start + i_bs);
+        end = saturate<dim_t>(0, i, cur_start + i_bs);
     };
     get_start_end(id_start, id_end, virt_id_start, virt_id_end, btc.odb,
             jcp.od_block, nstl::min(ID, IDP - FP), OD, SD, FP, KD, DD - 1,
@@ -1942,12 +1956,12 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
         bool has_inp_buffer_overlap = true && last_btc.g == btc.g
                 && last_btc.n == btc.n && last_btc.owb == btc.owb;
 
-        for_(int id = id_start; id < id_end; id++)
-        for (int doh = 0; doh < jcp.oh_block; doh++) {
-            const int ih_overlap = doh == 0
-                    ? has_inp_buffer_overlap * nstl::max(0, KH - SH)
+        for_(dim_t id = id_start; id < id_end; id++)
+        for (dim_t doh = 0; doh < jcp.oh_block; doh++) {
+            const dim_t ih_overlap = doh == 0
+                    ? has_inp_buffer_overlap * nstl::max<dim_t>(0, KH - SH)
                     : 0;
-            const int kh_eff = jcp.kh - ih_overlap;
+            const dim_t kh_eff = jcp.kh - ih_overlap;
 
             const auto sdst = base_out_offset_start
                     + btc.ohb
@@ -1955,20 +1969,22 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                                     + jcp.stride_h * jcp.inp_ic_block)
                     + ih_overlap * jcp.inp_ic_block;
 
-            const int ih_s = (doh + oh) * jcp.stride_h - jcp.t_pad + ih_overlap;
-            const int ih_e = ih_s + kh_eff;
-            const int ih = nstl::max(0, ih_s);
-            p.t_overflow = nstl::max(0, -ih_s);
-            p.b_overflow = nstl::min<int>(kh_eff, nstl::max(0, ih_e - jcp.ih));
+            const dim_t ih_s
+                    = (doh + oh) * jcp.stride_h - jcp.t_pad + ih_overlap;
+            const dim_t ih_e = ih_s + kh_eff;
+            const dim_t ih = nstl::max<dim_t>(0, ih_s);
+            p.t_overflow = nstl::max<dim_t>(0, -ih_s);
+            p.b_overflow = nstl::min<dim_t>(
+                    kh_eff, nstl::max<dim_t>(0, ih_e - jcp.ih));
             p.kh_padding
-                    = nstl::max<int>(0, (kh_eff - p.t_overflow - p.b_overflow));
+                    = nstl::max<dim_t>(0, kh_eff - p.t_overflow - p.b_overflow);
             p.kh_offset = kh_eff;
 
-            const int iw_s = ow * jcp.stride_w - jcp.l_pad;
-            const int iw_e = iw_s + jcp.iwp;
-            p.f_overflow = nstl::max(0, -iw_s);
-            p.back_overflow = nstl::max(0, iw_e - jcp.iw);
-            p.kw_padding = nstl::max<int>(
+            const dim_t iw_s = ow * jcp.stride_w - jcp.l_pad;
+            const dim_t iw_e = iw_s + jcp.iwp;
+            p.f_overflow = nstl::max<dim_t>(0, -iw_s);
+            p.back_overflow = nstl::max<dim_t>(0, iw_e - jcp.iw);
+            p.kw_padding = nstl::max<dim_t>(
                     0, jcp.iwp - p.f_overflow - p.back_overflow);
 
             const auto first_actual_h = ih;
@@ -1998,15 +2014,16 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
         // TODO: extend M_mask (may be different for different kh) to avoid copying
         // top/bottom padded rows and avoid extra calculations in kernel
         // also for convolutions with pw == 0 the copy routine maybe not needed
-        cp.t_pad = jcp.is_os_blocking ? nstl::max(0, -virt_ih_start) : 0;
-        cp.b_pad = jcp.is_os_blocking ? nstl::max(0, virt_ih_end - IH) : 0;
+        cp.t_pad = jcp.is_os_blocking ? nstl::max<dim_t>(0, -virt_ih_start) : 0;
+        cp.b_pad = jcp.is_os_blocking ? nstl::max<dim_t>(0, virt_ih_end - IH)
+                                      : 0;
 
-        cp.h_count = nstl::max(0, rows_to_copy) + cp.t_pad + cp.b_pad;
+        cp.h_count = nstl::max<dim_t>(0, rows_to_copy) + cp.t_pad + cp.b_pad;
         inp_offset_start = base_inp_offset_start + ih_start * src_w_sz;
         // inp_buffer has physical padding
         out_offset_start = base_out_offset_start - cp.t_pad * _pd->pbuf_w_sz;
 
-        for (int id = id_start; id < id_end; id++) {
+        for (dim_t id = id_start; id < id_end; id++) {
             const auto inp_offset = inp_offset_start + id * src_h_sz;
             const auto id_buf = id - (jcp.copy_block_only ? id_start : 0) + FP;
             const auto out_offset = out_offset_start + id_buf * _pd->pbuf_h_sz;
@@ -2029,7 +2046,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                 }
                 const auto actual_iw_block = nstl::min(jcp.iw_block, IW - iw);
                 if (actual_iw_block < jcp.iw_block) {
-                    int size_to_sero = 0;
+                    dim_t size_to_sero = 0;
                     const auto zero_elem_size
                             = (dim_t)src_dsz * jcp.inp_ic_block;
                     size_to_sero
@@ -2055,28 +2072,31 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
     const char *const __restrict src = btc.brgemm_ctx.src; \
     const char *const __restrict weights = btc.weights; \
     const char *const __restrict bias = btc.brgemm_ctx.bias; \
-    const int oc = btc.ocb * jcp.oc_block; \
-    const int g_oc = btc.g * jcp.oc + oc; \
-    const int icb = btc.icc * jcp.nb_ic_blocking; \
-    const int ic = icb * jcp.ic_block; \
-    const int ow = btc.owb * jcp.ow_block; \
-    const int oh = btc.ohb * jcp.oh_block; \
-    const int iid = ndims_pick(btc.od * SD - FP, 0, 0); \
-    const int kd_s = ndims_pick(div_up(nstl::max(0, -iid), DD), 0, 0); \
-    const int kd_f = ndims_pick( \
-            KD - div_up(nstl::max(0, iid - ID + (KD - 1) * DD + 1), DD), 1, \
-            1); \
+    const dim_t oc = btc.ocb * jcp.oc_block; \
+    const dim_t g_oc = btc.g * jcp.oc + oc; \
+    const dim_t icb = btc.icc * jcp.nb_ic_blocking; \
+    const dim_t ic = icb * jcp.ic_block; \
+    const dim_t ow = btc.owb * jcp.ow_block; \
+    const dim_t oh = btc.ohb * jcp.oh_block; \
+    const dim_t iid = ndims_pick(btc.od * SD - FP, 0, 0); \
+    const dim_t kd_s \
+            = ndims_pick(div_up(nstl::max<dim_t>(0, -iid), DD), 0, 0); \
+    const dim_t kd_f = ndims_pick(KD \
+                    - div_up( \
+                            nstl::max<dim_t>(0, iid - ID + (KD - 1) * DD + 1), \
+                            DD), \
+            1, 1); \
     const auto kd_l = kd_f - kd_s; \
     const auto adj_sh = jcp.is_relo_whi() ? 1 : SH; \
     const auto adj_tp = jcp.is_relo_whi() ? 0 : TP; \
     const auto iih = ndims_pick( \
             btc.oh * adj_sh - adj_tp, btc.oh * adj_sh - adj_tp, 0); \
-    const auto kh_s_ = div_up(nstl::max(0, -iih), DH); \
+    const auto kh_s_ = div_up(nstl::max<dim_t>(0, -iih), DH); \
     const auto kh_s = (jcp.is_os_blocking || jcp.is_relo_whi()) \
             ? 0 \
             : ndims_pick(kh_s_, kh_s_, 0); \
-    const auto kh_f_ \
-            = KH - div_up(nstl::max(0, iih - IH + (KH - 1) * DH + 1), DH); \
+    const auto kh_f_ = KH \
+            - div_up(nstl::max<dim_t>(0, iih - IH + (KH - 1) * DH + 1), DH); \
     const auto kh_f = jcp.is_relo_whi() ? 1 : ndims_pick(kh_f_, kh_f_, 1); \
     const auto kh_l = kh_f - kh_s; \
     const bool is_oc_tail = (jcp.oc - oc < jcp.oc_block); \
@@ -2086,7 +2106,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
     const bool is_oh_tail = (OH - oh < jcp.oh_block); \
     const char *const __restrict bias_w \
             = bias ? bias + (bias_d.blk_off(g_oc) * bia_dsz) : nullptr; \
-    const auto nb_ic_b = nstl::min(jcp.nb_ic_blocking, jcp.nb_ic - icb) \
+    const auto nb_ic_b = nstl::min<dim_t>(jcp.nb_ic_blocking, jcp.nb_ic - icb) \
             - (is_ic_tail ? 1 : 0); \
     const memory_desc_wrapper dst_d(pd()->dst_md()); \
     char *const __restrict dst_base = btc.brgemm_ctx.dst \
@@ -2097,7 +2117,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                             + oc); \
     char *ptr_C; \
     char *ptr_D; \
-    int kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0), iiw_b(0);
+    dim_t kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0), iiw_b(0);
 
 template <cpu_isa_t isa>
 void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
@@ -2110,11 +2130,12 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
     MAYBE_UNUSED(is_ow_tail);
     MAYBE_UNUSED(is_oh_tail);
 
-    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0}, kw_b(0), kw_e(0);
+    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
+    dim_t kw_b {0}, kw_e {0};
     int ow_b {0}, ow_e {0};
 
     brgemm_convolution_utils::get_kw_range(
-            jcp, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+            jcp, static_cast<int>(ow), kw_s, kw_full_s, kw_full_f, kw_f);
 
     const auto src_base = src + get_src_base_offset(btc, ic);
     const auto wei_base = weights
@@ -2122,9 +2143,9 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
                     * (btc.g * _pd->wei_g_stride
                             + btc.ocb * _pd->wei_ocb_stride);
 
-    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
-                                     size_t comp_ker_offs, bool do_postops,
-                                     bool do_only_comp) {
+    const auto call_brgemm = [&](int brg_idx, dim_t ic_block_s,
+                                     dim_t n_ic_blocks, size_t comp_ker_offs,
+                                     bool do_postops, bool do_only_comp) {
         if (brg_idx == -1) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -2144,13 +2165,15 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
                     kh_b, kh_e, kw_b, kw_e, k_l, btc.brg_batch);
             if (k_l <= 0) return;
         }
-        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
-                bias_w, g_oc, do_postops, comp_ker_offs, do_only_comp);
+        call_brgemm_kernel(btc, brg_ker, static_cast<int>(k_l * n_ic_blocks),
+                ptr_C, ptr_D, bias_w, g_oc, do_postops, comp_ker_offs,
+                do_only_comp);
     };
 
     const auto kdhw_loop = [&]() {
         if (kw_e - kw_b <= 0) return;
-        brgemm_convolution_utils::get_ow_range(jcp, ow, kw_b, ow_b, ow_e);
+        brgemm_convolution_utils::get_ow_range(
+                jcp, static_cast<int>(ow), static_cast<int>(kw_b), ow_b, ow_e);
         const auto do_init
                 = btc.icc == 0 && kd_b == kd_s && kh_b == kh_s && kw_b == kw_s;
         const auto do_postwork = _pd->need_postwork
@@ -2178,16 +2201,20 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
                     : 0;
 
             if (nb_ic_b > 0) {
-                const auto brg_idx = _pd->get_brg_idx(ow_l, do_init, is_oc_tail,
-                        false, kd_s, kd_f, kh_s, kh_f);
+                const int brg_idx = _pd->get_brg_idx(static_cast<int>(ow_l),
+                        do_init, is_oc_tail, false, static_cast<int>(kd_s),
+                        static_cast<int>(kd_f), static_cast<int>(kh_s),
+                        static_cast<int>(kh_f));
                 call_brgemm(brg_idx, 0, nb_ic_b, comp_ker_offs,
                         do_postwork && !is_ic_tail, false);
             }
 
             if (is_ic_tail) {
                 const auto use_init_ker = (do_init && nb_ic_b == 0);
-                const auto brg_ic_tail_idx = _pd->get_brg_idx(ow_l,
-                        use_init_ker, is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+                const int brg_ic_tail_idx = _pd->get_brg_idx(
+                        static_cast<int>(ow_l), use_init_ker, is_oc_tail, true,
+                        static_cast<int>(kd_s), static_cast<int>(kd_f),
+                        static_cast<int>(kh_s), static_cast<int>(kh_f));
                 call_brgemm(brg_ic_tail_idx, nb_ic_b, 1, comp_ker_offs,
                         do_postwork, false);
             }
@@ -2204,9 +2231,9 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         // kw values with left padding
         if (kw_s < kw_full_s) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK_PAD);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK_PAD);
                     for (auto kw = kw_s; kw < kw_full_s; kw++) {
                         kw_b = kw;
                         kw_e = kw + 1;
@@ -2219,11 +2246,11 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         // kw values covering full ow_block
         if (kw_full_s < kw_full_f) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                     for (kw_b = kw_full_s; kw_b < kw_full_f; kw_b += KW_BLOCK) {
-                        kw_e = nstl::min(kw_full_f, kw_b + KW_BLOCK);
+                        kw_e = nstl::min<dim_t>(kw_full_f, kw_b + KW_BLOCK);
                         kdhw_loop();
                     }
                 }
@@ -2233,9 +2260,9 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         // kw values with right padding
         if (kw_full_f < kw_f) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK_PAD);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK_PAD);
                     for (int kw = kw_full_f; kw < kw_f; kw++) {
                         kw_b = kw;
                         kw_e = kw + 1;
@@ -2248,7 +2275,8 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         const auto do_init = btc.icc == 0;
         const auto do_postwork
                 = _pd->need_postwork && btc.icc == (_pd->ic_chunks - 1);
-        brgemm_convolution_utils::get_ow_range(jcp, ow, kw_b, ow_b, ow_e);
+        brgemm_convolution_utils::get_ow_range(
+                jcp, static_cast<int>(ow), static_cast<int>(kw_b), ow_b, ow_e);
         perform_outwork(btc, dst_base, bias_w, ow, g_oc, is_oc_tail, ow_b, ow_e,
                 kd_l, kh_l, do_init, do_postwork, 0, false);
     }
@@ -2269,15 +2297,15 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
             + wei_dsz
                     * (btc.g * _pd->wei_g_stride
                             + btc.ocb * _pd->wei_ocb_stride);
-    const int ow_b {ow},
+    const dim_t ow_b {ow},
             ow_e {ow + (is_ow_tail ? jcp.ow % jcp.ow_block : jcp.ow_block)};
-    const int oh_b {oh},
+    const dim_t oh_b {oh},
             oh_e {oh + (is_oh_tail ? jcp.oh % jcp.oh_block : jcp.oh_block)};
     const auto iid_shift = jcp.copy_block_only
-            ? nstl::max(0, btc.odb * jcp.od_block * SD - FP)
+            ? nstl::max<dim_t>(0, btc.odb * jcp.od_block * SD - FP)
             : 0;
     const auto iih_shift = jcp.copy_block_only
-            ? nstl::max(0, btc.ohb * jcp.oh_block * adj_sh - adj_tp)
+            ? nstl::max<dim_t>(0, btc.ohb * jcp.oh_block * adj_sh - adj_tp)
             : 0;
     const auto iiw_shift
             = jcp.copy_block_only ? (btc.owb * jcp.ow_block * SW) : 0;
@@ -2299,14 +2327,16 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
 
     const auto ker_i = (jcp.is_os_blocking ? oh_l * ow_l : ow_l);
     const auto comp_iih = ndims_pick(btc.oh * SH - TP, btc.oh * SH - TP, 0);
-    const auto comp_kh_s_ = div_up(nstl::max(0, -comp_iih), DH);
-    const auto comp_kh_f_
-            = KH - div_up(nstl::max(0, comp_iih - IH + (KH - 1) * DH + 1), DH);
+    const auto comp_kh_s_ = div_up(nstl::max<dim_t>(0, -comp_iih), DH);
+    const auto comp_kh_f_ = KH
+            - div_up(
+                    nstl::max<dim_t>(0, comp_iih - IH + (KH - 1) * DH + 1), DH);
     const auto comp_kh_s = ndims_pick(comp_kh_s_, comp_kh_s_, 0);
     const auto comp_kh_f = ndims_pick(comp_kh_f_, comp_kh_f_, 1);
 
-    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
-                                     size_t comp_ker_offs, bool do_postops) {
+    const auto call_brgemm
+            = [&](int brg_idx, dim_t ic_block_s, dim_t n_ic_blocks,
+                      size_t comp_ker_offs, bool do_postops) {
         if (brg_idx == -1) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -2338,8 +2368,8 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
             if (k_l <= 0) return;
         }
 
-        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
-                bias_w, g_oc, do_postops, comp_ker_offs, false);
+        call_brgemm_kernel(btc, brg_ker, static_cast<int>(k_l * n_ic_blocks),
+                ptr_C, ptr_D, bias_w, g_oc, do_postops, comp_ker_offs, false);
     };
 
     const auto kdhw_loop = [&]() {
@@ -2355,16 +2385,20 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
                 : 0;
 
         if (nb_ic_b > 0) {
-            const auto brg_idx = _pd->get_brg_idx(
-                    ker_i, do_init, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+            const int brg_idx = _pd->get_brg_idx(static_cast<int>(ker_i),
+                    do_init, is_oc_tail, false, static_cast<int>(kd_s),
+                    static_cast<int>(kd_f), static_cast<int>(kh_s),
+                    static_cast<int>(kh_f));
             call_brgemm(brg_idx, 0, nb_ic_b, comp_ker_offs,
                     do_postwork && !is_ic_tail);
         }
 
         if (is_ic_tail) {
             const auto use_init_ker = (do_init && nb_ic_b == 0);
-            const auto brg_ic_tail_idx = _pd->get_brg_idx(ker_i, use_init_ker,
-                    is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+            const int brg_ic_tail_idx = _pd->get_brg_idx(
+                    static_cast<int>(ker_i), use_init_ker, is_oc_tail, true,
+                    static_cast<int>(kd_s), static_cast<int>(kd_f),
+                    static_cast<int>(kh_s), static_cast<int>(kh_f));
 
             call_brgemm(
                     brg_ic_tail_idx, nb_ic_b, 1, comp_ker_offs, do_postwork);
@@ -2374,9 +2408,9 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
     if (kd_f > kd_s && kh_f > kh_s) {
         // kw values covering full ow_block
         for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-            kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+            kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
             for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                 kdhw_loop();
             }
         }
@@ -2405,7 +2439,7 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
                     * (btc.g * _pd->wei_g_stride
                             + btc.ocb * _pd->wei_ocb_stride);
 
-    const int ow_b {ow}, ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
+    const dim_t ow_b {ow}, ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
     iiw_b = ow_b * SW - LP;
     ptr_D = dst_base
             + dst_dsz
@@ -2421,8 +2455,9 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
     const dim_t *const __restrict kw_bottom_vpads
             = owb_kw_bottom_vpads.data() + btc.owb * KW;
 
-    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
-                                     size_t comp_ker_offs, bool do_postops) {
+    const auto call_brgemm
+            = [&](int brg_idx, dim_t ic_block_s, dim_t n_ic_blocks,
+                      size_t comp_ker_offs, bool do_postops) {
         if (brg_idx < 0) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -2437,8 +2472,8 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
                 kh_b, kh_e, 0, KW, k_l, btc.brg_batch);
         if (k_l <= 0) return;
 
-        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
-                bias_w, g_oc, do_postops, comp_ker_offs, false);
+        call_brgemm_kernel(btc, brg_ker, static_cast<int>(k_l * n_ic_blocks),
+                ptr_C, ptr_D, bias_w, g_oc, do_postops, comp_ker_offs, false);
     };
 
     const auto kdhw_loop = [&]() {
@@ -2453,16 +2488,20 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
                 btc.g, btc.ocb, 0, 0, kd_s, kd_f, kh_s, kh_f, 0, KW);
 
         if (nb_ic_b > 0) {
-            const auto brg_idx = _pd->get_brg_idx(
-                    ow_l, do_init, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+            const int brg_idx = _pd->get_brg_idx(static_cast<int>(ow_l),
+                    do_init, is_oc_tail, false, static_cast<int>(kd_s),
+                    static_cast<int>(kd_f), static_cast<int>(kh_s),
+                    static_cast<int>(kh_f));
             call_brgemm(
                     brg_idx, 0, nb_ic_b, comp_offs, do_postwork && !is_ic_tail);
         }
 
         if (is_ic_tail) {
             const auto use_init_ker = (do_init && nb_ic_b == 0);
-            const auto brg_ic_tail_idx = _pd->get_brg_idx(ow_l, use_init_ker,
-                    is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+            const int brg_ic_tail_idx = _pd->get_brg_idx(static_cast<int>(ow_l),
+                    use_init_ker, is_oc_tail, true, static_cast<int>(kd_s),
+                    static_cast<int>(kd_f), static_cast<int>(kh_s),
+                    static_cast<int>(kh_f));
 
             call_brgemm(brg_ic_tail_idx, nb_ic_b, 1, comp_offs, do_postwork);
         }
@@ -2471,9 +2510,9 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
     if (kd_f > kd_s && kh_f > kh_s) {
         // kw values covering full ow_block
         for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-            kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+            kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
             for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                 kdhw_loop();
             }
         }

--- a/src/cpu/x64/jit_brgemm_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_conv.hpp
@@ -59,76 +59,79 @@ struct brgemm_convolution_fwd_t : public primitive_t {
 
         status_t init(engine_t *engine);
 
-        int brgs_sz_ {};
+        dim_t brgs_sz_ {};
         std::shared_ptr<brgemm_containers::brgemm_desc_container_t>
                 brgemm_descriptors_;
         bool with_sum_ = false;
         jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
-        int ic_chunks {};
+        dim_t ic_chunks {};
         bool need_postwork {};
         dim_t wei_g_stride {}, wei_ic_stride {}, wei_ocb_stride {};
         dim_t wei_kw_stride {}, wei_kh_stride {}, wei_kd_stride {};
         dim_t pbuf_w_sz {}, pbuf_h_sz {}, pbuf_d_sz {};
         int ndims {0};
-        int rd {0};
+        dim_t rd {0};
 
         // batch sizes info for unrolled kernels
         int bs_c {};
         // need custom hasher to use array as key in unordered_map
-        template <int asize>
+        template <int asize, typename T = int>
         struct hasher_t {
-            size_t operator()(const std::array<int, asize> &a) const {
+            size_t operator()(const std::array<T, asize> &a) const {
                 size_t seed = 0;
                 for (auto e : a)
                     seed = hash_combine(seed, e);
                 return seed;
             }
         };
-        template <int asize>
-        using Arrmap = std::unordered_map<std::array<int, asize>, int,
-                hasher_t<asize>>;
+        template <int asize, typename T = int>
+        using Arrmap = std::unordered_map<std::array<T, asize>, T,
+                hasher_t<asize, T>>;
 
         Arrmap<4> batchsizes;
         int brg_indices_c {0};
+        // Bounded kernel-variant lookup key/index, not tensor-scale.
         Arrmap<8> brg_indices;
 
         int get_brg_idx(int m, bool do_initialization, bool is_N_tail,
                 bool is_K_tail, int kd_b, int kd_e, int kh_b, int kh_e) const;
 
-        inline int get_bs(int kd_b, int kd_e, int kh_b, int kh_e) const {
-            const auto kd_l = nstl::min(KD_BLOCK, kd_e - kd_b);
-            const auto kh_l = nstl::min(KH_BLOCK, kh_e - kh_b);
+        inline int get_bs(dim_t kd_b, dim_t kd_e, dim_t kh_b,
+                dim_t kh_e) const {
+            const auto kd_l = nstl::min<dim_t>(KD_BLOCK, kd_e - kd_b);
+            const auto kh_l = nstl::min<dim_t>(KH_BLOCK, kh_e - kh_b);
             const auto bs = kd_l
                     * (jcp_.is_relo_whi()
                                     ? 1
                                     : (kh_l * (jcp_.is_relo_wi() ? 1 : KW)));
-            return bs;
+            return static_cast<int>(bs);
         }
 
         int get_any_brg_idx(bool is_N_tail, bool is_K_tail) const;
 
-        inline int maybe_invert(int k, int K) const {
+        inline dim_t maybe_invert(dim_t k, dim_t K) const {
             return desc()->use_inversion ? K - 1 - k : k;
         }
 
         // This method calculates the value of k_l
-        void init_batch(int icc, const char *src_base, const char *wei_base,
-                int n_ic_blocks, int ic_block_s, int iid_b, int iih_b,
-                int iiw_b, const dim_t *const __restrict kw_top_vpads,
-                const dim_t *const __restrict kw_bottom_vpads, int kd_b,
-                int kd_e, int kh_b, int kh_e, int kw_b, int kw_e, int &k_l,
-                brgemm_batch_element_t *brg_batch) const;
+        void init_batch(dim_t icc, const char *src_base, const char *wei_base,
+                dim_t n_ic_blocks, dim_t ic_block_s, dim_t iid_b, dim_t iih_b,
+                dim_t iiw_b, const dim_t *const __restrict kw_top_vpads,
+                const dim_t *const __restrict kw_bottom_vpads, dim_t kd_b,
+                dim_t kd_e, dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e,
+                dim_t &k_l, brgemm_batch_element_t *brg_batch) const;
 
-        void get_A_B(int icc, const char *src_base, const char *wei_base,
-                int ic_block_s, int iid_b, int iih_b, int iiw_b, int kd_b,
-                int kh_b, const void *&ptrA, const void *&ptrB) const;
+        void get_A_B(dim_t icc, const char *src_base, const char *wei_base,
+                dim_t ic_block_s, dim_t iid_b, dim_t iih_b, dim_t iiw_b,
+                dim_t kd_b, dim_t kh_b, const void *&ptrA,
+                const void *&ptrB) const;
 
-        status_t add_brg_descriptor(int M, bool is_N_tail, bool is_K_tail,
+        status_t add_brg_descriptor(dim_t M, bool is_N_tail, bool is_K_tail,
                 bool do_init, int kd_b, int kd_e, int kh_b, int kh_e);
 
     protected:
-        int KD {}, KH {}, KW {}, EXT_KD {}, EXT_KH {}, EXT_KW {}, KS {},
+        dim_t KD {}, KH {}, KW {}, EXT_KD {}, EXT_KH {}, EXT_KW {}, KS {},
                 KD_BLOCK {}, KH_BLOCK {}, KW_BLOCK {}, KD_BLOCK_PAD {},
                 KH_BLOCK_PAD {}, ID {}, IH {}, IW {}, IDP {}, IHP {}, IWP {},
                 OD {}, OH {}, OW {}, SD {}, SH {}, SW {}, FP {}, TP {}, LP {},
@@ -166,20 +169,21 @@ private:
         const std::vector<const void *> post_ops_binary_rhs_arg_vec;
     };
 
-    inline static int get_ker_po_idx(int m, bool do_postwork, bool is_N_tail) {
-        return (m * 2 + static_cast<int>(do_postwork)) * 2
-                + static_cast<int>(is_N_tail);
+    inline static int get_ker_po_idx(dim_t m, bool do_postwork, bool is_N_tail) {
+        return static_cast<int>((m * 2 + static_cast<int>(do_postwork)) * 2
+                + static_cast<int>(is_N_tail));
     }
 
-    inline static int get_inp_size(
-            int max_src_size, int dst_size, int k, int stride, int dilate) {
-        const auto res = nstl::min(max_src_size,
+    inline static dim_t get_inp_size(dim_t max_src_size, dim_t dst_size,
+            dim_t k, dim_t stride, dim_t dilate) {
+        const auto res = nstl::min<dim_t>(max_src_size,
                 calculate_end_padding(0, dst_size, 0, stride,
                         calculate_extended_filter_size(k, dilate)));
         return res;
     }
 
-    inline int maybe_invert_range(int k, int k_inv, int K) const {
+    inline dim_t maybe_invert_range(
+            dim_t k, dim_t k_inv, dim_t K) const {
         return pd()->desc()->use_inversion ? K - k_inv : k;
     }
 
@@ -191,13 +195,14 @@ private:
     void ker_vpad(brgemm_thread_ctx_t &btc) const;
 
     void perform_outwork(const brgemm_thread_ctx_t &btc, char *dst_base,
-            const char *bias_w, int ow, int g_oc, bool is_oc_tail, int ker_ow_s,
-            int ker_ow_f, int kd_l, int kh_l, bool maybe_do_init,
-            bool do_postwork, size_t comp_ker_offs, bool do_post_comp) const;
+            const char *bias_w, dim_t ow, dim_t g_oc, bool is_oc_tail,
+            dim_t ker_ow_s, dim_t ker_ow_f, dim_t kd_l, dim_t kh_l,
+            bool maybe_do_init, bool do_postwork, size_t comp_ker_offs,
+            bool do_post_comp) const;
 
     void call_brgemm_kernel(const brgemm_thread_ctx_t &btc,
             const brgemm_kernel_t *brg_ker, int batch_size, char *ptr_C,
-            char *ptr_D, const char *bias_w, int g_oc, bool do_postops,
+            char *ptr_D, const char *bias_w, dim_t g_oc, bool do_postops,
             size_t comp_ker_offs, bool do_only_comp) const;
 
     void maybe_conv_inp(brgemm_thread_ctx_t &btc,
@@ -209,17 +214,16 @@ private:
             const char *__restrict &wei) const;
 
     status_t add_po_kernel(brgemm_desc_t *bcfg, int ker_idx, bool is_init);
-    status_t add_po_kernels(int i_N, int init_bcast_dim, int po_bcast_dim);
+    status_t add_po_kernels(int i_N, dim_t init_bcast_dim, dim_t po_bcast_dim);
     status_t add_brg_kernel(int brg_idx);
 
     status_t cal_compensation(const char *__restrict weights,
             int32_t *src_zp_buffer, int32_t *s8s8_comp_buffer) const;
-    int get_comp_oh(const int oh) const;
-    int get_comp_ker_idx(const int kd_b, const int kd_e, const int kh_b,
-            const int kh_e, const int kw_b, const int kw_e, const int oh) const;
-    int get_comp_offset(const int g, const int ocb, const int oh, const int ow,
-            const int kd_b, const int kd_e, const int kh_b, const int kh_e,
-            const int kw_b, const int kw_e) const;
+    dim_t get_comp_oh(dim_t oh) const;
+    dim_t get_comp_ker_idx(dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e,
+            dim_t kw_b, dim_t kw_e, dim_t oh) const;
+    dim_t get_comp_offset(dim_t g, dim_t ocb, dim_t oh, dim_t ow, dim_t kd_b,
+            dim_t kd_e, dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e) const;
     inline const pd_t *pd() const {
         return static_cast<const pd_t *>(primitive_t::pd().get());
     }
@@ -247,7 +251,7 @@ private:
     std::vector<dim_t> kd_bs, kd_es, kh_bs, kh_es, kw_bs, kw_es, oh_kh_b,
             oh_kh_e, comp_oh, comp_oh_kh_b, comp_oh_kh_e, comp_owb;
 
-    int KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
+    dim_t KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
             KD_BLOCK_PAD, KH_BLOCK_PAD, ID, IH, IW, IDP, IHP, IWP, OD, OH, OW,
             SD, SH, SW, FP, TP, LP, DD, DH, DW;
     dim_t src_w_sz, src_h_sz, dst_w_sz, dst_h_sz;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.cpp
@@ -74,13 +74,13 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::store(
 template <>
 void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Xbyak::Ymm>::load(
         const Xbyak::Ymm &x, const Xbyak::Address &addr, const int load_size) {
-    load_bytes(x, addr, jcp.dst_dsz * load_size, true);
+    load_bytes(x, addr, static_cast<int>(jcp.dst_dsz * load_size), true);
 }
 
 template <>
 void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Xbyak::Ymm>::store(
         const Xbyak::Address &addr, const Xbyak::Ymm &x, const int store_size) {
-    store_bytes(x, addr, jcp.dst_dsz * store_size);
+    store_bytes(x, addr, static_cast<int>(jcp.dst_dsz * store_size));
 }
 
 template <typename Vmm>
@@ -99,7 +99,7 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
     const auto iw_tail = jcp.iw % jcp.iw_block;
     const auto ic_tail = jcp.ic % jcp.ic_block;
     if (is_zmm_ && ic_tail) {
-        int simd_tail = ic_tail % simd_w;
+        int simd_tail = static_cast<int>(ic_tail % simd_w);
         uint64_t mask = (UINT64_C(1) << simd_tail) - 1;
         mov(reg_tmp, mask);
         kmovq(ktail_mask, reg_tmp);
@@ -117,8 +117,10 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
             const auto iw_off = iw * jcp.ic_without_padding * jcp.dst_dsz;
             auto nvec = is_ic_tail ? n_tail_vec : n_vec;
             for (size_t iv = 0; iv < nvec; iv++) {
-                load(vmm_tmp, ptr[inp_ptr + iw_off + iv * VL], simd_w);
-                store(ptr[dst_ptr + iw_off + iv * VL], vmm_tmp, simd_w);
+                load(vmm_tmp, ptr[inp_ptr + iw_off + iv * VL],
+                        static_cast<int>(simd_w));
+                store(ptr[dst_ptr + iw_off + iv * VL], vmm_tmp,
+                        static_cast<int>(simd_w));
             }
             const auto last_inp_off = inp_ptr + iw_off + nvec * VL;
             const auto last_dst_off = dst_ptr + iw_off + nvec * VL;
@@ -129,7 +131,7 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
                     load(zmm_tmp_mask, ptr[last_inp_off]);
                     store(ptr[last_dst_off] | ktail_mask, vmm_tmp);
                 } else {
-                    int simd_tail = ic_tail % simd_w;
+                    int simd_tail = static_cast<int>(ic_tail % simd_w);
                     load(vmm_tmp, ptr[last_inp_off], simd_tail);
                     store(ptr[last_dst_off], vmm_tmp, simd_tail);
                 }
@@ -139,8 +141,10 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
                     load(zmm_tmp_mask, ptr[last_inp_off]);
                     store(ptr[last_dst_off] | kblock_tail_mask, vmm_tmp);
                 } else {
-                    load(vmm_tmp, ptr[last_inp_off], block_tail);
-                    store(ptr[last_dst_off], vmm_tmp, block_tail);
+                    load(vmm_tmp, ptr[last_inp_off],
+                            static_cast<int>(block_tail));
+                    store(ptr[last_dst_off], vmm_tmp,
+                            static_cast<int>(block_tail));
                 }
             }
         }

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -177,15 +177,15 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
     if (jcp_.exec_type == exec_trans && is_amx) {
         std::set<int> bs_set;
         bs_set.insert(0); // for skip_accumulation case
-        for (int kd_range = 1; kd_range <= KD_BLOCK; kd_range++) {
+        for (dim_t kd_range = 1; kd_range <= KD_BLOCK; kd_range++) {
             const auto kd_l = div_up(kd_range, SD);
-            for (int kh_range = 1; kh_range <= KH_BLOCK; kh_range++) {
+            for (dim_t kh_range = 1; kh_range <= KH_BLOCK; kh_range++) {
                 const auto kh_l = div_up(kh_range, SH);
-                for (int kw_s_off = 0; kw_s_off < nstl::min(KW, SW);
+                for (int kw_s_off = 0; kw_s_off < nstl::min<dim_t>(KW, SW);
                         kw_s_off++) {
                     const auto kw_range = KW - kw_s_off;
                     const auto kw_l = div_up(kw_range, SW);
-                    bs_set.insert(kd_l * kh_l * kw_l);
+                    bs_set.insert(static_cast<int>(kd_l * kh_l * kw_l));
                 }
             }
         }
@@ -224,14 +224,14 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
         const auto eff_iw = jcp_.iw_tail > 0 ? jcp_.iw_tail : jcp_.iw;
         for (int sw = 0; sw < SW; sw++) {
             if (eff_iw <= sw) continue;
-            const auto M_sw = static_cast<int>(div_up(eff_iw - sw, SW));
+            const dim_t M_sw = div_up(eff_iw - sw, SW);
             if (M_sw > 0 && M_sw < M_full) {
                 if (jcp_.use_uker) {
                     // AMX uker: use bd_mask with constant M to avoid tile
                     // reconfiguration. The uker skips masked rows during
                     // postops store.
                     std::vector<char> mask(M_full, 0);
-                    for (int i = 0; i < M_sw; i++)
+                    for (dim_t i = 0; i < M_sw; i++)
                         mask[i] = 1;
                     for_(int i_N = N_begin; i_N < N_end; i_N++)
                     for_(int i_init = i_init_begin; i_init < i_init_end;
@@ -260,11 +260,13 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
         int kw_s {0}, kw_full_s {0}, kw_full_f {0}, kw_f {0}, iw_s {0},
                 M_without_overflow {0};
 
-        auto init_kernels_kw_loop = [&](int sw, int iw) -> status_t {
+        auto init_kernels_kw_loop = [&](dim_t sw, dim_t iw) -> status_t {
             const auto iw_str = iw + sw;
-            get_kw_range(iw_str, iw, kw_s, kw_full_s, kw_full_f, kw_f);
+            get_kw_range(static_cast<int>(iw_str), static_cast<int>(iw), kw_s,
+                    kw_full_s, kw_full_f, kw_f);
             for (int kw = kw_s; kw < kw_f; kw++) {
-                get_iw_range(iw_str, iw, kw, iw_s, M_without_overflow);
+                get_iw_range(static_cast<int>(iw_str), static_cast<int>(iw), kw,
+                        iw_s, M_without_overflow);
                 if (M_without_overflow <= 0) continue;
                 for_(int i_init = 0; i_init < 2; i_init++)
                 for_(int i_N = 0; i_N < 2; i_N++)
@@ -276,18 +278,18 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
             return status::success;
         };
         for (int sw = 0; sw < SW; sw++) {
-            for (int iw = 0; iw < IW; iw += jcp_.iw_block) {
+            for (dim_t iw = 0; iw < IW; iw += jcp_.iw_block) {
                 CHECK(init_kernels_kw_loop(sw, iw));
                 if (kw_f == jcp_.kw && kw_s == 0) break;
             }
-            for (int iw = (jcp_.nb_iw - 1) * jcp_.iw_block; iw >= 0;
+            for (dim_t iw = (jcp_.nb_iw - 1) * jcp_.iw_block; iw >= 0;
                     iw -= jcp_.iw_block) {
                 CHECK(init_kernels_kw_loop(sw, iw));
                 if (kw_f == jcp_.kw && kw_s == 0) break;
             }
         }
     }
-    brgs_sz_ = brgs_->refs_size();
+    brgs_sz_ = static_cast<int>(brgs_->refs_size());
 
     auto scratchpad = scratchpad_registry().registrar();
     brgemm_convolution_bwd_utils::init_scratchpad(scratchpad, jcp_);
@@ -296,9 +298,9 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(engine_t *engine) {
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
-        bool is_N_tail, bool is_K_tail, bool do_init, int bd_mask_idx,
-        const std::vector<char> &bd_mask, int bs) {
+status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(
+        dim_t vM, bool is_N_tail, bool is_K_tail, bool do_init,
+        dim_t bd_mask_idx, const std::vector<char> &bd_mask, int bs) {
 
     if (do_init && is_K_tail && jcp_.K > 0) return status::success;
 
@@ -313,8 +315,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
 
     if (vN == 0 || vK == 0) return status::success;
 
-    auto brg_idx
-            = get_brg_idx(vM, do_init, is_N_tail, is_K_tail, bd_mask_idx, bs);
+    int brg_idx = get_brg_idx(static_cast<int>(vM), do_init, is_N_tail,
+            is_K_tail, static_cast<int>(bd_mask_idx), bs);
     // if brgemm_desc_t already created then skip this iteration
     if (brg_idx != -1) return status::success;
 
@@ -363,8 +365,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
         brgattr.max_top_vpad = 0;
         brgattr.max_bottom_vpad = 0;
     } else {
-        brgattr.max_top_vpad = jcp_.max_vpad;
-        brgattr.max_bottom_vpad = jcp_.max_vpad;
+        brgattr.max_top_vpad = static_cast<int>(jcp_.max_vpad);
+        brgattr.max_bottom_vpad = static_cast<int>(jcp_.max_vpad);
     }
     brgattr.generate_skip_accumulation = true;
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
@@ -376,13 +378,13 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
             &brg, attr(), &diff_src_md_, LDD, jcp_.bia_dt));
     CHECK(brgemm_desc_finalize(&brg));
 
-    jcp_.amx_buf_size_per_thread = nstl::max(
+    jcp_.amx_buf_size_per_thread = nstl::max<dim_t>(
             brg.get_wsp_buffer_size(), jcp_.amx_buf_size_per_thread);
-    brg_idx = brgs_->insert(
-            brg, bd_mask, std::vector<brgemm_batch_element_t> {});
+    brg_idx = brgs_->insert(brg, bd_mask,
+            std::vector<brgemm_batch_element_t> {});
 
-    const std::array<int, 6> key
-            = {vM, is_N_tail, is_K_tail, do_init, bd_mask_idx, bs};
+    const std::array<int, 6> key = {static_cast<int>(vM), is_N_tail, is_K_tail,
+            do_init, static_cast<int>(bd_mask_idx), bs};
     if (brg_indices.find(key) == brg_indices.end()) {
         brg_indices.insert({key, brg_idx});
         brg_indices_c++;
@@ -433,8 +435,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::add_po_kernel(
     bcfg->LDD = (is_init && jcp.use_buffer) ? jcp.LDC : jcp.LDD;
     bcfg->dt_c = (!is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt;
     bcfg->dt_d = (is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt;
-    bcfg->typesize_C = types::data_type_size(bcfg->dt_c);
-    bcfg->typesize_D = types::data_type_size(bcfg->dt_d);
+    bcfg->typesize_C = static_cast<int>(types::data_type_size(bcfg->dt_c));
+    bcfg->typesize_D = static_cast<int>(types::data_type_size(bcfg->dt_d));
     bcfg->alpha
             = (!is_init && IMPLICATION(jcp.with_sum, jcp.use_buffer)) ? 1 : 0;
     bcfg->beta = is_init ? 0 : 1;
@@ -447,7 +449,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::add_po_kernel(
 
 template <cpu_isa_t isa>
 void brgemm_convolution_bwd_strided_t<isa>::add_po_kernels(
-        int i_N, int init_bcast_dim, int po_bcast_dim) {
+        int i_N, dim_t init_bcast_dim, dim_t po_bcast_dim) {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
     const auto &brgs = *(_pd->brgs_);
@@ -456,7 +458,7 @@ void brgemm_convolution_bwd_strided_t<isa>::add_po_kernels(
     if (N <= 0) return;
     auto i_K = (jcp.K_tail > 0);
 
-    const auto brg_idx = _pd->get_any_brg_idx(i_N, i_K);
+    const int brg_idx = _pd->get_any_brg_idx(i_N, i_K);
 
     if (init_bcast_dim > 0) {
         if (brgs[brg_idx]) {
@@ -482,9 +484,8 @@ void brgemm_convolution_bwd_strided_t<isa>::add_po_kernels(
 }
 
 template <cpu_isa_t isa>
-int brgemm_convolution_bwd_strided_t<isa>::get_comp_ker_idx(const int kd_b,
-        const int kd_e, const int kh_b, const int kh_e, const int kw_b,
-        const int kw_e) const {
+dim_t brgemm_convolution_bwd_strided_t<isa>::get_comp_ker_idx(dim_t kd_b,
+        dim_t kd_e, dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
@@ -492,7 +493,7 @@ int brgemm_convolution_bwd_strided_t<isa>::get_comp_ker_idx(const int kd_b,
 
     assert(IMPLICATION(kd_e <= kd_b && kh_e <= kh_b,
             everyone_is(0, kd_b, kd_e, kh_b, kh_e, kw_b, kw_e)));
-    for (int k = 0; k < jcp.ker_ranges_size; k++) {
+    for (dim_t k = 0; k < jcp.ker_ranges_size; k++) {
         if (kd_b == kd_bs[k] && kd_e == kd_es[k] && kh_b == kh_bs[k]
                 && kh_e == kh_es[k] && kw_b == kw_bs[k] && kw_e == kw_es[k]) {
             return k;
@@ -503,9 +504,9 @@ int brgemm_convolution_bwd_strided_t<isa>::get_comp_ker_idx(const int kd_b,
 }
 
 template <cpu_isa_t isa>
-int brgemm_convolution_bwd_strided_t<isa>::get_comp_offset(const int g,
-        const int icb, const int iw, const int kd_b, const int kd_e,
-        const int kh_b, const int kh_e, const int kw_b, const int kw_e) const {
+dim_t brgemm_convolution_bwd_strided_t<isa>::get_comp_offset(dim_t g, dim_t icb,
+        dim_t iw, dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e, dim_t kw_b,
+        dim_t kw_e) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
@@ -561,13 +562,16 @@ void brgemm_convolution_bwd_strided_t<isa>::create_kernels() {
         // create brgemm kernels for iw_blocks with padded areas and
         // apply post-ops on final iteration by kw to padded areas in iw_block
         int kw_s {0}, kw_full_s {0}, kw_full_f {0}, kw_f {0}, iw_s {0},
-                iw_f {0}, M_without_overflow {0};
+                M_without_overflow {0};
+        dim_t iw_f {0};
 
-        auto init_kernels_kw_loop = [&](int sw, int iw) {
+        auto init_kernels_kw_loop = [&](dim_t sw, dim_t iw) {
             const auto iw_str = iw + sw;
-            _pd->get_kw_range(iw_str, iw, kw_s, kw_full_s, kw_full_f, kw_f);
+            _pd->get_kw_range(static_cast<int>(iw_str), static_cast<int>(iw),
+                    kw_s, kw_full_s, kw_full_f, kw_f);
             for (int kw = kw_s; kw < kw_f; kw++) {
-                _pd->get_iw_range(iw_str, iw, kw, iw_s, M_without_overflow);
+                _pd->get_iw_range(static_cast<int>(iw_str),
+                        static_cast<int>(iw), kw, iw_s, M_without_overflow);
                 if (M_without_overflow <= 0) continue;
 
                 bool is_iw_tail = (jcp.iw - iw < jcp.iw_block);
@@ -578,14 +582,17 @@ void brgemm_convolution_bwd_strided_t<isa>::create_kernels() {
                                       SW)
                             * SW;
                     if (M <= 0) continue;
-                    _pd->get_iw_range(iw_str, iw, kw, iw_s, M_without_overflow);
+                    _pd->get_iw_range(static_cast<int>(iw_str),
+                            static_cast<int>(iw), kw, iw_s,
+                            M_without_overflow);
                     iw_f = iw_s + (M_without_overflow * SW);
                     const auto init_bcast_dim
                             = ((i_side == 0) ? (iw_s - iw_str)
                                              : (iw_str + M - iw_f))
                             / SW;
-                    _pd->get_iw_range(
-                            iw_str, iw, kw_f - kw, iw_s, M_without_overflow);
+                    _pd->get_iw_range(static_cast<int>(iw_str),
+                            static_cast<int>(iw), kw_f - kw, iw_s,
+                            M_without_overflow);
                     iw_f = iw_s + (M_without_overflow * SW);
                     const auto po_bcast_dim
                             = ((i_side == 0) ? (iw_s - iw_str)
@@ -604,11 +611,11 @@ void brgemm_convolution_bwd_strided_t<isa>::create_kernels() {
             }
         };
         for (int sw = 0; sw < SW; sw++) {
-            for (int iw = 0; iw < IW; iw += jcp.iw_block) {
+            for (dim_t iw = 0; iw < IW; iw += jcp.iw_block) {
                 init_kernels_kw_loop(sw, iw);
                 if (kw_f == jcp.kw && kw_s == 0) break;
             }
-            for (int iw = (jcp.nb_iw - 1) * jcp.iw_block; iw >= 0;
+            for (dim_t iw = (jcp.nb_iw - 1) * jcp.iw_block; iw >= 0;
                     iw -= jcp.iw_block) {
                 init_kernels_kw_loop(sw, iw);
                 if (kw_f == jcp.kw && kw_s == 0) break;
@@ -700,7 +707,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::init(engine_t *engine) {
     brg_kernels_.resize(_pd->brgs_sz_);
     brgemm_palettes_.resize(_pd->brgs_sz_);
 
-    int num_po_kernels = nstl::max(jcp.M, jcp.M_tail);
+    const dim_t num_po_kernels = nstl::max<dim_t>(jcp.M, jcp.M_tail);
     kernels_po_.resize(num_po_kernels * 2 * 2);
     for (int i = 0; i < num_po_kernels; i++) {
         for_(int i_init = 0; i_init < 2; i_init++)
@@ -881,7 +888,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
 
         dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
-        int n {0}, g {0}, icb {0}, idb {0}, ihb {0}, iwb {0};
+        dim_t n {0}, g {0}, icb {0}, idb {0}, ihb {0}, iwb {0};
 
         nd_iterator_init(start, n, jcp.mb, idb, jcp.nb_id, ihb, jcp.nb_ih, iwb,
                 jcp.nb_iw, g, jcp.ngroups, icb, jcp.nb_ic);
@@ -898,12 +905,12 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
         brgemm_bwd_thread_ctx_t btc(
                 brgemm_ctx, ithr, brg_batch, c_buffer, out_buffer, wsp_tile);
 
-        int last_n = -1;
-        int last_g = -1;
-        int last_occ = -1;
-        int last_idb = -1;
-        int last_ihb = -1;
-        int last_iwb = -1;
+        dim_t last_n = -1;
+        dim_t last_g = -1;
+        dim_t last_occ = -1;
+        dim_t last_idb = -1;
+        dim_t last_ihb = -1;
+        dim_t last_iwb = -1;
         for (auto work = start; work < end; work++) {
             btc.g = g;
             btc.n = n;
@@ -922,13 +929,13 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                     = jcp.s8s8_compensation_required ? s8s8_comp_base : nullptr;
 
             auto id_begin = idb * jcp.id_block;
-            auto id_end = nstl::min(ID, id_begin + jcp.id_block);
+            auto id_end = nstl::min<dim_t>(ID, id_begin + jcp.id_block);
             auto ih_begin = ihb * jcp.ih_block;
-            auto ih_end = nstl::min(IH, ih_begin + jcp.ih_block);
+            auto ih_end = nstl::min<dim_t>(IH, ih_begin + jcp.ih_block);
             auto iw_begin = iwb * jcp.iw_block;
 
-            for_(int id = id_begin; id < id_end; id++)
-            for (int ih = ih_begin; ih < ih_end; ih++) {
+            for_(dim_t id = id_begin; id < id_end; id++)
+            for (dim_t ih = ih_begin; ih < ih_end; ih++) {
                 // Zero out_buffer before processing the tail iw block to
                 // prevent stale scratchpad data from leaking into positions
                 // that may not be written (e.g., stride sectors with no
@@ -971,7 +978,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                         && iwb == jcp.nb_iw - 1) {
                     const bool is_ic_tail
                             = jcp.ic - (btc.icb * jcp.ic_block) < jcp.ic_block;
-                    const int ic_size
+                    const dim_t ic_size
                             = is_ic_tail ? jcp.ic % jcp.ic_block : jcp.ic_block;
 
                     auto cp = jit_brgemm_conv_bwd_copy_kernel_args_t();
@@ -1023,7 +1030,7 @@ void brgemm_convolution_bwd_strided_t<isa>::cal_compensation(
         if (ithr >= work_amount) return;
 
         dim_t start {0}, end {0};
-        int g {0}, icb {0}, k {0};
+        dim_t g {0}, icb {0}, k {0};
         balance211(work_amount, nthr, ithr, start, end);
         nd_iterator_init(
                 start, g, jcp.ngroups, icb, jcp.nb_ic, k, jcp.ker_ranges_size);
@@ -1096,9 +1103,10 @@ void brgemm_convolution_bwd_strided_t<isa>::cal_compensation(
 
 template <cpu_isa_t isa>
 void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
-        char *dst, char *c_buffer, const char *bias_w, int id, int ih, int iw,
-        int iw_raw, int g_ic, bool is_ic_tail, int ker_iw_s, int ker_iw_f,
-        int kd_l, int kh_l, const void *post_ops_binary_rhs_arg_vec,
+        char *dst, char *c_buffer, const char *bias_w, dim_t id, dim_t ih,
+        dim_t iw, dim_t iw_raw, dim_t g_ic, bool is_ic_tail, dim_t ker_iw_s,
+        dim_t ker_iw_f, dim_t kd_l, dim_t kh_l,
+        const void *post_ops_binary_rhs_arg_vec,
         int32_t src_zp_val, int32_t *src_zp_ptr, const int32_t *dst_zp_ptr,
         int32_t *s8s8_compensation, size_t comp_ker_offs, bool maybe_do_init,
         bool do_postwork, bool do_post_comp, const void *src_scales,
@@ -1137,7 +1145,7 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
     }
 
     auto call_outwork_ker = [&](bool is_postwork, bool has_postcomp,
-                                    int iw_pw_s, int iw_pw_l) {
+                                    dim_t iw_pw_s, dim_t iw_pw_l) {
         auto ker_po_idx = get_ker_po_idx(iw_pw_l - 1, is_postwork, is_ic_tail);
         const auto outwork_ker = kernels_po_[ker_po_idx].get();
         const auto comp_iw_s = get_comp_iw(iw_pw_s);
@@ -1159,7 +1167,7 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
             p.ptr_in = static_cast<void *>(jcp.use_buffer
                             ? (c_buffer
                                       + acc_dsz
-                                              * div_up(nstl::max(
+                                              * div_up(nstl::max<dim_t>(
                                                                0, iw_pw_s - iw),
                                                       SW)
                                               * jcp.LDC)
@@ -1168,7 +1176,10 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
             p.apply_comp = has_postcomp;
             char *const ptr_Cz = jcp.use_buffer
                     ? (c_buffer
-                              + acc_dsz * div_up(nstl::max(0, iw_pw_s - iw), SW)
+                              + acc_dsz
+                                      * div_up(nstl::max<dim_t>(
+                                                       0, iw_pw_s - iw),
+                                              SW)
                                       * jcp.LDC)
                     : dst_base
                             + dst_dsz
@@ -1194,7 +1205,7 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
 template <cpu_isa_t isa>
 void brgemm_convolution_bwd_strided_t<isa>::call_brgemm_kernel(
         brgemm_bwd_thread_ctx_t &btc, int brg_idx, int batch_size, char *ptr_C,
-        char *ptr_D, const char *bias_w, int g_ic, bool do_postops,
+        char *ptr_D, const char *bias_w, dim_t g_ic, bool do_postops,
         const void *binary_post_ops_rhs, int32_t src_zp_val,
         int32_t *src_zp_ptr, const int32_t *dst_zp_ptr, int32_t *s8s8_comp,
         bool do_only_comp, bool is_first_call_postops,
@@ -1246,9 +1257,9 @@ void brgemm_convolution_bwd_strided_t<isa>::call_brgemm_kernel(
 template <cpu_isa_t isa>
 void brgemm_convolution_bwd_strided_t<isa>::maybe_trans_inp(int ithr,
         const char *__restrict src, char *__restrict inp_buffer,
-        uint8_t *__restrict inp_buffer_mask, int g, int n, int occ, int idb,
-        int ihb, int iwb, int last_g, int last_n, int last_occ, int last_idb,
-        int last_ihb, int last_iwb) const {
+        uint8_t *__restrict inp_buffer_mask, dim_t g, dim_t n, dim_t occ,
+        dim_t idb, dim_t ihb, dim_t iwb, dim_t last_g, dim_t last_n,
+        dim_t last_occ, dim_t last_idb, dim_t last_ihb, dim_t last_iwb) const {
 
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
@@ -1278,7 +1289,7 @@ void brgemm_convolution_bwd_strided_t<isa>::maybe_trans_inp(int ithr,
     const auto ow = (iwb * jcp.iw_block + jcp.l_pad - kw_x * (jcp.dilate_w + 1))
             / jcp.stride_w;
 
-    int od_start {0}, od_end {0}, oh_start {0}, oh_end {0};
+    dim_t od_start {0}, od_end {0}, oh_start {0}, oh_end {0};
 
     const auto sh = jcp.t_pad % jcp.stride_h;
     const auto kh = (jcp.kh - 1) % jcp.stride_h;
@@ -1294,27 +1305,30 @@ void brgemm_convolution_bwd_strided_t<isa>::maybe_trans_inp(int ithr,
             / jcp.stride_d;
     od_end = od_start + jcp.od_block;
 
-    const auto rows_to_copy = min(jcp.oh, oh_end) - nstl::max(0, oh_start);
+    const dim_t rows_to_copy
+            = nstl::min<dim_t>(jcp.oh, oh_end) - nstl::max<dim_t>(0, oh_start);
     cp.iwb = iwb;
     cp.oc = oc;
-    const auto ow_buf = ow;
+    const dim_t ow_buf = ow;
     dim_t inp_offset_start, out_offset_start;
 
     cp.t_pad = 0;
     cp.b_pad = 0;
-    cp.h_count = nstl::max(0, rows_to_copy);
+    cp.h_count = nstl::max<dim_t>(0, rows_to_copy);
 
-    const auto oh_buf = nstl::max(0, oh_start);
+    const dim_t oh_buf = nstl::max<dim_t>(0, oh_start);
 
     inp_offset_start = static_cast<dim_t>(n) * src_d_sz
-            + nstl::max(0, oh_start) * src_w_sz
-            + nstl::max(0, ow) * jcp.ngroups * jcp.oc_without_padding + g_oc;
+            + nstl::max<dim_t>(0, oh_start) * src_w_sz
+            + nstl::max<dim_t>(0, ow) * jcp.ngroups * jcp.oc_without_padding
+            + g_oc;
     out_offset_start = oh_buf * pbuf_w_sz + ow_buf * jcp.oc_block;
 
-    for (int od = nstl::max(0, od_start); od < min(jcp.od, od_end); od++) {
-        const auto inp_offset = inp_offset_start + od * src_h_sz;
-        const auto od_buf = od;
-        const auto out_offset = out_offset_start + od_buf * pbuf_h_sz;
+    for (dim_t od = nstl::max<dim_t>(0, od_start);
+            od < nstl::min<dim_t>(jcp.od, od_end); od++) {
+        const dim_t inp_offset = inp_offset_start + od * src_h_sz;
+        const dim_t od_buf = od;
+        const dim_t out_offset = out_offset_start + od_buf * pbuf_h_sz;
         cp.src = src + src_dsz * inp_offset;
         cp.dst = inp_buffer + src_dsz * out_offset;
 
@@ -1336,11 +1350,11 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     const auto diff_dst = btc.brgemm_ctx.diff_dst;
     const std::vector<const void *> &post_ops_binary_rhs_arg_vec
             = btc.brgemm_ctx.post_ops_binary_rhs_arg_vec;
-    const int ic = btc.icb * jcp.ic_block;
-    const int g_ic = btc.g * jcp.ic + ic;
-    const int ocb = btc.occ * jcp.nb_oc_blocking;
-    const int oc = ocb * jcp.oc_block;
-    const int g_oc = btc.g * jcp.oc + oc;
+    const dim_t ic = btc.icb * jcp.ic_block;
+    const dim_t g_ic = btc.g * jcp.ic + ic;
+    const dim_t ocb = btc.occ * jcp.nb_oc_blocking;
+    const dim_t oc = ocb * jcp.oc_block;
+    const dim_t g_oc = btc.g * jcp.oc + oc;
     const dim_t iw = static_cast<dim_t>(btc.iwb) * jcp.iw_block + btc.sw;
     const dim_t iw_raw = static_cast<dim_t>(btc.iwb) * jcp.iw_block;
     const dim_t ih = btc.ih;
@@ -1350,9 +1364,11 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     const bool is_ic_tail = (jcp.ic - ic < jcp.ic_block);
     const char *const __restrict bias_w
             = bias ? bias + (bias_d.blk_off(g_ic) * bia_dsz) : nullptr;
-    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0}, kw_b(0), kw_e(0);
+    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
+    dim_t kw_b {0}, kw_e {0};
     int kd_s_(0), kh_s_(0), kd_f_(0), kh_f_(0);
-    _pd->get_kw_range(iw, iw_raw, kw_s, kw_full_s, kw_full_f, kw_f);
+    _pd->get_kw_range(static_cast<int>(iw), static_cast<int>(iw_raw), kw_s,
+            kw_full_s, kw_full_f, kw_f);
 
     // od = (id + FP - kd * DD) / SD <-- general relation for all sets of (od, id, kd) that overlap
     // for a given index from diff_src, we need to find the appropriate stride sector
@@ -1373,19 +1389,19 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
             = diff_src + dst_dsz * (btc.n * dst_d_sz + g_ic);
     const auto wei_base
             = weights + wei_dsz * (btc.g * wei_icb_sz + btc.icb * wei_kd_sz);
-    const auto nb_oc_b = nstl::min(jcp.nb_oc_blocking, jcp.nb_oc - ocb)
+    const dim_t nb_oc_b = nstl::min<dim_t>(jcp.nb_oc_blocking, jcp.nb_oc - ocb)
             - (is_oc_tail ? 1 : 0);
     char *ptr_C;
     char *ptr_D;
-    int kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0);
+    dim_t kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0);
 
     const auto kd_l_full = kd_f - kd_s;
     const auto kh_l_full = kh_f - kh_s;
 
     bool is_first_call_postops = false,
          is_first_call_postops_state_changed = false;
-    const auto call_brgemm = [&](int iw, int brg_idx, int oc_block_s,
-                                     int n_oc_blocks, size_t comp_ker_offs,
+    const auto call_brgemm = [&](dim_t iw, int brg_idx, dim_t oc_block_s,
+                                     dim_t n_oc_blocks, size_t comp_ker_offs,
                                      bool do_postops, bool do_only_comp) {
         if (brg_idx < 0) {
             assert(!"Requested brgemm kernel was not created.");
@@ -1399,7 +1415,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
         int32_t *s8s8_comp = jcp.s8s8_compensation_required
                 ? &btc.s8s8_comp_ptr[comp_ker_offs]
                 : nullptr;
-        for (int i_ocb = 0; i_ocb < n_oc_blocks; i_ocb++) {
+        for (dim_t i_ocb = 0; i_ocb < n_oc_blocks; i_ocb++) {
             const auto oc_off = (oc_block_s + i_ocb) * jcp.oc_block;
             const auto src_oc = oc_off;
             const auto wei_oc = oc + oc_off;
@@ -1408,14 +1424,14 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
             const auto wei_base_oc = wei_base + wei_dsz * wei_oc * jcp.ic_block;
 
             auto k = 0;
-            for (int kd = kd_b; kd < kd_e; kd++) {
+            for (dim_t kd = kd_b; kd < kd_e; kd++) {
                 auto od = (id - kd * DD + FP);
                 if (od % SD != 0) continue;
                 od /= SD;
                 const auto diff_dst_base_kd
                         = diff_dst_base_oc + src_dsz * od * src_h_sz;
                 const auto wei_base_kd = wei_base_oc + wei_dsz * kd * wei_kh_sz;
-                for (int kh = kh_b; kh < kh_ee; kh++) {
+                for (dim_t kh = kh_b; kh < kh_ee; kh++) {
                     auto oh = (ih - kh * DH + TP);
                     if (oh % SH != 0) continue;
                     oh /= SH;
@@ -1423,7 +1439,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
                             = diff_dst_base_kd + src_dsz * oh * src_w_sz;
                     const auto wei_base_kh
                             = wei_base_kd + wei_dsz * kh * wei_kw_sz;
-                    for (int kw = kw_b; kw < kw_e; kw += SW) {
+                    for (dim_t kw = kw_b; kw < kw_e; kw += SW) {
                         auto ow = (iw - kw * DW + LP) / SW;
                         // inp_buffer layout is Cdhw<oc_block>c
                         btc.brg_batch[n_ocb_off + k].ptr.A = diff_dst_base_kh
@@ -1457,7 +1473,8 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     const auto kdhw_loop = [&]() {
         if (kw_e - kw_b <= 0 || kw_b >= jcp.kw) return;
         int iw_b {0}, M_without_overflow {0};
-        _pd->get_iw_range(iw, iw_raw, kw_b, iw_b, M_without_overflow);
+        _pd->get_iw_range(static_cast<int>(iw), static_cast<int>(iw_raw),
+                static_cast<int>(kw_b), iw_b, M_without_overflow);
         const auto iw_e = iw_b + M_without_overflow;
         const auto do_init
                 = btc.occ == 0 && kd_b == kd_s && kh_b == kh_s && kw_b == kw_s;
@@ -1469,9 +1486,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
                 && btc.occ == (oc_chunks - 1);
         if (iw_e - iw_b <= 0 && !do_init && !do_postwork) return;
 
-        const int kd_l = div_up(nstl::max(0, kd_e - kd_b), SD);
-        const int kh_l = div_up(nstl::max(0, kh_e - kh_b), SH);
-        const int kw_l = div_up(nstl::max(0, kw_e - kw_b), SW);
+        const dim_t kd_l = div_up(nstl::max<dim_t>(0, kd_e - kd_b), SD);
+        const dim_t kh_l = div_up(nstl::max<dim_t>(0, kh_e - kh_b), SH);
+        const dim_t kw_l = div_up(nstl::max<dim_t>(0, kw_e - kw_b), SW);
         k_l = kd_l * kh_l * kw_l;
         const auto iw_l = iw_e - iw_b;
 
@@ -1494,16 +1511,17 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
 
         if (iw_l > 0 && k_l > 0) {
             if (nb_oc_b > 0) {
-                const auto brg_idx
-                        = _pd->get_brg_idx(ker_i, do_init, is_ic_tail, false);
+                const int brg_idx = _pd->get_brg_idx(
+                        static_cast<int>(ker_i), do_init, is_ic_tail, false);
                 call_brgemm(iw_b, brg_idx, 0, nb_oc_b, comp_ker_offs,
                         do_postwork && !is_oc_tail, do_only_comp);
             }
 
             if (is_oc_tail) {
                 const auto use_init_ker = (do_init && nb_oc_b == 0);
-                const auto brg_oc_tail_idx = _pd->get_brg_idx(
-                        ker_i, use_init_ker, is_ic_tail, true);
+                const int brg_oc_tail_idx
+                        = _pd->get_brg_idx(static_cast<int>(ker_i),
+                                use_init_ker, is_ic_tail, true);
                 call_brgemm(iw_b, brg_oc_tail_idx, nb_oc_b, 1, comp_ker_offs,
                         do_postwork, do_only_comp);
             }
@@ -1521,9 +1539,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s && kw_s < jcp.kw) {
         if (kw_s < kw_full_s) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK_PAD);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK_PAD);
                     for (auto kw = kw_s; kw < kw_full_s; kw += SW) {
                         kw_b = kw;
                         kw_e = kw + 1;
@@ -1535,11 +1553,11 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
 
         if (kw_full_s < kw_full_f) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                     for (kw_b = kw_full_s; kw_b < kw_full_f; kw_b += KW_BLOCK) {
-                        kw_e = nstl::min(kw_full_f, kw_b + KW_BLOCK);
+                        kw_e = nstl::min<dim_t>(kw_full_f, kw_b + KW_BLOCK);
                         kdhw_loop();
                     }
                 }
@@ -1548,9 +1566,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
 
         if (kw_full_f < kw_f) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK_PAD);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK_PAD);
                     for (int kw = kw_full_f; kw < kw_f; kw += SW) {
                         kw_b = kw;
                         kw_e = kw + 1;
@@ -1564,10 +1582,10 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
         const auto do_postwork = need_postwork && btc.occ == (oc_chunks - 1);
         perform_outwork(diff_src_base, diff_src, btc.c_buffer, bias_w, btc.id,
                 btc.ih, iw, iw_raw, g_ic, is_ic_tail, iw, iw, kd_l_full,
-                kh_l_full, post_ops_binary_rhs_arg_vec.data(), btc.src_zp_val,
-                btc.src_zp_comp_ptr, btc.dst_zp_vals, btc.s8s8_comp_ptr, 0,
-                do_init, do_postwork, false, btc.src_scales, btc.wei_scales,
-                btc.dst_scales);
+                kh_l_full, post_ops_binary_rhs_arg_vec.data(),
+                btc.src_zp_val, btc.src_zp_comp_ptr, btc.dst_zp_vals,
+                btc.s8s8_comp_ptr, 0, do_init, do_postwork, false,
+                btc.src_scales, btc.wei_scales, btc.dst_scales);
     }
 }
 
@@ -1584,10 +1602,10 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
     char *const __restrict diff_src = btc.brgemm_ctx.diff_src;
     const std::vector<const void *> &post_ops_binary_rhs_arg_vec
             = btc.brgemm_ctx.post_ops_binary_rhs_arg_vec;
-    const int ic = btc.icb * jcp.ic_block;
-    const int g_ic = btc.g * jcp.ic + ic;
-    const int ocb = btc.occ * jcp.nb_oc_blocking;
-    const int oc = ocb * jcp.oc_block;
+    const dim_t ic = btc.icb * jcp.ic_block;
+    const dim_t g_ic = btc.g * jcp.ic + ic;
+    const dim_t ocb = btc.occ * jcp.nb_oc_blocking;
+    const dim_t oc = ocb * jcp.oc_block;
     const dim_t iw = static_cast<dim_t>(btc.iwb) * jcp.iw_block + btc.sw;
     const dim_t ih = btc.ih;
     const dim_t id = btc.id;
@@ -1615,7 +1633,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
     const bool is_ic_tail = (jcp.ic - ic < jcp.ic_block);
     const char *const __restrict bias_w
             = bias ? bias + (bias_d.blk_off(g_ic) * bia_dsz) : nullptr;
-    const auto nb_oc_b = nstl::min(jcp.nb_oc_blocking, jcp.nb_oc - ocb)
+    const dim_t nb_oc_b = nstl::min<dim_t>(jcp.nb_oc_blocking, jcp.nb_oc - ocb)
             - (is_oc_tail ? 1 : 0);
 
     const bool is_tail_iwb = btc.iwb == jcp.nb_iw - 1;
@@ -1626,7 +1644,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                     : diff_src + dst_dsz * (btc.n * dst_d_sz + g_ic));
     char *ptr_C;
     char *ptr_D;
-    int kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0);
+    dim_t kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0);
 
     const auto wei_base
             = weights + wei_dsz * (btc.g * wei_icb_sz + btc.icb * wei_kd_sz);
@@ -1654,8 +1672,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
 
     bool is_first_call_postops = false,
          is_first_call_postops_state_changed = false;
-    const auto call_brgemm = [&](int brg_idx, int oc_block_s, int n_oc_blocks,
-                                     size_t comp_ker_offs, bool do_postops) {
+    const auto call_brgemm
+            = [&](int brg_idx, dim_t oc_block_s, dim_t n_oc_blocks,
+                      size_t comp_ker_offs, bool do_postops) {
         if (brg_idx < 0) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -1671,7 +1690,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                 : nullptr;
 
         int k_sum = 0;
-        for (int i_ocb = 0; i_ocb < n_oc_blocks; i_ocb++) {
+        for (dim_t i_ocb = 0; i_ocb < n_oc_blocks; i_ocb++) {
             const auto oc_off = (oc_block_s + i_ocb) * jcp.oc_block;
             const auto wei_oc = oc + oc_off;
             const auto n_ocb_off = i_ocb * k_l;
@@ -1679,14 +1698,14 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
             const auto wei_base_oc = wei_base + wei_dsz * wei_oc * jcp.ic_block;
 
             auto k = 0;
-            for (int kd = kd_b; kd < kd_e; kd++) {
+            for (dim_t kd = kd_b; kd < kd_e; kd++) {
                 auto od = (id - kd * DD + FP);
                 if (od % SD != 0) continue;
                 od /= SD;
                 const auto pbuf_base_kd
                         = pbuf_base_oc + src_dsz * od * pbuf_h_sz;
                 const auto wei_base_kd = wei_base_oc + wei_dsz * kd * wei_kh_sz;
-                for (int kh = kh_b; kh < kh_ee; kh++) {
+                for (dim_t kh = kh_b; kh < kh_ee; kh++) {
                     auto oh = (ih - kh * DH + TP);
                     if (oh % SH != 0) continue;
                     oh /= SH;
@@ -1694,7 +1713,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                             = pbuf_base_kd + src_dsz * oh * pbuf_w_sz;
                     const auto wei_base_kh
                             = wei_base_kd + wei_dsz * kh * wei_kw_sz;
-                    for (int kw = kw_s; kw < kw_e; kw += SW) {
+                    for (dim_t kw = kw_s; kw < kw_e; kw += SW) {
                         const auto ow = (iw - kw * DW + LP) / SW;
                         // inp_buffer layout is Cdhw<oc_block>c
                         btc.brg_batch[n_ocb_off + k].ptr.A = pbuf_base_kh
@@ -1720,7 +1739,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                             * (btc.n * dst_d_sz + g_ic + id * dst_h_sz
                                     + ih * dst_w_sz
                                     + iw_begin * jcp.ic_without_padding);
-            const int ic_len = is_ic_tail ? (jcp.ic - ic) : jcp.ic_block;
+            const dim_t ic_len = is_ic_tail ? (jcp.ic - ic) : jcp.ic_block;
             const auto ic_bytes = static_cast<size_t>(ic_len) * dst_dsz;
             const auto stride_bytes = static_cast<size_t>(jcp.stride_w)
                     * jcp.ic_without_padding * dst_dsz;
@@ -1762,15 +1781,16 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
         const auto do_postwork = need_postwork && btc.occ == (oc_chunks - 1)
                 && kd_e == kd_f && kh_e == kh_f;
 
-        const int kd_l = div_up(nstl::max(0, kd_e - kd_b), SD);
-        const int kh_l = div_up(nstl::max(0, kh_e - kh_b), SH);
-        const int kw_l = div_up(nstl::max(0, kw_f - kw_s), SW);
+        const dim_t kd_l = div_up(nstl::max<dim_t>(0, kd_e - kd_b), SD);
+        const dim_t kh_l = div_up(nstl::max<dim_t>(0, kh_e - kh_b), SH);
+        const dim_t kw_l = div_up(nstl::max<dim_t>(0, kw_f - kw_s), SW);
         k_l = kd_l * kh_l * kw_l;
 
         const auto comp_ker_offs = kd_l * kh_l > 0
-                ? get_comp_offset(
-                          btc.g, btc.icb, iw, kd_s, kd_f, kh_s, kh_f, 0, KW)
-                : get_comp_offset(btc.g, btc.icb, iw, 0, 0, 0, 0, 0, 0);
+                ? get_comp_offset(btc.g, btc.icb, static_cast<int>(iw), kd_s,
+                          kd_f, kh_s, kh_f, 0, KW)
+                : get_comp_offset(btc.g, btc.icb, static_cast<int>(iw), 0, 0, 0,
+                          0, 0, 0);
 
         if (nb_oc_b > 0) {
             const auto do_postops_here = do_postwork && !is_oc_tail;
@@ -1779,11 +1799,14 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                 // AMX: always use full_m, masked descriptor for postops
                 const auto is_masked
                         = do_postops_here && (ker_i_postops < full_m);
-                brg_idx = _pd->get_brg_idx(full_m, do_init, is_ic_tail, false,
-                        is_masked ? ker_i_postops : 0, k_l);
+                brg_idx = _pd->get_brg_idx(static_cast<int>(full_m), do_init,
+                        is_ic_tail, false,
+                        is_masked ? static_cast<int>(ker_i_postops) : 0,
+                        static_cast<int>(k_l));
             } else {
                 // Non-AMX: use actual reduced M for postops call
-                const auto m = do_postops_here ? ker_i_postops : full_m;
+                const int m = do_postops_here ? static_cast<int>(ker_i_postops)
+                                              : static_cast<int>(full_m);
                 brg_idx = _pd->get_brg_idx(m, do_init, is_ic_tail, false);
             }
             call_brgemm(brg_idx, 0, nb_oc_b, comp_ker_offs, do_postops_here);
@@ -1794,10 +1817,13 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
             const auto use_init_ker = (do_init && nb_oc_b == 0);
             if (jcp.use_uker) {
                 const auto is_masked = do_postwork && (ker_i_postops < full_m);
-                brg_oc_tail_idx = _pd->get_brg_idx(full_m, use_init_ker,
-                        is_ic_tail, true, is_masked ? ker_i_postops : 0, k_l);
+                brg_oc_tail_idx = _pd->get_brg_idx(static_cast<int>(full_m),
+                        use_init_ker, is_ic_tail, true,
+                        is_masked ? static_cast<int>(ker_i_postops) : 0,
+                        static_cast<int>(k_l));
             } else {
-                const auto m = do_postwork ? ker_i_postops : full_m;
+                const int m = do_postwork ? static_cast<int>(ker_i_postops)
+                                          : static_cast<int>(full_m);
                 brg_oc_tail_idx
                         = _pd->get_brg_idx(m, use_init_ker, is_ic_tail, true);
             }
@@ -1809,9 +1835,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
     if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s) {
         // kw values covering full ow_block
         for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-            kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+            kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
             for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                 kdhw_loop();
             }
         }
@@ -1834,7 +1860,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                                 * (btc.n * dst_d_sz + g_ic + id * dst_h_sz
                                         + ih * dst_w_sz
                                         + iw_begin * jcp.ic_without_padding);
-                const int ic_len = is_ic_tail ? (jcp.ic - ic) : jcp.ic_block;
+                const dim_t ic_len = is_ic_tail ? (jcp.ic - ic) : jcp.ic_block;
                 const auto ic_bytes = static_cast<size_t>(ic_len) * dst_dsz;
                 const auto stride_bytes = static_cast<size_t>(jcp.stride_w)
                         * jcp.ic_without_padding * dst_dsz;
@@ -1848,11 +1874,11 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
             if (!need_out_buffer) {
                 const dim_t iw_raw = static_cast<dim_t>(btc.iwb) * jcp.iw_block;
                 perform_outwork(diff_src_base, diff_src, btc.c_buffer, bias_w,
-                        btc.id, btc.ih, iw, iw_raw, g_ic, is_ic_tail, iw, iw, 0,
-                        0, post_ops_binary_rhs_arg_vec.data(), btc.src_zp_val,
-                        btc.src_zp_comp_ptr, btc.dst_zp_vals, btc.s8s8_comp_ptr,
-                        0, do_init, do_postwork, false, btc.src_scales,
-                        btc.wei_scales, btc.dst_scales);
+                        btc.id, btc.ih, iw, iw_raw, g_ic, is_ic_tail, iw, iw,
+                        0, 0, post_ops_binary_rhs_arg_vec.data(),
+                        btc.src_zp_val, btc.src_zp_comp_ptr, btc.dst_zp_vals,
+                        btc.s8s8_comp_ptr, 0, do_init, do_postwork, false,
+                        btc.src_scales, btc.wei_scales, btc.dst_scales);
             }
         } else {
             // Non-AMX: brgemm handles batch_size=0 (skip_accumulation)

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
@@ -58,20 +58,21 @@ struct brgemm_convolution_bwd_strided_t : public primitive_t {
         const int first_bs = 0;
 
         // need custom hasher to use array as key in unordered_map
-        template <int asize>
+        template <int asize, typename T = int>
         struct hasher_t {
-            size_t operator()(const std::array<int, asize> &a) const {
+            size_t operator()(const std::array<T, asize> &a) const {
                 size_t seed = 0;
                 for (auto e : a)
                     seed = hash_combine(seed, e);
                 return seed;
             }
         };
-        template <int asize>
-        using Arrmap = std::unordered_map<std::array<int, asize>, int,
-                hasher_t<asize>>;
+        template <int asize, typename T = int>
+        using Arrmap = std::unordered_map<std::array<T, asize>, T,
+                hasher_t<asize, T>>;
 
         int brg_indices_c {0};
+        // Bounded kernel-variant lookup key/index, not tensor-scale.
         Arrmap<6> brg_indices;
 
         int get_brg_idx(int m, bool do_initialization, bool is_N_tail,
@@ -94,8 +95,8 @@ struct brgemm_convolution_bwd_strided_t : public primitive_t {
             return 0;
         }
 
-        status_t add_brg_descriptor(int M, bool is_N_tail, bool is_K_tail,
-                bool do_init, int bd_mask_idx = 0,
+        status_t add_brg_descriptor(dim_t M, bool is_N_tail, bool is_K_tail,
+                bool do_init, dim_t bd_mask_idx = 0,
                 const std::vector<char> &bd_mask = {}, int bs = 0);
         void get_kw_range(int iw, int iw_raw, int &kw_s, int &kw_full_s,
                 int &kw_full_e, int &kw_e) const;
@@ -166,10 +167,10 @@ private:
         char *out_buffer;
         char *wsp_tile;
         int cur_brg_idx;
-        int g, n, icb;
-        int id, idb, ih, ihb, iwb;
-        int occ;
-        int sw;
+        dim_t g, n, icb;
+        dim_t id, idb, ih, ihb, iwb;
+        dim_t occ;
+        dim_t sw;
         const void *src_scales;
         const void *wei_scales;
         const void *dst_scales;
@@ -179,12 +180,12 @@ private:
         int32_t *s8s8_comp_ptr;
     };
 
-    inline static int get_ker_po_idx(int m, bool do_postwork, bool is_N_tail) {
-        return (m * 2 + static_cast<int>(do_postwork)) * 2
-                + static_cast<int>(is_N_tail);
+    inline static int get_ker_po_idx(dim_t m, bool do_postwork, bool is_N_tail) {
+        return static_cast<int>((m * 2 + static_cast<int>(do_postwork)) * 2
+                + static_cast<int>(is_N_tail));
     }
 
-    inline int get_comp_iw(const int iw) const {
+    inline dim_t get_comp_iw(dim_t iw) const {
         return utils::div_up(IW, SW) * (iw % SW) + iw / SW;
     }
 
@@ -192,8 +193,9 @@ private:
     void ker_trans(brgemm_bwd_thread_ctx_t &btc, char *inp_buffer) const;
 
     void perform_outwork(char *dst_base, char *dst, char *c_buffer,
-            const char *bias_w, int od, int oh, int ow, int iw_raw, int g_oc,
-            bool is_oc_tail, int ker_ow_s, int ker_ow_f, int kd_l, int kh_l,
+            const char *bias_w, dim_t od, dim_t oh, dim_t ow, dim_t iw_raw,
+            dim_t g_oc, bool is_oc_tail, dim_t ker_ow_s, dim_t ker_ow_f,
+            dim_t kd_l, dim_t kh_l,
             const void *post_ops_binary_rhs_arg_vec, int32_t src_zp_val,
             int32_t *src_zp_ptr, const int32_t *dst_zp_ptr,
             int32_t *s8s8_compensation, size_t comp_ker_offs,
@@ -203,28 +205,27 @@ private:
 
     void call_brgemm_kernel(brgemm_bwd_thread_ctx_t &btc, int brg_idx,
             int batch_size, char *ptr_C, char *ptr_D, const char *bias_w,
-            int g_ic, bool do_postops, const void *binary_post_ops_rhs,
+            dim_t g_ic, bool do_postops, const void *binary_post_ops_rhs,
             int32_t src_zp_val, int32_t *src_zp_ptr, const int32_t *dst_zp_ptr,
             int32_t *s8s8_comp, bool do_only_comp, bool is_first_call_postops,
             const char *dst_orig_override = nullptr) const;
 
     void maybe_trans_inp(int ithr, const char *__restrict input,
             char *__restrict inp_buffer, uint8_t *__restrict inp_buffer_mask,
-            int g, int n, int icc, int odb, int ohb, int owb, int last_g,
-            int last_n, int last_icc, int last_odb, int last_ohb,
-            int last_owb) const;
+            dim_t g, dim_t n, dim_t icc, dim_t odb, dim_t ohb, dim_t owb,
+            dim_t last_g, dim_t last_n, dim_t last_icc, dim_t last_odb,
+            dim_t last_ohb, dim_t last_owb) const;
 
     status_t add_po_kernel(brgemm_desc_t *bcfg, int ker_idx, bool is_init);
-    void add_po_kernels(int i_N, int init_bcast_dim, int po_bcast_dim);
+    void add_po_kernels(int i_N, dim_t init_bcast_dim, dim_t po_bcast_dim);
     status_t add_brg_kernel(int brg_idx);
 
     void cal_compensation(const char *__restrict weights,
             int32_t *src_zp_buffer, int32_t *s8s8_comp_buffer) const;
-    int get_comp_ker_idx(const int kd_b, const int kd_e, const int kh_b,
-            const int kh_e, const int kw_b, const int kw_e) const;
-    int get_comp_offset(const int g, const int icb, const int iw,
-            const int kd_b, const int kd_e, const int kh_b, const int kh_e,
-            const int kw_b, const int kw_e) const;
+    dim_t get_comp_ker_idx(dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e,
+            dim_t kw_b, dim_t kw_e) const;
+    dim_t get_comp_offset(dim_t g, dim_t icb, dim_t iw, dim_t kd_b, dim_t kd_e,
+            dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e) const;
     void create_kernels();
 
     const pd_t *pd() const {
@@ -254,7 +255,7 @@ private:
     // precalculated values
     std::vector<dim_t> kd_bs, kd_es, kh_bs, kh_es, kw_bs, kw_es;
 
-    int KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
+    dim_t KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
             KD_BLOCK_PAD, KH_BLOCK_PAD, ID, IH, IW, ODP, OHP, OWP, OD, OH, OW,
             SD, SH, SW, FP, TP, LP, DD, DH, DW;
     dim_t src_w_sz, src_h_sz, src_d_sz, dst_w_sz, dst_h_sz, dst_d_sz, wei_oc_sz,
@@ -262,7 +263,7 @@ private:
     dim_t pbuf_w_sz, pbuf_h_sz, pbuf_d_sz;
     dim_t comp_icb_sz, comp_ker_sz, comp_kw_sz, comp_iw_sz;
 
-    int oc_chunks;
+    dim_t oc_chunks;
     bool need_postwork;
     bool need_compensation;
     bool is_amx;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.cpp
@@ -48,16 +48,16 @@ jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::
     , n_tail_vec((jcp.oc_without_padding % jcp.oc_block) / jcp.simd_w) {}
 
 template <typename Vmm>
-int jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::inp_w(
-        int out_w) const {
+dim_t jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::inp_w(
+        dim_t out_w) const {
     const auto res = div_up(out_w + jcp.l_pad % jcp.stride_w, jcp.stride_w)
             + (jcp.ext_kw - 1 - jcp.l_pad % jcp.stride_w) / jcp.stride_w;
     return res;
 }
 
 template <typename Vmm>
-int jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::inp_w_start(
-        int iwb) const {
+dim_t jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::inp_w_start(
+        dim_t iwb) const {
     const auto sw = jcp.l_pad % jcp.stride_w;
     const auto kw = (jcp.kw - 1) % jcp.stride_w;
     const auto kw_x = (jcp.kw - 1) - nstl::modulo(kw - sw, jcp.stride_w);
@@ -104,13 +104,13 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::store(
 template <>
 void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Xbyak::Ymm>::load(
         const Xbyak::Ymm &x, const Xbyak::Address &addr, const int load_size) {
-    load_bytes(x, addr, jcp.src_dsz * load_size, true);
+    load_bytes(x, addr, static_cast<int>(jcp.src_dsz * load_size), true);
 }
 
 template <>
 void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Xbyak::Ymm>::store(
         const Xbyak::Address &addr, const Xbyak::Ymm &x, const int store_size) {
-    store_bytes(x, addr, jcp.src_dsz * store_size);
+    store_bytes(x, addr, static_cast<int>(jcp.src_dsz * store_size));
 }
 
 template <typename Vmm>
@@ -312,7 +312,7 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
     int start_last_partial_block = -1;
     int end_last_partial_block = -1;
 
-    int iw_block_tail = jcp.iw % jcp.iw_block;
+    dim_t iw_block_tail = jcp.iw % jcp.iw_block;
 
     for (int iwb = 0; iwb < jcp.nb_iw; iwb++) {
         const auto inp_block = inp_w(jcp.iw_block);
@@ -350,18 +350,19 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
     if (start_first_partial_block != -1) {
         for (int b = start_first_partial_block; b <= end_first_partial_block;
                 b++) {
-            int cur_iw_block = (b == jcp.nb_iw - 1 && iw_block_tail > 0)
+            dim_t cur_iw_block = (b == jcp.nb_iw - 1 && iw_block_tail > 0)
                     ? iw_block_tail
                     : jcp.iw_block;
             const auto inp_block = inp_w(cur_iw_block);
             const auto inp_start = inp_w_start(b);
             const auto inp_end = inp_start + inp_block;
             const auto block_lpad = -inp_start;
-            const auto block_len = nstl::min(jcp.ow, inp_end);
+            const dim_t block_len = nstl::min<dim_t>(jcp.ow, inp_end);
             Xbyak::Label skip_first_partial_block;
             cmp(reg_iwb, b);
             jne(skip_first_partial_block, T_NEAR);
-            copy_iw_block_body(block_lpad, jcp.iw_block, block_len, is_oc_tail);
+            copy_iw_block_body(
+                    block_lpad, jcp.iw_block, block_len, is_oc_tail);
             jmp(copy_block_done_label, T_NEAR);
             L(skip_first_partial_block);
         }
@@ -370,7 +371,8 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
         Xbyak::Label skip_full_blocks;
         cmp(reg_iwb, end_full_block);
         jg(skip_full_blocks, T_NEAR);
-        copy_iw_block_body(0, jcp.iw_block, inp_w(jcp.iw_block), is_oc_tail);
+        copy_iw_block_body(
+                0, jcp.iw_block, inp_w(jcp.iw_block), is_oc_tail);
         jmp(copy_block_done_label, T_NEAR);
 
         L(skip_full_blocks);
@@ -378,18 +380,20 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
     if (start_last_partial_block != -1) {
         for (int b = start_last_partial_block; b <= end_last_partial_block;
                 b++) {
-            int cur_iw_block = (b == jcp.nb_iw - 1 && iw_block_tail > 0)
+            dim_t cur_iw_block = (b == jcp.nb_iw - 1 && iw_block_tail > 0)
                     ? iw_block_tail
                     : jcp.iw_block;
             const auto inp_block = inp_w(cur_iw_block);
             const auto inp_start = inp_w_start(b);
             const auto inp_end = inp_start + inp_block;
             const auto block_lpad = 0;
-            const auto block_len = nstl::min(jcp.ow, inp_end) - inp_start;
+            const dim_t block_len
+                    = nstl::min<dim_t>(jcp.ow, inp_end) - inp_start;
             Xbyak::Label skip_last_partial_block;
             cmp(reg_iwb, b);
             jne(skip_last_partial_block, T_NEAR);
-            copy_iw_block_body(block_lpad, cur_iw_block, block_len, is_oc_tail);
+            copy_iw_block_body(
+                    block_lpad, cur_iw_block, block_len, is_oc_tail);
             jmp(copy_block_done_label, T_NEAR);
 
             L(skip_last_partial_block);
@@ -405,7 +409,7 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
 
 template <typename Vmm>
 void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block_body(
-        int lpad, int iw_len, int ow_len, bool is_oc_tail) {
+        dim_t lpad, dim_t iw_len, dim_t ow_len, bool is_oc_tail) {
     const auto dst_width = inp_w(iw_len) + lpad;
     for (dim_t ind_w = 0; ind_w < dst_width; ind_w++) {
         auto ow_idx = ind_w - lpad;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.hpp
@@ -89,10 +89,11 @@ protected:
             bool do_load = true);
     void generate() override;
     void copy_iw_block(bool is_oc_tail);
-    void copy_iw_block_body(int lpad, int iw_len, int ow_len, bool is_oc_tail);
+    void copy_iw_block_body(
+            dim_t lpad, dim_t iw_len, dim_t ow_len, bool is_oc_tail);
 
-    int inp_w(int out_w) const;
-    int inp_w_start(int iwb) const;
+    dim_t inp_w(dim_t out_w) const;
+    dim_t inp_w_start(dim_t iwb) const;
 };
 
 } // namespace jit_avx512_core_brgemm_conv_bwd_trans_kernel

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -436,8 +436,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         bcast_simd = acc_simd_w;
     }
 
-    int ur, ur_block, ur_block_tail;
-    int nb_kd, nb_kh, nb_kw;
+    dim_t ur, ur_block, ur_block_tail;
+    dim_t nb_kd, nb_kh, nb_kw;
     int max_regs;
     int bcast_simd;
     float eff;
@@ -455,7 +455,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     static constexpr float mem_k = 15.f;
     static constexpr int bench_iterations = 1;
 
-    int sp, sp_block, nb_sp;
+    dim_t sp, sp_block, nb_sp;
 
     void get_from_jcp(const jit_brgemm_conv_conf_t &jcp) { *this = jcp; }
     void save_to_jcp(jit_brgemm_conv_conf_t &jcp) const { jcp = *this; }
@@ -475,16 +475,16 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     void update_blocks();
     bool fast_check_ic_block() const;
     float est_eff();
-    void iterate_ker_block(brg_blocking_t &best_brgb, int kd_block,
-            int kh_block, bool maybe_use_buffer, int max_iw_block_thr);
+    void iterate_ker_block(brg_blocking_t &best_brgb, dim_t kd_block,
+            dim_t kh_block, bool maybe_use_buffer, dim_t max_iw_block_thr);
     status_t calc_blocks();
 
     bool fast_check_ic_block_1x1() const;
     float est_eff_1x1();
 
     // utils
-    static int get_inp_size(
-            int max_src_size, int dst_size, int k, int stride, int dilate) {
+    static dim_t get_inp_size(dim_t max_src_size, dim_t dst_size, dim_t k,
+            dim_t stride, dim_t dilate) {
         auto adj_str = nstl::min(k, stride);
         const auto res = nstl::min(max_src_size,
                 calculate_end_padding(0, dst_size, 0, adj_str,
@@ -492,8 +492,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         return res;
     }
 
-    static int get_inp_block_size(
-            int out_size, int stride, int ext_k, int padding) {
+    static dim_t get_inp_block_size(
+            dim_t out_size, dim_t stride, dim_t ext_k, dim_t padding) {
         const auto res = div_up(out_size + padding % stride, stride)
                 + (ext_k - 1 - padding % stride) / stride;
         return res;
@@ -513,13 +513,13 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         return est_ur;
     }
 
-    int inp_w(int out_w, int ker_w) const {
+    dim_t inp_w(dim_t out_w, dim_t ker_w) const {
         return get_inp_size(ow, out_w, ker_w, stride_w, dilate_w);
     }
 
-    int rnd_simd(int val) const { return rnd_up(val, simd_w); }
+    dim_t rnd_simd(dim_t val) const { return rnd_up(val, simd_w); }
 
-    int rnd_inp_simd(int out_w, int ker_w, int voc) const {
+    dim_t rnd_inp_simd(dim_t out_w, dim_t ker_w, dim_t voc) const {
         const auto vsp = inp_w(out_w, ker_w);
         return ((stride_w == 1 && voc >= oc) ? rnd_up(vsp * voc, simd_w)
                                              : vsp * rnd_up(voc, simd_w));
@@ -594,7 +594,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
             is_bf32, is_tf32));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
-    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
+    ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
     if (ur == 0) return status::invalid_arguments;
     ur_block = brg.bd_block;
     if (is_1x1 && is_amx(isa) && M > 0 && M_tail > 0) {
@@ -654,8 +654,8 @@ status_t brg_blocking_t::get_brgemm_ur(
 
                     brgemm_attr_t brgattr;
                     brgattr.max_bs = max_batch;
-                    const auto max_vpad = (exec_type == exec_vpad)
-                            ? nstl::max(l_pad, r_pad)
+                    const int max_vpad = (exec_type == exec_vpad)
+                            ? static_cast<int>(nstl::max(l_pad, r_pad))
                             : 0;
                     brgattr.max_top_vpad = max_vpad;
                     brgattr.max_bottom_vpad = max_vpad;
@@ -732,22 +732,29 @@ float brg_blocking_t::est_eff() {
     const auto icblock = ic_block / acc_simd_w;
 
     const auto brgemm_microkernel_eff
-            = (static_cast<float>(icblock) * ur) / ((ur + icblock) * max_regs);
+            = (static_cast<float>(icblock) * static_cast<float>(ur))
+            / static_cast<float>((ur + icblock) * max_regs);
 
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
-    const auto brgemm_eff = squeeze_val(ur
-                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+    const auto ur_eff = static_cast<float>(sp_block)
+            / static_cast<float>(rnd_up(sp_block, ur));
+    const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    static_cast<float>(ur)
+                                            / static_cast<float>(sp_block)))
                     / 64,
             0.5f);
 
     const auto sp_amount = nb_id * nb_ih * nb_sp;
     const auto work_amount = mb * ngroups * nb_ic * sp_amount;
-    const auto sp_eff = (static_cast<float>(sp) / rnd_up(sp, sp_block));
+    const auto sp_eff = (static_cast<float>(sp)
+            / static_cast<float>(rnd_up(sp, sp_block)));
 
     const auto thr_eff = static_cast<float>(work_amount)
-            / utils::rnd_up(work_amount, nthr);
+            / static_cast<float>(utils::rnd_up(work_amount, nthr));
 
-    const auto ic_block_eff = static_cast<float>(ic) / rnd_up(ic, ic_block);
+    const auto ic_block_eff
+            = static_cast<float>(ic) / static_cast<float>(rnd_up(ic, ic_block));
 
     const auto job = div_up(work_amount, nthr);
 
@@ -759,9 +766,9 @@ float brg_blocking_t::est_eff() {
             thr_jobs[ithr] = 0;
             if (ithr >= work_amount) continue;
             dim_t thr_job = 0;
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr, ithr, start, end);
-            int n {0}, g {0}, icb {0}, idp {0}, ihp {0}, spb {0};
+            dim_t n {0}, g {0}, icb {0}, idp {0}, ihp {0}, spb {0};
             if (loop_order == loop_ndhwgc)
                 nd_iterator_init(start, n, mb, idp, id, ihp, ih, spb, nb_sp, g,
                         ngroups, icb, nb_ic);
@@ -770,10 +777,10 @@ float brg_blocking_t::est_eff() {
                         ihp, ih, spb, nb_sp);
 
             for (auto work = start; work < end; work++) {
-                const int icp = icb * ic_block;
-                const auto ic_sz = nstl::min(ic - icp, ic_block);
-                int sp_sz = 0;
-                const int spp = spb * sp_block;
+                const dim_t icp = icb * ic_block;
+                const auto ic_sz = nstl::min<dim_t>(ic - icp, ic_block);
+                dim_t sp_sz = 0;
+                const dim_t spp = spb * sp_block;
                 sp_sz = nstl::min(sp - spp, sp_block);
                 thr_job += sp_sz * ic_sz;
 
@@ -796,7 +803,8 @@ float brg_blocking_t::est_eff() {
             sum_job += thr_jobs[ithr];
         }
         job_eff = max_job == 0 ? 1
-                               : static_cast<float>(sum_job) / (max_job * nthr);
+                               : static_cast<float>(sum_job)
+                        / static_cast<float>(max_job * nthr);
 
     } else {
         job_eff = thr_eff;
@@ -810,14 +818,14 @@ float brg_blocking_t::est_eff() {
     // -- brgemm kernel: loop by simd_w  --
     l++;
     const auto inp_ur = inp_w(ur, kw_block);
-    loop[l].src.set(inp_ur * simd_w, 1, bcast_simd);
+    loop[l].src.set(inp_ur * simd_w, 1, static_cast<float>(bcast_simd));
     loop[l].dst.set(0, 1);
     loop[l].wei.set(ic_block, 1);
 
     // -- brgemm kernel: loop by kw in kw_block  --
     l++;
     auto src_is = rnd_inp_simd(ur, kw_block, oc_blocking_size);
-    loop[l].src.set(src_is, 1, kw_block);
+    loop[l].src.set(src_is, 1, static_cast<float>(kw_block));
     loop[l].dst.set(0, 1);
     loop[l].wei.set(ic_blocking_size, 1);
 
@@ -833,49 +841,50 @@ float brg_blocking_t::est_eff() {
     loop[l].src.set(kd_block * kh_block * src_is, 1);
     loop[l].dst.set(ur * ic_block, 1);
     wei_is = kd_block * kh_block * kw_block * ic_blocking_size;
-    loop[l].wei.set(wei_is, nb_ur);
+    loop[l].wei.set(wei_is, static_cast<float>(nb_ur));
 
     // -- harness: loop by k_blocks in ks --
     l++;
     loop[l].src.set(kd_block * kh_block
                     * rnd_inp_simd(sp_block, kw_block, oc_blocking_size),
             1);
-    loop[l].dst.set(sp_block * ic_block, nb_kd * nb_kh * nb_kw);
+    loop[l].dst.set(
+            sp_block * ic_block, static_cast<float>(nb_kd * nb_kh * nb_kw));
     loop[l].wei.set(wei_is, 1);
 
     // -- brgemm kernel: loop by oc_chunks --
     l++;
     const auto oc_chunks = div_up(nb_oc, nb_oc_blocking);
     loop[l].src.set(kd * kh * rnd_inp_simd(sp_block, kw, oc_blocking_size), 1);
-    loop[l].dst.set(sp_block * ic_block, oc_chunks);
+    loop[l].dst.set(sp_block * ic_block, static_cast<float>(oc_chunks));
     wei_is = kd * kh * kw * ic_blocking_size;
     loop[l].wei.set(wei_is, 1);
 
     const auto dim_ic = (loop_order == loop_ndhwgc) ? 1 : sp_amount;
-    const auto nb_ic_thr = nstl::min(nb_ic, div_up(job, dim_ic));
-    const auto ic_thr = nstl::min(ic, nb_ic_thr * ic_block);
+    const dim_t nb_ic_thr = nstl::min<dim_t>(nb_ic, div_up(job, dim_ic));
+    const dim_t ic_thr = nstl::min<dim_t>(ic, nb_ic_thr * ic_block);
     const auto nsimd_ic_thr = div_up(ic_thr, simd_w);
 
     const auto dim_sp = (loop_order == loop_ndhwgc) ? ngroups * nb_ic : 1;
-    const auto nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
-    const auto sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
+    const dim_t nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
+    const dim_t sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
 
     const auto dim_ih = nb_sp * dim_sp;
-    const int nb_ih_thr = nstl::min(nb_ih, div_up(job, dim_ih));
-    const int ih_thr = nstl::min(ih, nb_ih_thr * ih_block);
+    const dim_t nb_ih_thr = nstl::min<dim_t>(nb_ih, div_up(job, dim_ih));
+    const dim_t ih_thr = nstl::min<dim_t>(ih, nb_ih_thr * ih_block);
 
     const auto dim_id = nb_ih * dim_ih;
-    const int nb_id_thr = nstl::min(nb_id, div_up(job, dim_id));
-    const int id_thr = nstl::min(id, nb_id_thr * id_block);
+    const dim_t nb_id_thr = nstl::min<dim_t>(nb_id, div_up(job, dim_id));
+    const dim_t id_thr = nstl::min<dim_t>(id, nb_id_thr * id_block);
 
     src_is = kd * kh * rnd_inp_simd(sp_block, kw, oc);
 
-    auto wei_op = kd * kh * kw * icblock * oc;
+    dim_t wei_op = kd * kh * kw * icblock * oc;
 
     if (loop_order == loop_ndhwgc) {
         // -- harness: loop by ic_block --
         l++;
-        loop[l].src.set(src_is, nb_ic_thr);
+        loop[l].src.set(src_is, static_cast<float>(nb_ic_thr));
         loop[l].dst.set(sp_block * ic_block, 1);
         wei_is = kd * kh * kw * ic_block * oc;
         wei_op = kd * kh * kw * nsimd_ic_thr * oc;
@@ -888,35 +897,38 @@ float brg_blocking_t::est_eff() {
     const auto rnd_ic_for_sp
             = simd_w * ((loop_order == loop_ndhwgc) ? nsimd_ic_thr : icblock);
     loop[l].dst.set(sp_block * rnd_ic_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_sp_thr));
     // oh_block almost all is 1. TODO: manage oh_block != 1
     // -- harness: loop by oh_blocks --
     l++;
     src_is = kd * kh * rnd_inp_simd(sp_thr, kw, oc);
     loop[l].src.set(ih_block * src_is, 1);
     loop[l].dst.set(sp_thr * rnd_ic_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_ih_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_ih_thr));
     // od_block almost all is 1. TODO: manage oh_block != 1
     // -- harness: loop by od_blocks --
     l++;
     loop[l].src.set(id_block * ih_thr * src_is, 1);
     loop[l].dst.set(ih_thr * sp_thr * rnd_ic_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_id_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_id_thr));
 
     if (loop_order != loop_ndhwgc) {
         // -- harness: loop by ic_block --
         l++;
-        loop[l].src.set(id_thr * ih_thr * src_is, nb_ic_thr);
+        loop[l].src.set(
+                id_thr * ih_thr * src_is, static_cast<float>(nb_ic_thr));
         loop[l].dst.set(ic_block * id_thr * ih_thr * sp_thr, 1);
         loop[l].wei.set(kd * kh * kw * ic_block * oc, 1);
     }
 
     // -- harness: loop by mb --
     l++;
-    const auto mb_thr = nstl::min(mb, div_up(job, sp_amount * ngroups * nb_ic));
+    const dim_t mb_thr
+            = nstl::min<dim_t>(mb, div_up(job, sp_amount * ngroups * nb_ic));
     loop[l].src.set(id_thr * ih_thr * src_is, 1);
     loop[l].dst.set(id_thr * ih_thr * sp_thr * nsimd_ic_thr * simd_w, 1);
-    loop[l].wei.set(kd * kh * kw * nsimd_ic_thr * simd_w * oc, mb_thr);
+    loop[l].wei.set(kd * kh * kw * nsimd_ic_thr * simd_w * oc,
+            static_cast<float>(mb_thr));
 
     const auto src_op = static_cast<dim_t>(mb_thr) * id_thr * ih_thr * sp_thr
             * kd * kh * kw * oc;
@@ -948,24 +960,28 @@ float brg_blocking_t::est_eff() {
         dst_rp *= loop[il].dst.repeatn;
         wei_rp *= loop[il].wei.repeatn;
     }
-    const auto src_ops = (src_op * src_rp) / iterations;
-    const auto dst_ops = (dst_op * dst_rp) / iterations;
-    const auto wei_ops = (wei_op * wei_rp) / iterations;
+    const auto src_ops = (static_cast<float>(src_op) * src_rp) / iterations;
+    const auto dst_ops = (static_cast<float>(dst_op) * dst_rp) / iterations;
+    const auto wei_ops = (static_cast<float>(wei_op) * wei_rp) / iterations;
 
     const auto src_cost = src_mem_k * src_ops;
     const auto dst_cost = dst_mem_k * dst_ops;
     const auto wei_cost = wei_mem_k * wei_ops;
     const auto call_kernel_cost = job * oc_chunks * nb_kd * nb_kh * nb_kw;
 
-    const auto cache_eff = (static_cast<dim_t>(mb) * id * ih * sp * oc * ic)
-            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto cache_eff = static_cast<float>(static_cast<dim_t>(mb) * id * ih
+                                   * sp * oc * ic)
+            / (static_cast<float>(nthr)
+                    * (src_cost + dst_cost + wei_cost
+                            + static_cast<float>(call_kernel_cost)));
     const auto res_eff = ic_block_eff * brgemm_microkernel_eff * sp_eff
             * job_eff * ur_eff * cache_eff * brgemm_eff;
     return res_eff;
 }
 
-void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
-        int kh_block_, bool maybe_use_buffer, int max_iw_block_thr) {
+void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb,
+        dim_t kd_block_, dim_t kh_block_, bool maybe_use_buffer,
+        dim_t max_iw_block_thr) {
     kd_block = kd_block_;
     kh_block = kh_block_;
 
@@ -977,14 +993,15 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
     const auto w_block_size = 2 * src_dsz * oc * owp + dst_dsz * iw * ic_block;
     const auto other_size = wei_dsz * kd * kh * kw * oc * ic_block
             + acc_dsz * 2 * amx_h * ic_block;
-    const auto L2_available = nstl::min(static_cast<size_t>(div_up(L2, 2)),
-            other_size > L2 ? 0 : L2 - other_size);
+    const auto L2_available
+            = nstl::min<size_t>(static_cast<size_t>(div_up(L2, 2)),
+                    other_size > L2 ? 0 : L2 - other_size);
     if (odp * ohp * w_block_size > L2_available) {
-        id_block = utils::saturate(
-                1, id, int(L2_available / (ohp * w_block_size)));
+        id_block = utils::saturate<dim_t>(
+                1, id, L2_available / (ohp * w_block_size));
         if (id_block == 1)
-            ih_block = utils::saturate(
-                    1, ih, int(L2_available / (w_block_size)));
+            ih_block = utils::saturate<dim_t>(
+                    1, ih, L2_available / w_block_size);
         else
             ih_block = ih;
     } else {
@@ -999,16 +1016,20 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
         const auto src_w_block_size
                 = src_dsz * oc * owp + dst_dsz * iw * ic_block;
         if (src_w_block_size < L1) {
-            cur_id_block = utils::saturate(
-                    1, id, int(L1 / (ohp * src_w_block_size)));
+            cur_id_block = utils::saturate<dim_t>(
+                    1, id, L1 / (ohp * src_w_block_size));
             if (cur_id_block == 1)
                 cur_ih_block
-                        = utils::saturate(1, ih, int(L1 / (src_w_block_size)));
+                        = utils::saturate<dim_t>(1, ih, L1 / src_w_block_size);
         }
         for (; cur_id_block > 1; cur_id_block--) {
             const auto sp_size = cur_id_block * cur_ih_block * owp;
-            if ((static_cast<float>(id) / rnd_up(id, cur_id_block)) > 0.9f
-                    && static_cast<float>(sp_size) / rnd_up(sp, amx_h) > 0.8f) {
+            if ((static_cast<float>(id)
+                        / static_cast<float>(rnd_up(id, cur_id_block)))
+                            > 0.9f
+                    && static_cast<float>(sp_size)
+                                    / static_cast<float>(rnd_up(sp, amx_h))
+                            > 0.8f) {
                 L1_fit_res = true;
                 break;
             }
@@ -1016,7 +1037,9 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
         if (cur_id_block == 1) {
             for (; cur_ih_block > 1; cur_ih_block--) {
                 const auto sp_size = cur_ih_block * owp;
-                if ((static_cast<float>(ih) / rnd_up(ih, cur_ih_block)) > 0.9f
+                if ((static_cast<float>(ih)
+                            / static_cast<float>(rnd_up(ih, cur_ih_block)))
+                                > 0.9f
                         && sp_size > 128) {
                     L1_fit_res = true;
                     break;
@@ -1054,11 +1077,11 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
 
     // --- Select iw_block ----
     const auto max_iw_block_L2 = iw;
-    auto start_iw_block = nstl::min(max_iw_block_thr, max_iw_block_L2);
+    auto start_iw_block = nstl::min<dim_t>(max_iw_block_thr, max_iw_block_L2);
     sp = has_uneven_iw ? rnd_up(iw, stride_w) : iw;
     const auto start_sp_block
             = has_uneven_iw ? rnd_up(start_iw_block, stride_w) : start_iw_block;
-    auto prev_spb = 0;
+    auto prev_spb = dim_t(0);
     for (auto ns = 1; ns <= sp; ns++) {
         const auto spb = div_up(sp, ns);
         if (spb == prev_spb || spb > start_sp_block) continue;
@@ -1106,7 +1129,7 @@ status_t brg_blocking_t::calc_blocks() {
     const auto maybe_use_buffer = (dst_dt != acc_dt || with_sum);
 
     // kd/kh block should be either kd/kh or a multiple of stride_d/stride_h
-    std::vector<int> kd_blocks(1), kh_blocks(1);
+    std::vector<dim_t> kd_blocks(1), kh_blocks(1);
     kd_blocks[0] = kd;
     kh_blocks[0] = kh;
     if (kd != 1) {
@@ -1119,9 +1142,10 @@ status_t brg_blocking_t::calc_blocks() {
     }
 
     const auto thr_eff_threshold = 0.9f;
-    const auto max_iw_block_thr = utils::saturate(1, sp,
-            static_cast<int>(ceil(
-                    mb * ngroups * nb_ic * is / (thr_eff_threshold * nthr))));
+    const auto max_iw_block_thr = utils::saturate<dim_t>(1, sp,
+            static_cast<dim_t>(
+                    ceil(static_cast<float>(mb * ngroups * nb_ic * is)
+                            / (thr_eff_threshold * static_cast<float>(nthr)))));
 
     iw_block = is_block = sp_block = -1;
     brg_blocking_t best_brgb = *this;
@@ -1154,7 +1178,8 @@ bool brg_blocking_t::fast_check_ic_block_1x1() const {
                 = id * ih * iw >= 64 * stride_d * stride_h * stride_w;
         res = (rnd_ic % ic_block == 0 && big_spatial);
     } else if (ic_block == 48) {
-        const auto ic_block_eff = static_cast<float>(ic) / rnd_up(ic, ic_block);
+        const auto ic_block_eff = static_cast<float>(ic)
+                / static_cast<float>(rnd_up(ic, ic_block));
         res = (ic_block_eff >= 0.95f);
     } else
         res = true;
@@ -1165,14 +1190,16 @@ bool brg_blocking_t::fast_check_ic_block_1x1() const {
 float brg_blocking_t::est_eff_1x1() {
     const auto icblock = ic_block / acc_simd_w;
 
-    auto calc_ave_blk = [&](int dim, int block, bool use_ave) -> float {
-        const int nb = dim / block;
+    auto calc_ave_blk = [&](dim_t dim, dim_t block, bool use_ave) -> float {
+        const dim_t nb = dim / block;
         constexpr int max_nb = 2; // only consider 2x2 tile blocking
-        const int block2 = nstl::min(max_nb, nb);
-        const int nb2 = nb / block2;
-        const int nb2_tail = nb % block2;
-        if (!use_ave) return block2;
-        return (float(nb2) * block2 + nb2_tail) / div_up(nb, block2);
+        const dim_t block2 = nstl::min<dim_t>(max_nb, nb);
+        const dim_t nb2 = nb / block2;
+        const dim_t nb2_tail = nb % block2;
+        if (!use_ave) return static_cast<float>(block2);
+        return (float(nb2) * static_cast<float>(block2)
+                       + static_cast<float>(nb2_tail))
+                / static_cast<float>(div_up(nb, block2));
     };
     const bool use_ocb_ave = true;
     const auto icb_ave = calc_ave_blk(ic_block, acc_simd_w, use_ocb_ave);
@@ -1188,46 +1215,54 @@ float brg_blocking_t::est_eff_1x1() {
             || (ic == 1024 && oc == 512) || (ic == 256 && oc == 1024)
             || (ic == 512 && oc == 1024) || (ic == 512 && oc == 2048);
     const auto amx_fac = maskrcnn_cond
-            ? (div_up(M + M_tail, 16) / (M_n_sp_blks + M_tail_n_sp_blks))
+            ? (static_cast<float>(div_up(M + M_tail, 16))
+                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks))
             : (static_cast<float>(div_up(M + M_tail, 16))
-                      / (M_n_sp_blks + M_tail_n_sp_blks));
+                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks));
 
     const auto brgemm_microkernel_eff = is_amx(isa)
             ? amx_fac * (static_cast<float>(icb_ave) * spb_ave)
                     / (icb_ave + spb_ave)
-            : (static_cast<float>(icblock) * ur) / ((ur + icblock) * max_regs);
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
-    const auto brgemm_eff = squeeze_val(ur
-                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+            : (static_cast<float>(icblock) * static_cast<float>(ur))
+                    / static_cast<float>((ur + icblock) * max_regs);
+    const auto ur_eff = static_cast<float>(sp_block)
+            / static_cast<float>(rnd_up(sp_block, ur));
+    const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    static_cast<float>(ur)
+                                            / static_cast<float>(sp_block)))
                     / 64,
             0.5f);
 
     const auto sp_amount = nb_id * nb_ih * nb_sp;
     const auto work_amount = mb * ngroups * nb_ic * sp_amount;
 
-    const auto sp_eff = static_cast<float>(sp) / rnd_up(sp, sp_block);
+    const auto sp_eff
+            = static_cast<float>(sp) / static_cast<float>(rnd_up(sp, sp_block));
     const auto thr_eff = static_cast<float>(work_amount)
-            / utils::rnd_up(work_amount, nthr);
-    const auto ic_block_eff = static_cast<float>(ic) / rnd_up(ic, ic_block);
+            / static_cast<float>(utils::rnd_up(work_amount, nthr));
+    const auto ic_block_eff
+            = static_cast<float>(ic) / static_cast<float>(rnd_up(ic, ic_block));
 
     const auto job = div_up(work_amount, nthr);
 
     const auto dim_ic = (loop_order == loop_ndhwgc) ? 1 : sp_amount;
-    const auto nb_ic_thr = nstl::min(nb_ic, div_up(job, dim_ic));
-    const auto ic_thr = nstl::min(ic, nb_ic_thr * ic_block);
+    const dim_t nb_ic_thr = nstl::min<dim_t>(nb_ic, div_up(job, dim_ic));
+    const dim_t ic_thr = nstl::min<dim_t>(ic, nb_ic_thr * ic_block);
     const auto nsimd_ic_thr = div_up(ic_thr, simd_w);
 
     const auto dim_sp = (loop_order == loop_ndhwgc) ? ngroups * nb_ic : 1;
-    const auto nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
-    const auto sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
+    const dim_t nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
+    const dim_t sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
 
     const auto dim_ih = nb_sp * dim_sp;
-    const int nb_ih_thr = nstl::min(nb_ih, div_up(job, dim_ih));
-    const int ih_thr = nstl::min(ih, nb_ih_thr * ih_block);
+    const dim_t nb_ih_thr = nstl::min<dim_t>(nb_ih, div_up(job, dim_ih));
+    const dim_t ih_thr = nstl::min<dim_t>(ih, nb_ih_thr * ih_block);
 
     const auto dim_id = nb_ih * dim_ih;
-    const int nb_id_thr = nstl::min(nb_id, div_up(job, dim_id));
-    const int id_thr = nstl::min(id, nb_id_thr * id_block);
+    const dim_t nb_id_thr = nstl::min<dim_t>(nb_id, div_up(job, dim_id));
+    const dim_t id_thr = nstl::min<dim_t>(id, nb_id_thr * id_block);
 
     auto job_eff = 1.f;
     if (job < nthr) {
@@ -1236,9 +1271,9 @@ float brg_blocking_t::est_eff_1x1() {
             thr_jobs[ithr] = 0;
             if (ithr >= work_amount) continue;
             dim_t thr_job = 0;
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr, ithr, start, end);
-            int n {0}, g {0}, icb {0}, idp {0}, ihp {0}, spb {0};
+            dim_t n {0}, g {0}, icb {0}, idp {0}, ihp {0}, spb {0};
             nd_iterator_init(start, n, mb, idp, id, ihp, ih, spb, nb_sp, g,
                     ngroups, icb, nb_ic);
 
@@ -1251,10 +1286,10 @@ float brg_blocking_t::est_eff_1x1() {
             }
 
             for (auto work = start; work < end; work++) {
-                const int icp = icb * ic_block;
-                const auto ic_sz = nstl::min(ic - icp, ic_block);
-                int sp_sz = 0;
-                const int spp = spb * sp_block;
+                const dim_t icp = icb * ic_block;
+                const auto ic_sz = nstl::min<dim_t>(ic - icp, ic_block);
+                dim_t sp_sz = 0;
+                const dim_t spp = spb * sp_block;
                 sp_sz = nstl::min(sp - spp, sp_block);
                 thr_job += sp_sz * ic_sz;
                 nd_iterator_step(n, mb, idp, id, ihp, ih, spb, nb_sp, g,
@@ -1278,7 +1313,8 @@ float brg_blocking_t::est_eff_1x1() {
         }
 
         job_eff = max_job == 0 ? 1
-                               : static_cast<float>(sum_job) / (max_job * nthr);
+                               : static_cast<float>(sum_job)
+                        / static_cast<float>(max_job * nthr);
     } else {
         job_eff = thr_eff;
     }
@@ -1289,7 +1325,7 @@ float brg_blocking_t::est_eff_1x1() {
     int l = -1;
     // -- brgemm kernel: loop by simd_w  --
     l++;
-    loop[l].src.set(ur * simd_w, 1, bcast_simd);
+    loop[l].src.set(ur * simd_w, 1, static_cast<float>(bcast_simd));
     loop[l].dst.set(0, 1);
     loop[l].wei.set(ic_block, 1);
 
@@ -1302,20 +1338,21 @@ float brg_blocking_t::est_eff_1x1() {
             = (nb_sp_no_tail * nb_ur + div_up(sp_block_tail, ur)) / nb_sp;
     loop[l].src.set(ur * rnd_simd(oc_blocking_size), 1);
     loop[l].dst.set(ur * ic_block, 1);
-    loop[l].wei.set(ic_blocking_size, is_amx(isa) ? nb_ur_average : nb_ur);
+    loop[l].wei.set(ic_blocking_size,
+            static_cast<float>(is_amx(isa) ? nb_ur_average : nb_ur));
     // -- brgemm kernel: loop by ic_chunks --
     l++;
     const auto oc_chunks = div_up(nb_oc, nb_oc_blocking);
     loop[l].src.set(sp_block * oc_blocking_size, 1);
-    loop[l].dst.set(sp_block * ic_block, oc_chunks);
+    loop[l].dst.set(sp_block * ic_block, static_cast<float>(oc_chunks));
     auto wei_is = ic_blocking_size;
-    auto wei_op = icblock * oc;
+    dim_t wei_op = icblock * oc;
     loop[l].wei.set(wei_is, 1);
 
     if (loop_order == loop_ndhwgc) {
         // -- harness: loop by oc_block --
         l++;
-        loop[l].src.set(sp_block * rnd_simd(ic), nb_ic_thr);
+        loop[l].src.set(sp_block * rnd_simd(ic), static_cast<float>(nb_ic_thr));
         loop[l].dst.set(sp_block * ic_block, 1);
         wei_is = ic_block * ic;
         wei_op = nsimd_ic_thr * ic;
@@ -1328,33 +1365,34 @@ float brg_blocking_t::est_eff_1x1() {
     l++;
     loop[l].src.set(sp_block * oc_blocking_size, 1);
     loop[l].dst.set(sp_block * rnd_ic_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_sp_thr));
     // -- harness: loop by oh_blocks --
     l++;
     loop[l].src.set(ih_block * sp_thr * rnd_simd(oc_blocking_size), 1);
     loop[l].dst.set(ih_block * sp_thr * rnd_ic_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_ih_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_ih_thr));
     // -- harness: loop by od_blocks --
     l++;
     loop[l].src.set(id_block * ih_thr * sp_thr * rnd_simd(oc_blocking_size), 1);
     loop[l].dst.set(id_block * ih_thr * sp_thr * rnd_ic_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_id_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_id_thr));
 
     if (loop_order != loop_ndhwgc) {
         // -- harness: loop by oc_block --
         l++;
         loop[l].src.set(id_thr * ih_thr * rnd_simd(sp_thr * oc_blocking_size),
-                nb_ic_thr);
+                static_cast<float>(nb_ic_thr));
         loop[l].dst.set(ic_block * id_thr * ih_thr * sp_thr, 1);
         loop[l].wei.set(ic_block * oc, 1);
     }
 
     // -- harness: loop by mb --
     l++;
-    const auto mb_thr = nstl::min(mb, div_up(job, sp_amount * ngroups * nb_ic));
+    const dim_t mb_thr
+            = nstl::min<dim_t>(mb, div_up(job, sp_amount * ngroups * nb_ic));
     loop[l].src.set(id_thr * ih_thr * sp_thr * rnd_simd(oc_blocking_size), 1);
     loop[l].dst.set(nsimd_ic_thr * simd_w * id_thr * ih_thr * sp_thr, 1);
-    loop[l].wei.set(nsimd_ic_thr * oc * simd_w, mb_thr);
+    loop[l].wei.set(nsimd_ic_thr * oc * simd_w, static_cast<float>(mb_thr));
 
     const auto src_op = static_cast<dim_t>(mb_thr) * id_thr * ih_thr * sp_thr
             * oc_blocking_size;
@@ -1384,9 +1422,9 @@ float brg_blocking_t::est_eff_1x1() {
         dst_rp *= loop[il].dst.repeatn;
         wei_rp *= loop[il].wei.repeatn;
     }
-    const auto src_ops = (src_op * src_rp) / iterations;
-    const auto dst_ops = (dst_op * dst_rp) / iterations;
-    const auto wei_ops = (wei_op * wei_rp) / iterations;
+    const auto src_ops = (static_cast<float>(src_op) * src_rp) / iterations;
+    const auto dst_ops = (static_cast<float>(dst_op) * dst_rp) / iterations;
+    const auto wei_ops = (static_cast<float>(wei_op) * wei_rp) / iterations;
 
     const auto src_cost = src_mem_k * src_ops;
     const auto dst_cost = dst_mem_k * dst_ops;
@@ -1395,8 +1433,11 @@ float brg_blocking_t::est_eff_1x1() {
 
     const auto up_sp_size = id * ih;
 
-    const auto cache_eff = (static_cast<dim_t>(mb) * up_sp_size * sp * oc * ic)
-            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto cache_eff = static_cast<float>(static_cast<dim_t>(mb)
+                                   * up_sp_size * sp * oc * ic)
+            / (static_cast<float>(nthr)
+                    * (src_cost + dst_cost + wei_cost
+                            + static_cast<float>(call_kernel_cost)));
 
     const auto res_eff = ic_block_eff * brgemm_microkernel_eff * sp_eff
             * job_eff * ur_eff * cache_eff * brgemm_eff;
@@ -1522,7 +1563,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = jcp.is_f32_f16 || jcp.is_f32_bf16 ? jcp.src_dt : jcp.wei_dt;
     const data_type_t last_oc_block_dt
             = get_mac_emu_data_type(wei_dt, isa, isa == avx512_core_fp16);
-    jcp.vnni_block = data_type_vnni_granularity(last_oc_block_dt);
+    jcp.vnni_block
+            = static_cast<int>(data_type_vnni_granularity(last_oc_block_dt));
 
     // TODO: optimize grouped convolutions with small oc
     const bool is_grouped_small_oc
@@ -1702,26 +1744,27 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     return status::success;
 }
 
-void set_k_range(int P, int D, int S, dim_t i, dim_t O, int K, int &k_s,
+void set_k_range(dim_t P, dim_t D, dim_t S, dim_t i, dim_t O, dim_t K, int &k_s,
         int &k_f, bool is_w) {
-    int s(0), o_test(0);
+    dim_t s(0), o_test(0);
     while (true) {
         o_test = i + P - s * D;
         if (o_test % S == 0) break;
         s++;
     }
 
-    k_f = is_w ? K : nstl::min(K, static_cast<int>(div_up(i + P + 1, D)));
+    k_f = static_cast<int>(
+            is_w ? K : nstl::min<dim_t>(K, div_up(i + P + 1, D)));
     k_s = is_w ? 0
                : static_cast<int>(
-                         div_up(nstl::max((dim_t)0, i + P - O * S + 1), D));
+                         div_up(nstl::max<dim_t>(0, i + P - O * S + 1), D));
 
     while (k_s % S != s)
         k_s++;
 }
 
-void get_iw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw, int kw,
-        int &iw_s, int &M_without_overflow) {
+void get_iw_range(const jit_brgemm_conv_conf_t &jcp, dim_t iw, dim_t iw_raw,
+        dim_t kw, int &iw_s, int &M_without_overflow) {
     // This function is needed for exec_base only
     using namespace dnnl::impl::utils;
     using namespace nstl;
@@ -1739,9 +1782,9 @@ void get_iw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw, int kw,
     auto ow = (iw - kw * DW + LP) / SW;
     auto ow_l_ovf = ow;
     const auto ow_r_ovf = ow_l_ovf + (M - 1) - OW + 1;
-    iw_s = iw;
+    iw_s = static_cast<int>(iw);
 
-    int ker_idx = 0;
+    dim_t ker_idx = 0;
     if (ow_l_ovf < 0) {
         ow_l_ovf = nstl::abs(ow_l_ovf);
         ker_idx += ow_l_ovf;
@@ -1750,21 +1793,23 @@ void get_iw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw, int kw,
 
     if (ow_r_ovf > 0) ker_idx += ow_r_ovf;
 
-    int iw_f = iw_s + (M - ker_idx);
+    dim_t iw_s_d = iw_s;
+    dim_t iw_f = iw_s_d + (M - ker_idx);
 
-    iw_s = nstl::min(iw_s, iw + M);
-    iw_f = nstl::min(nstl::max(iw_f, iw_s), iw + M);
+    iw_s_d = nstl::min<dim_t>(iw_s_d, iw + M);
+    iw_f = nstl::min<dim_t>(nstl::max<dim_t>(iw_f, iw_s_d), iw + M);
 
-    M_without_overflow = iw_f - iw_s;
-    iw_s = iw;
-    ow = (iw_s - kw * DW + LP) / SW;
-    while (ow < 0 && iw_s + SW < IW) {
-        iw_s += SW;
-        ow = (iw_s - kw * DW + LP) / SW;
+    M_without_overflow = static_cast<int>(iw_f - iw_s_d);
+    iw_s_d = iw;
+    ow = (iw_s_d - kw * DW + LP) / SW;
+    while (ow < 0 && iw_s_d + SW < IW) {
+        iw_s_d += SW;
+        ow = (iw_s_d - kw * DW + LP) / SW;
     }
+    iw_s = static_cast<int>(iw_s_d);
 }
 
-void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw,
+void get_kw_range(const jit_brgemm_conv_conf_t &jcp, dim_t iw, dim_t iw_raw,
         int &kw_s, int &kw_full_s, int &kw_full_f, int &kw_f) {
     // This function is needed for exec_base only
     using namespace dnnl::impl::utils;
@@ -1779,16 +1824,16 @@ void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw,
     const bool is_iw_tail = (IW - iw_raw < IW_BLOCK);
     const auto M = div_up(is_iw_tail ? IW_TAIL : IW_BLOCK, SW);
     kw_s = kw_full_s = kw_full_f = kw_f = -1;
-    for (int kw = 0; kw < KW; kw++) {
+    for (dim_t kw = 0; kw < KW; kw++) {
         int iw_s {0}, iw_f {0}, M_without_overflow {0};
         get_iw_range(jcp, iw, iw_raw, kw, iw_s, M_without_overflow);
         iw_f = iw_s + M_without_overflow;
         if (iw_s < iw_f) {
-            if (kw_s == -1) kw_s = kw;
-            kw_f = kw + 1;
+            if (kw_s == -1) kw_s = static_cast<int>(kw);
+            kw_f = static_cast<int>(kw + 1);
             if (iw_f - iw_s == M) {
-                if (kw_full_s == -1) kw_full_s = kw;
-                kw_full_f = kw + 1;
+                if (kw_full_s == -1) kw_full_s = static_cast<int>(kw);
+                kw_full_f = static_cast<int>(kw + 1);
             }
         }
     }
@@ -1799,7 +1844,7 @@ void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw,
     }
     if (kw_full_f == -1) kw_full_s = kw_full_f = kw_f;
 
-    int s(0), o_test(0);
+    dim_t s(0), o_test(0);
     while (true) {
         o_test = iw + LP - s * DW;
         if (o_test % SW == 0) break;
@@ -1844,7 +1889,7 @@ dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,
 
     const bool fill_k_ranges
             = !any_null(kd_bs, kd_es, kh_bs, kh_es, kw_bs, kw_es);
-    std::set<std::vector<int>> unique_kernels;
+    std::set<std::vector<dim_t>> unique_kernels;
     dim_t k = 0;
     if (fill_k_ranges) {
         kd_bs->resize(jcp.ker_ranges_size);
@@ -1855,8 +1900,8 @@ dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,
         kw_es->resize(jcp.ker_ranges_size);
     }
 
-    const auto update_kernels
-            = [&](int kd_b, int kd_e, int kh_b, int kh_e, int kw_b, int kw_e) {
+    const auto update_kernels = [&](dim_t kd_b, dim_t kd_e, dim_t kh_b,
+                                        dim_t kh_e, dim_t kw_b, dim_t kw_e) {
         unique_kernels.insert({kd_b, kd_e, kh_b, kh_e, kw_b, kw_e});
         if (k == static_cast<dim_t>(unique_kernels.size())) return;
         if (fill_k_ranges) {
@@ -1871,19 +1916,19 @@ dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,
         assert(IMPLICATION(fill_k_ranges, k <= jcp.ker_ranges_size));
     };
 
-    for_(int idb = 0; idb < jcp.nb_id; idb++)
-    for_(int ihb = 0; ihb < jcp.nb_ih; ihb++)
-    for (int iwb = 0; iwb < jcp.nb_iw; iwb++) {
+    for_(dim_t idb = 0; idb < jcp.nb_id; idb++)
+    for_(dim_t ihb = 0; ihb < jcp.nb_ih; ihb++)
+    for (dim_t iwb = 0; iwb < jcp.nb_iw; iwb++) {
         auto id_begin = idb * ID_BLOCK;
         auto id_end = nstl::min(ID, id_begin + ID_BLOCK);
         auto ih_begin = ihb * IH_BLOCK;
         auto ih_end = jcp.is_is_blocking ? ih_begin + 1
                                          : nstl::min(IH, ih_begin + IH_BLOCK);
-        for_(int id = id_begin; id < id_end; id++)
-        for_(int ih = ih_begin; ih < ih_end; ih++)
-        for (int sw = 0; sw < SW; sw++) {
-            const int iw = iwb * IW_BLOCK + sw;
-            const int iw_raw = iwb * IW_BLOCK;
+        for_(dim_t id = id_begin; id < id_end; id++)
+        for_(dim_t ih = ih_begin; ih < ih_end; ih++)
+        for (dim_t sw = 0; sw < SW; sw++) {
+            const dim_t iw = iwb * IW_BLOCK + sw;
+            const dim_t iw_raw = iwb * IW_BLOCK;
 
             int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
             int kd_s_(0), kh_s_(0), kd_f_(0), kh_f_(0);
@@ -1907,8 +1952,8 @@ dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,
                     if (kw_full_s < kw_full_f) {
                         for (auto kw = kw_full_s; kw < kw_full_f;
                                 kw += KW_BLOCK) {
-                            const auto kw_e
-                                    = nstl::min(kw_full_f, kw + KW_BLOCK);
+                            const auto kw_e = nstl::min<dim_t>(
+                                    kw_full_f, kw + KW_BLOCK);
                             update_kernels(kd_s, kd_f, kh_s, kh_f, kw, kw_e);
                         }
                     }
@@ -1945,12 +1990,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     const memory_desc_wrapper diff_src_d(&diff_src_md);
     const memory_desc_wrapper bias_d(&bias_md);
 
-    jcp.l_ovf = nstl::max(0, jcp.ext_kw - 1 - jcp.l_pad) / jcp.stride_w;
-    jcp.r_ovf = nstl::max(0, jcp.ext_kw - 1 - jcp.r_pad) / jcp.stride_w;
-    jcp.t_ovf = nstl::max(0, jcp.ext_kh - 1 - jcp.t_pad) / jcp.stride_h;
-    jcp.b_ovf = nstl::max(0, jcp.ext_kh - 1 - jcp.b_pad) / jcp.stride_h;
-    jcp.f_ovf = nstl::max(0, jcp.ext_kd - 1 - jcp.f_pad) / jcp.stride_d;
-    jcp.back_ovf = nstl::max(0, jcp.kd - 1 - jcp.back_pad) / jcp.stride_d;
+    jcp.l_ovf = nstl::max<dim_t>(0, jcp.ext_kw - 1 - jcp.l_pad) / jcp.stride_w;
+    jcp.r_ovf = nstl::max<dim_t>(0, jcp.ext_kw - 1 - jcp.r_pad) / jcp.stride_w;
+    jcp.t_ovf = nstl::max<dim_t>(0, jcp.ext_kh - 1 - jcp.t_pad) / jcp.stride_h;
+    jcp.b_ovf = nstl::max<dim_t>(0, jcp.ext_kh - 1 - jcp.b_pad) / jcp.stride_h;
+    jcp.f_ovf = nstl::max<dim_t>(0, jcp.ext_kd - 1 - jcp.f_pad) / jcp.stride_d;
+    jcp.back_ovf
+            = nstl::max<dim_t>(0, jcp.kd - 1 - jcp.back_pad) / jcp.stride_d;
 
     jcp.odp = jcp.od + jcp.f_ovf + jcp.back_ovf;
     jcp.ohp = jcp.oh + jcp.t_ovf + jcp.b_ovf;
@@ -1960,7 +2006,7 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     // ======================= blocking =================================
 
     const int min_ic_block = jcp.acc_simd_w;
-    int selected_ur = 0;
+    dim_t selected_ur = 0;
 
     //-----------------------------------------------------------------------
 
@@ -2011,7 +2057,8 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         best_brgb.ic_block = min_ic_block;
         brg_blocking_t cur_brgb = zero<decltype(best_brgb)>();
         cur_brgb.get_from_jcp(jcp);
-        const auto start_icb = nstl::min(div_up(jcp.ic, jcp.acc_simd_w), 4);
+        const auto start_icb
+                = nstl::min<dim_t>(div_up(jcp.ic, jcp.acc_simd_w), 4);
 
         auto finish_icb = 1;
         for (auto icb = start_icb; icb >= finish_icb; icb--) {

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.hpp
@@ -39,13 +39,14 @@ constexpr size_t P4K = 4096;
 
 bool is_amx(cpu_isa_t isa);
 
-void set_k_range(int P, int D, int S, dim_t i, dim_t O, int K, int &k_s,
+void set_k_range(dim_t P, dim_t D, dim_t S, dim_t i, dim_t O, dim_t K, int &k_s,
         int &k_f, bool is_w = false);
 
-void get_iw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw, int kw,
+void get_iw_range(const jit_brgemm_conv_conf_t &jcp, dim_t iw, dim_t iw_raw,
+        dim_t kw,
         int &iw_s, int &M_without_overflow);
 
-void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw,
+void get_kw_range(const jit_brgemm_conv_conf_t &jcp, dim_t iw, dim_t iw_raw,
         int &kw_s, int &kw_full_s, int &kw_full_f, int &kw_f);
 
 dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -221,8 +221,8 @@ void brgemm_convolution_bwd_weights_t::pd_t::copy2jit_jcp() {
     jit_jcp_.oc_block = jcp_.oc_block;
     jit_jcp_.nb_oc_blocking = jcp_.nb_oc_blocking;
 
-    jit_jcp_.ic_tail = jcp_.tr_ic_tail;
-    jit_jcp_.oc_tail = jcp_.oc_tail;
+    jit_jcp_.ic_tail = static_cast<int>(jcp_.tr_ic_tail);
+    jit_jcp_.oc_tail = static_cast<int>(jcp_.oc_tail);
 
     jit_jcp_.tr_iw = jcp_.tr_iw;
     jit_jcp_.tr_ow = jcp_.tr_ow;
@@ -233,7 +233,7 @@ void brgemm_convolution_bwd_weights_t::pd_t::copy2jit_jcp() {
 }
 
 status_t brgemm_convolution_bwd_weights_t::add_brg_kernel(
-        int bs, int M, int i_N, int i_K, int i_init) {
+        int bs, dim_t M, int i_N, int i_K, int i_init) {
     if (M <= 0) return status::success;
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
@@ -275,8 +275,12 @@ status_t brgemm_convolution_bwd_weights_t::init(engine_t *engine) {
     }
     if (jcp.transform_to_vnni) {
         CHECK(safe_ptr_assign(diff_wei_trans_kernel_,
-                new jit_diff_wei_trans_to_vnni_t(jcp.wei_dt, jcp.kd, jcp.kh,
-                        jcp.kw, jcp.ic_block, jcp.oc_block, jcp.nb_ic)));
+                new jit_diff_wei_trans_to_vnni_t(jcp.wei_dt,
+                        static_cast<int>(jcp.kd), static_cast<int>(jcp.kh),
+                        static_cast<int>(jcp.kw),
+                        static_cast<int>(jcp.ic_block),
+                        static_cast<int>(jcp.oc_block),
+                        static_cast<int>(jcp.nb_ic))));
         CHECK(diff_wei_trans_kernel_->create_kernel());
     }
 
@@ -336,10 +340,10 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
     int ithr_but_oc = 0;
     int ithr_but_ic = 0;
 
-    int img_start = 0, img_end = 0, img_work = 0;
-    int g_start = 0, g_end = 0, g_work = 0;
-    int oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
-    int ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
+    dim_t img_start = 0, img_end = 0, img_work = 0;
+    dim_t g_start = 0, g_end = 0, g_work = 0;
+    dim_t oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
+    dim_t ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
 
     int cur_brg_idx = -1;
     brgemm_batch_element_t *__restrict brg_batch;
@@ -404,7 +408,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
         ithr_but_ic
                 = (ithr_mb * jcp.nthr_g + ithr_g) * jcp.nthr_oc_b + ithr_oc_b;
 
-        int work_amount = jcp.nthr_mb_work;
+        dim_t work_amount = jcp.nthr_mb_work;
         /* reduction dimension */
         balance211(work_amount, jcp.nthr_mb, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
@@ -417,20 +421,23 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
         oc_b_work = oc_b_end - oc_b_start;
 
         if (jcp.transform_to_vnni) {
-            const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+            const int vnni_granularity
+                    = static_cast<int>(data_type_vnni_granularity(jcp.wei_dt));
             if (vnni_granularity == 0) {
                 assert(!"Invalid vnni granularity.");
                 return;
             }
 
             const auto icb_work = div_up(jcp.nb_ic, vnni_granularity);
-            balance211(
-                    icb_work, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
-            ic_b_start = nstl::min(jcp.nb_ic, ic_b_start * vnni_granularity);
-            ic_b_end = nstl::min(jcp.nb_ic, ic_b_end * vnni_granularity);
+            balance211(icb_work, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
+                    ic_b_end);
+            ic_b_start
+                    = nstl::min<dim_t>(jcp.nb_ic, ic_b_start * vnni_granularity);
+            ic_b_end
+                    = nstl::min<dim_t>(jcp.nb_ic, ic_b_end * vnni_granularity);
         } else {
-            balance211(
-                    jcp.nb_ic, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
+            balance211(jcp.nb_ic, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
+                    ic_b_end);
         }
 
         ic_b_work = ic_b_end - ic_b_start;
@@ -450,35 +457,36 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
 
     const pd_t *pd() const { return self->pd(); }
 
-    inline int get_inp_start(int out_s, int pad, int str) const {
-        return nstl::max(0, -pad + out_s * str);
+    inline dim_t get_inp_start(dim_t out_s, dim_t pad, dim_t str) const {
+        return nstl::max<dim_t>(0, -pad + out_s * str);
     }
 
-    inline int get_inp_end(int out_e, int is, int pad, int str, int ek) const {
-        return nstl::min(is, -pad + (out_e - 1) * str + ek);
+    inline dim_t get_inp_end(
+            dim_t out_e, dim_t is, dim_t pad, dim_t str, dim_t ek) const {
+        return nstl::min<dim_t>(is, -pad + (out_e - 1) * str + ek);
     }
 
-    inline int get_id_start(int od_s) const {
+    inline dim_t get_id_start(dim_t od_s) const {
         return get_inp_start(od_s, jcp.f_pad, jcp.stride_d);
     }
-    inline int get_ih_start(int oh_s) const {
+    inline dim_t get_ih_start(dim_t oh_s) const {
         return get_inp_start(oh_s, jcp.t_pad, jcp.stride_h);
     }
 
-    inline int get_id_end(int od_e) const {
+    inline dim_t get_id_end(dim_t od_e) const {
         return get_inp_end(od_e, jcp.id, jcp.f_pad, jcp.stride_d, jcp.ext_kd);
     }
-    inline int get_ih_end(int oh_e) const {
+    inline dim_t get_ih_end(dim_t oh_e) const {
         return get_inp_end(oh_e, jcp.ih, jcp.t_pad, jcp.stride_h, jcp.ext_kh);
     }
 
-    size_t tr_src_buf_number(int g, int icb) const {
+    size_t tr_src_buf_number(dim_t g, dim_t icb) const {
         return jcp.global_transpose
                 ? ithr_mb * jcp.nb_ic * jcp.ngroups + g * jcp.nb_ic + icb
                 : ithr;
     }
 
-    size_t tr_diff_dst_buf_number(int g, int ocb) const {
+    size_t tr_diff_dst_buf_number(dim_t g, dim_t ocb) const {
         // for current loop order (xoi) if jcp.tr_ocb_chunk then we can reuse
         // same area in tr_diff_dst buffer
         if (jcp.tr_ocb_chunk)
@@ -493,7 +501,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                     : ithr;
     }
 
-    size_t tr_src_off(int g, int icb, int id, int ih) const {
+    size_t tr_src_off(dim_t g, dim_t icb, dim_t id, dim_t ih) const {
         const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         const size_t tr_3d_size = tr_row_size * jcp.ih_block;
         // Aligned to buffer end to use guard elements
@@ -502,14 +510,16 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 * jcp.src_dsz;
     }
 
-    inline size_t tr_ic_block_src_off(int g, int tr_icb, int id, int ih) const {
-        const int nb_tr_icb = jcp.ic_block / jcp.tr_ic_block;
+    inline size_t tr_ic_block_src_off(
+            dim_t g, dim_t tr_icb, dim_t id, dim_t ih) const {
+        const dim_t nb_tr_icb = jcp.ic_block / jcp.tr_ic_block;
         return tr_src_off(g, tr_icb / nb_tr_icb, id, ih)
                 + (tr_icb % nb_tr_icb) * jcp.tr_ic_block * jcp.tr_iw
                 * jcp.src_dsz;
     }
 
-    inline size_t tr_diff_dst_off(int g, int ocb, int od, int oh) const {
+    inline size_t tr_diff_dst_off(
+            dim_t g, dim_t ocb, dim_t od, dim_t oh) const {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         const size_t tr_3d_size = tr_row_size * jcp.oh_block;
         return (tr_diff_dst_buf_number(g, ocb) * jcp.tr_diff_dst_buf_size
@@ -517,24 +527,25 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 * jcp.dst_dsz;
     }
 
-    void trans_src_nxc(char *tr_src, const char *src_base, int tr_icb,
-            int row_count, int ih_s) const {
-        const int src_stride = jcp.iw * jcp.ngroups * jcp.ic * jcp.src_dsz;
-        const int tr_src_stride = jcp.tr_iw * jcp.ic_block * jcp.src_dsz;
+    void trans_src_nxc(char *tr_src, const char *src_base, dim_t tr_icb,
+            dim_t row_count, dim_t ih_s) const {
+        const dim_t src_stride = jcp.iw * jcp.ngroups * jcp.ic * jcp.src_dsz;
+        const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block * jcp.src_dsz;
 
-        int sp_work = row_count;
+        dim_t sp_work = row_count;
         const char *src = src_base;
-        const int tr_ic_tail_work
+        const dim_t tr_ic_tail_work
                 = jcp.tr_ic_tail ? jcp.tr_ic_tail : jcp.tr_ic_block;
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             // For 1x1 convolutions with strides we transpose only
             // needed lines
             if (IMPLICATION(jcp.kh == 1, (ih_s + iwork) % jcp.stride_h == 0)) {
                 auto ctx = jit_trans_src_t::ctx_t();
                 ctx.src = src;
                 ctx.tr_src = tr_src;
-                ctx.ch_work = (tr_icb + 1) == jcp.nb_tr_ic ? tr_ic_tail_work
-                                                           : jcp.tr_ic_block;
+                ctx.ch_work = static_cast<int>((tr_icb + 1) == jcp.nb_tr_ic
+                                ? tr_ic_tail_work
+                                : jcp.tr_ic_block);
                 ctx.src_prf = nullptr;
                 ctx.tr_src_prf = nullptr;
                 (*self->trans_kernel_)(&ctx);
@@ -545,25 +556,27 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
     }
 
     void trans_dst_nxc(char *tr_diff_dst, const char *diff_dst_base,
-            int spatial_start, dim_t spatial_start_offset, int ocb_start,
-            dim_t chb_stride, int row_count) const {
-        const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc * jcp.dst_dsz;
-        const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block * jcp.dst_dsz;
-        int work_rest = row_count;
-        int max_spatial_work = jcp.od * jcp.oh;
-        int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+            dim_t spatial_start, dim_t spatial_start_offset, dim_t ocb_start,
+            dim_t chb_stride, dim_t row_count) const {
+        const dim_t diff_dst_stride
+                = jcp.ow * jcp.ngroups * jcp.oc * jcp.dst_dsz;
+        const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block * jcp.dst_dsz;
+        dim_t work_rest = row_count;
+        const dim_t max_spatial_work = jcp.od * jcp.oh;
+        dim_t sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
         const char *diff_dst
                 = diff_dst_base + spatial_start_offset * jcp.dst_dsz;
-        int ocb = 0;
-        const int oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
+        dim_t ocb = 0;
+        const dim_t oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
         while (work_rest > 0) {
-            for (int iwork = 0; iwork < sp_work; iwork++) {
+            for (dim_t iwork = 0; iwork < sp_work; iwork++) {
                 auto ctx = jit_trans_dst_t::ctx_t();
                 ctx.src = diff_dst;
                 ctx.tr_src = tr_diff_dst;
                 assert(ocb_start + ocb < jcp.nb_oc);
-                ctx.ch_work = (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
-                                                                 : jcp.oc_block;
+                ctx.ch_work = static_cast<int>((ocb_start + ocb + 1) == jcp.nb_oc
+                                ? oc_tail_work
+                                : jcp.oc_block);
                 ctx.src_prf = nullptr;
                 ctx.tr_src_prf = nullptr;
                 (*self->trans_dst_kernel_)(&ctx);
@@ -577,19 +590,20 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
         }
     }
 
-    void maybe_global_transpose(int img, int ocb_s, int ocb_e, int icb_s,
-            int icb_e, int od_s, int odb_s, int odb_e, int oh_s, int ohb_s,
-            int ohb_e) const {
+    void maybe_global_transpose(dim_t img, dim_t ocb_s, dim_t ocb_e, dim_t icb_s,
+            dim_t icb_e, dim_t od_s, dim_t odb_s, dim_t odb_e, dim_t oh_s,
+            dim_t ohb_s, dim_t ohb_e) const {
         if (!jcp.global_transpose) return;
 
         using simple_barrier::barrier;
         // use tr_ic_block to transform src
         assert(jcp.ic_block % jcp.tr_ic_block == 0);
-        const int nb_tr_icb = jcp.ic_block / jcp.tr_ic_block;
-        const int tr_icb_s = icb_s * nb_tr_icb;
-        const int tr_icb_e = nstl::min(icb_e * nb_tr_icb, jcp.nb_tr_ic);
-        const int tr_icb_work = tr_icb_e - tr_icb_s;
-        const int ocb_work = ocb_e - ocb_s;
+        const dim_t nb_tr_icb = jcp.ic_block / jcp.tr_ic_block;
+        const dim_t tr_icb_s = icb_s * nb_tr_icb;
+        const dim_t tr_icb_e
+                = nstl::min<dim_t>(icb_e * nb_tr_icb, jcp.nb_tr_ic);
+        const dim_t tr_icb_work = tr_icb_e - tr_icb_s;
+        const dim_t ocb_work = ocb_e - ocb_s;
 
         // The barrier should stay outside of work condition to avoid
         // possible hang
@@ -606,25 +620,26 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             const auto ihb_s = get_ih_start(ohb_s);
             const auto ihb_e = get_ih_end(ohb_e);
 
-            int work_amount
+            dim_t work_amount
                     = g_work * tr_icb_work * (idb_e - idb_s) * (ihb_e - ihb_s);
-            int tr_start {0}, tr_end {0};
+            dim_t tr_start {0}, tr_end {0};
             balance211(work_amount, jcp.nthr_oc_b, ithr_oc_b, tr_start, tr_end);
 
-            int g {0}, tr_ic_b {0}, jd {0}, jh {0};
+            dim_t g {0}, tr_ic_b {0}, jd {0}, jh {0};
             nd_iterator_init(tr_start, g, g_work, tr_ic_b, tr_icb_work, jd,
                     idb_e - idb_s, jh, ihb_e - ihb_s);
 
             while (tr_start < tr_end) {
-                int g_ = g + g_start;
-                int tr_ic_b_ = tr_ic_b + tr_icb_s;
+                dim_t g_ = g + g_start;
+                dim_t tr_ic_b_ = tr_ic_b + tr_icb_s;
 
-                int jd_s = jd + idb_s;
+                dim_t jd_s = jd + idb_s;
 
-                int jh_s = jh + ihb_s;
-                int jh_e = jh_s + nstl::min(tr_end - tr_start, ihb_e - jh_s);
+                dim_t jh_s = jh + ihb_s;
+                dim_t jh_e = jh_s + nstl::min(tr_end - tr_start, ihb_e - jh_s);
 
-                const int ic_off_idx = g_ * jcp.ic + tr_ic_b_ * jcp.tr_ic_block;
+                const dim_t ic_off_idx
+                        = g_ * jcp.ic + tr_ic_b_ * jcp.tr_ic_block;
 
                 const char *p_src {nullptr};
                 if (jcp.harness == harness_2d_reduction) {
@@ -653,26 +668,27 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             barrier(&tr_diff_dst_bctx[ithr_but_ic], jcp.nthr_ic_b);
 
         if (ocb_work > 0) {
-            int jd = 0;
-            int jh = 0;
-            int work_amount
+            dim_t jd = 0;
+            dim_t jh = 0;
+            dim_t work_amount
                     = g_work * ocb_work * (odb_e - odb_s) * (ohb_e - ohb_s);
-            int tr_start = 0;
-            int tr_end = 0;
+            dim_t tr_start = 0;
+            dim_t tr_end = 0;
             balance211(work_amount, jcp.nthr_ic_b, ithr_ic_b, tr_start, tr_end);
 
-            int g = 0;
-            int oc_b = 0;
+            dim_t g = 0;
+            dim_t oc_b = 0;
             nd_iterator_init(tr_start, g, g_work, oc_b, ocb_work, jd,
                     odb_e - odb_s, jh, ohb_e - ohb_s);
 
             while (tr_start < tr_end) {
-                int g_ = g + g_start;
-                int oc_b_ = oc_b + ocb_s;
-                int jd_s = jd + odb_s;
-                int jh_s = jh + ohb_s;
-                int jh_e = jh_s + nstl::min(tr_end - tr_start, ohb_e - jh_s);
-                const int oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
+                dim_t g_ = g + g_start;
+                dim_t oc_b_ = oc_b + ocb_s;
+                dim_t jd_s = jd + odb_s;
+                dim_t jh_s = jh + ohb_s;
+                dim_t jh_e = jh_s + nstl::min(tr_end - tr_start, ohb_e - jh_s);
+                const dim_t oc_off_idx
+                        = g_ * jcp.oc + oc_b_ * jcp.oc_block;
 
                 const char *p_diff_dst {nullptr};
                 if (jcp.harness == harness_2d_reduction) {
@@ -699,18 +715,18 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             barrier(&tr_diff_dst_bctx[ithr_but_ic], jcp.nthr_ic_b);
     }
 
-    void maybe_local_traspose(char *&p_src, char *&p_dst, int img, int g,
-            int ic_b, int oc_b, int od_s, int odb_s, int odb_e, int oh_s,
-            int ohb_s, int ohb_e) const {
+    void maybe_local_traspose(char *&p_src, char *&p_dst, dim_t img, dim_t g,
+            dim_t ic_b, dim_t oc_b, dim_t od_s, dim_t odb_s, dim_t odb_e,
+            dim_t oh_s, dim_t ohb_s, dim_t ohb_e) const {
 
-        const int idb_s = get_id_start(odb_s);
-        const int ihb_s = get_ih_start(ohb_s);
+        const dim_t idb_s = get_id_start(odb_s);
+        const dim_t ihb_s = get_ih_start(ohb_s);
 
-        const int idb_e = get_id_end(odb_e);
-        const int ihb_e = get_ih_end(ohb_e);
+        const dim_t idb_e = get_id_end(odb_e);
+        const dim_t ihb_e = get_ih_end(ohb_e);
 
-        const int id_s = get_id_start(od_s);
-        const int ih_s = get_ih_start(oh_s);
+        const dim_t id_s = get_id_start(od_s);
+        const dim_t ih_s = get_ih_start(oh_s);
 
         if (jcp.global_transpose) {
             p_src = &tr_src[tr_src_off(g, ic_b, 0, 0)];
@@ -718,17 +734,18 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             return;
         }
 
-        const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ic_b_end)
+        const dim_t nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ic_b_end)
                 ? 1
                 : jcp.nb_ic_blocking;
 
-        const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > oc_b_end)
+        const dim_t nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > oc_b_end)
                 ? 1
                 : jcp.nb_oc_blocking;
 
-        for_(int idb = idb_s; idb < idb_e; idb++)
-        for (int icb = 0; icb < nb_ic_blocks; icb++) {
-            const int ic_off_idx = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
+        for_(dim_t idb = idb_s; idb < idb_e; idb++)
+        for (dim_t icb = 0; icb < nb_ic_blocks; icb++) {
+            const dim_t ic_off_idx
+                    = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
             char *p_tr_src
                     = &tr_src[tr_src_off(0, 0, idb - id_s, ihb_s - ih_s)];
             char *tr_src_local
@@ -750,9 +767,10 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
 
         p_src = &tr_src[tr_src_off(0, 0, 0, 0)]; // p_tr_src;
 
-        for_(int odb = odb_s; odb < odb_e; odb++)
-        for (int ocb = 0; ocb < nb_oc_blocks; ocb++) {
-            const int oc_off_idx = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
+        for_(dim_t odb = odb_s; odb < odb_e; odb++)
+        for (dim_t ocb = 0; ocb < nb_oc_blocks; ocb++) {
+            const dim_t oc_off_idx
+                    = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
             const char *p_raw_diff_dst {nullptr};
             if (jcp.harness == harness_2d_reduction) {
                 p_raw_diff_dst
@@ -775,7 +793,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
     }
 
     bool just_init_output(
-            int start, int end, float *diff_wei, float *diff_bias) {
+            dim_t start, dim_t end, float *diff_wei, float *diff_bias) {
         if (g_start >= g_end || oc_b_start >= oc_b_end
                 || ic_b_start >= ic_b_end)
             return false;
@@ -783,7 +801,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             // for rare case if thread has no work by spatial dimension then we
             // need to initialize the output at least
             if (jcp.with_bias) {
-                for_(int g = g_start; g < g_end; ++g)
+                for_(dim_t g = g_start; g < g_end; ++g)
                 {
                     void *p_bias = diff_bias + g * rnd_up(jcp.oc, jcp.oc_block)
                             + oc_b_start * jcp.oc_block;
@@ -792,8 +810,8 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 }
             }
 
-            for_(int g = g_start; g < g_end; ++g)
-            for (int oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
                 auto wei_offs_ext = pd()->ndims() == 3
                         ? wht_blk_off(diff_weights_d, g, oc_b, ic_b_start, 0)
                         : (pd()->ndims() == 4
@@ -817,8 +835,8 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             // For small ic we may calculate only needed part of diff_weights.
             // So we have to initialize diff_weights
             // TODO: initialize only not calculated part of diff_weights
-            for_(int g = g_start; g < g_end; ++g)
-            for (int oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
                 auto wei_offs_ext = pd()->ndims() == 3
                         ? wht_blk_off(diff_weights_d, g, oc_b, ic_b_start, 0)
                         : (pd()->ndims() == 4
@@ -843,7 +861,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
 };
 
 void brgemm_convolution_bwd_weights_t::call_brgemm_kernel(
-        thread_info_t &btc, int brg_idx, int batch_size, void *ptr_C) const {
+        thread_info_t &btc, int brg_idx, dim_t batch_size, void *ptr_C) const {
 
     const auto brg_ker = brg_kernels_[brg_idx];
     assert(brg_ker != nullptr);
@@ -861,10 +879,10 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kd * jcp.kh * jcp.kw;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_spblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_spblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() != data_type::f32)
@@ -884,26 +902,27 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    int img {0}, oh_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int img_s {0};
+    dim_t img_s {0};
     nd_iterator_init(start, img_s, jcp.mb, oh_s, jcp.oh);
     img = img_s;
 
     auto do_brgemm_call
-            = [&](int g, int bs, int ic_b, int oc_b, int ohb_s, int bs_ih_s,
-                      const char *p_src, const char *p_dst, int kh, int kw,
+            = [&](dim_t g, dim_t bs, dim_t ic_b, dim_t oc_b, dim_t ohb_s,
+                      dim_t bs_ih_s, const char *p_src, const char *p_dst,
+                      dim_t kh, dim_t kw,
                       bool do_init) {
-        const int ihb_s = ti->get_ih_start(ohb_s);
+        const dim_t ihb_s = ti->get_ih_start(ohb_s);
 
-        const int bs_oh_s = utils::saturate(0, jcp.oh,
+        const dim_t bs_oh_s = utils::saturate<dim_t>(0, jcp.oh,
                 (bs_ih_s + jcp.t_pad - kh * (jcp.dilate_h + 1)) / jcp.stride_h);
 
         auto ocb_end = get_end(oc_b, jcp.nb_oc_blocking, ti->oc_b_end);
         auto icb_end = get_end(ic_b, jcp.nb_ic_blocking, ti->ic_b_end);
-        const int src_stride_w_shift = jcp.tr_iw / jcp.stride_w;
+        const dim_t src_stride_w_shift = jcp.tr_iw / jcp.stride_w;
         const auto a_off = _pd->filter_w_to_src(kw) / jcp.stride_w
                 + (kw % jcp.stride_w) * src_stride_w_shift
                 + (bs_ih_s - ihb_s) * jcp.tr_iw * jcp.ic_block;
@@ -924,7 +943,7 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
         auto brg_idx = _pd->get_brg_idx(
                 bs, M_tail ? jcp.M_tail : jcp.M, do_init, N_tail, false);
 
-        for (int ohb = 0; ohb < bs; ohb++) {
+        for (dim_t ohb = 0; ohb < bs; ohb++) {
             ti->brg_batch[ohb].ptr.A = (char *)ptr_A
                     + ohb * jcp.tr_iw * jcp.ic_block * jcp.stride_h
                             * jcp.src_dsz;
@@ -938,14 +957,15 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
     if (ti->just_init_output(start, end, diff_wei, diff_bias)) return;
 
     while (start < end) {
-        const int oh_e = _pd->get_finish_oh(
+        const dim_t oh_e = _pd->get_finish_oh(
                 oh_s, start, get_end(start, jcp.oh_block, end));
-        int height_block = jcp.global_transpose ? oh_e - oh_s : optimal_spblock;
+        dim_t height_block
+                = jcp.global_transpose ? oh_e - oh_s : optimal_spblock;
 
         // loop by ohb_s have only one iteration for global_transpose case
         // because height_block = oh_e - oh_s
-        for (int ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block) {
-            const int ohb_e = get_end(ohb_s, height_block, oh_e);
+        for (dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block) {
+            const dim_t ohb_e = get_end(ohb_s, height_block, oh_e);
             assert(ohb_e <= jcp.oh);
 
             ti->maybe_global_transpose(img,
@@ -955,20 +975,20 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
                     jcp.tr_icb_chunk ? 0 : ti->ic_b_end, 0, 0, 1, oh_s, ohb_s,
                     ohb_e);
 
-            for_(int g = ti->g_start; g < ti->g_end; ++g)
-            for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+            for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+            for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                     oc_b += jcp.nb_oc_blocking) {
-                const int oc_b_e
+                const dim_t oc_b_e
                         = get_end(oc_b, jcp.nb_oc_blocking, ti->oc_b_end);
 
                 if (jcp.tr_ocb_chunk)
                     ti->maybe_global_transpose(img, oc_b, oc_b_e, 0, 0, 0, 0, 1,
                             oh_s, ohb_s, ohb_e);
 
-                for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+                for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                         ic_b += jcp.nb_ic_blocking) {
 
-                    const int ic_b_e
+                    const dim_t ic_b_e
                             = get_end(ic_b, jcp.nb_ic_blocking, ti->ic_b_end);
 
                     if (oc_b == ti->oc_b_start && jcp.tr_icb_chunk)
@@ -1007,15 +1027,17 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
 
                     const auto do_init = (start == ti->img_start);
 
-                    for (int kh = 0; kh < jcp.kh; kh++) {
-                        const int bs_ih_s = _pd->get_start_ih(kh, ohb_s);
-                        const int bs_ih_e = _pd->get_finish_ih(kh, ohb_e);
-                        const auto bs = div_up(
-                                nstl::max(0, bs_ih_e - bs_ih_s), jcp.stride_h);
+                    for (dim_t kh = 0; kh < jcp.kh; kh++) {
+                        const dim_t bs_ih_s = _pd->get_start_ih(kh, ohb_s);
+                        const dim_t bs_ih_e = _pd->get_finish_ih(kh, ohb_e);
+                        const auto bs
+                                = div_up(nstl::max<dim_t>(0, bs_ih_e - bs_ih_s),
+                                        jcp.stride_h);
                         if (bs == 0 && !do_init) continue;
 
-                        for_(int s = 0; s < jcp.stride_w; s++)
-                        for (int kw = s; kw < jcp.kw; kw += jcp.stride_w)
+                        for_(dim_t s = 0; s < jcp.stride_w; s++)
+                        for (dim_t kw = s; kw < jcp.kw;
+                                kw += jcp.stride_w)
                             do_brgemm_call(g, bs, ic_b, oc_b, ohb_s, bs_ih_s,
                                     p_src, p_dst, kh, kw, do_init);
                     }
@@ -1023,8 +1045,11 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
             }
         }
 
-        nd_iterator_jump(start, get_end(start, jcp.oh_block, end), img, jcp.mb,
-                oh_s, jcp.oh);
+        dim_t jump_start = start;
+        const dim_t jump_end = get_end(start, jcp.oh_block, end);
+        nd_iterator_jump(
+                jump_start, jump_end, img, jcp.mb, oh_s, jcp.oh);
+        start = jump_start;
     }
 }
 
@@ -1035,10 +1060,10 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kd * jcp.kh * jcp.kw;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_spblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_spblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() != data_type::f32)
@@ -1058,30 +1083,31 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    int img {0}, od_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int img_s {0};
+    dim_t img_s {0};
     nd_iterator_init(start, img_s, jcp.mb, od_s, jcp.od);
     img = img_s;
 
     auto do_brgemm_call
-            = [&](int g, int bs_d, int bs_h, int ic_b, int oc_b, int od_s,
-                      int oh_s, int bs_id_s, int bs_ih_s, const char *p_src,
-                      const char *p_dst, int kd, int kh, int kw, bool do_init) {
-        const int id_s = ti->get_id_start(od_s);
-        const int ih_s = ti->get_ih_start(oh_s);
+            = [&](dim_t g, dim_t bs_d, dim_t bs_h, dim_t ic_b, dim_t oc_b,
+                      dim_t od_s, dim_t oh_s, dim_t bs_id_s, dim_t bs_ih_s,
+                      const char *p_src, const char *p_dst, dim_t kd, dim_t kh,
+                      dim_t kw, bool do_init) {
+        const dim_t id_s = ti->get_id_start(od_s);
+        const dim_t ih_s = ti->get_ih_start(oh_s);
 
-        const int bs_od_s = utils::saturate(0, jcp.od,
+        const dim_t bs_od_s = utils::saturate<dim_t>(0, jcp.od,
                 (bs_id_s + jcp.f_pad - kd * (jcp.dilate_d + 1)) / jcp.stride_d);
 
-        const int bs_oh_s = utils::saturate(0, jcp.oh,
+        const dim_t bs_oh_s = utils::saturate<dim_t>(0, jcp.oh,
                 (bs_ih_s + jcp.t_pad - kh * (jcp.dilate_h + 1)) / jcp.stride_h);
 
         auto ocb_end = get_end(oc_b, jcp.nb_oc_blocking, ti->oc_b_end);
         auto icb_end = get_end(ic_b, jcp.nb_ic_blocking, ti->ic_b_end);
-        const int src_stride_w_shift = jcp.tr_iw / jcp.stride_w;
+        const dim_t src_stride_w_shift = jcp.tr_iw / jcp.stride_w;
         const auto a_off = _pd->filter_w_to_src(kw) / jcp.stride_w
                 + (kw % jcp.stride_w) * src_stride_w_shift
                 + (bs_ih_s - ih_s) * jcp.tr_iw * jcp.ic_block
@@ -1102,8 +1128,8 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
         auto brg_idx = _pd->get_brg_idx(
                 bs, M_tail ? jcp.M_tail : jcp.M, do_init, N_tail, false);
 
-        for (int odb = 0; odb < bs_d; odb++) {
-            for (int ohb = 0; ohb < bs_h; ohb++) {
+        for (dim_t odb = 0; odb < bs_d; odb++) {
+            for (dim_t ohb = 0; ohb < bs_h; ohb++) {
                 const auto a_off_batch = (odb * jcp.ih_block * jcp.stride_d
                                                  + ohb * jcp.stride_h)
                         * jcp.tr_iw * jcp.ic_block * jcp.src_dsz;
@@ -1125,17 +1151,19 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
     const auto oh_e = jcp.oh;
 
     while (start < end) {
-        const int od_e = _pd->get_finish_od(
+        const dim_t od_e = _pd->get_finish_od(
                 od_s, start, get_end(start, jcp.od_block, end));
-        int sp_block = jcp.global_transpose ? od_e - od_s : optimal_spblock;
+        dim_t sp_block
+                = jcp.global_transpose ? od_e - od_s : optimal_spblock;
 
         // loop by odb_s have only one iteration for global_transpose case
         // because sp_block = od_e - od_s
-        for (int odb_s = od_s; odb_s < od_e; odb_s += sp_block) {
-            const int odb_e = get_end(odb_s, sp_block, od_e);
+        for (dim_t odb_s = od_s; odb_s < od_e; odb_s += sp_block) {
+            const dim_t odb_e = get_end(odb_s, sp_block, od_e);
             assert(odb_e <= jcp.od);
 
-            for (int ohb_s = oh_s; ohb_s < oh_e; ohb_s += jcp.oh_block) {
+            for (dim_t ohb_s = oh_s; ohb_s < oh_e;
+                    ohb_s += jcp.oh_block) {
                 const auto ohb_e = get_end(ohb_s, jcp.oh_block, jcp.oh);
 
                 ti->maybe_global_transpose(img,
@@ -1145,19 +1173,19 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
                         jcp.tr_icb_chunk ? 0 : ti->ic_b_end, od_s, odb_s, odb_e,
                         oh_s, ohb_s, ohb_e);
 
-                for_(int g = ti->g_start; g < ti->g_end; ++g)
-                for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+                for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+                for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                         oc_b += jcp.nb_oc_blocking) {
-                    const int oc_b_e
+                    const dim_t oc_b_e
                             = get_end(oc_b, jcp.nb_oc_blocking, ti->oc_b_end);
                     if (jcp.tr_ocb_chunk)
                         ti->maybe_global_transpose(img, oc_b, oc_b_e, 0, 0,
                                 od_s, odb_s, odb_e, oh_s, ohb_s, ohb_e);
 
-                    for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+                    for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                             ic_b += jcp.nb_ic_blocking) {
 
-                        const int ic_b_e = get_end(
+                        const dim_t ic_b_e = get_end(
                                 ic_b, jcp.nb_ic_blocking, ti->ic_b_end);
 
                         if (oc_b == ti->oc_b_start && jcp.tr_icb_chunk)
@@ -1170,7 +1198,7 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
                                 oc_b, od_s, odb_s, odb_e, oh_s, ohb_s, ohb_e);
 
                         if (jcp.with_bias && ic_b == 0) {
-                            for (int iodb = odb_s; iodb < odb_e; iodb++) {
+                            for (dim_t iodb = odb_s; iodb < odb_e; iodb++) {
                                 auto bp = jit_conv_args_t();
 
                                 bp.bias = diff_bias
@@ -1205,28 +1233,28 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
                         const auto do_init
                                 = (start == ti->img_start && ohb_s == oh_s);
 
-                        for (int kd = 0; kd < jcp.kd; kd++) {
-                            const int bs_id_s = _pd->get_start_id(kd, odb_s);
-                            const int bs_id_e = _pd->get_finish_id(kd, odb_e);
-                            const auto bs_d
-                                    = div_up(nstl::max(0, bs_id_e - bs_id_s),
-                                            jcp.stride_d);
+                        for (dim_t kd = 0; kd < jcp.kd; kd++) {
+                            const dim_t bs_id_s = _pd->get_start_id(kd, odb_s);
+                            const dim_t bs_id_e = _pd->get_finish_id(kd, odb_e);
+                            const auto bs_d = div_up(
+                                    nstl::max<dim_t>(0, bs_id_e - bs_id_s),
+                                    jcp.stride_d);
                             // bs_d may be 0 but we may still need to call brgemm to
                             // initialize output
                             if (bs_d == 0 && !do_init) continue;
 
-                            for (int kh = 0; kh < jcp.kh; kh++) {
-                                const int bs_ih_s
+                            for (dim_t kh = 0; kh < jcp.kh; kh++) {
+                                const dim_t bs_ih_s
                                         = _pd->get_start_ih(kh, ohb_s);
-                                const int bs_ih_e
+                                const dim_t bs_ih_e
                                         = _pd->get_finish_ih(kh, ohb_e);
                                 const auto bs_h = div_up(
-                                        nstl::max(0, bs_ih_e - bs_ih_s),
+                                        nstl::max<dim_t>(0, bs_ih_e - bs_ih_s),
                                         jcp.stride_h);
                                 if (bs_h == 0 && !do_init) continue;
 
-                                for_(int s = 0; s < jcp.stride_w; s++)
-                                for (int kw = s; kw < jcp.kw;
+                                for_(dim_t s = 0; s < jcp.stride_w; s++)
+                                for (dim_t kw = s; kw < jcp.kw;
                                         kw += jcp.stride_w)
                                     do_brgemm_call(g, bs_d, bs_h, ic_b, oc_b,
                                             od_s, oh_s, bs_id_s, bs_ih_s, p_src,
@@ -1238,8 +1266,10 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
             }
         }
 
-        nd_iterator_jump(start, get_end(start, jcp.od_block, end), img, jcp.mb,
-                od_s, jcp.od);
+        dim_t jump_start = start;
+        const dim_t jump_end = get_end(start, jcp.od_block, end);
+        nd_iterator_jump(jump_start, jump_end, img, jcp.mb, od_s, jcp.od);
+        start = jump_start;
     }
 }
 
@@ -1248,7 +1278,8 @@ void brgemm_convolution_bwd_weights_t::store_in_vnni_format(
     const auto &jcp = pd()->jcp_;
     if (one_of(0, ti->g_work, ti->oc_b_work, ti->ic_b_work)) return;
 
-    const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+    const int vnni_granularity
+            = static_cast<int>(data_type_vnni_granularity(jcp.wei_dt));
     if (vnni_granularity == 0) {
         assert(!"Invalid vnni granularity.");
         return;
@@ -1257,15 +1288,16 @@ void brgemm_convolution_bwd_weights_t::store_in_vnni_format(
     const auto icb2_work = div_up(ti->ic_b_work, vnni_granularity);
     const auto work = ti->g_work * ti->oc_b_work * icb2_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, jcp.nthr_mb, ti->ithr_mb, start, end);
-    int sub_g_start {0}, sub_oc_b_start {0}, sub_icb2_start {0};
+    dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_icb2_start {0};
     nd_iterator_init(start, sub_g_start, ti->g_work, sub_oc_b_start,
             ti->oc_b_work, sub_icb2_start, icb2_work);
-    for (int w = start; w < end; w++) {
-        const int g = ti->g_start + sub_g_start;
-        const int oc_b = ti->oc_b_start + sub_oc_b_start;
-        const int ic_b = ti->ic_b_start + vnni_granularity * sub_icb2_start;
+    for (dim_t w = start; w < end; w++) {
+        const dim_t g = ti->g_start + sub_g_start;
+        const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+        const dim_t ic_b
+                = ti->ic_b_start + vnni_granularity * sub_icb2_start;
         jit_conv_args_t p = jit_conv_args_t();
 
         float *input = ti->wei_bia_reduction + wei_offset_int(g, oc_b, ic_b, 0);
@@ -1287,7 +1319,7 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = pd()->jcp_;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1);
 
     const auto wei_dt = diff_weights_d.data_type();
@@ -1301,8 +1333,8 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
             if (jcp.transform_to_vnni) {
                 store_in_vnni_format(ti);
             } else {
-                for_(int g = ti->g_start; g < ti->g_end; g++)
-                for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
+                for_(dim_t g = ti->g_start; g < ti->g_end; g++)
+                for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
                     const size_t acc_size = (size_t)ti->ic_b_work * jcp.kh
                             * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1)
                             * jcp.ic_block * jcp.oc_block;
@@ -1316,10 +1348,10 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
         }
         if (pd()->with_bias() && !is_f32_bias && ti->ithr_ic_b == 0
                 && ti->ic_b_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
-                int result_start_idx
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
+                dim_t result_start_idx
                         = g * jcp.oc + ti->oc_b_start * jcp.oc_block;
-                int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 const size_t acc_size
                         = nstl::min(jcp.oc, ti->oc_b_end * jcp.oc_block)
@@ -1338,7 +1370,7 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
     if (jcp.global_transpose)
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, jcp.nthr);
 
-    const int ic_b_kh_work
+    const dim_t ic_b_kh_work
             = ti->ic_b_work * ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
     if (ic_b_kh_work <= 0 || ti->oc_b_work == 0 || ti->g_work == 0) {
         // TODO: double check if a barrier is needed here
@@ -1348,24 +1380,24 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
         return;
     }
 
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, jcp.nthr_mb, ti->ithr_mb, start, end);
     if (!jcp.transform_to_vnni && start == end) return;
 
     const int _start_nthr_mb = 1;
     for (int thr_mb = _start_nthr_mb; thr_mb < jcp.nthr_mb; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = start;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start
                     + sub_ic_b_kh_start / ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-            const int kX
+            const dim_t kX
                     = sub_ic_b_kh_start % ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
 
             const size_t acc_size = (size_t)jcp.kw * jcp.ic_block * jcp.oc_block
@@ -1414,22 +1446,23 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
         }
         if (jcp.with_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0
                 && ti->ithr_mb == 0 && ti->img_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
                 float *bias_reduced = is_f32_bias ? (float *)(ti->diff_bias)
                                                   : ti->bia_reduction;
                 int thr_mb_buffer_idx = is_f32_bias ? thr_mb - 1 : thr_mb;
-                int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+                const dim_t bias_buf_size
+                        = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
                 float *bias_to_reduce
                         = ti->bia_reduction + thr_mb_buffer_idx * bias_buf_size;
                 const size_t acc_size
                         = nstl::min(jcp.oc, ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
-                int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 if (!is_f32_bias && thr_mb == jcp.nthr_mb - 1) {
                     // the last iteration for bfloat16 requires conversion and
                     // store to diff_weights array
-                    int diff_bias_idx
+                    dim_t diff_bias_idx
                             = g * jcp.oc + ti->oc_b_start * jcp.oc_block;
                     if (bia_dt == bf16)
                         add_floats_and_cvt_to_bfloat16(
@@ -1583,9 +1616,9 @@ void brgemm_convolution_bwd_weights_t::execute_backward_weights(
                     = ctx.get_scratchpad_grantor().template get<const float>(
                             key_conv_padded_bias);
             auto diff_bias_in = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.hpp
@@ -59,63 +59,63 @@ struct brgemm_convolution_bwd_weights_t : public primitive_t {
         jit_conv_conf_t jit_jcp_;
         void copy2jit_jcp();
 
-        int brgs_sz_ = 0;
+        dim_t brgs_sz_ = 0;
         std::shared_ptr<brgemm_containers::brgemm_desc_container_t> brgs_;
 
-        int bs_c = 0;
+        dim_t bs_c = 0;
         std::vector<int> batchsizes;
         bool are_empty_bs {false};
 
-        int get_brg_idx(int bs, int m, bool do_initialization, bool is_N_tail,
+        int get_brg_idx(dim_t bs, dim_t m, bool do_initialization, bool is_N_tail,
                 bool is_K_tail) const {
             auto my_bs = jcp_.var_bs ? 1 : bs;
             auto bs_idx = jcp_.use_uker ? batchsizes[my_bs] : 0;
             assert(bs_idx >= 0);
-            return (((m * bs_c + bs_idx) * 2
+            return static_cast<int>((((m * bs_c + bs_idx) * 2
                             + static_cast<int>(do_initialization))
                                    * 2
                            + static_cast<int>(is_N_tail))
                     * 2
-                    + static_cast<int>(is_K_tail);
+                    + static_cast<int>(is_K_tail));
         }
-        inline int filter_w_to_src(int kw) const {
+        inline dim_t filter_w_to_src(dim_t kw) const {
             return kw * (jcp_.dilate_w + 1);
         }
-        inline int filter_h_to_src(int kh) const {
+        inline dim_t filter_h_to_src(dim_t kh) const {
             return kh * (jcp_.dilate_h + 1) - jcp_.t_pad;
         }
-        inline int filter_d_to_src(int kd) const {
+        inline dim_t filter_d_to_src(dim_t kd) const {
             return kd * (jcp_.dilate_d + 1) - jcp_.f_pad;
         }
-        inline int get_start_ih(int kh, int oh_s) const {
-            const auto real_ih = filter_h_to_src(kh) + oh_s * jcp_.stride_h;
-            return utils::saturate(0, jcp_.ih,
+        inline dim_t get_start_ih(dim_t kh, dim_t oh_s) const {
+            const dim_t real_ih = filter_h_to_src(kh) + oh_s * jcp_.stride_h;
+            return utils::saturate<dim_t>(0, jcp_.ih,
                     real_ih
-                            + utils::rnd_up(
-                                    nstl::max(0, -real_ih), jcp_.stride_h));
+                            + utils::rnd_up(nstl::max<dim_t>(0, -real_ih),
+                                    jcp_.stride_h));
         }
-        inline int get_finish_ih(int kh, int oh_e) const {
-            return utils::saturate(0, jcp_.ih,
+        inline dim_t get_finish_ih(dim_t kh, dim_t oh_e) const {
+            return utils::saturate<dim_t>(0, jcp_.ih,
                     filter_h_to_src(kh) + (oh_e - 1) * jcp_.stride_h + 1);
         }
-        inline int get_start_id(int kd, int od_s) const {
-            const auto real_id = filter_d_to_src(kd) + od_s * jcp_.stride_d;
-            return utils::saturate(0, jcp_.id,
+        inline dim_t get_start_id(dim_t kd, dim_t od_s) const {
+            const dim_t real_id = filter_d_to_src(kd) + od_s * jcp_.stride_d;
+            return utils::saturate<dim_t>(0, jcp_.id,
                     real_id
-                            + utils::rnd_up(
-                                    nstl::max(0, -real_id), jcp_.stride_d));
+                            + utils::rnd_up(nstl::max<dim_t>(0, -real_id),
+                                    jcp_.stride_d));
         }
-        inline int get_finish_id(int kd, int od_e) const {
-            return utils::saturate(0, jcp_.id,
+        inline dim_t get_finish_id(dim_t kd, dim_t od_e) const {
+            return utils::saturate<dim_t>(0, jcp_.id,
                     filter_d_to_src(kd) + (od_e - 1) * jcp_.stride_d + 1);
         }
 
-        inline int get_finish_oh(int oh_s, int start, int end) const {
-            int work_rem = end - start;
+        inline dim_t get_finish_oh(dim_t oh_s, dim_t start, dim_t end) const {
+            const dim_t work_rem = end - start;
             return (oh_s + work_rem > jcp_.oh ? jcp_.oh : oh_s + work_rem);
         }
-        inline int get_finish_od(int od_s, int start, int end) const {
-            int work_rem = end - start;
+        inline dim_t get_finish_od(dim_t od_s, dim_t start, dim_t end) const {
+            const dim_t work_rem = end - start;
             return (od_s + work_rem > jcp_.od ? jcp_.od : od_s + work_rem);
         }
     };
@@ -151,12 +151,13 @@ private:
     brgemm_containers::brgemm_kernel_container_t brg_kernels_;
     brgemm_containers::brgemm_palette_container_t brgemm_palettes_;
 
-    status_t add_brg_kernel(int bs, int M, int i_N, int i_K, int i_init);
+    status_t add_brg_kernel(int bs, dim_t M, int i_N, int i_K, int i_init);
     void call_brgemm_kernel(
-            thread_info_t &btc, int brg_idx, int batch_size, void *ptr_C) const;
+            thread_info_t &btc, int brg_idx, dim_t batch_size, void *ptr_C) const;
 
     inline dim_t wei_offset_int(
-            int g, int oc_b, int ic_b, int kd, int kh, int kw) const {
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kd, dim_t kh,
+            dim_t kw) const {
         const auto &jcp = pd()->jcp_;
         const dim_t kw_offset = jcp.ic_block * jcp.oc_block;
         dim_t extra_offset = ((kd * jcp.kh + kh) * jcp.kw + kw) * kw_offset;
@@ -165,7 +166,8 @@ private:
                 + extra_offset;
     }
 
-    inline dim_t wei_offset_int(int g, int oc_b, int ic_b, int kX) const {
+    inline dim_t wei_offset_int(
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kX) const {
         const auto &jcp = pd()->jcp_;
         const dim_t kh_offset = jcp.kw * jcp.ic_block * jcp.oc_block;
         dim_t extra_offset
@@ -177,17 +179,18 @@ private:
         return res;
     }
 
-    inline dim_t wei_offset_ext(int g, int oc_b, int ic_b) const {
+    inline dim_t wei_offset_ext(dim_t g, dim_t oc_b, dim_t ic_b) const {
         const auto &jcp = pd()->jcp_;
-        const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+        const dim_t vnni_granularity
+                = data_type_vnni_granularity(jcp.wei_dt);
         if (vnni_granularity == 0) {
             assert(!"Invalid vnni granularity.");
             return 0;
         }
 
-        const int vnni_ic_b = ic_b / vnni_granularity;
-        const int vnni_ic_block = vnni_granularity * jcp.ic_block;
-        const int vnni_nb_ic = utils::div_up(jcp.ic, vnni_ic_block);
+        const dim_t vnni_ic_b = ic_b / vnni_granularity;
+        const dim_t vnni_ic_block = vnni_granularity * jcp.ic_block;
+        const dim_t vnni_nb_ic = utils::div_up(jcp.ic, vnni_ic_block);
         const dim_t kh_offset
                 = static_cast<dim_t>(jcp.kw) * jcp.oc_block * vnni_ic_block;
         const auto res
@@ -196,7 +199,7 @@ private:
         return res;
     }
 
-    inline int get_end(int start, int step, int limit) const {
+    inline dim_t get_end(dim_t start, dim_t step, dim_t limit) const {
         return nstl::min(start + step, limit);
     }
 };

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -61,14 +61,14 @@ jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::
     , isa_max_regs(isa_num_vregs(jcp_.isa)) {}
 
 template <typename Vmm>
-size_t jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::out_oc_offset(
-        const int n, const int w) const {
-    return static_cast<size_t>(out_dsz_) * n * m_block2_ + w * out_ow_sz_;
+dim_t jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::out_oc_offset(
+        const dim_t n, const dim_t w) const {
+    return out_dsz_ * n * m_block2_ + w * out_ow_sz_;
 }
 template <typename Vmm>
-size_t jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::inp_ic_offset(
+dim_t jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::inp_ic_offset(
         const int m_block, const int icb, const int m, const int n) const {
-    return static_cast<size_t>(inp_dsz_) * n * m_block2_ * last_ic_block_
+    return inp_dsz_ * n * m_block2_ * last_ic_block_
             + ((icb * m_block) + m) * inp_ic_sz_;
 }
 template <typename Vmm>
@@ -79,7 +79,8 @@ Vmm jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::accum(
 
 template <typename Vmm>
 void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
-        const int m_block, const int n_block, const int ow_b, const int ow_e) {
+        const int m_block, const int n_block, const dim_t ow_b,
+        const dim_t ow_e) {
     if (jcp_.src_zero_point) {
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
@@ -88,7 +89,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
             auto vmm_tmp2 = vmm_one_bytes;
             uni_vpmulld(vmm_tmp, vmm, vmm_zp_shift);
 
-            for (int w = ow_b; w < ow_e; w++) {
+            for (dim_t w = ow_b; w < ow_e; w++) {
                 const auto offset = out_oc_offset(n, w);
                 auto zp_addr = is_superset(jcp_.isa, avx512_core)
                         ? EVEX_compress_addr(reg_zp_comp_out, offset)
@@ -108,7 +109,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
             auto vmm_tmp2 = vmm_one_bytes;
             uni_vpmulld(vmm_tmp, vmm, vmm_cp_shift);
 
-            for (int w = ow_b; w < ow_e; w++) {
+            for (dim_t w = ow_b; w < ow_e; w++) {
                 const auto offset = out_oc_offset(n, w);
                 auto cp_addr = is_superset(jcp_.isa, avx512_core)
                         ? EVEX_compress_addr(reg_comp_out, offset)
@@ -128,10 +129,10 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
 
 template <typename Vmm>
 void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow_body(
-        const int n_block, const int ow_b, const int ow_e) {
+        const int n_block, const dim_t ow_b, const dim_t ow_e) {
 
     if (jcp_.src_zero_point) {
-        for_(int w = ow_b; w < ow_e; w++)
+        for_(dim_t w = ow_b; w < ow_e; w++)
         for (int n = 0; n < n_block; n++) {
             auto vmm_tmp = vmm_tmp_1();
             const auto offset = out_oc_offset(n, w);
@@ -145,7 +146,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow_body(
     }
 
     if (jcp_.s8s8_compensation_required) {
-        for_(int w = ow_b; w < ow_e; w++)
+        for_(dim_t w = ow_b; w < ow_e; w++)
         for (int n = 0; n < n_block; n++) {
             auto vmm_tmp = vmm_tmp_1();
             const auto offset = out_oc_offset(n, w);
@@ -158,8 +159,8 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow_body(
 }
 
 template <typename Vmm>
-void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow(
-        const int m_block, const int n_block, const int ow_b, const int ow_e) {
+void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow(const int m_block,
+        const int n_block, const dim_t ow_b, const dim_t ow_e) {
     mov(reg_ker_l, ptr[param1 + GET_OFF(ker_l)]);
     mov(reg_aux_zp_comp_out, reg_zp_comp_out);
     mov(reg_aux_comp_out, reg_comp_out);
@@ -227,7 +228,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::icb_loop(const int icb,
         cmp(reg_icb, 0);
         je(label_loop_end, T_NEAR);
         compute(ic_step, m_block, n_block, 0, false);
-        add(reg_aux_in, ic_step * m_block * inp_ic_sz_);
+        add(reg_aux_in, static_cast<dim_t>(ic_step * m_block * inp_ic_sz_));
         dec(reg_icb);
         jmp(label_icb_loop, T_NEAR);
     }
@@ -255,16 +256,18 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::kdh_loop(const int icb,
             je(label_kh_end, T_NEAR);
             icb_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block);
             add(reg_aux_kh_in,
-                    jcp_.prop_kind == backward_data ? inp_kh_sz_ * jcp_.stride_h
-                                                    : inp_kh_sz_);
+                    static_cast<dim_t>(jcp_.prop_kind == backward_data
+                                    ? inp_kh_sz_ * jcp_.stride_h
+                                    : inp_kh_sz_));
             dec(reg_kh_l);
             jmp(label_kh_loop, T_NEAR);
         }
         L_aligned(label_kh_end);
 
         add(reg_aux_kd_in,
-                jcp_.prop_kind == backward_data ? inp_kd_sz_ * jcp_.stride_d
-                                                : inp_kd_sz_);
+                static_cast<dim_t>(jcp_.prop_kind == backward_data
+                                ? inp_kd_sz_ * jcp_.stride_d
+                                : inp_kd_sz_));
         dec(reg_kd_l);
         jmp(label_kd_loop, T_NEAR);
     }
@@ -281,22 +284,24 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::bwd_kw_iw_loop(const int icb,
     const auto LP = jcp_.l_pad;
     const auto nb_iw = div_up(jcp_.iw, SW);
 
-    vector<int> ker_kw_ow_b(SW * KW, -1);
-    vector<int> ker_kw_ow_e(SW * KW, -1);
+    vector<dim_t> ker_kw_ow_b(SW * KW, -1);
+    vector<dim_t> ker_kw_ow_e(SW * KW, -1);
 
     for_(int sw = 0; sw < SW; sw++)
     for (int iwb = 0; iwb < nb_iw; iwb++) {
         const auto iw = iwb * SW + sw;
         const auto ker_iw = sw * nb_iw + iwb;
 
-        int s {0}, o_test {0};
+        dim_t s {0}, o_test {0};
         while (true) {
             o_test = iw + LP - s * DW;
             if (o_test % SW == 0) break;
             s++;
         }
-        const int k_f = nstl::min(jcp_.kw, div_up(iw + LP + 1, DW));
-        int k_s = div_up(nstl::max(0, iw + LP - jcp_.ow * SW + 1), DW);
+        const int k_f = static_cast<int>(
+                nstl::min<dim_t>(jcp_.kw, div_up(iw + LP + 1, DW)));
+        int k_s = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, iw + LP - jcp_.ow * SW + 1), DW));
         while (k_s % SW != s)
             k_s++;
 
@@ -331,25 +336,26 @@ template <typename Vmm>
 void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::fwd_kw_ow_loop(const int icb,
         const int icb_tail, const int ic_step, const int m_block,
         const int mb_tail, const int n_block, const bool use_inversion) {
-    vector<int> kw_ow_b(jcp_.kw, -1);
-    vector<int> kw_ow_e(jcp_.kw, -1);
-    vector<int> comp_ow_kw_s(jcp_.comp_ow_size, -1);
-    vector<int> comp_ow_kw_f(jcp_.comp_ow_size, -1);
+    vector<dim_t> kw_ow_b(jcp_.kw, -1);
+    vector<dim_t> kw_ow_e(jcp_.kw, -1);
+    vector<dim_t> comp_ow_kw_s(jcp_.comp_ow_size, -1);
+    vector<dim_t> comp_ow_kw_f(jcp_.comp_ow_size, -1);
     dim_t comp_ow_l = 0;
     const auto DW = jcp_.dilate_w + 1;
 
-    for (int ow = 0; ow < jcp_.ow;) {
+    for (dim_t ow = 0; ow < jcp_.ow;) {
         const auto iiw = ow * jcp_.stride_w - jcp_.l_pad;
-        const auto kw_s = div_up(nstl::max(0, -iiw), DW);
+        const auto kw_s = div_up(nstl::max<dim_t>(0, -iiw), DW);
         const auto kw_f = jcp_.kw
-                - div_up(nstl::max(0, iiw - jcp_.iw + (jcp_.kw - 1) * DW + 1),
+                - div_up(nstl::max<dim_t>(
+                                 0, iiw - jcp_.iw + (jcp_.kw - 1) * DW + 1),
                         DW);
-        int ow_e = ow;
+        dim_t ow_e = ow;
         while (ow_e < jcp_.ow) {
             const auto iiw_e = ow_e * jcp_.stride_w - jcp_.l_pad;
-            const auto cur_kw_s = div_up(nstl::max(0, -iiw_e), DW);
+            const auto cur_kw_s = div_up(nstl::max<dim_t>(0, -iiw_e), DW);
             const auto cur_kw_f = jcp_.kw
-                    - div_up(nstl::max(0,
+                    - div_up(nstl::max<dim_t>(0,
                                      iiw_e - jcp_.iw + (jcp_.kw - 1) * DW + 1),
                             DW);
             if (cur_kw_s != kw_s || cur_kw_f != kw_f) break;
@@ -363,7 +369,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::fwd_kw_ow_loop(const int icb,
         ow = ow_e;
     }
 
-    for_(int ow = 0; ow < comp_ow_l; ow++)
+    for_(dim_t ow = 0; ow < comp_ow_l; ow++)
     for (int kw = 0; kw < jcp_.kw; kw++) {
         if (kw >= comp_ow_kw_s[ow] && kw < comp_ow_kw_f[ow]) {
             const auto inv_kw = use_inversion ? jcp_.kw - 1 - kw : kw;
@@ -444,22 +450,25 @@ int jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::compute_ic_step(
     int best_ic_step = 1;
     float best_block_eff = 0.f;
 
-    int max_ic_step
-            = nstl::min(static_cast<size_t>(m_block), div_up(nb_ic_, m_block));
+    int max_ic_step = static_cast<int>(
+            nstl::min<dim_t>(m_block, div_up(nb_ic_, m_block)));
 
     // Introduce ic_step to increase kernel efficiency
     // Compute the ic_step based on the optimal kernel efficiency
     for (int ic_s = max_ic_step; ic_s >= 1; --ic_s) {
         const auto blocks = ic_s * m_block;
-        const float block_disb
-                = static_cast<float>(nb_ic_) / rnd_up(nb_ic_, blocks);
-        const float eff = (static_cast<float>(n_block) * blocks)
-                / ((n_block + blocks) * max_ic_step);
+        const float block_disb = static_cast<float>(nb_ic_)
+                / static_cast<float>(rnd_up(nb_ic_, blocks));
+        const float eff = static_cast<float>(n_block)
+                * static_cast<float>(blocks)
+                / static_cast<float>((n_block + blocks) * max_ic_step);
         const float block_eff = block_disb * eff;
-        float block_footprint = static_cast<float>(inp_dsz_) * blocks
-                * (jcp_.prop_kind == backward_data ? jcp_.ic_block
-                                                   : jcp_.oc_block)
-                * last_ic_block_;
+        float block_footprint = static_cast<float>(inp_dsz_)
+                * static_cast<float>(blocks)
+                * static_cast<float>(jcp_.prop_kind == backward_data
+                                ? jcp_.ic_block
+                                : jcp_.oc_block)
+                * static_cast<float>(last_ic_block_);
         if (block_footprint <= static_cast<float>(
                     platform::get_per_core_cache_size(1))
                 && (block_eff > best_block_eff)) {
@@ -499,18 +508,19 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::generate() {
     const int max_regs = isa_max_regs
             - (is_int8_avx512_core ? 6
                                    : (jcp_.s8s8_compensation_required ? 4 : 3));
-    const int nb = div_up(
+    const int nb = static_cast<int>(div_up(
             nstl::min(jcp_.prop_kind == backward_data ? jcp_.ic : jcp_.oc,
                     jcp_.prop_kind == backward_data ? jcp_.ic_block
                                                     : jcp_.oc_block),
-            m_block2_);
+            m_block2_));
     const int nb2 = nb / n_max_regs_;
     const int nb2_tail = nb % n_max_regs_;
     const int n_block = (nb2 == 0) ? nstl::max(1, nb2_tail) : n_max_regs_;
 
     const size_t m_max_regs = max_regs / n_block;
-    const int m_block = nstl::min(m_max_regs, nb_ic_);
-    const int ic_step = compute_ic_step(m_max_regs, m_block, n_block);
+    const int m_block = static_cast<int>(nstl::min<dim_t>(m_max_regs, nb_ic_));
+    const int ic_step
+            = compute_ic_step(static_cast<int>(m_max_regs), m_block, n_block);
 
     assert(m_block * n_block <= max_regs);
 
@@ -524,26 +534,27 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::generate() {
     mov(reg_use_inversion, ptr[param1 + GET_OFF(use_inversion)]);
     cmp(reg_use_inversion, 0);
     jz(label_kw_without_inversion, T_NEAR);
-    kw_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block, true);
+    kw_loop(static_cast<int>(icb), static_cast<int>(icb_tail), ic_step, m_block,
+            static_cast<int>(mb_tail), n_block, true);
     jmp(label_done, T_NEAR);
 
     L_aligned(label_kw_without_inversion);
-    kw_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block, false);
+    kw_loop(static_cast<int>(icb), static_cast<int>(icb_tail), ic_step, m_block,
+            static_cast<int>(mb_tail), n_block, false);
 
     L_aligned(label_done);
 
     postamble();
 }
 template <typename Vmm>
-size_t jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::out_oc_offset(
-        const int n, const int w) const {
-    return static_cast<size_t>(out_dsz_) * n * inp_oc_block_ + w * out_ow_sz_;
+dim_t jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::out_oc_offset(
+        const dim_t n, const dim_t w) const {
+    return out_dsz_ * n * inp_oc_block_ + w * out_ow_sz_;
 }
 template <typename Vmm>
-size_t jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::inp_ic_offset(
-        const int kw, const int ic, const int n) const {
-    return static_cast<size_t>(kw) * inp_kw_sz_ + n * inp_oc_sz_
-            + ic * inp_ic_sz_;
+dim_t jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::inp_ic_offset(
+        const dim_t kw, const dim_t ic, const dim_t n) const {
+    return kw * inp_kw_sz_ + n * inp_oc_sz_ + ic * inp_ic_sz_;
 }
 
 template <typename Vmm>
@@ -561,10 +572,10 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::zero_accumulators(
 }
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store_accumulators(
-        const int n_block, const int ow_b, const int ow_e) {
+        const int n_block, const dim_t ow_b, const dim_t ow_e) {
     if (jcp_.src_zero_point) {
         for_(int n = 0; n < n_block; n++)
-        for (int w = ow_b; w < ow_e; w++) {
+        for (dim_t w = ow_b; w < ow_e; w++) {
             auto vmm = accum(n);
             const auto offset = out_oc_offset(n, w);
             auto zp_addr = ptr[reg_aux_zp_comp_out + offset];
@@ -574,7 +585,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store_accumulators(
 
     if (jcp_.s8s8_compensation_required) {
         for_(int n = 0; n < n_block; n++)
-        for (int w = ow_b; w < ow_e; w++) {
+        for (dim_t w = ow_b; w < ow_e; w++) {
             auto vmm = accum(n, true);
             const auto offset = out_oc_offset(n, w);
             auto cp_addr = ptr[reg_aux_comp_out + offset];
@@ -585,7 +596,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store_accumulators(
 
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store(
-        const int n_block, const int ow_b, const int ow_e) {
+        const int n_block, const dim_t ow_b, const dim_t ow_e) {
     mov(reg_aux_zp_comp_out, reg_zp_comp_out);
     mov(reg_aux_comp_out, reg_comp_out);
     mov(reg_ker_l, ptr[param1 + GET_OFF(ker_l)]);
@@ -607,29 +618,30 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store(
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::kw_loop(
         const int n_block) {
-    vector<int> ow_kw_b(jcp_.ow, -1);
-    vector<int> ow_kw_e(jcp_.ow, -1);
-    int prev_comp_ow = 0;
+    vector<dim_t> ow_kw_b(jcp_.ow, -1);
+    vector<dim_t> ow_kw_e(jcp_.ow, -1);
+    dim_t prev_comp_ow = 0;
     const auto DW = jcp_.dilate_w + 1;
-    for (int ow = 0; ow < jcp_.ow; ow++) {
+    for (dim_t ow = 0; ow < jcp_.ow; ow++) {
         const auto iiw = ow * jcp_.stride_w - jcp_.l_pad;
-        const auto kw_s = div_up(nstl::max(0, -iiw), DW);
+        const auto kw_s = div_up(nstl::max<dim_t>(0, -iiw), DW);
         const auto kw_f = jcp_.kw
-                - div_up(nstl::max(0, iiw - jcp_.iw + (jcp_.kw - 1) * DW + 1),
+                - div_up(nstl::max<dim_t>(
+                                 0, iiw - jcp_.iw + (jcp_.kw - 1) * DW + 1),
                         DW);
         ow_kw_b[ow] = kw_s;
         ow_kw_e[ow] = kw_f;
     }
 
-    for (int ow = 0; ow < jcp_.ow;) {
+    for (dim_t ow = 0; ow < jcp_.ow;) {
         const auto kw_b = ow_kw_b[ow];
         const auto kw_e = ow_kw_e[ow];
-        int ow_e = ow + 1;
+        dim_t ow_e = ow + 1;
         while (ow_e < jcp_.ow) {
             if (ow_kw_b[ow_e] != kw_b || ow_kw_e[ow_e] != kw_e) break;
             ow_e++;
         }
-        const auto ow_l = nstl::min(ow_e - ow, jcp_.ow_block);
+        const auto ow_l = nstl::min<dim_t>(ow_e - ow, jcp_.ow_block);
 
         if (kw_b < kw_e) {
             zero_accumulators(n_block);
@@ -643,7 +655,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::kw_loop(
 
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::compute(
-        const int n_block, const int kw_b, const int kw_e) {
+        const int n_block, const dim_t kw_b, const dim_t kw_e) {
     Xbyak::Label label_kh_loop, label_end;
     mov(reg_kh_l, ptr[param1 + GET_OFF(kh_l)]);
     mov(reg_aux_in, reg_in);
@@ -652,7 +664,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::compute(
     {
         cmp(reg_kh_l, 0);
         je(label_end, T_NEAR);
-        for_(int kw = kw_b; kw < kw_e; kw++)
+        for_(dim_t kw = kw_b; kw < kw_e; kw++)
         for_(int n = 0; n < n_block; n++)
         for (int ic = 0; ic < jcp_.ic; ic++) {
             auto vmm = accum(n);
@@ -694,9 +706,10 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::generate() {
     mov(reg32_scratch, 128);
     uni_vpbroadcastd(vmm_cp_shift, reg32_scratch);
 
-    const int last_oc_block = nstl::min(
-            jcp_.oc_block, jcp_.oc - (jcp_.nb_oc - 1) * jcp_.oc_block);
-    const int max_n_block = div_up(jcp_.oc_block, inp_oc_block_);
+    const int last_oc_block = static_cast<int>(nstl::min(
+            jcp_.oc_block, jcp_.oc - (jcp_.nb_oc - 1) * jcp_.oc_block));
+    const int max_n_block
+            = static_cast<int>(div_up(jcp_.oc_block, inp_oc_block_));
     const int last_n_block = div_up(last_oc_block, inp_oc_block_);
 
     Xbyak::Label label_last_ocb, label_done;

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -56,15 +56,15 @@ protected:
     static constexpr bool is_ymm_ = std::is_same<Vmm, Xbyak::Ymm>::value;
 
     jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
-    const int inp_dsz_;
-    const int out_dsz_;
-    const size_t nb_ic_;
-    const size_t inp_ic_sz_;
-    const size_t inp_kw_sz_;
-    const size_t inp_kh_sz_;
-    const size_t inp_kd_sz_;
-    const size_t out_ow_sz_;
-    const size_t out_ker_sz_;
+    const dim_t inp_dsz_;
+    const dim_t out_dsz_;
+    const dim_t nb_ic_;
+    const dim_t inp_ic_sz_;
+    const dim_t inp_kw_sz_;
+    const dim_t inp_kh_sz_;
+    const dim_t inp_kd_sz_;
+    const dim_t out_ow_sz_;
+    const dim_t out_ker_sz_;
     const int isa_max_regs;
 
     // Register decomposition
@@ -103,14 +103,14 @@ protected:
     const Vmm &vmm_tmp_1() const noexcept { return vmm_tmp; }
 
     Vmm accum(const int n_block, const int m, const int n) const;
-    size_t out_oc_offset(const int n, const int w) const;
-    size_t inp_ic_offset(
+    dim_t out_oc_offset(const dim_t n, const dim_t w) const;
+    dim_t inp_ic_offset(
             const int m_block, const int icb, const int m, const int n) const;
     int compute_ic_step(
             const int m_max_regs, const int m_block, const int n_block) const;
 
     void store_accumulators(const int m_block, const int n_block,
-            const int ow_b, const int ow_e);
+            const dim_t ow_b, const dim_t ow_e);
     void zero_accumulators(const int m_block, const int n_block);
     void compute(const int ic_step, const int m_block, const int n_block,
             const int m_tail, const bool is_mb_tail);
@@ -118,9 +118,9 @@ protected:
             const int m_block, const int mb_tail, const int n_block);
     void kdh_loop(const int icb, const int icb_tail, const int ic_step,
             const int m_block, const int mb_tail, const int n_block);
-    void copy_ow(const int m_block, const int n_block, const int ow_b,
-            const int ow_e);
-    void copy_ow_body(const int n_block, const int ow_b, const int ow_e);
+    void copy_ow(const int m_block, const int n_block, const dim_t ow_b,
+            const dim_t ow_e);
+    void copy_ow_body(const int n_block, const dim_t ow_b, const dim_t ow_e);
     void kw_loop(const int icb, const int icb_tail, const int ic_step,
             const int m_block, const int mb_tail, const int n_block,
             const bool use_inversion);
@@ -147,15 +147,15 @@ struct jit_uni_brgemm_conv_relo_comp_pad_kernel_t : public jit_generator_t {
 
 protected:
     jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
-    const int inp_dsz_;
-    const int out_dsz_;
+    const dim_t inp_dsz_;
+    const dim_t out_dsz_;
     const int inp_oc_block_;
-    const size_t inp_ic_sz_;
-    const size_t inp_kw_sz_;
-    const size_t inp_kh_sz_;
-    const size_t inp_oc_sz_;
-    const size_t out_ow_sz_;
-    const size_t out_ker_sz_;
+    const dim_t inp_ic_sz_;
+    const dim_t inp_kw_sz_;
+    const dim_t inp_kh_sz_;
+    const dim_t inp_oc_sz_;
+    const dim_t out_ow_sz_;
+    const dim_t out_ker_sz_;
     const int isa_max_regs_;
 
     // Register decomposition
@@ -178,13 +178,15 @@ protected:
     const int n_max_regs_ = 4;
 
     Vmm accum(const int n, const bool has_s8s8_shift = false) const;
-    size_t out_oc_offset(const int n, const int w) const;
-    size_t inp_ic_offset(const int kw, const int ic, const int m) const;
+    dim_t out_oc_offset(const dim_t n, const dim_t w) const;
+    dim_t inp_ic_offset(
+            const dim_t kw, const dim_t ic, const dim_t m) const;
     void zero_accumulators(const int n_block);
-    void store_accumulators(const int n_block, const int ow_b, const int ow_e);
-    void store(const int n_block, const int ow_b, const int ow_e);
+    void store_accumulators(
+            const int n_block, const dim_t ow_b, const dim_t ow_e);
+    void store(const int n_block, const dim_t ow_b, const dim_t ow_e);
     void kw_loop(const int n_block);
-    void compute(const int n_block, const int kw_b, const int kw_e);
+    void compute(const int n_block, const dim_t kw_b, const dim_t kw_e);
     void load_params();
 
     void generate() override;

--- a/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.cpp
@@ -45,10 +45,11 @@ void jit_brgemm_relo_copy_to_wbuffer_t::generate() {
 
     preamble();
 
-    const int vnni_width = data_type_vnni_granularity(wjcp.wei_dt);
-    const auto wei_dsz = types::data_type_size(wjcp.wei_dt);
-    const auto inp_ocb_size = wjcp.inp_oc_block * vnni_width * wei_dsz;
-    const auto out_ocb_size = wjcp.out_oc_block * vnni_width * wei_dsz;
+    const int vnni_width
+            = static_cast<int>(data_type_vnni_granularity(wjcp.wei_dt));
+    const dim_t wei_dsz = types::data_type_size(wjcp.wei_dt);
+    const dim_t inp_ocb_size = wjcp.inp_oc_block * vnni_width * wei_dsz;
+    const dim_t out_ocb_size = wjcp.out_oc_block * vnni_width * wei_dsz;
     const auto oc_chunks = wjcp.out_oc_block / wjcp.inp_oc_block;
     const auto has_ocb_tail = (oc_chunks != wjcp.last_occ_to_copy);
     auto nb_rd = div_up(wjcp.rd, vnni_width);
@@ -89,7 +90,7 @@ void jit_brgemm_relo_copy_to_wbuffer_t::generate() {
                 else
                     copy_zmm(false);
 
-                add(aux_reg_src, wjcp.inp_ocb_offs);
+                add(aux_reg_src, static_cast<dim_t>(wjcp.inp_ocb_offs));
                 add(aux_reg_dst, inp_ocb_size);
             }
             add(reg_src, inp_ocb_size);

--- a/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.hpp
@@ -30,10 +30,10 @@ struct jit_brgemm_relo_copy_to_wbuffer_t : public jit_generator_t {
         data_type_t wei_dt {data_type_t::dnnl_data_type_undef};
         int out_oc_block {0};
         int inp_oc_block {0};
-        int rd {0};
+        dim_t rd {0};
         bool is_rd_padded_to_block {false};
-        int inp_ocb_offs {0};
-        int last_occ_to_copy {0};
+        dim_t inp_ocb_offs {0};
+        dim_t last_occ_to_copy {0};
     };
 
     struct ctx_t {

--- a/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
@@ -40,7 +40,7 @@ jit_avx512_core_brgemm_conv_trans_kernel_t::
               jcp.is_reduced_rtus ? jcp.rtus_padded_ic_size : jcp.inp_ic_block)
     , ic_block_offset(inp_dsz * ic_block_sz)
     , iw_size(inp_dsz * jcp.ngroups * jcp.ic_without_padding)
-    , dst_w_block(dst_w(jcp, jcp.ow_block))
+    , dst_w_block(dst_w(jcp, static_cast<int>(jcp.ow_block)))
     , dst_stride(jcp.copy_block_only ? dst_w_block : jcp.iwp)
     , VL(cpu_isa_traits_t<avx512_core>::vlen)
     , n_vec(ic_block_sz / jcp.simd_w)
@@ -54,7 +54,7 @@ jit_avx512_core_brgemm_conv_trans_kernel_t::
 
 int get_inp_size(int dst_size, int ext_k, int stride, int dilate) {
     const auto res = calculate_end_padding(0, dst_size, 0, stride, ext_k);
-    return res;
+    return static_cast<int>(res);
 }
 
 int get_inp_start(int b, int b_size, int stride, int pad) {
@@ -62,23 +62,26 @@ int get_inp_start(int b, int b_size, int stride, int pad) {
 }
 
 int jit_avx512_core_brgemm_conv_trans_kernel_t::inp_w(int out_w, int kw) const {
-    return get_inp_size(out_w, kw, jcp.stride_w, jcp.dilate_w);
+    return get_inp_size(out_w, kw, static_cast<int>(jcp.stride_w),
+            static_cast<int>(jcp.dilate_w));
 }
 
 int jit_avx512_core_brgemm_conv_trans_kernel_t::inp_w(int out_w) const {
-    return inp_w(out_w, jcp.ext_kw);
+    return inp_w(out_w, static_cast<int>(jcp.ext_kw));
 }
 
 int jit_avx512_core_brgemm_conv_trans_kernel_t::dst_w(
         const jit_brgemm_conv_conf_t &ajcp, int out_w) {
     int res = 0;
-    res = get_inp_size(out_w, ajcp.ext_kw, ajcp.stride_w, ajcp.dilate_w);
+    res = get_inp_size(out_w, static_cast<int>(ajcp.ext_kw),
+            static_cast<int>(ajcp.stride_w), static_cast<int>(ajcp.dilate_w));
     if (ajcp.is_os_blocking) res = rnd_up(res, ajcp.stride_w);
     return res;
 }
 
 int jit_avx512_core_brgemm_conv_trans_kernel_t::inp_w_start(int owb) const {
-    return get_inp_start(owb, jcp.ow_block, jcp.stride_w, jcp.l_pad);
+    return get_inp_start(owb, static_cast<int>(jcp.ow_block),
+            static_cast<int>(jcp.stride_w), static_cast<int>(jcp.l_pad));
 }
 
 // use different vmovdqu32/16/8 due to case when tail mask used
@@ -284,7 +287,9 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::generate() {
 void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
         bool is_ic_tail) {
     if (jcp.nb_ow == 1) {
-        copy_ow_block_body(jcp.l_pad, jcp.ow_block, jcp.iw, is_ic_tail);
+        copy_ow_block_body(static_cast<int>(jcp.l_pad),
+                static_cast<int>(jcp.ow_block), static_cast<int>(jcp.iw),
+                is_ic_tail);
         return;
     }
 
@@ -301,10 +306,10 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
 
     const auto adj_iw = nstl::min(jcp.iw, jcp.iwp - jcp.l_pad);
 
-    int ow_block_tail = jcp.ow % jcp.ow_block;
+    const int ow_block_tail = static_cast<int>(jcp.ow % jcp.ow_block);
 
     for (int owb = 0; owb < jcp.nb_ow; owb++) {
-        const auto inp_block = inp_w(jcp.ow_block);
+        const auto inp_block = inp_w(static_cast<int>(jcp.ow_block));
         const auto inp_start = inp_w_start(owb);
         const auto inp_end = inp_start + inp_block;
         if (inp_start + inp_block < 0) {
@@ -331,7 +336,7 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
         cmp(reg_owb, end_first_zero_block);
         jg(skip_first_zero_blocks, T_NEAR);
         // zero block
-        copy_ow_block_body(0, jcp.ow_block, 0, is_ic_tail);
+        copy_ow_block_body(0, static_cast<int>(jcp.ow_block), 0, is_ic_tail);
         jmp(copy_block_done_label, T_NEAR);
 
         L(skip_first_zero_blocks);
@@ -341,16 +346,17 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
                 b++) {
             int cur_ow_block = (b == jcp.nb_ow - 1 && ow_block_tail > 0)
                     ? ow_block_tail
-                    : jcp.ow_block;
+                    : static_cast<int>(jcp.ow_block);
             const auto inp_block = inp_w(cur_ow_block);
             const auto inp_start = inp_w_start(b);
             const auto inp_end = inp_start + inp_block;
             const auto block_lpad = -inp_start;
-            const auto block_len = nstl::min(adj_iw, inp_end);
+            const auto block_len = nstl::min<dim_t>(adj_iw, inp_end);
             Xbyak::Label skip_first_partial_block;
             cmp(reg_owb, b);
             jne(skip_first_partial_block, T_NEAR);
-            copy_ow_block_body(block_lpad, jcp.ow_block, block_len, is_ic_tail);
+            copy_ow_block_body(block_lpad, static_cast<int>(jcp.ow_block),
+                    static_cast<int>(block_len), is_ic_tail);
             jmp(copy_block_done_label, T_NEAR);
             L(skip_first_partial_block);
         }
@@ -359,7 +365,8 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
         Xbyak::Label skip_full_blocks;
         cmp(reg_owb, end_full_block);
         jg(skip_full_blocks, T_NEAR);
-        copy_ow_block_body(0, jcp.ow_block, inp_w(jcp.ow_block), is_ic_tail);
+        copy_ow_block_body(0, static_cast<int>(jcp.ow_block),
+                inp_w(static_cast<int>(jcp.ow_block)), is_ic_tail);
         jmp(copy_block_done_label, T_NEAR);
 
         L(skip_full_blocks);
@@ -369,16 +376,18 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
                 b++) {
             int cur_ow_block = (b == jcp.nb_ow - 1 && ow_block_tail > 0)
                     ? ow_block_tail
-                    : jcp.ow_block;
+                    : static_cast<int>(jcp.ow_block);
             const auto inp_block = inp_w(cur_ow_block);
             const auto inp_start = inp_w_start(b);
             const auto inp_end = inp_start + inp_block;
             const auto block_lpad = 0;
-            const auto block_len = nstl::min(adj_iw, inp_end) - inp_start;
+            const auto block_len
+                    = nstl::min<dim_t>(adj_iw, inp_end) - inp_start;
             Xbyak::Label skip_last_partial_block;
             cmp(reg_owb, b);
             jne(skip_last_partial_block, T_NEAR);
-            copy_ow_block_body(block_lpad, cur_ow_block, block_len, is_ic_tail);
+            copy_ow_block_body(block_lpad, cur_ow_block,
+                    static_cast<int>(block_len), is_ic_tail);
             jmp(copy_block_done_label, T_NEAR);
 
             L(skip_last_partial_block);
@@ -387,7 +396,7 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
 
     // if not any above case then owb is among last zero blocks
     // check is this needed and check may it be partial
-    copy_ow_block_body(0, jcp.ow_block, 0, is_ic_tail);
+    copy_ow_block_body(0, static_cast<int>(jcp.ow_block), 0, is_ic_tail);
 
     L(copy_block_done_label);
 }

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -110,8 +110,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         max_regs = isa == isa_undef ? 0 : isa_num_vregs(isa);
     }
 
-    int ur, ur_block, ur_block_tail, adj_ocblock;
-    int nb_kd, nb_kh, nb_kw;
+    dim_t ur, ur_block, ur_block_tail, adj_ocblock;
+    dim_t nb_kd, nb_kh, nb_kw;
     int max_regs;
     float eff;
     static unsigned L1;
@@ -125,7 +125,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     static float mem_k;
     static constexpr int bench_iterations = 1;
 
-    int sp, sp_block, nb_sp;
+    dim_t sp, sp_block, nb_sp;
 
     void get_from_jcp(const jit_brgemm_conv_conf_t &jcp) { *this = jcp; }
     void save_to_jcp(jit_brgemm_conv_conf_t &jcp) const { jcp = *this; }
@@ -145,8 +145,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     void update_blocks();
     bool fast_check_oc_block() const;
     float est_eff();
-    void iterate_ker_block(brg_blocking_t &best_brgb, int kd_block,
-            int kh_block, bool maybe_use_buffer, int max_ow_block_thr);
+    void iterate_ker_block(brg_blocking_t &best_brgb, dim_t kd_block,
+            dim_t kh_block, bool maybe_use_buffer, dim_t max_ow_block_thr);
     status_t calc_blocks();
 
     bool fast_check_oc_block_1x1() const;
@@ -154,8 +154,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     void calc_blocks_1x1();
 
     // utils
-    static int get_inp_size(
-            int max_src_size, int dst_size, int k, int stride, int dilate) {
+    static dim_t get_inp_size(dim_t max_src_size, dim_t dst_size, dim_t k,
+            dim_t stride, dim_t dilate) {
         const auto res = nstl::min(max_src_size,
                 calculate_end_padding(0, dst_size, 0, stride,
                         calculate_extended_filter_size(k, dilate)));
@@ -169,7 +169,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         return (k > 1.f) ? (k - 1 + eff) / k : eff * koeff;
     }
 
-    static int estimate_ur(cpu_isa_t isa, int oc_block) {
+    static int estimate_ur(cpu_isa_t isa, dim_t oc_block) {
         if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2)) {
             switch (oc_block) {
                 case 32: return 3;
@@ -187,16 +187,19 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         }
     }
 
-    int inp_w(int out_w, int ker_w) const {
+    dim_t inp_w(dim_t out_w, dim_t ker_w) const {
         return get_inp_size(iw, out_w, ker_w, stride_w, dilate_w);
     }
 
-    int rnd_simd(int val) const { return rnd_up(val, simd_w); }
+    dim_t rnd_simd(dim_t val) const {
+        return rnd_up(val, static_cast<dim_t>(simd_w));
+    }
 
-    int rnd_inp_simd(int out_w, int ker_w, int vic) const {
+    dim_t rnd_inp_simd(dim_t out_w, dim_t ker_w, dim_t vic) const {
         const auto vsp = inp_w(out_w, ker_w);
-        return ((stride_w == 1 && vic >= ic) ? rnd_up(vsp * vic, simd_w)
-                                             : vsp * rnd_up(vic, simd_w));
+        return ((stride_w == 1 && vic >= ic)
+                        ? rnd_up(vsp * vic, static_cast<dim_t>(simd_w))
+                        : vsp * rnd_up(vic, static_cast<dim_t>(simd_w)));
     }
     dim_t grid_coverage(
             dim_t nb, dim_t x, dim_t nx, dim_t xb, dim_t y, dim_t yb);
@@ -216,15 +219,17 @@ dim_t get_comp_ow_size(const jit_brgemm_conv_conf_t &jcp) {
 
     for (int ow = 0; ow < jcp.ow;) {
         const auto iiw = ow * SW - LP;
-        const auto kw_s = div_up(nstl::max(0, -iiw), DW);
-        const auto kw_f
-                = KW - div_up(nstl::max(0, iiw - IW + (KW - 1) * DW + 1), DW);
+        const auto kw_s = div_up(nstl::max<dim_t>(0, -iiw), DW);
+        const auto kw_f = KW
+                - div_up(nstl::max<dim_t>(0, iiw - IW + (KW - 1) * DW + 1), DW);
         int ow_e = ow;
         while (ow_e < jcp.ow) {
             const auto iiw_e = ow_e * SW - LP;
-            const auto cur_kw_s = div_up(nstl::max(0, -iiw_e), DW);
+            const auto cur_kw_s = div_up(nstl::max<dim_t>(0, -iiw_e), DW);
             const auto cur_kw_f = KW
-                    - div_up(nstl::max(0, iiw_e - IW + (KW - 1) * DW + 1), DW);
+                    - div_up(
+                            nstl::max<dim_t>(0, iiw_e - IW + (KW - 1) * DW + 1),
+                            DW);
             if (cur_kw_s != kw_s || cur_kw_f != kw_f) break;
             if (ow_e - ow < jcp.ow_block) comp_ow_size++;
             ow_e++;
@@ -454,13 +459,13 @@ void brg_blocking_t::select_ic_block() {
         MAYBE_UNUSED(ic_padded_block);
         // Note: bf32 and tf32 require ic_block be less than 64, otherwise it results
         // in incorrect output.
-        ic_block = is_xf32 && (!is_rtus) ? nstl::min(64, ic) : ic;
+        ic_block = is_xf32 && (!is_rtus) ? nstl::min<dim_t>(64, ic) : ic;
         nb_ic = utils::div_up(ic, ic_block); // trivially 1 for now
         inp_ic_block = ic_block;
         return;
     }
     auto nb_simd = utils::div_up(ic, simd_w);
-    auto max_simd_blocks = nstl::min(5 * simd_w, nb_simd);
+    auto max_simd_blocks = nstl::min<dim_t>(5 * simd_w, nb_simd);
     const auto nb_icb_eff_threshold = 0.5f;
     const auto padded_rd
             = vnni_block * (is_rd_padded_to_block ? acc_simd_w : 1);
@@ -489,10 +494,10 @@ void brg_blocking_t::select_ic_block() {
             if (exec_type == exec_trans) {
                 // TODO: double check calculation of ic_block here:
                 // for example for ic == 48
-                auto simd_blocks = 1;
-                for (int nb_icb = max_simd_blocks; nb_icb >= 1; nb_icb--) {
+                dim_t simd_blocks = 1;
+                for (dim_t nb_icb = max_simd_blocks; nb_icb >= 1; nb_icb--) {
                     auto nb_icb_eff = static_cast<float>(nb_simd)
-                            / rnd_up(nb_simd, nb_icb);
+                            / static_cast<float>(rnd_up(nb_simd, nb_icb));
                     if (nb_icb_eff >= nb_icb_eff_threshold) {
                         simd_blocks = nb_icb;
                         break;
@@ -504,20 +509,20 @@ void brg_blocking_t::select_ic_block() {
         }
     } else {
         const auto est_ur = sp_block > 0
-                ? nstl::min(sp_block, estimate_ur(isa, oc_block))
+                ? nstl::min<dim_t>(sp_block, estimate_ur(isa, oc_block))
                 : estimate_ur(isa, oc_block);
         const auto inp_ur = is_os_blocking ? est_ur : inp_w(est_ur, kw_block);
 
         if (kw_block > 1) {
             // try to fit src into L1
             const auto inp_per_ic = static_cast<unsigned int>(inp_ur) * src_dsz;
-            max_simd_blocks = saturate(1, max_simd_blocks,
-                    static_cast<int>(L1 / (inp_per_ic * simd_w)));
+            max_simd_blocks = utils::saturate<dim_t>(1, max_simd_blocks,
+                    static_cast<dim_t>(L1 / (inp_per_ic * simd_w)));
         }
         // try to fit all batch for ur into L2
         const bool adjust = wei_plain && math::is_pow2(oc)
                 && utils::everyone_is(1, kd_block, kh_block, kw_block);
-        const int adj_oc_block = adjust ? oc : oc_block; // due to aliasing
+        const dim_t adj_oc_block = adjust ? oc : oc_block; // due to aliasing
         const auto wei_per_ic = static_cast<unsigned int>(kd_block) * kh_block
                 * kw_block * adj_oc_block * wei_dsz;
         const auto inp_per_ic = static_cast<unsigned int>(kd_block) * kh_block
@@ -525,8 +530,8 @@ void brg_blocking_t::select_ic_block() {
         const auto out_size
                 = static_cast<unsigned int>(ur) * oc_block * dst_dsz;
 
-        max_simd_blocks = saturate(1, max_simd_blocks,
-                static_cast<int>((L2 - out_size)
+        max_simd_blocks = utils::saturate<dim_t>(1, max_simd_blocks,
+                static_cast<dim_t>((L2 - out_size)
                         / ((wei_per_ic + inp_per_ic) * simd_w)));
 
         // use nb_simd as max_simd_blocks for some shapes on avx2
@@ -535,17 +540,18 @@ void brg_blocking_t::select_ic_block() {
             max_simd_blocks = nb_simd;
 
         auto simd_blocks = 1;
-        for (int nb_icb = nstl::min(max_simd_blocks, nb_simd); nb_icb >= 1;
-                nb_icb--) {
-            auto nb_icb_eff
-                    = static_cast<float>(nb_simd) / rnd_up(nb_simd, nb_icb);
+        for (int nb_icb
+                = static_cast<int>(nstl::min<dim_t>(max_simd_blocks, nb_simd));
+                nb_icb >= 1; nb_icb--) {
+            auto nb_icb_eff = static_cast<float>(nb_simd)
+                    / static_cast<float>(rnd_up(nb_simd, nb_icb));
             if (nb_icb_eff >= nb_icb_eff_threshold) {
                 simd_blocks = nb_icb;
                 break;
             }
         }
 
-        ic_block = nstl::min(
+        ic_block = nstl::min<dim_t>(
                 exec_type == exec_trans ? rnd_up(ic, padded_rd) : ic,
                 simd_blocks * simd_w);
     }
@@ -663,14 +669,15 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     brgattr.use_uker = use_uker;
     brgattr.max_bs = max_batch;
     max_vpad = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
-    brgattr.max_top_vpad = max_vpad;
-    brgattr.max_bottom_vpad = max_vpad;
+    brgattr.max_top_vpad = static_cast<int>(max_vpad);
+    brgattr.max_bottom_vpad = static_cast<int>(max_vpad);
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
-    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
+    ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
     ur_block = brg.bd_block;
-    adj_ocblock = nstl::max(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
+    adj_ocblock = nstl::max<dim_t>(
+            1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
     if (((is_1x1 && is_amx(isa)) || max_vpad > 0) && M > 0 && M_tail > 0) {
         brgemm_desc_t brg_sp_tail;
 
@@ -764,8 +771,8 @@ status_t brg_blocking_t::get_brgemm_ur(
         brgattr.use_uker = use_uker;
         brgattr.max_bs = max_batch;
         max_vpad = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
-        brgattr.max_top_vpad = max_vpad;
-        brgattr.max_bottom_vpad = max_vpad;
+        brgattr.max_top_vpad = static_cast<int>(max_vpad);
+        brgattr.max_bottom_vpad = static_cast<int>(max_vpad);
         brgattr.fpmath_mode = attr->fpmath_.mode_;
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
 
@@ -873,20 +880,27 @@ float brg_blocking_t::est_eff() {
     const auto N_regs = static_cast<float>(adj_ocblock);
     const auto M_regs = is_amx(isa) ? div_up(ur, amx_h) : ur;
     const auto tot_regs = is_amx(isa) ? brgemm_desc_t::AMX_TILES_NUM : max_regs;
-    const auto brgemm_microkernel_eff
-            = (N_regs * M_regs) / ((N_regs + M_regs) * tot_regs);
+    const auto brgemm_microkernel_eff = (N_regs * static_cast<float>(M_regs))
+            / ((N_regs + static_cast<float>(M_regs))
+                    * static_cast<float>(tot_regs));
 
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
-    const auto brgemm_eff = squeeze_val(ur
-                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+    const auto ur_eff = static_cast<float>(sp_block)
+            / static_cast<float>(rnd_up(sp_block, ur));
+    const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    static_cast<float>(ur)
+                                            / static_cast<float>(sp_block)))
                     / 64,
             0.5f);
 
     const dim_t sp_amount = static_cast<dim_t>(nb_od) * nb_oh * nb_sp;
     const auto work_amount = sp_amount * mb * ngroups * nb_oc;
-    const auto sp_eff = (static_cast<float>(sp) / rnd_up(sp, sp_block));
+    const auto sp_eff = (static_cast<float>(sp)
+            / static_cast<float>(rnd_up(sp, sp_block)));
 
-    const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+    const auto oc_block_eff
+            = static_cast<float>(oc) / static_cast<float>(rnd_up(oc, oc_block));
 
     const auto job = div_up(work_amount, static_cast<dim_t>(nthr));
 
@@ -903,7 +917,7 @@ float brg_blocking_t::est_eff() {
 
     const float job_eff = max_job == 0
             ? 1.f
-            : static_cast<float>(sum_job) / (max_job * nthr);
+            : static_cast<float>(sum_job) / static_cast<float>(max_job * nthr);
 
     const auto ic_blocking_size = ic_block * nb_ic_blocking;
     const auto oc_blocking_size = oc_block * ic_blocking_size;
@@ -913,14 +927,14 @@ float brg_blocking_t::est_eff() {
     // -- brgemm kernel: loop by simd_w  --
     l++;
     const auto inp_ur = inp_w(ur, kw_block);
-    loop[l].src.set(inp_ur * simd_w, 1, acc_simd_w);
+    loop[l].src.set(inp_ur * simd_w, 1, static_cast<float>(acc_simd_w));
     loop[l].dst.set(0, 1);
     loop[l].wei.set(oc_block, 1);
 
     // -- brgemm kernel: loop by kw in kw_block  --
     l++;
     auto src_is = rnd_inp_simd(ur, kw_block, ic_blocking_size);
-    loop[l].src.set(src_is, 1, kw_block);
+    loop[l].src.set(src_is, 1, static_cast<float>(kw_block));
     loop[l].dst.set(0, 1);
     loop[l].wei.set(oc_blocking_size, 1);
 
@@ -937,21 +951,22 @@ float brg_blocking_t::est_eff() {
     loop[l].dst.set(ur * oc_block, 1);
     wei_is = static_cast<dim_t>(kd_block) * kh_block * kw_block
             * oc_blocking_size;
-    loop[l].wei.set(wei_is, nb_ur);
+    loop[l].wei.set(wei_is, static_cast<float>(nb_ur));
 
     // -- harness: loop by k_blocks in ks --
     l++;
     loop[l].src.set(kd_block * kh_block
                     * rnd_inp_simd(sp_block, kw_block, ic_blocking_size),
             1);
-    loop[l].dst.set(sp_block * oc_block, nb_kd * nb_kh * nb_kw);
+    loop[l].dst.set(
+            sp_block * oc_block, static_cast<float>(nb_kd * nb_kh * nb_kw));
     loop[l].wei.set(wei_is, 1);
 
     // -- brgemm kernel: loop by ic_chunks --
     l++;
     const auto ic_chunks = div_up(nb_ic, nb_ic_blocking);
     loop[l].src.set(kd * kh * rnd_inp_simd(sp_block, kw, ic_blocking_size), 1);
-    loop[l].dst.set(sp_block * oc_block, ic_chunks);
+    loop[l].dst.set(sp_block * oc_block, static_cast<float>(ic_chunks));
     wei_is = static_cast<dim_t>(kd) * kh * kw * oc_blocking_size;
     loop[l].wei.set(wei_is, 1);
 
@@ -966,15 +981,15 @@ float brg_blocking_t::est_eff() {
             = nstl::min(static_cast<dim_t>(nb_sp), div_up(job, dim_sp));
     const auto sp_thr = nstl::min(static_cast<dim_t>(sp), nb_sp_thr * sp_block);
 
-    int nb_oh_thr {1}, oh_thr {1}, nb_od_thr {1}, od_thr {1};
+    dim_t nb_oh_thr {1}, oh_thr {1}, nb_od_thr {1}, od_thr {1};
     if (!is_os_blocking) {
         const auto dim_oh = nb_sp * dim_sp;
         nb_oh_thr = nstl::min(static_cast<dim_t>(nb_oh), div_up(job, dim_oh));
-        oh_thr = nstl::min(oh, nb_oh_thr * oh_block);
+        oh_thr = nstl::min(static_cast<dim_t>(oh), nb_oh_thr * oh_block);
 
         const auto dim_od = nb_oh * dim_oh;
         nb_od_thr = nstl::min(static_cast<dim_t>(nb_od), div_up(job, dim_od));
-        od_thr = nstl::min(od, nb_od_thr * od_block);
+        od_thr = nstl::min(static_cast<dim_t>(od), nb_od_thr * od_block);
     }
 
     src_is = kd * kh * rnd_inp_simd(sp_block, kw, ic);
@@ -983,7 +998,7 @@ float brg_blocking_t::est_eff() {
     if (loop_order == loop_ndhwgc) {
         // -- harness: loop by oc_block --
         l++;
-        loop[l].src.set(src_is, nb_oc_thr);
+        loop[l].src.set(src_is, static_cast<float>(nb_oc_thr));
         loop[l].dst.set(sp_block * oc_block, 1);
         wei_is = static_cast<dim_t>(kd) * kh * kw * oc_block * ic;
         wei_op = kd * kh * kw * nsimd_oc_thr * ic;
@@ -996,25 +1011,26 @@ float brg_blocking_t::est_eff() {
     const auto rnd_oc_for_sp = simd_w
             * ((loop_order == loop_ndhwgc) ? nsimd_oc_thr : adj_ocblock);
     loop[l].dst.set(sp_block * rnd_oc_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_sp_thr));
     // oh_block almost all is 1. TODO: manage oh_block != 1
     // -- harness: loop by oh_blocks --
     l++;
     src_is = kd * kh * rnd_inp_simd(sp_thr, kw, ic);
     loop[l].src.set(oh_block * src_is, 1);
     loop[l].dst.set(sp_thr * rnd_oc_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_oh_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_oh_thr));
     // od_block almost all is 1. TODO: manage oh_block != 1
     // -- harness: loop by od_blocks --
     l++;
     loop[l].src.set(od_block * oh_thr * src_is, 1);
     loop[l].dst.set(oh_thr * sp_thr * rnd_oc_for_sp, 1);
-    loop[l].wei.set(wei_op * simd_w, nb_od_thr);
+    loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_od_thr));
 
     if (loop_order != loop_ndhwgc) {
         // -- harness: loop by oc_block --
         l++;
-        loop[l].src.set(od_thr * oh_thr * src_is, nb_oc_thr);
+        loop[l].src.set(
+                od_thr * oh_thr * src_is, static_cast<float>(nb_oc_thr));
         loop[l].dst.set(oc_block * od_thr * oh_thr * sp_thr, 1);
         loop[l].wei.set(kd * kh * kw * oc_block * ic, 1);
     }
@@ -1027,7 +1043,7 @@ float brg_blocking_t::est_eff() {
     loop[l].dst.set(od_thr * oh_thr * sp_thr * nsimd_oc_thr * simd_w, 1);
     loop[l].wei.set(
             static_cast<dim_t>(kd) * kh * kw * nsimd_oc_thr * simd_w * ic,
-            mb_thr);
+            static_cast<float>(mb_thr));
 
     const auto src_op = static_cast<dim_t>(mb_thr) * od_thr * oh_thr * sp_thr
             * kd * kh * kw * ic;
@@ -1059,34 +1075,38 @@ float brg_blocking_t::est_eff() {
         dst_rp *= loop[il].dst.repeatn;
         wei_rp *= loop[il].wei.repeatn;
     }
-    const auto src_ops = (src_op * src_rp) / iterations;
-    const auto dst_ops = (dst_op * dst_rp) / iterations;
-    const auto wei_ops = (wei_op * wei_rp) / iterations;
+    const auto src_ops = (static_cast<float>(src_op) * src_rp) / iterations;
+    const auto dst_ops = (static_cast<float>(dst_op) * dst_rp) / iterations;
+    const auto wei_ops = (static_cast<float>(wei_op) * wei_rp) / iterations;
 
     const auto src_cost = src_mem_k * src_ops;
     const auto dst_cost = dst_mem_k * dst_ops;
     const auto wei_cost = wei_mem_k * wei_ops;
-    const auto call_kernel_cost
-            = 1000.f * job * ic_chunks * nb_kd * nb_kh * nb_kw;
+    const auto call_kernel_cost = 1000.f * static_cast<float>(job)
+            * static_cast<float>(ic_chunks) * static_cast<float>(nb_kd)
+            * static_cast<float>(nb_kh) * static_cast<float>(nb_kw);
 
     // Avoid huge batch sizes if possible (ie prefer to block on kd/kh/kw).
-    const float gemm_batch_bytes
-            = sizeof(brgemm_batch_element_t) * gemm_batch_size;
+    const float gemm_batch_bytes = sizeof(brgemm_batch_element_t)
+            * static_cast<float>(gemm_batch_size);
     const float batch_eff = uses_batch_elements(brg_type, exec_type)
-            ? nstl::min(1.f, L2 / (gemm_batch_bytes))
+            ? nstl::min(1.f, static_cast<float>(L2) / (gemm_batch_bytes))
             : 1.f;
 
-    const auto cache_eff = (static_cast<dim_t>(mb) * od * oh * sp * ic * oc)
-            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto cache_eff = static_cast<float>(static_cast<dim_t>(mb) * od * oh
+                                   * sp * ic * oc)
+            / (static_cast<float>(nthr)
+                    * (src_cost + dst_cost + wei_cost + call_kernel_cost));
     const auto res_eff = oc_block_eff * brgemm_microkernel_eff * sp_eff
             * job_eff * ur_eff * cache_eff * brgemm_eff * batch_eff;
     return res_eff;
 }
 
-void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
-        int kh_block_, bool maybe_use_buffer, int max_ow_block_thr) {
+void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb,
+        dim_t kd_block_, dim_t kh_block_, bool maybe_use_buffer,
+        dim_t max_ow_block_thr) {
 
-    unsigned est_k_amount = ic * oc_block * wei_dsz;
+    unsigned est_k_amount = static_cast<unsigned>(ic * oc_block * wei_dsz);
 
     kd_block = kd_block_;
     kh_block = kh_block_;
@@ -1119,14 +1139,15 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
                 = 2 * src_dsz * ic_size * iwp + dst_dsz * ow * oc_block;
         const auto other_size = wei_dsz * kd * kh * kw * ic_size * oc_block
                 + acc_dsz * 2 * amx_h * oc_block;
-        const auto L2_available = nstl::min(static_cast<size_t>(div_up(L2, 2)),
-                other_size > L2 ? 0 : L2 - other_size);
+        const auto L2_available
+                = nstl::min<size_t>(static_cast<size_t>(div_up(L2, 2)),
+                        other_size > L2 ? 0 : L2 - other_size);
         if (idp * ihp * w_block_size > L2_available) {
-            od_block = utils::saturate(
-                    1, od, int(L2_available / (ihp * w_block_size)));
+            od_block = utils::saturate<dim_t>(
+                    1, od, L2_available / (ihp * w_block_size));
             if (od_block == 1)
-                oh_block = utils::saturate(
-                        1, oh, int(L2_available / (w_block_size)));
+                oh_block = utils::saturate<dim_t>(
+                        1, oh, L2_available / w_block_size);
             else
                 oh_block = oh;
         } else {
@@ -1141,16 +1162,19 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
             const auto src_w_block_size
                     = src_dsz * ic * iwp + dst_dsz * ow * oc_block;
             if (src_w_block_size < L1) {
-                cur_od_block = utils::saturate(
-                        1, od, int(L1 / (ihp * src_w_block_size)));
+                cur_od_block = utils::saturate<dim_t>(
+                        1, od, L1 / (ihp * src_w_block_size));
                 if (cur_od_block == 1)
-                    cur_oh_block = utils::saturate(
-                            1, oh, static_cast<int>(L1 / src_w_block_size));
+                    cur_oh_block = utils::saturate<dim_t>(
+                            1, oh, L1 / src_w_block_size);
             }
             for (; cur_od_block > 1; cur_od_block--) {
                 const auto sp_size = cur_od_block * cur_oh_block * iwp;
-                if ((static_cast<float>(od) / rnd_up(od, cur_od_block)) > 0.9f
-                        && static_cast<float>(sp_size) / rnd_up(sp, amx_h)
+                if ((static_cast<float>(od)
+                            / static_cast<float>(rnd_up(od, cur_od_block)))
+                                > 0.9f
+                        && static_cast<float>(sp_size)
+                                        / static_cast<float>(rnd_up(sp, amx_h))
                                 > 0.8f) {
                     L1_fit_res = true;
                     break;
@@ -1160,7 +1184,8 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
                 auto tmp_oh_block = cur_oh_block;
                 while (tmp_oh_block >= 1) {
                     const auto sp_size = tmp_oh_block * iwp;
-                    if ((static_cast<float>(oh) / rnd_up(oh, tmp_oh_block))
+                    if ((static_cast<float>(oh)
+                                / static_cast<float>(rnd_up(oh, tmp_oh_block)))
                                     > 0.9f
                             && sp_size > 128) {
                         L1_fit_res = true;
@@ -1191,11 +1216,11 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
 
     // --- Select ow_block ----
     const auto max_ow_block_L2 = ow;
-    auto start_ow_block = nstl::min(max_ow_block_thr, max_ow_block_L2);
+    auto start_ow_block = nstl::min<dim_t>(max_ow_block_thr, max_ow_block_L2);
 
     sp = ow * (is_os_blocking ? oh : 1);
     const auto start_sp_block = is_os_blocking ? ow : start_ow_block;
-    auto prev_spb = 0;
+    auto prev_spb = dim_t(0);
     for (auto ns = 1; ns <= sp; ns++) {
         const auto spb = div_up(sp, ns);
         if (spb == prev_spb || spb > start_sp_block) continue;
@@ -1234,7 +1259,7 @@ status_t brg_blocking_t::calc_blocks() {
     // results then we need the out buffer
     const auto maybe_use_buffer = (dst_dt != acc_dt || with_sum);
 
-    std::vector<int> kd_blocks(1), kh_blocks(1);
+    std::vector<dim_t> kd_blocks(1), kh_blocks(1);
     kd_blocks[0] = kd;
     kh_blocks[0] = kh;
     if (kd != 1) {
@@ -1247,9 +1272,10 @@ status_t brg_blocking_t::calc_blocks() {
     }
 
     const auto thr_eff_threshold = 0.9f;
-    const auto max_ow_block_thr = utils::saturate(1, ow,
-            static_cast<int>(ceil(
-                    mb * ngroups * nb_oc * os / (thr_eff_threshold * nthr))));
+    const auto max_ow_block_thr = utils::saturate<dim_t>(1, ow,
+            static_cast<dim_t>(
+                    ceil(static_cast<float>(mb * ngroups * nb_oc * os)
+                            / (thr_eff_threshold * static_cast<float>(nthr)))));
 
     ow_block = os_block = sp_block = -1;
     brg_blocking_t best_brgb = *this;
@@ -1288,7 +1314,8 @@ bool brg_blocking_t::fast_check_oc_block_1x1() const {
                 = od * oh * ow >= 64 * stride_d * stride_h * stride_w;
         res = (rnd_oc % oc_block == 0 && big_spatial);
     } else if (oc_block == 48) {
-        const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+        const auto oc_block_eff = static_cast<float>(oc)
+                / static_cast<float>(rnd_up(oc, oc_block));
         res = (oc_block_eff >= 0.95f);
     } else
         res = true;
@@ -1298,14 +1325,16 @@ bool brg_blocking_t::fast_check_oc_block_1x1() const {
 
 float brg_blocking_t::est_eff_1x1() {
 
-    auto calc_ave_blk = [&](int dim, int block, bool use_ave) -> float {
-        const int nb = dim / block;
+    auto calc_ave_blk = [&](dim_t dim, dim_t block, bool use_ave) -> float {
+        const dim_t nb = dim / block;
         constexpr int max_nb = 2; // only consider 2x2 tile blocking
-        const int block2 = nstl::min(max_nb, nb);
-        const int nb2 = nb / block2;
-        const int nb2_tail = nb % block2;
-        if (!use_ave) return block2;
-        return (float(nb2) * block2 + nb2_tail) / div_up(nb, block2);
+        const dim_t block2 = nstl::min<dim_t>(max_nb, nb);
+        const dim_t nb2 = nb / block2;
+        const dim_t nb2_tail = nb % block2;
+        if (!use_ave) return static_cast<float>(block2);
+        return (float(nb2) * static_cast<float>(block2)
+                       + static_cast<float>(nb2_tail))
+                / static_cast<float>(div_up(nb, block2));
     };
     const bool use_ocb_ave = true;
     const auto ocb_ave = calc_ave_blk(oc_block, acc_simd_w, use_ocb_ave);
@@ -1321,21 +1350,29 @@ float brg_blocking_t::est_eff_1x1() {
             || (ic == 1024 && oc == 512) || (ic == 256 && oc == 1024)
             || (ic == 512 && oc == 1024) || (ic == 512 && oc == 2048);
     const auto amx_fac = maskrcnn_cond
-            ? (div_up(M + M_tail, 16) / (M_n_sp_blks + M_tail_n_sp_blks))
+            ? (static_cast<float>(div_up(M + M_tail, 16))
+                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks))
             : (static_cast<float>(div_up(M + M_tail, 16))
-                      / (M_n_sp_blks + M_tail_n_sp_blks));
+                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks));
 
     const auto brgemm_microkernel_eff = is_amx(isa)
             ? amx_fac * (static_cast<float>(ocb_ave) * spb_ave)
                     / (ocb_ave + spb_ave)
-            : (static_cast<float>(adj_ocblock) * ur)
-                    / ((ur + adj_ocblock) * max_regs);
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
+            : (static_cast<float>(adj_ocblock) * static_cast<float>(ur))
+                    / static_cast<float>((ur + adj_ocblock) * max_regs);
+    const auto ur_eff = static_cast<float>(sp_block)
+            / static_cast<float>(rnd_up(sp_block, ur));
 
     // heuristic sp_block: for reduced rtus, prioritize a smaller sp_block
-    const auto heur_sp_block = is_reduced_rtus ? 1.f / sp_block : sp_block;
-    const auto brgemm_eff = squeeze_val(
-            ur * (2.f - nstl::min(1.9f, static_cast<float>(ur) / heur_sp_block))
+    const auto heur_sp_block = is_reduced_rtus
+            ? 1.f / static_cast<float>(sp_block)
+            : static_cast<float>(sp_block);
+    const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    static_cast<float>(ur)
+                                            / static_cast<float>(
+                                                    heur_sp_block)))
                     / 64,
             0.5f);
 
@@ -1344,8 +1381,10 @@ float brg_blocking_t::est_eff_1x1() {
     const auto work_amount
             = static_cast<dim_t>(mb) * ngroups * nb_oc * sp_amount;
 
-    const auto sp_eff = static_cast<float>(sp) / rnd_up(sp, sp_block);
-    const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+    const auto sp_eff
+            = static_cast<float>(sp) / static_cast<float>(rnd_up(sp, sp_block));
+    const auto oc_block_eff
+            = static_cast<float>(oc) / static_cast<float>(rnd_up(oc, oc_block));
 
     const auto job = div_up(work_amount, nthr);
 
@@ -1393,8 +1432,9 @@ float brg_blocking_t::est_eff_1x1() {
 
     const dim_t sum_job = static_cast<dim_t>(mb) * od * oh * ow * ngroups * oc;
 
-    const float job_eff
-            = max_job == 0 ? 1 : static_cast<float>(sum_job) / (max_job * nthr);
+    const float job_eff = max_job == 0
+            ? 1.f
+            : static_cast<float>(sum_job) / static_cast<float>(max_job * nthr);
 
     const auto ic_blocking_size = ic_block * nb_ic_blocking;
     const auto oc_blocking_size = oc_block * ic_blocking_size;
@@ -1402,7 +1442,7 @@ float brg_blocking_t::est_eff_1x1() {
     int l = -1;
     // -- brgemm kernel: loop by simd_w  --
     l++;
-    loop[l].src.set(ur * simd_w, 1, acc_simd_w);
+    loop[l].src.set(ur * simd_w, 1, static_cast<float>(acc_simd_w));
     loop[l].dst.set(0, 1);
     loop[l].wei.set(oc_block, 1);
 
@@ -1415,12 +1455,13 @@ float brg_blocking_t::est_eff_1x1() {
             = (nb_sp_no_tail * nb_ur + div_up(sp_block_tail, ur)) / nb_sp;
     loop[l].src.set(ur * rnd_simd(ic_blocking_size), 1);
     loop[l].dst.set(ur * oc_block, 1);
-    loop[l].wei.set(oc_blocking_size, is_amx(isa) ? nb_ur_average : nb_ur);
+    loop[l].wei.set(oc_blocking_size,
+            static_cast<float>(is_amx(isa) ? nb_ur_average : nb_ur));
     // -- brgemm kernel: loop by ic_chunks --
     l++;
     const auto ic_chunks = div_up(nb_ic, nb_ic_blocking);
     loop[l].src.set(sp_block * ic_blocking_size, 1);
-    loop[l].dst.set(sp_block * oc_block, ic_chunks);
+    loop[l].dst.set(sp_block * oc_block, static_cast<float>(ic_chunks));
     auto wei_is = oc_blocking_size;
     auto wei_op = adj_ocblock * ic;
     loop[l].wei.set(wei_is, 1);
@@ -1428,7 +1469,7 @@ float brg_blocking_t::est_eff_1x1() {
     if (loop_order == loop_ndhwgc) {
         // -- harness: loop by oc_block --
         l++;
-        loop[l].src.set(sp_block * rnd_simd(ic), nb_oc_thr);
+        loop[l].src.set(sp_block * rnd_simd(ic), static_cast<float>(nb_oc_thr));
         loop[l].dst.set(sp_block * oc_block, 1);
         wei_is = oc_block * ic;
         wei_op = nsimd_oc_thr * ic;
@@ -1442,31 +1483,31 @@ float brg_blocking_t::est_eff_1x1() {
         l++;
         loop[l].src.set(sp_block * ic_blocking_size, 1);
         loop[l].dst.set(sp_block * rnd_oc_for_sp, 1);
-        loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
+        loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_sp_thr));
     } else {
         // -- harness: loop by sp_blocks --
         l++;
         loop[l].src.set(sp_block * ic_blocking_size, 1);
         loop[l].dst.set(sp_block * rnd_oc_for_sp, 1);
-        loop[l].wei.set(wei_op * simd_w, nb_sp_thr);
+        loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_sp_thr));
         // -- harness: loop by oh_blocks --
         l++;
         loop[l].src.set(oh_block * sp_thr * rnd_simd(ic_blocking_size), 1);
         loop[l].dst.set(oh_block * sp_thr * rnd_oc_for_sp, 1);
-        loop[l].wei.set(wei_op * simd_w, nb_oh_thr);
+        loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_oh_thr));
         // -- harness: loop by od_blocks --
         l++;
         loop[l].src.set(
                 od_block * oh_thr * sp_thr * rnd_simd(ic_blocking_size), 1);
         loop[l].dst.set(od_block * oh_thr * sp_thr * rnd_oc_for_sp, 1);
-        loop[l].wei.set(wei_op * simd_w, nb_od_thr);
+        loop[l].wei.set(wei_op * simd_w, static_cast<float>(nb_od_thr));
     }
 
     if (loop_order != loop_ndhwgc) {
         // -- harness: loop by oc_block --
         l++;
         loop[l].src.set(od_thr * oh_thr * rnd_simd(sp_thr * ic_blocking_size),
-                nb_oc_thr);
+                static_cast<float>(nb_oc_thr));
         loop[l].dst.set(oc_block * od_thr * oh_thr * sp_thr, 1);
         loop[l].wei.set(oc_block * ic, 1);
     }
@@ -1477,7 +1518,7 @@ float brg_blocking_t::est_eff_1x1() {
             static_cast<dim_t>(mb), div_up(job, sp_amount * ngroups * nb_oc));
     loop[l].src.set(od_thr * oh_thr * sp_thr * rnd_simd(ic_blocking_size), 1);
     loop[l].dst.set(nsimd_oc_thr * simd_w * od_thr * oh_thr * sp_thr, 1);
-    loop[l].wei.set(nsimd_oc_thr * ic * simd_w, mb_thr);
+    loop[l].wei.set(nsimd_oc_thr * ic * simd_w, static_cast<float>(mb_thr));
 
     const auto src_op = static_cast<dim_t>(mb_thr) * od_thr * oh_thr * sp_thr
             * ic_blocking_size;
@@ -1507,19 +1548,22 @@ float brg_blocking_t::est_eff_1x1() {
         dst_rp *= loop[il].dst.repeatn;
         wei_rp *= loop[il].wei.repeatn;
     }
-    const auto src_ops = (src_op * src_rp) / iterations;
-    const auto dst_ops = (dst_op * dst_rp) / iterations;
-    const auto wei_ops = (wei_op * wei_rp) / iterations;
+    const auto src_ops = (static_cast<float>(src_op) * src_rp) / iterations;
+    const auto dst_ops = (static_cast<float>(dst_op) * dst_rp) / iterations;
+    const auto wei_ops = (static_cast<float>(wei_op) * wei_rp) / iterations;
 
     const auto src_cost = src_mem_k * src_ops;
     const auto dst_cost = dst_mem_k * dst_ops;
     const auto wei_cost = wei_mem_k * wei_ops;
-    const auto call_kernel_cost = 1000.f * job * ic_chunks;
+    const auto call_kernel_cost
+            = 1000.f * static_cast<float>(job) * static_cast<float>(ic_chunks);
 
     const auto up_sp_size = is_os_blocking ? 1 : od * oh;
 
-    const auto cache_eff = (static_cast<dim_t>(mb) * up_sp_size * sp * ic * oc)
-            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto cache_eff = static_cast<float>(static_cast<dim_t>(mb)
+                                   * up_sp_size * sp * ic * oc)
+            / (static_cast<float>(nthr)
+                    * (src_cost + dst_cost + wei_cost + call_kernel_cost));
 
     const auto res_eff = oc_block_eff * brgemm_microkernel_eff * sp_eff
             * job_eff * ur_eff * cache_eff * brgemm_eff;
@@ -1559,17 +1603,17 @@ void brg_blocking_t::calc_blocks_1x1() {
     const auto max_sp_block_L2 = os;
     // TODO: nb_os_blocking always is 1 for now. Update this code
     nb_os_blocking = 1;
-    int start_sp_block = 0;
+    dim_t start_sp_block = 0;
 
     if (is_os_blocking) {
         ow_block = 0;
 
         const auto max_os_block_thr
                 = (src_dsz * ic >= 1024 && src_dsz * ic < 4096)
-                ? nstl::max(nstl::min(16, os),
+                ? nstl::max<dim_t>(nstl::min<dim_t>(16, os),
                           div_up(os, div_up(nthr, mb * div_up(oc, oc_block))))
-                : nstl::max(div_up(2048, oc_block),
-                          static_cast<int>(div_up(mb * ngroups * os, nthr)));
+                : nstl::max<dim_t>(div_up(2048, oc_block),
+                          div_up(mb * ngroups * os, nthr));
         const auto max_os_block_L2 = max_sp_block_L2;
 
         auto max_os_block_aliasing = 1000000 / nthr;
@@ -1586,32 +1630,34 @@ void brg_blocking_t::calc_blocks_1x1() {
         max_os_block_aliasing
                 = nstl::min(div_up(1001, dst_dsz), max_os_block_aliasing);
 
-        start_sp_block = utils::saturate(1, os,
-                nstl::min(nstl::min(max_os_block_thr, max_os_block_L2),
+        start_sp_block = utils::saturate<dim_t>(1, os,
+                nstl::min<dim_t>(
+                        nstl::min<dim_t>(max_os_block_thr, max_os_block_L2),
                         max_os_block_aliasing));
 
     } else {
         os_block = 0;
 
-        const auto max_ow_block_thr = utils::saturate(1, ow,
-                static_cast<int>(ceil(mb * ngroups * nb_oc * os
-                        / (thr_eff_threshold * nthr))));
+        const auto max_ow_block_thr = utils::saturate<dim_t>(1, ow,
+                static_cast<dim_t>(ceil(
+                        static_cast<float>(mb * ngroups * nb_oc * os)
+                        / (thr_eff_threshold * static_cast<float>(nthr)))));
         const auto max_ow_block_L2 = max_sp_block_L2;
 
-        start_sp_block = utils::saturate(
-                1, ow, nstl::min(max_ow_block_thr, max_ow_block_L2));
+        start_sp_block = utils::saturate<dim_t>(
+                1, ow, nstl::min<dim_t>(max_ow_block_thr, max_ow_block_L2));
     }
     os_block = ow_block = sp_block = -1;
     brg_blocking_t best_brgb = *this;
 
-    auto prev_spb = 0;
+    auto prev_spb = dim_t(0);
     for (auto ns = 1; ns <= sp; ns++) {
         auto spb = div_up(sp, ns);
         if (is_amx(isa)) {
-            auto min_dis = 16;
-            auto best_w = 16;
-            const auto max_tile_width = nstl::min(16, sp);
-            const auto min_tile_width = utils::saturate(1, 11, sp / 2);
+            dim_t min_dis = 16;
+            dim_t best_w = 16;
+            const auto max_tile_width = nstl::min<dim_t>(16, sp);
+            const auto min_tile_width = utils::saturate<dim_t>(1, 11, sp / 2);
             if (spb < min_tile_width) break;
             for (auto w = max_tile_width; w >= min_tile_width; w--) {
                 const auto dis = nstl::additive_inverse_modulo(spb, w);
@@ -1625,7 +1671,8 @@ void brg_blocking_t::calc_blocks_1x1() {
         }
         if (spb == prev_spb || spb > start_sp_block) continue;
         prev_spb = spb;
-        os_block = ow_block = sp_block = spb;
+        sp_block = spb;
+        os_block = ow_block = spb;
         select_ic_block();
         const status_t st = estimate_brgemm_ur();
         if (st != status::success) continue;
@@ -1786,7 +1833,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                                                                    : jcp.wei_dt;
     const data_type_t vnni_block_dt
             = get_mac_emu_data_type(vnni_dt, isa, isa == avx10_1_512);
-    jcp.vnni_block = data_type_vnni_granularity(vnni_block_dt);
+    jcp.vnni_block
+            = static_cast<int>(data_type_vnni_granularity(vnni_block_dt));
 
     if (one_of(jcp.prop_kind, prop_kind::forward_training,
                 prop_kind::forward_inference)
@@ -1989,7 +2037,7 @@ void adjust_nthr(jit_brgemm_conv_conf_t &jcp, const memory_desc_wrapper &src_d,
     const bool out_small = dst_d.size() < threshold;
     if (in_small && out_small && jcp.ngroups < jcp.nthr
             && jcp.nb_oc < jcp.nthr) {
-        int nthr = nstl::max(jcp.ngroups, jcp.nb_oc);
+        int nthr = static_cast<int>(nstl::max<dim_t>(jcp.ngroups, jcp.nb_oc));
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 }
@@ -2056,13 +2104,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     const int min_oc_block = jcp.acc_simd_w;
 
-    int selected_ur = 0;
+    dim_t selected_ur = 0;
     MAYBE_UNUSED(selected_ur);
 
     auto try_exec_type = [&]() {
         brg_blocking_t best_brgb = zero<decltype(best_brgb)>();
         best_brgb.oc_block = min_oc_block;
-        const int est_amx_job = div_up(jcp.mb * div_up(jcp.os, 4 * 16)
+        const dim_t est_amx_job = div_up(jcp.mb * div_up(jcp.os, 4 * 16)
                         * jcp.ngroups * div_up(jcp.oc, 4 * 16),
                 jcp.nthr);
         const bool small_amx_job = est_amx_job < 64 || jcp.oc < 256;
@@ -2075,7 +2123,8 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                 && jcp.oh * jcp.ow >= 150 * 150)
             start_ocb = 2;
 
-        start_ocb = nstl::min(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
+        start_ocb = static_cast<int>(
+                nstl::min<dim_t>(div_up(jcp.oc, jcp.acc_simd_w), start_ocb));
 
         auto finish_ocb = 1;
         for (auto ocb = start_ocb; ocb >= finish_ocb; ocb--) {
@@ -2111,8 +2160,9 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     // TODO: this logic seems not taking dilation into which can avoid pure
     // kernel-in-pad cases.
-    if (!is_amx(isa) && div_up(nstl::max(0, jcp.l_pad), jcp.stride_w) < jcp.kw
-            && div_up(nstl::max(0, jcp.r_pad), jcp.stride_w) < jcp.kw) {
+    if (!is_amx(isa)
+            && div_up(nstl::max<dim_t>(0, jcp.l_pad), jcp.stride_w) < jcp.kw
+            && div_up(nstl::max<dim_t>(0, jcp.r_pad), jcp.stride_w) < jcp.kw) {
         try_exec_vpad = true;
     }
 
@@ -2160,11 +2210,11 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                 && IMPLICATION(jcp.id > 1, relo_conv_weights_wi == false)
                 && !cd.use_inversion && jcp.dilate_w == 0;
 
-        const auto rnd_kwic = (float)jcp.kw * rnd_up(jcp.ic, jcp.simd_w);
-        const auto src_per_ic
-                = (float)jcp.src_dsz * jcp.mb * jcp.id * jcp.ih * jcp.iw;
-        const auto wei_per_ic
-                = (float)jcp.wei_dsz * jcp.oc * jcp.kd * jcp.kh * jcp.kw;
+        const auto rnd_kwic = (float)jcp.kw * (float)rnd_up(jcp.ic, jcp.simd_w);
+        const auto src_per_ic = (float)jcp.src_dsz * (float)jcp.mb
+                * (float)jcp.id * (float)jcp.ih * (float)jcp.iw;
+        const auto wei_per_ic = (float)jcp.wei_dsz * (float)jcp.oc
+                * (float)jcp.kd * (float)jcp.kh * (float)jcp.kw;
         bool perf_relo = false;
         if (is_amx(jcp.isa)) {
             if (jcp.ic < jcp.simd_w / 2
@@ -2190,7 +2240,7 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     bool relo_conv_weights_whi = true;
     if (!jcp.wei_plain && relo_supported_isa && relo_reasonable_isa
             && !jcp.is_fp8) {
-        const int rd_whi = jcp.kh * jcp.kw * jcp.ic;
+        const dim_t rd_whi = jcp.kh * jcp.kw * jcp.ic;
         //TODO: support fp8
         if (jcp.ic % jcp.vnni_block == 0
                 && IMPLICATION(rd_whi > jcp.simd_w, rd_whi % jcp.simd_w == 0)
@@ -2203,13 +2253,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                 && IMPLICATION(jcp.s8s8_compensation_required,
                         everyone_is(0, jcp.t_pad, jcp.b_pad));
 
-        const float rnd_rd_whi = rnd_up(rd_whi, jcp.simd_w);
-        const auto rnd_khkwic
-                = (float)jcp.kh * jcp.kw * rnd_up(jcp.ic, jcp.simd_w);
-        const auto src_per_ic
-                = (float)jcp.src_dsz * jcp.mb * jcp.id * jcp.ih * jcp.iw;
-        const auto wei_per_ic
-                = (float)jcp.wei_dsz * jcp.oc * jcp.kd * jcp.kh * jcp.kw;
+        const float rnd_rd_whi = (float)rnd_up(rd_whi, jcp.simd_w);
+        const auto rnd_khkwic = (float)jcp.kh * (float)jcp.kw
+                * (float)rnd_up(jcp.ic, jcp.simd_w);
+        const auto src_per_ic = (float)jcp.src_dsz * (float)jcp.mb
+                * (float)jcp.id * (float)jcp.ih * (float)jcp.iw;
+        const auto wei_per_ic = (float)jcp.wei_dsz * (float)jcp.oc
+                * (float)jcp.kd * (float)jcp.kh * (float)jcp.kw;
         // Heuristics for determining relo_whi makes sense for performance
         bool perf_relo = false;
         if (is_amx(jcp.isa)) {
@@ -2218,9 +2268,10 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                                 && rnd_rd_whi / rnd_khkwic < 0.5f
                                 && IMPLICATION(relo_conv_weights_whi,
                                         wei_per_ic / src_per_ic <= 4)))
-                    && rd_whi / rnd_rd_whi > rd_wi / rnd_rd_wi
+                    && (float)rd_whi / rnd_rd_whi > (float)rd_wi / rnd_rd_wi
                     && (jcp.ow > 48 || jcp.ow % 16 == 0)
-                    && IMPLICATION(try_relo_wi, rd_whi / rnd_rd_whi > 0.7f))
+                    && IMPLICATION(
+                            try_relo_wi, (float)rd_whi / rnd_rd_whi > 0.7f))
                 perf_relo = true;
         } else {
             if (one_of(jcp.wei_dt, f32, s8)) {
@@ -2369,13 +2420,14 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         dim_t ds = jcp.copy_block_only
                 ? (brg_blocking_t::get_inp_size(jcp.idp, jcp.od_block, jcp.kd,
                            jcp.stride_d, jcp.dilate_d)
-                          + nstl::max(0, jcp.f_pad)
-                          + nstl::max(0, jcp.back_pad))
+                          + nstl::max<dim_t>(0, jcp.f_pad)
+                          + nstl::max<dim_t>(0, jcp.back_pad))
                 : jcp.idp;
         dim_t hs = jcp.copy_block_only
                 ? (brg_blocking_t::get_inp_size(jcp.ihp, jcp.oh_block, jcp.kh,
                            jcp.stride_h, jcp.dilate_h)
-                          + nstl::max(0, jcp.t_pad) + nstl::max(0, jcp.b_pad))
+                          + nstl::max<dim_t>(0, jcp.t_pad)
+                          + nstl::max<dim_t>(0, jcp.b_pad))
                 : jcp.ihp;
         if (jcp.is_os_blocking)
             hs = div_up(rnd_up(hs * jcp.iwp, jcp.brgM), jcp.iwp)
@@ -2505,9 +2557,9 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     if (is_amx(isa)) {
         // round up ic if needed
-        const int n_vnni_blocks = utils::div_up(jcp.ic, jcp.vnni_block);
-        const int ic_block
-                = nstl::min(jcp.acc_simd_w, n_vnni_blocks) * jcp.vnni_block;
+        const dim_t n_vnni_blocks = utils::div_up(jcp.ic, jcp.vnni_block);
+        const dim_t ic_block = nstl::min<dim_t>(jcp.acc_simd_w, n_vnni_blocks)
+                * jcp.vnni_block;
 
         jcp.extendable_k
                 = !jcp.is_tf32 && jcp.ic > jcp.simd_w && jcp.ic % jcp.simd_w;
@@ -2523,11 +2575,11 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         // try to choose optimal loop order
         // TODO: incorporate loop order into smart blocking selection
         auto wei_size = (size_t)jcp.oc * jcp.ic * jcp.wei_dsz;
-        auto max_size = 0.75f * brg_blocking_t::L2;
+        auto max_size = 0.75f * static_cast<float>(brg_blocking_t::L2);
         const dim_t os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
         const dim_t os_cutoff = 400; // approximate and empiric
-        const bool use_loop_ngcdhw
-                = max_size < wei_size || (jcp.mb == 1 && os < os_cutoff);
+        const bool use_loop_ngcdhw = max_size < static_cast<float>(wei_size)
+                || (jcp.mb == 1 && os < os_cutoff);
         jcp.loop_order = use_loop_ngcdhw ? loop_ngcdhw : loop_ndhwgc;
     }
 
@@ -2540,10 +2592,10 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     brg_blocking_t best_brgb = zero<decltype(best_brgb)>();
     best_brgb.oc_block = min_oc_block;
-    auto start_ocb = 4;
-    start_ocb = nstl::min(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
+    dim_t start_ocb = 4;
+    start_ocb = nstl::min<dim_t>(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
 
-    auto finish_ocb = 1;
+    dim_t finish_ocb = 1;
 
     const bool is_os_blocking_ok
             = utils::everyone_is(1, jcp.stride_d, jcp.stride_h)
@@ -2641,10 +2693,10 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
      **/
     constexpr int int8_outer_vnni_block = 16; // currently, only for AMX
     const int ic_padded_block = int8_outer_vnni_block * jcp.vnni_block;
-    const int ic_vnni_block = jcp.ic_without_padding / ic_padded_block;
-    const int effective_rtus_ic_block
+    const dim_t ic_vnni_block = jcp.ic_without_padding / ic_padded_block;
+    const dim_t effective_rtus_ic_block
             = jcp.ic_without_padding - (ic_vnni_block * ic_padded_block);
-    const int rtus_padded_ic_size
+    const dim_t rtus_padded_ic_size
             = rnd_up(effective_rtus_ic_block, ic_padded_block);
     // used as K dimension for BRGeMM:
     jcp.rtus_ic_size = jcp.is_reduced_rtus ? effective_rtus_ic_block : 1;
@@ -2825,8 +2877,11 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         dim_t dst_size = dst_spatial * jcp.oc * src_type_size;
         dim_t wei_size = (dim_t)jcp.oc * jcp.ic * wei_ks * wei_type_size;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
-        float oi_channels_ratio = (float)(oc_chunks) / ic_chunks;
+        float wei_compensation_scale = 0.5f
+                * static_cast<float>(dst_size + src_size)
+                / static_cast<float>(wei_size);
+        float oi_channels_ratio
+                = (float)(oc_chunks) / static_cast<float>(ic_chunks);
 
         auto get_src_coef = [=]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
@@ -2861,12 +2916,16 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         const auto thr_oc_b = div_up(oc_chunks, nb_oc_job * nthr_oc_b);
 
         const auto thr_oc_amount = thr_oc_b * nb_oc_job;
-        float src_v
-                = src_type_size * src_coef * thr_g * thr_ic_amount * thr_src_sp;
-        float dst_v
-                = src_type_size * dst_coef * thr_g * thr_oc_amount * thr_dst_sp;
-        float wei_v = acc_type_size * wei_coef * thr_g * thr_oc_amount
-                * thr_ic_amount * wei_ks;
+        float src_v = src_type_size * src_coef * static_cast<float>(thr_g)
+                * static_cast<float>(thr_ic_amount)
+                * static_cast<float>(thr_src_sp);
+        float dst_v = src_type_size * dst_coef * static_cast<float>(thr_g)
+                * static_cast<float>(thr_oc_amount)
+                * static_cast<float>(thr_dst_sp);
+        float wei_v = acc_type_size * wei_coef * static_cast<float>(thr_g)
+                * static_cast<float>(thr_oc_amount)
+                * static_cast<float>(thr_ic_amount)
+                * static_cast<float>(wei_ks);
 
         return src_v + dst_v + wei_v;
     };
@@ -2881,7 +2940,7 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
             return;
         }
 
-        nthr_g_ = jcp.ngroups;
+        nthr_g_ = static_cast<int>(jcp.ngroups);
         const int nthr = jcp.nthr / nthr_g_;
 
         float best_mem_cost
@@ -2892,11 +2951,12 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         const int nthr_mb_max = nstl::min(nthr, jcp.nthr_mb_work);
         for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
             const int nthr_par = nthr / nthr_mb;
-            const int nthr_oc_b_max = nstl::min(nthr_par,
-                    oc_chunks); // Amount of nb_oc_blocks
+            const int nthr_oc_b_max = static_cast<int>(nstl::min<dim_t>(
+                    nthr_par, oc_chunks)); // Amount of nb_oc_blocks
             for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-                int nthr_ic_b = nstl::min(
-                        nthr_par / nthr_oc_b, (jcp.nb_ic / jcp.nb_ic_blocking));
+                int nthr_ic_b = static_cast<int>(
+                        nstl::min<dim_t>(nthr_par / nthr_oc_b,
+                                (jcp.nb_ic / jcp.nb_ic_blocking)));
 
                 float mem_cost
                         = calc_mem_cost(nthr_mb, nthr_g_, nthr_oc_b, nthr_ic_b);
@@ -2960,15 +3020,21 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         // Keep dimension values as a vector
         std::vector<std::pair<double, bwd_w_dims>> dv;
         const auto ks = jcp.kd * jcp.kh * jcp.kw;
-        double v = (jcp.ngroups > 1) ? static_cast<double>(jcp.ic) * jcp.oc
-                        * jcp.ngroups * jcp.ngroups * ks
-                                     : 1;
+        double v = (jcp.ngroups > 1)
+                ? static_cast<double>(jcp.ic) * static_cast<double>(jcp.oc)
+                        * static_cast<double>(jcp.ngroups)
+                        * static_cast<double>(jcp.ngroups)
+                        * static_cast<double>(ks)
+                : 1;
         dv.emplace_back(v, bwd_w_dims::g);
-        v = 5 * div_up(jcp.ic, jcp.amx_h) * ks;
+        v = 5 * static_cast<double>(div_up(jcp.ic, jcp.amx_h))
+                * static_cast<double>(ks);
         dv.emplace_back(v, bwd_w_dims::ic);
-        v = 3 * div_up(jcp.oc, jcp.amx_h) * ks;
+        v = 3 * static_cast<double>(div_up(jcp.oc, jcp.amx_h))
+                * static_cast<double>(ks);
         dv.emplace_back(v, bwd_w_dims::oc);
-        v = div_up(jcp.mb * jcp.od * jcp.oh * jcp.ow, jcp.amx_w);
+        v = static_cast<double>(
+                div_up(jcp.mb * jcp.od * jcp.oh * jcp.ow, jcp.amx_w));
         dv.emplace_back(v, bwd_w_dims::sp);
         // Estimate the size of "cubic" piece
         double xd = 1;
@@ -2987,7 +3053,7 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
                 xd = 1;
                 for (int j = i + 1; j < nd; j++)
                     xd *= dv[j].first;
-                xd = pow(xd / jcp.nthr, 1.f / (nd - i - 1));
+                xd = pow(xd / jcp.nthr, 1.f / static_cast<float>(nd - i - 1));
             } else {
                 v = nstl::min(dvf / xd, maxvf);
             }
@@ -3005,7 +3071,7 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
             const auto maxvf = static_cast<double>(maxv[dvs]);
             const auto new_dvf = dvf * knorm;
             dvf = utils::saturate(1., maxvf, new_dvf);
-            knorm *= pow(new_dvf / dvf, 1.f / (nd - i - 1));
+            knorm *= pow(new_dvf / dvf, 1.f / static_cast<float>(nd - i - 1));
             tot_v *= dvf;
         }
         std::sort(dv.begin(), dv.end());
@@ -3109,10 +3175,11 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         }
         nthr = nthr_mb * nthr_g * nthr_oc_b * nthr_ic_b;
     } else if (jcp.kw > 100 && jcp.id == 1 && jcp.ih == 1) {
-        nthr_g = nstl::min(jcp.nthr, jcp.ngroups);
-        nthr_oc_b = nstl::min(jcp.nthr / nthr_g, div_up(jcp.nb_oc, 2));
-        nthr_ic_b = nstl::min(
-                jcp.nthr / (nthr_g * nthr_oc_b), div_up(jcp.nb_ic, 2));
+        nthr_g = static_cast<int>(nstl::min<dim_t>(jcp.nthr, jcp.ngroups));
+        nthr_oc_b = static_cast<int>(
+                nstl::min<dim_t>(jcp.nthr / nthr_g, div_up(jcp.nb_oc, 2)));
+        nthr_ic_b = static_cast<int>(nstl::min<dim_t>(
+                jcp.nthr / (nthr_g * nthr_oc_b), div_up(jcp.nb_ic, 2)));
         nthr_mb = jcp.nthr / (nthr_g * nthr_oc_b * nthr_ic_b);
         nthr = nthr_mb * nthr_g * nthr_oc_b * nthr_ic_b;
     }
@@ -3178,7 +3245,7 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
             && everyone_is(0, jcp.f_pad, jcp.back_pad, jcp.t_pad, jcp.b_pad))
         jcp.var_bs = false;
 
-    jcp.typesize_in = jcp.src_dsz;
+    jcp.typesize_in = static_cast<int>(jcp.src_dsz);
     jcp.typesize_out = sizeof(float);
 
     bool ok = true
@@ -3260,7 +3327,7 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = jcp.ext_kh / 2;
+    const dim_t max_pad_h = jcp.ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < jcp.ext_kw
             && jcp.r_pad < jcp.ext_kw && jcp.t_pad <= max_pad_h
             && jcp.b_pad <= max_pad_h && jcp.f_pad < jcp.ext_kd
@@ -3274,8 +3341,8 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ic_tail = jcp.ic % jcp.ic_block;
-    jcp.oc_tail = jcp.oc % jcp.oc_block;
+    jcp.ic_tail = static_cast<int>(jcp.ic % jcp.ic_block);
+    jcp.oc_tail = static_cast<int>(jcp.oc % jcp.oc_block);
 
     jcp.nb_oc_blocking = (jcp.nb_oc > 1) ? 2 : 1;
     jcp.nb_ic_blocking = (jcp.nb_ic > 1) ? 2 : 1;
@@ -3286,13 +3353,13 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     // TODO: Find more shapes (especially 3D with large spatials) for which
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
-    int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    dim_t optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
 
     jcp.global_transpose = dnnl_thr_syncable();
     jcp.spatial_blk_size = optimal_blk_size;
 
     const int tr_round = 32; // To load full tile register
-    int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    dim_t tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
     jcp.tr_iw = rnd_up(div_up(jcp.iw + jcp.l_pad + jcp.r_pad, jcp.stride_w),
                         tr_round)
             * jcp.stride_w;
@@ -3303,9 +3370,9 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.tr_ow = rnd_up(jcp.ow, rnd_val);
     if (jcp.tr_ow > tr_round) {
         // we may increase tr_ow to have better bd_block in brgemm kernel
-        int best_bdb = jcp.tr_ow / rnd_val;
-        int best_tr_ow = jcp.tr_ow;
-        for (int tr_ow = jcp.tr_ow; tr_ow <= rnd_up(jcp.tr_ow, tr_round);
+        dim_t best_bdb = jcp.tr_ow / rnd_val;
+        dim_t best_tr_ow = jcp.tr_ow;
+        for (dim_t tr_ow = jcp.tr_ow; tr_ow <= rnd_up(jcp.tr_ow, tr_round);
                 tr_ow += rnd_val) {
             for (int i = tr_round; i > 0; i -= rnd_val) {
                 if (tr_ow % i == 0) {
@@ -3334,9 +3401,15 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     }
 
     switch (jcp.harness) {
-        case harness_2d_reduction: jcp.nthr_mb_work = jcp.mb * jcp.oh; break;
-        case harness_3d_reduction: jcp.nthr_mb_work = jcp.mb * jcp.od; break;
-        default: assert(!"Invalid harness"); jcp.nthr_mb_work = jcp.mb;
+        case harness_2d_reduction:
+            jcp.nthr_mb_work = static_cast<int>(jcp.mb * jcp.oh);
+            break;
+        case harness_3d_reduction:
+            jcp.nthr_mb_work = static_cast<int>(jcp.mb * jcp.od);
+            break;
+        default:
+            assert(!"Invalid harness");
+            jcp.nthr_mb_work = static_cast<int>(jcp.mb);
     }
 
     balance_bwd_w(jcp);
@@ -3371,19 +3444,22 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.tr_ocb_chunk = tr_ocb_chunk_allowed && (jcp.oh * jcp.ow > 38 * 38);
     jcp.tr_icb_chunk = false;
 
-    const int irow_size = jcp.src_dsz * jcp.tr_iw * jcp.ic_block
-            * div_up(jcp.nb_ic, jcp.nthr_ic_b)
+    const dim_t irow_size = static_cast<dim_t>(jcp.src_dsz) * jcp.tr_iw
+            * jcp.ic_block * div_up(jcp.nb_ic, jcp.nthr_ic_b)
             * 2 /*we have real and transposed input */;
-    const int orow_size = jcp.dst_dsz * jcp.tr_ow * jcp.oc_block
-            * div_up(jcp.nb_oc, jcp.nthr_oc_b)
+    const dim_t orow_size = static_cast<dim_t>(jcp.dst_dsz) * jcp.tr_ow
+            * jcp.oc_block * div_up(jcp.nb_oc, jcp.nthr_oc_b)
             * 2 /*we have real and transposed diff_dst*/;
-    int oh_block_limit = nstl::max(1.f,
-            nstl::max(0.f, 0.8f * brg_blocking_t::L2 - jcp.kh * irow_size)
-                    / (irow_size + orow_size));
+    dim_t oh_block_limit = static_cast<dim_t>(nstl::max(1.f,
+            nstl::max(0.f,
+                    0.8f * static_cast<float>(brg_blocking_t::L2)
+                            - static_cast<float>(jcp.kh)
+                                    * static_cast<float>(irow_size))
+                    / static_cast<float>(irow_size + orow_size)));
     // try to split oh by equal oh blocks
     oh_block_limit = div_up(jcp.oh, div_up(jcp.oh, oh_block_limit));
-    jcp.oh_block = utils::saturate(1, jcp.oh, oh_block_limit);
-    jcp.ih_block = nstl::min(jcp.ih,
+    jcp.oh_block = utils::saturate<dim_t>(1, jcp.oh, oh_block_limit);
+    jcp.ih_block = nstl::min<dim_t>(jcp.ih,
             jcp.stride_h
                     * brg_blocking_t::get_inp_size(jcp.ih, jcp.oh_block, jcp.kh,
                             jcp.stride_h, jcp.dilate_h));
@@ -3392,12 +3468,13 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     // among nthr_oc_b
     jcp.tr_ic_block = jcp.ic_block;
     if (jcp.ic <= jcp.ic_block) {
-        for (int itr_icb = jcp.ic_block; itr_icb > 1; itr_icb--) {
+        for (dim_t itr_icb = jcp.ic_block; itr_icb > 1; itr_icb--) {
             if (jcp.ic_block % itr_icb != 0) continue;
             const auto icb_per_thr_ic_b = div_up(jcp.nb_ic, jcp.nthr_ic_b);
             const auto ic_per_thr_ic_b
-                    = nstl::min(jcp.ic, icb_per_thr_ic_b * jcp.ic_block);
-            const auto ic_block_per_thr_ic_b = nstl::min(jcp.ic, jcp.ic_block);
+                    = nstl::min<dim_t>(jcp.ic, icb_per_thr_ic_b * jcp.ic_block);
+            const auto ic_block_per_thr_ic_b
+                    = nstl::min<dim_t>(jcp.ic, jcp.ic_block);
             if (ic_block_per_thr_ic_b % itr_icb != 0) continue;
             const auto tr_icb_per_thr = div_up(ic_per_thr_ic_b, itr_icb);
             const auto sp_per_thr_mb
@@ -3427,14 +3504,17 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.tr_diff_dst_buf_size = jcp.tr_diff_dst_block_size
             * (jcp.global_transpose ? 1 : jcp.nb_oc_blocking);
 
-    const int iframe_size = irow_size * jcp.id;
-    const int oframe_size = orow_size * jcp.od;
-    int od_block_limit = nstl::max(1.f,
-            nstl::max(0.f, 0.8f * brg_blocking_t::L2 - jcp.kd * iframe_size)
-                    / (iframe_size + oframe_size));
+    const dim_t iframe_size = irow_size * jcp.id;
+    const dim_t oframe_size = orow_size * jcp.od;
+    dim_t od_block_limit = static_cast<dim_t>(nstl::max(1.f,
+            nstl::max(0.f,
+                    0.8f * static_cast<float>(brg_blocking_t::L2)
+                            - static_cast<float>(jcp.kd)
+                                    * static_cast<float>(iframe_size))
+                    / static_cast<float>(iframe_size + oframe_size)));
     // try to split od by equal od blocks
     od_block_limit = div_up(jcp.od, div_up(jcp.od, od_block_limit));
-    jcp.od_block = utils::saturate(1, jcp.od, od_block_limit);
+    jcp.od_block = utils::saturate<dim_t>(1, jcp.od, od_block_limit);
 
     jcp.use_interleave_stores = false;
     jcp.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf0;
@@ -3570,10 +3650,10 @@ void get_ow_range(const jit_brgemm_conv_conf_t &jcp, int ow, int kw, int &ow_s,
         ow_s += ker_idx;
     }
     if (iw_rp > 0) ker_idx += div_up(iw_rp, SW);
-    ow_f = nstl::max(ow_s, ow_s + (M - ker_idx));
+    ow_f = static_cast<int>(nstl::max<dim_t>(ow_s, ow_s + (M - ker_idx)));
 
-    ow_s = nstl::min(ow_s, ow + M);
-    ow_f = nstl::min(ow_f, ow + M);
+    ow_s = static_cast<int>(nstl::min<dim_t>(ow_s, ow + M));
+    ow_f = static_cast<int>(nstl::min<dim_t>(ow_f, ow + M));
 }
 
 // Sets pairs of `kw_s`-`kw_f` and `kw_full_s`-`kw_full_f` based on given `jcp`.

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -82,11 +82,10 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(vmm_tmp(4).getIdx()), this->r14, this->r15,
-                this->r13, preserve_gpr, preserve_vmm,
-                GET_OFF(ptr_binary_post_ops_rhs), GET_OFF(dst_orig),
-                memory_desc_wrapper(brg_.dst_md()),
-                static_cast<size_t>(brg_.load_dim % brg_.ld_block), k_tail_mask,
+                vmm_tmp(4).getIdx(), this->r14, this->r15, this->r13,
+                preserve_gpr, preserve_vmm, GET_OFF(ptr_binary_post_ops_rhs),
+                GET_OFF(dst_orig), memory_desc_wrapper(brg_.dst_md()),
+                static_cast<dim_t>(brg_.load_dim % brg_.ld_block), k_tail_mask,
                 use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp(this->param1,
                 binary_injector::get_all_strategies_supported_by_injector(),
@@ -117,8 +116,9 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
 }
 
 template <typename Vmm>
-int dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::zp_c_values_offset(
-        int n, bool is_tail /*= false*/) const noexcept {
+dim_t dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
+        Vmm>::zp_c_values_offset(int n,
+        bool is_tail /*= false*/) const noexcept {
     if (brg_.zp_type_c == brgemm_broadcast_t::per_n) {
         return (is_tail) ? sizeof(int32_t) * brg_.ldb_tail
                          : sizeof(int32_t) * n * brg_.ld_block;
@@ -128,7 +128,7 @@ int dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::zp_c_values_offset(
 }
 
 template <typename Vmm>
-int dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
+dim_t dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         Vmm>::zp_comp_a_vpad_offset(int n, int m,
         bool is_tail /*= false*/) const noexcept {
     return (is_tail) ? sizeof(int32_t) * (brg_.ldb_tail + m * brg_.LDB)
@@ -136,13 +136,13 @@ int dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
 }
 
 template <typename Vmm>
-int dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
+dim_t dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         Vmm>::mb_zp_comp_a_offset(int m_block) const noexcept {
     return sizeof(int32_t) * m_block * brg_.LDB;
 }
 
 template <typename Vmm>
-int dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
+dim_t dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         Vmm>::compensation_vpad_offset(int n, int m,
         bool is_tail /*= false*/) const noexcept {
     return (is_tail) ? sizeof(int32_t) * (brg_.ldb_tail + m * brg_.LDB)
@@ -475,7 +475,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
         }
         for (int n = 0; n < n_block; n++) {
             if (brg_.zp_type_c == brgemm_broadcast_t::per_n) {
-                int zp_c_off = zp_c_values_offset(n);
+                const dim_t zp_c_off = zp_c_values_offset(n);
                 auto zp_c_addr = is_superset(brg_.isa_impl, avx512_core)
                         ? EVEX_compress_addr(aux_reg_zp_c_values, zp_c_off)
                         : ptr[aux_reg_zp_c_values + zp_c_off];
@@ -577,8 +577,8 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::apply_post_ops(
 
 template <typename Vmm>
 void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
-        int m_block, int nb2, int nb2_tail, int nb_tail) {
-    if (brg_.alpha) { mov(aux_reg_in, reg_in); }
+        int m_block, dim_t nb2, int nb2_tail, dim_t nb_tail) {
+    if (brg_.alpha != 0) { mov(aux_reg_in, reg_in); }
     if (brg_.beta != 0) {
         if (brg_.with_bias) mov(aux_reg_bias, reg_bias);
         if (brg_.zp_type_c != brgemm_broadcast_t::none) {
@@ -597,7 +597,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
     }
     mov(aux_reg_out, reg_out);
 
-    for (int n_loop_ = 0; n_loop_ < nb2; n_loop_++) {
+    for (dim_t n_loop_ = 0; n_loop_ < nb2; n_loop_++) {
         apply_post_ops(m_block, n_block2_);
 
         const auto oc_l_offset = n_block2_ * brg_.ld_block;
@@ -613,17 +613,21 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.zp_type_a != brgemm_broadcast_t::none) {
                 mov(aux_reg_zp_a_comp, ptr[rsp + aux_reg_zp_a_comp_offs_]);
-                add(aux_reg_zp_a_comp, sizeof(int32_t) * oc_l_offset);
+                add(aux_reg_zp_a_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * oc_l_offset);
                 mov(ptr[rsp + aux_reg_zp_a_comp_offs_], aux_reg_zp_a_comp);
             }
             if (brg_.req_s8s8_compensation) {
                 mov(aux_reg_s8s8_comp, ptr[rsp + aux_reg_s8s8_comp_offs_]);
-                add(aux_reg_s8s8_comp, sizeof(int32_t) * oc_l_offset);
+                add(aux_reg_s8s8_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * oc_l_offset);
                 mov(ptr[rsp + aux_reg_s8s8_comp_offs_], aux_reg_s8s8_comp);
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_per_n_wei_scales * sizeof(float) * oc_l_offset);
+                        static_cast<dim_t>(
+                                brg_.is_per_n_wei_scales * sizeof(float))
+                                * oc_l_offset);
         }
     }
     if (nb2_tail > 0) {
@@ -641,21 +645,25 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.zp_type_a != brgemm_broadcast_t::none) {
                 mov(aux_reg_zp_a_comp, ptr[rsp + aux_reg_zp_a_comp_offs_]);
-                add(aux_reg_zp_a_comp, sizeof(int32_t) * oc_l_offset);
+                add(aux_reg_zp_a_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * oc_l_offset);
                 mov(ptr[rsp + aux_reg_zp_a_comp_offs_], aux_reg_zp_a_comp);
             }
             if (brg_.req_s8s8_compensation) {
                 mov(aux_reg_s8s8_comp, ptr[rsp + aux_reg_s8s8_comp_offs_]);
-                add(aux_reg_s8s8_comp, sizeof(int32_t) * oc_l_offset);
+                add(aux_reg_s8s8_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * oc_l_offset);
                 mov(ptr[rsp + aux_reg_s8s8_comp_offs_], aux_reg_s8s8_comp);
             }
             if (brg_.with_wei_scales)
                 add(aux_reg_wei_scales,
-                        brg_.is_per_n_wei_scales * sizeof(float) * oc_l_offset);
+                        static_cast<dim_t>(
+                                brg_.is_per_n_wei_scales * sizeof(float))
+                                * oc_l_offset);
         }
     }
     if (nb_tail > 0) {
-        apply_post_ops(m_block, 1, nb_tail);
+        apply_post_ops(m_block, 1, static_cast<int>(nb_tail));
 
         if (brg_.alpha != 0) { add(aux_reg_in, inp_typesize_ * (nb_tail)); }
         if (brg_.beta != 0) {
@@ -667,12 +675,14 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::loop_by_N(
             }
             if (brg_.zp_type_a != brgemm_broadcast_t::none) {
                 mov(aux_reg_zp_a_comp, ptr[rsp + aux_reg_zp_a_comp_offs_]);
-                add(aux_reg_zp_a_comp, sizeof(int32_t) * nb_tail);
+                add(aux_reg_zp_a_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * nb_tail);
                 mov(ptr[rsp + aux_reg_zp_a_comp_offs_], aux_reg_zp_a_comp);
             }
             if (brg_.req_s8s8_compensation) {
                 mov(aux_reg_s8s8_comp, ptr[rsp + aux_reg_s8s8_comp_offs_]);
-                add(aux_reg_s8s8_comp, sizeof(int32_t) * nb_tail);
+                add(aux_reg_s8s8_comp,
+                        static_cast<dim_t>(sizeof(int32_t)) * nb_tail);
                 mov(ptr[rsp + aux_reg_s8s8_comp_offs_], aux_reg_s8s8_comp);
             }
             if (brg_.with_wei_scales)
@@ -689,21 +699,22 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::generate() {
 
     sub(rsp, stack_space_needed_);
 
-    int nb = brg_.load_dim / brg_.ld_block;
-    int nb_tail = brg_.load_dim % brg_.ld_block;
+    const dim_t nb = brg_.load_dim / brg_.ld_block;
+    const dim_t nb_tail = brg_.load_dim % brg_.ld_block;
 
-    int nb2 = nb / n_block2_;
-    int nb2_tail = nb % n_block2_;
+    dim_t nb2 = nb / n_block2_;
+    int nb2_tail = static_cast<int>(nb % n_block2_);
     int n_block = (nb2 == 0) ? nstl::max(1, nb2_tail) : n_block2_;
 
     int m_max_regs = (brg_.is_bf16_emu
                     ? 24
                     : (brg_.is_fp8_via_convert() ? 23 : max_vregs_ - 4));
     m_max_regs /= n_block;
-    int m_block = nstl::min(brg_.bcast_dim, m_max_regs);
+    int m_block
+            = static_cast<int>(nstl::min<dim_t>(brg_.bcast_dim, m_max_regs));
 
-    int mb = brg_.bcast_dim / m_block;
-    int mb_tail = brg_.bcast_dim % m_block;
+    const dim_t mb = brg_.bcast_dim / m_block;
+    const dim_t mb_tail = brg_.bcast_dim % m_block;
 
     if (isa_has_masks(brg_.isa_impl)) {
         const auto full_mask = size_t {0xffffffffffffffff};
@@ -751,7 +762,7 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::generate() {
     }
     mov(reg_out, ptr[param1 + GET_OFF(ptr_out)]);
 
-    for (int mb_ = 0; mb_ < mb; mb_++) {
+    for (dim_t mb_ = 0; mb_ < mb; mb_++) {
         loop_by_N(m_block, nb2, nb2_tail, nb_tail);
 
         if (brg_.alpha != 0) add(reg_in, inp_typesize_ * (m_block * brg_.LDC));
@@ -769,7 +780,8 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::generate() {
         }
         add(reg_out, out_typesize_ * (m_block * brg_.LDD));
     }
-    if (mb_tail > 0) loop_by_N(mb_tail, nb2, nb2_tail, nb_tail);
+    if (mb_tail > 0)
+        loop_by_N(static_cast<int>(mb_tail), nb2, nb2_tail, nb_tail);
 
     add(rsp, stack_space_needed_);
 

--- a/src/cpu/x64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.hpp
@@ -66,7 +66,7 @@ struct jit_brgemm_kernel_post_ops_base_t {
     virtual void operator()(const brgemm_kernel_post_ops_args_t *args) const
             = 0;
 
-    virtual int get_bcast_dim() const = 0;
+    virtual dim_t get_bcast_dim() const = 0;
 };
 
 // An implementation class for post-ops based on `Vmm` template argument.
@@ -97,7 +97,7 @@ struct jit_brgemm_kernel_post_ops_t : public jit_brgemm_kernel_post_ops_base_t,
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_kernel_post_ops_t)
 
     // Used for assertion on implementation side in debug mode.
-    int get_bcast_dim() const override { return brg_.bcast_dim; }
+    dim_t get_bcast_dim() const override { return brg_.bcast_dim; }
 
 private:
     // This can't be a reference, otherwise, `get_bcast_dim()` would return
@@ -123,9 +123,9 @@ private:
     int max_vregs_;
     const bool with_binary_non_scalar_bcast_;
 
-    int inp_typesize_;
-    int out_typesize_;
-    int bia_typesize_;
+    dim_t inp_typesize_;
+    dim_t out_typesize_;
+    dim_t bia_typesize_;
 
     using reg64_t = const Xbyak::Reg64;
 
@@ -189,13 +189,13 @@ private:
 
     Vmm vmm_tmp(int i) const { return Vmm(max_vregs_ - 1 - i); }
 
-    int zp_c_values_offset(int n, bool is_tail = false) const noexcept;
-    int zp_comp_a_vpad_offset(
+    dim_t zp_c_values_offset(int n, bool is_tail = false) const noexcept;
+    dim_t zp_comp_a_vpad_offset(
             int n, int m, bool is_tail = false) const noexcept;
-    int mb_zp_comp_a_offset(int m_block) const noexcept;
-    int compensation_vpad_offset(
+    dim_t mb_zp_comp_a_offset(int m_block) const noexcept;
+    dim_t compensation_vpad_offset(
             int n, int m, bool is_tail = false) const noexcept;
-    int mb_compensation_offset(int m_block) const noexcept {
+    dim_t mb_compensation_offset(int m_block) const noexcept {
         return sizeof(int32_t) * m_block * brg_.LDB;
     }
 
@@ -218,7 +218,7 @@ private:
     void apply_comp(int m_block, int n_block, int tail = 0);
     void maybe_apply_comp(int m_block, int n_block, int tail = 0);
     void apply_post_ops(int m_block, int n_block, int tail = 0);
-    void loop_by_N(int m_block, int nb2, int nb2_tail, int nb_tail);
+    void loop_by_N(int m_block, dim_t nb2, int nb2_tail, dim_t nb_tail);
     void generate() override;
 };
 

--- a/src/cpu/x64/jit_brgemm_primitive_conf.cpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.cpp
@@ -23,11 +23,11 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-int jit_brgemm_primitive_conf_t::ks() const {
+dim_t jit_brgemm_primitive_conf_t::ks() const {
     return kd * kh * kw;
 }
 
-int jit_brgemm_primitive_conf_t::get_weights_oc_block() const {
+dim_t jit_brgemm_primitive_conf_t::get_weights_oc_block() const {
     using namespace format_tag;
 
     assert(wei_tag != undef && "Weights tag not defined!");

--- a/src/cpu/x64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.hpp
@@ -30,15 +30,15 @@ struct jit_brgemm_primitive_conf_t {
     conv_harness_t harness;
     int simd_w;
     int ndims;
-    int mb, os;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
-    int id = 1, ih = 1, iw = 1;
-    int od = 1, oh = 1, ow = 1;
-    int kd = 1, kh = 1, kw = 1;
-    int f_pad, l_pad, t_pad;
-    int back_pad, r_pad, b_pad;
-    int stride_d, stride_h, stride_w;
-    int dilate_d, dilate_h, dilate_w;
+    dim_t mb, os;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t id = 1, ih = 1, iw = 1;
+    dim_t od = 1, oh = 1, ow = 1;
+    dim_t kd = 1, kh = 1, kw = 1;
+    dim_t f_pad, l_pad, t_pad;
+    dim_t back_pad, r_pad, b_pad;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t dilate_d, dilate_h, dilate_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool is_wei_layout_any;
     bool with_bias;
@@ -46,14 +46,14 @@ struct jit_brgemm_primitive_conf_t {
     bool with_eltwise;
     bool with_binary;
     bool req_s8s8_compensation;
-    int nb_ic, ic_block, ic_block_ext;
-    int nb_oc, oc_block, oc_block_ext;
-    int nb_iw, iw_block;
-    int nb_ow, ow_block;
-    int nb_os, os_block;
-    int nb_oc_blocking;
-    int nb_ic_blocking;
-    int nb_os_blocking;
+    dim_t nb_ic, ic_block, ic_block_ext;
+    dim_t nb_oc, oc_block, oc_block_ext;
+    dim_t nb_iw, iw_block;
+    dim_t nb_ow, ow_block;
+    dim_t nb_os, os_block;
+    dim_t nb_oc_blocking;
+    dim_t nb_ic_blocking;
+    dim_t nb_os_blocking;
 
     data_type_t src_dt;
     data_type_t dst_dt;
@@ -73,9 +73,9 @@ struct jit_brgemm_primitive_conf_t {
     bool with_dst_scales;
     int is_oc_scale;
 
-    int LDA, LDB, LDC, LDD;
-    int M, N, K, M_tail, N_tail, K_tail;
-    int gemm_batch_size, adjusted_batch_size;
+    dim_t LDA, LDB, LDC, LDD;
+    dim_t M, N, K, M_tail, N_tail, K_tail;
+    dim_t gemm_batch_size, adjusted_batch_size;
     brgemm_batch_kind_t brg_type;
     int num_gemm_kernels;
     int nthr, nthr_mb, nthr_oc_b, nthr_ic_b;
@@ -88,10 +88,10 @@ struct jit_brgemm_primitive_conf_t {
             = brgemm_kernel_prefetching_t::brgemm_prf_default;
 
     // Compute kernel-spatial dimension size.
-    int ks() const;
+    dim_t ks() const;
 
     // Compute foward weights oc-block.
-    int get_weights_oc_block() const;
+    dim_t get_weights_oc_block() const;
 };
 
 } // namespace x64

--- a/src/cpu/x64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.hpp
@@ -83,7 +83,7 @@ struct jit_brgemm_primitive_conf_t {
     cpu_isa_t isa;
     bool use_uker;
     bool use_interleave_stores;
-    int amx_buf_size_per_thread;
+    dim_t amx_buf_size_per_thread;
     brgemm_kernel_prefetching_t hint_prefetching
             = brgemm_kernel_prefetching_t::brgemm_prf_default;
 

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -314,7 +314,7 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
 #define PARAM_OFF(field) offsetof(ker_args_t, field)
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
-        static const size_t helper_vmm_idx = is_avx512_ ? 31 : 15;
+        static const int helper_vmm_idx = is_avx512_ ? 31 : 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
         const auto dst_md_wrapper = memory_desc_wrapper(*dst_md);
 
@@ -327,7 +327,7 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
             OC_loop = vlen * max_OC_loop_unroll_;
             OC_tail = OC % OC_loop;
         }
-        size_t tail_size = OC_tail % vlen;
+        dim_t tail_size = OC_tail % vlen;
         // enable tail processing for runtime load even if there is no tail
         // for the OC
         tail_size = !!tail_size ? tail_size : 1;
@@ -382,7 +382,7 @@ void jit_pp_kernel_t<isa>::advance_binary_postops_per_oc_off(const T &offset) {
 
     if (this->ndims_ == 2) {
         Xbyak::Label end;
-        cmp(binary_post_op_oc_off_reg, this->OC_);
+        cmp(binary_post_op_oc_off_reg, static_cast<dim_t>(this->OC_));
         jl(end, T_NEAR);
         xor_(binary_post_op_oc_off_reg, binary_post_op_oc_off_reg);
         L(end);
@@ -401,7 +401,8 @@ void jit_pp_kernel_t<isa>::update_binary_postops_per_tensor_off() {
     mov(binary_post_op_offset_reg, reg_dst);
     sub(binary_post_op_offset_reg, ptr[rsp + reg_origin_dst_ptr_]);
     sar(binary_post_op_offset_reg,
-            std::log2(types::data_type_size(get_data_type(arg_t::dst))));
+            static_cast<int>(std::log2(
+                    types::data_type_size(get_data_type(arg_t::dst)))));
     mov(binary_post_op_current_offset_on_stack, binary_post_op_offset_reg);
 }
 
@@ -425,12 +426,13 @@ void jit_pp_kernel_t<isa>::advance_binary_postops_channel_bcast_off(
 template <cpu_isa_t isa>
 void jit_pp_kernel_t<isa>::advance_binary_postops_off(const size_t offset) {
     if (offset) {
+        const auto off_dimt = static_cast<dim_t>(offset);
         if (any_binary_postop_is_per_oc_bcast_type_)
-            advance_binary_postops_per_oc_off(offset);
+            advance_binary_postops_per_oc_off(off_dimt);
         if (any_binary_postop_is_no_bcast_type_)
             update_binary_postops_per_tensor_off();
         if (any_binary_postop_is_oc_bcast_type_)
-            advance_binary_postops_channel_bcast_off(offset);
+            advance_binary_postops_channel_bcast_off(off_dimt);
     }
 }
 
@@ -513,7 +515,8 @@ void jit_pp_kernel_t<isa>::load_tail(const Vmm v, const arg_t arg_num,
         if (utils::one_of(dt, s8, u8)) {
             const Xbyak::Xmm x = Xbyak::Xmm(v.getIdx());
             for (size_t i = 0; i < tail; i++)
-                uni_vpinsrb(x, x, get_address(arg_num, i + off), i);
+                uni_vpinsrb(x, x, get_address(arg_num, i + off),
+                        static_cast<int>(i));
             if (dt == s8)
                 uni_vpmovsxbd(v, v);
             else
@@ -525,8 +528,8 @@ void jit_pp_kernel_t<isa>::load_tail(const Vmm v, const arg_t arg_num,
             } else {
                 const size_t dt_size = types::data_type_size(f32);
                 for (size_t i = 0; i < tail; i++)
-                    uni_vpinsrd(
-                            v, v, get_address(arg_num, i * dt_size + off), i);
+                    uni_vpinsrd(v, v, get_address(arg_num, i * dt_size + off),
+                            static_cast<int>(i));
             }
         }
     }
@@ -606,8 +609,10 @@ void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Ymm v,
         switch (dt) {
             case s8:
             case u8:
-                for (size_t i = 0; i < tail; i++)
-                    vpextrb(get_address(arg_num, off + i), x, i);
+                for (size_t i = 0; i < tail; i++) {
+                    vpextrb(get_address(arg_num, off + i), x,
+                            static_cast<uint8_t>(i));
+                }
                 break;
             case f32:
             case s32: vmaskmovps(dst, vmm_rem_mask, v); break;
@@ -648,14 +653,17 @@ void jit_pp_kernel_t<isa>::cvt_and_store(const Xbyak::Xmm v,
         switch (dt) {
             case s8:
             case u8:
-                for (size_t i = 0; i < tail; i++)
-                    uni_vpextrb(get_address(arg_num, off + i), v, i);
+                for (size_t i = 0; i < tail; i++) {
+                    uni_vpextrb(get_address(arg_num, off + i), v,
+                            static_cast<int>(i));
+                }
                 break;
             case f32:
             case s32: {
                 const size_t dt_size = types::data_type_size(f32);
                 for (size_t i = 0; i < tail; i++)
-                    uni_vpextrd(get_address(arg_num, off + i * dt_size), v, i);
+                    uni_vpextrd(get_address(arg_num, off + i * dt_size), v,
+                            static_cast<int>(i));
             } break;
             default: assert(!"unimplemented");
         }
@@ -794,11 +802,13 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
     // Advance all pointers by an immediate
     auto advance_ptrs_imm = [&](size_t offset) {
-        add(reg_dst, offset * this->dst_data_type_size_);
-        add(reg_acc, offset * this->acc_data_type_size_);
+        add(reg_dst, static_cast<dim_t>(offset * this->dst_data_type_size_));
+        add(reg_acc, static_cast<dim_t>(offset * this->acc_data_type_size_));
         if (this->do_scale_ && this->scale_idx_mult_ == 1)
-            add(reg_scales, offset * sizeof(float));
-        if (this->do_bias()) add(reg_bias, offset * this->bias_data_type_size_);
+            add(reg_scales, static_cast<dim_t>(offset * sizeof(float)));
+        if (this->do_bias())
+            add(reg_bias,
+                    static_cast<dim_t>(offset * this->bias_data_type_size_));
         if (this->do_binary_ || this->do_prelu_) {
             advance_binary_postops_off(offset);
         }
@@ -806,12 +816,22 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
     // Advance all pointers by a value stored in a register
     auto advance_ptrs_reg = [&](const Reg64 offset) {
-        lea(reg_dst, ptr[reg_dst + offset * this->dst_data_type_size_]);
-        lea(reg_acc, ptr[reg_acc + offset * this->acc_data_type_size_]);
+        lea(reg_dst,
+                ptr[reg_dst
+                        + offset
+                                * static_cast<int>(this->dst_data_type_size_)]);
+        lea(reg_acc,
+                ptr[reg_acc
+                        + offset
+                                * static_cast<int>(this->acc_data_type_size_)]);
         if (this->do_scale_ && this->scale_idx_mult_ == 1)
             lea(reg_scales, ptr[reg_scales + offset * sizeof(float)]);
         if (this->do_bias())
-            lea(reg_bias, ptr[reg_bias + offset * this->bias_data_type_size_]);
+            lea(reg_bias,
+                    ptr[reg_bias
+                            + offset
+                                    * static_cast<int>(
+                                            this->bias_data_type_size_)]);
         if (this->do_binary_ || this->do_prelu_)
             advance_binary_postops_off(offset);
     };
@@ -821,10 +841,14 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
         if (!this->has_trivial_mb_stride()) {
             lea(reg_dst,
                     ptr[reg_dst
-                            + reg_dst_mb_stride * this->dst_data_type_size_]);
+                            + reg_dst_mb_stride
+                                    * static_cast<int>(
+                                            this->dst_data_type_size_)]);
             lea(reg_acc,
                     ptr[reg_acc
-                            + reg_acc_mb_stride * this->acc_data_type_size_]);
+                            + reg_acc_mb_stride
+                                    * static_cast<int>(
+                                            this->acc_data_type_size_)]);
         }
         if ((this->do_binary_ || this->do_prelu_)
                 && any_binary_postop_is_no_bcast_type_)
@@ -836,7 +860,11 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
     auto rewind_ptrs = [&]() {
         neg(reg_oc);
         if (this->do_bias())
-            lea(reg_bias, ptr[reg_bias + reg_oc * this->bias_data_type_size_]);
+            lea(reg_bias,
+                    ptr[reg_bias
+                            + reg_oc
+                                    * static_cast<int>(
+                                            this->bias_data_type_size_)]);
         if (this->do_scale_ && this->scale_idx_mult_ == 1)
             lea(reg_scales, ptr[reg_scales + reg_oc * sizeof(float)]);
 
@@ -846,7 +874,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
     // Process one row of reg_tmp elements
     auto process_runtime_oc = [&]() {
         Label l_loop, l_loop_tail, l_loop_end;
-        cmp(reg_tmp, vlen);
+        cmp(reg_tmp, static_cast<uint32_t>(vlen));
         jl(l_loop_tail, T_NEAR);
 
         L(l_loop);
@@ -854,8 +882,8 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
             compute(0, 0, true);
             advance_ptrs_imm(vlen);
 
-            sub(reg_tmp, vlen);
-            cmp(reg_tmp, vlen);
+            sub(reg_tmp, static_cast<uint32_t>(vlen));
+            cmp(reg_tmp, static_cast<uint32_t>(vlen));
             jge(l_loop, T_NEAR);
         }
 
@@ -941,7 +969,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
             assert(!!OC_loop || !!OC_tail);
 
-            const int vlen_tail = OC_tail % vlen;
+            const int vlen_tail = static_cast<int>(OC_tail % vlen);
             if (vlen_tail) prepare_mask(vlen_tail);
 
             if (OC_loop) {
@@ -950,9 +978,9 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
                 L(l_oc_loop);
                 {
                     for (size_t offset = 0; offset < OC_loop; offset += vlen)
-                        compute(offset, offset / vlen, false);
+                        compute(offset, static_cast<int>(offset / vlen), false);
                     advance_ptrs_imm(OC_loop);
-                    sub(reg_tmp, OC_loop);
+                    sub(reg_tmp, static_cast<dim_t>(OC_loop));
                     jnz(l_oc_loop);
                 }
             }
@@ -960,7 +988,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
             if (OC_tail) {
                 for (size_t offset = 0; offset < OC_tail; offset += vlen) {
                     const bool use_mask = (offset + vlen) > OC_tail;
-                    compute(offset, offset / vlen, false,
+                    compute(offset, static_cast<int>(offset / vlen), false,
                             use_mask ? vlen_tail : 0);
                 }
                 advance_ptrs_imm(OC_tail);
@@ -969,7 +997,8 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
             if (any_binary_postop_is_per_oc_sp_bcast_type_
                     && this->ndims_ <= 3) {
                 static constexpr size_t offset_oc_spatial = 1;
-                advance_binary_postops_per_oc_off(offset_oc_spatial);
+                advance_binary_postops_per_oc_off(
+                        static_cast<dim_t>(offset_oc_spatial));
             }
 
             rewind_ptrs();
@@ -1030,7 +1059,7 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         load_and_cvt(vmm_bias, arg_t::bias, 0, this->OC_, false);
 
         // write repeated MB*OC entries into stack
-        sub(rsp, mb_oc_blk * sizeof(uint32_t));
+        sub(rsp, static_cast<uint32_t>(mb_oc_blk * sizeof(uint32_t)));
         for (size_t i = 0; i < mb_step; ++i)
             cvt_and_store(vmm_bias, arg_t::stack,
                     i * this->OC_ * sizeof(uint32_t), this->OC_);
@@ -1043,13 +1072,15 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         uni_vcvtdq2ps(vmm_bias, vmm_bias);
     L(mb_main_loop);
     {
-        cmp(reg_len, mb_oc_blk);
+        cmp(reg_len, static_cast<uint32_t>(mb_oc_blk));
         jl(end_main_loop, T_NEAR);
 
-        compute(!expl_broadcast ? tail_size : 0);
-        add(reg_dst, mb_oc_blk * this->dst_data_type_size_);
-        add(reg_acc, mb_oc_blk * this->acc_data_type_size_);
-        sub(reg_len, mb_oc_blk);
+        compute(static_cast<int>(!expl_broadcast ? tail_size : 0));
+        add(reg_dst,
+                static_cast<uint32_t>(mb_oc_blk * this->dst_data_type_size_));
+        add(reg_acc,
+                static_cast<uint32_t>(mb_oc_blk * this->acc_data_type_size_));
+        sub(reg_len, static_cast<uint32_t>(mb_oc_blk));
         jmp(mb_main_loop, T_NEAR);
     }
     L(end_main_loop);
@@ -1060,12 +1091,16 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         if (tail_size) prepare_mask(tail_size);
         L(mb_tail_loop);
         {
-            cmp(reg_len, tail_size);
+            cmp(reg_len, static_cast<uint32_t>(tail_size));
             jl(runtime_tail, T_NEAR);
-            compute(tail_size);
-            add(reg_dst, tail_size * this->dst_data_type_size_);
-            add(reg_acc, tail_size * this->acc_data_type_size_);
-            sub(reg_len, tail_size);
+            compute(static_cast<int>(tail_size));
+            add(reg_dst,
+                    static_cast<uint32_t>(
+                            tail_size * this->dst_data_type_size_));
+            add(reg_acc,
+                    static_cast<uint32_t>(
+                            tail_size * this->acc_data_type_size_));
+            sub(reg_len, static_cast<uint32_t>(tail_size));
             jmp(mb_tail_loop, T_NEAR);
         }
         // Load tail in runtime if len < mb_tail * oc
@@ -1080,12 +1115,13 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
                 sub(reg_rem_mask, 1);
                 kmovq(kreg_rem_mask, reg_rem_mask);
             }
-            compute(tail_size, !is_avx512_);
+            compute(static_cast<int>(tail_size), !is_avx512_);
         }
         L(end_runtime_tail);
     }
 
-    if (!expl_broadcast) add(rsp, mb_oc_blk * sizeof(uint32_t));
+    if (!expl_broadcast)
+        add(rsp, static_cast<uint32_t>(mb_oc_blk * sizeof(uint32_t)));
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -14,7 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <cstdlib>
 #include <functional>
 
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
@@ -50,9 +49,9 @@ struct jit_pp_ker_t : pp_ker_t, public jit_generator_t {
 
 private:
     void apply_postops(
-            const Xbyak::Reg64 &reg_dst, const int idx, const size_t offset);
+            const Xbyak::Reg64 &reg_dst, const int idx, const dim_t offset);
     void generate() override;
-    void append_zp_src_comp(size_t offset, int idx, bool apply_mask);
+    void append_zp_src_comp(dim_t offset, int idx, bool apply_mask);
     void load_as_f32(const Xbyak::Zmm &dst, const Xbyak::Opmask &mask,
             const Xbyak::Address &src_addr, const data_type_t &src_dt);
 
@@ -74,14 +73,14 @@ private:
         float dst_scale;
         float sum_scale;
         float signed_scale;
-        size_t len;
-        size_t oc_offset;
+        dim_t len;
+        dim_t oc_offset;
         const int32_t *zp_src;
         const int32_t *zp_dst;
         const int32_t *zp_src_comp;
         const int32_t *zp_src_pad_comp;
-        size_t g_oc_offset_prologue;
-        size_t g_oc_offset;
+        dim_t g_oc_offset_prologue;
+        dim_t g_oc_offset;
         const void *post_ops_binary_rhs_arg_vec;
         const void *dst_orig;
         dim_t h;
@@ -95,9 +94,9 @@ private:
     std::unique_ptr<injector::jit_uni_postops_injector_t<avx512_core>>
             postops_injector_;
 
-    size_t number_of_reserved_zmm_regs_;
-    const size_t bias_data_type_size_;
-    const size_t dst_data_type_size_;
+    int number_of_reserved_zmm_regs_;
+    const dim_t bias_data_type_size_;
+    const dim_t dst_data_type_size_;
     const bool saturation_needed_;
 
     const Xbyak::Reg64 &reg_param_ = rdi;
@@ -130,11 +129,11 @@ private:
     const Xbyak::Opmask &kreg_rem_mask_short_ = k3;
     const Xbyak::Opmask &kreg_rem_mask_vlen_ = k4;
 
-    static constexpr size_t def_unroll_ = 4u;
-    size_t zmm_step_;
-    const size_t bias_step_factor_;
-    const size_t sum_step_factor_;
-    const size_t max_unroll_;
+    static constexpr int def_unroll_ = 4;
+    int zmm_step_;
+    const int bias_step_factor_;
+    const int sum_step_factor_;
+    const int max_unroll_;
 
     std::unique_ptr<jit_gemm_x8s8s32x_zp_pad_comp_helper_t> zp_pad_comp_helper_;
 };
@@ -214,27 +213,30 @@ void jit_pp_ker_t::operator()(void *void_dst, const acc_data_t *acc,
 
     char *dst = (char *)void_dst;
 
+    const dim_t start_dim = static_cast<dim_t>(start);
+    const dim_t end_dim = static_cast<dim_t>(end);
     ker_args_t args;
-    const auto dv = std::div(start, jcp_.oc);
-    const size_t oc_offset = dv.rem;
-    const size_t os_offset = dv.quot;
-    args.acc = acc + start;
+    const dim_t oc_offset = start_dim % jcp_.oc;
+    const dim_t os_offset = start_dim / jcp_.oc;
+    const dim_t dst_os_stride = jcp_.dst_os_stride;
+    const dim_t scale_idx_mult = jcp_.scale_idx_mult;
+    args.acc = acc + start_dim;
     args.dst = dst
-            + (os_offset * jcp_.dst_os_stride + oc_offset)
+            + (os_offset * dst_os_stride + oc_offset)
                     * dst_data_type_size_;
 
-    const ptrdiff_t g_oc_offset = g * jcp_.oc;
-    const ptrdiff_t g_oc_offset_prologue = g_oc_offset + oc_offset;
+    const dim_t g_oc_offset = g * jcp_.oc;
+    const dim_t g_oc_offset_prologue = g_oc_offset + oc_offset;
     args.bias = bias + g_oc_offset_prologue * bias_data_type_size_;
     args.zp_src = zp.src + (jcp_.zp.src_is_common ? 0 : g_oc_offset_prologue);
     args.zp_src_comp
             = zp.src_comp ? zp.src_comp + g_oc_offset_prologue : nullptr;
     args.zp_dst = zp.dst;
-    args.scales = scales + jcp_.scale_idx_mult * g_oc_offset_prologue;
+    args.scales = scales + scale_idx_mult * g_oc_offset_prologue;
     args.dst_scale = dst_scale;
     args.sum_scale = sum_scale;
     args.signed_scale = signed_scale;
-    args.len = end - start;
+    args.len = end_dim - start_dim;
     args.oc_offset = oc_offset;
 
     args.g_oc_offset = g_oc_offset;
@@ -244,10 +246,8 @@ void jit_pp_ker_t::operator()(void *void_dst, const acc_data_t *acc,
     args.dst_orig = dst_orig;
 
     if (zp_pad_comp_helper_) {
-        const auto hw
-                = std::div(static_cast<dim_t>(os_offset), chunk_desc.w_size_);
-        args.h = hw.quot + chunk_desc.h_off_;
-        args.w = hw.rem + chunk_desc.w_off_;
+        args.h = os_offset / chunk_desc.w_size_ + chunk_desc.h_off_;
+        args.w = os_offset % chunk_desc.w_size_ + chunk_desc.w_off_;
         args.w_size = chunk_desc.w_size_ + chunk_desc.w_off_;
         args.w_off = chunk_desc.w_off_;
         args.zp_src_pad_comp = zp.src_pad_comp;
@@ -282,7 +282,8 @@ Xbyak::Zmm jit_pp_ker_t::get_vreg_prev_dst(int idx) const {
     return Xbyak::Zmm(vreg_dst_idx(idx) + sum_step_factor_);
 }
 
-Xbyak::Zmm jit_pp_ker_t::get_masked_vreg_dst(int idx, bool apply_mask) const {
+Xbyak::Zmm jit_pp_ker_t::get_masked_vreg_dst(
+        int idx, bool apply_mask) const {
     auto vreg_dst = this->get_vreg_dst(idx);
     if (apply_mask)
         vreg_dst = vreg_dst | kreg_rem_mask_short_;
@@ -291,10 +292,12 @@ Xbyak::Zmm jit_pp_ker_t::get_masked_vreg_dst(int idx, bool apply_mask) const {
     return vreg_dst;
 }
 
-void jit_pp_ker_t::append_zp_src_comp(size_t offset, int idx, bool apply_mask) {
+void jit_pp_ker_t::append_zp_src_comp(
+        dim_t offset, int idx, bool apply_mask) {
     const auto vreg_dst_masked = get_masked_vreg_dst(idx, apply_mask);
     const auto vreg_dst = get_vreg_dst(idx);
-    const auto zp_src_comp_offset = offset * sizeof(int32_t);
+    const dim_t zp_src_comp_offset
+            = offset * static_cast<dim_t>(sizeof(int32_t));
     const auto zp_src_comp_addr = ptr[reg_zp_src_comp_ + zp_src_comp_offset];
 
     vpaddd(vreg_dst_masked, vreg_dst, zp_src_comp_addr);
@@ -308,7 +311,7 @@ void jit_pp_ker_t::append_zp_src_comp(size_t offset, int idx, bool apply_mask) {
 }
 
 void jit_pp_ker_t::apply_postops(
-        const Xbyak::Reg64 &reg_dst, const int idx, const size_t offset) {
+        const Xbyak::Reg64 &reg_dst, const int idx, const dim_t offset) {
 #define PARAM_OFF(x) offsetof(ker_args_t, x)
     if (jcp_.with_eltwise || jcp_.with_binary) {
         if (jcp_.with_binary) {
@@ -317,7 +320,7 @@ void jit_pp_ker_t::apply_postops(
 
             rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_dst);
             rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(vmm_idx,
-                    offset * types::data_type_size(jcp_.dst_data_type));
+                    offset * dst_data_type_size_);
             rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
 
             postops_injector_->compute_vector(
@@ -350,8 +353,10 @@ void jit_pp_ker_t::generate() {
     using namespace Xbyak;
     using namespace utils;
 
-    size_t vlen = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
+    dim_t vlen = cpu_isa_traits_t<avx512_core>::vlen
+            / static_cast<dim_t>(sizeof(float));
     for (; vlen >= 1 && (jcp_.oc % vlen != 0); --vlen) {}
+    const dim_t dst_os_stride = jcp_.dst_os_stride;
 
     preamble();
 
@@ -393,7 +398,9 @@ void jit_pp_ker_t::generate() {
 #undef PARAM_OFF
 
     mov(reg_rem_mask_vlen_, 1);
-    shl(reg_rem_mask_vlen_, vlen);
+    // vlen is a SIMD-width-bounded shift count (<= 16 elements), so this
+    // narrowing is provably safe regardless of vlen's declared (dim_t) type.
+    shl(reg_rem_mask_vlen_, static_cast<int>(vlen));
     sub(reg_rem_mask_vlen_, 1);
     kmovq(kreg_rem_mask_vlen_, reg_rem_mask_vlen_);
 
@@ -405,15 +412,17 @@ void jit_pp_ker_t::generate() {
     // Load accumulated value, convert to float, apply sum (if any),
     // bias (if any), scaling, and relu (if any);
     // then convert to destination type and store
-    const auto compute = [&](size_t offset, int idx, bool apply_mask) {
-        auto acc_addr = ptr[reg_acc_ + offset * sizeof(acc_data_t)];
+    const auto compute = [&](dim_t offset, int idx, bool apply_mask) {
+        auto acc_addr = ptr[reg_acc_
+                + offset * static_cast<dim_t>(sizeof(acc_data_t))];
 
         const auto &mask_reg
                 = apply_mask ? kreg_rem_mask_short_ : kreg_rem_mask_vlen_;
 
         if (jcp_.scale_idx_mult > 0) {
             assert(jcp_.scale_idx_mult == 1);
-            const auto scale_addr = ptr[reg_scales_ + offset * sizeof(float)];
+            const auto scale_addr = ptr[reg_scales_
+                    + offset * static_cast<dim_t>(sizeof(float))];
             auto vreg_scale = vreg_scale_;
             vreg_scale = vreg_scale | mask_reg;
             vmovups(vreg_scale, scale_addr);
@@ -478,21 +487,22 @@ void jit_pp_ker_t::generate() {
 
     // Advance all pointers by an immediate
     const auto advance_ptrs_imm
-            = [&](const size_t offset, const size_t binary_offset) {
+            = [&](const dim_t offset, const dim_t binary_offset) {
         add(reg_dst_, offset * dst_data_type_size_);
-        add(reg_acc_, offset * sizeof(acc_data_t));
+        add(reg_acc_, offset * static_cast<dim_t>(sizeof(acc_data_t)));
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            add(reg_scales_, offset * sizeof(float));
+            add(reg_scales_, offset * static_cast<dim_t>(sizeof(float)));
         }
         if (jcp_.with_bias) add(reg_bias_, offset * bias_data_type_size_);
         if (jcp_.zp.src_exists) {
-            add(reg_zp_src_comp_, offset * sizeof(int32_t));
+            add(reg_zp_src_comp_, offset * static_cast<dim_t>(sizeof(int32_t)));
 
             if (zp_pad_comp_helper_) {
                 zp_pad_comp_helper_->zp_src_comp_pad_operation(
                         [&](const Xbyak::Reg64 &reg_zp_pad_comp) {
-                    add(reg_zp_pad_comp, offset * sizeof(int32_t));
+                    add(reg_zp_pad_comp,
+                            offset * static_cast<dim_t>(sizeof(int32_t)));
                 });
             }
         }
@@ -501,24 +511,35 @@ void jit_pp_ker_t::generate() {
     // Advance all pointers by a value stored in a register
     const auto advance_ptrs_reg
             = [&](const Reg64 offset, const Reg64 binary_offset) {
-        lea(reg_dst_, ptr[reg_dst_ + offset * dst_data_type_size_]);
-        lea(reg_acc_, ptr[reg_acc_ + offset * sizeof(acc_data_t)]);
+        lea(reg_dst_,
+                ptr[reg_dst_
+                        + offset * static_cast<int>(dst_data_type_size_)]);
+        lea(reg_acc_,
+                ptr[reg_acc_
+                        + offset * static_cast<int>(sizeof(acc_data_t))]);
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            lea(reg_scales_, ptr[reg_scales_ + offset * sizeof(float)]);
+            lea(reg_scales_,
+                    ptr[reg_scales_
+                            + offset * static_cast<int>(sizeof(float))]);
         }
         if (jcp_.with_bias)
-            lea(reg_bias_, ptr[reg_bias_ + offset * bias_data_type_size_]);
+            lea(reg_bias_,
+                    ptr[reg_bias_
+                            + offset * static_cast<int>(bias_data_type_size_)]);
 
         if (jcp_.zp.src_exists) {
             lea(reg_zp_src_comp_,
-                    ptr[reg_zp_src_comp_ + offset * sizeof(int32_t)]);
+                    ptr[reg_zp_src_comp_
+                            + offset * static_cast<int>(sizeof(int32_t))]);
 
             if (zp_pad_comp_helper_)
                 zp_pad_comp_helper_->zp_src_comp_pad_operation(
                         [&](const Xbyak::Reg64 &reg_zp_pad_comp) {
                     lea(reg_zp_pad_comp,
-                            ptr[reg_zp_pad_comp + offset * sizeof(int32_t)]);
+                            ptr[reg_zp_pad_comp
+                                    + offset * static_cast<int>(
+                                            sizeof(int32_t))]);
                 });
         }
     };
@@ -528,16 +549,16 @@ void jit_pp_ker_t::generate() {
     const auto rewind_ptrs = [&]() {
         if (jcp_.with_bias) sub(reg_bias_, jcp_.oc * bias_data_type_size_);
         if (jcp_.zp.src_exists) {
-            const auto offset = jcp_.oc * sizeof(int32_t);
+            const dim_t offset = jcp_.oc * static_cast<dim_t>(sizeof(int32_t));
             sub(reg_zp_src_comp_, offset);
             if (zp_pad_comp_helper_)
                 zp_pad_comp_helper_->load_next_point_zp_src_comp_pad_addr();
         }
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            sub(reg_scales_, jcp_.oc * sizeof(float));
+            sub(reg_scales_, jcp_.oc * static_cast<dim_t>(sizeof(float)));
         }
-        add(reg_dst_, (jcp_.dst_os_stride - jcp_.oc) * dst_data_type_size_);
+        add(reg_dst_, (dst_os_stride - jcp_.oc) * dst_data_type_size_);
     };
 
     //                    <--------- OC --------------->
@@ -601,8 +622,8 @@ void jit_pp_ker_t::generate() {
         Label main_loop;
         L(main_loop);
         {
-            size_t OC_loop, OC_tail;
-            if (static_cast<size_t>(jcp_.oc) < max_unroll_ * vlen) {
+            dim_t OC_loop, OC_tail;
+            if (jcp_.oc < max_unroll_ * vlen) {
                 // Fully unroll small loops
                 OC_loop = 0;
                 OC_tail = jcp_.oc;
@@ -613,9 +634,10 @@ void jit_pp_ker_t::generate() {
 
             assert(!!OC_loop || !!OC_tail);
 
-            const int vlen_tail = OC_tail % vlen;
+            const dim_t vlen_tail = OC_tail % vlen;
             if (vlen_tail) {
-                unsigned tail_mask = (1 << vlen_tail) - 1;
+                const uint32_t tail_mask
+                        = (uint32_t(1) << vlen_tail) - 1;
                 mov(reg_tmp_, tail_mask);
                 kmovq(kreg_rem_mask_short_, reg_tmp_);
             }
@@ -625,8 +647,8 @@ void jit_pp_ker_t::generate() {
                 Label oc_loop;
                 L(oc_loop);
                 {
-                    for (size_t offset = 0; offset < OC_loop; offset += vlen)
-                        compute(offset, offset / vlen, false);
+                    for (dim_t offset = 0; offset < OC_loop; offset += vlen)
+                        compute(offset, static_cast<int>(offset / vlen), false);
                     advance_ptrs_imm(OC_loop, vlen);
                     sub(reg_tmp_, OC_loop);
                     jnz(oc_loop);
@@ -634,12 +656,12 @@ void jit_pp_ker_t::generate() {
             }
 
             if (OC_tail) {
-                for (size_t offset = 0; offset < OC_tail; offset += vlen) {
+                for (dim_t offset = 0; offset < OC_tail; offset += vlen) {
                     bool use_mask = (offset + vlen) > OC_tail;
-                    compute(offset, offset / vlen, use_mask);
+                    compute(offset, static_cast<int>(offset / vlen), use_mask);
                 }
-                const size_t oc_tail_rem = OC_tail % vlen;
-                const size_t binary_offset = oc_tail_rem ? oc_tail_rem : vlen;
+                const dim_t oc_tail_rem = OC_tail % vlen;
+                const dim_t binary_offset = oc_tail_rem ? oc_tail_rem : vlen;
                 advance_ptrs_imm(OC_tail, binary_offset);
             }
 

--- a/src/cpu/x64/jit_generator.cpp
+++ b/src/cpu/x64/jit_generator.cpp
@@ -85,7 +85,8 @@ void jit_generator_t::transpose(const Xbyak::Reg64 &reg_src,
             // Load the remaining xf16 values one by one.
             for (int i = 0; i < rem; i++) {
                 vpinsrw(xmm_tmp, xmm_tmp,
-                        ptr[reg_src + r * src_stride + (c + i) * dt_size], i);
+                        ptr[reg_src + r * src_stride + (c + i) * dt_size],
+                        static_cast<uint8_t>(i));
             }
         }
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -251,6 +251,14 @@ public:
                 op, static_cast<uint32_t>(static_cast<int32_t>(imm)));
     }
 
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void imul(const Xbyak::Reg64 &dst, const Xbyak::Operand &src, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::imul(dst, src, static_cast<int>(imm));
+    }
+
     static int xbyak_register_index(dim_t index) {
         // The fallback is returned only after XByak records the error.
         JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
@@ -2288,7 +2296,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Address &src_addr,
-            int load_size, const bool zero_vmm = true) {
+            dim_t load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2307,7 +2315,7 @@ public:
 
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            int load_size, const bool zero_vmm = true) {
+            dim_t load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2328,8 +2336,8 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void helper_load_bytes(const Vmm &vmm, int load_size, const AddrFunc &addr,
-            const bool zero_vmm = true) {
+    void helper_load_bytes(const Vmm &vmm, dim_t load_size,
+            const AddrFunc &addr, const bool zero_vmm = true) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2361,8 +2369,8 @@ private:
         // use clean execution sequence
         if (zero_vmm) uni_vpxor(vmm, vmm, vmm);
 
-        int start_bytes = 0;
-        int bytes_to_load = load_size;
+        dim_t start_bytes = 0;
+        dim_t bytes_to_load = load_size;
 
         if (load_size > 16) {
             // Prepare to insert to upper bits of ymm
@@ -2459,7 +2467,7 @@ public:
 
     template <typename Vmm>
     void store_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            int store_size) {
+            dim_t store_size) {
 
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2473,7 +2481,7 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void store_bytes(const Vmm &vmm, int store_size, const AddrFunc &addr) {
+    void store_bytes(const Vmm &vmm, dim_t store_size, const AddrFunc &addr) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2503,8 +2511,8 @@ private:
             return;
         }
 
-        int start_bytes = 0;
-        int bytes_to_store = store_size;
+        dim_t start_bytes = 0;
+        dim_t bytes_to_store = store_size;
 
         if (store_size > 16) {
             vmovdqu(addr(0), xmm); // load lower bits from ymm
@@ -2587,7 +2595,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, bool is_signed, int load_size,
+            int64_t offset, bool is_signed, dim_t load_size,
             const bool zero_vmm) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2597,7 +2605,7 @@ public:
 
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm,
-            const Xbyak::Address &src_addr, bool is_signed, int load_size,
+            const Xbyak::Address &src_addr, bool is_signed, dim_t load_size,
             const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
@@ -2657,7 +2665,7 @@ public:
      */
     template <typename Vmm>
     void store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
         using supported_vmm_t = typename utils::conditional<is_vmm_supported,
@@ -2674,7 +2682,7 @@ public:
 private:
     template <typename Vmm>
     void helper_store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
 
         assert(is_valid_isa(sse41)
                 && "routine is not supported for the current isa");
@@ -2734,7 +2742,7 @@ public:
      */
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, int load_size, const bool zero_vmm = true) {
+            int64_t offset, dim_t load_size, const bool zero_vmm = true) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
         load_data(type_in, vmm, ptr[reg + offset], load_size, zero_vmm);
@@ -2742,7 +2750,7 @@ public:
 
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm,
-            const Xbyak::Address &src_addr, int load_size,
+            const Xbyak::Address &src_addr, dim_t load_size,
             const bool zero_vmm = true) {
 
         assert(is_valid_isa(sse41)

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -19,6 +19,7 @@
 
 #include <limits.h>
 #include <vector>
+#include <type_traits>
 
 #include "common/bit_cast.hpp"
 #include "common/compiler_workarounds.hpp"
@@ -75,6 +76,11 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
+// Required so XBYAK_THROW's unqualified 'Error' resolves in this namespace.
+#ifndef XBYAK_NO_EXCEPTION
+using Xbyak::Error;
+#endif
+
 // TODO: move this to jit_generator_t class?
 namespace {
 
@@ -84,12 +90,19 @@ inline int float2int(float x) {
     return utils::bit_cast<int>(x);
 }
 
-inline void tc_configure_tile(palette_config_t *tc, int t, int rows, int cols) {
-    const bool rows_ok = (size_t)t < sizeof(tc->rows) / sizeof(tc->rows[0]);
-    const bool cols_ok = (size_t)t < sizeof(tc->cols) / sizeof(tc->cols[0]);
-    if (rows_ok && cols_ok) {
-        tc->rows[t] = rows;
-        tc->cols[t] = cols;
+inline void tc_configure_tile(
+        palette_config_t *tc, dim_t t, dim_t rows, dim_t cols) {
+    // AMX tile config is a fixed hardware register layout (tile index
+    // bounded by palette_config_t::max_size, uint8_t rows, uint16_t cols)
+    // - narrowing here is unavoidable, so it's consolidated in this single
+    // boundary helper with bounds checks, rather than scattered across
+    // call sites.
+    const bool idx_ok = t >= 0 && t < palette_config_t::max_size;
+    const bool rows_ok = rows >= 0 && rows <= UINT8_MAX;
+    const bool cols_ok = cols >= 0 && cols <= UINT16_MAX;
+    if (idx_ok && rows_ok && cols_ok) {
+        tc->rows[t] = static_cast<uint8_t>(rows);
+        tc->cols[t] = static_cast<uint16_t>(cols);
     } else {
         assert(!"out of range");
     }
@@ -165,13 +178,13 @@ public:
     using c_compatible::operator delete[];
 
 private:
-    const size_t xmm_len = 16;
+    const dim_t xmm_len = 16;
 #ifdef _WIN32
-    const size_t xmm_to_preserve_start = 6;
-    const size_t xmm_to_preserve = 10;
+    const dim_t xmm_to_preserve_start = 6;
+    const dim_t xmm_to_preserve = 10;
 #else
-    const size_t xmm_to_preserve_start = 0;
-    const size_t xmm_to_preserve = 0;
+    const dim_t xmm_to_preserve_start = 0;
+    const dim_t xmm_to_preserve = 0;
 #endif
 
     const size_t num_abi_save_gpr_regs
@@ -194,6 +207,62 @@ public:
         _op_mxcsr = 4u,
     };
 
+    using Xbyak::CodeGenerator::add;
+    using Xbyak::CodeGenerator::cmp;
+    using Xbyak::CodeGenerator::imul;
+    using Xbyak::CodeGenerator::sub;
+
+    // These are the dim_t immediate forms used by brgemm. x86 accepts at
+    // most a 32-bit immediate. Offsets and shifts are non-negative; cmp also
+    // supports the verified negative-vpad case.
+    // TODO: Use a scratch register or rebase a pointer for values > INT_MAX.
+    // Note: the enable_if constrains this to T == dim_t exactly, so int/
+    // uint32_t call sites keep resolving to the native Xbyak overloads above
+    // instead of becoming ambiguous with these dim_t ones.
+    // Keep these overloads limited to add/sub/cmp/imul, the Xbyak calls that
+    // genuinely receive a potentially large tensor-scale offset or stride
+    // (imul is used to scale a runtime stride into a byte offset). Small,
+    // fixed-range immediates (8-bit lane/blend/shift/predicate values) must
+    // stay `int`/`uint8_t` at their creation site instead of gaining a
+    // dim_t overload here.
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void add(const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::add(op, static_cast<uint32_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void sub(const Xbyak::Operand &op, T imm) {
+        JIT_ASSERT(imm >= 0 && imm <= INT_MAX);
+        Xbyak::CodeGenerator::sub(op, static_cast<uint32_t>(imm));
+    }
+
+    template <typename T,
+            typename std::enable_if<std::is_same<T, dim_t>::value, int>::type
+            = 0>
+    void cmp(const Xbyak::Operand &op, T imm) {
+        // Negative virtual padding is compared by brgemm kernels.
+        JIT_ASSERT(imm >= INT_MIN && imm <= INT_MAX);
+        Xbyak::CodeGenerator::cmp(
+                op, static_cast<uint32_t>(static_cast<int32_t>(imm)));
+    }
+
+    static int xbyak_register_index(dim_t index) {
+        // The fallback is returned only after XByak records the error.
+        JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
+        return static_cast<int>(index);
+    }
+
+    static int xbyak_address_scale(dim_t scale) {
+        // The fallback is returned only after XByak records the error.
+        JIT_ASSERT_RET(utils::one_of(scale, 1, 2, 4, 8), 0);
+        return static_cast<int>(scale);
+    }
+
     Xbyak::Reg64 param1 = abi_param1;
     const int EVEX_max_8b_offt = 0x200;
     const Xbyak::Reg64 reg_EVEX_max_8b_offt = rbp;
@@ -214,9 +283,10 @@ public:
     void preamble() {
         if (xmm_to_preserve) {
             sub(rsp, xmm_to_preserve * xmm_len);
-            for (size_t i = 0; i < xmm_to_preserve; ++i)
+            for (dim_t i = 0; i < xmm_to_preserve; ++i)
                 uni_vmovdqu(ptr[rsp + i * xmm_len],
-                        Xbyak::Xmm(xmm_to_preserve_start + i));
+                        Xbyak::Xmm(xbyak_register_index(
+                                xmm_to_preserve_start + i)));
         }
         for (size_t i = 0; i < num_abi_save_gpr_regs; ++i) {
             push(Xbyak::Reg64(abi_save_gpr_regs[i]));
@@ -260,7 +330,7 @@ public:
     // Note: that we cannot use RBP inside as we override it in preamble
     // for address computation in EVEX instructions
     inline Xbyak::RegExp get_stack_params_address(bool after_prolog = true) {
-        int saved_regs_size = after_prolog ? get_size_of_abi_save_regs() : 0;
+        size_t saved_regs_size = after_prolog ? get_size_of_abi_save_regs() : 0;
 #ifdef _WIN32
         // Using stack layout described in MS ABI
         // (https://docs.microsoft.com/en-us/cpp/build/stack-usage?view=vs-2019)
@@ -290,8 +360,9 @@ public:
         for (size_t i = 0; i < num_abi_save_gpr_regs; ++i)
             pop(Xbyak::Reg64(abi_save_gpr_regs[num_abi_save_gpr_regs - 1 - i]));
         if (xmm_to_preserve) {
-            for (size_t i = 0; i < xmm_to_preserve; ++i)
-                uni_vmovdqu(Xbyak::Xmm(xmm_to_preserve_start + i),
+            for (dim_t i = 0; i < xmm_to_preserve; ++i)
+                uni_vmovdqu(Xbyak::Xmm(xbyak_register_index(
+                                    xmm_to_preserve_start + i)),
                         ptr[rsp + i * xmm_len]);
             add(rsp, xmm_to_preserve * xmm_len);
         }
@@ -309,7 +380,7 @@ public:
         using Xbyak::RegExp;
         using Xbyak::Zmm;
 
-        assert(raw_offt <= INT_MAX);
+        JIT_ASSERT_RET(raw_offt <= INT_MAX, ptr[RegExp() + base]);
         auto offt = static_cast<int>(raw_offt);
         int scale = 0;
 
@@ -370,7 +441,7 @@ public:
         }
     }
 
-    void safe_add(const Xbyak::Reg64 &base, size_t raw_offt,
+    void safe_add(const Xbyak::Reg64 &base, dim_t raw_offt,
             const Xbyak::Reg64 &reg_offt) {
         if (raw_offt > INT_MAX) {
             mov(reg_offt, raw_offt);
@@ -380,7 +451,7 @@ public:
         }
     }
 
-    void safe_sub(const Xbyak::Reg64 &base, size_t raw_offt,
+    void safe_sub(const Xbyak::Reg64 &base, dim_t raw_offt,
             const Xbyak::Reg64 &reg_offt) {
         if (raw_offt > INT_MAX) {
             mov(reg_offt, raw_offt);
@@ -2226,7 +2297,7 @@ public:
             return;
         }
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[src_addr.getRegExp()
                     + Xbyak::RegExp(bytes_offset * sizeof(int8_t))];
         };
@@ -2248,7 +2319,7 @@ public:
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[reg + offset + bytes_offset * sizeof(int8_t)];
         };
 
@@ -2379,7 +2450,7 @@ public:
     template <typename Vmm>
     void store_bytes(
             const Vmm &vmm, const Xbyak::Address &dst_addr, int store_size) {
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[dst_addr.getRegExp()
                     + Xbyak::RegExp(bytes_offset * sizeof(int8_t))];
         };
@@ -2393,7 +2464,7 @@ public:
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
 
-        const auto addr = [&](int bytes_offset) {
+        const auto addr = [&](dim_t bytes_offset) {
             return ptr[reg + offset + bytes_offset * sizeof(int8_t)];
         };
 
@@ -2737,7 +2808,7 @@ public:
         jmp(label_tbl_end, T_NEAR);
         for (size_t i = 1; i < simd_w; i++) {
             L(l_case[i]);
-            tail_process(i);
+            tail_process(static_cast<int>(i));
             jmp(label_tbl_end, T_NEAR);
         }
         L(label_tbl_end);

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -260,8 +260,12 @@ public:
     }
 
     static int xbyak_register_index(dim_t index) {
-        // The fallback is returned only after XByak records the error.
-        JIT_ASSERT_RET(index >= 0 && index <= INT_MAX, 0);
+        // The fallback is returned only after XByak records the error,
+        // INT_MIN is used, because some primitives(e.g. pooling)
+        // are creating registers with invlid index, but never uses it,
+        // currently those objects are gracefully die without assertion.
+        // TODO: refactor pooling primitive in order to follow the contract.
+        JIT_ASSERT_RET(index >= INT_MIN && index <= INT_MAX, 0);
         return static_cast<int>(index);
     }
 
@@ -1522,7 +1526,7 @@ public:
     void uni_vpslld(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpslld(x, op, imm);
+            vpslld(x, op, static_cast<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) movdqa(x, op);
             pslld(x, imm);
@@ -1530,13 +1534,13 @@ public:
     }
     void uni_vpslld(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpslld(x, op, imm);
+        vpslld(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpsrld(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpsrld(x, op, imm);
+            vpsrld(x, op, static_cast<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) uni_vmovups(x, op);
             psrld(x, imm);
@@ -1544,7 +1548,7 @@ public:
     }
     void uni_vpsrld(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpsrld(x, op, imm);
+        vpsrld(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vmaxps(const Xbyak::Xmm &x, const Xbyak::Operand &op1,
@@ -1620,15 +1624,15 @@ public:
     void uni_vcmpps(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, int cmp_predicate) {
         if (is_valid_isa(avx))
-            vcmpps(x1, x2, op, cmp_predicate);
+            vcmpps(x1, x2, op, static_cast<uint8_t>(cmp_predicate));
         else {
             if (x1.getIdx() != x2.getIdx()) uni_vmovups(x1, x2);
-            cmpps(x1, op, cmp_predicate);
+            cmpps(x1, op, static_cast<uint8_t>(cmp_predicate));
         }
     }
     void uni_vcmpps(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, int cmp_predicate) {
-        vcmpps(x1, x2, op, cmp_predicate);
+        vcmpps(x1, x2, op, static_cast<uint8_t>(cmp_predicate));
     }
 
     void uni_vtestps(const Xbyak::Xmm &x1, const Xbyak::Operand &op) {
@@ -1672,7 +1676,7 @@ public:
             const Xbyak::Operand &op, const int imm) {
         assert(!x1.isZMM() && !x2.isZMM());
         if (is_valid_isa(avx))
-            vblendps(x1, x2, op, imm);
+            vblendps(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (!x1.isEqualIfNotInherited(x2)) movups(x1, x2);
             blendps(x1, op, imm);
@@ -1684,9 +1688,9 @@ public:
         if (is_valid_isa(avx512_core))
             vrndscaleps(x, op, imm & 0x3);
         else if (is_valid_isa(avx))
-            vroundps(x, op, imm);
+            vroundps(x, op, static_cast<uint8_t>(imm));
         else
-            roundps(x, op, imm);
+            roundps(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vroundps(
@@ -1694,7 +1698,7 @@ public:
         if (is_valid_isa(avx512_core))
             vrndscaleps(x, op, imm & 0x3);
         else
-            vroundps(x, op, imm);
+            vroundps(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vroundps(
@@ -1854,50 +1858,50 @@ public:
     void uni_vpinsrb(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrb(x1, x2, op, imm);
+            vpinsrb(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrb(x1, op, imm);
+            pinsrb(x1, op, static_cast<uint8_t>(imm));
         }
     }
 
     void uni_vpinsrb(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrb(x1, x2, op, imm);
+        vpinsrb(x1, x2, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpinsrd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrd(x1, x2, op, imm);
+            vpinsrd(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrd(x1, op, imm);
+            pinsrd(x1, op, static_cast<uint8_t>(imm));
         }
     }
     void uni_vpinsrd(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrd(x1, x2, op, imm);
+        vpinsrd(x1, x2, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpinsrq(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrq(x1, x2, op, imm);
+            vpinsrq(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
-            pinsrq(x1, op, imm);
+            pinsrq(x1, op, static_cast<uint8_t>(imm));
         }
     }
     void uni_vpinsrq(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrq(x1, x2, op, imm);
+        vpinsrq(x1, x2, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpinsrw(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
             const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpinsrw(x1, x2, op, imm);
+            vpinsrw(x1, x2, op, static_cast<uint8_t>(imm));
         else {
             if (x1.getIdx() != x2.getIdx()) movdqa(x1, x2);
             pinsrw(x1, op, imm);
@@ -1905,56 +1909,56 @@ public:
     }
     void uni_vpinsrw(const Xbyak::Ymm &x1, const Xbyak::Ymm &x2,
             const Xbyak::Operand &op, const int imm) {
-        vpinsrw(x1, x2, op, imm);
+        vpinsrw(x1, x2, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrb(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrb(op, x, imm);
+            vpextrb(op, x, static_cast<uint8_t>(imm));
         else
-            pextrb(op, x, imm);
+            pextrb(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrb(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrb(op, x, imm);
+        vpextrb(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrw(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrw(op, x, imm);
+            vpextrw(op, x, static_cast<uint8_t>(imm));
         else
-            pextrw(op, x, imm);
+            pextrw(op, x, static_cast<uint8_t>(imm));
     }
     void uni_vpextrw(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrw(op, x, imm);
+        vpextrw(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrd(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrd(op, x, imm);
+            vpextrd(op, x, static_cast<uint8_t>(imm));
         else
-            pextrd(op, x, imm);
+            pextrd(op, x, static_cast<uint8_t>(imm));
     }
     void uni_vpextrd(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrd(op, x, imm);
+        vpextrd(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpextrq(
             const Xbyak::Operand &op, const Xbyak::Xmm &x, const int imm) {
         if (is_valid_isa(avx))
-            vpextrq(op, x, imm);
+            vpextrq(op, x, static_cast<uint8_t>(imm));
         else
-            pextrq(op, x, imm);
+            pextrq(op, x, static_cast<uint8_t>(imm));
     }
     void uni_vpextrq(
             const Xbyak::Operand &op, const Xbyak::Ymm &x, const int imm) {
-        vpextrq(op, x, imm);
+        vpextrq(op, x, static_cast<uint8_t>(imm));
     }
 
     void uni_vpmaxsd(const Xbyak::Xmm &x1, const Xbyak::Xmm &x2,
@@ -2030,7 +2034,7 @@ public:
     void uni_vpslldq(
             const Xbyak::Xmm &x, const Xbyak::Operand &op, const int imm) {
         if (is_valid_isa(avx))
-            vpslldq(x, op, imm);
+            vpslldq(x, op, static_cast<uint8_t>(imm));
         else {
             if (!x.isEqualIfNotInherited(op)) movdqa(x, op);
             pslldq(x, imm);
@@ -2038,7 +2042,7 @@ public:
     }
     void uni_vpslldq(
             const Xbyak::Ymm &x, const Xbyak::Operand &op, const int imm) {
-        vpslldq(x, op, imm);
+        vpslldq(x, op, static_cast<uint8_t>(imm));
     }
 
     void uni_vpmovsxwd(const Xbyak::Xmm &x, const Xbyak::Operand &op) {
@@ -2296,7 +2300,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Address &src_addr,
-            dim_t load_size, const bool zero_vmm = true) {
+            int load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2315,7 +2319,7 @@ public:
 
     template <typename Vmm>
     void load_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            dim_t load_size, const bool zero_vmm = true) {
+            int load_size, const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
@@ -2336,8 +2340,8 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void helper_load_bytes(const Vmm &vmm, dim_t load_size,
-            const AddrFunc &addr, const bool zero_vmm = true) {
+    void helper_load_bytes(const Vmm &vmm, int load_size, const AddrFunc &addr,
+            const bool zero_vmm = true) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2369,8 +2373,8 @@ private:
         // use clean execution sequence
         if (zero_vmm) uni_vpxor(vmm, vmm, vmm);
 
-        dim_t start_bytes = 0;
-        dim_t bytes_to_load = load_size;
+        int start_bytes = 0;
+        int bytes_to_load = load_size;
 
         if (load_size > 16) {
             // Prepare to insert to upper bits of ymm
@@ -2467,7 +2471,7 @@ public:
 
     template <typename Vmm>
     void store_bytes(const Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset,
-            dim_t store_size) {
+            int store_size) {
 
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2481,7 +2485,7 @@ public:
 
 private:
     template <typename Vmm, typename AddrFunc>
-    void store_bytes(const Vmm &vmm, dim_t store_size, const AddrFunc &addr) {
+    void store_bytes(const Vmm &vmm, int store_size, const AddrFunc &addr) {
 
         constexpr bool is_xmm = std::is_same<Vmm, Xbyak::Xmm>::value;
         constexpr bool is_ymm = std::is_same<Vmm, Xbyak::Ymm>::value;
@@ -2511,8 +2515,8 @@ private:
             return;
         }
 
-        dim_t start_bytes = 0;
-        dim_t bytes_to_store = store_size;
+        int start_bytes = 0;
+        int bytes_to_store = store_size;
 
         if (store_size > 16) {
             vmovdqu(addr(0), xmm); // load lower bits from ymm
@@ -2595,7 +2599,7 @@ public:
     */
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, bool is_signed, dim_t load_size,
+            int64_t offset, bool is_signed, int load_size,
             const bool zero_vmm) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
@@ -2605,7 +2609,7 @@ public:
 
     template <typename Vmm>
     void load_bytes_to_dword_extension(const Vmm &vmm,
-            const Xbyak::Address &src_addr, bool is_signed, dim_t load_size,
+            const Xbyak::Address &src_addr, bool is_signed, int load_size,
             const bool zero_vmm = true) {
 
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
@@ -2665,7 +2669,7 @@ public:
      */
     template <typename Vmm>
     void store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
         constexpr bool is_vmm_supported = std::is_same<Vmm, Xbyak::Ymm>::value
                 || std::is_same<Vmm, Xbyak::Xmm>::value;
         using supported_vmm_t = typename utils::conditional<is_vmm_supported,
@@ -2682,7 +2686,7 @@ public:
 private:
     template <typename Vmm>
     void helper_store_data(data_type_t type_out, const Vmm &vmm,
-            const Xbyak::Reg64 &reg, int64_t offset, dim_t store_size) {
+            const Xbyak::Reg64 &reg, int64_t offset, int store_size) {
 
         assert(is_valid_isa(sse41)
                 && "routine is not supported for the current isa");
@@ -2742,7 +2746,7 @@ public:
      */
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm, const Xbyak::Reg64 &reg,
-            int64_t offset, dim_t load_size, const bool zero_vmm = true) {
+            int64_t offset, int load_size, const bool zero_vmm = true) {
         // Ensure offset is at most 4 bytes to be encoded in the instruction
         assert(offset >= INT_MIN && offset <= INT_MAX);
         load_data(type_in, vmm, ptr[reg + offset], load_size, zero_vmm);
@@ -2750,7 +2754,7 @@ public:
 
     template <typename Vmm>
     void load_data(data_type_t type_in, const Vmm &vmm,
-            const Xbyak::Address &src_addr, dim_t load_size,
+            const Xbyak::Address &src_addr, int load_size,
             const bool zero_vmm = true) {
 
         assert(is_valid_isa(sse41)

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -562,11 +562,11 @@ struct jit_1x1_conv_args_t {
 
 struct jit_pool_conf_t {
     int ndims;
-    int mb, c, c_without_padding;
-    int id, ih, iw, od, oh, ow;
-    int stride_d, stride_h, stride_w;
-    int kd, kh, kw;
-    int f_pad, t_pad, l_pad;
+    dim_t mb, c, c_without_padding;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t kd, kh, kw;
+    dim_t f_pad, t_pad, l_pad;
     alg_kind_t alg;
     bool is_training;
     bool pad_w_is_null;
@@ -575,10 +575,10 @@ struct jit_pool_conf_t {
     bool is_c_padded;
     data_type_t ind_dt;
 
-    int c_block, c_tail, nb_c;
-    int ur_bc, ur_bc_tail;
-    int ur_c, ur_c_tail;
-    int ur;
+    dim_t c_block, c_tail, nb_c;
+    dim_t ur_bc, ur_bc_tail;
+    dim_t ur_c, ur_c_tail;
+    dim_t ur;
     size_t tail[4];
     bool safe_c_tail;
     data_type_t src_dt;

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -630,16 +630,16 @@ struct jit_uni_pooling_args_t {
 };
 
 struct jit_resampling_conf_t {
-    unsigned ndims = 0;
+    dim_t ndims = 0;
 
-    unsigned c = 0;
-    unsigned id = 0, ih = 0, iw = 0;
-    unsigned od = 0, oh = 0, ow = 0;
+    dim_t c = 0;
+    dim_t id = 0, ih = 0, iw = 0;
+    dim_t od = 0, oh = 0, ow = 0;
 
-    unsigned stride_d = 0;
-    unsigned stride_h = 0;
-    unsigned stride_w = 0;
-    unsigned inner_stride = 0;
+    dim_t stride_d = 0;
+    dim_t stride_h = 0;
+    dim_t stride_w = 0;
+    dim_t inner_stride = 0;
 
     // The linear algorithm is an approximation of the point
     // value based on the limit values. For one dimension,

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -89,14 +89,14 @@ struct jit_conv_conf_t {
 
     int simd_w;
     int ndims;
-    int mb;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
-    int id, ih, iw, od, oh, ow;
-    int f_pad, l_pad, t_pad;
-    int back_pad, r_pad, b_pad;
-    int kd, kh, kw;
-    int stride_d, stride_h, stride_w;
-    int dilate_d, dilate_h, dilate_w;
+    dim_t mb;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t f_pad, l_pad, t_pad;
+    dim_t back_pad, r_pad, b_pad;
+    dim_t kd, kh, kw;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t dilate_d, dilate_h, dilate_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool with_bias;
     bool with_sum;
@@ -109,7 +109,7 @@ struct jit_conv_conf_t {
     bool with_binary_no_bcast;
 
     bool is_fused_conv;
-    int dw_conv_buffer_oc;
+    dim_t dw_conv_buffer_oc;
 
     post_ops_t::entry_t::eltwise_t eltwise;
     post_ops_t post_ops;
@@ -117,36 +117,39 @@ struct jit_conv_conf_t {
 
     int nthr, nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b, nthr_oh;
 
-    int idp, ihp, iwp, ohp, owp, icp;
-    int nb_ic, ic_block;
-    int nb_oc, oc_block;
-    int nb_iw, iw_block;
-    int nb_ow, ow_block;
+    dim_t idp, ihp, iwp, ohp, owp, icp;
+    dim_t nb_ic, nb_oc;
+    dim_t ic_block, oc_block;
+    dim_t nb_iw;
+    dim_t iw_block;
+    dim_t nb_ow;
+    dim_t ow_block;
     int nb_oc_blocking; /* used in jit kernels for nb_oc work blocking taking
                            into account vector registers distribution */
     int nb_oc_blocking_thr_chunk; /* used for distribution of nb_oc work
                                       within threads */
     int nb_ic_blocking, nb_ic_blocking_max; // blocking of nb_ic work
-    int nb_ic_L2;
-    int h_blocking;
-    int nb_oc_L2;
+    dim_t nb_ic_L2;
+    dim_t h_blocking;
+    dim_t nb_oc_L2;
     int ic_tail, oc_tail, ch_tail;
     int ur_h, ur_w;
-    int ur_w_tail, ur_w_blocks;
+    int ur_w_tail;
+    dim_t ur_w_blocks;
     int ur_ic, ur_kw;
     bool is_1stconv;
     int nonblk_group_off;
     /* fma avx512_core */
     conv_kernel_kind_t kernel_kind;
 
-    int tr_iw, tr_ih;
-    int tr_kw, tr_kh;
-    int tr_src_num_guard_elems;
+    dim_t tr_iw, tr_ih;
+    dim_t tr_kw, tr_kh;
+    dim_t tr_src_num_guard_elems;
 
     // Transpose buffer management
     size_t tr_src_buf_size, tr_src_buf_count;
     size_t tr_diff_dst_buf_size, tr_diff_dst_buf_count;
-    int nthr_mb_work;
+    dim_t nthr_mb_work;
 
     int typesize_in;
     int typesize_out;
@@ -156,7 +159,7 @@ struct jit_conv_conf_t {
     int ic_nb1, ic_nb2;
     int oc_nb1;
     int ur_ow_max, ur_ow, ur_ow_tail;
-    int ur_ow_nsteps;
+    dim_t ur_ow_nsteps;
     data_type_t bia_dt;
     /* bf16 data-type for output */
     data_type_t dst_dt;
@@ -173,18 +176,20 @@ struct jit_conv_conf_t {
     int is_ic_scale, is_oc_scale;
     int max_regs_ur; // maximum accumulation registers
     // dw conv
-    int nb_ch, ch_block, nb_ch_blocking;
+    dim_t nb_ch;
+    dim_t ch_block;
+    int nb_ch_blocking;
     bool is_depthwise, is_fast_depthwise, is_resrc_depthwise;
     int aligned_threads;
     // large spatial
-    int ih_blk_size, oh_blk_size;
+    dim_t ih_blk_size, oh_blk_size;
     // s8s8 convolution
     bool signed_input;
     bool need_saturation;
     float wei_adj_scale;
     // zero-point compensation
     bool src_zero_point;
-    int zp_pbuff_size;
+    dim_t zp_pbuff_size;
     bool dst_zero_point;
     bool zp_src_is_common; // common, otherwise (TODO) per-channel
     bool req_zero_point_buffer; // used for calculating padding compensation
@@ -195,14 +200,15 @@ struct jit_conv_conf_t {
     bool with_dst_scales = false;
 
     // a separate parallel region
-    int ow_pad, oh_pad, od_pad; // output elements with padding & filter overlap
+    dim_t ow_pad, oh_pad,
+            od_pad; // output elements with padding & filter overlap
 
     //output elements requiring zero-point padding compensation
-    int f_pad_output, back_pad_output;
-    int t_pad_output, b_pad_output;
-    int l_pad_output, r_pad_output;
+    dim_t f_pad_output, back_pad_output;
+    dim_t t_pad_output, b_pad_output;
+    dim_t l_pad_output, r_pad_output;
     // The number of output blocks corresponding to {l_pad, no_pad, r_pad}
-    int l_pad_blk, no_pad_w_blk, r_pad_blk;
+    dim_t l_pad_blk, no_pad_w_blk, r_pad_blk;
 
     bool od_mid, oh_mid, ow_mid; // indicate if there is overlap between the
             //width and height padded regions
@@ -212,37 +218,37 @@ struct jit_conv_conf_t {
     bool uses_permw_transposition;
     bool transpose_src;
     bool transpose_dst;
-    int ic_block_step;
+    dim_t ic_block_step;
 
     cpu_isa_t isa;
     // bf16 bwdw conv
-    int tr_ow;
+    dim_t tr_ow;
     bool is_hw_transp; // spatial dim height-width transposed
-    int spatial_blk_size; // Height/depth block size inside the driver
+    dim_t spatial_blk_size; // Height/depth block size inside the driver
     bool global_transpose; // diff_dst & src tensors are transposed in one go
     bool use_nt_stores_ddst; // Use non temporal stores in diff_dst transform
 
     // Needed for Intel(R) Advanced Matrix Extensions (Intel(R) AMX) kernels
     bool is_nspc; // activations in nwc, nhwc, or ndhwc layout
     bool is_relo; // reduced lowering optimization
-    int nreduce; // used with is_relo
+    dim_t nreduce; // used with is_relo
     bool is_pbuffer_strided; // does pbuffer have strided sectors?
-    int n_stride_sets; // number of stride sectors (or sets) in pbuffer
-    int kw_step; // usually stride_w, unless !is_pbuffer_strided
-    int kw_per_tile; // mostly for 1st convs
+    dim_t n_stride_sets; // number of stride sectors (or sets) in pbuffer
+    dim_t kw_step; // usually stride_w, unless !is_pbuffer_strided
+    dim_t kw_per_tile; // mostly for 1st convs
     // The suffix _int refers to the block sizes of the src and diff_dst tiles,
     // as opposed to the vector registers. This distinction is needed due to
     // support for blocked layout (ie nChw16c) with bf16 data type.
-    int ic_block_int, ic_block_int_np, oc_block_int;
-    int nb_ic_int, nb_oc_int;
-    int nb_ih_blocking, nb_oh_blocking;
+    dim_t ic_block_int, ic_block_int_np, oc_block_int;
+    dim_t nb_ic_int, nb_oc_int;
+    dim_t nb_ih_blocking, nb_oh_blocking;
 
     int full_tile_width;
     int max_tiles;
     int tile_width;
     int tile_tail;
     int oh_per_tile;
-    int iw_blocks, ow_blocks;
+    dim_t iw_blocks, ow_blocks;
 
     int per_one_pstore;
 
@@ -250,7 +256,7 @@ struct jit_conv_conf_t {
     size_t wei_buffer_size;
     size_t wsp_buffer_size;
 
-    int nb_os;
+    dim_t nb_os;
     int nb_os_blocking;
     int nb_os2_blocking;
     int os_tail;
@@ -261,12 +267,12 @@ struct jit_conv_conf_t {
 };
 
 // calculates filter size taking into account dilation
-inline int calculate_extended_filter_size(int filter_size, int dilation) {
+inline dim_t calculate_extended_filter_size(dim_t filter_size, dim_t dilation) {
     return (filter_size - 1) * (dilation + 1) + 1;
 }
 
-inline int calculate_end_padding(int start_padding, int dst_size, int src_size,
-        int spatial_stride, int dilated_filter_size) {
+inline dim_t calculate_end_padding(dim_t start_padding, dim_t dst_size,
+        dim_t src_size, dim_t spatial_stride, dim_t dilated_filter_size) {
     return (dst_size - 1) * spatial_stride + dilated_filter_size
             - (src_size + start_padding);
 }
@@ -457,12 +463,12 @@ struct jit_1x1_conv_conf_t {
     bool has_vnni;
 
     int ndims;
-    int mb;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
-    int id, ih, iw, od, oh, ow;
-    int f_pad, t_pad, l_pad;
-    int kd, kh, kw;
-    int stride_d, stride_h, stride_w;
+    dim_t mb;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t f_pad, t_pad, l_pad;
+    dim_t kd, kh, kw;
+    dim_t stride_d, stride_h, stride_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool with_bias;
     bool with_sum;
@@ -473,23 +479,24 @@ struct jit_1x1_conv_conf_t {
     post_ops_t post_ops;
 
     dim_t is, os;
-    int ic_block, oc_block;
+    dim_t ic_block, oc_block;
 
     int ur, ur_tail;
 
     dim_t reduce_dim;
-    int reduce_block, nb_reduce, nb_reduce_blocking, nb_reduce_blocking_max;
-    int load_dim, load_block, nb_load, nb_load_blocking, nb_load_blocking_max,
+    dim_t reduce_block, nb_reduce, nb_reduce_blocking, nb_reduce_blocking_max;
+    dim_t load_dim;
+    dim_t load_block, nb_load, nb_load_blocking, nb_load_blocking_max,
             nb_load_chunk;
     dim_t bcast_dim;
-    int bcast_block, nb_bcast, nb_bcast_blocking, nb_bcast_blocking_max;
+    dim_t bcast_block, nb_bcast, nb_bcast_blocking, nb_bcast_blocking_max;
 
-    int reduce_loop_unroll;
+    dim_t reduce_loop_unroll;
     dim_t reduce_loop_bcast_step;
-    int reduce_loop_load_step;
-    int load_loop_load_step, load_loop_iter_step;
-    int bcast_loop_output_step, bcast_loop_output_substep;
-    int bcast_loop_bcast_step, bcast_loop_bcast_substep;
+    dim_t reduce_loop_load_step;
+    dim_t load_loop_load_step, load_loop_iter_step;
+    dim_t bcast_loop_output_step, bcast_loop_output_substep;
+    dim_t bcast_loop_bcast_step, bcast_loop_bcast_substep;
     int load_grp_count;
     conv_1x1_loop_order_t loop_order;
     bool use_vmovntps;
@@ -692,17 +699,17 @@ struct jit_uni_resampling_args_t {
 struct jit_brdgmm_conv_conf_t {
 
     int nthr;
-    int mb, ngroups, ic, oc;
-    int id, ih, iw, od, oh, ow;
-    int f_pad, back_pad, l_pad, r_pad, t_pad, b_pad;
-    int kd, kh, kw;
-    int stride_d, stride_h, stride_w;
-    int nb_ch, ch_block, chb_tail;
-    int nb_ch_blocking;
-    int ow_block, ow_tail, nb_ow;
+    dim_t mb, ngroups, ic, oc;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t f_pad, back_pad, l_pad, r_pad, t_pad, b_pad;
+    dim_t kd, kh, kw;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t nb_ch, ch_block, chb_tail;
+    dim_t nb_ch_blocking;
+    dim_t ow_block, ow_tail, nb_ow;
     // idx of jit kernel when mutiple jit kernels are used in a primitive.
     int chb_tail_idx, ow_tail_idx, nb_ch_blocking_idx;
-    int adjusted_batch_size;
+    dim_t adjusted_batch_size;
 
     bool with_bias;
     bool with_post_ops;
@@ -754,12 +761,12 @@ struct jit_brgemm_conv_conf_t {
     conv_harness_t harness;
     int simd_w, acc_simd_w, amx_w, amx_h;
     int ndims;
-    int mb;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t mb;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
 
-    int od_block, oh_block, nb_od,
+    dim_t od_block, oh_block, nb_od,
             nb_oh; // blocking  - included in parallelization
-    int id_block, ih_block, nb_id, nb_ih;
+    dim_t id_block, ih_block, nb_id, nb_ih;
     dim_t inp_buffer_size, inp_buffer_mask_size, out_buffer_size;
     conv_brgemm_exec_type_t exec_type;
 
@@ -773,15 +780,17 @@ struct jit_brgemm_conv_conf_t {
     }
     inline bool is_relo() const { return is_relo_whi() || is_relo_wi(); }
 
-    int id, ih, iw, od, oh, ow, os, is, idp, ihp, iwp, icp, odp, ohp, owp, ocp;
-    int f_pad, l_pad, t_pad;
-    int back_pad, r_pad, b_pad;
-    int l_ovf, r_ovf, t_ovf, b_ovf, f_ovf, back_ovf;
-    int kd, kh, kw;
-    int ext_kd, ext_kh, ext_kw;
-    int kd_block, kh_block, kw_block, kd_block_pad, kh_block_pad, kw_block_pad;
-    int stride_d, stride_h, stride_w;
-    int dilate_d, dilate_h, dilate_w;
+    dim_t id, ih, iw, od, oh, ow, os, is, idp, ihp, iwp, icp, odp, ohp, owp,
+            ocp;
+    dim_t f_pad, l_pad, t_pad;
+    dim_t back_pad, r_pad, b_pad;
+    dim_t l_ovf, r_ovf, t_ovf, b_ovf, f_ovf, back_ovf;
+    dim_t kd, kh, kw;
+    dim_t ext_kd, ext_kh, ext_kw;
+    dim_t kd_block, kh_block, kw_block, kd_block_pad, kh_block_pad,
+            kw_block_pad;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t dilate_d, dilate_h, dilate_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool with_bias;
     bool with_sum;
@@ -793,15 +802,15 @@ struct jit_brgemm_conv_conf_t {
     bool is_os_blocking;
     bool is_rtus;
     bool is_reduced_rtus;
-    size_t rtus_ic_size, rtus_padded_ic_size;
+    dim_t rtus_ic_size, rtus_padded_ic_size;
     bool ununroll_bd_loop {false};
-    int nb_ic, ic_block, inp_ic_block;
-    int nb_tr_ic, tr_ic_block, tr_ic_tail;
-    int nb_oc, oc_block;
-    int nb_iw, iw_block, iw_tail;
-    int nb_ow, ow_block, ow_tail;
-    int nb_is, is_block;
-    int nb_os, os_block;
+    dim_t nb_ic, ic_block, inp_ic_block;
+    dim_t nb_tr_ic, tr_ic_block, tr_ic_tail;
+    dim_t nb_oc, oc_block;
+    dim_t nb_iw, iw_block, iw_tail;
+    dim_t nb_ow, ow_block, ow_tail;
+    dim_t nb_is, is_block;
+    dim_t nb_os, os_block;
     int nb_oc_blocking;
     int nb_ic_blocking;
     int nb_is_blocking;
@@ -830,21 +839,21 @@ struct jit_brgemm_conv_conf_t {
     bool with_dst_scales;
     int is_ic_scale, is_oc_scale;
 
-    int LDA, LDB, LDC, LDD;
+    dim_t LDA, LDB, LDC, LDD;
 
-    int M, N, K, M_tail, N_tail, K_tail;
+    dim_t M, N, K, M_tail, N_tail, K_tail;
     // Note: M for brgemm kernel. For use_store_mask it is usually greater than
     // M (M_tail). Otherwise it is equal to M (M_tail).
-    int brgM, brgM_tail;
-    int gemm_batch_size, adjusted_batch_size;
+    dim_t brgM, brgM_tail;
+    dim_t gemm_batch_size, adjusted_batch_size;
     brgemm_batch_kind_t brg_type;
     // strides for brg_type == brgemm_strd
     dim_t brg_stride_a, brg_stride_b;
     int nthr;
 
-    int max_batch;
-    int max_vpad;
-    int amx_buf_size_per_thread;
+    dim_t max_batch;
+    dim_t max_vpad;
+    dim_t amx_buf_size_per_thread;
 
     bool wei_plain;
     bool is_rd_padded_to_block {false}, is_rd_padded_to_vnni {false},
@@ -853,7 +862,7 @@ struct jit_brgemm_conv_conf_t {
     bool copy_block_only;
     bool amx_tile_load_xx;
     int use_M_mask;
-    int oskip, iskip;
+    dim_t oskip, iskip;
     bool brgemm_bd_loop_innermost;
 
     bool use_uker;
@@ -881,11 +890,11 @@ struct jit_brgemm_conv_conf_t {
     int ic_tail, oc_tail;
     size_t tr_src_block_size, tr_src_buf_size, tr_src_buf_count;
     size_t tr_diff_dst_block_size, tr_diff_dst_buf_size, tr_diff_dst_buf_count;
-    int tr_src_num_guard_elems;
+    dim_t tr_src_num_guard_elems;
     bool global_transpose; // diff_dst & src tensors are transposed in one go
     int nthr_mb_work;
-    int tr_iw, tr_ow;
-    int spatial_blk_size; // Height/depth block size inside the driver
+    dim_t tr_iw, tr_ow;
+    dim_t spatial_blk_size; // Height/depth block size inside the driver
     int typesize_in;
     int typesize_out;
     bool tr_ocb_chunk = false;
@@ -964,7 +973,7 @@ struct jit_binary_conf_t {
     bool is_ternary_op = false;
     bool is_src_different_layouts = false;
     dim_t outer_dims = 1;
-    int src1_stride = 1;
+    dim_t src1_stride = 1;
     int not_bcasted_sp_dims = 0;
     cpu_isa_t isa = isa_undef;
 

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -47,7 +47,7 @@ jit_sse41_1x1_conv_kernel_f32_t::jit_sse41_1x1_conv_kernel_f32_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t tail_size = jcp.oc_without_padding % simd_w_;
+        const dim_t tail_size = jcp.oc_without_padding % simd_w_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {
@@ -77,7 +77,7 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate_bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const int num_substeps = static_cast<int>(jcp.bcast_block / jcp.ur);
         assert(num_substeps > 0 && num_substeps < 10);
         for (int i = 0; i < num_substeps; i++) {
             generate_reduce_loop(load_loop_blk, jcp.ur);
@@ -422,7 +422,9 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate_diff_bias_loop(
         movups(diff_bias_ptr(i, 1), diff_bias_reg(i, 1));
     }
 
-    add(reg_diff_bias_data, load_loop_blk * jcp.oc_block * sizeof(float));
+    add(reg_diff_bias_data,
+            static_cast<uint32_t>(
+                    load_loop_blk * jcp.oc_block * sizeof(float)));
     mov(ptr[rsp + reg_diff_bias_data_stack_offt], reg_diff_bias_data);
 
     L(diff_bias_loop_out);
@@ -473,18 +475,21 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate() {
             case forward_training:
             case forward_inference:
                 add(reg_bias_data,
-                        load_loop_blk * jcp.oc_block * sizeof(float));
-                add(reg_output_data, offst_with_dw_conv);
+                        static_cast<uint32_t>(
+                                load_loop_blk * jcp.oc_block * sizeof(float)));
+                add(reg_output_data, static_cast<uint32_t>(offst_with_dw_conv));
                 if (jcp.with_binary && jcp.with_dw_conv) {
                     mov(aux_reg_load_data, ptr[rsp + reg_dw_binary_output_off]);
                     add(aux_reg_load_data,
-                            offst_wo_dw_conv - offst_with_dw_conv);
+                            static_cast<uint32_t>(
+                                    offst_wo_dw_conv - offst_with_dw_conv));
                     mov(ptr[rsp + reg_dw_binary_output_off], aux_reg_load_data);
                 }
                 break;
             case backward_data:
                 add(reg_output_data,
-                        load_loop_blk * jcp.is * jcp.ic_block * sizeof(float));
+                        static_cast<uint32_t>(load_loop_blk * jcp.is
+                                * jcp.ic_block * sizeof(float)));
                 break;
             case backward_weights:
                 for (int i = 0; i < load_loop_blk; i++)
@@ -669,7 +674,8 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
             args_ok, VERBOSE_BLOCKING_FAIL, "bad blocking parameters");
 
     jcp.ur = 1;
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
     int load_blocking {0};
     int load_blocking_max {0};
@@ -704,12 +710,13 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         jcp.load_loop_iter_step = jcp.oc_block;
 
         load_blocking = is_data_layout_nxc
-                ? jcp.load_dim
+                ? static_cast<int>(jcp.load_dim)
                 : 120; // assumes the kernel is jcp.ur x 3
-        load_blocking_max = is_data_layout_nxc ? jcp.load_dim : 144;
+        load_blocking_max
+                = is_data_layout_nxc ? static_cast<int>(jcp.load_dim) : 144;
         bcast_blocking = 128; // affects load balancing across threads
         bcast_blocking_max = 192;
-        reduce_blocking = is_data_layout_nxc ? jcp.reduce_dim
+        reduce_blocking = is_data_layout_nxc ? static_cast<int>(jcp.reduce_dim)
                                              : 128; // affects L1$ utilization
     } else if (jcp.prop_kind == backward_data) {
         jcp.reduce_dim = jcp.oc;
@@ -767,7 +774,7 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
 
         /* --- */
 
-        load_blocking = div_up(jcp.load_dim, jcp.load_block);
+        load_blocking = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
         while (true) {
             if (load_blocking <= 32)
                 break;
@@ -782,7 +789,8 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         load_blocking_max = load_blocking;
         assert(jcp.load_dim % load_blocking == 0);
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         while (true) {
             if (bcast_blocking <= 9)
                 break;
@@ -808,7 +816,8 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     assert(reduce_blocking);
 
     assert(jcp.bcast_block % jcp.ur == 0);
-    jcp.ur_tail = (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur;
+    jcp.ur_tail = static_cast<int>(
+            (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.ur);
 
     jcp.nb_bcast_blocking = bcast_blocking / jcp.bcast_block;
     jcp.nb_bcast_blocking_max = bcast_blocking_max / jcp.bcast_block;

--- a/src/cpu/x64/jit_sse41_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.cpp
@@ -48,7 +48,8 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward(
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_ != nullptr
             ? binary_injector::prepare_binary_args(
                       pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -85,20 +86,21 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
     auto par_conv = jit_1x1_conv_args_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
-            ? jcp.nb_load_blocking
-            : jcp.nb_load_blocking_max;
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max
+            = jcp.with_dw_conv ? jcp.nb_load_blocking
+                               : jcp.nb_load_blocking_max;
     const bool is_dst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
     const bool is_src_layout_nxc = utils::one_of(
@@ -107,25 +109,25 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     // Begin: declare Variables needed for dw conv.
     data_t *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<data_t *> addrs;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int &n, int &g, int &bcast_step, int bcast_end,
-                      int &oh, int &ow, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t &n, dim_t &g, dim_t &bcast_step,
+                              dim_t bcast_end, dim_t &oh, dim_t &ow, dim_t &ih,
+                              dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
 
-        bcast_step = step(
-                nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
+        bcast_step = step(nb_bcast_blocking, nb_bcast - osb,
+                nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         ow = os % jcp.ow;
         oh = os / jcp.ow;
 
@@ -135,19 +137,19 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         par_conv.bcast_dim = this_block_size(os, jcp.os, bcast_step * os_block);
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         par_conv.load_dim = this_block_size(
                 ocb * jcp.oc_block, jcp.oc, load_step * jcp.oc_block);
     };
 
-    auto inner_ker = [&](int ocb, int icb, int n, int g, int oh, int ow, int ih,
-                             int iw) {
-        const size_t _ocb = g * nb_oc + ocb;
-        const size_t _icb = g * nb_ic + icb;
+    auto inner_ker = [&](dim_t ocb, dim_t icb, dim_t n, dim_t g, dim_t oh, dim_t ow,
+                             dim_t ih, dim_t iw) {
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g * nb_ic + icb;
 
-        const int oc_off_idx = (is_dst_layout_nxc ? jcp.oc_block : 1) * _ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, oh, ow);
+        const dim_t oc_off_idx = (is_dst_layout_nxc ? jcp.oc_block : 1) * _ocb;
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, oh, ow);
         par_conv.output_data = jcp.with_dw_conv
                 ? pbuf + (oh % pd()->dw_conv_pd_->jcp_.kh) * row_offset
                 : &dst[dst_off];
@@ -160,7 +162,7 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         par_conv.reduce_dim = this_block_size(
                 icb * jcp.ic_block, jcp.ic, nb_ic_blocking * jcp.ic_block);
 
-        const int ic_off_idx = (is_src_layout_nxc ? jcp.ic_block : 1) * _icb;
+        const dim_t ic_off_idx = (is_src_layout_nxc ? jcp.ic_block : 1) * _icb;
 
         const size_t src_off = data_blk_off(src_d, n, ic_off_idx, ih, iw);
         par_conv.bcast_data = &src[src_off];
@@ -176,19 +178,20 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         (*kernel_)(&par_conv);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
 
-        int iwork = bcast_start;
+        dim_t iwork = bcast_start;
         while (iwork < bcast_end) {
-            int n {0}, g {0}, bcast_step, oh, ow, ih, iw;
+            dim_t n {0}, g {0}, oh, ow, ih, iw;
+            dim_t bcast_step;
             init_bcast(iwork, n, g, bcast_step, bcast_end, oh, ow, ih, iw);
-            int ocb = 0;
+            dim_t ocb = 0;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                     inner_ker(ocb, icb, n, g, oh, ow, ih, iw);
                 }
                 ocb += load_step;
@@ -197,9 +200,11 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step,
+                             dim_t &dw_oh) {
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
 
         for (int i = 0; i < jcp_dw.kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw.kh) * row_offset;
@@ -207,31 +212,32 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         const auto ocb_end = ocb_start + load_step;
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw.iw)
                 * jcp_dw.nb_ch_blocking * jcp_dw.ch_block;
-        const int dil_h = jcp_dw.dilate_h + 1;
-        const int str_h = jcp_dw.stride_h;
-        const int ch_num = jcp_dw.nb_ch_blocking;
+        const dim_t dil_h = jcp_dw.dilate_h + 1;
+        const dim_t str_h = jcp_dw.stride_h;
+        const dim_t ch_num = jcp_dw.nb_ch_blocking;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end;
+                ch += jcp_dw.nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw.t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw.ih,
-                              (int)(dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
-                                      - jcp_dw.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw.t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw.ih,
+                              dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
+                                      - jcp_dw.t_pad + 1)
                     - jcp_dw.ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            const int ow = 0;
-            const int kw = 0;
+            const dim_t ow = 0;
+            const dim_t kw = 0;
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw.ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -242,9 +248,10 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw.ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw.nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw.nb_ch) - ch)
                     * jcp_dw.ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -272,37 +279,41 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, 1);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        balance2D(nthr, ithr,
+                jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
+                bcast_end, nb_oc, ocb_start, ocb_end, dim_t(1));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw.oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw.kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_range
+                        = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw.kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
                 oh_1x1 = oh_1x1_end;
-                ker_dw(n, g * nb_oc + ocb_start, load_step, oh_dw);
+                ker_dw(n, static_cast<int>(g * nb_oc + ocb_start), load_step,
+                        oh_dw);
 
                 bcast_iter += nb_bcast_blocking;
             }
@@ -313,8 +324,8 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int start {0}, end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
         conv_1x1(start, end, 0, jcp.nb_load);
     }

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -46,7 +46,7 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t tail_size = jcp.oc_without_padding % simd_w_;
+        const dim_t tail_size = jcp.oc_without_padding % simd_w_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {
@@ -65,17 +65,18 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
 
 void jit_sse41_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int dilate_w = jcp.dilate_w + 1;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const int ic_blk = static_cast<int>(jcp.ic_block);
 
     for (int ki = 0; ki < kw; ki++) {
-        int jj_start = div_up(nstl::max(0, pad_l - ki * dilate_w), stride_w);
-        int jj_end = ur_w
-                - div_up(nstl::max(0,
+        int jj_start = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, pad_l - ki * dilate_w), stride_w));
+        int jj_end = static_cast<int>(ur_w
+                - div_up(nstl::max<dim_t>(0,
                                  ki * dilate_w + pad_r - (kw - 1) * dilate_w),
-                        stride_w);
+                        stride_w));
         for (int ifm2 = 0; ifm2 < ic_blk; ifm2++) {
             for (int jj = jj_start; jj < jj_end; jj++) {
                 size_t inp_off = get_input_offset(
@@ -103,8 +104,8 @@ void jit_sse41_conv_fwd_kernel_f32_t::oh_step_nopad(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     Label kw_loop;
 
-    int kw = jcp.kw;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    const int ic_blk = static_cast<int>(jcp.ic_block);
 
     xor_(ki_iter, ki_iter);
     L(kw_loop);
@@ -182,8 +183,8 @@ void jit_sse41_conv_fwd_kernel_f32_t::apply_postops(
 
 void jit_sse41_conv_fwd_kernel_f32_t::width_blk_step(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int oc_blk = jcp.oc_block;
+    const int kw = static_cast<int>(jcp.kw);
+    const int oc_blk = static_cast<int>(jcp.oc_block);
 
     xor_(simd_iter, simd_iter);
 
@@ -293,26 +294,29 @@ void jit_sse41_conv_fwd_kernel_f32_t::width_blk_step(
 }
 
 inline void jit_sse41_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
-    int ur_w = jcp.ur_w;
-    int ur_w_tail = jcp.ur_w_tail;
-    int n_oi = jcp.ow / ur_w;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int str_w = jcp.stride_w;
+    const int ur_w = jcp.ur_w;
+    const int ur_w_tail = jcp.ur_w_tail;
+    int n_oi = static_cast<int>(jcp.ow / ur_w);
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t str_w = jcp.stride_w;
 
-    int l_pad = jcp.l_pad;
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, str_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    const dim_t l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            str_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
     if (r_pad1 > 0) n_oi--;
 
     if (l_pad > 0) {
         n_oi--;
         if (n_oi < 0 && r_pad1 > 0)
-            width_blk_step(ur_w, l_pad, r_pad1, oc_blocks); // "lrpad"
+            width_blk_step(ur_w, static_cast<int>(l_pad), r_pad1,
+                    oc_blocks); // "lrpad"
         else
-            width_blk_step(ur_w, l_pad, 0, oc_blocks); // "lpad"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
+            width_blk_step(ur_w, static_cast<int>(l_pad), 0,
+                    oc_blocks); // "lpad"
+        add(reg_input,
+                get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
         add(reg_output, get_output_offset(0, ur_w));
     }
 
@@ -407,7 +411,8 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.oh = (ndims == 3) ? 1 : dst_d.dims()[2];
     jcp.ow = dst_d.dims()[ndims - 1];
 
-    jcp.kh = (ndims == 3) ? 1 : weights_d.dims()[with_groups + 2];
+    jcp.kh = (ndims == 3) ? 1
+                          : weights_d.dims()[with_groups + 2];
     jcp.kw = weights_d.dims()[with_groups + ndims - 1];
 
     jcp.t_pad = (ndims == 3) ? 0 : cd.padding[0][0];
@@ -419,8 +424,8 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[0];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -504,7 +509,7 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.ur_h = 1; /* no code-unrolling by h so far */
     jcp.ur_w = 3;
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     jcp.nb_oc_blocking
@@ -517,24 +522,26 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(mimo, jcp.ic % simd_w == 0);
     VDISPATCH_CONV_IC(args_ok, VERBOSE_BLOCKING_FAIL, "bad parameters");
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
 
     // kernel needs 1 temporary YMM register
     const int num_avail_regs = 15;
     if (r_pad_no_tail > jcp.ur_w * jcp.stride_w && jcp.ow / jcp.ur_w > 1) {
         /* recalculate ur_w, nb_oc_blocking and ur_w_tail */
-        jcp.ur_w = nstl::min(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
-                nstl::min(jcp.ow, num_avail_regs / 2));
+        jcp.ur_w = static_cast<int>(
+                nstl::min<dim_t>(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
+                        nstl::min<dim_t>(jcp.ow, num_avail_regs / 2)));
         jcp.nb_oc_blocking = (num_avail_regs - jcp.ur_w) / jcp.ur_w;
-        jcp.ur_w_tail = jcp.ow % jcp.ur_w;
+        jcp.ur_w_tail = static_cast<int>(jcp.ow % jcp.ur_w);
         /* check again ... */
-        r_pad_no_tail = nstl::max(0,
+        r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                        jcp.stride_w, ext_kw));
+                        jcp.stride_w, ext_kw)));
 
-        VDISPATCH_CONV_IC(jcp.ur_w >= nstl::max(jcp.l_pad, r_pad_no_tail),
+        VDISPATCH_CONV_IC(
+                jcp.ur_w >= nstl::max<dim_t>(jcp.l_pad, r_pad_no_tail),
                 VERBOSE_UNSUPPORTED_PAD_FEATURE,
                 "width unroll exceeds padding size");
     }

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
@@ -73,51 +73,48 @@ private:
     inline void width_blk_step(int ur_w, int pad_l, int pad_r, int oc_blocks);
     inline void solve_common(int oc_blocks);
 
-    inline dim_t filter_w_to_input(int ki, int oi = 0, int pad_l = 0) const {
-        return static_cast<dim_t>(ki) * (jcp.dilate_w + 1)
-                + static_cast<dim_t>(oi) * jcp.stride_w - pad_l;
+    inline dim_t filter_w_to_input(
+            dim_t ki, dim_t oi = 0, dim_t pad_l = 0) const {
+        return ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
     }
 
-    inline dim_t filter_h_to_input(int ki) const {
-        return static_cast<dim_t>(ki) * (jcp.dilate_h + 1) * jcp.iw;
+    inline dim_t filter_h_to_input(dim_t ki) const {
+        return ki * (jcp.dilate_h + 1) * jcp.iw;
     }
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(dim_t i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
-            offset = static_cast<dim_t>(i_ic) * jcp.ih * jcp.iw + i_iw;
+            offset = i_ic * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_output_offset(int i_oc_block, int i_ow) const {
+    inline dim_t get_output_offset(dim_t i_oc_block, dim_t i_ow) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block;
         } else {
-            offset = (static_cast<dim_t>(i_oc_block) * jcp.oh * jcp.ow + i_ow)
-                    * jcp.oc_block;
+            offset = (i_oc_block * jcp.oh * jcp.ow + i_ow) * jcp.oc_block;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_kernel_offset(int i_oc_block, int ki, int i_ic) const {
-        dim_t block_step_size = static_cast<dim_t>(jcp.ic_block) * jcp.oc_block;
+    inline dim_t get_kernel_offset(
+            dim_t i_oc_block, dim_t ki, dim_t i_ic) const {
+        dim_t block_step_size = jcp.ic_block * jcp.oc_block;
         dim_t ic_block_step_size
-                = static_cast<dim_t>(jcp.kh) * jcp.kw * block_step_size;
-        dim_t oc_block_step_size
-                = static_cast<dim_t>(jcp.nb_ic) * ic_block_step_size;
-        dim_t offset = static_cast<dim_t>(i_oc_block) * oc_block_step_size
-                + static_cast<dim_t>(ki) * block_step_size
-                + static_cast<dim_t>(i_ic) * jcp.oc_block;
+                = jcp.kh * jcp.kw * block_step_size;
+        dim_t oc_block_step_size = jcp.nb_ic * ic_block_step_size;
+        dim_t offset = i_oc_block * oc_block_step_size + ki * block_step_size
+                + i_ic * jcp.oc_block;
         return sizeof(float) * offset;
     }
 

--- a/src/cpu/x64/jit_sse41_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_convolution.cpp
@@ -52,7 +52,7 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper weights_d(pd()->weights_md(0));
     const memory_desc_wrapper bias_d(pd()->weights_md(1));
 
-    int ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
+    const dim_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
     const size_t work_amount = jcp.mb * jcp.ngroups * ocb_work * jcp.oh;
 
     const bool is_src_layout_nxc
@@ -66,26 +66,28 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         size_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int icbb = 0;
+        dim_t icbb = 0;
         while (icbb < jcp.nb_ic) {
-            int icb_step = jcp.nb_ic_blocking;
-            int icb_step_rem = jcp.nb_ic - icbb;
-            if (icb_step_rem < jcp.nb_ic_blocking_max) icb_step = icb_step_rem;
+            dim_t icb_step = jcp.nb_ic_blocking;
+            const dim_t icb_step_rem = jcp.nb_ic - icbb;
+            if (icb_step_rem < jcp.nb_ic_blocking_max)
+                icb_step = icb_step_rem;
 
             size_t n {0}, g {0}, ocbb {0}, oh {0};
             nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
                     oh, jcp.oh);
             for (size_t iwork = start; iwork < end; ++iwork) {
-                int ocb = ocbb * jcp.nb_oc_blocking;
-                int ocb_num = jcp.nb_oc_blocking;
+                const dim_t ocb = ocbb * jcp.nb_oc_blocking;
+                const dim_t ocb_num = jcp.nb_oc_blocking;
 
-                for (int icb = icbb; icb < icbb + icb_step; ++icb) {
+                for (dim_t icb = icbb; icb < icbb + icb_step; ++icb) {
                     auto par_conv = jit_conv_args_t();
 
-                    const int ij = oh * jcp.stride_h;
-                    const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
-                    const int i_b_overflow
-                            = nstl::max(jcp.ih,
+                    const dim_t ij = oh * jcp.stride_h;
+                    const dim_t i_t_overflow
+                            = nstl::max<dim_t>(0, jcp.t_pad - ij);
+                    const dim_t i_b_overflow
+                            = nstl::max<dim_t>(jcp.ih,
                                       ij + (jcp.kh - 1) * (jcp.dilate_h + 1)
                                               - jcp.t_pad + 1)
                             - jcp.ih;
@@ -97,7 +99,8 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                             = g * (is_src_layout_nxc ? jcp.ic : jcp.nb_ic)
                             + icb * (is_src_layout_nxc ? jcp.ic_block : 1);
 
-                    const int ih = nstl::max(ij - jcp.t_pad
+                    const dim_t ih = nstl::max<dim_t>(
+                            ij - jcp.t_pad
                                     + div_up(i_t_overflow, (jcp.dilate_h + 1))
                                             * (jcp.dilate_h + 1),
                             0);
@@ -105,7 +108,8 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
                     par_conv.dst = &dst[src_blk_off(dst_d, n, _oc, oh, 0)];
 
-                    const int wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
+                    const dim_t wh
+                            = div_up(i_t_overflow, (jcp.dilate_h + 1));
                     par_conv.filt = &weights[wht_blk_off(
                             weights_d, g, ocb, icb, wh, 0)];
 
@@ -122,13 +126,13 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                     }
 
                     par_conv.oc_blocks
-                            = nstl::min(ocb + ocb_num, jcp.nb_oc) - ocb;
+                            = nstl::min<dim_t>(ocb + ocb_num, jcp.nb_oc) - ocb;
 
                     par_conv.kw_padding = 0;
-                    const int kh_padding = jcp.kh
+                    const dim_t kh_padding = jcp.kh
                             - div_up(i_t_overflow, (jcp.dilate_h + 1))
                             - div_up(i_b_overflow, (jcp.dilate_h + 1));
-                    par_conv.kh_padding = nstl::max(0, kh_padding);
+                    par_conv.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
                     par_conv.post_ops_binary_rhs_arg_vec
                             = post_ops_binary_rhs_arg_vec.data();

--- a/src/cpu/x64/jit_transpose_utils.cpp
+++ b/src/cpu/x64/jit_transpose_utils.cpp
@@ -54,10 +54,10 @@ struct jit_trans_iw_ic_t : public jit_trans_src_t, public jit_generator_t {
     }
 
 private:
-    int typesize = 0;
+    dim_t typesize = 0;
     bool is_layout_nxc = false;
     static constexpr int transpose_size = 16;
-    size_t src_stride = 0, tr_src_stride = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
 
     Opmask kLoadMask1 = k1;
     Opmask kLoadMask2 = k2;
@@ -111,14 +111,17 @@ private:
         jit_generator_t::vmovdqa32(z, ptr[imm_addr64]);
     }
 
-    void transpose(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
-    void transpose_2b(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
-    void transpose_1b(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
+    void transpose(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
+    void transpose_2b(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
+    void transpose_1b(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
     void generate() override;
 };
 
 void jit_trans_iw_ic_t::transpose(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 16, "Unsupported transpose size");
     if (!nrows) return;
@@ -132,7 +135,7 @@ void jit_trans_iw_ic_t::transpose(
 }
 
 void jit_trans_iw_ic_t::transpose_2b(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
     auto load_ymm = [this](int i) {
         vmovups(src_ymm(i), EVEX_compress_addr(reg_src, i * src_stride));
     };
@@ -141,28 +144,28 @@ void jit_trans_iw_ic_t::transpose_2b(
         mov(regw_tmp, w);
         jit_generator_t::kmovd(k, regw_tmp);
     };
-    int l_pad_tail {0}, l_pad_rows {0};
-    int r_pad_tail {0}, r_pad_rows {0};
+    dim_t l_pad_tail {0}, l_pad_rows {0};
+    dim_t r_pad_tail {0}, r_pad_rows {0};
 
     if (l_pad > 0) {
-        int store_pad = 2 * transpose_size;
+        dim_t store_pad = 2 * transpose_size;
         l_pad_rows = l_pad / store_pad;
         l_pad_tail = div_up(l_pad % store_pad, 2);
         kmovw(kLPad, (1 << l_pad_tail) - 1);
     }
     if (r_pad > 0) {
-        int store_pad = div_up(r_pad, 2);
+        dim_t store_pad = div_up(r_pad, 2);
         r_pad_rows = store_pad / transpose_size;
         r_pad_tail = store_pad % transpose_size;
         kmovw(kRPad, (1 << r_pad_tail) - 1);
     }
 
-    auto padding = [this](Reg64 base, int addr_shift, int pad_rows,
-                           int pad_tail, const Opmask &mask, int i) {
+    auto padding = [this](Reg64 base, dim_t addr_shift, dim_t pad_rows,
+                           dim_t pad_tail, const Opmask &mask, dim_t i) {
         // note: pad can be bigger than 16 because of dilation
-        const size_t row_offset = 2 * transpose_size * typesize;
+        const dim_t row_offset = 2 * transpose_size * typesize;
         const auto pshift = addr_shift * typesize + i * tr_src_stride;
-        for (int i_row = 0; i_row < pad_rows; i_row++) {
+        for (dim_t i_row = 0; i_row < pad_rows; i_row++) {
             auto addr = EVEX_compress_addr(base, pshift + i_row * row_offset);
             vmovups(addr, zmm_zero);
         }
@@ -174,14 +177,14 @@ void jit_trans_iw_ic_t::transpose_2b(
         }
     };
 
-    auto store = [&](Zmm r, int i) {
+    auto store = [&](Zmm r, dim_t i) {
         mov(reg_tr_src_tmp, reg_tr_src);
         if (l_pad > 0) {
             padding(reg_tr_src_tmp, 0, l_pad_rows, l_pad_tail, kLPad, i);
             add(reg_tr_src_tmp, l_pad * typesize);
         }
         if (r_pad > 0) {
-            int addr_shift = nrows - r_pad % 2;
+            dim_t addr_shift = nrows - r_pad % 2;
             padding(reg_tr_src_tmp, addr_shift, r_pad_rows, r_pad_tail, kRPad,
                     i);
         }
@@ -194,12 +197,12 @@ void jit_trans_iw_ic_t::transpose_2b(
     };
 
     if (l_pad > 0 || r_pad > 0) vpxord(zmm_zero, zmm_zero, zmm_zero);
-    int store_tail = rnd_up(nrows, 2);
+    dim_t store_tail = rnd_up(nrows, 2);
     kmovw(kTail, (1 << store_tail / 2) - 1);
 
-    const int ic_block = conf_->ic_block;
+    const dim_t ic_block = conf_->ic_block;
     const bool is_short_block = ic_block != 16;
-    const int ic_tail = conf_->ic_tail;
+    const dim_t ic_tail = conf_->ic_tail;
     // Assertion below as we need vmovdqu16 for ic_tails.
     // If needed, can be extended by using load_bytes() helper.
     assert(IMPLICATION(ic_tail, mayiuse(avx512_core)));
@@ -245,14 +248,14 @@ void jit_trans_iw_ic_t::transpose_2b(
 
         // for odd numbers we need to mix row with zeroes
         if (nrows % 2) {
-            int i = nrows - 1;
+            int i = static_cast<int>(nrows - 1);
             auto zmm_src0 = src_zmm(i);
             vmovdqu16(zmm_src0 | kLoadMask1 | T_z,
                     EVEX_compress_addr(reg_src, i * src_stride));
             vpermw(zmm_src0, vidx5, zmm_src0);
         }
 
-        for (int i = rnd_up(nrows, 2); i < 16; i += 2) {
+        for (int i = static_cast<int>(rnd_up(nrows, 2)); i < 16; i += 2) {
             vpxord(src_zmm(i), src_zmm(i), src_zmm(i));
         }
     } else {
@@ -277,7 +280,7 @@ void jit_trans_iw_ic_t::transpose_2b(
 
         // for odd numbers we need to mix row with zeroes
         if (nrows % 2) {
-            int i = nrows - 1;
+            int i = static_cast<int>(nrows - 1);
             auto src0 = src_ymm(i);
             auto src1 = src_ymm(i + 1); // zero
 
@@ -396,7 +399,7 @@ void jit_trans_iw_ic_t::transpose_2b(
 }
 
 void jit_trans_iw_ic_t::transpose_1b(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
 
     auto load = [this, nrows](int i) {
         auto zmm_src = src_zmm(i);
@@ -407,7 +410,7 @@ void jit_trans_iw_ic_t::transpose_1b(
             vpxord(zmm_src, zmm_src, zmm_src);
     };
 
-    int l_pad_tail {0}, r_pad_tail {0}, l_pad_rows {0}, r_pad_rows {0};
+    dim_t l_pad_tail {0}, r_pad_tail {0}, l_pad_rows {0}, r_pad_rows {0};
 
     if (l_pad > 0) {
         l_pad_rows = l_pad / transpose_size;
@@ -420,13 +423,13 @@ void jit_trans_iw_ic_t::transpose_1b(
         kmovw(kRPad, (1 << r_pad_tail) - 1);
     }
 
-    auto padding = [this](Reg64 base, int addr_shift, int pad_rows,
-                           int pad_tail, const Opmask &mask, int i) {
+    auto padding = [this](Reg64 base, dim_t addr_shift, dim_t pad_rows,
+                           dim_t pad_tail, const Opmask &mask, dim_t i) {
         // note: pad can be bigger than 16 because of dilation
-        const size_t row_off = transpose_size;
+        const dim_t row_off = transpose_size;
         auto xmm_zero = Xmm(zmm_zero.getIdx());
         const auto pshift = addr_shift * typesize + i * tr_src_stride;
-        for (int i_row = 0; i_row < pad_rows; i_row++) {
+        for (dim_t i_row = 0; i_row < pad_rows; i_row++) {
             auto addr = EVEX_compress_addr(base, pshift + i_row * row_off);
             vmovups(addr, xmm_zero);
         }
@@ -437,7 +440,7 @@ void jit_trans_iw_ic_t::transpose_1b(
         }
     };
 
-    auto store = [&](Zmm r, int i) {
+    auto store = [&](Zmm r, dim_t i) {
         mov(reg_tr_src_tmp, reg_tr_src);
         if (l_pad > 0) {
             padding(reg_tr_src_tmp, 0, l_pad_rows, l_pad_tail, kLPad, i);
@@ -455,7 +458,7 @@ void jit_trans_iw_ic_t::transpose_1b(
     };
 
     if (l_pad > 0 || r_pad > 0) vpxord(zmm_zero, zmm_zero, zmm_zero);
-    int store_tail = rnd_up(nrows, 4);
+    dim_t store_tail = rnd_up(nrows, 4);
     kmovw(kTail, (1 << store_tail) - 1);
 
     // load rows and swap bytes
@@ -479,7 +482,8 @@ void jit_trans_iw_ic_t::transpose_1b(
         vpermb(zmm_src0, vidx1, zmm_src0);
     }
     // zero rest zmm_src
-    for (int i = rnd_up(nrows, 4); i < transpose_size; i += 4) {
+    for (int i = static_cast<int>(rnd_up(nrows, 4)); i < transpose_size;
+            i += 4) {
         auto zmm_src0 = src_zmm(i);
         vpxord(zmm_src0, zmm_src0, zmm_src0);
     }
@@ -537,7 +541,7 @@ void jit_trans_iw_ic_t::transpose_1b(
         return mod * 4 + div;
     };
 
-    const int ic_block = conf_->ic_block;
+    const dim_t ic_block = conf_->ic_block;
     for (int col_idx = 0; col_idx < ic_block; col_idx++) {
         store(src_zmm(get_vec_idx(col_idx)), col_idx);
     }
@@ -547,7 +551,7 @@ void jit_trans_iw_ic_t::generate() {
     preamble();
 
     if (mayiuse(avx512_core)) {
-        const int ic_block = conf_->ic_block;
+        const dim_t ic_block = conf_->ic_block;
         const int ic_tail = conf_->ic_tail;
         if (conf_->stride_w > 1 || is_layout_nxc) {
             kmovd(kLoadMask1, (1 << ic_block) - 1);
@@ -607,39 +611,41 @@ void jit_trans_iw_ic_t::generate() {
     } else
         assert(!"unsupported data type");
 
-    const int ic_block = conf_->ic_block;
-    const size_t src_mult
+    const dim_t ic_block = conf_->ic_block;
+    const dim_t src_mult
             = is_layout_nxc ? conf_->ngroups * conf_->ic : ic_block;
-    const int iw = conf_->iw;
-    const int tr_iw = conf_->tr_iw;
-    const int str_w = conf_->stride_w;
+    const dim_t iw = conf_->iw;
+    const dim_t tr_iw = conf_->tr_iw;
+    const dim_t str_w = conf_->stride_w;
     assert(tr_iw % str_w == 0);
-    const int tr_iw_s = tr_iw / str_w;
+    const dim_t tr_iw_s = tr_iw / str_w;
     assert(transpose_size >= ic_block);
 
     // Data for every strided case is placed consecutively
     // For 1x1 convolutions with strides we transpose only needed elements
     const auto str_w_end = (conf_->kw == 1) ? 1 : str_w;
-    for (int s = 0; s < str_w_end; s++) {
-        const int left_pad = div_up(nstl::max(0, conf_->l_pad - s), str_w);
-        const int iw1 = iw + conf_->l_pad;
-        const int iw_s = (s < (iw1 % str_w) ? div_up(nstl::max(0, iw1), str_w)
-                                            : iw1 / str_w)
+    for (dim_t s = 0; s < str_w_end; s++) {
+        const dim_t left_pad
+                = div_up(nstl::max<dim_t>(0, conf_->l_pad - s), str_w);
+        const dim_t iw1 = iw + conf_->l_pad;
+        const dim_t iw_s
+                = (s < (iw1 % str_w) ? div_up(nstl::max<dim_t>(0, iw1), str_w)
+                                     : iw1 / str_w)
                 - left_pad;
-        const int right_pad = tr_iw_s - iw_s - left_pad;
+        const dim_t right_pad = tr_iw_s - iw_s - left_pad;
 
-        const int transposes
-                = utils::div_up(nstl::max(0, iw_s), transpose_size);
-        int loop_iters = nstl::max(0, transposes - 1);
-        int tail = iw_s - loop_iters * transpose_size;
+        const dim_t transposes
+                = utils::div_up(nstl::max<dim_t>(0, iw_s), transpose_size);
+        dim_t loop_iters = nstl::max<dim_t>(0, transposes - 1);
+        dim_t tail = iw_s - loop_iters * transpose_size;
 
         src_stride = src_mult * typesize * str_w;
         tr_src_stride = tr_iw * typesize;
 
         bool nontemporal_stores = false;
 
-        const size_t src_step = src_mult * transpose_size * str_w * typesize;
-        const size_t tr_src_step = transpose_size * typesize;
+        const dim_t src_step = src_mult * transpose_size * str_w * typesize;
+        const dim_t tr_src_step = transpose_size * typesize;
 
         mov(reg_src, ptr[param1 + GET_OFF(src)]);
         mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
@@ -647,8 +653,8 @@ void jit_trans_iw_ic_t::generate() {
         mov(reg_tr_src_prf, ptr[param1 + GET_OFF(tr_src_prf)]);
 
         if (str_w > 1) {
-            int tr_src_shift = s;
-            int src_shift = (str_w - (conf_->l_pad % str_w) + s) % str_w;
+            dim_t tr_src_shift = s;
+            dim_t src_shift = (str_w - (conf_->l_pad % str_w) + s) % str_w;
             add(reg_src, src_shift * src_mult * typesize);
             add(reg_tr_src, tr_src_shift * tr_iw_s * typesize);
             add(reg_src_prf, src_shift * src_mult * typesize);
@@ -709,12 +715,12 @@ struct jit_trans_ow_oc_t : public jit_trans_dst_t, public jit_generator_t {
     }
 
 private:
-    int typesize = 0;
+    dim_t typesize = 0;
     bool is_layout_nxc = false;
-    int vnni_block = 0;
+    dim_t vnni_block = 0;
     static constexpr int transpose_size = 16;
-    size_t src_stride = 0, tr_src_stride = 0;
-    int tail = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
+    dim_t tail = 0;
 
     Opmask kFF = k1;
     Opmask mask_lo = k2;
@@ -755,18 +761,19 @@ private:
         return Xmm(i);
     }
 
-    void transpose(int nrows, bool nontemporal_stores, bool do_convert = true);
+    void transpose(
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void transpose_2b(
-            int nrows, bool nontemporal_stores, bool do_convert = true);
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void transpose_1b(
-            int nrows, bool nontemporal_stores, bool do_convert = true);
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void generate() override;
 };
 
 // do_convert (default is 'true') is a flag that determines when to do the
 // transformation of the input data and when to simply zero out the output data
 void jit_trans_ow_oc_t::transpose(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 16, "Unsupported transpose size");
     if (!nrows) return;
@@ -779,7 +786,7 @@ void jit_trans_ow_oc_t::transpose(
 }
 
 void jit_trans_ow_oc_t::transpose_2b(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
 
     auto load_ymm = [this](int i) {
         auto ymm_reg = src_ymm(i);
@@ -827,7 +834,7 @@ void jit_trans_ow_oc_t::transpose_2b(
             } else {
                 vpxord(zmm_src0, zmm_src0, zmm_src0);
             }
-            store(zmm_src0, nrows - 1);
+            store(zmm_src0, static_cast<int>(nrows - 1));
         }
     } else {
         for (int i = 0; i < rnd_dn(nrows, 2); i += 2) {
@@ -856,11 +863,11 @@ void jit_trans_ow_oc_t::transpose_2b(
             store(zmm_src0, i);
         }
         if (row_pad > 0) {
-            auto src0 = src_ymm(nrows - 1);
-            auto src1 = src_ymm(nrows);
+            auto src0 = src_ymm(static_cast<int>(nrows - 1));
+            auto src1 = src_ymm(static_cast<int>(nrows));
             auto zmm_src0 = src_zmm(30);
             if (do_convert) {
-                load_ymm(nrows - 1);
+                load_ymm(static_cast<int>(nrows - 1));
 
                 vpxor(src1, src1, src1);
                 vpunpckhwd(src1, src0, src1);
@@ -872,13 +879,13 @@ void jit_trans_ow_oc_t::transpose_2b(
             } else {
                 vpxord(zmm_src0, zmm_src0, zmm_src0);
             }
-            store(zmm_src0, nrows - 1);
+            store(zmm_src0, static_cast<int>(nrows - 1));
         }
     }
 }
 
 void jit_trans_ow_oc_t::transpose_1b(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
     auto load_xmm = [this](int i) {
         auto xmm_reg = src_xmm(i);
         auto addr = EVEX_compress_addr(reg_src, i * src_stride);
@@ -903,7 +910,8 @@ void jit_trans_ow_oc_t::transpose_1b(
     assert(is_layout_nxc);
     assert(vnni_block == 4);
 
-    for (int i = 0; i < rnd_up(nrows, vnni_block); i += vnni_block) {
+    for (int i = 0; i < static_cast<int>(rnd_up(nrows, vnni_block));
+            i += static_cast<int>(vnni_block)) {
         const auto idx0 = i;
         const auto idx1 = i + 1;
         const auto idx2 = i + 2;
@@ -997,12 +1005,12 @@ void jit_trans_ow_oc_t::generate() {
         vmovdqa64(vidx4 /*vreg_idx_hi_128*/, (const int64_t *)idx_hi_8);
     }
 
-    const int oc_block = conf_->oc_block;
-    const size_t src_mult
+    const dim_t oc_block = conf_->oc_block;
+    const dim_t src_mult
             = is_layout_nxc ? conf_->ngroups * conf_->oc : oc_block;
-    const int ow = conf_->ow;
-    const int transposes = utils::div_up(ow, transpose_size);
-    int loop_iters = nstl::max(0, transposes - 1);
+    const dim_t ow = conf_->ow;
+    const dim_t transposes = utils::div_up(ow, transpose_size);
+    dim_t loop_iters = nstl::max<dim_t>(0, transposes - 1);
     tail = ow - loop_iters * transpose_size;
 
     src_stride = src_mult * typesize;
@@ -1010,10 +1018,11 @@ void jit_trans_ow_oc_t::generate() {
 
     bool nontemporal_stores = conf_->use_nt_stores_ddst;
 
-    const size_t src_step = src_mult * transpose_size * typesize;
-    const size_t tr_src_step = (size_t)oc_block * transpose_size * typesize;
+    const dim_t src_step = src_mult * transpose_size * typesize;
+    const dim_t tr_src_step = oc_block * transpose_size * typesize;
 
-    const auto zero_tr_ow = nstl::max(0, conf_->tr_ow - rnd_up(ow, vnni_block));
+    const dim_t zero_tr_ow
+            = nstl::max<dim_t>(0, conf_->tr_ow - rnd_up(ow, vnni_block));
 
     mov(reg_src, ptr[param1 + GET_OFF(src)]);
     mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
@@ -1047,11 +1056,11 @@ void jit_trans_ow_oc_t::generate() {
     transpose(tail, nontemporal_stores);
     if (zero_tr_ow) {
         const auto zero_transposes = utils::div_up(zero_tr_ow, transpose_size);
-        const auto zero_loop_iters = nstl::max(0, zero_transposes - 1);
+        const auto zero_loop_iters = nstl::max<dim_t>(0, zero_transposes - 1);
         const auto zero_tail = zero_tr_ow - zero_loop_iters * transpose_size;
 
         // shift over tail
-        add(reg_tr_src, (size_t)oc_block * rnd_up(tail, vnni_block) * typesize);
+        add(reg_tr_src, oc_block * rnd_up(tail, vnni_block) * typesize);
 
         // zero the tr_ow - ow
         if (zero_loop_iters) {
@@ -1077,7 +1086,7 @@ void jit_trans_ow_oc_t::generate() {
 // -------------------------------------------------
 */
 
-void jit_transpose4x16_src_t::transpose(int nrows) {
+void jit_transpose4x16_src_t::transpose(dim_t nrows) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 4, "Unsupported transpose size");
     if (!nrows) return;
@@ -1135,8 +1144,9 @@ void jit_transpose4x16_src_t::transpose(int nrows) {
         load(i);
     }
 
-    for (size_t i = nrows; i < 4; i++) {
-        vpxord(src_zmm(i), src_zmm(i), src_zmm(i));
+    for (dim_t i = nrows; i < 4; i++) {
+        const int reg_idx = static_cast<int>(i);
+        vpxord(src_zmm(reg_idx), src_zmm(reg_idx), src_zmm(reg_idx));
     }
 
     vmovupd(tmp0, src0);
@@ -1200,16 +1210,16 @@ alignas(64) static constexpr const int32_t idxP[16]
 void jit_transpose4x16_src_t::generate() {
     preamble();
 
-    const int ic_block = params->ic_block;
-    const int is = params->is;
-    int tail = is % transpose_size;
+    const dim_t ic_block = params->ic_block;
+    const dim_t is = params->is;
+    dim_t tail = is % transpose_size;
 
     src_stride = ic_block * typesize;
     assert(src_stride == 64);
     tr_src_stride = ic_block * typesize;
 
-    const int src_step = ic_block * transpose_size * typesize;
-    const int tr_src_step = ic_block * transpose_size * typesize;
+    const dim_t src_step = ic_block * transpose_size * typesize;
+    const dim_t tr_src_step = ic_block * transpose_size * typesize;
 
 #define GET_TR_OFF(x) offsetof(jit_transpose_src_args_t, x)
     mov(reg_loop, ptr[param1 + GET_TR_OFF(size)]);
@@ -1275,9 +1285,9 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
     /* Reorder part of F32 weights tensor
        from [VNNI_GRANULARITY][I][kd][kh][kw][16i][16o] to VNNI format [kd][kh][kw][16i][16o][VNNI_GRANULARITY][i]
        and down-convert it to required float. */
-    const int ts_out = types::data_type_size(out_dt_);
-    const int ts_inp = 4;
-    const int simd_w = 16;
+    const dim_t ts_out = types::data_type_size(out_dt_);
+    const dim_t ts_inp = 4;
+    const dim_t simd_w = 16;
 
     const Reg64 &reg_output = r15;
     const Reg64 &reg_output_kd = r14;
@@ -1316,7 +1326,7 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
     auto get_zmm_src = [&](int idx, int ic) { return Zmm(4 * idx + ic); };
     auto get_zmm_bf16 = [&](int ic) { return Zmm(16 + ic); };
 
-    const int vnni_granularity = data_type_vnni_granularity(out_dt_);
+    const dim_t vnni_granularity = data_type_vnni_granularity(out_dt_);
 
     Xbyak::Label prm_table, zero_buffer;
     Xbyak::Label kd_loop_label, kh_loop_label;
@@ -1477,10 +1487,10 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
         L(prm_table);
         uint8_t prm_array[64];
         for (size_t i = 0; i < 16; i++) {
-            prm_array[4 * i] = i;
-            prm_array[4 * i + 1] = i + 16;
-            prm_array[4 * i + 2] = i + 32;
-            prm_array[4 * i + 3] = i + 48;
+            prm_array[4 * i] = static_cast<uint8_t>(i);
+            prm_array[4 * i + 1] = static_cast<uint8_t>(i + 16);
+            prm_array[4 * i + 2] = static_cast<uint8_t>(i + 32);
+            prm_array[4 * i + 3] = static_cast<uint8_t>(i + 48);
         }
 
         for (size_t i = 0; i < 64; ++i)

--- a/src/cpu/x64/jit_transpose_utils.hpp
+++ b/src/cpu/x64/jit_transpose_utils.hpp
@@ -90,7 +90,7 @@ struct jit_transpose4x16_src_t : public jit_generator_t {
 private:
     static const int typesize = sizeof(float);
 
-    int src_stride = 0, tr_src_stride = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
 
     Xbyak::Reg64 imm_addr64 = rbx;
 
@@ -112,8 +112,8 @@ private:
     Xbyak::Reg64 reg_tr_src_tmp = r13;
     Xbyak::Reg32 regw_tmp = r14d;
 
-    void transpose_block(int ur, int nrows);
-    void transpose(int nrows);
+    void transpose_block(dim_t ur, dim_t nrows);
+    void transpose(dim_t nrows);
     void generate() override;
 };
 

--- a/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
@@ -87,7 +87,7 @@ inline void rtus_prepare(conv_pd_t *self, const convolution_desc_t *&conv_d,
     if (ndims == 4) self->rtus_.conv_d_.strides[1] = 1;
     utils::array_set(self->rtus_.conv_d_.padding[0], 0, 2);
     if (ndims == 4) utils::array_set(self->rtus_.conv_d_.padding[1], 0, 2);
-    const int ic = src_d->dims[1];
+    const dim_t ic = src_d->dims[1];
     if (self->desc()->prop_kind == prop_kind::backward_data) {
         data_type_t data_type = self->rtus_.conv_d_.diff_src_desc.data_type;
         src_d = &(self->rtus_.conv_d_.diff_src_desc = *dst_d);
@@ -113,9 +113,9 @@ inline void rtus_prepare_space_info(conv_pd_t *self,
     const bool is_nspc
             = utils::one_of(jcp.src_tag, format_tag::nhwc, format_tag::nwc);
 
-    const size_t factor = utils::pick_by_prop_kind(self->desc()->prop_kind,
+    const dim_t factor = utils::pick_by_prop_kind(self->desc()->prop_kind,
             jcp.nb_reduce, jcp.nb_load_blocking_max, jcp.nb_bcast_blocking);
-    size_t typesize
+    const dim_t typesize
             = types::data_type_size(self->invariant_src_md()->data_type);
 
     self->rtus_.space_per_thread_
@@ -156,19 +156,20 @@ struct rtus_driver_t : public jit_generator_t {
     Xbyak::Reg64 reg_icb_remainder = rcx;
     Xbyak::Reg64 reg_ws_copy = r15;
 
-    int iw_, stride_w_;
-    int src_step_h_, src_step_icb_, ws_step_icb_, vlen_, vlen_shift_;
+    dim_t iw_, stride_w_;
+    dim_t src_step_h_, src_step_icb_, ws_step_icb_;
+    int vlen_, vlen_shift_;
     bool src_to_ws_;
-    size_t typesize_;
-    int ic_, ic_tail_;
+    dim_t typesize_;
+    dim_t ic_, ic_tail_;
     bool is_nspc_;
 
     Xbyak::Xmm reg_zero;
     Xbyak::Xmm reg_v;
 
-    rtus_driver_t(int iw, int stride_w, int src_step_h, int src_step_icb,
-            int ws_step_icb, bool src_to_ws, size_t typesize, int ic,
-            bool is_nspc = false)
+    rtus_driver_t(dim_t iw, dim_t stride_w, dim_t src_step_h,
+            dim_t src_step_icb, dim_t ws_step_icb, bool src_to_ws,
+            dim_t typesize, dim_t ic, bool is_nspc = false)
         : jit_generator_t(jit_name(), isa)
         , iw_(iw)
         , stride_w_(stride_w)
@@ -189,7 +190,7 @@ struct rtus_driver_t : public jit_generator_t {
          * fail to work on reg_v, reg_zero because of this
          * data_type change, e.g. uni_vpxor doen't
          * work on reg_zero now*/
-        auto Vmm = [this](int idx, size_t typesize) {
+        auto Vmm = [this](int idx, dim_t typesize) {
             Xmm res;
             if (is_nspc_) {
                 switch (isa) {
@@ -235,13 +236,13 @@ struct rtus_driver_t : public jit_generator_t {
         vlen_ = reg_v.getBit() / 8;
         vlen_shift_ = 0;
 
-        int tvlen = is_nspc_ ? typesize_ : vlen_;
+        dim_t tvlen = is_nspc_ ? typesize_ : vlen_;
         while (tvlen > 1) {
             tvlen /= 2;
             vlen_shift_++;
         }
 
-        const int simd_w = vlen_ / sizeof(float);
+        const dim_t simd_w = vlen_ / sizeof(float);
         ic_tail_ = ic_ % simd_w;
     }
 
@@ -328,7 +329,7 @@ struct rtus_driver_t : public jit_generator_t {
         }
 
         auto load_reg = [this](const Xmm &vreg, const Reg64 &reg,
-                                const int64_t offset, const int load_size) {
+                                const dim_t offset, const int load_size) {
             if (isa == avx512_core) {
                 const Address &addr = ptr[reg + offset];
                 switch (typesize_) {
@@ -349,7 +350,7 @@ struct rtus_driver_t : public jit_generator_t {
         };
 
         auto store_reg = [this](const Reg64 &reg, const Xmm &vreg,
-                                 const int64_t offset, const int store_size) {
+                                 const dim_t offset, const int store_size) {
             if (isa == avx512_core) {
                 const Address &addr = ptr[reg + offset];
                 switch (typesize_) {
@@ -372,15 +373,15 @@ struct rtus_driver_t : public jit_generator_t {
         mov(reg_ws_copy, reg_ws);
         shl(reg_icb, vlen_shift_);
 
-        const size_t w_step_factor = ic_ * typesize_;
-        const size_t max_load_store_bytes = isa == sse41
-                ? typesize_ == 4 ? 16 : 8
-                : typesize_ == 4 ? 32
-                                 : 16;
-        const size_t load_store_size
+        const dim_t w_step_factor = ic_ * typesize_;
+        const int max_load_store_bytes = isa == sse41 ? typesize_ == 4 ? 16 : 8
+                : typesize_ == 4                      ? 32
+                                                      : 16;
+        const int load_store_size
                 = isa == avx512_core ? vlen_ : max_load_store_bytes;
-        size_t load_store_tail_size = (typesize_ == 1 ? max_load_store_bytes
-                                                      : ic_tail_ * typesize_);
+        const int load_store_tail_size = typesize_ == 1
+                ? max_load_store_bytes
+                : static_cast<int>(ic_tail_ * typesize_);
 
         Label is_loop, ic_loop, ic_loop_tail, ic_loop_finish;
         L(is_loop);
@@ -550,25 +551,25 @@ inline status_t init_rtus_driver(conv_t *self) {
     if (!conf.rtus_.reduce_src_) return status::success;
 
     const auto &cd = *conf.desc();
-    const int ndims = conf.ndims();
-    const int stride_h = (conf.ndims() == 3) ? 1 : cd.strides[0];
-    const int stride_w = cd.strides[ndims - 3];
+    const dim_t ndims = conf.ndims();
+    const dim_t stride_h = (conf.ndims() == 3) ? 1 : cd.strides[0];
+    const dim_t stride_w = cd.strides[ndims - 3];
 
     const bool is_bwd_data = cd.prop_kind == prop_kind::backward_data;
     const auto &src_d = is_bwd_data ? *conf.diff_src_md() : *conf.src_md();
 
-    const int ih = ndims == 3 ? 1 : src_d.dims[2];
-    const int iw = src_d.dims[ndims - 1];
-    const int ic = src_d.dims[1];
+    const dim_t ih = ndims == 3 ? 1 : src_d.dims[2];
+    const dim_t iw = src_d.dims[ndims - 1];
+    const dim_t ic = src_d.dims[1];
 
     const auto src_tag = memory_desc_wrapper(src_d).matches_one_of_tag(
             format_tag::nhwc, format_tag::nwc);
     const bool is_nspc = src_tag != format_tag::undef;
-    const int src_step_h = stride_h * iw;
-    const int src_step_icb = !is_nspc ? ih * iw : 1;
-    const int ws_step_icb = !is_nspc ? conf.jcp_.is : 1;
+    const dim_t src_step_h = stride_h * iw;
+    const dim_t src_step_icb = !is_nspc ? ih * iw : 1;
+    const dim_t ws_step_icb = !is_nspc ? conf.jcp_.is : 1;
     const bool src_to_ws = !is_bwd_data;
-    const size_t typesize
+    const dim_t typesize
             = types::data_type_size(self->pd()->invariant_src_md()->data_type);
 
     CHECK(safe_ptr_assign(self->rtus_driver_,
@@ -578,19 +579,22 @@ inline status_t init_rtus_driver(conv_t *self) {
     return self->rtus_driver_->create_kernel();
 }
 
-inline int best_divider(int value, int min_divider, int max_divider,
+inline int best_divider(dim_t value, int min_divider, dim_t max_divider,
         bool find_max, int step = 1) {
     using namespace dnnl::impl::utils;
-    max_divider = nstl::max(1, nstl::min(max_divider, value));
-    min_divider = nstl::max(1, nstl::min(min_divider, max_divider));
+    const int max_divider_int = static_cast<int>(
+            nstl::max<dim_t>(1, nstl::min<dim_t>(max_divider, value)));
+    min_divider = nstl::max(1, nstl::min(min_divider, max_divider_int));
 
-    auto loss_ratio = [](int total, int chunk) {
-        return float(rnd_up(total, chunk) - total) / rnd_up(total, chunk);
+    auto loss_ratio = [](dim_t total, int chunk) {
+        return float(rnd_up(total, chunk) - total)
+                / float(rnd_up(total, chunk));
     };
 
     float min_loss = FLT_MAX;
-    int x_divider = max_divider;
-    for (int divider = max_divider; divider >= min_divider; divider -= step) {
+    int x_divider = max_divider_int;
+    for (int divider = max_divider_int; divider >= min_divider;
+            divider -= step) {
         const float loss = loss_ratio(value, divider);
         if ((find_max && loss < min_loss) || (!find_max && loss <= min_loss)) {
             min_loss = loss;

--- a/src/cpu/x64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_batch_normalization.cpp
@@ -2202,7 +2202,7 @@ struct driver_t : public c_compatible {
         p.N_ithr = SP_N_ithr;
         p.N_nthr = SP_N_nthr;
 
-        int global_C_blk_s;
+        dim_t global_C_blk_s;
         int global_barriers_per_iter = jbp_.C_nthr_;
 
         for (int64_t it = 0; it < jbp_.iters_; it++) {
@@ -2223,8 +2223,8 @@ struct driver_t : public c_compatible {
                             : it * jbp_.C_blks_per_iter_ + C_blk_s
                                                : C_blk_s;
 
-            int C_blks_thr = C_blk_e - C_blk_s;
-            int N_thr = N_e - N_s;
+            dim_t C_blks_thr = C_blk_e - C_blk_s;
+            dim_t N_thr = N_e - N_s;
 
             if (C_blks_thr == 0 || N_thr == 0) continue;
 
@@ -2290,7 +2290,7 @@ struct driver_t : public c_compatible {
     void init_barriers(const memory_tracking::grantor_t &scratchpad) {
         auto barriers = scratchpad.get<barrier::ctx_64_t>(key_barrier);
         if (barriers) {
-            const int n_barriers = get_c_padded(pd_) / simd_w;
+            const dim_t n_barriers = get_c_padded(pd_) / simd_w;
             for (int i = 0; i < n_barriers; ++i)
                 barrier::ctx_init(&barriers[i]);
         }

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -984,8 +984,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
                               : 0);
 
     if (op_type == op_t::c_blocked) {
-        const dim_t C_blocks = std::ceil(
-                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        const dim_t C_blocks = utils::div_up(src0_d.padded_dims()[1], simd_w);
         // Compute strategy:
         // Each block is individual - parallel over MB and C_blocks safely.
 
@@ -1110,8 +1109,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
             = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
 
     if (op_type == op_t::c_blocked) {
-        const dim_t C_blocks = std::ceil(
-                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        const dim_t C_blocks = utils::div_up(src0_d.padded_dims()[1], simd_w);
         // Compute strategy:
         // Each line of channels is individual, parallel over MB, C_blocks
         // and spatial (broadcasted and not broadcasted spatial dims

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -143,8 +143,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::init_post_ops_injector() {
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {10, reg_tmp_,
             reg_elt_inj_table_, r13, true /*preserve gpr*/,
             true /*preserve vmm*/, PARAM_OFF(post_ops_binary_rhs_arg_vec),
-            PARAM_OFF(dst_orig), dst_d, tail_size_, tail_opmask_,
-            false /*use_exact_tail_scalar_bcast*/};
+            PARAM_OFF(dst_orig), dst_d, static_cast<dim_t>(tail_size_),
+            tail_opmask_, false /*use_exact_tail_scalar_bcast*/};
     const binary_injector::static_params_t bsp(this->param1,
             get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 
@@ -345,7 +345,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::perform_op(
     else if (alg == binary_sub)
         uni_vsubps(v0, v0, v1);
     else if (cmp_op) {
-        const unsigned int predicate = cmp_predicate(alg);
+        const uint8_t predicate = static_cast<uint8_t>(cmp_predicate(alg));
         if (is_avx512) {
             vcmpps(cmp_mask, v0, v1, predicate);
             vmovups(v0 | cmp_mask | T_z, vreg_one_);

--- a/src/cpu/x64/jit_uni_convert_xf16.cpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.cpp
@@ -72,29 +72,32 @@ void jit_uni_cvt_ps_to_xf16_t<isa>::generate() {
 
         L(l_simd_notail);
     } else {
-        const size_t blocked_size = (nelems_ / simd_w_) * simd_w_;
-        constexpr size_t unroll_length = 1024;
-        const size_t number_of_loops = blocked_size / unroll_length;
-        const size_t loop_tail = blocked_size % unroll_length;
+        constexpr dim_t simd_w = simd_w_;
+        const dim_t blocked_size = (nelems_ / simd_w) * simd_w;
+        constexpr dim_t unroll_length = 1024;
+        const dim_t number_of_loops = blocked_size / unroll_length;
+        const dim_t loop_tail = blocked_size % unroll_length;
 
         if (number_of_loops > 0) {
             Xbyak::Label l_number_of_loops;
             mov(reg_nelems, number_of_loops);
             L(l_number_of_loops);
-            for (size_t i = 0; i < unroll_length; i += simd_w_)
-                cvt_ps_to_xf16(i, false);
-            add(reg_input, sizeof(float) * unroll_length);
-            add(reg_output, sizeof(float16_t) * unroll_length);
+            for (dim_t i = 0; i < unroll_length; i += simd_w)
+                cvt_ps_to_xf16(static_cast<int>(i), false);
+            add(reg_input, static_cast<dim_t>(sizeof(float)) * unroll_length);
+            add(reg_output,
+                    static_cast<dim_t>(sizeof(float16_t)) * unroll_length);
 
             dec(reg_nelems);
             cmp(reg_nelems, 0);
             jg(l_number_of_loops, T_NEAR);
         }
         if (loop_tail > 0) {
-            for (size_t i = 0; i < loop_tail; i += simd_w_)
-                cvt_ps_to_xf16(i, false);
-            add(reg_input, sizeof(float) * loop_tail);
-            add(reg_output, sizeof(float16_t) * loop_tail);
+            for (dim_t i = 0; i < loop_tail; i += simd_w)
+                cvt_ps_to_xf16(static_cast<int>(i), false);
+            add(reg_input, static_cast<dim_t>(sizeof(float)) * loop_tail);
+            add(reg_output,
+                    static_cast<dim_t>(sizeof(float16_t)) * loop_tail);
         }
         if (tail_size_ != 0) {
             setup_mask();

--- a/src/cpu/x64/jit_uni_convert_xf16.hpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.hpp
@@ -18,6 +18,7 @@
 #define CPU_X64_JIT_UNI_CONVERT_XF16_HPP
 
 #include <assert.h>
+#include <limits>
 
 #include "common/c_types_map.hpp"
 #include "common/float16.hpp"
@@ -58,15 +59,15 @@ struct jit_uni_cvt_ps_to_xf16_t : public jit_generator_t {
     jit_uni_cvt_ps_to_xf16_t(impl::data_type_t dt, size_t nelems = 0)
         : jit_generator_t(jit_name())
         , output_dt_(dt)
-        , nelems_(nelems)
+        , nelems_(to_dim_t(nelems))
         , is_dynamic_size_(nelems_ == 0)
-        , tail_size_(nelems_ % simd_w_) {}
+        , tail_size_(static_cast<int>(nelems_ % simd_w_)) {}
 
     void generate() override;
 
 protected:
     const impl::data_type_t output_dt_; // bf16 or f16
-    const size_t nelems_;
+    const dim_t nelems_;
     const bool is_dynamic_size_;
     const int tail_size_;
 
@@ -95,6 +96,13 @@ protected:
     Xbyak::Reg64 reg_tail = rcx;
     Xbyak::Reg64 reg_tmp = r8;
     Xbyak::Reg64 reg_scratch = r9;
+
+    static dim_t to_dim_t(size_t nelems) {
+        JIT_ASSERT_RET(nelems <= static_cast<size_t>(
+                                      std::numeric_limits<dim_t>::max()),
+                0);
+        return static_cast<dim_t>(nelems);
+    }
 
     void setup_mask();
     virtual void cvt_ps_to_xf16(const int idx, const bool is_tail);

--- a/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -59,13 +59,13 @@ void jit_uni_deconv_zp_pad_str_kernel_base_t::compute() {
     for (dim_t icb = 0; icb < jcp_.nb_ic; ++icb) {
         const bool is_last_icb = icb == jcp_.nb_ic - 1;
 
-        const int n_inner_ic_blk = jcp_.is_depthwise
+        const int n_inner_ic_blk = static_cast<int>(jcp_.is_depthwise
                 ? 1
                 : (is_last_icb && ic_tail_exists
                                   ? utils::div_up(jcp_.ic_without_padding
                                                     % jcp_.ic_block,
                                             4)
-                                  : (jcp_.ic_block / 4));
+                                  : (jcp_.ic_block / 4)));
 
         const dim_t outer_wei_offset = icb * outer_icb_step;
 
@@ -82,10 +82,14 @@ template <cpu_isa_t isa, typename Vmm>
 jit_uni_deconv_zp_pad_str_kernel_t<isa,
         Vmm>::jit_uni_deconv_zp_pad_str_kernel_t(const jit_conv_conf_t &jcp)
     : jit_uni_deconv_zp_pad_str_kernel_base_t(jcp)
-    , result_acc_(reserve_vmm())
-    , vmm_tmp_((jcp.has_vnni || jcp.is_depthwise) ? 0 : reserve_vmm())
-    , vmm_one_bytes_(jcp.is_depthwise ? 0 : reserve_vmm())
-    , vmm_one_words_((jcp.has_vnni || jcp.is_depthwise) ? 0 : reserve_vmm())
+    , result_acc_(static_cast<int>(reserve_vmm()))
+    , vmm_tmp_((jcp.has_vnni || jcp.is_depthwise)
+                    ? 0
+                    : static_cast<int>(reserve_vmm()))
+    , vmm_one_bytes_(jcp.is_depthwise ? 0 : static_cast<int>(reserve_vmm()))
+    , vmm_one_words_((jcp.has_vnni || jcp.is_depthwise)
+                    ? 0
+                    : static_cast<int>(reserve_vmm()))
     , current_vmm_(number_reserved_vmms_) {}
 
 template <cpu_isa_t isa, typename Vmm>
@@ -158,7 +162,7 @@ template <cpu_isa_t isa, typename Vmm,
         typename T = std::integral_constant<bool, (isa < avx512_core)>>
 struct helper_store_t {
     static void store(jit_generator_t *gen, const Vmm &vmm,
-            const Xbyak::Reg64 &reg_dst, const size_t size,
+            const Xbyak::Reg64 &reg_dst, const int size,
             const Xbyak::Opmask &opmask) {
         gen->store_bytes(vmm, reg_dst, 0, size);
     }
@@ -168,7 +172,7 @@ using isa_at_least_avx512_core = std::false_type;
 template <cpu_isa_t isa, typename Vmm>
 struct helper_store_t<isa, Vmm, isa_at_least_avx512_core> {
     static void store(jit_generator_t *gen, const Vmm &vmm,
-            const Xbyak::Reg64 &reg_dst, const size_t size,
+            const Xbyak::Reg64 &reg_dst, const int size,
             const Xbyak::Opmask &opmask) {
         using namespace Xbyak::util;
         gen->vmovups(gen->ptr[reg_dst], vmm | opmask);
@@ -184,7 +188,7 @@ void jit_uni_deconv_zp_pad_str_kernel_t<isa, Vmm>::store_result() {
         cmp(reg_last_oc_block_, 0);
         je(store_no_tail, T_NEAR);
         helper_store_t<isa, Vmm>::store(this, result_acc_, reg_dst_,
-                tail_size_ * sizeof(int32_t), ktail_mask_);
+                static_cast<int>(tail_size_ * sizeof(int32_t)), ktail_mask_);
         jmp(end, T_NEAR);
     }
 
@@ -220,7 +224,8 @@ struct helper_create_deconv_ker_t {
     static jit_uni_deconv_zp_pad_str_kernel_base_t *
     create_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp) {
 
-        const int ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+        const dim_t ch_block
+                = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
         switch (ch_block) {
             case 8:
                 if (isa == avx2) {
@@ -242,7 +247,8 @@ template <cpu_isa_t isa>
 struct helper_create_deconv_ker_t<isa, isa_at_least_avx512_core> {
     static jit_uni_deconv_zp_pad_str_kernel_base_t *
     create_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp) {
-        const int ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+        const dim_t ch_block
+                = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
         switch (ch_block) {
             case 16:
                 return new jit_uni_deconv_zp_pad_str_kernel_t<avx512_core,
@@ -325,10 +331,10 @@ void compute_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp,
             : 1;
 
     parallel(nthrs, [=](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int ch_b {0}, oc_b {0}, d {0}, h {0}, w {0};
+        dim_t ch_b {0}, oc_b {0}, d {0}, h {0}, w {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, ch_b, jcp.nb_ch, oc_b, jcp.nb_oc, d, jcp.kd,
                     h, jcp.kh, w, jcp.kw);

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -45,7 +45,7 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         static constexpr bool use_exact_tail_scalar_bcast = true;
-        const size_t tail_size = jcp.oc_without_padding
+        const dim_t tail_size = jcp.oc_without_padding
                 % (cpu_isa_traits_t<isa>::vlen / sizeof(float));
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r14, r15,
                 r12, preserve_gpr, preserve_vmm,
@@ -60,7 +60,7 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
     }
 }
 
-bool check_if_tail_load(const bool is_ch_tail, const int c_tail, const int ch,
+bool check_if_tail_load(const bool is_ch_tail, const dim_t c_tail, const int ch,
         const int ur_ch_blocks, const int vlen, const int i) {
     return is_ch_tail && (ch + 1 == ur_ch_blocks) && ((i + 1) * vlen > c_tail);
 }
@@ -74,7 +74,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
-    const int c_tail = jcp.oc % jcp.ch_block;
+    const dim_t c_tail = jcp.oc % jcp.ch_block;
 
     const int repeats = max_repeats();
     for (int i = 0; i < repeats; i++) {
@@ -87,11 +87,12 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                 Vmm vmm_acc
                         = get_acc_reg(i * ur_ch_blocks * ur_w + ch * ur_w + ow);
 
-                const int b_off = ch * ch_blk + i * vlen;
+                const dim_t b_off = ch * ch_blk + i * vlen;
                 if (this->jcp.with_bias) {
                     if (is_tail_load) {
                         load_tail(vmm_acc, reg_bias, b_off * sizeof(float),
-                                (c_tail - i * vlen) * sizeof(float));
+                                static_cast<int>(
+                                        (c_tail - i * vlen) * sizeof(float)));
                     } else {
                         uni_vmovups(vmm_acc,
                                 vmmword[reg_bias + b_off * sizeof(float)]);
@@ -100,7 +101,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                     uni_vpxor(vmm_acc, vmm_acc, vmm_acc);
                 }
 
-                const int o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
                 if (this->jcp.with_sum) {
                     if (is_tail_load) {
                         if (this->jcp.with_bias) {
@@ -108,12 +109,13 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                             auto vmm_tmp = get_ker_reg(0);
                             add_tail_from_mem(vmm_acc, vmm_tmp, reg_output,
                                     o_off * sizeof(float),
-                                    (c_tail - i * vlen) * sizeof(float));
+                                    static_cast<int>((c_tail - i * vlen)
+                                            * sizeof(float)));
                         } else {
                             // nothing to add, just load dst.
                             load_tail(vmm_acc, reg_output,
                                     o_off * sizeof(float),
-                                    c_tail * sizeof(float));
+                                    static_cast<int>(c_tail * sizeof(float)));
                         }
                     } else {
                         // blocked layout has dst padded, so no tail handling.
@@ -129,10 +131,10 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
 template <cpu_isa_t isa>
 void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r, bool is_ch_tail) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -142,25 +144,25 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
             : (jcp.is_fused_conv ? 1 : jcp.ih) * jcp.iw * ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
 
-    auto get_input_spatial_index = [=](int oi, int ki) {
+    auto get_input_spatial_index = [=](dim_t oi, dim_t ki) -> dim_t {
         return (ki * dilate_w + oi * stride_w - pad_l);
     };
 
-    auto get_input_offset = [&](int ii, int ci, int rep) {
+    auto get_input_offset = [&](dim_t ii, dim_t ci, dim_t rep) -> dim_t {
         return (ci * icb_stride + ii * iw_stride + rep * vlen)
                 * jcp.typesize_in;
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise) {
         // find bounds of input spatial indices
         bool first = true;
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = get_input_spatial_index(oi, ki);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; oi++) {
+                const dim_t ii = get_input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -181,7 +183,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
             mov(aux_reg_input, ptr[aux_reg_input_buffer_ptr]);
             add(aux_reg_input, reg_iw_offset);
         }
-        const int c_tail = jcp.oc % jcp.ch_block;
+        const dim_t c_tail = jcp.oc % jcp.ch_block;
         const int repeats = max_repeats();
         for (int i = 0; i < repeats; i++) {
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
@@ -192,56 +194,61 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
                     continue;
                 if (jcp.is_resrc_depthwise) {
                     // now we can load input once and reuse up to jcp.kw times
-                    for (int ii = ii_start; ii <= ii_end; ii++) {
-                        Vmm vmm_src = get_src_reg(ii);
-                        const int inp_off = get_input_offset(ii, ch, i);
+                    for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                        Vmm vmm_src = get_src_reg(static_cast<int>(ii));
+                        const dim_t inp_off = get_input_offset(ii, ch, i);
                         if (is_tail_load) {
                             load_tail(vmm_src, aux_reg_input, inp_off,
-                                    (c_tail - i * vlen) * jcp.typesize_in);
+                                    static_cast<int>((c_tail - i * vlen)
+                                            * jcp.typesize_in));
                         } else {
                             uni_vmovups(vmm_src, ptr[aux_reg_input + inp_off]);
                         }
                     }
                 }
-                for (int kw = 0; kw < jcp.kw; kw++) {
-                    const int ker_off = ch * jcp.kh * jcp.kw * ch_blk
+                for (dim_t kw = 0; kw < jcp.kw; kw++) {
+                    const dim_t ker_off = ch * jcp.kh * jcp.kw * ch_blk
                             + kw * ch_blk + i * vlen;
 
                     Vmm vmm_ker = get_ker_reg(0);
                     uni_vmovups(vmm_ker,
                             ptr[aux_reg_kernel + ker_off * sizeof(float)]);
 
-                    int ow_start = get_ow_start(kw, pad_l);
-                    int ow_end = get_ow_end(ur_w, kw, pad_r);
-                    for (int ow = ow_start; ow < ow_end; ow++) {
+                    const dim_t ow_start = get_ow_start(kw, pad_l);
+                    const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                    for (dim_t ow = ow_start; ow < ow_end; ow++) {
 
-                        const int ii = get_input_spatial_index(ow, kw);
-                        Vmm vmm_src = jcp.is_resrc_depthwise ? get_src_reg(ii)
-                                                             : get_src_reg(0);
+                        const dim_t ii = get_input_spatial_index(ow, kw);
+                        Vmm vmm_src = jcp.is_resrc_depthwise
+                                ? get_src_reg(static_cast<int>(ii))
+                                : get_src_reg(0);
                         if (!jcp.is_resrc_depthwise) {
-                            const int inp_off = get_input_offset(ii, ch, i);
+                            const dim_t inp_off = get_input_offset(ii, ch, i);
                             if (is_tail_load) {
                                 load_tail(vmm_src, aux_reg_input, inp_off,
-                                        (c_tail - i * vlen) * jcp.typesize_in);
+                                        static_cast<int>((c_tail - i * vlen)
+                                                * jcp.typesize_in));
                             } else {
                                 uni_vmovups(
                                         vmm_src, ptr[aux_reg_input + inp_off]);
                             }
                         }
-                        Vmm vmm_acc = get_acc_reg(
-                                i * ur_ch_blocks * ur_w + ch * ur_w + ow);
+                        Vmm vmm_acc = get_acc_reg(static_cast<int>(
+                                i * ur_ch_blocks * ur_w + ch * ur_w + ow));
                         uni_vfmadd231ps(vmm_acc, vmm_src, vmm_ker);
                     }
                 }
             }
         }
 
-        add(aux_reg_kernel, jcp.kw * ch_blk * sizeof(float));
+        add(aux_reg_kernel,
+                static_cast<uint32_t>(jcp.kw * ch_blk * sizeof(float)));
         if (jcp.is_fused_conv) {
             // Move to next row pointer in the buffer
             add(aux_reg_input_buffer_ptr, sizeof(void *));
         } else {
-            add(aux_reg_input, ih_stride * dilate_h * sizeof(float));
+            add(aux_reg_input,
+                    static_cast<int>(ih_stride * dilate_h * sizeof(float)));
         }
 
         dec(iter_kh);
@@ -285,7 +292,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_postops(
             const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
             const auto mask_tail_blocked_layout
                     = jcp.oc_without_padding % jcp.ch_block && !dst_layout_nxc;
-            const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+            const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
             iterate(repeats, ur_ch_blocks, ur_w, mask_tail_blocked_layout,
                     [&](const int r, const int ch, const int ow,
                             const bool mask_flag_blocked_layout) {
@@ -408,7 +415,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
-    const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+    const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
 
     const int repeats = max_repeats();
     for (int i = 0; i < repeats; i++) {
@@ -418,12 +425,13 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
             if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= i * vlen)
                 continue;
             for (int ow = 0; ow < ur_w; ow++) {
-                const int o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
                 Vmm vmm_dst
                         = get_acc_reg(i * ur_ch_blocks * ur_w + ch * ur_w + ow);
                 if (is_tail_load) {
                     store_tail(vmm_dst, reg_output, o_off * sizeof(float),
-                            (c_tail - i * vlen) * sizeof(float));
+                            static_cast<int>(
+                                    (c_tail - i * vlen) * sizeof(float)));
                 } else
                     uni_vmovups(vmmword[reg_output + o_off * sizeof(float)],
                             vmm_dst);
@@ -465,9 +473,9 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
     mov(aux_reg_ch_blocks, reg_ch_blocks);
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int ch_block_tail = jcp.nb_ch
-                - (utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int ch_block_tail = static_cast<int>(jcp.nb_ch
+                - utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         push(reg_kernel);
         push(reg_input);
@@ -483,10 +491,11 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
             L(ch_loop_label);
             {
                 compute(jcp.nb_ch_blocking, false);
-                add(reg_kernel, wei_ch_stride);
-                add(reg_input, inp_ch_stride);
-                add(reg_output, out_ch_stride);
-                if (jcp.with_bias) add(reg_bias, bias_stride);
+                add(reg_kernel, static_cast<uint32_t>(wei_ch_stride));
+                add(reg_input, static_cast<uint32_t>(inp_ch_stride));
+                add(reg_output, static_cast<uint32_t>(out_ch_stride));
+                if (jcp.with_bias)
+                    add(reg_bias, static_cast<uint32_t>(bias_stride));
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
                 jge(ch_loop_label, T_NEAR);
@@ -515,26 +524,26 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
 template <cpu_isa_t isa>
 void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    int iw = static_cast<int>(jcp.iw);
+    int ow = static_cast<int>(jcp.ow);
+    int kw = static_cast<int>(jcp.kw);
+    int l_pad = static_cast<int>(jcp.l_pad);
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    int stride_w = static_cast<int>(jcp.stride_w);
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
@@ -546,7 +555,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
         if (n_oi == 0) {
             compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
             add(reg_input, inp_shift_pad);
-            add(reg_output, out_shift);
+            add(reg_output, static_cast<uint32_t>(out_shift));
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
             }
@@ -554,7 +563,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
             if (l_pad > 0) {
                 compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
                 add(reg_input, inp_shift_pad);
-                add(reg_output, out_shift);
+                add(reg_output, static_cast<uint32_t>(out_shift));
                 inc(reg_oi);
             }
             if ((l_pad <= 0 && n_oi > 0) || (l_pad > 0 && n_oi > 1)) {
@@ -562,8 +571,8 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
                 L(ow_loop_label);
                 {
                     compute_loop(ur_w, ur_ch_blocks, 0, 0);
-                    add(reg_input, inp_shift);
-                    add(reg_output, out_shift);
+                    add(reg_input, static_cast<uint32_t>(inp_shift));
+                    add(reg_output, static_cast<uint32_t>(out_shift));
 
                     inc(reg_oi);
                     cmp(reg_oi, n_oi);
@@ -572,8 +581,8 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
             }
             if (r_pad1 > 0) {
                 compute_loop(ur_w, ur_ch_blocks, 0, r_pad1);
-                add(reg_input, inp_shift);
-                add(reg_output, out_shift);
+                add(reg_input, static_cast<uint32_t>(inp_shift));
+                add(reg_output, static_cast<uint32_t>(out_shift));
             }
             if (ur_w_tail != 0) {
                 compute_loop(ur_w_tail, ur_ch_blocks, 0, r_pad);
@@ -620,7 +629,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
         const auto oc_tail = jcp.oc_without_padding % jcp.ch_block;
         if (oc_tail != 0) {
             // Prepare masks for tailing
-            const int oc_tail_shift
+            const dim_t oc_tail_shift
                     = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
             static constexpr auto zmm_full_mask = ((1 << 16) - 1);
             Reg32 reg_tail_32 = reg_tail.cvt32();
@@ -630,7 +639,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        ow_loop(jcp.nb_ch);
+        ow_loop(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
@@ -666,7 +675,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_vmm(
 template <>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>::load_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
-    int bytes = (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     load_bytes(vmm, addr, bytes);
 }
 template <>
@@ -686,7 +696,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_vmm(
 template <>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>::store_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
-    int bytes = (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     store_bytes(vmm, addr, bytes);
 }
 template <>
@@ -713,14 +724,14 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_ddst(
 template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
         int ur_ch_blocks, int ur_str_w, bool is_last_ch) {
-    int kw = jcp.kw;
-    int kh = jcp.kh;
-    int ow = jcp.ow;
-    int oh = jcp.oh;
+    const dim_t kw = jcp.kw;
+    const dim_t kh = jcp.kh;
+    const dim_t ow = jcp.ow;
+    const dim_t oh = jcp.oh;
 
-    int ch_blk = jcp.ch_block;
-    int stride_h = jcp.stride_h;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const size_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
@@ -756,10 +767,12 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
                     if (last_block && isa == sse41 && tail_simd_overlap(r))
                         break;
 
-                    int ker_off = ch * kh * kw * ch_blk + r * simd_w_;
+                    const dim_t ker_off = ch * kh * kw * ch_blk + r * simd_w_;
                     Vmm vmm_ker = get_ker_reg(0);
                     load_vmm(vmm_ker,
-                            ptr[aux1_reg_kernel + ker_off * sizeof(float)],
+                            ptr[aux1_reg_kernel
+                                    + static_cast<int>(
+                                            ker_off * sizeof(float))],
                             masked_load);
 
                     for (int w = 0; w < ur_str_w; w++) {
@@ -780,16 +793,18 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
                 }
             }
 
-            add(aux1_reg_kernel, ch_blk * stride_w * sizeof(float));
-            sub(aux1_reg_ddst, sp_step * sizeof(float));
+            add(aux1_reg_kernel,
+                    static_cast<int>(ch_blk * stride_w * sizeof(float)));
+            sub(aux1_reg_ddst, static_cast<uint32_t>(sp_step * sizeof(float)));
 
             sub(iter_kw, stride_w);
             cmp(iter_kw, 0);
             jg(kw_label, T_NEAR);
         }
 
-        add(aux_reg_kernel, kw * ch_blk * stride_h * sizeof(float));
-        sub(aux_reg_ddst, ow * sp_step * sizeof(float));
+        add(aux_reg_kernel,
+                static_cast<int>(kw * ch_blk * stride_h * sizeof(float)));
+        sub(aux_reg_ddst, static_cast<uint32_t>(ow * sp_step * sizeof(float)));
 
         sub(iter_kh, stride_h);
         cmp(iter_kh, 0);
@@ -802,10 +817,10 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
 template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_dsrc(
         int ur_ch_blocks, int ur_str_w, bool is_last_ch) {
-    int ch_block = jcp.ch_block;
-    int iw = jcp.iw;
-    int ih = jcp.ih;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_block = jcp.ch_block;
+    const dim_t iw = jcp.iw;
+    const dim_t ih = jcp.ih;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dsrc_layout_nxc = is_dsrc_layout_nxc();
     const size_t ch_block_step = ch_block * (dsrc_layout_nxc ? 1 : ih * iw);
@@ -854,10 +869,10 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::ch_loop_body(
         assert(is_ddst_layout_nxc());
 
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_oc = jcp.oc / jcp.ch_block;
-        const int ch_block_tail
-                = jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int nb_oc = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int ch_block_tail = static_cast<int>(
+                jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking)));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kh
                 * jcp.kw * jcp.ch_block * sizeof(float);
@@ -879,9 +894,9 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::ch_loop_body(
             {
                 call_compute_body(jcp.nb_ch_blocking, unroll_w);
 
-                add(reg_kernel, wei_ch_stride);
-                add(reg_dsrc, data_ch_stride);
-                add(reg_ddst, data_ch_stride);
+                add(reg_kernel, static_cast<uint32_t>(wei_ch_stride));
+                add(reg_dsrc, static_cast<uint32_t>(data_ch_stride));
+                add(reg_ddst, static_cast<uint32_t>(data_ch_stride));
 
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
@@ -923,8 +938,9 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::unroll_width_body(
 
             ch_loop_body(ur_ch_blocks, unroll_w);
 
-            add(reg_dsrc, unroll_w * jcp.stride_w * ch_step);
-            add(reg_ddst, unroll_w * ch_step);
+            add(reg_dsrc,
+                    static_cast<uint32_t>(unroll_w * jcp.stride_w * ch_step));
+            add(reg_ddst, static_cast<uint32_t>(unroll_w * ch_step));
 
             sub(reg_ur_str_w, unroll_w);
             jmp(unroll_w_label);
@@ -952,7 +968,7 @@ void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
     if (is_dsrc_layout_nxc()) {
         if (isa == avx512_core && (jcp.ch_tail > 0)) {
             Label masking_done;
-            const size_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
+            const dim_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
             kxnorw(k_ch_tail_mask, k_ch_tail_mask,
                     k_ch_tail_mask); // dummy mask all 1's
             cmp(reg_ch_blocks, channel_step);
@@ -964,7 +980,7 @@ void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
             L(masking_done);
         }
 
-        unroll_width_body(jcp.nb_ch);
+        unroll_width_body(static_cast<int>(jcp.nb_ch));
     } else {
 
         auto ch_blocks_loop = [&](int ch_blocks) {
@@ -1002,7 +1018,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_xmm(
 template <>
 inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::load_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
-    int bytes = (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     load_bytes(vmm, addr, bytes);
 }
 template <>
@@ -1023,7 +1040,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::store_xmm(
 template <>
 inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::store_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
-    int bytes = (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     store_bytes(vmm, addr, bytes);
 }
 template <>
@@ -1065,8 +1083,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter() {
     for (int ch = 0; ch < jcp.nb_ch_blocking; ++ch) {
         for (int r = 0; r < reg_repeats_; ++r) {
             for (int i = 0; i < jcp.kw; ++i) {
-                Vmm vmm_acc
-                        = get_acc_reg(r * jcp.kw + i * jcp.nb_ch_blocking + ch);
+                Vmm vmm_acc = get_acc_reg(static_cast<int>(
+                        r * jcp.kw + i * jcp.nb_ch_blocking + ch));
                 uni_vpxor(vmm_acc, vmm_acc, vmm_acc);
             }
         }
@@ -1080,7 +1098,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::load_filter(
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
-        const int reg_set = r * jcp.kw;
+        const int reg_set = static_cast<int>(r * jcp.kw);
         for (int i = 0; i < jcp.kw; ++i) {
             size_t off_filter = static_cast<size_t>(
                     (i * jcp.ch_block + r * simd_w_) * sizeof(float));
@@ -1153,23 +1171,24 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
 
     assert(one_of(isa, avx2, avx512_core));
 
-    const size_t ch_step = jcp.ngroups;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const dim_t ch_step = jcp.ngroups;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const dim_t right_border = jcp.iw - iw_block;
+    const dim_t r_pad = jcp.r_pad;
+    const int cascade_input
+            = static_cast<int>(nstl::min<dim_t>(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const dim_t input_overlap = nstl::max<dim_t>(jcp.kw - l_pad, 0);
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
 
     /* LOAD initial input registers, then cascade LOADs and FMAs*/
     for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
-        int output_sp_offset = i_ur * ch_step;
+        const dim_t output_sp_offset = i_ur * ch_step;
         if (i_ur == 0) {
             for (int c = 0; c < input_overlap; ++c) {
-                int input_sp = c - pad_offset;
-                int input_sp_offset = input_sp * ch_step;
+                const dim_t input_sp = c - pad_offset;
+                const dim_t input_sp_offset = input_sp * ch_step;
                 if (input_sp_offset < 0 && unroll_w == jcp.ow) continue;
 
                 const bool over_steps_bdry = true && is_last_block
@@ -1180,17 +1199,17 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
                     bool masked_load = is_last_ch && ch == nb_ch_blocking - 1;
                     size_t input_offset = static_cast<size_t>(
                             (input_sp_offset + ch * simd_w_) * sizeof(float));
-                    Vmm vmm_input = get_input_reg(
-                            (c % jcp.kw) * jcp.nb_ch_blocking + ch);
+                    Vmm vmm_input = get_input_reg(static_cast<int>(
+                            (c % jcp.kw) * jcp.nb_ch_blocking + ch));
                     load_xmm(vmm_input, ptr[reg_tmp_input + input_offset],
                             masked_load);
                 }
             }
         } else {
             for (int c = 0; c < cascade_input; ++c) {
-                int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                int input_sp = overlap + c - pad_offset;
-                int input_sp_offset = input_sp * ch_step;
+                const dim_t overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
+                const dim_t input_sp = overlap + c - pad_offset;
+                const dim_t input_sp_offset = input_sp * ch_step;
                 if (input_sp_offset < 0 || overlap + c + l_pad > right_border)
                     continue;
 
@@ -1202,15 +1221,16 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
                     bool masked_load = is_last_ch && ch == nb_ch_blocking - 1;
                     size_t input_offset = static_cast<size_t>(
                             (input_sp_offset + ch * simd_w_) * sizeof(float));
-                    Vmm vmm_input = get_input_reg(
-                            ((overlap + c) % jcp.kw) * jcp.nb_ch_blocking + ch);
+                    Vmm vmm_input = get_input_reg(static_cast<int>(
+                            ((overlap + c) % jcp.kw) * jcp.nb_ch_blocking
+                            + ch));
                     load_xmm(vmm_input, ptr[reg_tmp_input + input_offset],
                             masked_load);
                 }
             }
         }
         for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-            int io_overlap = i_kw + (i_ur * jcp.stride_w);
+            const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
             /* Don't apply FMAs that fall into the padded region */
             if (io_overlap - l_pad < 0
@@ -1226,9 +1246,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
                 size_t output_offset = static_cast<size_t>(
                         (output_sp_offset + ch * simd_w_) * sizeof(float));
 
-                Vmm vmm_input = get_input_reg(
+                Vmm vmm_input = get_input_reg(static_cast<int>(
                         ((io_overlap - l_pad) % jcp.kw) * jcp.nb_ch_blocking
-                        + ch);
+                        + ch));
                 Vmm vmm_acc = get_acc_reg(i_kw * jcp.nb_ch_blocking + ch);
                 if (masked_load) {
                     Vmm vmm_output = get_output_reg(0);
@@ -1250,14 +1270,15 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         bool is_last_ch) {
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : simd_w_;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : simd_w_;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const dim_t right_border = jcp.iw - iw_block;
+    const dim_t r_pad = jcp.r_pad;
+    const int cascade_input
+            = static_cast<int>(nstl::min<dim_t>(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const dim_t input_overlap = nstl::max<dim_t>(jcp.kw - l_pad, 0);
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
     const bool nxc_sse41_offset = is_layout_nxc() && isa == sse41;
 
@@ -1267,7 +1288,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
         bool masked_load
                 = IMPLICATION(isa == sse41, tail_in_first_simd) && is_last_ch;
         for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
-            int output_sp_offset = nxc_sse41_offset
+            const dim_t output_sp_offset = nxc_sse41_offset
                     ? i_ur * ch_step + r * simd_w_
                     : (i_ur * reg_repeats_ + r) * ch_step;
             size_t output_offset
@@ -1277,8 +1298,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                     masked_load);
             if (i_ur == 0) {
                 for (int c = 0; c < input_overlap; ++c) {
-                    int input_sp = c - pad_offset;
-                    int input_sp_offset = nxc_sse41_offset
+                    const dim_t input_sp = c - pad_offset;
+                    const dim_t input_sp_offset = nxc_sse41_offset
                             ? input_sp * ch_step + r * simd_w_
                             : (input_sp * reg_repeats_ + r) * ch_step;
                     if (input_sp_offset < 0 && unroll_w == jcp.ow) continue;
@@ -1296,9 +1317,10 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                 }
             } else {
                 for (int c = 0; c < cascade_input; ++c) {
-                    int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                    int input_sp = overlap + c - pad_offset;
-                    int input_sp_offset = nxc_sse41_offset
+                    const dim_t overlap
+                            = (i_ur - 1) * jcp.stride_w + input_overlap;
+                    const dim_t input_sp = overlap + c - pad_offset;
+                    const dim_t input_sp_offset = nxc_sse41_offset
                             ? input_sp * ch_step + r * simd_w_
                             : (input_sp * reg_repeats_ + r) * ch_step;
                     if (input_sp_offset < 0
@@ -1312,14 +1334,14 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
 
                     size_t input_offset = static_cast<size_t>(
                             input_sp_offset * sizeof(float));
-                    Vmm vmm_input = get_input_reg(
-                            ((overlap + c) % jcp.kw) * reg_repeats_ + r);
+                    Vmm vmm_input = get_input_reg(static_cast<int>(
+                            ((overlap + c) % jcp.kw) * reg_repeats_ + r));
                     load_xmm(vmm_input, ptr[reg_tmp_input + input_offset],
                             masked_load);
                 }
             }
             for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-                int io_overlap = i_kw + (i_ur * jcp.stride_w);
+                const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
                 /* Don't apply FMAs that fall into the padded region */
                 if (io_overlap - l_pad < 0
@@ -1330,9 +1352,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                         && (io_overlap - jcp.l_pad + jcp.r_pad > right_border);
                 if (over_steps_bdry) continue;
 
-                Vmm vmm_input = get_input_reg(
-                        ((io_overlap - l_pad) % jcp.kw) * reg_repeats_ + r);
-                Vmm vmm_acc = get_acc_reg(r * jcp.kw + i_kw);
+                Vmm vmm_input = get_input_reg(static_cast<int>(
+                        ((io_overlap - l_pad) % jcp.kw) * reg_repeats_ + r));
+                Vmm vmm_acc = get_acc_reg(static_cast<int>(r * jcp.kw + i_kw));
                 Vmm vmm_aux = isa == sse41 ? get_aux_reg() : vmm_input;
                 if (isa == sse41) uni_vmovups(vmm_aux, vmm_input);
                 uni_vfmadd231ps(vmm_acc, vmm_aux, vmm_output);
@@ -1362,7 +1384,8 @@ template <>
 inline void
 jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::compute_bias_step_unroll(
         const int unroll_w, int nb_ch_blocking, bool is_last_ch) {
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
+    const int ch_step
+            = static_cast<int>(is_ddst_layout_nxc() ? jcp.ngroups : simd_w_);
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
@@ -1384,7 +1407,7 @@ template <cpu_isa_t isa>
 inline void
 jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_bias_step_unroll(
         const int unroll_w, int nb_ch_blocking, bool is_last_ch) {
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
+    const dim_t ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
     for (int i = 0; i < unroll_w; ++i) {
         for (int ch = 0; ch < nb_ch_blocking; ++ch) {
             Vmm vmm_bias = get_bias_reg(ch);
@@ -1407,7 +1430,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::store_filter(
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
-        const int reg_set = r * jcp.kw;
+        const int reg_set = static_cast<int>(r * jcp.kw);
         for (int i = 0; i < jcp.kw; ++i) {
             size_t off_filter = static_cast<size_t>(
                     (i * jcp.ch_block + r * simd_w_) * sizeof(float));
@@ -1469,9 +1492,12 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
     Label oh_label;
     Label ow_blk_label;
 
-    const int unroll_w = nstl::min(max_unroll_w_, jcp.ow);
-    const int unroll_w_trips = jcp.ow / unroll_w;
-    const int tail_w = jcp.ow > max_unroll_w_ ? jcp.ow % max_unroll_w_ : 0;
+    const int unroll_w
+            = static_cast<int>(nstl::min<dim_t>(max_unroll_w_, jcp.ow));
+    const int unroll_w_trips = static_cast<int>(jcp.ow / unroll_w);
+    const int tail_w = jcp.ow > max_unroll_w_
+            ? static_cast<int>(jcp.ow % max_unroll_w_)
+            : 0;
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
     const size_t ch_offset = ch_step * sizeof(float);
@@ -1487,7 +1513,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
         L(ow_blk_label);
         {
             compute_bias_step_unroll(unroll_w, nb_ch_blocking, is_last_ch);
-            add(reg_tmp_output, unroll_w * ch_offset);
+            add(reg_tmp_output, static_cast<uint32_t>(unroll_w * ch_offset));
 
             dec(reg_iter_ow_blk);
             cmp(reg_iter_ow_blk, 0);
@@ -1496,7 +1522,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
 
         if (tail_w > 0) {
             compute_bias_step_unroll(tail_w, nb_ch_blocking, is_last_ch);
-            add(reg_tmp_output, tail_w * ch_offset);
+            add(reg_tmp_output, static_cast<uint32_t>(tail_w * ch_offset));
         }
 
         inc(reg_oh);
@@ -1646,14 +1672,14 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter_kh_loop(
     {
         store_filter(nb_ch_blocking);
 
-        add(reg_tmp_filter, filter_offset_kw);
+        add(reg_tmp_filter, static_cast<uint32_t>(filter_offset_kw));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
     }
 
     /* Comeback pointers */
-    sub(reg_tmp_filter, filter_offset_kh);
+    sub(reg_tmp_filter, static_cast<uint32_t>(filter_offset_kh));
 }
 
 template <cpu_isa_t isa>
@@ -1729,8 +1755,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_kh_step(
                 nb_ch_blocking, is_last_ch);
         store_filter(nb_ch_blocking, is_last_ch);
 
-        add(reg_tmp_filter, filter_offset);
-        add(reg_tmp_input, input_offset);
+        add(reg_tmp_filter, static_cast<uint32_t>(filter_offset));
+        add(reg_tmp_input, static_cast<uint32_t>(input_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_loop_label, T_NEAR);
@@ -1741,8 +1767,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_kh_step(
     mov(reg_kh_aux, reg_kh);
     L(kh_comeback_label);
     {
-        sub(reg_tmp_input, input_offset);
-        sub(reg_tmp_filter, filter_offset);
+        sub(reg_tmp_input, static_cast<uint32_t>(input_offset));
+        sub(reg_tmp_filter, static_cast<uint32_t>(filter_offset));
         dec(reg_kh_aux);
         cmp(reg_kh_aux, 0);
         jg(kh_comeback_label, T_NEAR);
@@ -1800,7 +1826,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
     mov(reg_tmp_input, reg_input_baddr);
     mov(reg_tmp_filter, reg_filter_baddr);
 
-    const int input_bottom_padding_overlap
+    const dim_t input_bottom_padding_overlap
             = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1836,11 +1862,11 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         jge(top_padding_end_label, T_NEAR);
 
         /* Increment step counter and adjust filter position */
-        sub(reg_tmp_filter, filter_shift * jcp.stride_h);
+        sub(reg_tmp_filter, static_cast<uint32_t>(filter_shift * jcp.stride_h));
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -1848,14 +1874,17 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
-                add(reg_tmp_filter, filter_shift * inp_corr);
-                add(reg_tmp_input, input_shift * inp_corr);
+                const dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                add(reg_tmp_filter,
+                        static_cast<uint32_t>(filter_shift * inp_corr));
+                add(reg_tmp_input,
+                        static_cast<uint32_t>(input_shift * inp_corr));
             }
         } else {
             /* Filter still overlaps padding (complete reset) */
             sub(reg_tmp_filter,
-                    (jcp.t_pad - jcp.oh * jcp.stride_h) * filter_shift);
+                    static_cast<uint32_t>((jcp.t_pad - jcp.oh * jcp.stride_h)
+                            * filter_shift));
         }
 
         /* Apply correction */
@@ -1889,11 +1918,11 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
     }
 
     /* Compute middle block */
-    add(reg_tmp_input, input_shift * jcp.stride_h);
+    add(reg_tmp_input, static_cast<uint32_t>(input_shift * jcp.stride_h));
 
     /* Execute common block and loop */
     L(common_block_label);
-    add(reg_tmp_output, output_shift);
+    add(reg_tmp_output, static_cast<uint32_t>(output_shift));
     inc(reg_oh);
     cmp(reg_oh, reg_oh_worksize);
     jl(loop_begin_label, T_NEAR);
@@ -1907,10 +1936,10 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::calculate_w_unrolling(
 
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (do_unroll_w) {
-        unroll_w = nstl::min(block_size_, jcp.ow);
-        unroll_trips = jcp.ow / unroll_w;
+        unroll_w = static_cast<int>(nstl::min<dim_t>(block_size_, jcp.ow));
+        unroll_trips = static_cast<int>(jcp.ow / unroll_w);
         /* calculate tail */
-        unroll_w_tail = jcp.ow % unroll_w;
+        unroll_w_tail = static_cast<int>(jcp.ow % unroll_w);
         /* Perform some rebalancing if tail too small*/
         if ((unroll_w_tail == 0 && jcp.r_pad != 0)
                 || (jcp.r_pad > 0 && jcp.r_pad >= unroll_w_tail)) {
@@ -1924,7 +1953,7 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::calculate_w_unrolling(
             }
         }
     } else {
-        unroll_w_tail = jcp.ow;
+        unroll_w_tail = static_cast<int>(jcp.ow);
     }
 }
 
@@ -1934,7 +1963,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
 
     Label ow_blk_label; // for computing 'ow middle' block
     int pad_offset = 0;
-    int l_pad = jcp.l_pad;
+    int l_pad = static_cast<int>(jcp.l_pad);
 
     int unroll_w_tail = 0;
     int unroll_w = 0;
@@ -1955,8 +1984,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (l_pad && do_unroll_w) {
         compute_h_loop(unroll_w, l_pad, 0, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, static_cast<uint32_t>(data_offset));
+        add(reg_input_baddr, static_cast<uint32_t>(data_offset * jcp.stride_w));
         unroll_trips--;
         pad_offset = l_pad;
         l_pad = 0;
@@ -1971,8 +2000,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
     }
     if (unroll_trips > 0) {
         compute_h_loop(unroll_w, l_pad, pad_offset, 0);
-        add(reg_output_baddr, data_offset);
-        add(reg_input_baddr, data_offset * jcp.stride_w);
+        add(reg_output_baddr, static_cast<uint32_t>(data_offset));
+        add(reg_input_baddr, static_cast<uint32_t>(data_offset * jcp.stride_w));
     }
     if (do_ow_blk_loop) {
         dec(reg_iter_ow_blk);
@@ -1982,8 +2011,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
 
     /* compute right padded block */
     if (unroll_w_tail) {
-        compute_h_loop(
-                unroll_w_tail, l_pad, pad_offset, jcp.ow - unroll_w_tail);
+        compute_h_loop(unroll_w_tail, l_pad, pad_offset,
+                static_cast<int>(jcp.ow - unroll_w_tail));
     }
 }
 

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
@@ -97,15 +97,16 @@ private:
     void store_tail(
             Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size);
 
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
 
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
@@ -218,14 +219,17 @@ private:
      * is no larger than 3*/
     inline Vmm get_bias_reg(int idx = 0) { return Vmm(idx); }
     inline Vmm get_output_reg(int idx) {
-        int vmm_idx = jcp.is_fast_depthwise
-                ? idx + 2 * jcp.kw * jcp.nb_ch_blocking
+        // `jcp.kw` is a genuine (dim_t) kernel-width dimension, but is
+        // assumed no larger than 3 here (see comment above), so the
+        // resulting register index is bounded and narrowed once here.
+        const int vmm_idx = jcp.is_fast_depthwise
+                ? idx + static_cast<int>(2 * jcp.kw * jcp.nb_ch_blocking)
                 : idx + req_aux_vmm;
         return Vmm(vmm_idx);
     }
     inline Vmm get_input_reg(int idx) {
-        int vmm_idx = jcp.is_fast_depthwise
-                ? idx + jcp.kw * jcp.nb_ch_blocking
+        const int vmm_idx = jcp.is_fast_depthwise
+                ? idx + static_cast<int>(jcp.kw * jcp.nb_ch_blocking)
                 : idx + 4 * reg_repeats_ + req_aux_vmm;
         return Vmm(vmm_idx);
     }

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
@@ -134,8 +134,8 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[0];
     jcp.dilate_w = cd.dilates[1];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -146,8 +146,10 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
     VDISPATCH_CONV_IC(!kernel_outside_src, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weights and src size mismatch");
 
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
 
     jcp.loop_order = loop_ngcw;
 
@@ -155,25 +157,28 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
             : utils::one_of(isa, avx512_core, avx512_core_fp16) ? 6
             : isa == avx2                                       ? 4
                                                                 : 3;
-    jcp.ur_w = nstl::min(jcp.ur_w, jcp.ow);
+    jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ur_w, jcp.ow));
 
     jcp.ch_block = simd_w;
     jcp.nb_ch = div_up(jcp.oc, jcp.ch_block);
     jcp.nb_ch_blocking = is_superset(isa, avx512_core) ? 4
             : isa == avx2                              ? 3
                                                        : 2;
-    if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
+    if (jcp.nb_ch < jcp.nb_ch_blocking)
+        jcp.nb_ch_blocking = static_cast<int>(jcp.nb_ch);
 
     if (is_data_layout_nxc) {
         jcp.loop_order = loop_nhwcg;
-        const int resrc_depthwise_ur_w = (31 - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        const int resrc_depthwise_ur_w
+                = static_cast<int>((31 - jcp.kw + jcp.stride_w)
+                        / (jcp.nb_ch_blocking + jcp.stride_w));
         jcp.is_resrc_depthwise = (!is_bf16 && !is_f16)
                 && is_superset(isa, avx512_core) && jcp.stride_w < jcp.kw
                 && jcp.kw <= 5 && jcp.dilate_w == 0
                 && resrc_depthwise_ur_w >= 2;
         if (jcp.is_resrc_depthwise) {
-            jcp.ur_w = nstl::min(jcp.ow, resrc_depthwise_ur_w);
+            jcp.ur_w = static_cast<int>(
+                    nstl::min<dim_t>(jcp.ow, resrc_depthwise_ur_w));
         }
         bool cache_aliasing
                 = (jcp.ngroups * jcp.iw * jcp.typesize_in) % 1024 == 0;
@@ -211,9 +216,9 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(!(jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w),
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -334,8 +339,8 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[0];
     jcp.dilate_w = cd.dilates[1];
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -408,8 +413,10 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
             && jcp.ngroups <= weights_d.padded_dims()[0];
     VDISPATCH_CONV_IC(args_ok, VERBOSE_BAD_PARAM, "");
 
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     jcp.ur_w = is_bf16           ? (isa_has_bf16(jcp.isa) ? 6 : 4)
             : isa == avx512_core ? 6
@@ -418,10 +425,11 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.loop_order = is_data_layout_nxc ? loop_nhwcg : loop_ngcw;
 
-    jcp.ch_tail = jcp.ngroups % jcp.ch_block;
+    jcp.ch_tail = static_cast<int>(jcp.ngroups % jcp.ch_block);
     jcp.nb_ch = div_up(jcp.ic, jcp.ch_block);
     jcp.nb_ch_blocking = isa == avx512_core ? 4 : isa == avx2 ? 3 : 2;
-    if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
+    if (jcp.nb_ch < jcp.nb_ch_blocking)
+        jcp.nb_ch_blocking = static_cast<int>(jcp.nb_ch);
 
     const size_t max_ch_off
             = static_cast<size_t>(jcp.nb_ch_blocking - 1) * jcp.ch_block;
@@ -517,12 +525,12 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.with_bias = cd.diff_bias_desc.format_kind != format_kind::undef;
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    jcp.r_pad = nstl::max(0,
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
 
@@ -578,7 +586,7 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     }
 
     jcp.ch_block = isa == avx512_core ? 16 : 8;
-    jcp.ch_tail = jcp.oc_without_padding % jcp.ch_block;
+    jcp.ch_tail = static_cast<int>(jcp.oc_without_padding % jcp.ch_block);
 
     // note: bf16 to be supported in the next commit
     bool ok_to_pad_channels
@@ -610,15 +618,17 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     constexpr int max_reg_idx = isa == avx512_core ? 31 : 15;
     // Note: anything larger than 4 didn't show significant speedup
     const int max_isa_unroll = jcp.is_fast_depthwise ? 4 : 1;
-    int max_ch_unroll = nstl::min(max_isa_unroll, max_reg_idx / (2 * jcp.kw));
-    jcp.nb_ch_blocking = nstl::min(jcp.nb_ch, max_ch_unroll);
+    int max_ch_unroll = static_cast<int>(
+            nstl::min<dim_t>(max_isa_unroll, max_reg_idx / (2 * jcp.kw)));
+    jcp.nb_ch_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.nb_ch, max_ch_unroll));
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_hpad = (jcp.kh - 1 + 1) / 2;
-    const int max_wpad = (jcp.kw - 1 + 1) / 2;
-    const int min_ih = jcp.kh + nstl::modulo(-jcp.t_pad, jcp.stride_h);
+    const dim_t max_hpad = (jcp.kh - 1 + 1) / 2;
+    const dim_t max_wpad = (jcp.kw - 1 + 1) / 2;
+    const dim_t min_ih = jcp.kh + nstl::modulo(-jcp.t_pad, jcp.stride_h);
     const bool boundaries_ok = true && jcp.t_pad <= max_hpad
             && jcp.b_pad <= max_hpad && jcp.l_pad <= max_wpad
             && jcp.r_pad <= max_wpad
@@ -633,7 +643,8 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     /* BF16: accumulation of output happens in f32, down-conversion to bf16
      * happens during the reduction phase. */
     jcp.typesize_out = sizeof(float);
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
     jcp.bia_dt = jcp.with_bias ? cd.diff_bias_desc.data_type : data_type::undef;
 
     jcp.harness = is_data_layout_nxc ? harness_nxc : harness_mb_reduction;
@@ -707,8 +718,9 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::balance(
          * per-thread load when the number of threads is high (e.g. > 16).
          */
         jcp.oh_blk_size = 15;
-        jcp.nthr_g = nstl::min(jcp.nb_ch, nthreads);
-        jcp.nthr_mb = nstl::min(nstl::max(1, nthreads / jcp.nthr_g), jcp.mb);
+        jcp.nthr_g = static_cast<int>(nstl::min<dim_t>(jcp.nb_ch, nthreads));
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(
+                nstl::max<dim_t>(1, nthreads / jcp.nthr_g), jcp.mb));
         jcp.nthr = jcp.nthr_g * jcp.nthr_mb;
     } else if (jcp.harness == harness_nxc) {
         /* Allocate threads and partition space with regards to 'nb_ch', 'mb'
@@ -743,15 +755,16 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
     const int env_max_nthr_oh = nthreads; // DNNL_MAX_NTHR_OH
     const int env_min_oh_block = 1; // DNNL_MIN_OH_BLOCK
 
-    const int ch_outer_blocks = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
-    int max_g = nstl::min(env_max_nthr_g, nstl::min(ch_outer_blocks, nthreads));
+    const dim_t ch_outer_blocks = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
+    int max_g = static_cast<int>(nstl::min<dim_t>(
+            env_max_nthr_g, nstl::min<dim_t>(ch_outer_blocks, nthreads)));
     for (int g = max_g; g >= 1; --g) {
         int cur_nthr_g = g;
         auto div_nthr_g = nthreads / cur_nthr_g;
 
         int available_nthr_mb = div_nthr_g;
-        int max_mb = nstl::min(
-                env_max_nthr_mb, nstl::min(jcp.mb, available_nthr_mb));
+        int max_mb = static_cast<int>(nstl::min<dim_t>(
+                env_max_nthr_mb, nstl::min<dim_t>(jcp.mb, available_nthr_mb)));
         for (int mb = max_mb; mb >= 1; --mb) {
             int cur_nthr_mb = mb;
             auto div_nthr_mb = available_nthr_mb / cur_nthr_mb;
@@ -759,27 +772,30 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
             // used to skip cases where efficiency can only worsen
             bool prev_under_blocked = false;
 
-            int available_nthr_oh = nstl::min(
-                    jcp.oh, nstl::min(env_max_nthr_oh, div_nthr_mb));
-            int max_oh_block = jcp.oh;
+            int available_nthr_oh = static_cast<int>(nstl::min<dim_t>(
+                    jcp.oh, nstl::min(env_max_nthr_oh, div_nthr_mb)));
+            int max_oh_block = static_cast<int>(jcp.oh);
             // Note: maybe it's worth exploring a heuristic to determine
             // optimal_min(oh_block)
-            int min_oh_block
-                    = nstl::max(1, nstl::min(jcp.oh, env_min_oh_block));
+            int min_oh_block = static_cast<int>(nstl::max<dim_t>(
+                    1, nstl::min<dim_t>(jcp.oh, env_min_oh_block)));
             for (int oh_block = max_oh_block; oh_block >= min_oh_block;
                     --oh_block) {
 
                 // Calculate most efficient approximation for thread use and/or
                 // blocking:
-                int approx_g_block = utils::div_up(ch_outer_blocks, cur_nthr_g);
-                int approx_mb_block = utils::div_up(jcp.mb, cur_nthr_mb);
-                int approx_oh_block = utils::div_up(jcp.oh, oh_block);
+                int approx_g_block = static_cast<int>(
+                        utils::div_up(ch_outer_blocks, cur_nthr_g));
+                int approx_mb_block
+                        = static_cast<int>(utils::div_up(jcp.mb, cur_nthr_mb));
+                int approx_oh_block
+                        = static_cast<int>(utils::div_up(jcp.oh, oh_block));
 
                 int cur_nthr_oh = nstl::min(available_nthr_oh, approx_oh_block);
 
                 // calculate thread use efficiency
                 int total_nthr = cur_nthr_g * cur_nthr_mb * cur_nthr_oh;
-                float thr_eff = ((float)total_nthr) / nthreads;
+                float thr_eff = ((float)total_nthr) / (float)nthreads;
                 assert(total_nthr <= nthreads);
 
                 // efficiency can only worsen, skip
@@ -790,17 +806,17 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
                 // calculate imbalance
                 float imbalance_g = ((float)std::abs(approx_g_block * cur_nthr_g
                                             - ch_outer_blocks))
-                        / ch_outer_blocks;
+                        / (float)ch_outer_blocks;
                 float imbalance_mb
                         = ((float)std::abs(
                                   approx_mb_block * cur_nthr_mb - jcp.mb))
-                        / jcp.mb;
+                        / (float)jcp.mb;
                 float imbalance_oh
                         = ((float)std::abs(oh_block * cur_nthr_oh - jcp.oh))
-                        / jcp.oh;
-                float total_imbalance = imbalance_g * (jcp.mb * jcp.oh)
-                        + imbalance_mb * (ch_outer_blocks * jcp.oh)
-                        + imbalance_oh * (ch_outer_blocks * jcp.mb);
+                        / (float)jcp.oh;
+                float total_imbalance = imbalance_g * (float)(jcp.mb * jcp.oh)
+                        + imbalance_mb * (float)(ch_outer_blocks * jcp.oh)
+                        + imbalance_oh * (float)(ch_outer_blocks * jcp.mb);
 
                 /* 1) When 'prioritize_threading == true'
                  * First Condition: pick the blocking strategy that uses the

--- a/src/cpu/x64/jit_uni_dw_convolution.cpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.cpp
@@ -77,24 +77,24 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
             bias = const_cast<float *>(bias_in);
     }
 
-    const int dil_h = jcp.dilate_h + 1;
-    const int str_h = jcp.stride_h;
+    const dim_t dil_h = jcp.dilate_h + 1;
+    const dim_t str_h = jcp.stride_h;
     const int ch_step = jcp.nb_ch_blocking;
-    const int ow = 0;
-    const int iw = 0;
-    const int kw = 0;
-    const int chb_work = utils::div_up(jcp.nb_ch, ch_step);
+    const dim_t ow = 0;
+    const dim_t iw = 0;
+    const dim_t kw = 0;
+    const dim_t chb_work = utils::div_up(jcp.nb_ch, ch_step);
     const auto is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
     const auto is_dst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
 
-    const int work_amount = jcp.mb * chb_work * jcp.oh;
+    const dim_t work_amount = jcp.mb * chb_work * jcp.oh;
     const auto nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int n {0}, chb {0}, oh {0};
+        dim_t n {0}, chb {0}, oh {0};
         if (jcp.loop_order == loop_ngcw)
             utils::nd_iterator_init(
                     start, n, jcp.mb, chb, chb_work, oh, jcp.oh);
@@ -107,26 +107,24 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
         auto iwork = start;
         while (iwork < end) {
 
-            int ch = chb * ch_step;
+            const dim_t ch = chb * ch_step;
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp.t_pad - oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp.ih,
-                              (int)(oh * str_h + (jcp.kh - 1) * dil_h
-                                      - jcp.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp.t_pad - oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp.ih,
+                              oh * str_h + (jcp.kh - 1) * dil_h - jcp.t_pad + 1)
                     - jcp.ih;
 
-            const int ih
-                    = nstl::max((int)(oh * str_h - jcp.t_pad
-                                        + div_up(i_t_overflow, dil_h) * dil_h),
-                            0);
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp.kh - div_up(i_t_overflow, dil_h)
+            const dim_t ih = nstl::max<dim_t>(0,
+                    oh * str_h - jcp.t_pad
+                            + div_up(i_t_overflow, dil_h) * dil_h);
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            const auto ic_off_idx = is_src_layout_nxc ? ch * jcp.ch_block : ch;
-            const auto oc_off_idx = is_dst_layout_nxc ? ch * jcp.ch_block : ch;
+            const dim_t ic_off_idx = is_src_layout_nxc ? ch * jcp.ch_block : ch;
+            const dim_t oc_off_idx = is_dst_layout_nxc ? ch * jcp.ch_block : ch;
 
             auto par_conv = jit_conv_args_t();
             par_conv.src = jcp.is_fused_conv
@@ -137,12 +135,13 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
             par_conv.filt = &weights[weights_d.blk_off(ch, 0, 0, kh, kw)];
             if (bias) par_conv.bias = &bias[bias_d.blk_off(ch * jcp.ch_block)];
 
-            par_conv.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv.kh_padding
+                    = static_cast<size_t>(nstl::max<dim_t>(0, kh_padding));
 
             assert(IMPLICATION(
                     jcp.loop_order == loop_nhwcg, is_src_layout_nxc));
             // For is_src_layout_nxc maximize jit work along contiguous dim.
-            const int work_rem = end - iwork;
+            const dim_t work_rem = end - iwork;
             par_conv.load_work = utils::this_block_size(ch * jcp.ch_block,
                     jcp.oc_without_padding,
                     (is_src_layout_nxc ? work_rem * ch_step : ch_step)
@@ -191,38 +190,39 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
 
     const auto &jcp = pd()->jcp_;
 
-    auto kernel_params
-            = [=](int ur_str_w, int iw, int oh, int ih, int i_t_overflow,
-                      int i_b_overflow, int stride_off_h, int ch, int n,
-                      int work_remaining) {
+    auto kernel_params = [=](dim_t ur_str_w, dim_t iw, dim_t oh, dim_t ih,
+                                 dim_t i_t_overflow, dim_t i_b_overflow,
+                                 dim_t stride_off_h, dim_t ch, dim_t n,
+                                 dim_t work_remaining) {
         auto par_conv = jit_conv_args_t();
         const bool is_dsrc_layout_nxc
                 = utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc);
         const bool is_ddst_layout_nxc
                 = utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc);
-        const int nb_ch_blocking = jcp.nb_ch_blocking;
+        const dim_t nb_ch_blocking = jcp.nb_ch_blocking;
 
-        const int i_l_overflow = nstl::max(0, (jcp.kw - 1 - iw - jcp.l_pad));
-        const int i_r_overflow
-                = nstl::max(0, (jcp.kw - 1 - (jcp.iw - 1 - iw) - jcp.r_pad));
+        const dim_t i_l_overflow
+                = nstl::max<dim_t>(0, jcp.kw - 1 - iw - jcp.l_pad);
+        const dim_t i_r_overflow = nstl::max<dim_t>(
+                0, jcp.kw - 1 - (jcp.iw - 1 - iw) - jcp.r_pad);
 
-        int ow = iw + jcp.l_pad - i_r_overflow;
-        int stride_off_w = ow % jcp.stride_w;
+        dim_t ow = iw + jcp.l_pad - i_r_overflow;
+        const dim_t stride_off_w = ow % jcp.stride_w;
         ow /= jcp.stride_w;
 
-        const int ic_offset = is_dsrc_layout_nxc ? ch * jcp.ch_block : ch;
+        const dim_t ic_offset = is_dsrc_layout_nxc ? ch * jcp.ch_block : ch;
         par_conv.src = &diff_src[diff_src_d.blk_off(n, ic_offset, ih, iw)];
-        const int oc_offset = is_ddst_layout_nxc ? ch * jcp.ch_block : ch;
+        const dim_t oc_offset = is_ddst_layout_nxc ? ch * jcp.ch_block : ch;
         par_conv.dst = &diff_dst[diff_dst_d.blk_off(n, oc_offset, oh, ow)];
         par_conv.filt = &weights[weights_d.blk_off(ch, 0, 0,
                 i_b_overflow + stride_off_h, i_r_overflow + stride_off_w)];
 
-        par_conv.kh_padding = nstl::max(
+        par_conv.kh_padding = nstl::max<dim_t>(
                 0, jcp.kh - i_t_overflow - i_b_overflow - stride_off_h);
-        par_conv.kw_padding = nstl::max(
+        par_conv.kw_padding = nstl::max<dim_t>(
                 0, jcp.kw - i_l_overflow - i_r_overflow - stride_off_w);
 
-        par_conv.ur_str_w = ur_str_w;
+        par_conv.ur_str_w = static_cast<int>(ur_str_w);
 
         const size_t ch_work = (is_ddst_layout_nxc ? work_remaining : 1)
                 * nb_ch_blocking * jcp.ch_block;
@@ -234,10 +234,10 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
         return par_conv;
     };
 
-    const int aux_w
-            = nstl::min(jcp.iw, jcp.iw - jcp.kw + jcp.r_pad + jcp.stride_w);
-    const int chb_work = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
-    const dim_t work_amount = static_cast<dim_t>(jcp.mb) * chb_work * jcp.ih;
+    const dim_t aux_w = nstl::min<dim_t>(
+            jcp.iw, jcp.iw - jcp.kw + jcp.r_pad + jcp.stride_w);
+    const dim_t chb_work = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
+    const dim_t work_amount = jcp.mb * chb_work * jcp.ih;
     const auto nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
@@ -255,23 +255,24 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
 
         auto iwork = start;
         while (iwork < end) {
-            int ch = chb * jcp.nb_ch_blocking;
+            const dim_t ch = chb * jcp.nb_ch_blocking;
 
-            const int work_rem = end - iwork;
+            const dim_t work_rem = end - iwork;
             const dim_t i_t_overflow
                     = nstl::max(dim_t(0), jcp.kh - 1 - ih - jcp.t_pad);
             const dim_t i_b_overflow = nstl::max(
                     dim_t(0), jcp.kh - 1 - (jcp.ih - 1 - ih) - jcp.b_pad);
 
-            int oh = ih + jcp.t_pad - i_b_overflow;
-            int stride_off_h = oh % jcp.stride_h;
+            dim_t oh = ih + jcp.t_pad - i_b_overflow;
+            const dim_t stride_off_h = oh % jcp.stride_h;
             oh /= jcp.stride_h;
 
-            for (int i_str_w = 0; i_str_w < jcp.stride_w; i_str_w++) {
+            for (dim_t i_str_w = 0; i_str_w < jcp.stride_w; i_str_w++) {
                 // left border
-                int iw = i_str_w;
-                int l_border = nstl::min(jcp.kw - 1 - jcp.l_pad, jcp.iw);
-                int ur_str_w = 1;
+                dim_t iw = i_str_w;
+                const dim_t l_border
+                        = nstl::min<dim_t>(jcp.kw - 1 - jcp.l_pad, jcp.iw);
+                dim_t ur_str_w = 1;
                 for (; iw < l_border; iw += jcp.stride_w) {
                     jit_conv_args_t par_conv = kernel_params(ur_str_w, iw, oh,
                             ih, i_t_overflow, i_b_overflow, stride_off_h, ch, n,
@@ -374,24 +375,24 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
             ? diff_bias_f32_to_bf16_accum
             : CTX_OUT_MEM(f32_data_t *, DNNL_ARG_DIFF_BIAS);
 
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         auto conv_params = jit_dw_conv_args_t();
-        const int h_block_size = jcp.oh_blk_size;
+        const dim_t h_block_size = jcp.oh_blk_size;
 
-        const int ch_outer_blocks
+        const dim_t ch_outer_blocks
                 = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
         const int ithr_g = ithr % jcp.nthr_g;
-        int g_start {0}, g_end {0};
+        dim_t g_start {0}, g_end {0};
         balance211(ch_outer_blocks, jcp.nthr_g, ithr_g, g_start, g_end);
 
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
-        int mb_start {0}, mb_end {0};
+        dim_t mb_start {0}, mb_end {0};
         balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         const int ithr_oh = (ithr / (jcp.nthr_mb * jcp.nthr_g)) % jcp.nthr_oh;
-        const int nb_oh = div_up(jcp.oh, jcp.oh_blk_size);
-        int nb_oh_start {0}, nb_oh_end {0};
+        const dim_t nb_oh = div_up(jcp.oh, jcp.oh_blk_size);
+        dim_t nb_oh_start {0}, nb_oh_end {0};
         balance211(nb_oh, jcp.nthr_oh, ithr_oh, nb_oh_start, nb_oh_end);
 
         const size_t wei_size
@@ -416,23 +417,24 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 ? diff_bias_reduction_buffer + (ithr_block - 1) * bias_size
                 : nullptr;
         const int g_step = jcp.nb_ch_blocking;
-        for (int g_ = g_start; g_ < g_end; ++g_) {
-            const int g = g_ * jcp.nb_ch_blocking;
+        for (dim_t g_ = g_start; g_ < g_end; ++g_) {
+            const dim_t g = g_ * jcp.nb_ch_blocking;
             unsigned char last_g_flag
                     = (g + g_step) >= jcp.nb_ch ? FLAG_OC_LAST : 0;
             unsigned char zero_filter_flag = FLAG_ZERO_FILTER;
             unsigned char zero_bias_flag = jcp.with_bias ? FLAG_ZERO_BIAS : 0;
-            for (int mb = mb_start; mb < mb_end; mb++) {
-                for (int nb_oh = nb_oh_start; nb_oh < nb_oh_end; ++nb_oh) {
-                    const int oh_s = nb_oh * h_block_size;
-                    const int h_work = nstl::min(h_block_size, jcp.oh - oh_s);
-                    const int oh_e = oh_s + h_work;
-                    const int ih = -jcp.t_pad + oh_s * jcp.stride_h;
-                    const int kh_top_overflow = nstl::max(0, -ih);
-                    const int kh_bottom_overflow
-                            = nstl::max(0, ih - jcp.ih + jcp.kh);
-                    const int kh_padding_offset
-                            = nstl::min(jcp.kh - 1, kh_top_overflow);
+            for (dim_t mb = mb_start; mb < mb_end; mb++) {
+                for (dim_t nb_oh = nb_oh_start; nb_oh < nb_oh_end; ++nb_oh) {
+                    const dim_t oh_s = nb_oh * h_block_size;
+                    const dim_t h_work
+                            = nstl::min<dim_t>(h_block_size, jcp.oh - oh_s);
+                    const dim_t oh_e = oh_s + h_work;
+                    const dim_t ih = -jcp.t_pad + oh_s * jcp.stride_h;
+                    const dim_t kh_top_overflow = nstl::max<dim_t>(0, -ih);
+                    const dim_t kh_bottom_overflow
+                            = nstl::max<dim_t>(0, ih - jcp.ih + jcp.kh);
+                    const dim_t kh_padding_offset
+                            = nstl::min<dim_t>(jcp.kh - 1, kh_top_overflow);
                     conv_params.kh_count
                             = jcp.kh - kh_top_overflow - kh_bottom_overflow;
                     conv_params.filter_pad_off
@@ -499,21 +501,21 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
     const size_t wei_size = jcp.ngroups * jcp.kh * jcp.kw;
     const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
 
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
 
     auto set_kernel_params
-            = [=](jit_dw_conv_args_t *conv_params, const int batch,
-                      const int group, const int oh_start, const int work_size,
-                      const unsigned char exec_flag, const size_t kh_padding,
-                      const size_t filter_off) {
-        const int tpad_underflow_off = jcp.t_pad - filter_off;
+            = [=](jit_dw_conv_args_t *conv_params, const dim_t batch,
+                      const dim_t group, const dim_t oh_start,
+                      const dim_t work_size, const unsigned char exec_flag,
+                      const size_t kh_padding, const size_t filter_off) {
+        const dim_t tpad_underflow_off = jcp.t_pad - filter_off;
 
         conv_params->exec_flags = exec_flag;
         conv_params->kh_count = jcp.kh - kh_padding;
 
-        const int oh_s = oh_start;
-        const int oh_e = oh_start + work_size;
-        const int ih_s = oh_s * jcp.stride_h;
+        const dim_t oh_s = oh_start;
+        const dim_t oh_e = oh_start + work_size;
+        const dim_t ih_s = oh_s * jcp.stride_h;
 
         conv_params->filter_pad_off
                 = filter_off * jcp.kw * ch_block * jcp.typesize_out;
@@ -537,18 +539,18 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         assert(nthr == jcp.nthr);
 
         auto conv_params = jit_dw_conv_args_t();
-        const int h_block_size = jcp.oh_blk_size;
-        const int nb_ch = jcp.nb_ch;
+        const dim_t h_block_size = jcp.oh_blk_size;
+        const dim_t nb_ch = jcp.nb_ch;
 
         /* assign iteration space to thread */
         const int ithr_g = ithr % jcp.nthr_g;
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
 
         /* split dimensions */
-        int g_start {0}, g_end {0};
+        dim_t g_start {0}, g_end {0};
         balance211(nb_ch, jcp.nthr_g, ithr_g, g_start, g_end);
 
-        int mb_start {0}, mb_end {0};
+        dim_t mb_start {0}, mb_end {0};
         balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         auto i_mb = diff_weights_type == bf16 ? ithr_mb : ithr_mb - 1;
@@ -560,7 +562,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 ? diff_bias
                 : diff_bia_reduction_buf + (ithr_mb - 1) * bias_size;
 
-        for (int g = g_start; g < g_end; ++g) {
+        for (dim_t g = g_start; g < g_end; ++g) {
             unsigned char last_g_flag = g == nb_ch - 1 ? FLAG_OC_LAST : 0;
             unsigned char zero_filter_flag = FLAG_ZERO_FILTER;
             unsigned char zero_bias_flag = jcp.with_bias ? FLAG_ZERO_BIAS : 0;
@@ -570,14 +572,16 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
 
             if (jcp.with_bias) conv_params.bias = &diff_bia[g * ch_block];
 
-            for (int mb = mb_start; mb < mb_end; ++mb) {
-                int oh = 0;
+            for (dim_t mb = mb_start; mb < mb_end; ++mb) {
+                dim_t oh = 0;
                 while (oh < jcp.oh) {
-                    const int h_work = nstl::min(h_block_size, jcp.oh - oh);
-                    auto kh_t_padding = nstl::max(0, jcp.t_pad - oh);
-                    auto kh_b_padding
+                    const dim_t h_work
+                            = nstl::min<dim_t>(h_block_size, jcp.oh - oh);
+                    const dim_t kh_t_padding
+                            = nstl::max<dim_t>(0, jcp.t_pad - oh);
+                    const dim_t kh_b_padding
                             = (oh * jcp.stride_h + jcp.kh > jcp.ih + jcp.t_pad)
-                            ? nstl::max(jcp.b_pad - (h_work - 1), 0)
+                            ? nstl::max<dim_t>(jcp.b_pad - (h_work - 1), 0)
                             : 0;
 
                     set_kernel_params(&conv_params, mb, g, oh, h_work,
@@ -622,26 +626,26 @@ void jit_uni_dw_convolution_bwd_weights_t<avx512_core, bf16>::execute_reduction(
     const size_t wei_size
             = utils::rnd_up(jcp.ngroups, jcp.ch_block) * jcp.kh * jcp.kw;
     const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
 
     /* Apply single-threaded 'mb' reduction */
     if (jcp.with_bias && jcp.nthr_mb > 1) {
         for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
             size_t b_accum_offset = (thr_mb - 1) * bias_size;
-            const int bias_ch_tail = jcp.ch_tail;
-            const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+            const dim_t bias_ch_tail = jcp.ch_tail;
+            const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
 
-            for (int g = 0; g < nb_ch; ++g) {
+            for (dim_t g = 0; g < nb_ch; ++g) {
                 /* Reduction on Bias */
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     size_t bias_offset = g * ch_block + g_block;
                     diff_bias[bias_offset]
                             += diff_bia_reduction_buf[b_accum_offset
                                     + bias_offset];
                 }
             }
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 size_t bias_offset = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
                         += diff_bia_reduction_buf[b_accum_offset + bias_offset];
@@ -685,19 +689,19 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
 
     /* Apply single-threaded 'mb' reduction */
     for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t wei_size
                 = static_cast<size_t>(jcp.ngroups * jcp.kh * jcp.kw);
         const size_t mb_accum_offset = (thr_mb - 1) * wei_size;
         const size_t bias_size = jcp.ngroups;
         const size_t b_accum_offset = (thr_mb - 1) * bias_size;
 
-        const int bias_ch_tail = jcp.ch_tail;
-        const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-        for (int g = 0; g < nb_ch; ++g) {
+        const dim_t bias_ch_tail = jcp.ch_tail;
+        const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+        for (dim_t g = 0; g < nb_ch; ++g) {
             if (jcp.with_bias) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -705,11 +709,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
                                     + bias_offset];
                 }
             }
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = (g * jcp.kh + kh) * jcp.kw + kw;
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t wei_offset = static_cast<size_t>(
                             wei_sp_offset * ch_block + g_block);
                     diff_weights[wei_offset]
@@ -720,7 +724,7 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
         }
         // handle reduction for channel tail
         if (jcp.with_bias) {
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -729,11 +733,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
             }
         }
         if (bias_ch_tail > 0) {
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = static_cast<size_t>(
                         ((nb_ch * jcp.kh + kh) * jcp.kw + kw) * ch_block);
-                for (int g = 0; g < bias_ch_tail; ++g) {
+                for (dim_t g = 0; g < bias_ch_tail; ++g) {
                     const size_t wei_offset = wei_sp_offset + g;
                     diff_weights[wei_offset]
                             += diff_wei_reduction_buffer[mb_accum_offset
@@ -767,7 +771,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
 
     /* Apply single-threaded 'mb' reduction */
     for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t wei_size
                 = static_cast<size_t>(jcp.ngroups * jcp.kh * jcp.kw);
         const size_t mb_accum_offset = (thr_mb - 1) * wei_size;
@@ -775,11 +779,11 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         const size_t b_accum_offset = (thr_mb - 1) * bias_size;
 
         if (jcp.with_bias) { // Reduction on Bias:
-            const int bias_ch_tail = jcp.ch_tail;
-            const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-            for (int g = 0; g < nb_ch; ++g) {
+            const dim_t bias_ch_tail = jcp.ch_tail;
+            const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+            for (dim_t g = 0; g < nb_ch; ++g) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -788,7 +792,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 }
             }
             // handle reduction for channel tail
-            for (int g = 0; g < bias_ch_tail; g++) {
+            for (dim_t g = 0; g < bias_ch_tail; g++) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -857,17 +861,17 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                     reduction_size);
 
             const bool compute_bias = jcp.with_bias;
-            const int ch_block = jcp.ch_block;
+            const dim_t ch_block = jcp.ch_block;
             const size_t bias_size = jcp.ngroups;
             const size_t bias_accum_offset = ithr_offset * bias_size;
             if (compute_bias) {
                 const size_t nb_ch_offset = NB_CH * ch_block;
-                const int bias_ch_tail = jcp.ch_tail;
+                const dim_t bias_ch_tail = jcp.ch_tail;
                 const bool compute_ch_tail
                         = (NB_CH == jcp.nb_ch - 1) && bias_ch_tail > 0;
                 if (!compute_ch_tail) {
                     PRAGMA_OMP_SIMD()
-                    for (int g_block = 0; g_block < ch_block; ++g_block) {
+                    for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                         const size_t bias_offset
                                 = static_cast<size_t>(nb_ch_offset + g_block);
                         diff_bias[bias_offset]
@@ -876,7 +880,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                     }
                 } else {
                     // handle reduction for channel tail
-                    for (int g = 0; g < bias_ch_tail; g++) {
+                    for (dim_t g = 0; g < bias_ch_tail; g++) {
                         const size_t bias_offset
                                 = static_cast<size_t>(nb_ch_offset + g);
                         diff_bias[bias_offset]
@@ -929,17 +933,17 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
                 utils::rnd_up(jcp.ngroups, jcp.ch_block) * jcp.kh * jcp.kw);
         const size_t reduction_offset = ithr_offset * wei_size;
 
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t bias_size = jcp.ngroups;
         size_t b_accum_offset = ithr_offset * bias_size;
 
         const bool compute_bias = jcp.with_bias;
-        const int bias_ch_tail = jcp.ch_tail;
-        const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-        for (int g = 0; g < nb_ch; ++g) {
+        const dim_t bias_ch_tail = jcp.ch_tail;
+        const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+        for (dim_t g = 0; g < nb_ch; ++g) {
             if (compute_bias) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -947,12 +951,12 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
                                     + bias_offset];
                 }
             }
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset
                         = static_cast<size_t>((g * jcp.kh + kh) * jcp.kw + kw);
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t wei_offset = static_cast<size_t>(
                             wei_sp_offset * ch_block + g_block);
                     diff_weights[wei_offset]
@@ -963,7 +967,7 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
         }
         // handle reduction for channel tail
         if (compute_bias) {
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -972,11 +976,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
             }
         }
         if (bias_ch_tail > 0) {
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = static_cast<size_t>(
                         (nb_ch * jcp.kh + kh) * jcp.kw + kw);
-                for (int g = 0; g < bias_ch_tail; ++g) {
+                for (dim_t g = 0; g < bias_ch_tail; ++g) {
                     const size_t wei_offset
                             = static_cast<size_t>(wei_sp_offset * ch_block + g);
                     diff_weights[wei_offset]

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -64,7 +64,9 @@ protected:
         return utils::one_of(
                 data_type(), data_type::f8_e5m2, data_type::f8_e4m3);
     }
-    int dtype_size() const { return types::data_type_size(data_type()); }
+    int dtype_size() const {
+        return static_cast<int>(types::data_type_size(data_type()));
+    }
     cpu_isa_t get_io_isa(cpu_isa_t isa) const {
         // reusing avx512_core instantiation for bf16
         return is_bf16() && is_superset(isa, avx512_core)

--- a/src/cpu/x64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.cpp
@@ -36,7 +36,7 @@ struct jit_args_int8_t {
     const void *from;
     const void *for_comparison;
     const void *to;
-    size_t work_amount;
+    dim_t work_amount;
 };
 
 struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
@@ -50,7 +50,7 @@ struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
 
 protected:
     data_type_t data_type() const { return pd_->src_md()->data_type; }
-    int dtype_size() const { return types::data_type_size(data_type()); }
+    dim_t dtype_size() const { return types::data_type_size(data_type()); }
 
     const eltwise_desc_t &desc() const { return *pd_->desc(); }
 
@@ -80,11 +80,11 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
     void generate() override {
         Reg64 param = abi_param1;
 
-        const size_t vlen = cpu_isa_traits_t<isa>::vlen;
-        const size_t simd_w = vlen / sizeof(float);
-        const size_t loop_dec[] = {simd_w, 1};
-        const size_t uf[] = {1, 1};
-        const size_t shift[] = {dtype_size() * simd_w, (size_t)dtype_size()};
+        const dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+        const dim_t simd_w = vlen / sizeof(float);
+        const dim_t loop_dec[] = {simd_w, 1};
+        const dim_t uf[] = {1, 1};
+        const dim_t shift[] = {dtype_size() * simd_w, dtype_size()};
         const bool loop_vectorize[] = {true, false};
 
         preamble();
@@ -114,7 +114,8 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
 
         for (int id = 0; id < 2; id++) {
             L(loop_label[id]);
-            cmp(reg_work_amount, uf[id] * loop_dec[id] - 1);
+            cmp(reg_work_amount,
+                    static_cast<uint32_t>(uf[id] * loop_dec[id] - 1));
             jle(loop_label[id + 1], T_NEAR);
 
             compute_step(
@@ -123,7 +124,8 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
             add(reg_from, uf[id] * shift[id]);
             add(reg_to, uf[id] * shift[id]);
 
-            sub(reg_work_amount, uf[id] * loop_dec[id]);
+            sub(reg_work_amount,
+                    static_cast<uint32_t>(uf[id] * loop_dec[id]));
             jmp(loop_label[id]);
         }
 
@@ -232,35 +234,39 @@ private:
             store_8bit(vectorize, mem_to, vr_to, data_type() == data_type::s8);
     }
 
-    void compute_step(bool vectorize, const size_t uf, const size_t shift,
+    void compute_step(bool vectorize, const dim_t uf, const dim_t shift,
             const alg_kind_t alg) {
 
-        auto vreg_from = [&](const size_t i) -> Vmm { return Vmm(i + 1); };
-        auto vreg_to = [&](const size_t i) -> Vmm { return Vmm(uf + i + 1); };
+        auto vreg_from = [&](const dim_t i) -> Vmm {
+            return Vmm(static_cast<int>(i + 1));
+        };
+        auto vreg_to = [&](const dim_t i) -> Vmm {
+            return Vmm(static_cast<int>(uf + i + 1));
+        };
 
         // 1. Load (vregs <- mem)
-        for (size_t i = 0; i < uf; i++)
+        for (dim_t i = 0; i < uf; i++)
             load(vectorize, vreg_from(i), ptr[reg_from + i * shift]);
 
         // 2. Process (vregs <- vergs)
         switch (alg) {
             case alg_kind::eltwise_linear:
-                for (size_t i = 0; i < uf; i++)
+                for (dim_t i = 0; i < uf; i++)
                     process_linear(vreg_to(i), vreg_from(i));
                 break;
             case alg_kind::eltwise_relu:
-                for (size_t i = 0; i < uf; i++)
+                for (dim_t i = 0; i < uf; i++)
                     process_relu(vreg_to(i), vreg_from(i));
                 break;
             case alg_kind::eltwise_clip:
-                for (size_t i = 0; i < uf; i++)
+                for (dim_t i = 0; i < uf; i++)
                     process_clip(vreg_to(i), vreg_from(i));
                 break;
             default: assert(!"unsupported alg");
         }
 
         // 3. Store (mem <- vregs)
-        for (size_t i = 0; i < uf; i++)
+        for (dim_t i = 0; i < uf; i++)
             store(vectorize, ptr[reg_to + i * shift], vreg_to(i));
     }
 };
@@ -493,14 +499,15 @@ status_t jit_uni_eltwise_int_fwd_t<isa>::execute_forward(
 
     const memory_desc_wrapper src_d(pd()->src_md());
 
-    const size_t nelems = src_d.nelems(true);
+    const dim_t nelems = src_d.nelems(true);
 
-    src += src_d.data_type_size() * src_d.offset0();
-    dst += src_d.data_type_size() * src_d.offset0();
+    const dim_t data_type_size = src_d.data_type_size();
+    src += data_type_size * src_d.offset0();
+    dst += data_type_size * src_d.offset0();
 
-    const int cache_line = 64 / src_d.data_type_size();
+    const dim_t cache_line = 64 / data_type_size;
     parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
 
         balance211(utils::div_up(nelems, cache_line), nthr, ithr, start, end);
         start = nstl::min(nelems, start * cache_line);
@@ -508,9 +515,9 @@ status_t jit_uni_eltwise_int_fwd_t<isa>::execute_forward(
         if (start == end) return;
 
         jit_args_int8_t arg;
-        arg.from = src + src_d.data_type_size() * start;
-        arg.for_comparison = src + src_d.data_type_size() * start;
-        arg.to = dst + src_d.data_type_size() * start;
+        arg.from = src + data_type_size * start;
+        arg.for_comparison = src + data_type_size * start;
+        arg.to = dst + data_type_size * start;
         arg.work_amount = end - start;
         (*kernel_)(&arg);
     });

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -127,7 +127,7 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
             static constexpr bool preserve_gpr = true;
             static constexpr bool preserve_vmm = true;
             static constexpr bool use_exact_tail_scalar_bcast = true;
-            static const std::size_t tmp_vmm_injector = this->vmm_tmp.getIdx();
+            static const int tmp_vmm_injector = this->vmm_tmp.getIdx();
 
             const eltwise_injector::static_params_t esp(true /*save_state*/,
                     reg_po_injector_helper_, elt_inj_opmask, true /*is_fwd*/,
@@ -137,7 +137,7 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<size_t>(axis_simd_tail_), tail_opmask,
+                    dst_d_, static_cast<dim_t>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -32,8 +32,8 @@ static bcast_set_t get_supported_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc};
 }
 
-static inline dim_t get_offset(
-        const memory_desc_wrapper &mdw, int n, int c, int d, int h, int w) {
+static inline dim_t get_offset(const memory_desc_wrapper &mdw, dim_t n, dim_t c,
+        dim_t d, dim_t h, dim_t w) {
     switch (mdw.ndims()) {
         case 3: return mdw.blk_off(n, c, w);
         case 4: return mdw.blk_off(n, c, h, w);
@@ -70,9 +70,9 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_i8i8_pooling_fwd_ker_t)
 
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    Xmm xreg(int idx) const { return Xmm(idx); }
-    Ymm yreg(int idx) const { return Ymm(xreg(idx).getIdx()); }
-    Vmm vreg(int idx) const { return Vmm(xreg(idx).getIdx()); }
+    Xmm xreg(dim_t idx) const { return Xmm(xbyak_register_index(idx)); }
+    Ymm yreg(dim_t idx) const { return Ymm(xreg(idx).getIdx()); }
+    Vmm vreg(dim_t idx) const { return Vmm(xreg(idx).getIdx()); }
 
     // In case of avx2 with data type i8 we need to use
     // maskmovdqu and maskmovq instructions which has its destination hardcoded in rdi.
@@ -105,7 +105,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
 
     Opmask k_cmp_mask = Opmask(7);
 
-    Opmask mask(int idx) { return Opmask(6 - idx); }
+    Opmask mask(dim_t idx) { return Opmask(xbyak_register_index(6 - idx)); }
 
     // ref to any of XYZ-regs via xreg/yreg/vreg functions
     Xmm xmm_tmp = xreg(0); // temp to init vreg_tmp
@@ -143,15 +143,17 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     //"avg" pool uses more registers for unrolling.
     enum : int { avg_vidx_base = utils::one_of(isa, sse41, avx2) ? 4 : 2 };
 
-    Vmm max_base_vr(int idx) const { return vreg(max_vidx_base + idx); }
-    Vmm avg_base_vr(int idx) const { return vreg(avg_vidx_base + idx); }
+    Vmm max_base_vr(dim_t idx) const { return vreg(max_vidx_base + idx); }
+    Vmm avg_base_vr(dim_t idx) const { return vreg(avg_vidx_base + idx); }
 
     size_t sizeof_src_dt() const { return data_type_size(jpp.src_dt); }
     size_t sizeof_dst_dt() const { return data_type_size(jpp.dst_dt); }
 
     /* max pooling */
-    Vmm vreg_src(int idx) const { return max_base_vr(idx); } // [0    .. ur_c-1]
-    Vmm vreg_dst(int idx) const {
+    Vmm vreg_src(dim_t idx) const {
+        return max_base_vr(idx);
+    } // [0    .. ur_c-1]
+    Vmm vreg_dst(dim_t idx) const {
         return max_base_vr(jpp.ur_c + idx);
     } // [ur_c .. 2*ur_c-1]
 
@@ -166,7 +168,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
         mmx_msk_base_reg = 3
     };
 
-    inline size_t get_offset_dst(int jj, int ll) const {
+    inline size_t get_offset_dst(dim_t jj, dim_t ll) const {
         size_t offset = 0;
         switch (jpp.alg) {
             case pooling_max: {
@@ -184,20 +186,20 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
         return offset;
     }
 
-    Vmm vreg_src_s32(int jj, int ll) {
+    Vmm vreg_src_s32(dim_t jj, dim_t ll) {
         return avg_base_vr(3 * max_num_ll * jj + ll + 0 * max_num_ll);
     } // ll: 0..4 [0..3]
 
-    Vmm vreg_dst_s32(int jj, int ll) {
+    Vmm vreg_dst_s32(dim_t jj, dim_t ll) {
         return avg_base_vr(3 * max_num_ll * jj + ll + 1 * max_num_ll);
     } // ll: 0..4 [4..7]
 
-    Vmm vreg_dst_f32(int jj, int ll) {
+    Vmm vreg_dst_f32(dim_t jj, dim_t ll) {
         return avg_base_vr(3 * max_num_ll * jj + ll + 2 * max_num_ll);
     } // ll: 0..4 [8..11]
 
-    Mmx mmx_mask(int ll) {
-        return Mmx(mmx_msk_base_reg + ll);
+    Mmx mmx_mask(dim_t ll) {
+        return Mmx(xbyak_register_index(mmx_msk_base_reg + ll));
     } // ll: 0..4 [Mmx(2)...Mmx(5)]
 
     static status_t init_post_ops_conf(jit_pool_conf_t &jpp,
@@ -206,24 +208,31 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     void init_tmp_reg();
     void init_mask();
 
-    void load_vreg_mask_q(int ll) {};
+    // Narrows a small, fixed-range value (SIMD lane index or blend mask) to the
+    // XByak 8-bit immediate at the single instruction-emit boundary.
+    static uint8_t to_imm_uint8_t(dim_t v) noexcept {
+        assert(v >= 0 && v <= UINT8_MAX);
+        return static_cast<uint8_t>(v);
+    }
+
+    void load_vreg_mask_q(dim_t ll) {};
 
     void load_src_max_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+            dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk);
     void load_src_avg_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
-    void load_src(int jj, int ll, int c_tail);
+            dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk);
+    void load_src(dim_t jj, dim_t ll, dim_t c_tail);
 
     void store_dst_max_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+            dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk);
     void store_dst_avg_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
-    void store_dst(int jj, int ll, int c_tail);
+            dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk);
+    void store_dst(dim_t jj, dim_t ll, dim_t c_tail);
 
-    void compute_avg_step(int ur_c, int c_tail);
-    void compute_max_op(const int jj);
-    void compute_max_step(int ur_c, int c_tail);
-    void compute_step(int ur_c, int c_tail);
+    void compute_avg_step(dim_t ur_c, dim_t c_tail);
+    void compute_max_op(const dim_t jj);
+    void compute_max_step(dim_t ur_c, dim_t c_tail);
+    void compute_step(dim_t ur_c, dim_t c_tail);
 
     void compute_c_block();
     void generate() override;
@@ -253,12 +262,13 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
             static constexpr bool preserve_gpr = true;
             static constexpr bool preserve_vmm = true;
             static constexpr bool use_exact_tail_scalar_bcast = false;
-            static constexpr std::size_t tmp_vmm_injector = 0u;
+            static constexpr int tmp_vmm_injector = 0;
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
                     tmp_vmm_injector, r14, r15, r13, preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
-                    memory_desc_wrapper(*dst_md), c_tail_elems,
+                    memory_desc_wrapper(*dst_md),
+                    static_cast<dim_t>(c_tail_elems),
                     mask(post_op_tail_opmask_idx_),
                     use_exact_tail_scalar_bcast};
             const binary_injector::static_params_t bsp {
@@ -272,22 +282,22 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
 };
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_vreg_mask_q(int ll) {};
+void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_vreg_mask_q(dim_t ll) {};
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_vreg_mask_q(int ll) {
+void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_vreg_mask_q(dim_t ll) {
 
     // extract ll-th part of mask (ll-th QWORD)
     vpblendd(vreg_mask_q, vreg_zeros, vreg_mask,
-            0x3 << 2 * ll); // 0x3 - mask for 2 x DWORD
+            to_imm_uint8_t(0x3 << 2 * ll)); // 0x3 - mask for 2 x DWORD
 
     // Move mask from ll-th pos to 0-th pos
-    if (ll > 0) vpermq(vreg_mask_q, vreg_mask_q, ll);
+    if (ll > 0) vpermq(vreg_mask_q, vreg_mask_q, to_imm_uint8_t(ll));
 }
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -297,15 +307,16 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_max_op(
                         ptr[aux_reg_src_w + offset + i * data_type_size(s32)],
                         i);
         else
-            for (int i = 0; i < jpp.c_tail; i++)
-                pinsrb(vreg_src(jj), ptr[aux_reg_src_w + offset + i], i);
+            for (dim_t i = 0; i < jpp.c_tail; i++)
+                pinsrb(vreg_src(jj), ptr[aux_reg_src_w + offset + i],
+                        to_imm_uint8_t(i));
     } else
         movups(vreg_src(jj), ptr[aux_reg_src_w + offset]);
 }
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -318,7 +329,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
             // Example:  idx=[31..0]
             //    vreg_src = [x,x,x,x,.....,x,-,-,-,-,-] ; x => byte data
             //    shift to transform vreg_src = [-,-,-,-,-,x,..,x,x,x,x,]
-            const uint8_t shift = cpu_isa_traits_t<avx2>::vlen - jpp.c_tail;
+            const uint8_t shift = cpu_isa_traits_t<avx2>::vlen
+                    - static_cast<uint8_t>(jpp.c_tail);
 
             if (jpp.safe_c_tail) {
 
@@ -361,7 +373,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -375,7 +387,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     const Vmm &vr_src = vreg_src_s32(jj, ll);
@@ -391,8 +403,9 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
     } else if (utils::one_of(jpp.src_dt, s8, u8)) {
         if (masked) {
             const int copy_range = math::ilog2q(jpp.tail[ll] + 1);
-            for (int i = 0; i < copy_range; i++)
-                pinsrb(vr_src, ptr[aux_reg_src_w + offset + i], i);
+            for (dim_t i = 0; i < copy_range; i++)
+                pinsrb(vr_src, ptr[aux_reg_src_w + offset + i],
+                        to_imm_uint8_t(i));
 
             if (jpp.src_dt == s8)
                 pmovsxbd(vr_src, vr_src);
@@ -410,7 +423,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     auto load_i8 = [&](bool is_signed, const Vmm &vr_src) {
@@ -427,13 +440,14 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
             //    vreg_src = [x,x,x,x,.....,x,-,-,-,-,-] ; x => byte data
             //    shift to transform vreg_src = [-,-,-,-,-,x,..,x,x,x,x,]
             // Re-purposing vreg_zeros here. Set it back to zero immmediately.
-            const int msk_gran = cpu_isa_traits_t<avx2>::vlen
+            const dim_t msk_gran = cpu_isa_traits_t<avx2>::vlen
                     / data_type_size(avg_proc_dt);
 
             const uint8_t shift = cpu_isa_traits_t<avx2>::vlen
                     - (jpp.c_tail > (ll + 1) * msk_gran
-                                    ? msk_gran
-                                    : jpp.c_tail - (ll * msk_gran));
+                                    ? static_cast<uint8_t>(msk_gran)
+                                    : static_cast<uint8_t>(
+                                              jpp.c_tail - (ll * msk_gran)));
             if (jpp.safe_c_tail) {
                 /* load src_tail at 'src_address - shift' so that it does not
                  * spill over the memory boundary */
@@ -500,7 +514,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     const Vmm &vr_src
@@ -515,11 +529,12 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_avg_op(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(int jj, int ll, int c_tail) {
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(
+        dim_t jj, dim_t ll, dim_t c_tail) {
     using namespace data_type;
 
-    int c_block = jpp.c_block;
-    int ur_c = jpp.ur_c;
+    const auto c_block = jpp.c_block;
+    const auto ur_c = jpp.ur_c;
 
     switch (jpp.alg) {
         case pooling_max: {
@@ -542,7 +557,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(int jj, int ll, int c_tail) {
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -551,8 +566,9 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
                 pextrd(ptr[reg_ptr_dst_i8 + offset + i * data_type_size(s32)],
                         vreg_dst(jj), i);
         else if (utils::one_of(jpp.src_dt, u8, s8))
-            for (int i = 0; i < jpp.c_tail; i++)
-                pextrb(ptr[reg_ptr_dst_i8 + offset + i], vreg_dst(jj), i);
+            for (dim_t i = 0; i < jpp.c_tail; i++)
+                pextrb(ptr[reg_ptr_dst_i8 + offset + i], vreg_dst(jj),
+                        to_imm_uint8_t(i));
         else
             assert(!"unsupported src data type");
     } else
@@ -561,15 +577,16 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     Label store_data_safely, done;
 
-    int c_block = jpp.c_block;
+    const auto c_block = jpp.c_block;
 
     const uint64_t low_mask = (1ULL << (c_block / 2)) - 1;
-    const uint8_t shift = cpu_isa_traits_t<avx2>::vlen - jpp.c_tail;
+    const uint8_t shift
+            = cpu_isa_traits_t<avx2>::vlen - static_cast<uint8_t>(jpp.c_tail);
 
     if (masked) {
         switch (jpp.src_dt) {
@@ -633,7 +650,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -653,7 +670,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -678,15 +695,15 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
         const int copy_range = masked
                 ? math::ilog2q(jpp.tail[ll] + 1)
                 : cpu_isa_traits_t<sse41>::vlen / data_type_size(avg_proc_dt);
-        for (int i = 0; i < copy_range; i++)
-            pextrb(ptr[reg_ptr_dst_i8 + offset + i], vr_dst, i);
+        for (dim_t i = 0; i < copy_range; i++)
+            pextrb(ptr[reg_ptr_dst_i8 + offset + i], vr_dst, to_imm_uint8_t(i));
     } else
         assert(!"unsupported src data type");
 }
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -735,14 +752,15 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
         // mmx_full_msk - mask for all 8 bytes in zero-tail case
         // mmx_mask(ll) - ll-th mask of tail in non-zero-tail case
 
-        const int msk_gran
+        const dim_t msk_gran
                 = cpu_isa_traits_t<avx2>::vlen / data_type_size(avg_proc_dt);
 
-        const int ll_end = (ll + 1) * msk_gran; // ((ll + 1) * 8)
+        const dim_t ll_end = (ll + 1) * msk_gran; // ((ll + 1) * 8)
 
         if (is_masked && (ll_end > jpp.c_tail)) { //implies this tail not full.
             Label store_data_safely, done;
-            const uint8_t shift = msk_gran - jpp.c_tail % msk_gran;
+            const uint8_t shift
+                    = static_cast<uint8_t>(msk_gran - (jpp.c_tail % msk_gran));
 
             if (!jpp.safe_c_tail) {
                 cmp(reg_ptr_maskmovdqu_dst, reg_dst_safe_access);
@@ -786,7 +804,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        dim_t jj, dim_t ll, size_t offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -805,11 +823,11 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_avg_op(
 
 template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::store_dst(
-        int jj, int ll, int c_tail) {
+        dim_t jj, dim_t ll, dim_t c_tail) {
     using namespace data_type;
 
-    int c_block = jpp.c_block;
-    int ur_c = jpp.ur_c;
+    const auto c_block = jpp.c_block;
+    const auto ur_c = jpp.ur_c;
 
     switch (jpp.alg) {
         case pooling_max: {
@@ -831,7 +849,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::store_dst(
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::compute_max_op(const int jj) {
+void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::compute_max_op(const dim_t jj) {
     using namespace data_type;
     switch (jpp.src_dt) {
         case s32: pmaxsd(vreg_dst(jj), vreg_src(jj)); break;
@@ -842,7 +860,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::compute_max_op(const int jj) {
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::compute_max_op(const int jj) {
+void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::compute_max_op(const dim_t jj) {
     using namespace data_type;
     switch (jpp.src_dt) {
         case s32: vpmaxsd(vreg_dst(jj), vreg_dst(jj), vreg_src(jj)); break;
@@ -853,7 +871,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::compute_max_op(const int jj) {
 }
 
 template <>
-void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::compute_max_op(const int jj) {
+void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::compute_max_op(
+        const dim_t jj) {
     using namespace data_type;
 
     // Compare
@@ -879,14 +898,14 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::compute_max_op(const int jj) {
 
 template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
-        int ur_c, int c_tail) {
+        dim_t ur_c, dim_t c_tail) {
     Label l_kd, l_kh, l_kw;
 
-    int ih = jpp.ih;
-    int iw = jpp.iw;
-    int c = jpp.c;
+    const auto ih = jpp.ih;
+    const auto iw = jpp.iw;
+    const auto c = jpp.c;
 
-    for (int jj = 0; jj < ur_c; jj++)
+    for (dim_t jj = 0; jj < ur_c; jj++)
         uni_vmovups(vreg_dst(jj), vreg_tmp);
 
     mov(aux_reg_src_d, reg_ptr_src_i8);
@@ -901,7 +920,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
             xor_(reg_kw_index, reg_kw_index);
             L(l_kw);
             {
-                for (int jj = 0; jj < ur_c; jj++) {
+                for (dim_t jj = 0; jj < ur_c; jj++) {
                     load_src(jj, 0, c_tail);
                     compute_max_op(jj);
                 }
@@ -921,25 +940,25 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
         jl(l_kd, T_NEAR);
     }
 
-    for (int jj = 0; jj < ur_c; jj++)
+    for (dim_t jj = 0; jj < ur_c; jj++)
         store_dst(jj, 0, c_tail);
 }
 
 template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
-        int ur_c, int c_tail) {
+        dim_t ur_c, dim_t c_tail) {
     using namespace data_type;
 
     Label l_kd, l_kh, l_kw;
 
-    int ih = jpp.ih;
-    int iw = jpp.iw;
-    int c = jpp.c;
+    const auto ih = jpp.ih;
+    const auto iw = jpp.iw;
+    const auto c = jpp.c;
 
     const int num_ll = data_type_size(avg_proc_dt) / data_type_size(jpp.src_dt);
 
-    for (int jj = 0; jj < ur_c; jj++) {
-        for (int ll = 0; ll < num_ll; ll++) {
+    for (dim_t jj = 0; jj < ur_c; jj++) {
+        for (dim_t ll = 0; ll < num_ll; ll++) {
             bool masked = jj == ur_c - 1 && c_tail;
             size_t msk = jpp.tail[ll];
             if (!(masked && !msk)) {
@@ -962,10 +981,10 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
             xor_(reg_kw_index, reg_kw_index);
             L(l_kw);
             {
-                for (int jj = 0; jj < ur_c; jj++) {
-                    for (int ll = 0; ll < num_ll; ll++) {
-                        bool masked = jj == ur_c - 1 && c_tail;
-                        size_t msk = jpp.tail[ll];
+                for (dim_t jj = 0; jj < ur_c; jj++) {
+                    for (dim_t ll = 0; ll < num_ll; ll++) {
+                        const bool masked = jj == ur_c - 1 && c_tail;
+                        const size_t msk = jpp.tail[ll];
                         if (!(masked && !msk)) {
                             load_src(jj, ll, c_tail);
                             uni_vpaddd(vreg_dst_s32(jj, ll),
@@ -989,8 +1008,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
         jl(l_kd, T_NEAR);
     }
 
-    for (int jj = 0; jj < ur_c; jj++) {
-        for (int ll = 0; ll < num_ll; ll++) {
+    for (dim_t jj = 0; jj < ur_c; jj++) {
+        for (dim_t ll = 0; ll < num_ll; ll++) {
             const bool masked = jj == ur_c - 1 && c_tail;
             const size_t msk = jpp.tail[ll];
             if (!(masked && !msk)) {
@@ -1028,7 +1047,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_step(int ur_c, int c_tail) {
+void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_step(
+        dim_t ur_c, dim_t c_tail) {
     switch (jpp.alg) {
         case pooling_max: compute_max_step(ur_c, c_tail); break;
         case pooling_avg_include_padding:
@@ -1041,12 +1061,12 @@ template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_c_block() {
     Label l_main_loop;
 
-    int nb_c = jpp.nb_c;
-    int c_block = jpp.c_block;
-    int ur_c = jpp.ur_c;
-    int ur_c_tail = jpp.ur_c_tail;
-    int c_steps = nb_c / ur_c;
-    int c_tail = jpp.c_tail;
+    const auto nb_c = jpp.nb_c;
+    const auto c_block = jpp.c_block;
+    const auto ur_c = jpp.ur_c;
+    const auto ur_c_tail = jpp.ur_c_tail;
+    const auto c_steps = nb_c / ur_c;
+    const auto c_tail = jpp.c_tail;
 
     xor_(c_iter, c_iter);
     if (c_steps > 0) {
@@ -1122,7 +1142,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
             vinserti128(vreg_mask, vreg_mask, xreg_mask_hi, 1);
 
             // Compute mask algned to left from vreg_mask and store it in vreg_mask_2 to be use for tail processing.
-            const uint8_t shift = 32 - jpp.c_tail;
+            const uint8_t shift = 32 - static_cast<uint8_t>(jpp.c_tail);
             vperm2i128(vreg_mask_2, vreg_mask, vreg_mask, 0x08);
             if (shift <= 16) {
                 vpalignr(vreg_mask_2, vreg_mask, vreg_mask_2, 16 - shift);
@@ -1152,7 +1172,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
         }
     };
 
-    uint64_t tail_mask = (1ULL << jpp.c_tail) - 1;
+    const uint64_t tail_mask = (1ULL << jpp.c_tail) - 1;
     switch (jpp.alg) {
         case pooling_max:
             // For "max" we need mask only in case of non-zero tail
@@ -1302,11 +1322,11 @@ status_t jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(
     jpp.t_pad = is_1d ? 0 : pd.padding[0][ndims - 4];
     jpp.l_pad = pd.padding[0][ndims - 3];
 
-    int back_pad = calculate_end_padding(
+    const auto back_pad = calculate_end_padding(
             jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
-    int bottom_pad = calculate_end_padding(
+    const auto bottom_pad = calculate_end_padding(
             jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
-    int right_pad = calculate_end_padding(
+    const auto right_pad = calculate_end_padding(
             jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
 
     VDISPATCH_POOLING_IC(

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -117,7 +117,7 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
             static constexpr bool preserve_gpr = true;
             static constexpr bool preserve_vmm = true;
             static constexpr bool use_exact_tail_scalar_bcast = true;
-            static const std::size_t tmp_vmm_injector = this->vmm_tmp.getIdx();
+            static const int tmp_vmm_injector = this->vmm_tmp.getIdx();
 
             const eltwise_injector::static_params_t esp(true /*save_state*/,
                     reg_po_injector_helper_, elt_inj_opmask, true /*is_fwd*/,
@@ -127,7 +127,7 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<size_t>(axis_simd_tail_), tail_opmask,
+                    dst_d_, static_cast<dim_t>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {
@@ -589,7 +589,7 @@ protected:
         else
             compute_mean_block(unroll, tail);
     }
-    void add_mean(int c_block) { add(reg_mean, c_block * sizeof(float)); }
+    void add_mean(dim_t c_block) { add(reg_mean, c_block * sizeof(float)); }
 
     Vmm Vmm_mean(size_t ur = 0) { return Vmm(3 + ur); }
     Vmm Vmm_var(size_t ur = 0) { return Vmm(9 + ur); }
@@ -812,7 +812,7 @@ status_t jit_uni_instance_normalization_fwd_t::execute_forward(
         parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
             dim_t SP_start = 0, SP_end = 0;
             balance211(SP, nthr, ithr, SP_start, SP_end);
-            const int block_size = SP_end - SP_start;
+            const dim_t block_size = SP_end - SP_start;
             for (dim_t n = 0; n < N; ++n) {
                 float *local_mean = stat_reduction + n * nthr * C + ithr * C;
                 const size_t s_off

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -549,7 +549,7 @@ protected:
             static constexpr bool preserve_gpr = true;
             static constexpr bool preserve_vmm = true;
             static constexpr bool use_exact_tail_scalar_bcast = true;
-            static const std::size_t tmp_vmm_injector = this->vmm_tmp.getIdx();
+            static const int tmp_vmm_injector = this->vmm_tmp.getIdx();
 
             const eltwise_injector::static_params_t esp(true /*save_state*/,
                     reg_po_injector_helper_, elt_inj_opmask, true /*is_fwd*/,
@@ -559,7 +559,7 @@ protected:
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<size_t>(axis_simd_tail_), tail_opmask,
+                    dst_d_, static_cast<dim_t>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {reg_param,
@@ -1331,7 +1331,7 @@ status_t jit_uni_layer_normalization_fwd_t::execute_forward(
                 + N_start * C_padded * src_d.data_type_size();
         char *const __restrict dst_ptr = reinterpret_cast<char *>(dst)
                 + N_start * C_padded * dst_d.data_type_size();
-        const int block_size = N_end - N_start;
+        const dim_t block_size = N_end - N_start;
         float *mean_ptr = skip_mean ? nullptr : &mean[N_start];
         float *dst_scales_inv_ptr = nullptr;
         if (!pd()->attr()->scales_.has_default_values(DNNL_ARG_DST)) {
@@ -1400,7 +1400,7 @@ status_t jit_uni_layer_normalization_bwd_t::execute_backward(
     parallel(max_nthr, [= COMPAT_THIS_CAPTURE](int ithr, int nthr) {
         dim_t N_start = 0, N_end = 0;
         balance211(N, nthr, ithr, N_start, N_end);
-        const int block_size = N_end - N_start;
+        const dim_t block_size = N_end - N_start;
         const char *const __restrict src_ptr
                 = reinterpret_cast<const char *>(src)
                 + N_start * C_padded * src_d.data_type_size();
@@ -1433,7 +1433,7 @@ status_t jit_uni_layer_normalization_bwd_t::execute_backward(
     parallel(max_nthr, [= COMPAT_THIS_CAPTURE](int ithr, int nthr) {
         dim_t N_start = 0, N_end = 0;
         balance211(N, nthr, ithr, N_start, N_end);
-        const int block_size = N_end - N_start;
+        const dim_t block_size = N_end - N_start;
         const char *const __restrict src_ptr
                 = reinterpret_cast<const char *>(src)
                 + N_start * C_padded * src_d.data_type_size();

--- a/src/cpu/x64/jit_uni_ncsp_convolution.cpp
+++ b/src/cpu/x64/jit_uni_ncsp_convolution.cpp
@@ -91,10 +91,11 @@ status_t reduction_helper_t::reshape_weights(
         // matmul to conv: remove batch, restore spatial
         for (int d = 0; d < ndims_ch; ++d)
             reduce[d] = i_md->dims[d + 1]; // g, o, i
-        for (int d = ndims_ch; d < ndims_out; ++d)
+        for (int d = static_cast<int>(ndims_ch); d < ndims_out; ++d)
             reduce[d] = 1; // d, h, w
     }
-    return memory_desc_reshape(*o_md, *i_md, ndims_out, reduce);
+    return memory_desc_reshape(
+            *o_md, *i_md, static_cast<int>(ndims_out), reduce);
 }
 
 status_t reduction_helper_t::reshape_for_transpose(

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -89,14 +89,13 @@ jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<std::size_t>(this->xmm4.getIdx()), this->r14,
-                this->r15, this->r13, preserve_gpr, preserve_vmm,
+                this->xmm4.getIdx(), this->r14, this->r15, this->r13,
+                preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
                 memory_desc_wrapper(jpp.tag_kind == jit_memory_tag_kind_t::ncsp
                                 ? jpp.tmp_md
                                 : *dst_md),
-                static_cast<size_t>(tail_size), k_c_tail_mask,
-                use_exact_tail_scalar_bcast};
+                tail_size, k_c_tail_mask, use_exact_tail_scalar_bcast};
 
         const binary_injector::static_params_t bsp {reg_param,
                 get_supported_bcast_strategies(), rhs_sp, f8_e5m2_cvt_.get(),
@@ -367,11 +366,11 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
     jpp.t_pad = (ndims == 3) ? 0 : pd.padding[0][ndims - 4];
     jpp.l_pad = pd.padding[0][ndims - 3];
 
-    const int back_pad = calculate_end_padding(
+    const auto back_pad = calculate_end_padding(
             jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
-    const int bottom_pad = calculate_end_padding(
+    const auto bottom_pad = calculate_end_padding(
             jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
-    const int right_pad = calculate_end_padding(
+    const auto right_pad = calculate_end_padding(
             jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
 
     VDISPATCH_POOLING_IC(
@@ -425,13 +424,15 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
 
     // select jpp.ur_bc
     if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
-        auto min_ur_w = nstl::max(1, utils::div_up(jpp.l_pad, jpp.stride_w));
-        int min_ur_w1 = utils::div_up(nstl::max(0, right_pad), jpp.stride_w);
+        auto min_ur_w
+                = nstl::max(dim_t(1), utils::div_up(jpp.l_pad, jpp.stride_w));
+        auto min_ur_w1
+                = utils::div_up(nstl::max(dim_t(0), right_pad), jpp.stride_w);
         if (min_ur_w < min_ur_w1) { min_ur_w = min_ur_w1; }
-        jpp.ur_bc = nstl::min(jpp.nb_c, nstl::max(1, jpp.ur / min_ur_w));
+        jpp.ur_bc = nstl::min(jpp.nb_c, nstl::max(dim_t(1), jpp.ur / min_ur_w));
         //take into account threading - to have enough work for parallelization
         float best_eff = 0;
-        for (int ur_bc = jpp.ur_bc; ur_bc > 0; ur_bc--) {
+        for (dim_t ur_bc = jpp.ur_bc; ur_bc > 0; ur_bc--) {
 
             const auto nb2_c = utils::div_up(jpp.nb_c, ur_bc);
             auto work = jpp.is_backward
@@ -450,7 +451,8 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         //take into account cache re-usage after zeroing on backward
         if (jpp.is_backward && ndims < 5 && !jpp.needs_f32_accum_for_bf16) {
             const int L2 = platform::get_per_core_cache_size(2) / jpp.dt_size;
-            int ur_bc = nstl::max(1, L2 / (jpp.kh * jpp.iw * jpp.c_block));
+            auto ur_bc
+                    = nstl::max(dim_t(1), L2 / (jpp.kh * jpp.iw * jpp.c_block));
             jpp.ur_bc = nstl::min(jpp.ur_bc, ur_bc);
         }
 
@@ -469,7 +471,8 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         utils::array_copy(dims, src_d.dims(), ndims);
 
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
-        dims[0] = nstl::min(dnnl_get_max_threads(), jpp.mb * nb2_c);
+        const dim_t dnnl_max_threads = dnnl_get_max_threads();
+        dims[0] = nstl::min(dnnl_max_threads, jpp.mb * nb2_c);
         dims[1] = jpp.f32_accum_block_size;
 
         CHECK(memory_desc_init_by_tag(
@@ -485,7 +488,8 @@ void jit_uni_pool_kernel_t<isa>::init_scratchpad(
 
     // scratchpad for c_block slice of input and/or output
     using namespace memory_tracking::names;
-    const int nscr = nstl::min(dnnl_get_max_threads(), jpp.mb * jpp.nb_c);
+    const dim_t dnnl_max_threads = dnnl_get_max_threads();
+    const dim_t nscr = nstl::min(dnnl_max_threads, jpp.mb * jpp.nb_c);
     if (jpp.tag_kind == jit_memory_tag_kind_t::ncsp) {
         scratchpad.book(key_pool_src_plain2blocked_cvt,
                 static_cast<size_t>(jpp.c_block) * jpp.id * jpp.ih * jpp.iw
@@ -506,7 +510,8 @@ void jit_uni_pool_kernel_t<isa>::init_scratchpad(
     }
 }
 
-static int reg_ind(int shift, int bc, int j, int ur_bc, int ur_w) noexcept {
+static dim_t reg_ind(
+        dim_t shift, dim_t bc, dim_t j, dim_t ur_bc, dim_t ur_w) noexcept {
     return shift * ur_bc * ur_w + bc * ur_w + j;
 }
 
@@ -539,60 +544,64 @@ inline void jit_uni_pool_kernel_t<isa>::pop_vmm_val(const int idx) {
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::load(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
+        const dim_t idx, const reg64_t &reg_ptr, const dim_t offset,
         const bool is_c_tail_proccessing) {
-    io_[dt]->load(vmmword[reg_ptr + offset], Vmm(idx),
+    io_[dt]->load(vmmword[reg_ptr + offset], Vmm(xbyak_register_index(idx)),
             is_c_tail_proccessing && !jpp.is_c_padded);
 }
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::store(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
+        const dim_t idx, const reg64_t &reg_ptr, const dim_t offset,
         const bool is_c_tail_proccessing) {
     if (is_c_tail_proccessing && jpp.is_c_padded && jpp.with_postops)
         pad_with_zeros(idx);
-    io_[dt]->store(Vmm(idx), vmmword[reg_ptr + offset],
+    io_[dt]->store(Vmm(xbyak_register_index(idx)), vmmword[reg_ptr + offset],
             is_c_tail_proccessing && !jpp.is_c_padded);
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::pad_with_zeros(const int idx) {
+inline void jit_uni_pool_kernel_t<isa>::pad_with_zeros(const dim_t idx) {
+    const int vidx = xbyak_register_index(idx);
     if (isa == sse41) {
         uni_vxorps(xmm_tmp_1, xmm_tmp_1, xmm_tmp_1);
         if (jpp.c_tail <= sse41_single_block_size && sse_high_half) {
-            uni_vmovups(Vmm(idx), xmm_tmp_1);
+            uni_vmovups(Vmm(vidx), xmm_tmp_1);
         } else if ((jpp.c_tail < sse41_single_block_size && !sse_high_half)
                 || (jpp.c_tail > sse41_single_block_size && sse_high_half)) {
             const auto c_tail = jpp.c_tail % sse41_single_block_size;
             std::bitset<8> tail_mask((1 << c_tail) - 1);
             tail_mask.flip();
-            uni_vblendps(Vmm(idx), Vmm(idx), xmm_tmp_1, tail_mask.to_ulong());
+            const int tail_mask_val = static_cast<int>(tail_mask.to_ulong());
+            uni_vblendps(Vmm(vidx), Vmm(vidx), xmm_tmp_1, tail_mask_val);
         }
     } else if (isa == avx || isa == avx2) {
         uni_vxorps(ymm_tmp_1, ymm_tmp_1, ymm_tmp_1);
-        uni_vblendvps(Vmm(idx), ymm_tmp_1, Vmm(idx), vmm_c_tail_mask);
+        uni_vblendvps(Vmm(vidx), ymm_tmp_1, Vmm(vidx), vmm_c_tail_mask);
     } else
-        uni_vmovups(Vmm(idx) | k_c_tail_mask | T_z, Vmm(idx));
+        uni_vmovups(Vmm(vidx) | k_c_tail_mask | T_z, Vmm(vidx));
 }
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::load_indices(
-        const int indr_i, const int step_index, bool is_c_tail_processing) {
+        const dim_t indr_i, const dim_t step_index, bool is_c_tail_processing) {
     if (jpp.ind_dt == data_type::u8) {
         auto indvr = vreg(indr_i);
         auto indxr = xreg(indr_i);
         if (isa == sse41) {
             if (is_c_tail_processing && !jpp.is_c_padded) {
-                for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
-                    pinsrb(indxr, ptr[reg_index + step_index + i], i);
+                for (dim_t i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
+                    pinsrb(indxr, ptr[reg_index + step_index + i],
+                            to_imm_uint8_t(i));
             } else {
                 movd(indxr, ptr[reg_index + step_index]);
             }
             pmovzxbd(indvr, indxr);
         } else if (isa == avx || isa == avx2) {
             if (is_c_tail_processing && !jpp.is_c_padded) {
-                for (int i = 0; i < jpp.c_tail; i++)
-                    vpinsrb(indxr, indxr, ptr[reg_index + step_index + i], i);
+                for (dim_t i = 0; i < jpp.c_tail; i++)
+                    vpinsrb(indxr, indxr, ptr[reg_index + step_index + i],
+                            to_imm_uint8_t(i));
             } else {
                 vmovq(indxr, ptr[reg_index + step_index]);
             }
@@ -620,13 +629,13 @@ inline void jit_uni_pool_kernel_t<isa>::load_indices(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
-        const int step_index, const bool is_c_tail_processing,
+inline void jit_uni_pool_kernel_t<isa>::store_indices(const dim_t indr_i,
+        const dim_t step_index, const bool is_c_tail_processing,
         const bool is_first_w_block) {
     if (jpp.ind_dt == data_type::u8) {
         auto xr = xreg(indr_i);
         if (isa == sse41) {
-            for (int i = 0; i < (jpp.c_block / 2); ++i) {
+            for (dim_t i = 0; i < (jpp.c_block / 2); ++i) {
                 if (is_c_tail_processing
                         && i + (sse_high_half ? (jpp.c_block / 2) : 0)
                                 >= jpp.c_tail) {
@@ -639,32 +648,34 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
                     // bytes which should be stored are located in
                     // least significant bits(8 to be precise) of 32 bits parts
                     // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                    pextrb(ptr[reg_index + step_index + i], xr, 4 * i);
+                    pextrb(ptr[reg_index + step_index + i], xr,
+                            to_imm_uint8_t(4 * i));
                 }
             }
         } else if (utils::one_of(isa, avx, avx2, avx2_vnni_2)) {
             auto yr = yreg(indr_i);
             if (is_c_tail_processing && !jpp.is_c_padded) {
-                const int max_nr_of_vals = jpp.c_tail > (jpp.c_block / 2)
+                const auto max_nr_of_vals = jpp.c_tail > (jpp.c_block / 2)
                         ? (jpp.c_block / 2)
                         : jpp.c_tail;
-                for (int i = 0; i < max_nr_of_vals; ++i) {
+                for (dim_t i = 0; i < max_nr_of_vals; ++i) {
                     // bytes which should be stored are located in
                     // least significant bits(8 to be precise) of 32 bits parts
                     // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                    vpextrb(ptr[reg_index + step_index + i], xr, 4 * i);
+                    vpextrb(ptr[reg_index + step_index + i], xr,
+                            to_imm_uint8_t(4 * i));
                 }
 
                 if (jpp.c_tail > (jpp.c_block / 2)) {
                     Xmm higher_128bits(vmm_mask.getIdx());
                     vextractf128(higher_128bits, yr, 1);
-                    for (int i = 0; i < jpp.c_tail - (jpp.c_block / 2); ++i) {
+                    for (dim_t i = 0; i < jpp.c_tail - (jpp.c_block / 2); ++i) {
                         // bytes which should be stored are located in
                         // least significant bits(8 to be precise) of 32 bits parts
                         // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
                         vpextrb(ptr[reg_index + step_index + (jpp.c_block / 2)
                                         + i],
-                                higher_128bits, 4 * i);
+                                higher_128bits, to_imm_uint8_t(4 * i));
                     }
                 }
             } else {
@@ -746,17 +757,18 @@ bool jit_uni_pool_kernel_t<isa>::init_post_ops_conf(jit_pool_conf_t &jpp,
 }
 
 template <cpu_isa_t isa>
-void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
-        const std::function<bool(int, bool)> &is_tail_predicate) {
+void jit_uni_pool_kernel_t<isa>::apply_postops(dim_t ur_bc, dim_t ur_w,
+        dim_t c_block,
+        const std::function<bool(dim_t, bool)> &is_tail_predicate) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
-    const int end_idx = vmm_idx_upper_bound() + 1;
-    const int start_idx = end_idx - (ur_bc * ur_w);
+    const auto end_idx = vmm_idx_upper_bound() + 1;
+    const auto start_idx = end_idx - (ur_bc * ur_w);
     const bool sse41_postops_disabled
             = isa == sse41 && disable_postops_when_sse_high_half_processed_;
     if (end_idx - start_idx == 0) return;
     if (jpp.with_binary && !sse41_postops_disabled) {
 
-        const int c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
+        const auto c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
                 ? jpp.c
                 : c_block;
 
@@ -766,8 +778,8 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
             add(tmp_gpr, ptr[reg_param + GET_OFF(dst_po_helper)]);
         }
 
-        for (int jj = 0; jj < ur_w; jj++) {
-            for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t jj = 0; jj < ur_w; jj++) {
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
                 const auto vmm_idx
                         = vreg(reg_ind(0, bci, jj, ur_bc, ur_w)).getIdx();
 
@@ -792,15 +804,15 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(
-        int jj, int ur_w, int pad_l, int pad_r, bool with_c_tail_proccessing) {
+inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(dim_t jj,
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
     if (jpp.alg == pooling_avg_exclude_padding) {
-        int kw = jpp.kw;
-        int stride_w = jpp.stride_w;
+        auto kw = jpp.kw;
+        auto stride_w = jpp.stride_w;
 
-        int non_zero_kw = kw;
-        non_zero_kw -= nstl::max(0, pad_l - jj * stride_w);
-        non_zero_kw -= nstl::max(0, pad_r - (ur_w - 1 - jj) * stride_w);
+        auto non_zero_kw = kw;
+        non_zero_kw -= nstl::max(dim_t(0), pad_l - jj * stride_w);
+        non_zero_kw -= nstl::max(dim_t(0), pad_r - (ur_w - 1 - jj) * stride_w);
 
         if (non_zero_kw != prev_kw) {
             mov(tmp_gpr, float2int((float)non_zero_kw));
@@ -823,20 +835,20 @@ inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
-        int pad_r, bool with_c_tail_proccessing) {
+inline void jit_uni_pool_kernel_t<isa>::avg_step(dim_t ur_w, dim_t ur_bc,
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
 
-    auto iw = jpp.iw;
-    auto kw = jpp.kw;
-    auto stride_w = jpp.stride_w;
-    auto c_block = jpp.c_block;
-    auto dt_size = jpp.dt_size;
-    const int c_off
+    const auto iw = jpp.iw;
+    const auto kw = jpp.kw;
+    const auto stride_w = jpp.stride_w;
+    const auto c_block = jpp.c_block;
+    const auto dt_size = jpp.dt_size;
+    const auto c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
     Label kd_label, kh_label;
 
     const auto is_tail_processing
-            = [&](int bc, bool process_with_postops = false) {
+            = [&](dim_t bc, bool process_with_postops = false) {
         if (isa == sse41 && (!jpp.is_c_padded || process_with_postops)) {
             return with_c_tail_proccessing && bc == (ur_bc - 1)
                     && ((jpp.c_tail > (jpp.c_block / 2) && sse_high_half)
@@ -846,11 +858,11 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
             return with_c_tail_proccessing && bc == (ur_bc - 1);
     };
 
-    for (int jj = 0; jj < ur_w; jj++) {
+    for (dim_t jj = 0; jj < ur_w; jj++) {
         if (jpp.is_backward)
             maybe_recalculate_divisor(
                     jj, ur_w, pad_l, pad_r, with_c_tail_proccessing);
-        for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t bci = 0; bci < ur_bc; bci++) {
             const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
             auto accvr = vreg(accr_i);
             if (jpp.is_backward) {
@@ -878,21 +890,22 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const auto jj_start
+                    = utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w);
+            const auto jj_end = ur_w
+                    - utils::div_up(nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w);
 
-            for_(int jj = jj_start; jj < jj_end; jj++)
-            for (int bci = 0; bci < ur_bc; bci++) {
+            for_(dim_t jj = jj_start; jj < jj_end; jj++)
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
+                auto aux_input_offset
+                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
+                if (aux_input_offset >= iw * c_off) continue;
                 const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
                 auto inpvr = vreg(inpr_i);
-                int aux_input_offset
-                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
-                if (aux_input_offset >= iw * c_off) continue;
-                int input_offset = dt_size * aux_input_offset;
+                auto input_offset = dt_size * aux_input_offset;
                 if (jpp.is_backward) {
                     load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input,
                             input_offset, is_tail_processing(bci));
@@ -922,10 +935,10 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
     }
 
     if (!jpp.is_backward) {
-        for (int jj = 0; jj < ur_w; jj++) {
+        for (dim_t jj = 0; jj < ur_w; jj++) {
             maybe_recalculate_divisor(
                     jj, ur_w, pad_l, pad_r, with_c_tail_proccessing);
-            for (int bci = 0; bci < ur_bc; bci++) {
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
                 const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
                 const auto accvr = vreg(accr_i);
                 uni_vdivps(accvr, accvr, vmm_tmp);
@@ -935,8 +948,8 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
         if (jpp.with_postops)
             apply_postops(ur_bc, ur_w, c_block, is_tail_processing);
 
-        for (int jj = 0; jj < ur_w; jj++) {
-            for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t jj = 0; jj < ur_w; jj++) {
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
                 const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
                 const auto output_offset
                         = dt_size * (jj * c_off + bci * c_block);
@@ -948,17 +961,17 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
-        int pad_l, int pad_r, bool with_c_tail_proccessing) {
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int stride_w = jpp.stride_w;
-    int c_block = jpp.c_block;
-    const int c_off
+inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(dim_t ur_w, dim_t ur_bc,
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
+    const auto iw = jpp.iw;
+    const auto kw = jpp.kw;
+    const auto stride_w = jpp.stride_w;
+    const auto c_block = jpp.c_block;
+    const auto c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
     Label kd_label, kh_label;
 
-    auto is_tail_processing = [&](int bc, bool process_with_postops = false) {
+    auto is_tail_processing = [&](dim_t bc, bool process_with_postops = false) {
         if (isa == sse41 && (!jpp.is_c_padded || process_with_postops)) {
             return with_c_tail_proccessing && bc == (ur_bc - 1)
                     && ((jpp.c_tail > (jpp.c_block / 2) && sse_high_half)
@@ -972,8 +985,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     uni_vmovq(xmm_tmp, tmp_gpr);
     uni_vbroadcastss(vmm_tmp, xmm_tmp);
 
-    for_(int jj = 0; jj < ur_w; jj++)
-    for (int bci = 0; bci < ur_bc; bci++) {
+    for_(dim_t jj = 0; jj < ur_w; jj++)
+    for (dim_t bci = 0; bci < ur_bc; bci++) {
         const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
         uni_vmovups(accvr, vmm_tmp);
         if (jpp.is_training) {
@@ -998,22 +1011,23 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
-            for_(int jj = jj_start; jj < jj_end; jj++)
-            for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const auto jj_start
+                    = utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w);
+            const auto jj_end = ur_w
+                    - utils::div_up(nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w);
+            for_(dim_t jj = jj_start; jj < jj_end; jj++)
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
+                auto aux_input_offset
+                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
+                if (aux_input_offset >= iw * c_off) continue;
                 const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
                 const auto inpvr = vreg(inpr_i);
                 const auto indvr = vreg(reg_ind(2, bci, jj, ur_bc, ur_w));
                 const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
-                int aux_input_offset
-                        = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
-                if (aux_input_offset >= iw * c_off) continue;
-                int input_offset = jpp.dt_size * aux_input_offset;
+                auto input_offset = jpp.dt_size * aux_input_offset;
                 load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input, input_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
@@ -1083,8 +1097,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     if (jpp.with_postops)
         apply_postops(ur_bc, ur_w, c_block, is_tail_processing);
 
-    for_(int jj = 0; jj < ur_w; jj++)
-    for (int bci = 0; bci < ur_bc; bci++) {
+    for_(dim_t jj = 0; jj < ur_w; jj++)
+    for (dim_t bci = 0; bci < ur_bc; bci++) {
         const auto accr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
         const auto output_offset = jpp.dt_size * (jj * c_off + bci * c_block);
         const bool is_c_tail_processing = is_tail_processing(bci);
@@ -1104,16 +1118,16 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
-        int pad_l, int pad_r, bool with_c_tail_proccessing) {
+inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(dim_t ur_w, dim_t ur_bc,
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
 
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int stride_w = jpp.stride_w;
-    int c_block = jpp.c_block;
-    const int output_c_off
+    const auto iw = jpp.iw;
+    const auto kw = jpp.kw;
+    const auto stride_w = jpp.stride_w;
+    const auto c_block = jpp.c_block;
+    const auto output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
-    const int input_c_off = jpp.needs_f32_accum_for_bf16
+    const auto input_c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : output_c_off;
     const auto input_dt
@@ -1124,7 +1138,7 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
 
     Label kd_label, kh_label;
 
-    const auto is_tail_processing = [&](int bc) {
+    const auto is_tail_processing = [&](dim_t bc) {
         if (isa == sse41) {
             return with_c_tail_proccessing && bc == (ur_bc - 1)
                     && ((jpp.c_tail > (jpp.c_block / 2) && sse_high_half)
@@ -1136,8 +1150,8 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
             return with_c_tail_proccessing && bc == (ur_bc - 1);
     };
 
-    for_(int jj = 0; jj < ur_w; jj++)
-    for (int bci = 0; bci < ur_bc; bci++) {
+    for_(dim_t jj = 0; jj < ur_w; jj++)
+    for (dim_t bci = 0; bci < ur_bc; bci++) {
         const auto outr_i = reg_ind(0, bci, jj, ur_bc, ur_w);
         auto out_offset = output_dt_size * (jj * output_c_off + bci * c_block);
         const bool is_c_tail_processing = is_tail_processing(bci);
@@ -1167,22 +1181,23 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
-            for_(int jj = jj_start; jj < jj_end; jj++)
-            for (int bci = 0; bci < ur_bc; bci++) {
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const auto jj_start
+                    = utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w);
+            const auto jj_end = ur_w
+                    - utils::div_up(nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w);
+            for_(dim_t jj = jj_start; jj < jj_end; jj++)
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
+                auto aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
+                        + bci * c_block;
+                if (aux_inp_offset >= iw * input_c_off) continue;
                 const auto outvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
                 const auto indvr = vreg(reg_ind(1, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
                 const auto inpvr = vreg(inpr_i);
                 const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
-                int aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
-                        + bci * c_block;
-                if (aux_inp_offset >= iw * input_c_off) continue;
-                int inp_offset = input_dt_size * aux_inp_offset;
+                auto inp_offset = input_dt_size * aux_inp_offset;
                 load(input_dt, reg_idx(inpr_i), aux_reg_input, inp_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
@@ -1254,15 +1269,15 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
 
 template <cpu_isa_t isa>
 void jit_uni_pool_kernel_t<isa>::zero_diff_src(
-        int ur_bc, bool with_c_tail_proccessing) {
-    const int c_off = jpp.needs_f32_accum_for_bf16
+        dim_t ur_bc, bool with_c_tail_proccessing) {
+    const auto c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c
                                                              : jpp.c_block);
 
     Label l_skip, l_ih_loop, l_id_loop;
 
-    auto is_tail_processing = [&](int bc) {
+    auto is_tail_processing = [&](dim_t bc) {
         return with_c_tail_proccessing && bc == (ur_bc - 1);
     };
 
@@ -1282,7 +1297,7 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
     const auto src_dt
             = jpp.needs_f32_accum_for_bf16 ? data_type::f32 : jpp.src_dt;
     const auto dt_size = types::data_type_size(src_dt);
-    const int width_size = jpp.iw * c_off * dt_size;
+    const dim_t width_size = jpp.iw * c_off * dt_size;
 
     auto aux_reg_zero_ptr = tmp_gpr;
 
@@ -1293,12 +1308,12 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
         L(l_ih_loop);
         {
             const auto vlen = cpu_isa_traits_t<isa>::vlen;
-            const int step = c_off * dt_size;
+            const auto step = c_off * dt_size;
 
             // TODO: maybe a big code generated here
-            for_(int i = 0; i < width_size; i += step)
-            for (int bci = 0; bci < ur_bc; bci++) {
-                const int offs = i + bci * jpp.c_block * dt_size;
+            for_(dim_t i = 0; i < width_size; i += step)
+            for (dim_t bci = 0; bci < ur_bc; bci++) {
+                const auto offs = i + bci * jpp.c_block * dt_size;
                 if (isa == sse41) {
                     bool is_needed_c_tail_processing = false;
                     if (is_tail_processing(bci)
@@ -1338,16 +1353,16 @@ void jit_uni_pool_kernel_t<isa>::generate() {
 
     this->preamble();
 
-    int ow = jpp.ow;
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int kh = jpp.kh;
-    int c_block = jpp.c_block;
-    int stride_w = jpp.stride_w;
-    int l_pad = jpp.l_pad;
-    const int output_c_off
+    const auto ow = jpp.ow;
+    const auto iw = jpp.iw;
+    const auto kw = jpp.kw;
+    const auto kh = jpp.kh;
+    const auto c_block = jpp.c_block;
+    const auto stride_w = jpp.stride_w;
+    const auto l_pad = jpp.l_pad;
+    const auto output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
-    const int input_c_off = jpp.needs_f32_accum_for_bf16
+    const auto input_c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : output_c_off;
 
@@ -1368,7 +1383,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
     mov(reg_nbc, ptr[reg_param + GET_OFF(ur_bc)]);
 
     auto process_oi
-            = [&](int ur_w, int ur_bc, int lpad, int rpad,
+            = [&](dim_t ur_w, dim_t ur_bc, dim_t lpad, dim_t rpad,
                       bool with_c_tail_proccessing, bool inc_reg = true) {
         step(ur_w, ur_bc, lpad, rpad, with_c_tail_proccessing);
 
@@ -1400,7 +1415,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
         auto output_dt_size = jpp.dt_size;
         auto shift = (isa == sse41) ? vlen : 0;
         add(reg_input,
-                input_dt_size * nstl::max(0, ur_w * stride_w - lpad)
+                input_dt_size * nstl::max(dim_t(0), ur_w * stride_w - lpad)
                                 * input_c_off
                         - shift);
         add(reg_output, output_dt_size * ur_w * output_c_off - shift);
@@ -1411,7 +1426,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
         }
     };
 
-    auto perform_ker = [&](int ur_bc, bool with_c_tail_processing) {
+    auto perform_ker = [&](dim_t ur_bc, bool with_c_tail_processing) {
         prev_kw = 0; // re-initialize this value for avg steps
 
         if (jpp.is_backward && jpp.simple_alg)
@@ -1446,27 +1461,27 @@ void jit_uni_pool_kernel_t<isa>::generate() {
             }
         }
 
-        const int ur_w = nstl::min(jpp.ow, jpp.ur / jpp.ur_bc);
-        const int n_oi_iterations = utils::div_up(ow, ur_w);
-        const int ur_stride_w = ur_w * stride_w;
-        const int l_pad_iterations
+        const auto ur_w = nstl::min(jpp.ow, jpp.ur / jpp.ur_bc);
+        const auto n_oi_iterations = utils::div_up(ow, ur_w);
+        const auto ur_stride_w = ur_w * stride_w;
+        const auto l_pad_iterations
                 = nstl::min(n_oi_iterations, utils::div_up(l_pad, ur_stride_w));
 
-        for (int i = 0; i < l_pad_iterations; ++i) {
-            const int ow_s = i * ur_w;
-            const int ow_e = nstl::min(ow, ow_s + ur_w);
-            const int cur_l_pad = l_pad - i * ur_stride_w;
-            const int cur_r_pad = nstl::max(
-                    0, calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
-            const int cur_ur_w = ow_e - ow_s;
+        for (dim_t i = 0; i < l_pad_iterations; ++i) {
+            const auto ow_s = i * ur_w;
+            const auto ow_e = nstl::min(ow, ow_s + ur_w);
+            const auto cur_l_pad = l_pad - i * ur_stride_w;
+            const auto cur_r_pad = nstl::max(dim_t(0),
+                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+            const auto cur_ur_w = ow_e - ow_s;
             process_oi(cur_ur_w, ur_bc, cur_l_pad, cur_r_pad,
                     with_c_tail_processing);
         }
 
-        const int rem_n_oi_iters = n_oi_iterations - l_pad_iterations;
-        const int cur_iw = l_pad_iterations * ur_stride_w - l_pad;
-        const int cur_iw_rightmost_idx = cur_iw + kw - 1;
-        const int no_pad_full_n_oi_iters = utils::saturate<int>(
+        const auto rem_n_oi_iters = n_oi_iterations - l_pad_iterations;
+        const auto cur_iw = l_pad_iterations * ur_stride_w - l_pad;
+        const auto cur_iw_rightmost_idx = cur_iw + kw - 1;
+        const dim_t no_pad_full_n_oi_iters = utils::saturate<dim_t>(
                 0, rem_n_oi_iters, (iw - cur_iw_rightmost_idx) / ur_stride_w);
 
         if (no_pad_full_n_oi_iters > 0) {
@@ -1483,13 +1498,13 @@ void jit_uni_pool_kernel_t<isa>::generate() {
             }
         }
 
-        for (int i = l_pad_iterations + no_pad_full_n_oi_iters;
+        for (dim_t i = l_pad_iterations + no_pad_full_n_oi_iters;
                 i < n_oi_iterations; ++i) {
-            const int ow_s = i * ur_w;
-            const int ow_e = nstl::min(ow, ow_s + ur_w);
-            const int cur_r_pad = nstl::max(
-                    0, calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
-            const int cur_ur_w = ow_e - ow_s;
+            const auto ow_s = i * ur_w;
+            const auto ow_e = nstl::min(ow, ow_s + ur_w);
+            const auto cur_r_pad = nstl::max(dim_t(0),
+                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+            const auto cur_ur_w = ow_e - ow_s;
             process_oi(cur_ur_w, ur_bc, 0, cur_r_pad, with_c_tail_processing);
         }
     };

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -800,7 +800,8 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(dim_t ur_bc, dim_t ur_w,
             }
         }
     }
-    postops_injector_->compute_vector_range(start_idx, end_idx, rhs_arg_params);
+    postops_injector_->compute_vector_range(static_cast<int>(start_idx),
+            static_cast<int>(end_idx), rhs_arg_params);
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -65,12 +65,28 @@ private:
         return is_superset(isa, avx512_core) ? 31 : 15;
     }
 
-    int reg_idx(int idx) const noexcept { return vmm_idx_upper_bound() - idx; }
+    // Maps a logical index to a physical XByak register index. The narrowing
+    // and bounds check are done by jit_generator's xbyak_register_index at the
+    // single register-construction boundary.
+    int reg_idx(dim_t idx) const noexcept {
+        // The pooling primitive creates out-of-bounds registers, but never
+        // use it.
+        // TODO: do the proper refactoring eliminating creating registers with
+        // invalid indices.
+        return xbyak_register_index(vmm_idx_upper_bound() - idx);
+    }
 
-    Xmm xreg(int idx) const noexcept { return Xmm(reg_idx(idx)); }
-    Ymm yreg(int idx) const noexcept { return Ymm(reg_idx(idx)); }
-    Zmm zreg(int idx) const noexcept { return Zmm(reg_idx(idx)); }
-    Vmm vreg(int idx) const noexcept { return Vmm(reg_idx(idx)); }
+    Xmm xreg(dim_t idx) const noexcept { return Xmm(reg_idx(idx)); }
+    Ymm yreg(dim_t idx) const noexcept { return Ymm(reg_idx(idx)); }
+    Zmm zreg(dim_t idx) const noexcept { return Zmm(reg_idx(idx)); }
+    Vmm vreg(dim_t idx) const noexcept { return Vmm(reg_idx(idx)); }
+
+    // Narrows a small, fixed-range value (SIMD lane index or blend mask) to the
+    // XByak 8-bit immediate at the single instruction-emit boundary.
+    static uint8_t to_imm_uint8_t(dim_t v) noexcept {
+        assert(v >= 0 && v <= UINT8_MAX);
+        return static_cast<uint8_t>(v);
+    }
 
     const Xbyak::AddressFrame &vmmword = (isa == sse41)  ? xword
             : utils::one_of(isa, avx, avx2, avx2_vnni_2) ? yword
@@ -137,33 +153,34 @@ private:
     bool sse_high_half = false;
     bool disable_postops_when_sse_high_half_processed_ = false;
 
-    int prev_kw = 0;
+    dim_t prev_kw = 0;
 
     void put_one_in_vmm();
     void uni_broadcast_reg_val(const int reg_idx, const int vmm_idx);
     void push_vmm_val(const int idx);
     void pop_vmm_val(const int idx);
-    void load(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
-            const int offset, const bool is_c_tail_proccessing);
-    void store(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
-            const int offset, const bool is_c_tail_proccessing);
-    void pad_with_zeros(int idx);
-    void load_indices(int indr_i, int step_index, bool is_c_tail_processing);
-    void store_indices(int indr_i, int step_index, bool is_c_tail_processing,
-            bool is_first_w_block);
+    void load(const data_type_t dt, const dim_t idx, const reg64_t &reg_ptr,
+            const dim_t offset, const bool is_c_tail_proccessing);
+    void store(const data_type_t dt, const dim_t idx, const reg64_t &reg_ptr,
+            const dim_t offset, const bool is_c_tail_proccessing);
+    void pad_with_zeros(dim_t idx);
+    void load_indices(
+            dim_t indr_i, dim_t step_index, bool is_c_tail_processing);
+    void store_indices(dim_t indr_i, dim_t step_index,
+            bool is_c_tail_processing, bool is_first_w_block);
 
-    void maybe_recalculate_divisor(int jj, int ur_w, int pad_l, int pad_r,
+    void maybe_recalculate_divisor(dim_t jj, dim_t ur_w, dim_t pad_l,
+            dim_t pad_r, bool with_c_tail_proccessing);
+    void avg_step(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
-    void avg_step(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void max_step_fwd(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
-    void max_step_fwd(int ur_w, int ur_bc, int pad_l, int pad_r,
-            bool with_c_tail_proccessing);
-    void max_step_bwd(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void max_step_bwd(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
 
-    void zero_diff_src(int ur_bc, bool with_c_tail_proccessing);
+    void zero_diff_src(dim_t ur_bc, bool with_c_tail_proccessing);
 
-    void step(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void step(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing) {
         if (jpp.alg == alg_kind::pooling_max) {
             if (jpp.is_backward)
@@ -176,7 +193,7 @@ private:
             avg_step(ur_w, ur_bc, pad_l, pad_r, with_c_tail_proccessing);
     }
 
-    void step_high_half(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void step_high_half(dim_t ur_w, dim_t ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_processing) {
         add(reg_input, sizeof(float) * 4);
         add(reg_output, sizeof(float) * 4);
@@ -241,8 +258,8 @@ private:
         pcmpeqd(x0, x1);
     }
 
-    void apply_postops(int ur_bc, int ur_w, int c_block,
-            const std::function<bool(int, bool)> &is_tail_predicate);
+    void apply_postops(dim_t ur_bc, dim_t ur_w, dim_t c_block,
+            const std::function<bool(dim_t, bool)> &is_tail_predicate);
 
     static bool init_post_ops_conf(jit_pool_conf_t &jpp,
             const primitive_attr_t &attr, const memory_desc_wrapper &dst_d);

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -184,7 +184,7 @@ struct transpose_ncsp_to_block_fmt_t {
         , block_size_(block_size)
         , offset_multiplier_(offset_multiplier) {}
 
-    void operator()(std::size_t ithr, int n, int b_c) const {
+    void operator()(std::size_t ithr, dim_t n, dim_t b_c) const {
         const dim_t cs
                 = nstl::min(c_without_padding_ - b_c * c_block_, c_block_);
         const src_data_t *src_nscp = src_nscp_base_
@@ -199,8 +199,8 @@ struct transpose_ncsp_to_block_fmt_t {
 private:
     trans_wrapper_t *transposer_;
     trans_wrapper_t *transposer_tail_;
-    const int c_without_padding_;
-    const int c_block_;
+    const dim_t c_without_padding_;
+    const dim_t c_block_;
     const src_data_t *src_nscp_base_;
     const memory_desc_wrapper &src_nscp_desc_;
     dst_data_t *__restrict dst_blocked_base_;
@@ -241,8 +241,8 @@ struct transpose_block_fmt_to_ncsp_t {
 private:
     trans_wrapper_t *transposer_;
     trans_wrapper_t *transposer_tail_;
-    const int c_without_padding_;
-    const int c_block_;
+    const dim_t c_without_padding_;
+    const dim_t c_block_;
     const src_data_t *__restrict src_blocked_base_;
     const dim_t block_size_;
     dst_data_t *dst_ncsp_base_;
@@ -257,8 +257,8 @@ public:
             const memory_desc_wrapper &src_d, const memory_desc_wrapper &dst_d,
             const memory_desc_wrapper &indices_d, const char *indices,
             const data_type_t wsp_dt, const exec_ctx_t &ctx)
-        : src_sp_(static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw)
-        , dst_sp_(static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow)
+        : src_sp_(jpp.id * jpp.ih * jpp.iw)
+        , dst_sp_(jpp.od * jpp.oh * jpp.ow)
         , src_slice_(src_sp_ * jpp.c_block)
         , dst_slice_(dst_sp_ * jpp.c_block)
         , transpose_src_(jpp.tag_kind == jit_memory_tag_kind_t::ncsp)
@@ -292,40 +292,40 @@ public:
     inline bool should_transpose_dst() const noexcept { return transpose_dst_; }
 
     const void *get_src_addr(
-            std::size_t ithr, int ih, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t ih, const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_src_wsp_ + ithr * src_slice_;
         return static_cast<const void *>(&wsp[ih * jpp.iw * jpp.c_block]);
     }
 
     const void *get_dst_addr(
-            std::size_t ithr, int oh, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t oh, const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_dst_wsp_ + ithr * dst_slice_;
         return static_cast<const void *>(&wsp[oh * jpp.ow * jpp.c_block]);
     }
 
     const void *get_indices_addr(
-            std::size_t ithr, int oh, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t oh, const jit_pool_conf_t &jpp) const {
         const char *const wsp
                 = cvt_slice_ind_wsp_ + ithr * dst_slice_ * ind_dt_size_;
         return static_cast<const void *>(
                 &wsp[oh * jpp.ow * jpp.c_block * ind_dt_size_]);
     }
 
-    const void *get_src_addr_3d(std::size_t ithr, int id, int ih,
+    const void *get_src_addr_3d(std::size_t ithr, dim_t id, dim_t ih,
             const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_src_wsp_ + ithr * src_slice_;
         return static_cast<const void *>(&wsp[ih * jpp.iw * jpp.c_block
                 + id * jpp.ih * jpp.iw * jpp.c_block]);
     }
 
-    const void *get_dst_addr_3d(std::size_t ithr, int od, int oh,
+    const void *get_dst_addr_3d(std::size_t ithr, dim_t od, dim_t oh,
             const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_dst_wsp_ + ithr * dst_slice_;
         return static_cast<const void *>(&wsp[oh * jpp.ow * jpp.c_block
                 + od * jpp.oh * jpp.ow * jpp.c_block]);
     }
 
-    const void *get_indices_addr_3d(std::size_t ithr, int od, int oh,
+    const void *get_indices_addr_3d(std::size_t ithr, dim_t od, dim_t oh,
             const jit_pool_conf_t &jpp) const {
         const char *const wsp
                 = cvt_slice_ind_wsp_ + ithr * dst_slice_ * ind_dt_size_;
@@ -334,11 +334,11 @@ public:
                         + od * jpp.oh * jpp.ow * jpp.c_block * ind_dt_size_]);
     }
 
-    void execute_transpose_input(std::size_t ithr, int n, int b_c) const {
+    void execute_transpose_input(std::size_t ithr, dim_t n, dim_t b_c) const {
         execute_transpose_input_(ithr, n, b_c);
     }
 
-    void execute_transpose_output(std::size_t ithr, int n, int b_c) const {
+    void execute_transpose_output(std::size_t ithr, dim_t n, dim_t b_c) const {
         execute_transpose_output_(ithr, n, b_c);
     }
 
@@ -360,8 +360,8 @@ protected:
     wsp_data_t *__restrict cvt_slice_dst_wsp_;
     char *__restrict cvt_slice_ind_wsp_;
 
-    std::function<void(std::size_t, int, int)> execute_transpose_input_;
-    std::function<void(std::size_t, int, int)> execute_transpose_output_;
+    std::function<void(std::size_t, dim_t, dim_t)> execute_transpose_input_;
+    std::function<void(std::size_t, dim_t, dim_t)> execute_transpose_output_;
 };
 
 template <typename data_t, typename wsp_data_t, impl::data_type_t d_type>
@@ -554,8 +554,7 @@ void bwd_f32_accum_for_bf16_t::cvt_to_bf16_slice_2d(int ithr, bfloat16_t *dst,
             cvt_float_to_bfloat16(cur_dst, cur_src, nelems);
         } else {
             const auto c_b = jpp_.c_block * b_c;
-            const auto c_e = nstl::min(
-                    static_cast<dim_t>(jpp_.c), jpp_.c_block * (b_c + ur_bc));
+            const auto c_e = nstl::min(jpp_.c, jpp_.c_block * (b_c + ur_bc));
 
             if (c_b >= c_e) return;
 
@@ -609,8 +608,7 @@ void bwd_f32_accum_for_bf16_t::cvt_to_bf16_slice_3d(int ithr, bfloat16_t *dst,
                     dst + dst_d.blk_off(n), blk_data(ithr), nelems);
         } else {
             const auto c_b = jpp_.c_block * b_c;
-            const auto c_e = nstl::min(
-                    static_cast<dim_t>(jpp_.c), jpp_.c_block * (b_c + ur_bc));
+            const auto c_e = nstl::min(jpp_.c, jpp_.c_block * (b_c + ur_bc));
 
             if (c_b >= c_e) return;
 
@@ -653,8 +651,8 @@ status_t jit_uni_pooling_fwd_t<isa, d_type>::init_ncsp_trans_ctx() {
 
     const auto &jpp = pd()->jpp_;
     trans_ctx_ = utils::make_unique<trans_context_t>();
-    const dim_t src_sp = static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw;
-    const dim_t dst_sp = static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow;
+    const dim_t src_sp = jpp.id * jpp.ih * jpp.iw;
+    const dim_t dst_sp = jpp.od * jpp.oh * jpp.ow;
     const auto res = std::div(jpp.c_without_padding, jpp.c_block);
     const dim_t &nb_c = res.quot;
     const dim_t &c_tail = res.rem;
@@ -716,18 +714,18 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
     const auto trans_src = transpose_facade->should_transpose_src();
     const auto trans_dst = transpose_facade->should_transpose_dst();
 
-    const auto ker = [= COMPAT_THIS_CAPTURE](std::size_t ithr, int n, int b_c,
-                             int oh, int ur_bc) {
+    const auto ker = [= COMPAT_THIS_CAPTURE](std::size_t ithr, dim_t n,
+                             dim_t b_c, dim_t oh, dim_t ur_bc) {
         assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
         assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
-        const int c_off
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -768,8 +766,9 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         args.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
         args.kh_padding_shift = i_t_overflow * jpp.kw;
         args.ker_area_h = static_cast<float>(jpp.kh
-                - nstl::max(0, oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
-                - nstl::max(0, jpp.t_pad - oh * jpp.stride_h));
+                - nstl::max(dim_t(0),
+                        oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
+                - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h));
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         args.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
@@ -782,7 +781,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         parallel_nd(jpp.mb, jpp.oh, nb2_c, [=](dim_t n, dim_t oh, dim_t b2_c) {
             const auto b_c = b2_c * jpp.ur_bc;
-            const auto ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+            const auto ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
             ker(0, n, b_c, oh, ur_bc);
         });
     } else {
@@ -800,8 +799,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         } else {
             // nChw16c, nChw8c format
             parallel(nthr, [=](dim_t ithr, dim_t nthr) {
-                dim_t work_amount
-                        = static_cast<dim_t>(jpp.mb) * jpp.nb_c * jpp.oh;
+                dim_t work_amount = jpp.mb * jpp.nb_c * jpp.oh;
                 if (ithr >= work_amount) return;
 
                 dim_t start {0}, end {0};
@@ -848,18 +846,18 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
     const auto trans_src = transpose_facade->should_transpose_src();
     const auto trans_dst = transpose_facade->should_transpose_dst();
 
-    auto ker
-            = [= COMPAT_THIS_CAPTURE](int n, int b_c, int od, int oh, int id,
-                      int d_t_overflow, int d_b_overflow, int ur_bc, int ithr) {
+    auto ker = [= COMPAT_THIS_CAPTURE](dim_t n, dim_t b_c, dim_t od, dim_t oh,
+                       dim_t id, dim_t d_t_overflow, dim_t d_b_overflow,
+                       dim_t ur_bc, int ithr) {
         assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
-        const int c_off
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -900,15 +898,16 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         args.kh_padding_shift
                 = i_t_overflow * jpp.kw + d_t_overflow * jpp.kw * jpp.kh;
         args.kd_padding_shift = (i_t_overflow + i_b_overflow) * jpp.kw;
-        args.ker_area_h = (float)(jpp.kh
-                                  - nstl::max(0,
-                                          oh * jpp.stride_h - jpp.t_pad + jpp.kh
-                                                  - jpp.ih)
-                                  - nstl::max(0, jpp.t_pad - oh * jpp.stride_h))
+        args.ker_area_h
+                = (float)(jpp.kh
+                          - nstl::max(dim_t(0),
+                                  oh * jpp.stride_h - jpp.t_pad + jpp.kh
+                                          - jpp.ih)
+                          - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h))
                 * (jpp.kd
-                        - nstl::max(0,
+                        - nstl::max(dim_t(0),
                                 od * jpp.stride_d - jpp.f_pad + jpp.kd - jpp.id)
-                        - nstl::max(0, jpp.f_pad - od * jpp.stride_d));
+                        - nstl::max(dim_t(0), jpp.f_pad - od * jpp.stride_d));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
@@ -922,13 +921,12 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         parallel_nd(jpp.mb, jpp.od, nb2_c, [=](dim_t n, dim_t od, dim_t b2_c) {
             const dim_t b_c = b2_c * jpp.ur_bc;
-            const dim_t ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+            const dim_t ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
 
             const dim_t ik = od * jpp.stride_d;
             const dim_t d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
             const dim_t d_b_overflow
-                    = nstl::max(dim_t(jpp.id), ik + jpp.kd - jpp.f_pad)
-                    - jpp.id;
+                    = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
             const dim_t id = nstl::max(ik - jpp.f_pad, dim_t(0));
             for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                 ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, ur_bc,
@@ -938,18 +936,19 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
     } else {
         if (trans_src || trans_dst) {
             parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                    [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                    [=](int ithr, int nthr, dim_t n, dim_t b_c) {
                 if (trans_src)
                     transpose_facade->execute_transpose_input(ithr, n, b_c);
 
-                for (int od = 0; od < jpp.od; ++od) {
-                    const int ik = od * jpp.stride_d;
-                    const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-                    const int d_b_overflow
+                for (dim_t od = 0; od < jpp.od; ++od) {
+                    const auto ik = od * jpp.stride_d;
+                    const auto d_t_overflow
+                            = nstl::max(dim_t(0), jpp.f_pad - ik);
+                    const auto d_b_overflow
                             = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad)
                             - jpp.id;
-                    const int id = nstl::max(ik - jpp.f_pad, 0);
-                    for (int oh = 0; oh < jpp.oh; ++oh) {
+                    const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
+                    for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                         ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
                                 ithr);
                     }
@@ -961,12 +960,12 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         } else {
             parallel_nd(jpp.mb, jpp.nb_c, jpp.od,
                     [=](dim_t n, dim_t b_c, dim_t od) {
-                const int ik = od * jpp.stride_d;
-                const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-                const int d_b_overflow
+                const auto ik = od * jpp.stride_d;
+                const auto d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
+                const auto d_b_overflow
                         = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
-                const int id = nstl::max(ik - jpp.f_pad, 0);
-                for (int oh = 0; oh < jpp.oh; ++oh) {
+                const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
+                for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                     ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
                             first_ithr);
                 }
@@ -989,8 +988,8 @@ status_t jit_uni_pooling_bwd_t<isa, d_type>::init_ncsp_trans_ctx() {
 
     const auto &jpp = pd()->jpp_;
     trans_ctx_ = utils::make_unique<trans_context_t>();
-    const dim_t diff_src_sp = static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw;
-    const dim_t diff_dst_sp = static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow;
+    const dim_t diff_src_sp = jpp.id * jpp.ih * jpp.iw;
+    const dim_t diff_dst_sp = jpp.od * jpp.oh * jpp.ow;
     const auto res = std::div(jpp.c_without_padding, jpp.c_block);
     const dim_t &nb_c = res.quot;
     const dim_t &c_tail = res.rem;
@@ -1055,19 +1054,21 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
 
     auto f32_accum = std::make_shared<bwd_f32_accum_for_bf16_t>(jpp, ctx);
 
-    auto get_first_ih = [=](int oh) {
-        return nstl::min(nstl::max(oh * jpp.stride_h - jpp.t_pad, 0), jpp.ih);
+    auto get_first_ih = [=](dim_t oh) {
+        return nstl::min(
+                nstl::max(oh * jpp.stride_h - jpp.t_pad, dim_t(0)), jpp.ih);
     };
 
-    auto get_last_ih = [=](int oh) {
+    auto get_last_ih = [=](dim_t oh) {
         return nstl::min(
-                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, dim_t(0)),
+                jpp.ih);
     };
-    const auto ker = [= COMPAT_THIS_CAPTURE](
-                             int ithr, int n, int b_c, int oh, int ur_bc) {
+    const auto ker = [= COMPAT_THIS_CAPTURE](int ithr, dim_t n, dim_t b_c,
+                             dim_t oh, dim_t ur_bc) {
         jit_uni_pooling_args_t args;
 
-        const int ih = get_first_ih(oh);
+        const auto ih = get_first_ih(oh);
         assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
         assert(pd()->ndims() != 3 || utils::everyone_is(0, ih, oh));
 
@@ -1095,8 +1096,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
             }
         }
 
-        const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
-        const int zero_ih_end = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
+        const auto zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+        const auto zero_ih_end = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
 
         args.zero_id = 1;
         args.zero_ih = zero_ih_end - zero_ih_start;
@@ -1109,26 +1110,28 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
             args.zero_ptr
                     = &diff_src[diff_src_d.blk_off(n, c_off, zero_ih_start, 0)];
 
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - oh * jpp.stride_h);
-        const int i_b_overflow
+        const dim_t i_t_overflow
+                = nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h);
+        const dim_t i_b_overflow
                 = nstl::max(jpp.ih, oh * jpp.stride_h + jpp.kh - jpp.t_pad)
                 - jpp.ih;
         args.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
         args.kh_padding_shift = i_t_overflow * jpp.kw;
         args.ker_area_h = static_cast<float>(jpp.kh
-                - nstl::max(0, oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
-                - nstl::max(0, jpp.t_pad - oh * jpp.stride_h));
+                - nstl::max(dim_t(0),
+                        oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
+                - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         (*kernel_)(&args);
     };
 
-    auto process_block = [=](int ithr, int n, int b_c, int ur_bc) {
+    auto process_block = [=](int ithr, dim_t n, dim_t b_c, dim_t ur_bc) {
         if (transpose_facade->should_transpose_dst())
             transpose_facade->execute_transpose_input(ithr, n, b_c);
 
-        for (int oh = 0; oh < jpp.oh; ++oh)
+        for (dim_t oh = 0; oh < jpp.oh; ++oh)
             ker(ithr, n, b_c, oh, ur_bc);
 
         if (transpose_facade->should_transpose_src())
@@ -1193,27 +1196,29 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             ? sizeof(bwd_f32_accum_for_bf16_t::value_type)
             : jpp.dt_size;
 
-    auto get_last_ih = [=](int oh) {
+    auto get_last_ih = [=](dim_t oh) {
         return nstl::min(
-                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, dim_t(0)),
+                jpp.ih);
     };
 
-    auto get_last_id = [=](int od) {
+    auto get_last_id = [=](dim_t od) {
         return nstl::min(
-                nstl::max(od * jpp.stride_d - jpp.f_pad + jpp.kd, 0), jpp.id);
+                nstl::max(od * jpp.stride_d - jpp.f_pad + jpp.kd, dim_t(0)),
+                jpp.id);
     };
 
-    auto ker = [= COMPAT_THIS_CAPTURE](int n, int b_c, int od, int oh, int id,
-                       int d_t_overflow, int d_b_overflow, bool zero_inp,
-                       int kd, int ur_bc, int ithr) {
+    auto ker = [= COMPAT_THIS_CAPTURE](dim_t n, dim_t b_c, dim_t od, dim_t oh,
+                       dim_t id, dim_t d_t_overflow, dim_t d_b_overflow,
+                       bool zero_inp, dim_t kd, dim_t ur_bc, int ithr) {
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
-        const int c_off
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -1244,14 +1249,14 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         }
 
         if (zero_inp) {
-            const int zero_id_start = (od == 0) ? 0 : get_last_id(od - 1);
-            const int zero_id_end
+            const auto zero_id_start = (od == 0) ? 0 : get_last_id(od - 1);
+            const auto zero_id_end
                     = (od == jpp.od - 1) ? jpp.id : get_last_id(od);
 
             args.zero_id = zero_id_end - zero_id_start;
 
-            const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
-            const int zero_ih_end
+            const auto zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+            const auto zero_ih_end
                     = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
             args.zero_ih = zero_ih_end - zero_ih_start;
 
@@ -1274,29 +1279,31 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         args.kh_padding_shift = i_t_overflow * jpp.kw
                 + d_t_overflow * jpp.kw * jpp.kh + kd * jpp.kw * jpp.kh;
         args.kd_padding_shift = (i_t_overflow + i_b_overflow) * jpp.kw;
-        args.ker_area_h = (float)(jpp.kh
-                                  - nstl::max(0,
-                                          oh * jpp.stride_h - jpp.t_pad + jpp.kh
-                                                  - jpp.ih)
-                                  - nstl::max(0, jpp.t_pad - oh * jpp.stride_h))
+        args.ker_area_h
+                = (float)(jpp.kh
+                          - nstl::max(dim_t(0),
+                                  oh * jpp.stride_h - jpp.t_pad + jpp.kh
+                                          - jpp.ih)
+                          - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h))
                 * (jpp.kd
-                        - nstl::max(0,
+                        - nstl::max(dim_t(0),
                                 od * jpp.stride_d - jpp.f_pad + jpp.kd - jpp.id)
-                        - nstl::max(0, jpp.f_pad - od * jpp.stride_d));
+                        - nstl::max(dim_t(0), jpp.f_pad - od * jpp.stride_d));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         (*kernel_)(&args);
     };
 
-    auto process_simple = [=](int n, int b_c, int od, int ur_bc, int ithr) {
-        const int ik = od * jpp.stride_d;
-        const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-        const int d_b_overflow
+    auto process_simple
+            = [=](dim_t n, dim_t b_c, dim_t od, dim_t ur_bc, int ithr) {
+        const auto ik = od * jpp.stride_d;
+        const auto d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
+        const auto d_b_overflow
                 = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
-        const int id = nstl::max(ik - jpp.f_pad, 0);
+        const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
 
-        for (int oh = 0; oh < jpp.oh; ++oh) {
+        for (dim_t oh = 0; oh < jpp.oh; ++oh) {
             ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, true, 0, ur_bc,
                     ithr);
         }
@@ -1318,11 +1325,11 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                 });
             } else {
                 parallel_nd_ext(nthr, jpp.mb, nb2_c,
-                        [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b2_c) {
+                        [=](int ithr, dim_t nthr, dim_t n, dim_t b2_c) {
                     const dim_t b_c = b2_c * jpp.ur_bc;
                     const dim_t ur_bc
                             = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
+                    for (dim_t od = 0; od < jpp.od; ++od) {
                         process_simple(n, b_c, od, ur_bc, ithr);
                     }
                     f32_accum->cvt_to_bf16_slice_3d(ithr,
@@ -1333,10 +1340,10 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             assert(jpp.ur_bc == 1);
             if (trans_src || trans_dst || jpp.needs_f32_accum_for_bf16) {
                 parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                        [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                        [=](int ithr, dim_t nthr, dim_t n, dim_t b_c) {
                     if (trans_src)
                         transpose_facade->execute_transpose_input(ithr, n, b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
+                    for (dim_t od = 0; od < jpp.od; ++od) {
                         process_simple(n, b_c, od, 1, ithr);
                     }
                     if (trans_dst)
@@ -1370,7 +1377,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                     const size_t chunk_size
                             = (size_t)jpp.id * jpp.ih * jpp.iw * jpp.c_block;
                     parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                            [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                            [=](int ithr, dim_t nthr, dim_t n, dim_t b_c) {
                         const size_t offset
                                 = ((size_t)n * jpp.nb_c + b_c) * chunk_size;
                         PRAGMA_OMP_SIMD()
@@ -1384,7 +1391,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         if (trans_src || trans_dst || jpp.needs_f32_accum_for_bf16) {
             parallel_nd_ext(nthr, jpp.mb, nb2_c,
-                    [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b2_c) {
+                    [=](int ithr, int nthr, dim_t n, dim_t b2_c) {
                 const dim_t b_c = b2_c * jpp.ur_bc;
 
                 if (trans_dst) {
@@ -1395,15 +1402,15 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
 
                     const void *src = transpose_facade->get_src_addr_3d(
                             ithr, 0, 0, jpp);
-                    std::memset((void *)src, zero_val, block_size);
+                    std::memset((void *)src, 0, block_size);
                 }
 
                 if (jpp.needs_f32_accum_for_bf16) f32_accum->zero_data(ithr);
 
-                const dim_t ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+                const dim_t ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
                 for (dim_t kd = 0; kd < jpp.kd; ++kd) {
-                    for (int od = 0; od < jpp.od; ++od) {
-                        const dim_t ik = static_cast<dim_t>(od) * jpp.stride_d;
+                    for (dim_t od = 0; od < jpp.od; ++od) {
+                        const dim_t ik = od * jpp.stride_d;
                         const dim_t d_t_overflow
                                 = nstl::max(dim_t(0), jpp.f_pad - ik);
                         const dim_t d_b_overflow
@@ -1431,10 +1438,9 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             for (dim_t kd = 0; kd < jpp.kd; ++kd) {
                 parallel_nd(jpp.mb, nb2_c, [=](dim_t n, dim_t b2_c) {
                     const dim_t b_c = b2_c * jpp.ur_bc;
-                    const dim_t ur_bc
-                            = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
-                        const dim_t ik = static_cast<dim_t>(od) * jpp.stride_d;
+                    const dim_t ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+                    for (dim_t od = 0; od < jpp.od; ++od) {
+                        const dim_t ik = od * jpp.stride_d;
                         const dim_t d_t_overflow
                                 = nstl::max(dim_t(0), jpp.f_pad - ik);
                         const dim_t d_b_overflow

--- a/src/cpu/x64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.cpp
@@ -154,11 +154,11 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::init_post_ops_injector(
             reg_po_injector_helper_1_, elt_inj_opmask_, true /*is_fwd*/,
             false /*use_dst*/);
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {
-            static_cast<size_t>(rhs_dt_helper_vmm_.getIdx()),
-            reg_po_injector_helper_1_, reg_po_injector_helper_2_,
-            reg_po_injector_helper_3_, true /*preserve gpr*/,
-            true /*preserve vmm*/, GET_OFF(post_ops_binary_rhs_arg_vec),
-            GET_OFF(dst_orig), dst_d, store_tail_size_, k_tail_store_mask_,
+            rhs_dt_helper_vmm_.getIdx(), reg_po_injector_helper_1_,
+            reg_po_injector_helper_2_, reg_po_injector_helper_3_,
+            true /*preserve gpr*/, true /*preserve vmm*/,
+            GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig), dst_d,
+            store_tail_size_, k_tail_store_mask_,
             false /*use_exact_tail_scalar_bcast*/};
     const binary_injector::static_params_t bsp(
             reg_param_, get_supported_postops_bcast_strategies(), rhs_arg_bsp);

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -68,9 +68,12 @@ static bool prb_has_small_strides(const prb_t &prb) {
     constexpr ptrdiff_t max_stride = (1LL << 31) - 1;
     for (int d = 0; d < prb.ndims; ++d) {
         const ptrdiff_t cms = max_stride / prb.nodes[d].n;
-        const bool small_strides = true
-                && prb.nodes[d].is < cms / (int)data_type_size(prb.itype)
-                && prb.nodes[d].os < cms / (int)data_type_size(prb.otype);
+        const ptrdiff_t itype_sz
+                = static_cast<ptrdiff_t>(data_type_size(prb.itype));
+        const ptrdiff_t otype_sz
+                = static_cast<ptrdiff_t>(data_type_size(prb.otype));
+        const bool small_strides = true && prb.nodes[d].is < cms / itype_sz
+                && prb.nodes[d].os < cms / otype_sz;
         if (!small_strides) return false;
     }
     return true;
@@ -87,7 +90,7 @@ bool prb_has_huge_prime_number(const prb_t &prb) {
 /** Minimal reasonable/desirable kernel size.
  * The constant might be used to determine how a problem should be split
  * between kernel and threading driver. */
-const size_t ker_prb_size_min = 64;
+const dim_t ker_prb_size_min = 64;
 
 /* kernel */
 struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
@@ -113,9 +116,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
 
     struct simple_impl_desc_t {
         int ndims_full_unroll = 0;
-        int len_last_dim_unroll = 0;
-        int tail_len_unroll = 0;
-        int len_unroll = 0;
+        dim_t len_last_dim_unroll = 0;
+        dim_t tail_len_unroll = 0;
+        dim_t len_unroll = 0;
     };
 
 #define PARAM(x) \
@@ -130,9 +133,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         const int ndims = prb.ndims;
 
         int ndims_full_unroll = 0;
-        int len_last_dim_unroll = 1;
-        int tail_len_unroll = 0;
-        int len_unroll = 1;
+        dim_t len_last_dim_unroll = 1;
+        dim_t tail_len_unroll = 0;
+        dim_t len_unroll = 1;
 
         // It is responsible for finding as many values as kernel can unroll.
         // If tail is present, then kernel will unroll only last node.
@@ -145,7 +148,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             len_unroll = prb.nodes[0].n;
             tail_len_unroll = prb.nodes[0].is_zero_pad_needed
                     ? 0
-                    : static_cast<int>(prb.nodes[0].tail_size);
+                    : prb.nodes[0].tail_size;
         } else {
             for (int d = 0; d < ndims; ++d) {
                 const auto &node = prb.nodes[d];
@@ -212,26 +215,26 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         return is_superset(isa, avx512_core_fp16) || is_superset(isa, avx10_2);
     }
 
-    Address i_addr(int i_off) {
+    Address i_addr(dim_t i_off) {
         return ptr[reg_ptr_in_ + reg_off_in_ + i_off * itype_sz_];
     }
 
-    Address o_addr(int o_off, bool with_type_multiplier = true) {
+    Address o_addr(dim_t o_off, bool with_type_multiplier = true) {
         if (with_type_multiplier)
             return ptr[reg_ptr_out_ + reg_off_out_ + o_off * otype_sz_];
         else
             return ptr[reg_ptr_out_ + reg_off_out_ + o_off];
     }
 
-    Address src_s_addr(int s_off) {
+    Address src_s_addr(dim_t s_off) {
         return ptr[reg_ptr_src_scales_ + reg_off_scale_ + s_off * stype_sz_];
     }
 
-    Address dst_s_addr(int s_off) {
+    Address dst_s_addr(dim_t s_off) {
         return ptr[reg_ptr_dst_scales_ + reg_off_scale_ + s_off * stype_sz_];
     }
 
-    Address c_addr(int c_off) {
+    Address c_addr(dim_t c_off) {
         return ptr[reg_ptr_comp_ + reg_off_comp_ + c_off * sizeof(int32_t)];
     }
 
@@ -240,9 +243,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 + sizeof(int64_t) * (node_id)];
     }
 
-    void step(int off, int prev_i_off, int prev_o_off, int prev_s_off,
-            int prev_c_off, int &i_off, int &o_off, int &s_off, int &c_off,
-            int step_size = 1) {
+    void step(dim_t off, dim_t prev_i_off, dim_t prev_o_off, dim_t prev_s_off,
+            dim_t prev_c_off, dim_t &i_off, dim_t &o_off, dim_t &s_off,
+            dim_t &c_off, dim_t step_size = 1) {
         i_off = prev_i_off;
         o_off = prev_o_off;
         s_off = prev_s_off;
@@ -250,7 +253,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
 
         if (off == 0) return;
 
-        int start_dim = 0, dims_prod = 1;
+        int start_dim = 0;
+        dim_t dims_prod = 1;
         for (; start_dim < prb_.ndims && dims_prod != step_size; ++start_dim)
             dims_prod *= prb_.n(start_dim);
         assert(start_dim < prb_.ndims);
@@ -275,14 +279,14 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         }
     }
 
-    void step(int off, int prev_i_off, int prev_o_off, int &i_off, int &o_off,
-            int step_size = 1) {
-        int dummy = 0;
+    void step(dim_t off, dim_t prev_i_off, dim_t prev_o_off, dim_t &i_off,
+            dim_t &o_off, dim_t step_size = 1) {
+        dim_t dummy = 0;
         step(off, prev_i_off, prev_o_off, dummy, dummy, i_off, o_off, dummy,
                 dummy, step_size);
     }
 
-    void tr8x8_avx2(int i_off, int o_off) {
+    void tr8x8_avx2(dim_t i_off, dim_t o_off) {
         using namespace data_type;
 
         const auto cvt2ps
@@ -509,7 +513,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 = (utils::one_of(prb_.otype, u8, s8, s32) && interim_f32);
 
         for (int i = 0; i < unroll; i++) {
-            const int node_0_input_stride = prb_.is(0);
+            const ptrdiff_t node_0_input_stride = prb_.is(0);
             load(Ymm(i), i_addr(i_off + i * node_0_input_stride),
                     unroll * itype_sz_);
 
@@ -548,7 +552,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         }
 
         for (int i = 0; i < unroll; i++) {
-            const int node_1_output_stride = prb_.os(1);
+            const ptrdiff_t node_1_output_stride = prb_.os(1);
             if (prb_.otype != f32)
                 cvt2odt(Ymm(i), prb_.otype,
                         need_saturation       ? s32
@@ -563,7 +567,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     bool can_do_tr8x8() {
         using namespace data_type;
 
-        static constexpr size_t desirable_node_size = 8;
+        static constexpr dim_t desirable_node_size = 8;
         static constexpr ptrdiff_t desirable_stride = 1;
 
         // This process relies on swapping the two innermost dimensions.
@@ -582,12 +586,12 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 && !compensation_needed_;
     }
 
-    bool process_unroll_tr8x8(const int ndims, const int len) {
+    bool process_unroll_tr8x8(const int ndims, const dim_t len) {
         if (!can_do_tr8x8()) return false;
 
-        const int step_size = prb_.n(0) * prb_.n(1);
-        int i_off = 0, o_off = 0;
-        for (int off = 0; off < len; off += step_size) {
+        const dim_t step_size = prb_.n(0) * prb_.n(1);
+        dim_t i_off = 0, o_off = 0;
+        for (dim_t off = 0; off < len; off += step_size) {
             step(off, i_off, o_off, i_off, o_off, step_size);
             tr8x8_avx2(i_off, o_off);
         }
@@ -595,8 +599,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         return true;
     }
 
-    void process_unroll_generic_step(int reg_unroll, const int *i_off,
-            const int *o_off, const int *s_off, const int *c_off,
+    void process_unroll_generic_step(int reg_unroll, const dim_t *i_off,
+            const dim_t *o_off, const dim_t *s_off, const dim_t *c_off,
             const int *zero_padding, const bool tail_processing) {
         using namespace data_type;
 
@@ -927,17 +931,19 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             if (itype_sz_ == 4 || interim_f32) {
                 for (int ur = 0; ur < reg_unroll; ur += load_step)
                     for (int r = 1; r < load_step; ++r) {
-                        uni_vshufps(Xmm(ur + r), Xmm(ur), Xmm(ur), r);
+                        uni_vshufps(Xmm(ur + r), Xmm(ur), Xmm(ur),
+                                static_cast<Xbyak::uint8>(r));
                     }
             } else {
                 for (int ur = 0; ur < reg_unroll; ur += load_step)
                     for (int r = 1; r < load_step; ++r) {
                         if (mayiuse(avx))
                             vpalignr(Xmm(ur + r), Xmm(ur), Xmm(ur),
-                                    itype_sz_ * r);
+                                    static_cast<uint8_t>(itype_sz_ * r));
                         else {
                             movups(Xmm(ur + r), Xmm(ur));
-                            palignr(Xmm(ur + r), Xmm(ur), itype_sz_ * r);
+                            palignr(Xmm(ur + r), Xmm(ur),
+                                    static_cast<uint8_t>(itype_sz_ * r));
                         }
                     }
             }
@@ -1202,7 +1208,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                     for (int r = ur; r < ur + ur_step; ++r) {
                         if (zero_padding[r] == 0 || !tail_processing) {
                             uni_vshufps(xmm_tmp_, xmm_compensation,
-                                    xmm_compensation, r);
+                                    xmm_compensation,
+                                    static_cast<Xbyak::uint8>(r));
                             const Reg32 reg_tmp_32 = reg_tmp_.cvt32();
                             uni_vmovd(reg_tmp_32, xmm_tmp_);
                             const auto comp_addr = c_addr(c_off[r]);
@@ -1255,17 +1262,16 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     }
 
     void process_unroll_generic(
-            const int ndims, int len, const bool tail_processing) {
+            const int ndims, dim_t len, const bool tail_processing) {
         assert(IMPLICATION(prb_.nodes[0].tail_size > 0,
-                len == static_cast<int>(prb_.nodes[0].n)
-                        || len == static_cast<int>(prb_.nodes[0].tail_size)));
+                len == prb_.nodes[0].n || len == prb_.nodes[0].tail_size));
 
         const int blk = 8;
 
-        int i_off[2 * blk] = {0};
-        int o_off[2 * blk] = {0};
-        int s_off[2 * blk] = {0};
-        int c_off[2 * blk] = {0};
+        dim_t i_off[2 * blk] = {0};
+        dim_t o_off[2 * blk] = {0};
+        dim_t s_off[2 * blk] = {0};
+        dim_t c_off[2 * blk] = {0};
 
         int curr = 0; // will switch between 0 and 1
 
@@ -1280,8 +1286,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             if (interim_f32) uni_vcvtdq2ps(xmm_dst_zp_, xmm_dst_zp_);
         }
 
-        for (int off = 0; off < len; off += blk) {
-            const int reg_unroll = nstl::min(off + blk, len) - off;
+        for (dim_t off = 0; off < len; off += blk) {
+            const int reg_unroll
+                    = static_cast<int>(nstl::min<dim_t>(off + blk, len) - off);
             int zero_padding[blk] = {0};
             const auto curr_blk = curr * blk;
 
@@ -1289,8 +1296,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             for (int ur = off != 0 ? 0 : 1; ur < reg_unroll; ++ur) {
                 const int ur_c = curr_blk + ur;
                 const int ur_p = (ur_c - 1 + 2 * blk) % (2 * blk); // prev ur
-                const bool is_tail
-                        = off + ur >= static_cast<int>(prb_.nodes[0].tail_size);
+                const bool is_tail = off + ur >= prb_.nodes[0].tail_size;
                 step(off + ur, i_off[ur_p], o_off[ur_p], s_off[ur_p],
                         c_off[ur_p], i_off[ur_c], o_off[ur_c], s_off[ur_c],
                         c_off[ur_c]);
@@ -1305,14 +1311,14 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         }
     }
 
-    void compute_ker(
-            const int ndims, const int len_unroll, const bool tail_processing) {
+    void compute_ker(const int ndims, const dim_t len_unroll,
+            const bool tail_processing) {
         bool optimized = process_unroll_tr8x8(ndims, len_unroll);
         if (!optimized)
             process_unroll_generic(ndims, len_unroll, tail_processing);
     }
 
-    void loop_begin(Label &l, Reg64 reg_cnt, int len) {
+    void loop_begin(Label &l, Reg64 reg_cnt, dim_t len) {
         mov(reg_cnt, len);
         L(l);
     }
@@ -1331,13 +1337,11 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         cmp(reg_curr_chunk, last_chunk);
     }
 
-    void zero_dst_memory(const int bytes_to_zeroing) {
+    void zero_dst_memory(const dim_t bytes_to_zeroing) {
         static constexpr int num_of_bytes_in_xmm = 128 / 8;
 
-        const int xmms_to_zeroing
-                = std::div(bytes_to_zeroing, num_of_bytes_in_xmm).quot;
-        const int tail_to_zeroing
-                = std::div(bytes_to_zeroing, num_of_bytes_in_xmm).rem;
+        const dim_t xmms_to_zeroing = bytes_to_zeroing / num_of_bytes_in_xmm;
+        const dim_t tail_to_zeroing = bytes_to_zeroing % num_of_bytes_in_xmm;
 
         uni_vpxor(xmm_tmp_, xmm_tmp_, xmm_tmp_);
 
@@ -1352,7 +1356,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             jnz(loop);
         }
 
-        for (int i = 0; i < tail_to_zeroing; i++)
+        for (dim_t i = 0; i < tail_to_zeroing; i++)
             uni_vpextrb(o_addr(i, false), xmm_tmp_, 0);
 
         // Restore dst offset to initial value
@@ -1360,23 +1364,24 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             sub(reg_off_out_, num_of_bytes_in_xmm * xmms_to_zeroing);
     }
 
-    void finalize_tail_loop(int i_step, int o_step, int s_step, int c_step,
-            const int curr_node_id) {
+    void finalize_tail_loop(dim_t i_step, dim_t o_step, dim_t s_step,
+            dim_t c_step, const int curr_node_id) {
         static constexpr int empty_chunk_info = -1;
 
         mov(reg_tmp_, empty_chunk_info);
         mov(data_chunk_addr(curr_node_id), reg_tmp_);
 
-        const int padded_area = prb_.nodes[curr_node_id].n
+        const dim_t padded_area = prb_.nodes[curr_node_id].n
                 - prb_.nodes[curr_node_id].tail_size;
 
         if (prb_.nodes[curr_node_id].is_zero_pad_needed) {
-            int num_of_zero_padded_values = padded_area;
+            dim_t num_of_zero_padded_values = padded_area;
             for (int i = curr_node_id - 1; i >= 0; i--) {
                 num_of_zero_padded_values *= prb_.nodes[i].n;
             }
 
-            const int bytes_to_zeroing = num_of_zero_padded_values * otype_sz_;
+            const dim_t bytes_to_zeroing
+                    = num_of_zero_padded_values * otype_sz_;
             zero_dst_memory(bytes_to_zeroing);
         }
 
@@ -1394,17 +1399,19 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 || prb_.dst_scale_type == scale_type_t::MANY)
             add(reg_off_scale_, padded_area * s_step * stype_sz_);
         if (compensation_needed_)
-            add(reg_off_comp_, padded_area * c_step * sizeof(int32_t));
+            add(reg_off_comp_,
+                    padded_area * c_step * static_cast<dim_t>(sizeof(int32_t)));
     }
 
-    void loop_end(Label &l, const Reg64 reg_cnt, int len, int i_step,
-            int o_step, int s_step, int c_step, const int curr_node_id) {
+    void loop_end(Label &l, const Reg64 reg_cnt, dim_t len, dim_t i_step,
+            dim_t o_step, dim_t s_step, dim_t c_step, const int curr_node_id) {
         add(reg_off_in_, i_step * itype_sz_);
         add(reg_off_out_, o_step * otype_sz_);
         if (prb_.src_scale_type == scale_type_t::MANY
                 || prb_.dst_scale_type == scale_type_t::MANY)
             add(reg_off_scale_, s_step * stype_sz_);
-        if (compensation_needed_) add(reg_off_comp_, c_step * sizeof(int32_t));
+        if (compensation_needed_)
+            add(reg_off_comp_, c_step * static_cast<dim_t>(sizeof(int32_t)));
 
         dec(reg_cnt);
         jnz(l);
@@ -1430,7 +1437,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 || prb_.dst_scale_type == scale_type_t::MANY)
             sub(reg_off_scale_, len * s_step * stype_sz_);
         if (compensation_needed_)
-            sub(reg_off_comp_, len * c_step * sizeof(int32_t));
+            sub(reg_off_comp_,
+                    len * c_step * static_cast<dim_t>(sizeof(int32_t)));
     }
 
     void compute_blk_ker(const simple_impl_desc_t &desc) {
@@ -1446,7 +1454,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 jne(no_last_chunk, T_NEAR);
             }
 
-            const int len_unroll = desc.tail_len_unroll > 0
+            const dim_t len_unroll = desc.tail_len_unroll > 0
                     ? desc.tail_len_unroll
                     : desc.len_unroll;
             compute_ker(omp_ndims, len_unroll, with_tail_processing);
@@ -1464,12 +1472,12 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
 
         if (jit_loop > 0) {
             const int nfu = desc.ndims_full_unroll;
-            const int unroll_factor
+            const dim_t unroll_factor
                     = jit_loop == 1 ? desc.len_last_dim_unroll : 1;
             const int curr_node_id = nfu + (jit_loop - 1);
             const int parent_node_id = prb_.nodes[curr_node_id].parent_node_id;
-            const int tail_size = prb_.tail(curr_node_id) / unroll_factor;
-            const auto node_size = prb_.n(curr_node_id) / unroll_factor;
+            const dim_t tail_size = prb_.tail(curr_node_id) / unroll_factor;
+            const dim_t node_size = prb_.n(curr_node_id) / unroll_factor;
             const Reg64 reg_loop_cnt = reg_cnt[jit_loop - 1];
             const bool curr_node_has_tail = prb_.tail(curr_node_id) != 0;
             Label loop, if_no_tail, if_end;
@@ -1565,8 +1573,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         , f8_e5m2_cvt_(nullptr)
         , f8_e4m3_cvt_(nullptr) {
         assert(!utils::one_of(isa_, isa_undef, isa_all));
-        itype_sz_ = data_type_size(prb_.itype);
-        otype_sz_ = data_type_size(prb_.otype);
+        itype_sz_ = static_cast<int>(data_type_size(prb_.itype));
+        otype_sz_ = static_cast<int>(data_type_size(prb_.otype));
         stype_sz_ = sizeof(float);
         if (prb_.otype == data_type::bf16 && !mayiuse(avx512_core_bf16)
                 && !mayiuse(avx2_vnni_2)) {
@@ -1655,7 +1663,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             je(reorder_kernel, T_NEAR);
             // If zeroing data is set then all dst memory
             // will be zeroed and nothing more will be done.
-            int bytes_to_zeroing = otype_sz_;
+            dim_t bytes_to_zeroing = otype_sz_;
             for (int i = 0; i < prb_.ndims; i++) {
                 bytes_to_zeroing *= prb_.nodes[i].n;
             }
@@ -1822,15 +1830,15 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
     jit_single_blk_kernel_t(const tr::prb_t &prb)
         : jit_generator_t(jit_name())
         , prb_(prb)
-        , itype_sz_(data_type_size(prb_.itype))
-        , otype_sz_(data_type_size(prb_.otype))
-        , block_sz(prb.nodes[0].n) {}
+        , itype_sz_(static_cast<int>(data_type_size(prb_.itype)))
+        , otype_sz_(static_cast<int>(data_type_size(prb_.otype)))
+        , block_sz(static_cast<int>(prb.nodes[0].n)) {}
 
     void generate() override {
-        auto input_stride
-                = prb_.nodes[0].is != 1 ? prb_.nodes[0].is : prb_.nodes[1].is;
-        auto output_stride
-                = prb_.nodes[0].os != 1 ? prb_.nodes[0].os : prb_.nodes[1].os;
+        const int input_stride = static_cast<int>(
+                prb_.nodes[0].is != 1 ? prb_.nodes[0].is : prb_.nodes[1].is);
+        const int output_stride = static_cast<int>(
+                prb_.nodes[0].os != 1 ? prb_.nodes[0].os : prb_.nodes[1].os);
 
         Label tail_processing;
 
@@ -1950,7 +1958,7 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
         vxorps(ymm_tmp, ymm_tmp, ymm_tmp);
         vpcmpeqd(ymm_mask, ymm_mask, ymm_mask);
         // shift by mask to have tail nelems in ymm_mask
-        const uint8_t in_mask = 0xFF << mask;
+        const uint8_t in_mask = static_cast<uint8_t>(0xFF << mask);
         vpblendd(ymm_mask, ymm_mask, ymm_tmp, in_mask);
     }
 
@@ -2096,7 +2104,7 @@ status_t kernel_t::desc_init(
     if (ndims_ker_max > prb.ndims) return status::invalid_arguments;
 
     auto ndims_ker_max_f = [&]() {
-        size_t cur_size = 1;
+        dim_t cur_size = 1;
         for (int d = 0; d < prb.ndims; cur_size *= prb.nodes[d++].n)
             if (cur_size >= ker_prb_size_min) return d;
         return prb.ndims;
@@ -2138,10 +2146,10 @@ static void prb_block_for_cache(tr::prb_t &prb) {
             && !prb.is_tail_present;
 
     // performance improvement for shapes with large inner-most dimension
-    const size_t L1_cache_sz
-            = size_t(3) * platform::get_per_core_cache_size(1) / 4;
-    const size_t itype_sz_ = data_type_size(prb.itype);
-    const size_t inner_block_sz = prb.nodes[0].n * itype_sz_;
+    const dim_t L1_cache_sz = static_cast<dim_t>(static_cast<dim_t>(
+            size_t(3) * platform::get_per_core_cache_size(1) / 4));
+    const dim_t itype_sz_ = static_cast<dim_t>(data_type_size(prb.itype));
+    const dim_t inner_block_sz = prb.nodes[0].n * itype_sz_;
     const bool requires_inner_blocking = inner_block_sz > L1_cache_sz
             // 'is_tail_present' is not supported for cache_blocking when
             // asymmetric_comp is executed.
@@ -2202,7 +2210,8 @@ static void prb_block_for_cache(tr::prb_t &prb) {
                     [](const tr::node_t &lhs, const tr::node_t &rhs) {
                 return lhs.n < rhs.n;
             });
-            const auto min_idx = std::distance(dim_beg_it, min_n_node_it);
+            const int min_idx = static_cast<int>(
+                    std::distance(dim_beg_it, min_n_node_it));
             // check if min_idx node is parent of node with tail processing which
             // is currently unsupported (i.e. tail processing can only be handled
             // at the inner-most dimension)
@@ -2225,7 +2234,7 @@ static void prb_block_for_cache(tr::prb_t &prb) {
  * parallel driver and the kernel. */
 static void prb_thread_kernel_balance(
         tr::prb_t &prb, int &ndims_ker_max, int nthr) {
-    size_t size_total = 1;
+    dim_t size_total = 1;
     for (int d = 0; d < prb.ndims; ++d)
         size_total *= prb.nodes[d].n;
 
@@ -2233,23 +2242,23 @@ static void prb_thread_kernel_balance(
     // size_drv_min = C0 + FC * (nthr > 1 ? 1 : 0) + VC * (nthr - 1)
     // where FC and VC are fixed and variable costs respectively.
     // Though for now, the below heuristic seems to be good enough
-    const size_t size_drv_thr = (nthr > 1) ? 16 * nthr : 1;
+    const dim_t size_drv_thr = (nthr > 1) ? 16 * nthr : 1;
 
     /* size_drv_min is the minimal size for the parallel
      * driver required for good parallelization */
-    const size_t size_drv_min
-            = nstl::min<size_t>(size_drv_thr, utils::div_up(size_total, 1024));
+    const dim_t size_drv_min
+            = nstl::min<dim_t>(size_drv_thr, utils::div_up(size_total, 1024));
 
     /* kdims -- # of dimensions processed by a kernel
      * size_ker_cur -- product of the dimension processed by a kernel
      * size_drv_cur -- product of the dimension processed by a driver */
 
     int kdims = prb.ndims;
-    size_t size_drv_cur = 1;
+    dim_t size_drv_cur = 1;
     for (; kdims > 1 && size_drv_cur < size_drv_min; --kdims)
         size_drv_cur *= prb.nodes[kdims - 1].n;
 
-    size_t size_ker_cur = 1;
+    dim_t size_ker_cur = 1;
     for (int d = 0; d < kdims; ++d)
         size_ker_cur *= prb.nodes[d].n;
 
@@ -2271,8 +2280,8 @@ static void prb_thread_kernel_balance(
          *  In the worst case the minimal size_want_borrow is equal
          *  to the innermost driver dimension itself. In that case
          *  we will sacrifice it in favor of kernel (is it fine?). */
-        size_t size_want_borrow
-                = utils::div_up(tr::ker_prb_size_min, size_ker_cur);
+        dim_t size_want_borrow = utils::div_up(
+                static_cast<dim_t>(tr::ker_prb_size_min), size_ker_cur);
         for (; prb.nodes[kdims].n % size_want_borrow; ++size_want_borrow)
             ;
 
@@ -2289,14 +2298,17 @@ static void prb_thread_kernel_balance(
             && size_drv_cur < size_drv_min;
 
     VDEBUGINFO(5, primitive, reorder,
-            "size_drv_thr=%zu size_drv_min=%zu size_drv_cur=%zu "
-            "tr::ker_prb_size_min=%zu want_borrow_ker_from_drv=%d "
+            "size_drv_thr=%lld size_drv_min=%lld size_drv_cur=%lld "
+            "tr::ker_prb_size_min=%lld want_borrow_ker_from_drv=%d "
             "want_borrow_drv_from_ker=%d",
-            size_drv_thr, size_drv_min, size_drv_cur, tr::ker_prb_size_min,
+            static_cast<long long>(size_drv_thr),
+            static_cast<long long>(size_drv_min),
+            static_cast<long long>(size_drv_cur),
+            static_cast<long long>(tr::ker_prb_size_min),
             want_borrow_ker_from_drv, want_borrow_drv_from_ker);
 
     if (want_borrow_drv_from_ker) {
-        size_t size_want_borrow = utils::div_up(size_drv_min, size_drv_cur);
+        dim_t size_want_borrow = utils::div_up(size_drv_min, size_drv_cur);
         for (; prb.nodes[kdims - 1].n % size_want_borrow; ++size_want_borrow)
             ;
 
@@ -2448,7 +2460,7 @@ void jit_uni_reorder_t::omp_driver_1d(int ithr, int nthr, int off,
         int32_t *compensation_scratch) const {
     const tr::prb_t &prb = pd()->prb_;
     const tr::node_t *ns = prb.nodes + off;
-    for_nd(ithr, nthr, (ptrdiff_t)ns[0].n, [&](ptrdiff_t d0) {
+    for_nd(ithr, nthr, static_cast<dim_t>(ns[0].n), [&](dim_t d0) {
         tr::call_param_t base_params;
         base_params.in = in + d0 * ns[0].is * data_type_size(prb.itype);
         base_params.out = out + d0 * ns[0].os * data_type_size(prb.otype);
@@ -2467,7 +2479,7 @@ void jit_uni_reorder_t::omp_driver_1d(int ithr, int nthr, int off,
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 1;
-            const ptrdiff_t omp_data_chunks[omp_ndims] = {d0};
+            const dim_t omp_data_chunks[omp_ndims] = {d0};
             fill_curr_data_chunks(
                     prb, off, omp_data_chunks, omp_ndims, tail_params);
 
@@ -2484,8 +2496,8 @@ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
         int32_t *compensation_scratch) const {
     const tr::prb_t &prb = pd()->prb_;
     const tr::node_t *ns = prb.nodes + off;
-    for_nd(ithr, nthr, (ptrdiff_t)ns[1].n, (ptrdiff_t)ns[0].n,
-            [&](ptrdiff_t d1, ptrdiff_t d0) {
+    for_nd(ithr, nthr, static_cast<dim_t>(ns[1].n), static_cast<dim_t>(ns[0].n),
+            [&](dim_t d1, dim_t d0) {
         tr::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is) * data_type_size(prb.itype);
@@ -2507,7 +2519,7 @@ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 2;
-            const ptrdiff_t omp_data_chunks[omp_ndims] = {d0, d1};
+            const dim_t omp_data_chunks[omp_ndims] = {d0, d1};
             fill_curr_data_chunks(
                     prb, off, omp_data_chunks, omp_ndims, tail_params);
 
@@ -2524,8 +2536,8 @@ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
         int32_t *compensation_scratch) const {
     const tr::prb_t &prb = pd()->prb_;
     const tr::node_t *ns = prb.nodes + off;
-    for_nd(ithr, nthr, (ptrdiff_t)ns[2].n, (ptrdiff_t)ns[1].n,
-            (ptrdiff_t)ns[0].n, [&](ptrdiff_t d2, ptrdiff_t d1, ptrdiff_t d0) {
+    for_nd(ithr, nthr, static_cast<dim_t>(ns[2].n), static_cast<dim_t>(ns[1].n),
+            static_cast<dim_t>(ns[0].n), [&](dim_t d2, dim_t d1, dim_t d0) {
         tr::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is + d2 * ns[2].is)
@@ -2549,7 +2561,7 @@ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 3;
-            const ptrdiff_t omp_data_chunks[omp_ndims] = {d0, d1, d2};
+            const dim_t omp_data_chunks[omp_ndims] = {d0, d1, d2};
             fill_curr_data_chunks(
                     prb, off, omp_data_chunks, omp_ndims, tail_params);
 
@@ -2566,9 +2578,9 @@ void jit_uni_reorder_t::omp_driver_4d(int ithr, int nthr, int off,
         int32_t *compensation_scratch) const {
     const tr::prb_t &prb = pd()->prb_;
     const tr::node_t *ns = prb.nodes + off;
-    for_nd(ithr, nthr, (ptrdiff_t)ns[3].n, (ptrdiff_t)ns[2].n,
-            (ptrdiff_t)ns[1].n, (ptrdiff_t)ns[0].n,
-            [&](ptrdiff_t d3, ptrdiff_t d2, ptrdiff_t d1, ptrdiff_t d0) {
+    for_nd(ithr, nthr, static_cast<dim_t>(ns[3].n), static_cast<dim_t>(ns[2].n),
+            static_cast<dim_t>(ns[1].n), static_cast<dim_t>(ns[0].n),
+            [&](dim_t d3, dim_t d2, dim_t d1, dim_t d0) {
         tr::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is + d2 * ns[2].is
@@ -2596,7 +2608,7 @@ void jit_uni_reorder_t::omp_driver_4d(int ithr, int nthr, int off,
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 4;
-            const ptrdiff_t omp_data_chunks[omp_ndims] = {d0, d1, d2, d3};
+            const dim_t omp_data_chunks[omp_ndims] = {d0, d1, d2, d3};
             fill_curr_data_chunks(
                     prb, off, omp_data_chunks, omp_ndims, tail_params);
 
@@ -2646,7 +2658,7 @@ void jit_uni_reorder_t::reduce_compensation(char *out,
 }
 
 void jit_uni_reorder_t::fill_curr_data_chunks(const tr::prb_t &prb,
-        const int off, const ptrdiff_t *omp_data_chunks, const int omp_ndims,
+        const int off, const dim_t *omp_data_chunks, const int omp_ndims,
         tr::tail_call_param_t &c) const {
     // Chunks are backwards numered i.e:
     // [0] -> [node_size]
@@ -2672,10 +2684,10 @@ void jit_uni_reorder_t::fill_curr_data_chunks(const tr::prb_t &prb,
         if (is_drv_processing_this_node && is_tail_processing) {
             const int inner_idx = curr_node_id - off;
             assert(inner_idx < omp_ndims);
-            const int64_t node_size = prb.nodes[curr_node_id].tail_size > 0
+            const dim_t node_size = prb.nodes[curr_node_id].tail_size > 0
                     ? prb.nodes[curr_node_id].tail_size
                     : prb.nodes[curr_node_id].n;
-            const int64_t data_chunk = node_size - omp_data_chunks[inner_idx];
+            const dim_t data_chunk = node_size - omp_data_chunks[inner_idx];
 
             if (!prb.nodes[curr_node_id].is_parent_empty()) {
                 const bool is_parent_chunk_last
@@ -2852,8 +2864,8 @@ status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
 }
 
 void jit_blk_reorder_t::pd_t::prb_tile_normalize(tr::prb_t &p) {
-    if (!utils::one_of(p.nodes[0].n, 8ul, 16ul)
-            && utils::one_of(p.nodes[1].n, 8ul, 16ul)) {
+    if (!utils::one_of(p.nodes[0].n, 8, 16)
+            && utils::one_of(p.nodes[1].n, 8, 16)) {
         nstl::swap(p.nodes[0], p.nodes[1]);
     }
 }
@@ -2872,7 +2884,7 @@ status_t jit_blk_reorder_t::execute(const exec_ctx_t &ctx) const {
 
     // kernel handle 2-dimension tiles, a tail is possible
     auto &prb = this->pd()->prb_;
-    ptrdiff_t BH = 1;
+    dim_t BH = 1;
     for (int i = 2; i < prb.ndims; ++i) {
         BH *= prb.nodes[i].n;
     }
@@ -2884,8 +2896,10 @@ status_t jit_blk_reorder_t::execute(const exec_ctx_t &ctx) const {
     auto FL = (n1 + block_sz - 1) / block_sz;
     auto bh_stride = BH == 1 ? 0 : prb.is(2);
 
-    auto itype_sz_ = data_type_size(pd()->prb_.itype);
-    auto otype_sz_ = data_type_size(pd()->prb_.otype);
+    const dim_t itype_sz_
+            = static_cast<dim_t>(data_type_size(pd()->prb_.itype));
+    const dim_t otype_sz_
+            = static_cast<dim_t>(data_type_size(pd()->prb_.otype));
 
     parallel_nd(BH, FL, [= COMPAT_THIS_CAPTURE](dim_t bh, dim_t fl) {
         auto fl_b = fl * block_sz;

--- a/src/cpu/x64/jit_uni_reorder.hpp
+++ b/src/cpu/x64/jit_uni_reorder.hpp
@@ -36,8 +36,8 @@ constexpr int max_ndims = DNNL_MAX_NDIMS;
 struct node_t {
     static constexpr int64_t empty_field = -1;
 
-    size_t n = 0;
-    size_t tail_size = 0;
+    dim_t n = 0;
+    dim_t tail_size = 0;
     int dim_id = empty_field;
     int parent_node_id = empty_field;
     bool is_zero_pad_needed = false;
@@ -77,12 +77,12 @@ struct prb_t {
         return false;
     }
 
-    size_t tail(int d) const {
+    dim_t tail(int d) const {
         assert(d < ndims);
         return nodes[d].tail_size;
     }
 
-    size_t n(int d) const {
+    dim_t n(int d) const {
         assert(d < ndims);
         return nodes[d].n;
     }
@@ -137,7 +137,7 @@ void prb_simplify(prb_t &p);
 
 /** splits the node dim into two of sizes n1 and n / n1
  * @warning n must be multiple of n1 */
-void prb_node_split(prb_t &p, int dim, size_t n1);
+void prb_node_split(prb_t &p, int dim, dim_t n1);
 
 /** swaps d0 and d1 nodes */
 void prb_node_swap(prb_t &p, int d0, int d1);
@@ -259,7 +259,7 @@ private:
             int dst_zp, int32_t *compensation_scratch) const;
 
     void fill_curr_data_chunks(const tr::prb_t &prb, const int off,
-            const ptrdiff_t *omp_data_chunks, const int omp_ndims,
+            const dim_t *omp_data_chunks, const int omp_ndims,
             tr::tail_call_param_t &c) const;
 
     void reduce_compensation(char *out,

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
@@ -70,7 +70,7 @@ struct direct_copy_kernel_t
     int get_max_unroll() const override { return unroll_12_; }
 
     void operator()(
-            const void *src, void *dst, size_t work_amount) const override {
+            const void *src, void *dst, dim_t work_amount) const override {
         ker_args_t args;
         args.src = src;
         args.dst = dst;
@@ -82,9 +82,9 @@ struct direct_copy_kernel_t
         return jit_generator_t::create_kernel();
     }
 
-    Address src_ptr(size_t offt = 0) { return ptr[reg_src + offt]; }
+    Address src_ptr(dim_t offt = 0) { return ptr[reg_src + offt]; }
 
-    Address dst_ptr(size_t offt = 0) { return ptr[reg_dst + offt]; }
+    Address dst_ptr(dim_t offt = 0) { return ptr[reg_dst + offt]; }
 
     Vmm vmm_src(int idx) const {
         // Incorporate `+ 1` here as `0th` index is used for tail on AVX2.
@@ -92,47 +92,55 @@ struct direct_copy_kernel_t
     }
 
     void copy(const int unroll, const bool tail) {
+        const dim_t src_dt_size
+                = static_cast<dim_t>(types::data_type_size(src_dt_));
+        const dim_t dst_dt_size
+                = static_cast<dim_t>(types::data_type_size(dst_dt_));
+
         // Copy two simdw at once in vectorized loop first when `ne_convert`
         // instructions are available for xf16.
         if (isa_ == avx2_vnni_2
                 && (utils::one_of(src_dt_, data_type::bf16, data_type::f16))
                 && (unroll % 2 == 0)) {
-            for (size_t i = 0; i < static_cast<size_t>(unroll) / 2; i++) {
+            for (int i = 0; i < unroll / 2; i++) {
                 const Vmm &vmm_src_even = vmm_src(2 * i);
                 const Vmm &vmm_src_odd = vmm_src(2 * i + 1);
                 Vmm vmm_tmp(vmm_tmp_idx_);
                 io_[src_dt_]->load_two_simdw_xf16(
-                        src_ptr(2 * i * types::data_type_size(src_dt_)
-                                * simd_w_),
+                        src_ptr(2 * i * src_dt_size * simd_w_),
                         vmm_src_even, vmm_src_odd);
                 io_[src_dt_]->merge_interleaved_to_plain(
                         vmm_src_even, vmm_src_odd, vmm_tmp);
                 io_[dst_dt_]->store(vmm_src_even,
-                        dst_ptr(2 * i * types::data_type_size(dst_dt_)
-                                * simd_w_),
+                        dst_ptr(2 * i * dst_dt_size * simd_w_),
                         tail);
                 io_[dst_dt_]->store(vmm_src_odd,
-                        dst_ptr((2 * i + 1) * types::data_type_size(dst_dt_)
-                                * simd_w_),
+                        dst_ptr((2 * i + 1) * dst_dt_size * simd_w_),
                         tail);
             }
         } else {
             for (int i = 0; i < unroll; i++) {
                 io_[src_dt_]->load(
-                        src_ptr(i * types::data_type_size(src_dt_) * simd_w_),
+                        src_ptr(i * src_dt_size * simd_w_),
                         vmm_src(i), tail);
             }
             for (int i = 0; i < unroll; i++) {
                 io_[dst_dt_]->store(vmm_src(i),
-                        dst_ptr(i * types::data_type_size(dst_dt_) * simd_w_),
+                        dst_ptr(i * dst_dt_size * simd_w_),
                         tail);
             }
         }
 
         if (tail) return;
 
-        add(reg_src, unroll * types::data_type_size(src_dt_) * simd_w_);
-        add(reg_dst, unroll * types::data_type_size(dst_dt_) * simd_w_);
+        const dim_t src_step
+                = unroll * static_cast<dim_t>(types::data_type_size(src_dt_))
+                * simd_w_;
+        const dim_t dst_step
+                = unroll * static_cast<dim_t>(types::data_type_size(dst_dt_))
+                * simd_w_;
+        add(reg_src, src_step);
+        add(reg_dst, dst_step);
         sub(reg_work_amount, unroll * simd_w_);
     }
 
@@ -201,7 +209,7 @@ private:
     struct ker_args_t {
         const void *src;
         void *dst;
-        size_t work_amount;
+        dim_t work_amount;
     };
 
     bool is_bf16() const {
@@ -220,7 +228,7 @@ private:
     cpu_isa_t isa_;
     data_type_t src_dt_, dst_dt_;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
-    size_t tail_size_;
+    dim_t tail_size_;
 
     const Reg64 reg_tmp_ = rax;
     const Reg64 reg_src = r8;
@@ -368,8 +376,8 @@ status_t jit_uni_reorder_direct_copy_t::execute(const exec_ctx_t &ctx) const {
 
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper dst_d(pd()->dst_md());
-    const auto src_dt_size = src_d.data_type_size();
-    const auto dst_dt_size = dst_d.data_type_size();
+    const dim_t src_dt_size = static_cast<dim_t>(src_d.data_type_size());
+    const dim_t dst_dt_size = static_cast<dim_t>(dst_d.data_type_size());
     const auto nelems = src_d.nelems(true);
     const int simd_w = isa_max_vlen(pd()->isa_) / sizeof(float);
 

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.hpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.hpp
@@ -55,7 +55,7 @@ struct jit_uni_reorder_direct_copy_t : public primitive_t {
 
     struct kernel_base_t {
         virtual void operator()(
-                const void *src, void *dst, size_t work_amount) const
+                const void *src, void *dst, dim_t work_amount) const
                 = 0;
         static kernel_base_t *create(const reorder_pd_t *pd, cpu_isa_t isa);
         virtual status_t create_kernel() = 0;

--- a/src/cpu/x64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/x64/jit_uni_reorder_utils.cpp
@@ -161,11 +161,11 @@ static void prb_set_compensation_strides(prb_t &p) {
         const int parent = get_next_parent_node(p.nodes, p.ndims, cur_node);
         if (parent < 0) return false;
 
-        const size_t p_n = p.nodes[parent].n;
+        const dim_t p_n = p.nodes[parent].n;
 
         // if 'parent_node.n' is larger than 1, then cur_node stride
         // is 'cur_node.n'
-        return p_n > size_t(1);
+        return p_n > 1;
     };
 
     const auto compensation_needed = p.req_s8s8_comp || p.req_asymmetric_comp;
@@ -370,7 +370,7 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
         if (ild.dims[i_pos] == old.dims[o_pos]) {
             p.nodes[ndims].n = ild.dims[i_pos];
-            p.nodes[ndims].dim_id = old.id[o_pos];
+            p.nodes[ndims].dim_id = static_cast<int>(old.id[o_pos]);
             p.nodes[ndims].tail_size = old.tails[o_pos];
             p.nodes[ndims].is_zero_pad_needed
                     = old.is_blk[o_pos] && old.tails[o_pos] > 0;
@@ -389,14 +389,14 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
             dim_t factor = old.dims[o_pos] / ild.dims[i_pos];
 
-            const size_t tail_of_upper_dim
+            const dim_t tail_of_upper_dim
                     = utils::div_up(old.tails[o_pos], factor) == ild.dims[i_pos]
                     ? 0
                     : utils::div_up(old.tails[o_pos], factor);
-            const size_t tail_of_lower_dim = old.tails[o_pos] % factor;
+            const dim_t tail_of_lower_dim = old.tails[o_pos] % factor;
 
             p.nodes[ndims].n = ild.dims[i_pos];
-            p.nodes[ndims].dim_id = old.id[o_pos];
+            p.nodes[ndims].dim_id = static_cast<int>(old.id[o_pos]);
             p.nodes[ndims].tail_size = tail_of_upper_dim;
             p.nodes[ndims].is_zero_pad_needed
                     = old.is_blk[o_pos] && tail_of_upper_dim > 0;
@@ -416,7 +416,7 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
             dim_t factor = ild.dims[i_pos] / old.dims[o_pos];
             p.nodes[ndims].n = old.dims[o_pos];
-            p.nodes[ndims].dim_id = old.id[o_pos];
+            p.nodes[ndims].dim_id = static_cast<int>(old.id[o_pos]);
             p.nodes[ndims].tail_size = old.tails[o_pos];
             p.nodes[ndims].is_zero_pad_needed
                     = old.is_blk[o_pos] && old.tails[o_pos] > 0;
@@ -514,15 +514,15 @@ void prb_simplify(prb_t &p) {
                 = skip_dim_combining(d) || skip_dim_combining(d + 1);
         if (skip_dims_combining) continue;
 
-        const bool trivial_fold = next_node.n == static_cast<size_t>(1);
+        const bool trivial_fold = next_node.n == 1;
         const bool real_fold = next_node.is
-                        == static_cast<ptrdiff_t>(this_node.n * this_node.is)
+                        == this_node.n * this_node.is
                 && next_node.os
-                        == static_cast<ptrdiff_t>(this_node.n * this_node.os)
+                        == this_node.n * this_node.os
                 && next_node.ss
-                        == static_cast<ptrdiff_t>(this_node.n * this_node.ss)
+                        == this_node.n * this_node.ss
                 && next_node.cs
-                        == static_cast<ptrdiff_t>(this_node.n * this_node.cs);
+                        == this_node.n * this_node.cs;
         if (trivial_fold || real_fold) {
             this_node.n *= next_node.n;
             this_node.dim_id = node_t::empty_field;
@@ -540,7 +540,7 @@ void prb_simplify(prb_t &p) {
 #endif
 }
 
-void prb_node_split(prb_t &p, int dim, size_t new_node_size) {
+void prb_node_split(prb_t &p, int dim, dim_t new_node_size) {
     assert(dim < p.ndims);
     assert(p.ndims < max_ndims);
     assert(p.nodes[dim].n % new_node_size == 0);
@@ -551,18 +551,18 @@ void prb_node_split(prb_t &p, int dim, size_t new_node_size) {
     for (int d = p.ndims; d > dim + 1; --d)
         p.nodes[d] = p.nodes[d - 1];
 
-    const size_t upper_node_size = p.nodes[dim].n / new_node_size;
-    const size_t lower_node_size = new_node_size;
+    const dim_t upper_node_size = p.nodes[dim].n / new_node_size;
+    const dim_t lower_node_size = new_node_size;
     p.nodes[dim + 1].n = upper_node_size;
     p.nodes[dim].n = lower_node_size;
 
     const bool is_tail = p.nodes[dim].tail_size > 0;
-    const size_t upper_node_tail
+    const dim_t upper_node_tail
             = utils::div_up(p.nodes[dim].tail_size, lower_node_size)
                     == upper_node_size
             ? 0
             : utils::div_up(p.nodes[dim].tail_size, lower_node_size);
-    const size_t lower_node_tail = p.nodes[dim].tail_size % lower_node_size;
+    const dim_t lower_node_tail = p.nodes[dim].tail_size % lower_node_size;
     p.nodes[dim].tail_size = is_tail ? lower_node_tail : 0;
     p.nodes[dim + 1].tail_size = is_tail ? upper_node_tail : 0;
 

--- a/src/cpu/x64/jit_uni_resampling.cpp
+++ b/src/cpu/x64/jit_uni_resampling.cpp
@@ -35,6 +35,13 @@ namespace x64 {
 
 using namespace resampling_utils;
 
+// Offsets are stored in the 32-bit gather-index buffer
+// This function safely casts the offset.
+static unsigned to_gather_index(dim_t offset) {
+    assert(offset >= 0 && offset <= UINT32_MAX);
+    return static_cast<unsigned>(offset);
+}
+
 static cpu_isa_t get_supported_isa(bool is_plain) {
     if (is_plain && mayiuse(avx512_core_fp16)) return avx512_core_fp16;
     if (mayiuse(avx512_core_bf16)) return avx512_core_bf16;
@@ -109,7 +116,7 @@ status_t jit_uni_resampling_fwd_t::pd_t::init(engine_t *engine) {
     conf_.ndims = ndims();
 
     if (conf_.alg == alg_kind::resampling_linear)
-        conf_.number_of_corners = pow(2, conf_.ndims - 2);
+        conf_.number_of_corners = 1u << (conf_.ndims - 2);
 
     conf_.src_dt_size = types::data_type_size(conf_.src_data_type);
     conf_.dst_dt_size = types::data_type_size(conf_.dst_data_type);
@@ -301,18 +308,21 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_nearest() {
             + utils::rnd_up(pd()->OW(), kernel_->get_simd_w()));
 
     for (dim_t od = 0; od < pd()->OD(); od++) {
-        const int offset_id = nearest_idx(od, pd()->OD(), pd()->ID())
-                * pd()->get_conf().stride_d;
+        const unsigned offset_id
+                = to_gather_index(nearest_idx(od, pd()->OD(), pd()->ID())
+                        * pd()->get_conf().stride_d);
         indices_.emplace_back(offset_id);
     }
     for (dim_t oh = 0; oh < pd()->OH(); oh++) {
-        const int offset_ih = nearest_idx(oh, pd()->OH(), pd()->IH())
-                * pd()->get_conf().stride_h;
+        const unsigned offset_ih
+                = to_gather_index(nearest_idx(oh, pd()->OH(), pd()->IH())
+                        * pd()->get_conf().stride_h);
         indices_.emplace_back(offset_ih);
     }
     for (dim_t ow = 0; ow < pd()->OW(); ow++) {
-        const int offset_iw = nearest_idx(ow, pd()->OW(), pd()->IW())
-                * pd()->get_conf().stride_w;
+        const unsigned offset_iw
+                = to_gather_index(nearest_idx(ow, pd()->OW(), pd()->IW())
+                        * pd()->get_conf().stride_w);
         indices_.emplace_back(offset_iw);
     }
 
@@ -322,12 +332,12 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_nearest() {
 status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
     using namespace resampling_utils;
 
-    const unsigned number_of_corners = pd()->get_conf().number_of_corners;
-    const unsigned stride_w = pd()->get_conf().stride_w;
-    const unsigned stride_h = pd()->get_conf().stride_h;
-    const unsigned stride_d = pd()->get_conf().stride_d;
+    const dim_t number_of_corners = pd()->get_conf().number_of_corners;
+    const dim_t stride_w = pd()->get_conf().stride_w;
+    const dim_t stride_h = pd()->get_conf().stride_h;
+    const dim_t stride_d = pd()->get_conf().stride_d;
 
-    unsigned num_of_elements = 0;
+    dim_t num_of_elements = 0;
     if (pd()->get_conf().tag_kind == jit_memory_tag_kind_t::ncsp) {
         // In kernel is used vmovdqu to get indices. This instruction don't have
         // tail processing possibilities on sse41 and avx. To avoid problems
@@ -356,10 +366,10 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
                 for (unsigned i = 0; i < number_of_corners; i++) {
                     std::bitset<3> corners(i);
-                    indices_[i * indices_stride + offset]
-                            = coeffs_id.idx[corners.test(2)] * stride_d
+                    indices_[i * indices_stride + offset] = to_gather_index(
+                            coeffs_id.idx[corners.test(2)] * stride_d
                             + coeffs_ih.idx[corners.test(1)] * stride_h
-                            + coeffs_iw.idx[corners.test(0)] * stride_w;
+                            + coeffs_iw.idx[corners.test(0)] * stride_w);
                     weights_[i * weights_stride + offset]
                             = coeffs_id.wei[corners.test(2)]
                             * coeffs_ih.wei[corners.test(1)]
@@ -390,8 +400,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
             // to read and makes the operation faster.
             weights_w[2 * ow] = coeffs_iw.wei[0];
             weights_w[2 * ow + 1] = coeffs_iw.wei[1];
-            indices_w[2 * ow] = coeffs_iw.idx[0] * stride_w;
-            indices_w[2 * ow + 1] = coeffs_iw.idx[1] * stride_w;
+            indices_w[2 * ow] = to_gather_index(coeffs_iw.idx[0] * stride_w);
+            indices_w[2 * ow + 1]
+                    = to_gather_index(coeffs_iw.idx[1] * stride_w);
         }
 
         for (dim_t oh = 0; oh < pd()->OH(); oh++) {
@@ -399,8 +410,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
             weights_h[oh] = coeffs_ih.wei[0];
             weights_h[pd()->OH() + oh] = coeffs_ih.wei[1];
-            indices_h[oh] = coeffs_ih.idx[0] * stride_h;
-            indices_h[pd()->OH() + oh] = coeffs_ih.idx[1] * stride_h;
+            indices_h[oh] = to_gather_index(coeffs_ih.idx[0] * stride_h);
+            indices_h[pd()->OH() + oh]
+                    = to_gather_index(coeffs_ih.idx[1] * stride_h);
         }
 
         for (dim_t od = 0; od < pd()->OD(); od++) {
@@ -408,8 +420,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
             weights_d[od] = coeffs_id.wei[0];
             weights_d[pd()->OD() + od] = coeffs_id.wei[1];
-            indices_d[od] = coeffs_id.idx[0] * stride_d;
-            indices_d[pd()->OD() + od] = coeffs_id.idx[1] * stride_d;
+            indices_d[od] = to_gather_index(coeffs_id.idx[0] * stride_d);
+            indices_d[pd()->OD() + od]
+                    = to_gather_index(coeffs_id.idx[1] * stride_d);
         }
     } else {
         assert(!"Invalid memory format kind.");

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -56,10 +56,10 @@ jit_uni_resampling_kernel_t<isa, Vmm>::jit_uni_resampling_kernel_t(
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(vmm_post_op_helper_.getIdx()), r14, r15,
-                r13, preserve_gpr, preserve_vmm,
-                GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig), dst_d,
-                tail_size_, k_tail_mask_, use_exact_tail_scalar_bcast};
+                vmm_post_op_helper_.getIdx(), r14, r15, r13, preserve_gpr,
+                preserve_vmm, GET_OFF(post_ops_binary_rhs_arg_vec),
+                GET_OFF(dst_orig), dst_d, static_cast<dim_t>(tail_size_),
+                k_tail_mask_, use_exact_tail_scalar_bcast};
 
         const bcast_set_t accepted_broadcasts
                 = {broadcasting_strategy_t::scalar,
@@ -146,12 +146,13 @@ std::size_t jit_uni_resampling_kernel_t<isa, Vmm>::calculate_tail_size() const {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_resampling_kernel_t<isa, Vmm>::get_channels_to_compute_without_tail(
-        const bool is_tail_in_blocked_format) const {
+dim_t jit_uni_resampling_kernel_t<isa,
+        Vmm>::get_channels_to_compute_without_tail(const bool
+                is_tail_in_blocked_format) const {
     assert(utils::one_of(conf_.tag_kind, tag_kind::blocked, tag_kind::nspc)
             && "Incorrect memory tag.");
 
-    int c_to_compute_without_tail = 0;
+    dim_t c_to_compute_without_tail = 0;
 
     if (conf_.tag_kind == tag_kind::blocked && is_tail_in_blocked_format) {
         // Example:
@@ -301,17 +302,17 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::apply_postops(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding(
-        const int c_to_compute_without_tail, const bool is_tail) {
-    const int c_to_compute_with_tail
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
+    const dim_t c_to_compute_with_tail
             = is_tail ? utils::rnd_up(tail_size_, simd_w_) : 0;
-    const int c_to_zeroing = conf_.inner_stride - c_to_compute_without_tail
+    const dim_t c_to_zeroing = conf_.inner_stride - c_to_compute_without_tail
             - c_to_compute_with_tail;
 
     if (c_to_zeroing > 0) {
         assert(c_to_zeroing % simd_w_ == 0);
         const Vmm vmm_zeros(vmm_tmp_.getIdx());
 
-        for (int c = 0; c < c_to_zeroing; c += simd_w_) {
+        for (dim_t c = 0; c < c_to_zeroing; c += simd_w_) {
             uni_vxorps(vmm_zeros, vmm_zeros, vmm_zeros);
             const auto dst_address = ptr[reg_dst_ + c * conf_.dst_dt_size];
             io_.at(conf_.dst_data_type)->store(vmm_zeros, dst_address, false);
@@ -324,8 +325,8 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::interpolate_c_oriented_format(
         const c_oriented_generation_fn_t &generation_fn) {
-    const unsigned c_with_padding = utils::rnd_up(conf_.c, conf_.inner_stride);
-    const unsigned padding_size_to_preserve = c_with_padding - conf_.c;
+    const dim_t c_with_padding = utils::rnd_up(conf_.c, conf_.inner_stride);
+    const dim_t padding_size_to_preserve = c_with_padding - conf_.c;
 
     if (padding_size_to_preserve > 0 && conf_.tag_kind == tag_kind::blocked) {
         Label tail_label;
@@ -410,7 +411,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_ncsp_format() {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::compute_nearest_c_interpolate(
-        const int c_to_compute_without_tail, const bool is_tail) {
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
     const Reg64 &reg_c = reg_tmp_;
     const Reg64 &reg_src_shifted = reg_aux_src_0_;
 
@@ -454,7 +455,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::compute_nearest_c_interpolate(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa,
-        Vmm>::compute_ne_xf16_nearest_c_interpolate(const int
+        Vmm>::compute_ne_xf16_nearest_c_interpolate(const dim_t
                 c_to_compute_without_tail) {
     const Reg64 &reg_c = reg_tmp_;
     const Reg64 &reg_src_shifted = reg_aux_src_0_;
@@ -501,12 +502,12 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_c_oriented_format(
     const bool has_ne_xf16_supported = isa == avx2_vnni_2
             && utils::one_of(
                     conf_.src_data_type, data_type::bf16, data_type::f16);
-    const int total_c_to_compute_without_tail
+    const dim_t total_c_to_compute_without_tail
             = get_channels_to_compute_without_tail(is_tail_in_blocked_format);
-    const int c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
+    const dim_t c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
             ? utils::rnd_dn(total_c_to_compute_without_tail, 2 * simd_w_)
             : 0;
-    const int c_to_compute_without_tail = total_c_to_compute_without_tail
+    const dim_t c_to_compute_without_tail = total_c_to_compute_without_tail
             - c_to_compute_ne_xf16_without_tail;
     const bool insert_tail_processsing_code
             = (conf_.tag_kind == tag_kind::nspc && tail_size_ > 0)
@@ -549,10 +550,9 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_c_oriented_format(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::linear_ncsp_format() {
-    const unsigned indices_stride
+    const dim_t indices_stride
             = conf_.ow * conf_.oh * conf_.od * conf_.el_size_of_indices;
-    const unsigned weights_stride
-            = conf_.ow * conf_.oh * conf_.od * sizeof(float);
+    const dim_t weights_stride = conf_.ow * conf_.oh * conf_.od * sizeof(float);
 
     auto linear_interpolation = [&](const bool is_tail) {
         const Vmm vmm_dst(vmm_idx(0));
@@ -608,7 +608,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::linear_ncsp_format() {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa,
-        Vmm>::compute_ne_xf16_linear_c_interpolate(const int
+        Vmm>::compute_ne_xf16_linear_c_interpolate(const dim_t
                 c_to_compute_without_tail) {
     const Reg64 &reg_c = reg_tmp_;
 
@@ -692,7 +692,7 @@ void jit_uni_resampling_kernel_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::compute_linear_c_interpolate(
-        const int c_to_compute_without_tail, const bool is_tail) {
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
     const Reg64 &reg_c = reg_tmp_;
 
     const std::vector<std::reference_wrapper<const Vmm>> src_vmms
@@ -786,12 +786,12 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::linear_c_oriented_format(
     const bool has_ne_xf16_supported = isa == avx2_vnni_2 && conf_.ndims <= 4
             && utils::one_of(
                     conf_.src_data_type, data_type::bf16, data_type::f16);
-    const int total_c_to_compute_without_tail
+    const dim_t total_c_to_compute_without_tail
             = get_channels_to_compute_without_tail(is_tail_in_blocked_format);
-    const int c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
+    const dim_t c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
             ? utils::rnd_dn(total_c_to_compute_without_tail, 2 * simd_w_)
             : 0;
-    const int c_to_compute_without_tail = total_c_to_compute_without_tail
+    const dim_t c_to_compute_without_tail = total_c_to_compute_without_tail
             - c_to_compute_ne_xf16_without_tail;
     const bool insert_tail_processsing_code
             = (conf_.tag_kind == tag_kind::nspc && tail_size_ > 0)

--- a/src/cpu/x64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.hpp
@@ -75,7 +75,7 @@ private:
 
     bool can_movntps_be_used() const;
     std::size_t calculate_tail_size() const;
-    int get_channels_to_compute_without_tail(
+    dim_t get_channels_to_compute_without_tail(
             bool is_tail_in_blocked_format) const;
 
     std::map<data_type_t, io::io_saturation_conf_t>
@@ -90,7 +90,7 @@ private:
             const int data_idx, const bool is_tail, const size_t offset = 0);
 
     void preserve_zero_padding(
-            int c_to_compute_without_tail, const bool is_tail);
+            dim_t c_to_compute_without_tail, const bool is_tail);
 
     void interpolate_c_oriented_format(
             const c_oriented_generation_fn_t &generation_fn);
@@ -99,13 +99,13 @@ private:
     void linear_ncsp_format();
     void linear_c_oriented_format(const bool is_tail_in_blocked_format);
     void compute_nearest_c_interpolate(
-            const int c_to_compute_without_tail, const bool is_tail);
+            const dim_t c_to_compute_without_tail, const bool is_tail);
     void compute_ne_xf16_nearest_c_interpolate(
-            const int c_to_compute_without_tail);
+            const dim_t c_to_compute_without_tail);
     void compute_linear_c_interpolate(
-            const int c_to_compute_without_tail, const bool is_tail);
+            const dim_t c_to_compute_without_tail, const bool is_tail);
     void compute_ne_xf16_linear_c_interpolate(
-            const int c_to_compute_without_tail);
+            const dim_t c_to_compute_without_tail);
 
     void generate() override;
 

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -119,17 +119,17 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     bool with_dst_scales_ = false;
     bool use_ext_aux_vmms_ = false;
 
-    size_t unroll_regs_ = 4;
+    int unroll_regs_ = 4;
 
-    size_t axis_simd_full_;
-    size_t axis_simd_tail_;
-    size_t n_loops_;
-    size_t loop_tail_;
-    size_t process_n_elems_;
-    size_t src_next_vreg_stride_;
-    size_t interim_next_vreg_stride_;
-    size_t dst_next_vreg_stride_;
-    size_t diff_dst_next_vreg_stride_;
+    dim_t axis_simd_full_;
+    dim_t axis_simd_tail_;
+    dim_t n_loops_;
+    dim_t loop_tail_;
+    dim_t process_n_elems_;
+    dim_t src_next_vreg_stride_;
+    dim_t interim_next_vreg_stride_;
+    dim_t dst_next_vreg_stride_;
+    dim_t diff_dst_next_vreg_stride_;
 
     const int bf16_emu_zmm_1_idx_ = 23;
     const int bf16_emu_zmm_2_idx_ = 24;
@@ -281,9 +281,11 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         // `pre_body` and `post_body` functions are called with the maximum
         // unroll value of a `body` function as they operate over vmms,
         // which numeration depends on that value.
-        const auto max_body_unroll = n_loops_ ? unroll_regs_
-                : loop_tail_                  ? loop_tail_
-                                              : 1;
+        // `loop_tail_` is a genuine tensor-derived remainder count but is
+        // bounded by `unroll_regs_` here, so narrow it once at this boundary.
+        const int max_body_unroll = n_loops_ ? unroll_regs_
+                : loop_tail_ ? static_cast<int>(loop_tail_)
+                             : 1;
         pre_body(max_body_unroll);
 
         L(body_unroll_loop);
@@ -312,7 +314,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                 cmp(reg_reverse_n_elems, loop_tail_ * process_n_elems_);
                 jl(tail_axis, T_NEAR);
 
-                body(loop_tail_, max_body_unroll, false);
+                body(static_cast<int>(loop_tail_), max_body_unroll, false);
                 sub(reg_reverse_n_elems, loop_tail_ * process_n_elems_);
                 add(reg_src_spat_offt, loop_tail_ * src_next_vreg_stride_);
                 add(reg_dst_spat_offt, loop_tail_ * dst_next_vreg_stride_);
@@ -412,7 +414,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
 
         const auto pre_body = [](int max_unroll) {};
 
-        const auto body = [&](int unroll, int max_unroll, bool tail = false) {
+        const auto body = [&](int unroll, int max_unroll,
+                              bool tail = false) {
             for (int i = 0; i < unroll; i += 2) {
                 const bool can_load_two_simdw = unroll - i >= 2;
                 Vmm vreg_tmp_src_even = Vmm(i + 1);
@@ -457,7 +460,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         // Each unroll encounter accumulates maximum values into its own vmm.
         // It removes dependency on a single vmm when reading data, but
         // introduces a synchronization between them in a post-body call.
-        const auto body = [&](int unroll, int max_unroll, bool tail = false) {
+        const auto body = [&](int unroll, int max_unroll,
+                              bool tail = false) {
             for (int i = 0; i < unroll; i++) {
                 Vmm vreg_tmp_src = Vmm(i + 1);
                 Vmm vreg_tmp_max = get_aux_vmm(vreg_tmp_src, max_unroll);
@@ -523,7 +527,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
 
         const auto pre_body = [](int max_unroll) {};
 
-        const auto body = [&](int unroll, int max_unroll, bool tail = false) {
+        const auto body = [&](int unroll, int max_unroll,
+                              bool tail = false) {
             for (int i = 0; i < unroll; i += 2) {
                 const bool can_load_two_simdw = unroll - i >= 2;
                 Vmm vreg_tmp_src_even = Vmm(i + 1);
@@ -613,7 +618,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         // Each unroll encounter accumulates maximum values into its own vmm.
         // It removes dependency on a single vmm when reading data, but
         // introduces a synchronization between them in a post-body call.
-        const auto body = [&](int unroll, int max_unroll, bool tail = false) {
+        const auto body = [&](int unroll, int max_unroll,
+                              bool tail = false) {
             for (int i = 0; i < unroll; i++) {
                 Vmm vreg_tmp_src = Vmm(i + 1);
                 io_[src_d_.data_type()]->load(
@@ -634,14 +640,14 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                 if (use_ext_aux_vmms_) {
                     // Prepare indices for exp aux vmms.
                     injector_utils::vmm_index_set_t exp_aux_indices;
-                    const auto exp_vmm_aux_count
+                    const int exp_vmm_aux_count
                             = jit_uni_eltwise_injector_t<isa>::aux_vecs_count(
                                     alg_kind::eltwise_exp, pd_->is_fwd(), 0.f);
-                    for (size_t j = 0; j < exp_vmm_aux_count; j++) {
+                    for (int j = 0; j < exp_vmm_aux_count; j++) {
                         // Insert the next idx starting after `vreg_tmp_sum`.
-                        exp_aux_indices.insert(static_cast<size_t>(
-                                get_aux_vmm(vreg_tmp_sum, (j + 1) * max_unroll)
-                                        .getIdx()));
+                        exp_aux_indices.insert(get_aux_vmm(
+                                vreg_tmp_sum, (j + 1) * max_unroll)
+                                                        .getIdx());
                     }
                     exp_injector_->compute_vector(
                             vreg_tmp_src.getIdx(), exp_aux_indices);
@@ -722,7 +728,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     void compute_avx2_ne_xf16_dst() {
         const auto pre_body = [](int max_unroll) {};
 
-        const auto body = [&](int unroll, int max_unroll, bool tail = false) {
+        const auto body = [&](int unroll, int max_unroll,
+                              bool tail = false) {
             for (int i = 0; i < unroll; i += 2) {
                 const bool can_load_two_simdw = unroll - i >= 2;
                 Vmm vreg_tmp_src_even = Vmm(i + 1);
@@ -808,7 +815,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
 
         const auto pre_body = [](int max_unroll) {};
 
-        const auto body = [&](int unroll, int max_unroll, bool tail = false) {
+        const auto body = [&](int unroll, int max_unroll,
+                              bool tail = false) {
             for (int i = 0; i < unroll; i++) {
                 Vmm vreg_tmp_src = Vmm(i + 1);
                 if (need_scratchpad_)
@@ -868,7 +876,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
 
         const auto pre_body = [](int max_unroll) {};
 
-        const auto body = [&](int unroll, int max_unroll, bool tail = false) {
+        const auto body = [&](int unroll, int max_unroll,
+                              bool tail = false) {
             for (int i = 0; i < unroll; i++) {
                 Vmm vreg_tmp_dst = Vmm(i * 2 + 1);
                 Vmm vreg_tmp_diff_dst = Vmm(i * 2 + 2);
@@ -896,7 +905,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     void compute_diff_src() {
         const auto pre_body = [](int max_unroll) {};
 
-        const auto body = [&](int unroll, int max_unroll, bool tail = false) {
+        const auto body = [&](int unroll, int max_unroll,
+                              bool tail = false) {
             for (int i = 0; i < unroll; i++) {
                 Vmm vreg_tmp_dst = Vmm(i * 2 + 1);
                 Vmm vreg_tmp_diff_dst = Vmm(i * 2 + 2);
@@ -958,7 +968,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig),
-                    dst_d_, axis_simd_tail_, tail_opmask,
+                    dst_d_, static_cast<dim_t>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {
@@ -1100,19 +1110,19 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     bool with_src_scales_ = false;
     bool with_dst_scales_ = false;
 
-    size_t unroll_inner_size_ = 4;
-    size_t unroll_axis_size_ = 8;
+    int unroll_inner_size_ = 4;
+    dim_t unroll_axis_size_ = 8;
 
-    size_t axis_size_;
-    size_t axis_size_unroll_tail_;
-    size_t axis_stride_;
-    size_t axis_simd_full_;
-    size_t axis_simd_tail_;
-    size_t n_loops_;
-    size_t loop_tail_;
-    size_t src_next_vreg_stride_;
-    size_t interim_next_vreg_stride_;
-    size_t dst_next_vreg_stride_;
+    dim_t axis_size_;
+    dim_t axis_size_unroll_tail_;
+    dim_t axis_stride_;
+    dim_t axis_simd_full_;
+    dim_t axis_simd_tail_;
+    dim_t n_loops_;
+    dim_t loop_tail_;
+    dim_t src_next_vreg_stride_;
+    dim_t interim_next_vreg_stride_;
+    dim_t dst_next_vreg_stride_;
 
     const int bf16_emu_zmm_1_idx_ = 23;
     const int bf16_emu_zmm_2_idx_ = 24;
@@ -1297,7 +1307,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     // Why loops are needed, see `axis_size_loop_unroll` description.
     void axis_full_cycle(int unroll_inner, bool tail) {
         const auto vmax_body
-                = [&](int unroll_axis, int unroll_inner, bool tail) {
+                = [&](dim_t unroll_axis, int unroll_inner, bool tail) {
             for_(dim_t a = 0; a < unroll_axis; a++)
             for (int i = 0; i < unroll_inner; i++) {
                 Vmm vreg_tmp_src = Vmm(i + 1);
@@ -1318,7 +1328,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         };
 
         const auto vsum_body
-                = [&](int unroll_axis, int unroll_inner, bool tail) {
+                = [&](dim_t unroll_axis, int unroll_inner, bool tail) {
             for_(dim_t a = 0; a < unroll_axis; a++)
             for (int i = 0; i < unroll_inner; i++) {
                 Vmm vreg_tmp_src = Vmm(i + 1);
@@ -1356,7 +1366,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         };
 
         const auto store_body
-                = [&](int unroll_axis, int unroll_inner, bool tail) {
+                = [&](dim_t unroll_axis, int unroll_inner, bool tail) {
             for_(dim_t a = 0; a < unroll_axis; a++)
             for (int i = 0; i < unroll_inner; i++) {
                 Vmm vreg_tmp_src = Vmm(i + 1);
@@ -1442,9 +1452,11 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         axis_size_loop_unroll(store_body, unroll_inner, tail);
 
         add(reg_src_spat_offt,
-                unroll_inner * simd_w_ * src_d_.data_type_size());
+                static_cast<uint32_t>(
+                        unroll_inner * simd_w_ * src_d_.data_type_size()));
         add(reg_dst_spat_offt,
-                unroll_inner * simd_w_ * dst_d_.data_type_size());
+                static_cast<uint32_t>(
+                        unroll_inner * simd_w_ * dst_d_.data_type_size()));
     }
 
     // The function provides unrolling over inner size. A single compute block
@@ -1462,12 +1474,14 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         L(unroll_loop);
         {
             if (n_loops_) {
-                cmp(reg_reverse_n_elems, unroll_inner_size_ * simd_w_);
+                cmp(reg_reverse_n_elems,
+                        static_cast<uint32_t>(unroll_inner_size_ * simd_w_));
                 jl(unroll_tail_loop, T_NEAR);
 
                 axis_full_cycle(unroll_inner_size_, false);
 
-                sub(reg_reverse_n_elems, unroll_inner_size_ * simd_w_);
+                sub(reg_reverse_n_elems,
+                        static_cast<uint32_t>(unroll_inner_size_ * simd_w_));
                 jmp(unroll_loop);
             }
         }
@@ -1475,12 +1489,14 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         L(unroll_tail_loop);
         {
             if (loop_tail_) {
-                cmp(reg_reverse_n_elems, loop_tail_ * simd_w_);
+                cmp(reg_reverse_n_elems,
+                        static_cast<uint32_t>(loop_tail_ * simd_w_));
                 jl(tail_loop, T_NEAR);
 
-                axis_full_cycle(loop_tail_, false);
+                axis_full_cycle(static_cast<int>(loop_tail_), false);
 
-                sub(reg_reverse_n_elems, loop_tail_ * simd_w_);
+                sub(reg_reverse_n_elems,
+                        static_cast<uint32_t>(loop_tail_ * simd_w_));
                 // No jump, unroll_tail run once.
             }
         }
@@ -1543,7 +1559,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig),
-                    dst_d_, axis_simd_tail_, tail_opmask,
+                    dst_d_, static_cast<dim_t>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {

--- a/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
+++ b/src/cpu/x64/jit_uni_tbb_batch_normalization.cpp
@@ -757,7 +757,7 @@ struct jit_bnorm_fwd_statistics_t : public jit_generator_t {
         cmp(reg_do_normalise_, 0);
         jz(label_ret);
 
-        const int S = pd_->D() * pd_->H() * pd_->W();
+        const dim_t S = pd_->D() * pd_->H() * pd_->W();
         mov(reg_tmp_, float2int(pd_->MB() * S));
         Xmm xtmp = Xmm(vtmp_.getIdx());
         uni_vmovq(xtmp, reg_tmp_);
@@ -1306,7 +1306,7 @@ struct jit_bnorm_bwd_t : public jit_generator_t {
         uni_vmovq(x, reg_tmp_);
         uni_vbroadcastss(vone_, x);
 
-        const int S = pd_->D() * pd_->H() * pd_->W();
+        const dim_t S = pd_->D() * pd_->H() * pd_->W();
         mov(reg_tmp_, float2int(pd_->MB() * S));
         uni_vmovq(x, reg_tmp_);
         uni_vbroadcastss(vNS_, x);
@@ -1973,7 +1973,7 @@ public:
             const batch_normalization_pd_t *pd) {
 
         int nthrs = dnnl_get_max_threads();
-        int C_PADDED = get_c_padded(pd);
+        dim_t C_PADDED = get_c_padded(pd);
 
         auto sbuf_sz = use_tmp_stats(pd) * 2 * C_PADDED;
         auto pbuf_sz
@@ -1992,7 +1992,7 @@ public:
         std::tie(stride_N, stride_S, stride_C)
                 = get_data_strides<isa>(pd_, tag_kind_);
 
-        const int nthr_NS = nthr.N * nthr.S;
+        const int nthr_NS = static_cast<int>(nthr.N * nthr.S);
         const bool need_reduction = nthr_NS > 1;
         const dim_t tail_size = blk_has_tail ? C_ % simd_w : simd_w;
 
@@ -2020,7 +2020,7 @@ public:
 
         // find local mean
         acc_data_t *r_mean = need_reduction ? rbuf : mean;
-        parallel(nthr.glob,
+        parallel(static_cast<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
@@ -2035,7 +2035,7 @@ public:
             const size_t d_off = start.N * stride_N + start.C * stride_C
                     + start.S * stride_S;
             c.src = (void *)((char *)src + d_off * dt_size_);
-            const int ithr_NS = ithr.N * nthr.S + ithr.S;
+            const int ithr_NS = static_cast<int>(ithr.N * nthr.S + ithr.S);
             c.mean = &r_mean[ithr_NS * size_C_stat + start.C * simd_w];
             c.blk_has_tail = blk_has_tail && stop.C == C_blks;
             c.do_normalise = !need_reduction;
@@ -2047,7 +2047,7 @@ public:
 
         // find local var
         acc_data_t *r_var = need_reduction ? rbuf : var;
-        parallel(nthr.glob,
+        parallel(static_cast<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
@@ -2062,7 +2062,7 @@ public:
             const size_t d_off = start.N * stride_N + start.C * stride_C
                     + start.S * stride_S;
             c.src = (void *)((char *)src + d_off * dt_size_);
-            const int ithr_NS = ithr.N * nthr.S + ithr.S;
+            const int ithr_NS = static_cast<int>(ithr.N * nthr.S + ithr.S);
             c.mean = &mean[start.C * simd_w];
             c.var = &r_var[ithr_NS * size_C_stat + start.C * simd_w];
             c.blk_has_tail = blk_has_tail && stop.C == C_blks;
@@ -2083,7 +2083,7 @@ public:
         std::tie(stride_N, stride_S, stride_C)
                 = get_data_strides<isa>(pd_, tag_kind_);
 
-        parallel(nthr.glob,
+        parallel(static_cast<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
@@ -2161,7 +2161,7 @@ public:
         const dim_t tail_size = blk_has_tail ? C_ % simd_w : simd_w;
         const dim_t size_C_stat = (C_blks - 1) * simd_w + tail_size;
 
-        const int nthr_NS = nthr.N * nthr.S;
+        const int nthr_NS = static_cast<int>(nthr.N * nthr.S);
         const bool need_reduction = nthr_NS > 1;
 
         acc_data_t *diff_gamma = diff_scale;
@@ -2197,14 +2197,14 @@ public:
             });
         };
 
-        parallel(nthr.glob,
+        parallel(static_cast<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
             bnorm_dims_t start, stop;
             work_distribution(C_blks, ithr, nthr, start, stop);
 
-            const int ithr_NS = ithr.N * nthr.S + ithr.S;
+            const int ithr_NS = static_cast<int>(ithr.N * nthr.S + ithr.S);
             acc_data_t *loc_diff_gamma = &r_diff_gamma[ithr_NS * size_C_stat];
             acc_data_t *loc_diff_beta = &r_diff_beta[ithr_NS * size_C_stat];
 
@@ -2240,7 +2240,7 @@ public:
         std::tie(stride_N, stride_S, stride_C)
                 = get_data_strides<isa>(pd_, tag_kind_);
 
-        parallel(nthr.glob,
+        parallel(static_cast<int>(nthr.glob),
                 [= COMPAT_THIS_CAPTURE](int ithr_glob, int nthr_glob) {
             assert(nthr_glob == nthr.glob);
             const auto ithr = map_thread(ithr_glob, nthr);
@@ -2409,7 +2409,7 @@ private:
     bnorm_dims_t map_thread(int ithr_glob, const bnorm_dims_t &nthr) {
         auto ithr = bnorm_dims_t();
         ithr.glob = ithr_glob;
-        ithr.C = map_thread_c(ithr.glob, nthr);
+        ithr.C = map_thread_c(ithr_glob, nthr);
         ithr.N = ithr.glob / nthr.S % nthr.N;
         ithr.S = ithr.glob % nthr.S;
         return ithr;
@@ -2422,7 +2422,8 @@ private:
 
     void work_distribution(dim_t C_blks, const bnorm_dims_t &ithr,
             const bnorm_dims_t &nthr, bnorm_dims_t &start, bnorm_dims_t &stop) {
-        work_distribution_c(C_blks, ithr.C, nthr.C, start.C, stop.C);
+        work_distribution_c(C_blks, static_cast<int>(ithr.C),
+                static_cast<int>(nthr.C), start.C, stop.C);
         balance211(N_, nthr.N, ithr.N, start.N, stop.N);
         balance211(S_, nthr.S, ithr.S, start.S, stop.S);
     }

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -54,7 +54,7 @@ jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa,
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
-        const size_t tail_size = get_tail_size();
+        const dim_t tail_size = get_tail_size();
         static constexpr bool use_exact_tail_scalar_bcast = false;
         rhs_arg_static_params_t rhs_arg_static_params {15, r13, r14, r15,
                 preserve_gpr, preserve_vmm,
@@ -115,9 +115,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::bcast_loop(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::output_ptr(
+dim_t jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::output_ptr(
         const int i_load, const int i_ur) {
-    const size_t ur_stride = jcp.with_dw_conv
+    const dim_t ur_stride = jcp.with_dw_conv
             ? jcp.nb_load_blocking * jcp.oc_block * i_ur
             : jcp.oc_without_padding * i_ur;
 
@@ -163,7 +163,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_sum(const int ur,
 
             const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
             cvt2ps(jcp.sum_dt, ymm_prev_dst, aux_reg_output_data,
-                    output_ptr(i_load, i_ur),
+                    static_cast<int>(output_ptr(i_load, i_ur)),
                     mask_flag ? get_tail_size() : simd_w);
 
             if (sum_zp != 0) {
@@ -202,9 +202,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_postops(
         vmm_index_set_t vmm_idxs;
         if (jcp.with_binary) {
             iterate(ur, load_loop_blk, [&](const int i_ur, const int i_load) {
-                const int ur_stride
+                const dim_t ur_stride
                         = jcp.oc_without_padding * jcp.ngroups * i_ur;
-                const size_t aux_output_offset = jcp.typesize_out
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (ur_stride + i_load * jcp.load_block);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -213,7 +213,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_postops(
                 rhs_arg_params_tail.vmm_idx_to_out_reg.emplace(
                         vmm_idx, aux_reg_output_data);
                 rhs_arg_params_tail.vmm_idx_to_out_elem_off_val.emplace(
-                        vmm_idx, aux_output_offset);
+                        vmm_idx, static_cast<size_t>(aux_output_offset));
                 if (mask_flag_in && (i_load + 1 == load_loop_blk))
                     rhs_arg_params_tail.vmm_tail_idx_.emplace(vmm_idx);
             });
@@ -266,19 +266,20 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
         assert(i_reduce <= jcp.reduce_loop_unroll);
         assert(jcp.reduce_loop_unroll == jcp.reduce_block);
 
-        int offt = (jcp.ic_without_padding * i_ur + i_reduce);
+        const dim_t offt = jcp.ic_without_padding * i_ur + i_reduce;
 
-        return ptr[aux_reg_bcast_data + jcp.typesize_in * offt];
+        return ptr[aux_reg_bcast_data
+                + static_cast<int>(jcp.typesize_in * offt)];
     };
 
     auto load_ptr = [&](int i_reduce, int i_load) {
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
 
-        int offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
+        const dim_t offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
 
         return ptr[aux_reg_load_data + u1 * jcp.reduce_loop_load_step
-                + jcp.typesize_in * offt];
+                + static_cast<int>(jcp.typesize_in * offt)];
     };
 
     auto init = [&]() {
@@ -323,10 +324,13 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
             if (jcp.signed_input) {
                 mov(reg_comp_data, ptr[rsp + reg_comp_data_off]);
                 cvt2ps(data_type::s32, vmm_comp, reg_comp_data,
-                        sizeof(int32_t) * jcp.oc_block * i_load, load_size);
+                        static_cast<int>(
+                                sizeof(int32_t) * jcp.oc_block * i_load),
+                        load_size);
             }
             if (jcp.src_zero_point) {
-                const int zp_offset = sizeof(int32_t) * i_load * jcp.oc_block;
+                const int zp_offset = static_cast<int>(
+                        sizeof(int32_t) * i_load * jcp.oc_block);
                 load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation,
                         zp_offset, load_size);
                 uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_zp);
@@ -363,8 +367,8 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
                 if (!jcp.is_oc_scale) {
                     uni_vbroadcastss(vmm_scales_tmp, ptr[reg_wei_scales]);
                 } else {
-                    int scale_offset = jcp.is_oc_scale
-                            * (sizeof(float) * jcp.oc_block * i_load);
+                    const int scale_offset = static_cast<int>(jcp.is_oc_scale
+                            * (sizeof(float) * jcp.oc_block * i_load));
                     if (mask_flag) {
                         uni_vpxor(
                                 vmm_scales_tmp, vmm_scales_tmp, vmm_scales_tmp);
@@ -403,7 +407,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
                 if (jcp.signed_input || jcp.with_dst_scales)
                     mov(reg_bias_data, ptr[rsp + reg_bias_data_off]);
                 cvt2ps(jcp.bia_dt, vmm_bias, reg_bias_data,
-                        jcp.typesize_bia * jcp.oc_block * i_load, load_size);
+                        static_cast<int>(
+                                jcp.typesize_bia * jcp.oc_block * i_load),
+                        load_size);
             }
 
             for (int i_ur = 0; i_ur < ur; ++i_ur) {
@@ -466,7 +472,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
                         = mask_flag_in && i_load == load_loop_blk - 1;
                 auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                 store_data(jcp.dst_dt, r, aux_reg_output_data,
-                        output_ptr(i_load, i_ur),
+                        static_cast<int>(output_ptr(i_load, i_ur)),
                         mask_flag ? get_tail_size() : simd_w);
             }
         }
@@ -488,9 +494,10 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
     auto fma_block = [&](bool last_block) {
         int reduce_step = 4;
         int ic_tail_size = jcp.ic_without_padding % reduce_step;
-        int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
-                ? rnd_up(jcp.ic_without_padding % jcp.ic_block, reduce_step)
-                : jcp.reduce_loop_unroll;
+        const int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
+                ? static_cast<int>(rnd_up(
+                          jcp.ic_without_padding % jcp.ic_block, reduce_step))
+                : static_cast<int>(jcp.reduce_loop_unroll);
         for (int i_reduce = 0; i_reduce < loop_unroll;
                 i_reduce += reduce_step) {
             for (int i_load = 0; i_load < load_loop_blk; ++i_load)
@@ -625,21 +632,23 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::generate() {
         if (jcp.signed_input) {
             mov(reg_comp_data, ptr[rsp + reg_comp_data_off]);
             add(reg_comp_data,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(ptr[rsp + reg_comp_data_off], reg_comp_data);
         }
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[rsp + reg_zp_compensation_off]);
             add(reg_zp_compensation,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(ptr[rsp + reg_zp_compensation_off], reg_zp_compensation);
         }
         mov(ptr[rsp + reg_bcast_data_off], reg_bcast_data);
         if (jcp.with_wei_scales) {
             mov(reg_wei_scales, ptr[rsp + reg_wei_scales_off]);
             add(reg_wei_scales,
-                    jcp.is_oc_scale * load_loop_blk * jcp.load_block
-                            * sizeof(float));
+                    static_cast<uint32_t>(jcp.is_oc_scale * load_loop_blk
+                            * jcp.load_block * sizeof(float)));
             mov(ptr[rsp + reg_wei_scales_off], reg_wei_scales);
         }
         mov(reg_bcast_data, ptr[rsp + reg_bcast_data_off]);
@@ -815,10 +824,13 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     const int SMALL_SPATIAL = 7 * 7;
     const int BIG_REDUCE_DIM = 512;
@@ -844,9 +856,9 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             && (jcp.oh <= size_threshold && jcp.ow <= size_threshold)) {
         if (jcp.os <= SMALL_SPATIAL && jcp.oc * jcp.ic < L2_size)
             max_regs = min_regs = 3;
-        jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
     } else {
-        const int spatial = jcp.od * jcp.oh;
+        const dim_t spatial = jcp.od * jcp.oh;
         jcp.ur = 1;
         for (int ur_w = max_regs; ur_w >= min_regs; ur_w--) {
             if ((spatial >= size_threshold && spatial % ur_w == 0)
@@ -856,7 +868,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
                 int i_tail = jcp.os % i;
@@ -869,7 +881,8 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
         }
     }
 
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
     jcp.reduce_dim = jcp.ic;
     jcp.reduce_block = jcp.ic_block;
 
@@ -897,8 +910,10 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-    int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const int nb_bcast
+            = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    const int nb_reduce
+            = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     reduce_blocking = nb_reduce;
     if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -911,7 +926,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     bool cmp_reduce = reduce_blocking <= jcp.reduce_dim;
     if (cmp_reduce) jcp.loop_order = reduce_src ? loop_rbl : loop_rlb;
-    load_blocking = jcp.load_dim;
+    load_blocking = static_cast<int>(jcp.load_dim);
 
     jcp.load_grp_count = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
     jcp.load_grp_count = best_divider(
@@ -923,24 +938,26 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     } else if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.mb <= jcp.nthr
             && jcp.load_dim > 256 && jcp.load_dim / jcp.reduce_dim >= 4) {
         jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2);
-        load_blocking = jcp.load_block;
+        load_blocking = static_cast<int>(jcp.load_block);
     }
 
-    bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                             div_up(jcp.nthr, jcp.load_grp_count))
-            * jcp.bcast_block;
-    bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
-    bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
+    bcast_blocking
+            = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                       div_up(jcp.nthr, jcp.load_grp_count))
+                    * jcp.bcast_block);
+    bcast_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
+    bcast_blocking = static_cast<int>(rnd_up(bcast_blocking, jcp.bcast_block));
 
-    int space_for_bcast = (L2_capacity - /* kernel_size - */
+    dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
             2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
             - 3 * 1024);
     if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
 
-    int bcast_in_cache
-            = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-    bcast_blocking = nstl::min(
-            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+    const dim_t bcast_in_cache = nstl::max<dim_t>(
+            jcp.bcast_block, space_for_bcast / reduce_blocking);
+    bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
     load_blocking_max = load_blocking;
     bcast_blocking_max = bcast_blocking * 3 / 2;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -36,7 +36,9 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t : public jit_generator_t {
     jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
-    int get_tail_size() { return jcp.oc_without_padding % jcp.oc_block; }
+    int get_tail_size() {
+        return static_cast<int>(jcp.oc_without_padding % jcp.oc_block);
+    }
 
     jit_1x1_conv_conf_t jcp;
     const primitive_attr_t &attr_;
@@ -115,7 +117,7 @@ private:
     int vreg_accum_idx(
             const int load_loop_blk, const int i_load, const int i_ur);
     Vmm vreg_accum(const int load_loop_blk, const int i_load, const int i_ur);
-    int output_ptr(const int i_load, const int i_ur);
+    dim_t output_ptr(const int i_load, const int i_ur);
     void bcast_loop(int load_loop_blk);
     void apply_sum(const int ur, const int load_loop_blk,
             const bool mask_flag_in, const float *p_sum_scale,

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -54,7 +54,8 @@ status_t jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const int32_t *src_zero_points = CTX_IN_MEM(
@@ -114,12 +115,12 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
             ? scratchpad.get<char>(key_conv_rtus_space)
             : nullptr;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     const int ndims = dst_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     auto offset = weights_d.size() - weights_d.additional_buffer_size();
     char *w = const_cast<char *>(weights);
@@ -142,15 +143,16 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = typename rtus_driver_t<isa>::call_params_t();
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -185,27 +187,27 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
     char *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<char *> addrs;
     // End
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto dim_step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
-        bcast_step = step(
+        bcast_step = dim_step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -218,8 +220,9 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
-        load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
+        load_step = dim_step(
+                nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         p.load_dim = this_block_size(ocb * jcp.oc_block, ocb_end * jcp.oc_block,
                 load_step * jcp.oc_block);
 
@@ -231,15 +234,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
     auto init_reduce = [&]() {
         p.reduce_dim = this_block_size(
-                0, jcp.ic_without_padding, jcp.ic_without_padding);
+                dim_t {0}, jcp.ic_without_padding, jcp.ic_without_padding);
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int n, int g, int od, int oh,
-                           int ow, int id, int ih, int iw) {
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t n, dim_t g, dim_t od,
+                           dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
         const int icb = 0; // Start from the first IC block
-        const int _ocb = g * nb_oc + ocb;
-        const int _icb = g;
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g;
 
         const auto src_offset
                 = data_blk_off(src_d, n, _icb * jcp.ic_block, id, ih, iw);
@@ -286,18 +289,18 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_rlb) {
             init_reduce();
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                    dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                             id {0}, ih {0}, iw {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
@@ -307,13 +310,13 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                    dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                             id {0}, ih {0}, iw {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
@@ -325,15 +328,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
             }
         } else if (jcp.loop_order == loop_rbl) {
             init_reduce();
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                         id {0}, ih {0}, iw {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                     ocb += load_step;
@@ -341,15 +344,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
                 iwork += bcast_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                         id {0}, ih {0}, iw {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     init_reduce();
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -362,21 +365,23 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
-        int oh_1x1_begin = nstl::max(oh_1x1, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step,
+                              dim_t &dw_oh) {
+        dim_t oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
+        dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1_begin++) % jcp_dw->kh) * row_offset;
 
         const auto ocb_end = ocb_start + load_step;
         const size_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         auto par_conv_dw = jit_conv_args_t();
 
-        par_conv_dw.t_overflow = nstl::min(jcp_dw->kh, nstl::max(0, -oh_1x1));
-        par_conv_dw.b_overflow = nstl::min(
-                jcp_dw->kh, nstl::max(0, oh_1x1 - jcp.oh + jcp_dw->kh));
-        par_conv_dw.kh_padding = nstl::max<int>(0,
+        par_conv_dw.t_overflow
+                = nstl::max<dim_t>(0, nstl::min<dim_t>(jcp_dw->kh, -oh_1x1));
+        par_conv_dw.b_overflow = nstl::max<dim_t>(
+                0, nstl::min<dim_t>(jcp_dw->kh, oh_1x1 - jcp.oh + jcp_dw->kh));
+        par_conv_dw.kh_padding = nstl::max<dim_t>(0,
                 jcp_dw->kh - par_conv_dw.t_overflow - par_conv_dw.b_overflow);
 
         const size_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
@@ -385,7 +390,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         const auto wht_h_stride = dw_weights_d.blk_off(0, 0, 0, 1);
         const auto wei_stride = (!jcp_dw->signed_input) * par_conv_dw.t_overflow
                 * wht_h_stride;
-        for (int ocb = ocb_start; ocb < ocb_end;
+        for (dim_t ocb = ocb_start; ocb < ocb_end;
                 ocb += jcp_dw->nb_ch_blocking) {
 
             par_conv_dw.src = addrs.data();
@@ -416,7 +421,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
             (*kernel_dw_)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += src_ch_stride;
         }
     };
@@ -431,38 +436,42 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
-        balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        balance2D(nthr, ithr,
+                jcp.mb * jcp.ngroups * jcp_dw->oh,
+                bcast_start, bcast_end, nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
                 oh_1x1 = nstl::max(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
                 oh_1x1 = oh_1x1_end;
-                ker_dw(n, g * nb_oc + ocb_start, load_step, oh_dw);
+                ker_dw(n, static_cast<int>(g * nb_oc + ocb_start), load_step,
+                        oh_dw);
 
                 bcast_iter += nb_bcast_blocking;
             }
@@ -473,10 +482,10 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
-                jcp.nb_load / jcp.nb_load_chunk, ocb_start, ocb_end,
-                jcp.load_grp_count);
+                jcp.nb_load / jcp.nb_load_chunk, ocb_start,
+                ocb_end, static_cast<dim_t>(jcp.load_grp_count));
         if (jcp.nb_load_chunk > 1) {
             ocb_start *= jcp.nb_load_chunk;
             ocb_end *= jcp.nb_load_chunk;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -315,7 +315,8 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
                 --jcp_dw_->nb_ch_blocking;
 
             jcp_dw_->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+                    = static_cast<int>(
+                            jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
             jcp_1x1.bcast_loop_output_step = jcp_1x1.ur
                     * (jcp_1x1.nb_load_blocking * jcp_1x1.oc_block)
                     * jcp_1x1.typesize_out;

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -63,10 +63,10 @@ jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::jit_uni_x8s8s32x_fwd_kernel_vmm_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t block_tail
+        const dim_t block_tail
                 = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
                 % isa_simd_width_;
-        const size_t tail_size = block_tail
+        const dim_t tail_size = block_tail
                 ? block_tail
                 : (jcp.is_depthwise ? jcp.ngroups : jcp.oc_without_padding)
                         % isa_simd_width_;
@@ -144,10 +144,12 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_sum(
         const auto sum_injector_lam
                 = [this, oc_block, sum_scale, sum_zp](
                           const bool mask_flag, const int k, const int j) {
-            const int aux_output_offset = jcp.typesize_out
+            const dim_t aux_output_offset = jcp.typesize_out
                     * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
-            cvt2ps(jcp.sum_dt, vmm_prev_dst, reg_out, aux_output_offset,
-                    mask_flag ? get_tail_size() : get_blocking_size());
+            cvt2ps(jcp.sum_dt, vmm_prev_dst, reg_out,
+                    static_cast<int>(aux_output_offset),
+                    static_cast<int>(
+                            mask_flag ? get_tail_size() : get_blocking_size()));
             const Vmm vmm = vmm_out(j, k);
             if (sum_zp != 0) {
                 uni_vbroadcastss(vmm_tmp, ptr[reg_ptr_sum_zp]);
@@ -192,7 +194,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
             iterate(nb_oc_block, ur_w, last_oc_block_flag,
                     oc_blk_is_smaller_than_vmm,
                     [&](const bool mask_flag, const int k, const int j) {
-                const size_t aux_output_offset = jcp.typesize_out
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 const auto vmm_idx = vmm_out_idx(j, k);
@@ -200,7 +202,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
 
                 rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_out);
                 rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
-                        vmm_idx, aux_output_offset);
+                        vmm_idx, static_cast<size_t>(aux_output_offset));
 
                 if (mask_flag) rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
             });
@@ -220,9 +222,10 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         int ur_w, bool last_oc_block_flag) {
-    int nb_oc_block
-            = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-    int oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
+    const int nb_oc_block = static_cast<int>(
+            jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking);
+    const int oc_block
+            = static_cast<int>(jcp.is_depthwise ? jcp.ch_block : jcp.oc_block);
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
     if (jcp.signed_input)
@@ -246,16 +249,17 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
 
     for (int k = 0; k < nb_oc_block; ++k) {
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-        const int load_size = mask_flag ? get_tail_size() : get_blocking_size();
+        const int load_size = static_cast<int>(
+                mask_flag ? get_tail_size() : get_blocking_size());
         if (jcp.signed_input) {
-            const int comp_offset = sizeof(int32_t) * k * oc_block;
-            load_data(data_type::s32, vmm_comp, reg_compensation, comp_offset,
-                    load_size);
+            const dim_t comp_offset = sizeof(int32_t) * k * oc_block;
+            load_data(data_type::s32, vmm_comp, reg_compensation,
+                    static_cast<int>(comp_offset), load_size);
         }
         if (jcp.src_zero_point) {
-            const int zp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * k * oc_block;
             load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation,
-                    zp_offset, load_size);
+                    static_cast<int>(zp_offset), load_size);
             uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_zp);
         }
         // TODO: scales support is done not in the most optimal way.
@@ -286,14 +290,15 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
             if (!jcp.is_oc_scale) {
                 uni_vbroadcastss(vmm_scales_tmp, ptr[reg_wei_scales]);
             } else {
-                int scale_offset
+                const dim_t scale_offset
                         = jcp.is_oc_scale * (sizeof(float) * k * oc_block);
                 if (mask_flag) {
                     load_data(data_type::s32, vmm_scales_tmp, reg_wei_scales,
-                            scale_offset, get_tail_size());
+                            static_cast<int>(scale_offset), get_tail_size());
                 } else {
-                    uni_vmovups(
-                            vmm_scales_tmp, ptr[reg_wei_scales + scale_offset]);
+                    uni_vmovups(vmm_scales_tmp,
+                            ptr[reg_wei_scales
+                                    + static_cast<int>(scale_offset)]);
                 }
             }
             if (is_vmm_scales_set) {
@@ -321,8 +326,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         // temporary vector register for scales. Load bias data into it after
         // scales are processed.
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * k * oc_block;
-            cvt2ps(jcp.bia_dt, vmm_bias, reg_bias, bias_offset, load_size);
+            const dim_t bias_offset = jcp.typesize_bia * k * oc_block;
+            cvt2ps(jcp.bia_dt, vmm_bias, reg_bias,
+                    static_cast<int>(bias_offset), load_size);
         }
 
         for (int j = 0; j < ur_w; ++j) {
@@ -414,17 +420,20 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
         for (int j = 0; j < ur_w; ++j) {
             Vmm r_vmm = vmm_out(j, k);
-            int aux_output_offset = jcp.typesize_out
+            const dim_t aux_output_offset = jcp.typesize_out
                     * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
-            store_data(jcp.dst_dt, r_vmm, reg_out, aux_output_offset,
-                    mask_flag ? get_tail_size() : get_blocking_size());
+            store_data(jcp.dst_dt, r_vmm, reg_out,
+                    static_cast<int>(aux_output_offset),
+                    static_cast<int>(
+                            mask_flag ? get_tail_size() : get_blocking_size()));
         }
     }
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
 
     if (!(utils::one_of(isa, avx2) && std::is_same<Vmm, Xbyak::Ymm>::value)
             && !(utils::one_of(isa, sse41)
@@ -439,11 +448,11 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
         uni_vpbroadcastd(vmm_zp, ptr[reg_src_zero_point]);
     }
 
-    auto input_spatial_index = [this, pad_l](int oi, int ki) {
+    auto input_spatial_index = [this, pad_l](dim_t oi, int ki) -> dim_t {
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
 
-    auto input_offset2 = [this](int ii, int ci) {
+    auto input_offset2 = [this](dim_t ii, int ci) -> dim_t {
         if (jcp.is_fused_conv)
             return jcp.typesize_in
                     * (ii * jcp.dw_conv_buffer_oc + ci * jcp.ch_block);
@@ -452,11 +461,11 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
     };
 
     auto input_offset3 = [this, input_offset2, input_spatial_index](
-                                 int oi, int ci, int ki) {
+                                 dim_t oi, int ci, int ki) {
         return jcp.typesize_in * input_offset2(input_spatial_index(oi, ki), ci);
     };
 
-    auto kernel_offset = [this](int ci, int ki) {
+    auto kernel_offset = [this](int ci, int ki) -> dim_t {
         return jcp.typesize_in * ((ci * jcp.kh * jcp.kw + ki) * jcp.ch_block);
     };
 
@@ -470,16 +479,16 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
         }
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise && !h_padded) {
         // find bounds of input spatial indices
         bool first = true;
         for (int ki = 0; ki < jcp.kw; ++ki) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; ++oi) {
-                int ii = input_spatial_index(oi, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; ++oi) {
+                const dim_t ii = input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -492,21 +501,23 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
                 && ci == jcp.nb_ch_blocking - 1;
         if (jcp.is_resrc_depthwise && !h_padded) {
             // now we can load input once and reuse up to jcp.kw times
-            for (int ii = ii_start; ii <= ii_end; ++ii) {
-                int aux_input_offset = input_offset2(ii, ci);
-                const Vmm vmm_inp_tmp = vmm_inp(ii, jcp.nb_ch_blocking);
+            for (dim_t ii = ii_start; ii <= ii_end; ++ii) {
+                dim_t aux_input_offset = input_offset2(ii, ci);
+                const Vmm vmm_inp_tmp
+                        = vmm_inp(static_cast<int>(ii), jcp.nb_ch_blocking);
 
                 load_data(data_type::u8, vmm_inp_tmp, aux_reg_inp,
                         aux_input_offset,
-                        mask_flag ? get_tail_size() : get_blocking_size());
+                        static_cast<int>(mask_flag ? get_tail_size()
+                                                   : get_blocking_size()));
                 if (jcp.signed_input)
                     uni_vpaddb(vmm_inp_tmp, vmm_inp_tmp, vmm_shift);
             }
         }
         for (int ki = 0; ki < jcp.kw; ++ki) {
-            int aux_kernel_offset = kernel_offset(ci, ki);
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
+            dim_t aux_kernel_offset = kernel_offset(ci, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
 
             if (compute_kernel) {
                 uni_vpmovsxbd(vmm_wei, ptr[aux_reg_ker + aux_kernel_offset]);
@@ -515,28 +526,33 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
                     for (int oi = 0; oi < ur_w; ++oi)
                         compute(vmm_out(oi, ci), vmm_wei, vmm_shift);
                 } else {
-                    int start = jcp.signed_input ? 0 : oi_start;
-                    int end = jcp.signed_input ? ur_w : oi_end;
-                    for (int oi = start; oi < end; ++oi) {
+                    const dim_t start = jcp.signed_input ? 0 : oi_start;
+                    const dim_t end = jcp.signed_input ? ur_w : oi_end;
+                    for (dim_t oi = start; oi < end; ++oi) {
                         if (oi >= oi_start && oi < oi_end) {
                             if (jcp.is_resrc_depthwise) {
-                                int ii = input_spatial_index(oi, ki);
-                                vmm_dw_src = vmm_inp(ii, jcp.nb_ch_blocking);
+                                const dim_t ii = input_spatial_index(oi, ki);
+                                vmm_dw_src = vmm_inp(static_cast<int>(ii),
+                                        jcp.nb_ch_blocking);
                             } else {
-                                int aux_input_offset
+                                const dim_t aux_input_offset
                                         = input_offset3(oi, ci, ki);
                                 load_data(data_type::u8, vmm_dw_src,
-                                        aux_reg_inp, aux_input_offset,
-                                        mask_flag ? get_tail_size()
-                                                  : get_blocking_size());
+                                        aux_reg_inp,
+                                        static_cast<int>(aux_input_offset),
+                                        static_cast<int>(mask_flag
+                                                        ? get_tail_size()
+                                                        : get_blocking_size()));
                                 if (jcp.signed_input)
                                     uni_vpaddb(
                                             vmm_dw_src, vmm_dw_src, vmm_shift);
                             }
-                            compute(vmm_out(oi, ci), vmm_wei, vmm_dw_src);
+                            compute(vmm_out(static_cast<int>(oi), ci), vmm_wei,
+                                    vmm_dw_src);
                         } else {
                             assert(jcp.signed_input);
-                            compute(vmm_out(oi, ci), vmm_wei, vmm_shift);
+                            compute(vmm_out(static_cast<int>(oi), ci), vmm_wei,
+                                    vmm_shift);
                         }
                     }
                 }
@@ -565,17 +581,19 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
 
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int ch_block_all = jcp.ch_block * ic_block * oc_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const int ic_block = static_cast<int>(jcp.ic_block);
+    const int oc_block = static_cast<int>(jcp.oc_block);
+    const int ch_block_all
+            = static_cast<int>(jcp.ch_block * ic_block * oc_block);
 
-    int nb_oc_block = jcp.nb_oc_blocking;
+    const int nb_oc_block = static_cast<int>(jcp.nb_oc_blocking);
 
     const bool compute_kernel = IMPLICATION(h_padded, jcp.signed_input);
 
@@ -586,14 +604,15 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    auto input_offset = [this, stride_w, pad_l](int oi, int ic, int ki) {
+    auto input_offset
+            = [this, stride_w, pad_l](dim_t oi, int ic, int ki) -> dim_t {
         return jcp.typesize_in
                 * ((ki * (jcp.dilate_w + 1) + oi * stride_w - pad_l)
                                 * jcp.ic_without_padding * jcp.ngroups
                         + ic_sub_step * ic);
     };
     auto kernel_offset
-            = [this, ch_block_all, oc_block](int ii, int ic, int ki) {
+            = [this, ch_block_all, oc_block](int ii, int ic, int ki) -> dim_t {
         return jcp.typesize_in
                 * ((ii * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
@@ -610,18 +629,19 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
     };
 
     for (int ki = 0; ki < kw; ++ki) {
-        const int ow_start = get_ow_start(ki, pad_l);
-        const int ow_end = get_ow_end(ur_w, ki, pad_r);
+        const dim_t ow_start = get_ow_start(ki, pad_l);
+        const dim_t ow_end = get_ow_end(ur_w, ki, pad_r);
         const int ic_tail_size = jcp.ic_without_padding % ic_sub_step;
 
-        const int _start = jcp.signed_input ? 0 : ow_start;
-        const int _end = jcp.signed_input ? ur_w : ow_end;
+        const dim_t _start = jcp.signed_input ? 0 : ow_start;
+        const dim_t _end = jcp.signed_input ? ur_w : ow_end;
 
         /* Skip the last loads of input
             if (ic % 8) / ic_sub_step < ic_block / ic_sub_step */
-        const int icb = (last_ic_block_flag != no_last_block)
-                ? div_up((jcp.ic_without_padding % ic_block), ic_sub_step)
-                : ic_block / ic_sub_step;
+        const int icb = static_cast<int>((last_ic_block_flag != no_last_block)
+                        ? div_up((jcp.ic_without_padding % ic_block),
+                                  ic_sub_step)
+                        : ic_block / ic_sub_step);
 
         if (compute_kernel) {
             for (int ic = 0; ic < icb; ++ic) {
@@ -632,45 +652,54 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                         uni_vmovups(inp, vmm_shift);
                     }
                 } else {
-                    for (int jj = _start; jj < _end; ++jj) {
-                        int aux_input_offset = input_offset(jj, ic, ki);
+                    for (dim_t jj = _start; jj < _end; ++jj) {
+                        dim_t aux_input_offset = input_offset(jj, ic, ki);
                         if (jj >= ow_start && jj < ow_end) {
                             const bool need_partial_ic_bcast = true
                                     && last_ic_block_flag == last_sp_block
                                     && ic_tail_size != 0 && ic == icb - 1;
 
                             if (need_partial_ic_bcast) {
-                                const auto inp_bcastd_vmm
-                                        = vmm_inp(jj, nb_oc_block);
+                                const auto inp_bcastd_vmm = vmm_inp(
+                                        static_cast<int>(jj), nb_oc_block);
                                 const auto inp_bcastd
                                         = Xmm(inp_bcastd_vmm.getIdx());
                                 load_bytes(inp_bcastd_vmm, aux_reg_inp,
                                         aux_input_offset, ic_tail_size);
-                                uni_vpbroadcastd(
-                                        vmm_inp(jj, nb_oc_block), inp_bcastd);
+                                uni_vpbroadcastd(vmm_inp(static_cast<int>(jj),
+                                                         nb_oc_block),
+                                        inp_bcastd);
                             } else {
-                                uni_vpbroadcastd(vmm_inp(jj, nb_oc_block),
+                                uni_vpbroadcastd(vmm_inp(static_cast<int>(jj),
+                                                         nb_oc_block),
                                         ptr[aux_reg_inp + aux_input_offset]);
                             }
                             if (jcp.signed_input)
-                                uni_vpaddb(vmm_inp(jj, nb_oc_block),
-                                        vmm_inp(jj, nb_oc_block), vmm_shift);
+                                uni_vpaddb(vmm_inp(static_cast<int>(jj),
+                                                   nb_oc_block),
+                                        vmm_inp(static_cast<int>(jj),
+                                                nb_oc_block),
+                                        vmm_shift);
                         } else {
                             // fill padded area with shifted value in
                             // first iteration
                             if (jcp.signed_input && ic == 0) {
-                                const Vmm inp = vmm_inp(jj, nb_oc_block);
+                                const Vmm inp = vmm_inp(
+                                        static_cast<int>(jj), nb_oc_block);
                                 uni_vmovups(inp, vmm_shift);
                             }
                         }
                     }
                 }
                 for (int ii = 0; ii < nb_oc_block; ++ii) {
-                    const int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                    const dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                     uni_vmovdqu(vmm_wei, ptr[aux_reg_ker + aux_kernel_offset]);
-                    for (int jj = _start; jj < _end; ++jj) {
-                        const Vmm inp = vmm_inp(h_padded ? 0 : jj, nb_oc_block);
-                        compute(vmm_out(jj, ii), vmm_wei, inp);
+                    for (dim_t jj = _start; jj < _end; ++jj) {
+                        const Vmm inp
+                                = vmm_inp(static_cast<int>(h_padded ? 0 : jj),
+                                        nb_oc_block);
+                        compute(vmm_out(static_cast<int>(jj), ii), vmm_wei,
+                                inp);
                     }
                 }
             }
@@ -685,7 +714,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                     for (int ii = 0; ii < nb_oc_block; ii++) {
                         uni_vpxor(vmm_tmp, vmm_tmp, vmm_tmp);
                         for (int ic = 0; ic < icb; ic++) {
-                            const int aux_kernel_offset
+                            const dim_t aux_kernel_offset
                                     = kernel_offset(ii, ic, ki);
                             if (jcp.has_vnni) {
                                 vpdpbusd(vmm_tmp, vmm_zp_one,
@@ -710,7 +739,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
-        int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag) {
+        int ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag) {
 
     Label kd_label, kh_label, skip_kd_loop, skip_kh_loop;
     Label f_overflow_label, no_f_overflow_label, d_h_f_overflow_label,
@@ -718,9 +747,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
             no_b_overflow_label, back_overflow_label, no_back_overflow_label,
             d_h_back_overflow_label;
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
-    int shift_input_ptr
+    const dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    const dim_t shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
+    const dim_t shift_input_ptr
             = jcp.typesize_in * jcp.iw * jcp.ic_without_padding * jcp.ngroups;
 
     if (jcp.src_zero_point && !jcp.is_depthwise) {
@@ -867,7 +896,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
+        int ur_w, dim_t pad_l, dim_t pad_r, bool is_last_sp_block) {
     prepare_output(ur_w);
 
     // IC loop
@@ -900,7 +929,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        int inp_step = jcp.ic_block;
+        const int inp_step = static_cast<int>(jcp.ic_block);
         const size_t ker_step = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.oc_block
                 * jcp.ic_block;
         add(reg_inp, jcp.typesize_in * inp_step);
@@ -940,17 +969,20 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     Label permute_index_table;
-    int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
-                                        : jcp.ic_without_padding * jcp.ngroups;
-    const int urw_inp_stride = jcp.ur_w * jcp.stride_w;
-    const int n_urw_l_pad = nstl::min(
-            div_up(nstl::max(0, jcp.l_pad), urw_inp_stride), jcp.ow / jcp.ur_w);
-    const int inp_shift_pad = nstl::max(0,
+    int in_ic_shift = static_cast<int>(jcp.is_fused_conv
+                    ? jcp.dw_conv_buffer_oc
+                    : jcp.ic_without_padding * jcp.ngroups);
+    const int urw_inp_stride = static_cast<int>(jcp.ur_w * jcp.stride_w);
+    const int n_urw_l_pad = static_cast<int>(nstl::min<dim_t>(
+            div_up(nstl::max<dim_t>(0, jcp.l_pad), urw_inp_stride),
+            jcp.ow / jcp.ur_w));
+    const int inp_shift_pad = static_cast<int>(nstl::max<dim_t>(0,
             jcp.typesize_in * (n_urw_l_pad * urw_inp_stride - jcp.l_pad)
-                    * in_ic_shift);
-    int inp_shift = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
-    int out_shift = jcp.typesize_out
-            * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups);
+                    * in_ic_shift));
+    int inp_shift = static_cast<int>(
+            jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift));
+    int out_shift = static_cast<int>(jcp.typesize_out
+            * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups));
     preamble();
 
     if (jcp.is_depthwise) {
@@ -999,19 +1031,20 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
         mov(reg_oc_blocks, ptr[param1 + GET_OFF(oc_blocks)]);
     }
 
-    const int extended_filter_size
-            = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int r_pad = nstl::max(0, jcp.r_pad);
+    const int extended_filter_size = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
+    const int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     const int ow_with_no_rpad = 1
-            + (jcp.iw + jcp.l_pad + nstl::min(0, jcp.r_pad)
-                      - extended_filter_size)
-                    / jcp.stride_w;
-    const int n_urw_per_ow_block = jcp.ow_block / jcp.ur_w;
-    const int max_safe_iw = nstl::max(0,
+            + static_cast<int>(
+                    (jcp.iw + jcp.l_pad + nstl::min<dim_t>(0, jcp.r_pad)
+                            - extended_filter_size)
+                    / jcp.stride_w);
+    const int n_urw_per_ow_block = static_cast<int>(jcp.ow_block / jcp.ur_w);
+    const int max_safe_iw = static_cast<int>(nstl::max<dim_t>(0,
             jcp.iw
                     - div_up(static_cast<int>(ic_sub_step),
-                            jcp.ic_without_padding));
-    const int max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
+                            jcp.ic_without_padding)));
+    const dim_t max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
             ? jcp.ow
             : (max_safe_iw + jcp.l_pad - extended_filter_size) / jcp.stride_w;
     Label middle_block_label, done_compute;
@@ -1072,13 +1105,14 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
         // middle_region:
         int n_urw_middle_block_loop = 0;
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
             n_urw_middle_block_loop
-                    = nstl::max(0,
-                              nstl::min(ow_with_no_rpad, max_safe_ow) - cur_ow)
+                    = static_cast<int>(nstl::max<dim_t>(0,
+                              nstl::min<dim_t>(ow_with_no_rpad, max_safe_ow)
+                                      - cur_ow))
                     / jcp.ur_w;
             cur_ow += n_urw_middle_block_loop * jcp.ur_w;
         }
@@ -1088,11 +1122,11 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
         // r_pad or last_sp_block
         if (cur_ow + jcp.ur_w <= jcp.ow) {
             if (r_pad_fall_through_n_urw == 0) ++n_labels;
-            const int n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
-            n_labels += nstl::max(0,
+            const dim_t n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
+            n_labels += static_cast<int>(nstl::max<dim_t>(0,
                     div_up(r_pad_fall_through_n_urw + n_urw_r_pad_region,
                             n_urw_per_ow_block)
-                            - 1);
+                            - 1));
         }
 
         if (jcp.ur_w_tail != 0) {
@@ -1116,9 +1150,10 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
             L(middle_or_rpad_check);
             // harness passes shifted src pointer that does not take
             // left-padding into account. So, we must re-shift here.
-            const int inp_shift_pad_middle_block = -1 * jcp.typesize_in
-                    * nstl::min(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
-                    * in_ic_shift;
+            const int inp_shift_pad_middle_block = static_cast<int>(-1
+                    * jcp.typesize_in
+                    * nstl::min<dim_t>(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
+                    * in_ic_shift);
             add(reg_inp, inp_shift_pad_middle_block);
         }
         if (r_pad_fall_through_n_urw != 0) {
@@ -1161,7 +1196,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     int label_cntr = 0;
     int cur_l_pad = 0;
     if (jcp.l_pad > 0) {
-        for (cur_l_pad = jcp.l_pad;
+        for (cur_l_pad = static_cast<int>(jcp.l_pad);
                 cur_l_pad > 0 && cur_ow + jcp.ur_w <= jcp.ow;
                 cur_l_pad -= urw_inp_stride) {
             if (jcp.nb_ow > 1 && cur_n_oi == 0) {
@@ -1177,9 +1212,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
             }
 
             cur_ow += jcp.ur_w;
-            int cur_r_pad = nstl::max(0,
+            int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                     calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                            jcp.stride_w, extended_filter_size));
+                            jcp.stride_w, extended_filter_size)));
             icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_out, out_shift);
             dec(reg_oi);
@@ -1199,13 +1234,14 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
     // middle_block
     {
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
             int n_oi_middle_block_loop
-                    = nstl::max(0,
-                              nstl::min(ow_with_no_rpad, max_safe_ow) - cur_ow)
+                    = static_cast<int>(nstl::max<dim_t>(0,
+                              nstl::min<dim_t>(ow_with_no_rpad, max_safe_ow)
+                                      - cur_ow))
                     / jcp.ur_w;
             if (jcp.nb_ow == 1 && n_oi_middle_block_loop > 1)
                 mov(reg_oi, n_oi_middle_block_loop);
@@ -1242,8 +1278,8 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
                 L(ow_block_jmp_table[label_cntr++]);
             }
             cur_ow += jcp.ur_w;
-            int cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                    jcp.stride_w, extended_filter_size);
+            const dim_t cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow,
+                    jcp.iw, jcp.stride_w, extended_filter_size);
             assert(cur_r_pad > 0 || cur_ow > max_safe_ow); // else, why be here?
             icb_loop(jcp.ur_w, 0, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_inp, inp_shift);
@@ -1354,9 +1390,9 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1536,10 +1572,13 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, false, false, false));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -1556,7 +1595,8 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     // factor smaller than the left padding (special requirement for SSD:fc6),
     // then search for a smaller OC blocking that satisfies both constraints.
     auto is_oc_blocking_ok = [&](int block) {
-        int ur_w = nstl::min(jcp.ow, jcp.max_regs_ur / (block + 1));
+        int ur_w = static_cast<int>(
+                nstl::min<dim_t>(jcp.ow, jcp.max_regs_ur / (block + 1)));
         return jcp.nb_oc % block == 0 && jcp.l_pad <= ur_w
                 && jcp.ow % ur_w != 1;
     };
@@ -1564,28 +1604,28 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     // choose nb_oc work chunk size for distribution within threads
     int max_threading_nb_oc_chunk = 4;
 
-    jcp.nb_oc_blocking_thr_chunk
-            = nstl::min(max_threading_nb_oc_chunk, jcp.nb_oc);
+    jcp.nb_oc_blocking_thr_chunk = static_cast<int>(
+            nstl::min<dim_t>(max_threading_nb_oc_chunk, jcp.nb_oc));
     for (; jcp.nb_oc_blocking_thr_chunk > 1; --jcp.nb_oc_blocking_thr_chunk) {
         if (is_oc_blocking_ok(jcp.nb_oc_blocking_thr_chunk)) break;
     }
 
-    auto get_thr_eff = [&](int nb_ow, int nthr) {
-        int base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
+    auto get_thr_eff = [&](dim_t nb_ow, int nthr) {
+        const dim_t base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
                 * (jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk);
-        auto work_amount = base_work_amount * nb_ow;
-        return float(work_amount) / rnd_up(work_amount, nthr);
+        const dim_t work_amount = base_work_amount * nb_ow;
+        return float(work_amount) / float(rnd_up(work_amount, nthr));
     };
 
     auto get_ow_block = [&jcp, get_thr_eff](int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+        dim_t res_ow_block = jcp.ow;
         float best_thr_eff = get_thr_eff(1, nthr);
         float thr_eff;
 
-        int max_nb_ow = div_up(jcp.ow, ur_w);
-        for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, ur_w);
+        for (dim_t nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
                     && best_thr_eff > 0.8f)
                 break;
@@ -1597,20 +1637,20 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
             }
             if (best_thr_eff > 0.9f) break;
         }
-        return res_ow_block;
+        return static_cast<int>(res_ow_block);
     };
 
     // choose oc blocking for computational kernel
     jcp.nb_oc_blocking = jcp.nb_oc_blocking_thr_chunk;
 
     if (jcp.is_resrc_depthwise)
-        jcp.ur_w = (jcp.max_regs_ur - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        jcp.ur_w = static_cast<int>((jcp.max_regs_ur - jcp.kw + jcp.stride_w)
+                / (jcp.nb_ch_blocking + jcp.stride_w));
     else
-        jcp.ur_w = jcp.max_regs_ur
+        jcp.ur_w = static_cast<int>(jcp.max_regs_ur
                 / (jcp.is_depthwise ? jcp.nb_ch_blocking
-                                    : jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+                                    : jcp.nb_oc_blocking + 1));
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     jcp.ow_block = jcp.ow;
@@ -1632,10 +1672,10 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
     if (jcp.ngroups < jcp.nthr && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        int ow_block = static_cast<int>(jcp.ow_block);
         float best_thr_eff = thr_eff;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        const int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
             ow_block = get_ow_block(jcp.ur_w, nthr);
             eff = get_thr_eff(div_up(jcp.ow, ow_block), nthr);

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -150,33 +150,37 @@ private:
         assert(idx < ker_max_reg);
         return Vmm(ker_max_reg - idx);
     }
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
-    int get_blocking_size() {
+    dim_t get_blocking_size() {
         return jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
     }
     int get_tail_size() {
-        return jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
-                                : jcp.oc_without_padding % jcp.oc_block;
+        return static_cast<int>(jcp.is_depthwise
+                        ? jcp.ngroups % jcp.ch_block
+                        : jcp.oc_without_padding % jcp.oc_block);
     }
 
     void prepare_output(int ur_w);
     void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker_dw(int ur_w, int pad_l, int pad_r,
+    void compute_ker_dw(int ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void compute_ker(int ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded = false);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool is_last_spatial_block);
+    void kh_loop(
+            int ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag);
+    void icb_loop(
+            int ur_w, dim_t pad_l, dim_t pad_r, bool is_last_spatial_block);
     void generate() override;
 
     void cvt2ps(data_type_t type_in, const Vmm &vmm_in, const Xbyak::Reg64 &reg,
@@ -195,7 +199,8 @@ struct jit_uni_x8s8s32x_fwd_kernel_t {
     jit_uni_x8s8s32x_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 8:
                 if (utils::one_of(isa, avx2)) {

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
@@ -85,13 +85,15 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
+            = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_conv_args_t();
 
@@ -110,7 +112,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -129,18 +131,19 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
         while (start < end) {
             for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                const dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                const dim_t ow_s = owb * jcp.ow_block;
+                const dim_t iw_s = ow_s * jcp.stride_w;
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -152,17 +155,17 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
                 auto src_w = src + src_d.blk_off(n, g_ic, ih_s, iw_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow = nstl::min(
-                            jcp.kh, div_up(nstl::max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0,
+                    const dim_t dilate_h = jcp.dilate_h + 1;
+                    const dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(nstl::max<dim_t>(0, -ij), dilate_h));
+                    const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(nstl::max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    const dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     const size_t wei_stride
@@ -269,13 +272,14 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
                     + (jcp.signed_input ? ch_offset : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
+    const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_conv_args_t();
 
@@ -290,7 +294,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -311,13 +315,13 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int gb = gg * jcp.nb_ch_blocking;
-            int g = gb * group_block;
-            int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.nb_ic * jcp.ic_block;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t gb = gg * jcp.nb_ch_blocking;
+            const dim_t g = gb * group_block;
+            const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+            const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
+            const dim_t ow_s = owb * jcp.ow_block;
+            const dim_t iw_s = ow_s * jcp.stride_w;
 
             p.bias = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                           : nullptr;
@@ -419,8 +423,8 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.nb_ch * jcp.ch_block : 0)
             : nullptr;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [= COMPAT_THIS_CAPTURE](dim_t n, dim_t oh_s, dim_t owb, dim_t gg) {
@@ -429,12 +433,12 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int gb = gg * jcp.nb_ch_blocking;
-        int g = gb * group_block;
+        const dim_t gb = gg * jcp.nb_ch_blocking;
+        const dim_t g = gb * group_block;
 
-        int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        int ow_s = owb * jcp.ow_block;
-        int iw_s = ow_s * jcp.stride_w;
+        const dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        const dim_t ow_s = owb * jcp.ow_block;
+        const dim_t iw_s = ow_s * jcp.stride_w;
 
         auto bias_w = bias ? bias + (bias_d.blk_off(g) * bia_dt_size) : nullptr;
         const int32_t *compensation_w
@@ -459,14 +463,15 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
                 ? static_cast<const float *>(wei_scales) + jcp.is_oc_scale * g
                 : nullptr;
 
-        int dilate_h = jcp.dilate_h + 1;
-        int i_t_overflow
-                = nstl::min(jcp.kh, div_up(nstl::max(0, -ih_s), dilate_h));
-        int i_b_overflow = nstl::min(jcp.kh,
-                div_up(nstl::max(
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t i_t_overflow = nstl::min<dim_t>(
+                jcp.kh, div_up(nstl::max<dim_t>(0, -ih_s), dilate_h));
+        const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                div_up(nstl::max<dim_t>(
                                0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h));
-        int kh_padding = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+        const dim_t kh_padding
+                = nstl::max<dim_t>(0, jcp.kh - i_t_overflow - i_b_overflow);
 
         size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
                 ? 0
@@ -542,14 +547,15 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_conv_args_t();
 
@@ -570,7 +576,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -589,30 +595,31 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
         while (start < end) {
             for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                const dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-                int dilate_d = jcp.dilate_d + 1;
-                int d_f_overflow = nstl::min(
-                        jcp.kd, div_up(nstl::max(0, -id_s), dilate_d));
-                int d_back_overflow = nstl::min(jcp.kd,
-                        div_up(nstl::max(0,
+                const dim_t ow_s = owb * jcp.ow_block;
+                const dim_t iw_s = ow_s * jcp.stride_w;
+                const dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                const dim_t dilate_d = jcp.dilate_d + 1;
+                const dim_t d_f_overflow = nstl::min<dim_t>(
+                        jcp.kd, div_up(nstl::max<dim_t>(0, -id_s), dilate_d));
+                const dim_t d_back_overflow = nstl::min<dim_t>(jcp.kd,
+                        div_up(nstl::max<dim_t>(0,
                                        id_s - jcp.id + (jcp.kd - 1) * dilate_d
                                                + 1),
                                 dilate_d));
 
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+                const dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_f_overflow - d_back_overflow);
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -634,17 +641,17 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
                                           : d_f_overflow)
                                 * wht_d_stride;
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow = nstl::min(
-                            jcp.kh, div_up(nstl::max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0,
+                    const dim_t dilate_h = jcp.dilate_h + 1;
+                    const dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(nstl::max<dim_t>(0, -ij), dilate_h));
+                    const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(nstl::max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    const dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -239,9 +239,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride = 1' when 'dilate > 0'");
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.iw, jcp.ow, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -280,10 +280,13 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_oc = jcp.oc / jcp.oc_block;
@@ -293,18 +296,18 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     const int regs = jcp.has_vnni ? 14 : 12;
 
     jcp.nb_ch_blocking = 1;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
                 && jcp.l_pad <= regs / (jcp.nb_oc_blocking + 1))
             break;
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    const int l_overflow = max(
+    const dim_t l_overflow = max<dim_t>(
             0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
 
     if (jcp.ow < jcp.ur_w) {
-        jcp.ur_w = jcp.ow;
+        jcp.ur_w = static_cast<int>(jcp.ow);
         jcp.ur_w_tail = 0;
     } else {
         for (; jcp.ur_w >= 1; jcp.ur_w--) {
@@ -318,9 +321,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
             const bool left_boundary_covered
                     = jcp.ur_w >= l_overflow * jcp.stride_w;
             jcp.ur_w_tail = jcp.ow % jcp.ur_w;
-            const int r_overflow_no_tail = max(0,
-                    ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad)
-                            - jcp.ur_w_tail)
+            const dim_t r_overflow_no_tail = max<dim_t>(0,
+                    ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                            - max<dim_t>(0, jcp.r_pad) - jcp.ur_w_tail)
                             / jcp.stride_w);
             const bool right_boundary_covered
                     = jcp.ur_w >= r_overflow_no_tail * jcp.stride_w;
@@ -358,7 +361,7 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::jit_uni_x8s8s32x_deconv_fwd_kernel_t(
         const memory_desc_wrapper &dst_d)
     : kernel_(nullptr) {
 
-    const int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+    const dim_t ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
     switch (ch_block) {
         case 8:
             if (isa == avx2) {
@@ -429,7 +432,7 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
     , ker_max_regs_(jcp_.has_vnni ? 14 : 12) {
 
     if (jcp_.with_eltwise || jcp_.with_binary || jcp_.with_sum) {
-        const std::size_t tail_size = get_tail_size();
+        const dim_t tail_size = get_tail_size();
 
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
@@ -455,25 +458,25 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 Vmm jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::vmm_out(
-        int i_ur, int i_oc) const {
-    const int idx = i_ur * jcp_.nb_oc_blocking + i_oc;
+        dim_t i_ur, dim_t i_oc) const {
+    const dim_t idx = i_ur * jcp_.nb_oc_blocking + i_oc;
     assert(idx < ker_max_regs_);
     /* remap the reg indices to avoid using xmm0 in eltwise injector */
-    return Vmm(15 - idx);
+    return Vmm(15 - static_cast<int>(idx));
 }
 
 template <cpu_isa_t isa, typename Vmm>
 Vmm jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::vmm_inp(
-        int i_ic, int nb_x_blocking) const {
-    const int idx = i_ic + nb_x_blocking * jcp_.ur_w;
+        dim_t i_ic, dim_t nb_x_blocking) const {
+    const dim_t idx = i_ic + nb_x_blocking * jcp_.ur_w;
     assert(idx < ker_max_regs_);
-    return Vmm(15 - idx);
+    return Vmm(15 - static_cast<int>(idx));
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
-        int ki, int l_overflow) const noexcept {
-    int res = (jcp_.ow - 1 + jcp_.r_pad) % jcp_.stride_w
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
+        dim_t ki, dim_t l_overflow) const noexcept {
+    dim_t res = (jcp_.ow - 1 + jcp_.r_pad) % jcp_.stride_w
             + l_overflow * jcp_.stride_w
             - (jcp_.kw - 1 - ki) * (jcp_.dilate_w + 1);
     while (res < 0)
@@ -482,11 +485,11 @@ int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
-        int ur_w, int ki, int r_overflow) const noexcept {
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
+        dim_t ur_w, dim_t ki, dim_t r_overflow) const noexcept {
     if (utils::one_of(ur_w, jcp_.ow, jcp_.ur_w_tail))
-        ur_w += nstl::min(0, jcp_.r_pad); // remove negative padding
-    int res = (ur_w - 1 + jcp_.l_pad) % jcp_.stride_w
+        ur_w += nstl::min<dim_t>(0, jcp_.r_pad); // remove negative padding
+    dim_t res = (ur_w - 1 + jcp_.l_pad) % jcp_.stride_w
             + r_overflow * jcp_.stride_w - ki * (jcp_.dilate_w + 1);
     while (res < 0)
         res += jcp_.stride_w;
@@ -494,13 +497,13 @@ int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_blocking_size()
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_blocking_size()
         const noexcept {
     return jcp_.is_depthwise ? jcp_.ch_block : jcp_.oc_block;
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_tail_size()
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_tail_size()
         const noexcept {
     return jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
                              : jcp_.oc_without_padding % jcp_.oc_block;
@@ -525,7 +528,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute(
 
 template <cpu_isa_t isa, typename Vmm>
 std::function<Vmm()> jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::prepare_round_robin_vmm_inp_generator(int ur_w) const noexcept {
+        Vmm>::prepare_round_robin_vmm_inp_generator(dim_t ur_w) const noexcept {
 
     const int start_vmm_idx = vmm_inp(ur_w - 1, jcp_.nb_oc_blocking).getIdx();
     const int end_vmm_idx = vmm_inp(0, jcp_.nb_oc_blocking).getIdx() + 1;
@@ -542,8 +545,8 @@ std::function<Vmm()> jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::apply_zp_src_pad_str_comp(int ur_w, int l_overflow,
-        int r_overflow, bool h_padded) {
+        Vmm>::apply_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+        dim_t r_overflow, bool h_padded) {
     Xbyak::Label end_zp_pad, no_tail;
 
     // apply once per icb loop, zp src stride paddding compensation calculate as
@@ -573,8 +576,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::append_zp_src_pad_str_comp(int ur_w, int l_overflow,
-        int r_overflow, bool h_padded, bool last_oc_block) {
+        Vmm>::append_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+        dim_t r_overflow, bool h_padded, bool last_oc_block) {
 
     const auto &reg_zp_src_pad_comp = reg_scratch_;
     const auto get_next_comp_vmm = prepare_round_robin_vmm_inp_generator(ur_w);
@@ -596,35 +599,35 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
     const auto load_zp_src_pad_comp
             = [&](const Vmm zp_pad_comp_vmm, const Xbyak::Address &comp_addr,
-                      const int ocb) {
+                      const dim_t ocb) {
         const bool is_tail = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
 
         if (is_tail)
             load_data(data_type::s32, zp_pad_comp_vmm, comp_addr,
-                    get_tail_size());
+                    static_cast<int>(get_tail_size()));
         else
             uni_vmovups(zp_pad_comp_vmm, comp_addr);
     };
 
-    const auto get_zp_src_comp_pad_off = [&](int it_kw, int ocb) {
-        const auto kw_offset = it_kw * jcp_.oc_without_padding * jcp_.ngroups;
-        const auto oc_offset = ocb * jcp_.oc_block;
+    const auto get_zp_src_comp_pad_off = [&](dim_t it_kw, dim_t ocb) {
+        const dim_t kw_offset = it_kw * jcp_.oc_without_padding * jcp_.ngroups;
+        const dim_t oc_offset = ocb * jcp_.oc_block;
 
         return (kw_offset + oc_offset) * sizeof(int32_t);
     };
 
-    for (int it_kw = 0; it_kw < jcp_.kw; ++it_kw) {
-        const int ow_start = get_ow_start(it_kw, l_overflow);
-        const int ow_end = get_ow_end(ur_w, it_kw, r_overflow);
+    for (dim_t it_kw = 0; it_kw < jcp_.kw; ++it_kw) {
+        const dim_t ow_start = get_ow_start(it_kw, l_overflow);
+        const dim_t ow_end = get_ow_end(ur_w, it_kw, r_overflow);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
             Vmm zp_src_comp_pad_vmm; // will be assigned later
             bool ocb_zp_loaded = false;
 
             const auto zp_src_comp_pad_off
                     = get_zp_src_comp_pad_off(it_kw, ocb);
 
-            for (int it_ow = 0; it_ow < ur_w; ++it_ow) {
+            for (dim_t it_ow = 0; it_ow < ur_w; ++it_ow) {
 
                 const bool inside_padded_area = h_padded
                         || !(it_ow >= ow_start && it_ow < ow_end
@@ -656,7 +659,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
         const auto kh_offset = jcp_.kw * jcp_.oc_without_padding * jcp_.ngroups
                 * sizeof(int32_t);
 
-        add(reg_zp_src_pad_comp, kh_offset);
+        add(reg_zp_src_pad_comp, static_cast<uint32_t>(kh_offset));
         mov(zp_src_pad_comp_addr_, reg_zp_src_pad_comp);
     }
 
@@ -665,17 +668,17 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
-        int l_overflow, int r_overflow, ker_block_t last_ic_block_flag,
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(dim_t ur_w,
+        dim_t l_overflow, dim_t r_overflow, ker_block_t last_ic_block_flag,
         bool h_padded) {
 
     const bool signed_input_or_src_zp
             = (jcp_.signed_input || jcp_.src_zero_point);
 
-    const int ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
-    const int ur_w_stride = signed_input_or_src_zp ? 1 : jcp_.stride_w;
+    const dim_t ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
+    const dim_t ur_w_stride = signed_input_or_src_zp ? 1 : jcp_.stride_w;
 
-    const auto src_offset = [this](int oj, int icb, int ki) {
+    const auto src_offset = [this](dim_t oj, dim_t icb, dim_t ki) {
         return jcp_.typesize_in
                 * (((oj + jcp_.l_pad - ki * (jcp_.dilate_w + 1))
                            / jcp_.stride_w)
@@ -683,24 +686,25 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                         + icb * 4);
     };
 
-    const auto kernel_offset = [this, ch_block_all](int ocb, int icb, int ki) {
+    const auto kernel_offset
+            = [this, ch_block_all](dim_t ocb, dim_t icb, dim_t ki) {
         return jcp_.typesize_in
                 * ((ocb * jcp_.nb_ic * jcp_.kd * jcp_.kh * jcp_.kw + ki)
                                 * ch_block_all
                         + icb * jcp_.oc_block * IC_SUB_STEP);
     };
 
-    for (int ki = 0; ki < jcp_.kw; ki++) {
+    for (dim_t ki = 0; ki < jcp_.kw; ki++) {
 
-        const int jj_start = get_ow_start(ki, l_overflow);
-        const int jj_end = get_ow_end(ur_w, ki, r_overflow);
+        const dim_t jj_start = get_ow_start(ki, l_overflow);
+        const dim_t jj_end = get_ow_end(ur_w, ki, r_overflow);
 
-        const int _start = (signed_input_or_src_zp) ? 0 : jj_start;
-        const int _end = (signed_input_or_src_zp) ? ur_w : jj_end;
+        const dim_t _start = (signed_input_or_src_zp) ? 0 : jj_start;
+        const dim_t _end = (signed_input_or_src_zp) ? ur_w : jj_end;
 
-        const int tail_size = jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
-                                                : jcp_.ic_without_padding % 4;
-        const int n_ic_blocks = jcp_.is_depthwise
+        const dim_t tail_size = jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
+                                                  : jcp_.ic_without_padding % 4;
+        const dim_t n_ic_blocks = jcp_.is_depthwise
                 ? 1
                 : (last_ic_block_flag != no_last_block
                                   ? div_up(jcp_.ic_without_padding
@@ -708,7 +712,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                             4)
                                   : jcp_.ic_block / 4);
 
-        for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
+        for (dim_t icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded) {
                 /* fill padded area with shifted values */
                 if (jcp_.signed_input) {
@@ -718,9 +722,9 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                 }
             } else {
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
-                    const int aux_src_off = src_offset(jj, icb1, ki);
+                    const dim_t aux_src_off = src_offset(jj, icb1, ki);
                     const auto vmm_src = vmm_inp(jj, jcp_.nb_oc_blocking);
 
                     if (jj >= jj_start && jj < jj_end
@@ -733,12 +737,14 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                     && tail_size;
                             load_data(data_type::u8, vmm_src, aux_reg_src_,
                                     aux_src_off,
-                                    mask_flag ? tail_size : jcp_.ch_block);
+                                    static_cast<int>(mask_flag
+                                                    ? tail_size
+                                                    : jcp_.ch_block));
                         } else if ((last_ic_block_flag == last_sp_block)
                                 && tail_size != 0 && icb1 == n_ic_blocks - 1) {
                             const auto vmm_inp_tmp = Xmm(vmm_src.getIdx());
                             load_bytes(vmm_inp_tmp, aux_reg_src_, aux_src_off,
-                                    tail_size);
+                                    static_cast<int>(tail_size));
                             uni_vpbroadcastd(vmm_src, vmm_inp_tmp);
                         } else {
                             uni_vpbroadcastd(
@@ -755,8 +761,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                     }
                 }
             }
-            for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-                const int aux_filt_off = kernel_offset(ocb, icb1, ki);
+            for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+                const dim_t aux_filt_off = kernel_offset(ocb, icb1, ki);
 
                 if (_end - _start > 0) {
                     if (jcp_.is_depthwise) {
@@ -767,7 +773,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                 vmm_wei_, ptr[aux_reg_filt_ + aux_filt_off]);
                 }
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
                     const bool inside_padded_area = h_padded
                             || !(jj >= jj_start && jj < jj_end
@@ -789,22 +795,22 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
-        int l_overflow, int r_overflow, ker_block_t last_ic_block_flag) {
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(dim_t ur_w,
+        dim_t l_overflow, dim_t r_overflow, ker_block_t last_ic_block_flag) {
 
     const bool signed_input_or_src_zp
             = (jcp_.signed_input || jcp_.src_zero_point);
 
-    const int ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
-    const int shift_src_ih = jcp_.typesize_in * (jcp_.dilate_h + 1) * jcp_.iw
+    const dim_t ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
+    const dim_t shift_src_ih = jcp_.typesize_in * (jcp_.dilate_h + 1) * jcp_.iw
             * jcp_.ngroups * jcp_.ic_without_padding;
-    const int shift_src_id = jcp_.typesize_in * (jcp_.dilate_d + 1) * jcp_.ih
+    const dim_t shift_src_id = jcp_.typesize_in * (jcp_.dilate_d + 1) * jcp_.ih
             * jcp_.iw * jcp_.ngroups * jcp_.ic_without_padding;
-    const int stride_h = signed_input_or_src_zp ? 1 : jcp_.stride_h;
-    const int shift_filt_kh
+    const dim_t stride_h = signed_input_or_src_zp ? 1 : jcp_.stride_h;
+    const dim_t shift_filt_kh
             = jcp_.typesize_in * jcp_.kw * ch_block_all * stride_h;
-    const int stride_d = signed_input_or_src_zp ? 1 : jcp_.stride_d;
-    const int shift_filt_kd
+    const dim_t stride_d = signed_input_or_src_zp ? 1 : jcp_.stride_d;
+    const dim_t shift_filt_kd
             = jcp_.typesize_in * jcp_.kw * ch_block_all * jcp_.kh * stride_d;
 
     Label kd_loop_label, kh_loop_label, skip_kh_loop, skip_kd_loop;
@@ -847,7 +853,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
                 || ((!signed_input_or_src_zp)
                         && ((min(jcp_.f_pad, jcp_.back_pad) < 0)
                                 || ((jcp_.kd - 1) * (jcp_.dilate_d + 1)
-                                        < nstl::max(
+                                        < nstl::max<dim_t>(
                                                 jcp_.f_pad, jcp_.back_pad))))) {
             cmp(reg_ki_, 0);
             je(skip_kd_loop, T_NEAR);
@@ -885,7 +891,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
             || ((!signed_input_or_src_zp)
                     && ((min(jcp_.t_pad, jcp_.b_pad) < 0)
                             || ((jcp_.kh - 1) * (jcp_.dilate_h + 1)
-                                    < nstl::max(jcp_.t_pad, jcp_.b_pad))))) {
+                                    < nstl::max<dim_t>(
+                                            jcp_.t_pad, jcp_.b_pad))))) {
         cmp(reg_kh_, 0);
         je(skip_kh_loop, T_NEAR);
     }
@@ -988,9 +995,9 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::prepare_output(
-        int ur_w) {
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-        for (int ur = 0; ur < ur_w; ur++) {
+        dim_t ur_w) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const Vmm vmm = vmm_out(ur, ocb);
             uni_vpxor(vmm, vmm, vmm);
         }
@@ -1005,23 +1012,25 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::prepare_output(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::cvt2ps(
-        data_type_t type_in, const Vmm vmm_in, const Reg64 reg, int offset,
-        int load_size) {
+        data_type_t type_in, const Vmm vmm_in, const Reg64 reg, dim_t offset,
+        dim_t load_size) {
 
-    load_data(type_in, vmm_in, reg, offset, load_size);
+    load_data(type_in, vmm_in, reg, static_cast<int>(offset),
+            static_cast<int>(load_size));
     if (type_in != data_type::f32) uni_vcvtdq2ps(vmm_in, vmm_in);
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(int ur_w,
-        bool last_oc_block, const float *p_sum_scale, const int32_t *p_sum_zp) {
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
+        dim_t ur_w, bool last_oc_block, const float *p_sum_scale,
+        const int32_t *p_sum_zp) {
     const auto sum_injector = [&]() {
         if (p_sum_scale) { // post_op: sum
-            for (int k = 0; k < jcp_.nb_oc_blocking; k++) {
+            for (dim_t k = 0; k < jcp_.nb_oc_blocking; k++) {
                 const bool mask_flag
                         = last_oc_block == 1 && k == jcp_.nb_oc_blocking - 1;
-                for (int j = 0; j < ur_w; j++) {
-                    const int aux_output_offset = jcp_.typesize_out
+                for (dim_t j = 0; j < ur_w; j++) {
+                    const dim_t aux_output_offset = jcp_.typesize_out
                             * (k * jcp_.oc_block
                                     + j * jcp_.oc_without_padding
                                             * jcp_.ngroups);
@@ -1051,10 +1060,10 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(int ur_w,
 
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     if (jcp_.with_binary) {
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
             const bool mask_flag
                     = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-            for (int ur = 0; ur < ur_w; ur++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const int vmm_idx = vmm_out(ur, ocb).getIdx();
                 const size_t aux_output_offset = jcp_.typesize_out
                         * (ocb * jcp_.oc_block
@@ -1067,15 +1076,15 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(int ur_w,
             }
         }
     }
-    const int nb_oc_block
+    const dim_t nb_oc_block
             = jcp_.is_depthwise ? jcp_.nb_ch_blocking : jcp_.nb_oc_blocking;
     postops_injector_->compute_vector_range(
-            16 - nb_oc_block * ur_w, 16, rhs_arg_params);
+            static_cast<int>(16 - nb_oc_block * ur_w), 16, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
-        int ur_w, bool last_oc_block) {
+        dim_t ur_w, bool last_oc_block) {
     mov(reg_bias_, ptr[param1_ + GET_OFF(bias)]);
 
     if (jcp_.signed_input)
@@ -1098,24 +1107,24 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         const auto &vmm_zp_comp = vmm_scales_;
         uni_vbroadcastss(vmm_src_zp, ptr[reg_zp_src_]);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            const int zp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            const dim_t zp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
             const bool mask_flag
                     = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-            const int load_size
+            const dim_t load_size
                     = mask_flag ? get_tail_size() : get_blocking_size();
             load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation_,
-                    zp_offset, load_size);
+                    static_cast<int>(zp_offset), static_cast<int>(load_size));
             uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_src_zp);
 
-            for (int ur = 0; ur < ur_w; ur++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const auto vmm_dst = vmm_out(ur, ocb);
                 uni_vpaddd(vmm_dst, vmm_dst, vmm_zp_comp);
             }
         }
     }
 
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
 
         // TODO: scales support is done not in the most optimal way.
@@ -1146,7 +1155,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
             if (!jcp_.is_oc_scale) {
                 uni_vbroadcastss(vmm_scales_tmp_, ptr[reg_wei_scales_]);
             } else {
-                const int scale_offset = jcp_.is_oc_scale
+                const dim_t scale_offset = jcp_.is_oc_scale
                         * (sizeof(float) * ocb * jcp_.oc_block);
                 if (mask_flag) {
                     uni_vpxor(
@@ -1184,18 +1193,18 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         // after scales are processed.
         const auto vmm_bias_ = vmm_tmp_;
         if (jcp_.with_bias) {
-            int bias_offset = jcp_.typesize_bia * ocb * jcp_.oc_block;
+            dim_t bias_offset = jcp_.typesize_bia * ocb * jcp_.oc_block;
             cvt2ps(jcp_.bia_dt, vmm_bias_, reg_bias_, bias_offset,
                     mask_flag ? get_tail_size() : get_blocking_size());
         }
 
         if (jcp_.signed_input) {
-            const int comp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
             cvt2ps(data_type::s32, vmm_comp_, reg_compensation_, comp_offset,
                     mask_flag ? get_tail_size() : get_blocking_size());
         }
 
-        for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const Vmm vmm = vmm_out(ur, ocb);
             uni_vcvtdq2ps(vmm, vmm);
             if (jcp_.signed_input) uni_vaddps(vmm, vmm, vmm_comp_);
@@ -1218,8 +1227,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         mov(reg_dst_scales_, ptr[param1_ + GET_OFF(dst_scales)]);
         uni_vbroadcastss(vmm_dst_scales_, ptr[reg_dst_scales_]);
 
-        for_(int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
-        for (int ur = 0; ur < ur_w; ur++) {
+        for_(dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const auto vmm = vmm_out(ur, ocb);
             uni_vmulps(vmm, vmm, vmm_dst_scales_);
         }
@@ -1231,8 +1240,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         uni_vbroadcastss(vmm_zp_dst, ptr[reg_zp_dst_]);
         uni_vcvtdq2ps(vmm_zp_dst, vmm_zp_dst);
 
-        for_(int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
-        for (int ur = 0; ur < ur_w; ur++) {
+        for_(dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const auto vmm_dst = vmm_out(ur, ocb);
             uni_vaddps(vmm_dst, vmm_dst, vmm_zp_dst);
         }
@@ -1245,8 +1254,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     // saturation will happen when storing data
     if (jcp_.dst_dt == data_type::u8) {
         uni_vpxor(vmm_zero_, vmm_zero_, vmm_zero_);
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vmaxps(vmm, vmm, vmm_zero_);
             }
@@ -1260,8 +1269,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         uni_vmovq(xmm_saturation, reg_ptr_saturation_ubound_);
         uni_vbroadcastss(vmm_saturation_, xmm_saturation);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vminps(vmm, vmm, vmm_saturation_);
             }
@@ -1269,8 +1278,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     }
 
     if (one_of(jcp_.dst_dt, data_type::u8, data_type::s8, data_type::s32)) {
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vcvtps2dq(vmm, vmm);
             }
@@ -1278,24 +1287,26 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     }
 
     /* write out register to output_addr */
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-        for (int ur = 0; ur < ur_w; ur++) {
-            const int aux_dst_off = jcp_.typesize_out
+        for (dim_t ur = 0; ur < ur_w; ur++) {
+            const dim_t aux_dst_off = jcp_.typesize_out
                     * (ur * jcp_.ngroups * jcp_.oc_without_padding
                             + ocb * jcp_.oc_block);
             const Vmm r_vmm = vmm_out(ur, ocb);
-            store_data(jcp_.dst_dt, r_vmm, reg_dst_, aux_dst_off,
-                    mask_flag ? get_tail_size() : get_blocking_size());
+            store_data(jcp_.dst_dt, r_vmm, reg_dst_,
+                    static_cast<int>(aux_dst_off),
+                    static_cast<int>(
+                            mask_flag ? get_tail_size() : get_blocking_size()));
         }
     }
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
-        int ur_w, int l_overflow, int r_overflow, bool is_last_sp_block) {
+        dim_t ur_w, dim_t l_overflow, dim_t r_overflow, bool is_last_sp_block) {
 
-    const int shift_src_icb = jcp_.typesize_in * jcp_.ic_block;
+    const dim_t shift_src_icb = jcp_.typesize_in * jcp_.ic_block;
     const size_t shift_filt_icb = (size_t)jcp_.typesize_in * jcp_.kd * jcp_.kh
             * jcp_.kw * jcp_.ic_block * jcp_.oc_block;
 
@@ -1387,22 +1398,22 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     mov(reg_filt_, ptr[param1_ + GET_OFF(filt)]);
     mov(reg_dst_, ptr[param1_ + GET_OFF(dst)]);
 
-    const int dst_shift = jcp_.typesize_out * jcp_.ur_w * jcp_.ngroups
+    const dim_t dst_shift = jcp_.typesize_out * jcp_.ur_w * jcp_.ngroups
             * jcp_.oc_without_padding;
-    const int src_shift = jcp_.typesize_in * (jcp_.ur_w / jcp_.stride_w)
+    const dim_t src_shift = jcp_.typesize_in * (jcp_.ur_w / jcp_.stride_w)
             * jcp_.ngroups * jcp_.ic_without_padding;
 
-    const int l_overflow = max(0,
+    const dim_t l_overflow = max<dim_t>(0,
             ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - jcp_.l_pad) / jcp_.stride_w);
-    const int r_overflow = max(0,
-            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - max(0, jcp_.r_pad))
+    const dim_t r_overflow = max<dim_t>(0,
+            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - max<dim_t>(0, jcp_.r_pad))
                     / jcp_.stride_w);
 
-    const int r_overflow1 = nstl::max(0,
-            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - nstl::max(0, jcp_.r_pad)
-                    - jcp_.ur_w_tail)
+    const dim_t r_overflow1 = nstl::max<dim_t>(0,
+            ((jcp_.kw - 1) * (jcp_.dilate_w + 1)
+                    - nstl::max<dim_t>(0, jcp_.r_pad) - jcp_.ur_w_tail)
                     / jcp_.stride_w);
-    int nur_w = jcp_.ow / jcp_.ur_w;
+    dim_t nur_w = jcp_.ow / jcp_.ur_w;
     if (r_overflow1 > 0) nur_w--;
 
     if (jcp_.ur_w == jcp_.ow) {
@@ -1567,8 +1578,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const void *src_scales
             = CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
@@ -1588,9 +1599,10 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * nb_groups * oc_chunks;
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks;
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_deconv_args_t();
 
@@ -1605,7 +1617,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0};
+        dim_t n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks);
         else if (jcp.loop_order == loop_cgn)
@@ -1614,10 +1626,10 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
 
             p.dst = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             p.src = src + src_d.blk_off(n, g_ic);
@@ -1692,8 +1704,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const size_t src_h_stride = src_d.blk_off(0, 0, 1);
     const size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -1717,9 +1729,10 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_deconv_args_t();
 
@@ -1735,7 +1748,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     oh_s, jcp.oh);
@@ -1746,12 +1759,12 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
-            const int work_rem = end - start;
-            const int oh_e
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t work_rem = end - start;
+            const dim_t oh_e
                     = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
 
             const auto dst_w = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
@@ -1763,17 +1776,18 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             const int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    const int dilate_h = jcp.dilate_h + 1;
+                    const dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    const int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    const dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    const int o_b_overflow
-                            = div_up(max(0,
+                    const dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1781,15 +1795,16 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    const int o_t_overflow = max(
+                    const dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    const int o_b_overflow = max(0,
+                    const dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    const int overflow_kh_hi = jcp.kh - 1
+                    const dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    const int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    const dim_t overflow_kh_lo
+                            = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1797,21 +1812,21 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                const int wei_stride
+                const dim_t wei_stride
                         = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
-                p.src = src_w + ih_max * src_h_stride;
+                p.src = src_w + static_cast<size_t>(ih_max * src_h_stride);
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
-                p.filt = wht_w + wei_stride;
+                p.filt = wht_w + static_cast<size_t>(wei_stride);
                 p.bias = bias_w;
                 p.compensation = compensation_w;
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
@@ -1881,8 +1896,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int &nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t &nb_groups = jcp.nb_ch;
 
     const size_t src_d_stride = src_d.blk_off(0, 0, 1);
     const size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);
@@ -1909,9 +1924,11 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
-        balance211(work_amount, nthr, ithr, start, end);
+        dim_t start_i {0}, end_i {0};
+        const dim_t work_amount
+                = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
+        balance211(work_amount, nthr, ithr, start_i, end_i);
+        dim_t start = start_i, end = end_i;
 
         auto p = jit_deconv_args_t();
 
@@ -1927,7 +1944,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     od_s, jcp.od, oh_s, jcp.oh);
@@ -1938,25 +1955,26 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
-            const int work_rem = end - start;
-            const int oh_e
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t work_rem = end - start;
+            const dim_t oh_e
                     = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-            int input_d_s = 0, kd_len = 0, kd_lo = 0;
-            int d_t_overflow, d_back_overflow;
+            dim_t input_d_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t d_t_overflow, d_back_overflow;
 
             if (jcp.dilate_d != 0 && jcp.stride_d == 1) {
                 /* dilation */
-                int dilate_d = jcp.dilate_d + 1;
+                const dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
                 d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
                         dilate_d);
                 d_back_overflow
-                        = div_up(max(0,
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.od
                                                  + od_s - jcp.back_pad),
                                 dilate_d);
@@ -1964,15 +1982,15 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                 kd_lo = d_back_overflow;
                 input_d_s = od_s + jcp.f_pad - d_back_overflow * dilate_d;
             } else {
-                const int d_t_overflow = max(
+                const dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - (od_s + 1 + jcp.f_pad)) / jcp.stride_d);
-                const int d_back_overflow = max(0,
+                const dim_t d_back_overflow = max<dim_t>(0,
                         ((od_s + jcp.kd) - (jcp.od + jcp.back_pad))
                                 / jcp.stride_d);
-                const int overflow_kd_hi = jcp.kd - 1
+                const dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(jcp.od + jcp.back_pad - (od_s + 1),
                                 jcp.stride_d);
-                const int overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
+                const dim_t overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_back_overflow;
@@ -1994,17 +2012,18 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             const int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    const int dilate_h = jcp.dilate_h + 1;
+                    const dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    const int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    const dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    const int o_b_overflow
-                            = div_up(max(0,
+                    const dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -2012,15 +2031,16 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    const int o_t_overflow = max(
+                    const dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    const int o_b_overflow = max(0,
+                    const dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    const int overflow_kh_hi = jcp.kh - 1
+                    const dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    const int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    const dim_t overflow_kh_lo
+                            = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -2028,32 +2048,32 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                const int wei_stride
+                const dim_t wei_stride
                         = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
-                p.src = src_w + ih_max * src_h_stride;
+                p.src = src_w + static_cast<size_t>(ih_max * src_h_stride);
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
-                p.filt = wht_w + wei_stride;
+                p.filt = wht_w + static_cast<size_t>(wei_stride);
                 p.bias = bias_w;
                 p.compensation = compensation_w;
                 /* Note: Currently this kernel doesn't support dilations and
                 strides together */
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kd
                                           - (kd_lo
-                                                  + max(0, kd_len - 1)
+                                                  + max<dim_t>(0, kd_len - 1)
                                                           * jcp.stride_d
                                                   + 1));
                 p.back_overflow = kd_lo;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -123,32 +123,33 @@ private:
     const Vmm vmm_prev_dst_ = vmm_zero_;
     const Vmm vmm_sum_zp_ = vmm_tmp_;
 
-    Vmm vmm_out(int i_ur, int i_oc) const;
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) const;
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) const;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) const;
 
-    int get_ow_start(int ki, int l_overflow) const noexcept;
-    int get_ow_end(int ur_w, int ki, int r_overflow) const noexcept;
-    int get_blocking_size() const noexcept;
-    int get_tail_size() const noexcept;
+    dim_t get_ow_start(dim_t ki, dim_t l_overflow) const noexcept;
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t r_overflow) const noexcept;
+    dim_t get_blocking_size() const noexcept;
+    dim_t get_tail_size() const noexcept;
 
-    void prepare_output(int ur_w);
-    void apply_postops(int ur_w, bool last_oc_block, const float *p_sum_scale,
+    void prepare_output(dim_t ur_w);
+    void apply_postops(dim_t ur_w, bool last_oc_block, const float *p_sum_scale,
             const int32_t *p_sum_zp);
-    void store_output(int ur_w, bool last_oc_block);
-    void compute_ker(int ur_w, int l_overflow, int r_overflow,
+    void store_output(dim_t ur_w, bool last_oc_block);
+    void compute_ker(dim_t ur_w, dim_t l_overflow, dim_t r_overflow,
             ker_block_t last_ic_block_flag, bool h_padded = false);
     void compute(const Vmm vreg_acc, const Vmm vreg_wei, const Vmm vreg_src);
     std::function<Vmm()> prepare_round_robin_vmm_inp_generator(
-            int ur_w) const noexcept;
+            dim_t ur_w) const noexcept;
     void apply_zp_src_pad_str_comp(
-            int ur_w, int l_overflow, int r_overflow, bool h_padded);
-    void append_zp_src_pad_str_comp(int ur_w, int l_overflow, int r_overflow,
-            bool h_padded, bool last_oc_block);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ker_block_t last_ker_block);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool last_block);
+            dim_t ur_w, dim_t l_overflow, dim_t r_overflow, bool h_padded);
+    void append_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+            dim_t r_overflow, bool h_padded, bool last_oc_block);
+    void kh_loop(
+            dim_t ur_w, dim_t pad_l, dim_t pad_r, ker_block_t last_ker_block);
+    void icb_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r, bool last_block);
     void generate() override;
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Reg64 reg,
-            int offset, int load_size);
+            dim_t offset, dim_t load_size);
 };
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/lrn/jit_uni_lrn.cpp
+++ b/src/cpu/x64/lrn/jit_uni_lrn.cpp
@@ -37,7 +37,7 @@ static dnnl_dim_t compute_n_summands(
         dnnl_dim_t size, int ndims, const dnnl_alg_kind_t &alg_kind) {
     return alg_kind == alg_kind::lrn_across_channels
             ? size
-            : std::pow(size, ndims - 2);
+            : static_cast<dnnl_dim_t>(std::pow(size, ndims - 2));
 }
 
 template <cpu_isa_t isa, data_type_t d_type>
@@ -54,11 +54,11 @@ template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_lrn_fwd_t<isa, d_type>::init(engine_t *engine) {
     using namespace alg_kind;
 
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
+    const int C = static_cast<int>(pd()->C());
+    const int H = static_cast<int>(pd()->H());
+    const int W = static_cast<int>(pd()->W());
     const int ndims = memory_desc_wrapper(pd()->src_md()).ndims();
-    const int ls = pd()->desc()->local_size;
+    const int ls = static_cast<int>(pd()->desc()->local_size);
     const float K = pd()->desc()->lrn_k;
     const auto pk = pd()->desc()->prop_kind;
     const auto ak = pd()->desc()->alg_kind;
@@ -109,10 +109,10 @@ status_t jit_uni_lrn_fwd_t<isa, d_type>::execute_forward(
     auto ws = CTX_OUT_CLEAN_MEM(data_t *, DNNL_ARG_WORKSPACE, status);
     CHECK(status);
 
-    const int N = pd()->MB();
-    const int C = pd()->C();
-    const int HW = pd()->H() * pd()->W();
-    const int ls = pd()->desc()->local_size;
+    const dim_t N = pd()->MB();
+    const dim_t C = pd()->C();
+    const dim_t HW = pd()->H() * pd()->W();
+    const dim_t ls = pd()->desc()->local_size;
 
     const auto ak = pd()->desc()->alg_kind;
     const auto dat_tag = pd()->dat_tag_;
@@ -196,7 +196,7 @@ status_t jit_uni_lrn_fwd_t<isa, d_type>::pd_t::init(engine_t *engine) {
     dat_tag_ = memory_desc_matches_one_of_tag(
             *src_md(), nChw16c, nChw8c, nchw, nhwc);
 
-    const int HW = src_d.dims()[2] * src_d.dims()[3];
+    const dim_t HW = src_d.dims()[2] * src_d.dims()[3];
 
     const bool args_ok_across = true && desc()->alg_kind == lrn_across_channels
             && desc()->local_size == 5 && one_of(dat_tag_, nChw8c, nchw, nhwc)
@@ -245,10 +245,10 @@ jit_uni_lrn_bwd_t<isa, d_type>::~jit_uni_lrn_bwd_t() = default;
 template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_lrn_bwd_t<isa, d_type>::init(engine_t *engine) {
     using namespace alg_kind;
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
-    const int &ls = pd()->desc()->local_size;
+    const int C = static_cast<int>(pd()->C());
+    const int H = static_cast<int>(pd()->H());
+    const int W = static_cast<int>(pd()->W());
+    const int ls = static_cast<int>(pd()->desc()->local_size);
     const auto &ak = pd()->desc()->alg_kind;
     const int ndims = memory_desc_wrapper(pd()->src_md()).ndims();
     const float A = pd()->desc()->lrn_alpha / compute_n_summands(ls, ndims, ak);
@@ -290,10 +290,10 @@ status_t jit_uni_lrn_bwd_t<isa, d_type>::execute_backward(
     auto diff_src = CTX_OUT_CLEAN_MEM(data_t *, DNNL_ARG_DIFF_SRC, status);
     CHECK(status);
 
-    const int N = pd()->MB();
-    const int C = pd()->C();
-    const int H = pd()->H();
-    const int W = pd()->W();
+    const dim_t N = pd()->MB();
+    const dim_t C = pd()->C();
+    const dim_t H = pd()->H();
+    const dim_t W = pd()->W();
     const auto ak = pd()->desc()->alg_kind;
     const auto &dat_tag = pd()->dat_tag_;
 

--- a/src/cpu/x64/lrn/lrn_avx512_blocked_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_blocked_executor.hpp
@@ -36,11 +36,11 @@ public:
         , ker_last_(nullptr)
         , N_(pd->MB())
         , C_(pd->C())
-        , H_(pd->H())
-        , W_(pd->W())
+        , H_(static_cast<int>(pd->H()))
+        , W_(static_cast<int>(pd->W()))
         , use_h_parallelism_(H_ > 28 ? 1 : 0) {
 
-        const int local_size = pd->desc()->local_size;
+        const int local_size = static_cast<int>(pd->desc()->local_size);
         const float alpha = pd->desc()->lrn_alpha / local_size;
         const float beta = pd->desc()->lrn_beta;
         const auto pk = pd->desc()->prop_kind;
@@ -90,13 +90,13 @@ public:
 
         parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
             size_t start {0}, end {0};
-            const int C16 = C_ / vsize_;
+            const dim_t C16 = C_ / vsize_;
             const size_t work_amount
                     = use_h_parallelism_ ? N_ * C16 * H_ : N_ * C16;
 
             balance211(work_amount, nthr, ithr, start, end);
             if (use_h_parallelism_) {
-                int n {0}, c16 {0}, h {0};
+                dim_t n {0}, c16 {0}, h {0};
                 nd_iterator_init(start, n, N_, c16, C16, h, H_);
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     const auto offset = n * C_ * H_ * W_
@@ -123,7 +123,7 @@ public:
                     nd_iterator_step(n, N_, c16, C16, h, H_);
                 }
             } else {
-                int n {0}, c16 {0};
+                dim_t n {0}, c16 {0};
                 nd_iterator_init(start, n, N_, c16, C16);
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     const auto offset
@@ -160,8 +160,8 @@ private:
     std::unique_ptr<lrn::jit_avx512_common_lrn_kernel_fwd_blocked_t<d_type>>
             ker_, ker_first_, ker_last_;
     static constexpr int vsize_ = 16;
-    const int N_;
-    const int C_;
+    const dim_t N_;
+    const dim_t C_;
     const int H_;
     const int W_;
     const int use_h_parallelism_;
@@ -176,11 +176,11 @@ public:
         , ker_last_(nullptr)
         , N_(pd->MB())
         , C_(pd->C())
-        , H_(pd->H())
-        , W_(pd->W())
+        , H_(static_cast<int>(pd->H()))
+        , W_(static_cast<int>(pd->W()))
         , use_h_parallelism_(H_ > 28 ? 1 : 0) {
 
-        const int local_size = pd->desc()->local_size;
+        const int local_size = static_cast<int>(pd->desc()->local_size);
         const float alpha = pd->desc()->lrn_alpha / local_size;
         const float beta = pd->desc()->lrn_beta;
 
@@ -229,13 +229,13 @@ public:
 
         parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
             size_t start {0}, end {0};
-            const int C16 = C_ / vsize_;
+            const dim_t C16 = C_ / vsize_;
             const size_t work_amount
                     = use_h_parallelism_ ? N_ * C16 * H_ : N_ * C16;
 
             balance211(work_amount, nthr, ithr, start, end);
             if (use_h_parallelism_) {
-                int n {0}, c16 {0}, h {0};
+                dim_t n {0}, c16 {0}, h {0};
                 nd_iterator_init(start, n, N_, h, H_, c16, C16);
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     const auto offset = n * C_ * H_ * W_
@@ -263,7 +263,7 @@ public:
                     nd_iterator_step(n, N_, h, H_, c16, C16);
                 }
             } else {
-                int n {0}, c16 {0};
+                dim_t n {0}, c16 {0};
                 nd_iterator_init(start, n, N_, c16, C16);
                 for (size_t iwork = start; iwork < end; ++iwork) {
                     const auto offset
@@ -301,8 +301,8 @@ private:
     std::unique_ptr<lrn::jit_avx512_common_lrn_kernel_bwd_blocked_t<d_type>>
             ker_, ker_first_, ker_last_;
     static constexpr int vsize_ = 16;
-    const int N_;
-    const int C_;
+    const dim_t N_;
+    const dim_t C_;
     const int H_;
     const int W_;
     const int use_h_parallelism_;

--- a/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
+++ b/src/cpu/x64/lrn/lrn_avx512_nhwc_executor.hpp
@@ -32,11 +32,11 @@ class lrn_avx512_nhwc_executor_fwd_t : public i_lrn_executor_t {
 public:
     lrn_avx512_nhwc_executor_fwd_t(const PD_T *pd)
         : ker_(utils::make_unique<
-                  lrn::jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>>(pd->C(),
-                  pd->desc()->prop_kind,
+                  lrn::jit_avx512_common_lrn_kernel_fwd_nhwc_t<d_type>>(
+                  static_cast<unsigned>(pd->C()), pd->desc()->prop_kind,
                   pd->desc()->lrn_alpha / pd->desc()->local_size,
                   pd->desc()->lrn_beta, pd->desc()->lrn_k,
-                  pd->desc()->local_size))
+                  static_cast<int>(pd->desc()->local_size)))
         , N_(pd->MB())
         , C_(pd->C())
         , H_(pd->H())
@@ -88,9 +88,11 @@ class lrn_avx512_nhwc_executor_bwd_t : public i_lrn_executor_t {
 public:
     lrn_avx512_nhwc_executor_bwd_t(const PD_T *pd)
         : ker_ {utils::make_unique<
-                  lrn::jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>>(pd->C(),
+                  lrn::jit_avx512_common_lrn_kernel_bwd_nhwc_t<d_type>>(
+                  static_cast<unsigned>(pd->C()),
                   pd->desc()->lrn_alpha / pd->desc()->local_size,
-                  pd->desc()->lrn_beta, pd->desc()->local_size)}
+                  pd->desc()->lrn_beta,
+                  static_cast<int>(pd->desc()->local_size))}
         , N_(pd->MB())
         , C_(pd->C())
         , H_(pd->H())

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.cpp
@@ -133,7 +133,7 @@ bool matmul_amx_blocking_params_macro_t::divs_are_acceptable() const {
                 = rnd_up(n_per_thread, n_tmul) < min_mn_elem && nthr_n_ > 1;
     }
 
-    bool unacceptable_b_div = nthr_b_ > (size_t)batch;
+    bool unacceptable_b_div = nthr_b_ > batch;
     if (nthr_k_ > 1 && calculate_compensations_in_copy_routines()) {
         // If we have to calculate compensations in copy routines,
         // we cannot split K dimension
@@ -202,12 +202,14 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         best_blocking.n_decomposition
                 = nstl::min(bgmmc.N, (dim_t)bgmmc.wei_n_blk);
         best_blocking.m_decomposition = bgmmc.M;
-        uint32_t n_per_core = div_up(bgmmc.N, bgmmc.nthr);
+        dim_t n_per_core = div_up(bgmmc.N, bgmmc.nthr);
         n_per_core = rnd_up(n_per_core, best_blocking.n_decomposition);
-        best_blocking.set_core_divs(1, 1, 1, div_up(bgmmc.N, n_per_core));
+        best_blocking.set_core_divs(
+                1, 1, 1, static_cast<int>(div_up(bgmmc.N, n_per_core)));
 
-        if (best_blocking.nthr_n_
-                < core_utilization_threshold * best_blocking.nthr) {
+        if (static_cast<float>(best_blocking.nthr_n_)
+                < core_utilization_threshold
+                        * static_cast<float>(best_blocking.nthr)) {
             return false;
         }
         best_blocking.m_blk_ = bgmmc.M;
@@ -235,13 +237,15 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
 
     } else if (bgmmc.K <= best_blocking.wei_k_blk && bgmmc.batch == 1) {
 
-        const uint32_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
-        best_blocking.set_core_divs(1, div_up(bgmmc.M, m_per_core), 1, 1);
+        const dim_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
+        best_blocking.set_core_divs(
+                1, static_cast<int>(div_up(bgmmc.M, m_per_core)), 1, 1);
         best_blocking.set_tmul_sizes();
         best_blocking.set_decomposition();
 
-        if (best_blocking.nthr_m_
-                < core_utilization_threshold * best_blocking.nthr) {
+        if (static_cast<float>(best_blocking.nthr_m_)
+                < core_utilization_threshold
+                        * static_cast<float>(best_blocking.nthr)) {
             return false;
         }
         best_blocking.m_blk_ = best_blocking.m_decomposition;
@@ -270,7 +274,7 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
 
     } else if (bgmmc.N <= 32 && bgmmc.batch == 1) {
 
-        const uint32_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
+        const dim_t m_per_core = div_up(bgmmc.M, bgmmc.nthr);
 
         best_blocking.m_per_thread = m_per_core;
         // in this case 2 full are preferable
@@ -284,10 +288,11 @@ bool matmul_amx_blocking_params_macro_t::maybe_small_dims_heuristics(
         const size_t m_per_core_actual = rnd_up(
                 best_blocking.m_per_thread, best_blocking.m_decomposition);
         best_blocking.set_core_divs(
-                1, div_up(bgmmc.M, m_per_core_actual), 1, 1);
+                1, static_cast<int>(div_up(bgmmc.M, m_per_core_actual)), 1, 1);
 
-        if (best_blocking.nthr_m_
-                < core_utilization_threshold * best_blocking.nthr) {
+        if (static_cast<float>(best_blocking.nthr_m_)
+                < core_utilization_threshold
+                        * static_cast<float>(best_blocking.nthr)) {
             return false;
         }
 
@@ -327,8 +332,7 @@ bool matmul_amx_blocking_params_macro_t::find_best_blocking(
 
     if (maybe_small_dims_heuristics(bgmmc, best_blocking)) { return true; }
 
-    for (size_t nthr_to_check = bgmmc.nthr; nthr_to_check > 0;
-            nthr_to_check--) {
+    for (int nthr_to_check = bgmmc.nthr; nthr_to_check > 0; nthr_to_check--) {
         current_blocking.nthr_ = nthr_to_check;
 
         for (int b_div = 1; b_div <= current_blocking.nthr_; ++b_div) {
@@ -420,82 +424,92 @@ void matmul_amx_blocking_params_macro_t::calculate_layer_sizes(
         size_t strip_dst_size = m_decomposition * n_per_thread
                 * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
         // Amount of compute
-        layer_perf_characteristics.num_tmuls_per_strip = m_decomposition
-                * k_per_thread * n_per_thread / (m_tmul * k_tmul * n_tmul);
+        layer_perf_characteristics.num_tmuls_per_strip
+                = static_cast<float>(m_decomposition * k_per_thread
+                        * n_per_thread / (m_tmul * k_tmul * n_tmul));
         // Amount of strips in the execution
         layer_perf_characteristics.num_strip
-                = div_up(m_per_thread, m_decomposition);
+                = static_cast<float>(div_up(m_per_thread, m_decomposition));
         // B is blocked to the L2 in horizontal traversal, its loads are NT
         layer_perf_characteristics.nt_mat_l1_miss
-                = layer_perf_characteristics.b_size;
+                = static_cast<float>(layer_perf_characteristics.b_size);
         // Number of times A is reused from L1 in a strip
-        layer_perf_characteristics.l1_reuse = div_up(n_blk_, n_decomposition);
+        layer_perf_characteristics.l1_reuse
+                = static_cast<float>(div_up(n_blk_, n_decomposition));
 
         // In horizontal multiple cores load the same B to L2
         layer_perf_characteristics.strip_1_size_shared
-                = layer_perf_characteristics.b_size;
+                = static_cast<float>(layer_perf_characteristics.b_size);
         // In strip 1 there is no sharing of A since there are no prefetches
         size_t strip_1_size_private_a
                 = m_decomposition * k_per_thread * gemm_dt_sz;
         layer_perf_characteristics.strip_1_size_private
-                = strip_1_size_private_a + strip_dst_size;
+                = static_cast<float>(strip_1_size_private_a + strip_dst_size);
         // The cores that share B
-        layer_perf_characteristics.strip_1_share_coef = nthr_m_;
+        layer_perf_characteristics.strip_1_share_coef
+                = static_cast<float>(nthr_m_);
 
         // In the mid strips B is reused from L2 and
         // A is prefetched by multiple cores.
-        layer_perf_characteristics.strip_mid_size_shared = m_decomposition
-                * k_per_thread * gemm_dt_sz; // A size per strip
+        layer_perf_characteristics.strip_mid_size_shared
+                = static_cast<float>(m_decomposition * k_per_thread
+                        * gemm_dt_sz); // A size per strip
         // C is private to a core, since each core writes to a distinct buffer
-        layer_perf_characteristics.strip_mid_size_private = strip_dst_size;
+        layer_perf_characteristics.strip_mid_size_private
+                = static_cast<float>(strip_dst_size);
         // share_coeff - the cores that share A
         layer_perf_characteristics.strip_mid_share_coef
-                = std::max((size_t)1, nthr_n_);
+                = static_cast<float>(std::max(1, nthr_n_));
 
         // Calculate the number of cache lines to be processed in AVX postops
-        layer_perf_characteristics.num_postop_cache_lines
-                = m_decomposition * div_up(n_per_thread, n_tmul);
+        layer_perf_characteristics.num_postop_cache_lines = static_cast<float>(
+                m_decomposition * div_up(n_per_thread, n_tmul));
 
     } else {
         // Amount of C/D bytes that are written per core
         size_t strip_dst_size = n_decomposition * m_per_thread
                 * (nthr_k_ == 1 ? c_dt_sz : acc_dt_sz);
         // Amount of compute
-        layer_perf_characteristics.num_tmuls_per_strip = n_decomposition
-                * k_per_thread * m_per_thread / (m_tmul * k_tmul * n_tmul);
+        layer_perf_characteristics.num_tmuls_per_strip
+                = static_cast<float>(n_decomposition * k_per_thread
+                        * m_per_thread / (m_tmul * k_tmul * n_tmul));
         // Amount of strips in the execution
         layer_perf_characteristics.num_strip
-                = div_up(n_per_thread, n_decomposition);
+                = static_cast<float>(div_up(n_per_thread, n_decomposition));
         // A is blocked to the L2 in vertical traversal, its loads are NT
         layer_perf_characteristics.nt_mat_l1_miss
-                = layer_perf_characteristics.a_size;
+                = static_cast<float>(layer_perf_characteristics.a_size);
         // Number of times B is reused from L1 in a strip
-        layer_perf_characteristics.l1_reuse = div_up(m_blk_, m_decomposition);
+        layer_perf_characteristics.l1_reuse
+                = static_cast<float>(div_up(m_blk_, m_decomposition));
 
         // In vertical multiple cores load the same A to L2
         layer_perf_characteristics.strip_1_size_shared
-                = layer_perf_characteristics.a_size;
+                = static_cast<float>(layer_perf_characteristics.a_size);
         // In strip 1 there is no sharing of B since there are no prefetches
         size_t strip_1_size_private_b
                 = n_decomposition * k_per_thread * gemm_dt_sz;
         layer_perf_characteristics.strip_1_size_private
-                = strip_1_size_private_b + strip_dst_size;
+                = static_cast<float>(strip_1_size_private_b + strip_dst_size);
         // The cores that share A
-        layer_perf_characteristics.strip_1_share_coef = nthr_n_;
+        layer_perf_characteristics.strip_1_share_coef
+                = static_cast<float>(nthr_n_);
 
         // In the mid strips A is reused from L2 and
         // B is prefetched by multiple cores.
-        layer_perf_characteristics.strip_mid_size_shared = n_decomposition
-                * k_per_thread * gemm_dt_sz; // B size per strip
+        layer_perf_characteristics.strip_mid_size_shared
+                = static_cast<float>(n_decomposition * k_per_thread
+                        * gemm_dt_sz); // B size per strip
         // C is private to a core, since each core writes to a distinct buffer
-        layer_perf_characteristics.strip_mid_size_private = strip_dst_size;
+        layer_perf_characteristics.strip_mid_size_private
+                = static_cast<float>(strip_dst_size);
         // share_coeff - the cores that share B
         layer_perf_characteristics.strip_mid_share_coef
-                = std::max((size_t)1, nthr_m_);
+                = static_cast<float>(std::max(1, nthr_m_));
 
         // Calculate the number of cache lines to be processed in AVX postops
-        layer_perf_characteristics.num_postop_cache_lines
-                = m_per_thread * div_up(n_decomposition, n_tmul);
+        layer_perf_characteristics.num_postop_cache_lines = static_cast<float>(
+                m_per_thread * div_up(n_decomposition, n_tmul));
     }
 }
 
@@ -511,25 +525,29 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_mid_cycles(
             = layer_perf_characteristics.strip_mid_size_shared
             * (layer_perf_characteristics.l1_reuse - 1);
 
-    float c_elem_per_strip = m_blk_ * n_blk_;
+    float c_elem_per_strip = static_cast<float>(m_blk_ * n_blk_);
 
     // C post write miss in bytes = m_blk_ * (#n_decompositions in BRGEMM) * (#cache lines per n_decomposition) * 64
-    float c_post_write_miss = m_blk_ * div_up(n_blk_, n_decomposition)
-            * rnd_up(n_decomposition * c_dt_sz, 64);
+    float c_post_write_miss
+            = static_cast<float>(m_blk_ * div_up(n_blk_, n_decomposition)
+                    * rnd_up(n_decomposition * c_dt_sz, 64));
     // C post write total in bytes = m_blk_ * (#n_decompositions in BRGEMM) * (#writes per n_decomposition) * 64
-    float c_post_write_total = m_blk_ * div_up(n_blk_, n_decomposition)
-            * div_up(n_decomposition, 16) * 64;
+    float c_post_write_total
+            = static_cast<float>(m_blk_ * div_up(n_blk_, n_decomposition)
+                    * div_up(n_decomposition, 16) * 64);
     float c_post_write_hit = c_post_write_total - c_post_write_miss;
 
-    float c_post_read_c_tmp = c_elem_per_strip * acc_dt_sz;
+    float c_post_read_c_tmp = c_elem_per_strip * static_cast<float>(acc_dt_sz);
 
     float c_tmp_l1_cycles;
     if (k_blk_ == K) {
-        c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+        c_tmp_l1_cycles = static_cast<float>(acc_dt_sz) * c_elem_per_strip
+                * static_cast<float>(k_chunk_size_)
                 / bw_interpolator.l1_load_hit_bw;
     } else {
         // TODO: modify wrt wsp
-        c_tmp_l1_cycles = acc_dt_sz * c_elem_per_strip * k_chunk_size_
+        c_tmp_l1_cycles = static_cast<float>(acc_dt_sz) * c_elem_per_strip
+                * static_cast<float>(k_chunk_size_)
                 / bw_interpolator.l1_store_miss_bw;
     }
 
@@ -555,7 +573,8 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_mid_cycles(
     } else {
         strip_mid_dram = layer_perf_characteristics.strip_mid_size_shared
                         / bw_interpolator.get_bw(
-                                layer_perf_characteristics.strip_mid_share_coef)
+                                static_cast<int>(layer_perf_characteristics
+                                                         .strip_mid_share_coef))
                 + layer_perf_characteristics.strip_mid_size_private
                         / bw_interpolator.get_bw(1);
 
@@ -566,7 +585,8 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_mid_cycles(
     }
 
     float strip_tmul = layer_perf_characteristics.num_tmuls_per_strip
-            * layer_perf_characteristics.num_cycles_per_tmul;
+            * static_cast<float>(
+                    layer_perf_characteristics.num_cycles_per_tmul);
     float avx_insts_per_cache_line
             = calculate_avx_insts_per_cache_line(layer_perf_characteristics);
     float strip_avx = avx_insts_per_cache_line
@@ -585,8 +605,8 @@ float matmul_amx_blocking_params_macro_t::calculate_strip_1_cycles(
             && !layer_perf_characteristics.strip1_a_read_v) {
         // default for vertical and horizontal without b transform
         strip_1_cycles = layer_perf_characteristics.strip_1_size_shared
-                        / bw_interpolator.get_bw(
-                                layer_perf_characteristics.strip_1_share_coef)
+                        / bw_interpolator.get_bw(static_cast<int>(
+                                layer_perf_characteristics.strip_1_share_coef))
                 + layer_perf_characteristics.strip_1_size_private
                         / bw_interpolator.get_bw(1);
     } else if (layer_perf_characteristics.strip1_b_in_mlc_h
@@ -607,8 +627,9 @@ float matmul_amx_blocking_params_macro_t::calculate_reduction_cycles(
 
     if (nthr_k_ != 1) {
         if (c_size_per_core * 2 < L2_threshold() && batch == 1) {
-            float reduction_read_bytes = (M * rnd_up(N, 16) * acc_dt_sz)
-                    * ((nthr_k_ - 1)) / (nthr_m_ * nthr_n_);
+            float reduction_read_bytes
+                    = static_cast<float>((M * rnd_up(N, 16) * acc_dt_sz)
+                            * ((nthr_k_ - 1)) / (nthr_m_ * nthr_n_));
             float reduction_read_cycles;
             if (layer_perf_characteristics.a_size
                             + layer_perf_characteristics.b_size
@@ -621,8 +642,8 @@ float matmul_amx_blocking_params_macro_t::calculate_reduction_cycles(
                         = reduction_read_bytes / bw_interpolator.llc_bw;
             }
 
-            float reduction_write_bytes
-                    = (M * N * c_dt_sz) / (nthr_m_ * nthr_n_);
+            float reduction_write_bytes = static_cast<float>(
+                    (M * N * c_dt_sz) / (nthr_m_ * nthr_n_));
             float reduction_write_cycles
                     = reduction_write_bytes / bw_interpolator.get_bw(1);
             // Add reduction const overhead - measured
@@ -643,7 +664,7 @@ float matmul_amx_blocking_params_macro_t::calculate_avx_insts_per_cache_line(
         layer_perf_characteristics_t &layer_perf_characteristics) const {
     const float down_convert_inst = 4;
     float avx_insts_per_cache_line
-            = down_convert_inst + this->postops_inst_count;
+            = down_convert_inst + static_cast<float>(this->postops_inst_count);
 
     bool has_zp = this->src_zp_type != brgemm_broadcast_t::none
             || this->wei_zp_type != brgemm_broadcast_t::none
@@ -666,26 +687,26 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
 
     float b_transform_cycles_v = layer_perf_characteristics.strips_b_tranform_v
             ? layer_perf_characteristics.strip_mid_size_shared
-                    / bw_interpolator.get_bw(
-                            layer_perf_characteristics.strip_mid_share_coef)
+                    / bw_interpolator.get_bw(static_cast<int>(
+                            layer_perf_characteristics.strip_mid_share_coef))
             : 0;
 
     float b_transform_cycles_h = layer_perf_characteristics.strip1_b_tranform_h
             ? layer_perf_characteristics.strip_1_size_shared
-                    / bw_interpolator.get_bw(
-                            layer_perf_characteristics.strip_1_share_coef)
+                    / bw_interpolator.get_bw(static_cast<int>(
+                            layer_perf_characteristics.strip_1_share_coef))
             : 0;
 
     float a_read_cycles_v = layer_perf_characteristics.strip1_a_read_v
             ? layer_perf_characteristics.strip_1_size_shared
-                    / bw_interpolator.get_bw(
-                            layer_perf_characteristics.strip_1_share_coef)
+                    / bw_interpolator.get_bw(static_cast<int>(
+                            layer_perf_characteristics.strip_1_share_coef))
             : 0;
 
     float a_read_cycles_h = layer_perf_characteristics.strips_a_read_h
             ? layer_perf_characteristics.strip_mid_size_shared
-                    / bw_interpolator.get_bw(
-                            layer_perf_characteristics.strip_mid_share_coef)
+                    / bw_interpolator.get_bw(static_cast<int>(
+                            layer_perf_characteristics.strip_mid_share_coef))
             : 0;
 
     float strip_mid_cycles = calculate_strip_mid_cycles(
@@ -704,11 +725,13 @@ float matmul_amx_blocking_params_macro_t::calculate_blocking_scores() const {
     if (reduction_cycles < 0)
         return 0; //reduction is not feasible, so the score is 0
 
-    float total_macs = M * K * N * batch;
-    float total_cycles = (gemm_cycles + reduction_cycles) * b_per_thread;
+    float total_macs = static_cast<float>(M * K * N * batch);
+    float total_cycles = (gemm_cycles + reduction_cycles)
+            * static_cast<float>(b_per_thread);
 
     int macs_per_cycle_base = 1024;
-    float peak_macs_per_cycle = (macs_per_cycle_base / gemm_dt_sz) * nthr;
+    float peak_macs_per_cycle
+            = static_cast<float>((macs_per_cycle_base / gemm_dt_sz) * nthr);
     float peak_cycles = total_macs / peak_macs_per_cycle;
     return peak_cycles / total_cycles;
 }
@@ -800,7 +823,7 @@ std::set<dim_t> matmul_amx_blocking_params_macro_t::blk_candidates(
 size_t matmul_amx_blocking_params_macro_t::l2_matrix_usage(size_t k_chunk_size,
         size_t m_or_n_blk, size_t k_blk, bool is_horizontal,
         bool force_transform_matrix_to_l2) const {
-    int decomposition = is_horizontal ? m_decomposition : n_decomposition;
+    dim_t decomposition = is_horizontal ? m_decomposition : n_decomposition;
     size_t l1_matrix_size = 2 * decomposition
             * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * gemm_dt_sz; // 2 for prefetch
@@ -846,13 +869,13 @@ size_t matmul_amx_blocking_params_macro_t::l2_matrix_and_c_usage(
     return l1_matrix_size + l2_matrix_size + c_size;
 }
 
-int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
+size_t matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
         size_t k_blk, size_t n_blk, bool is_horizontal) const {
-    int a_bw = m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+    size_t a_bw = m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * gemm_dt_sz;
-    int b_bw = n_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
+    size_t b_bw = n_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * gemm_dt_sz;
-    int c_bw;
+    size_t c_bw;
 
     if ((l2_matrix_and_c_usage(k_chunk_size, is_horizontal ? n_blk : m_blk,
                  k_blk, is_horizontal)
@@ -867,7 +890,7 @@ int matmul_amx_blocking_params_macro_t::bw(size_t m_blk, size_t k_chunk_size,
     return a_bw + b_bw + c_bw;
 }
 
-int matmul_amx_blocking_params_macro_t::compute(
+size_t matmul_amx_blocking_params_macro_t::compute(
         size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk) const {
     return m_blk * nstl::min(k_blk * k_chunk_size, (size_t)k_per_thread)
             * n_blk;
@@ -877,7 +900,8 @@ float matmul_amx_blocking_params_macro_t::ratio(size_t m_blk,
         size_t k_chunk_size, size_t k_blk, size_t n_blk,
         bool is_horizontal) const {
     return static_cast<float>(compute(m_blk, k_chunk_size, k_blk, n_blk))
-            / bw(m_blk, k_chunk_size, k_blk, n_blk, is_horizontal);
+            / static_cast<float>(
+                    bw(m_blk, k_chunk_size, k_blk, n_blk, is_horizontal));
 }
 
 float matmul_amx_blocking_params_macro_t::evaluate_single_core_blocking(
@@ -953,10 +977,9 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
     bool vertical_not_possible = force_horizontal;
 
     auto calc_horizontal = [&](size_t k_blk_h, dim_t min_k_chunk_size = 0) {
-        if (rnd_up(m_per_thread, m_decomposition) * (nthr_m_ - 1)
-                >= (size_t)M) {
+        if (rnd_up(m_per_thread, m_decomposition) * (nthr_m_ - 1) >= M) {
             horizontal_not_possible = true;
-        } else if (rnd_up(k_per_thread, k_blk_h) * (nthr_k_ - 1) >= (size_t)K) {
+        } else if (rnd_up(k_per_thread, k_blk_h) * (nthr_k_ - 1) >= K) {
             // Early exit: There is no possible division of work for nthr_k threads
             horizontal_not_possible = true;
         } else {
@@ -985,11 +1008,10 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
             }
 
             if (rnd_up(n_per_thread, best_n_h * n_decomposition) * (nthr_n_ - 1)
-                    >= (size_t)N) {
+                    >= N) {
                 horizontal_not_possible = true;
             }
-            if (rnd_up(k_per_thread, best_k_h * k_blk_h) * (nthr_k_ - 1)
-                    >= (size_t)K) {
+            if (rnd_up(k_per_thread, best_k_h * k_blk_h) * (nthr_k_ - 1) >= K) {
                 // There is not enough work for nthr_k threads
                 horizontal_not_possible = true;
             }
@@ -1000,10 +1022,9 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
     calc_horizontal(k_blk_h);
 
     auto calc_vertical = [&](size_t k_blk_v, dim_t min_k_chunk_size = 0) {
-        if (rnd_up(n_per_thread, n_decomposition) * (nthr_n_ - 1)
-                >= (size_t)N) {
+        if (rnd_up(n_per_thread, n_decomposition) * (nthr_n_ - 1) >= N) {
             vertical_not_possible = true;
-        } else if (rnd_up(k_per_thread, k_blk_v) * (nthr_k_ - 1) >= (size_t)K) {
+        } else if (rnd_up(k_per_thread, k_blk_v) * (nthr_k_ - 1) >= K) {
             // Early exit: There is no possible division of work for nthr_k threads
             vertical_not_possible = true;
         } else {
@@ -1031,11 +1052,10 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
             }
 
             if (rnd_up(m_per_thread, best_m_v * m_decomposition) * (nthr_m_ - 1)
-                    >= (size_t)M) {
+                    >= M) {
                 vertical_not_possible = true;
             }
-            if (rnd_up(k_per_thread, best_k_v * k_blk_v) * (nthr_k_ - 1)
-                    >= (size_t)K) {
+            if (rnd_up(k_per_thread, best_k_v * k_blk_v) * (nthr_k_ - 1) >= K) {
                 // There is not enough work for nthr_k threads
                 vertical_not_possible = true;
             }
@@ -1052,7 +1072,7 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
             }
             bool repeat_loop_over_k = div_up(K, k_blk_v * best_k_v) != 1;
             bool critical_l2_set_issues_a
-                    = div_up((size_t)K, k_blk_v * best_k_v) != nthr_k_
+                    = div_up(K, k_blk_v * best_k_v) != nthr_k_
                     || (size_t)((l2_util_v * nthr_k_)) >= L2_threshold();
 
             if (repeat_loop_over_k && critical_l2_set_issues_a)
@@ -1095,7 +1115,8 @@ bool matmul_amx_blocking_params_macro_t::set_blocking_parameters(
         // If the number of cycles for postops per cache line is larger than
         // the number of AMX cycles per cache line, then the calculation is
         // postops bound.
-        return postops_inst_count / avx_ipc > div_up(k_blk, k_tmul);
+        return static_cast<float>(postops_inst_count) / avx_ipc
+                > static_cast<float>(div_up(k_blk, k_tmul));
     };
 
     if (is_horizontal) {
@@ -1272,7 +1293,8 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
     const bool runtime_dims
             = bgmmc.is_runtime_M || bgmmc.is_runtime_N || bgmmc.is_runtime_K;
     const int max_nthr_k = !runtime_dims && is_amx_xf16 && bgmmc.batch == 1
-            ? nstl::min(saturate(1, 7, bgmmc.nthr / 8), max_k_parallel_work)
+            ? nstl::min<int>(
+                      saturate<int>(1, 7, bgmmc.nthr / 8), max_k_parallel_work)
             : 1;
     int iter = 0;
     const int runtime_M_chunk = bgmmc.lda_big_pow2() ? 2 : 4;
@@ -1287,37 +1309,38 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
     for (int nthr_k = 1; nthr_k <= max_nthr_k; nthr_k++) {
         int nthr_bmn = bgmmc.nthr / nthr_k;
 
-        int num_M_blk = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, bgmmc.M_blk);
-        int num_N_blk = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, bgmmc.N_blk);
-        int k_parallel_work = nstl::min(max_k_parallel_work, nthr_k);
-        int num_parallel_work
+        dim_t num_M_blk = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, bgmmc.M_blk);
+        dim_t num_N_blk = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, bgmmc.N_blk);
+        dim_t k_parallel_work = nstl::min<dim_t>(max_k_parallel_work, nthr_k);
+        dim_t num_parallel_work
                 = bgmmc.batch * num_M_blk * num_N_blk * k_parallel_work;
         const bool a_lot_of_parallel_work_lvl2
                 = num_parallel_work > 16 * bgmmc.nthr;
-        const bool low_parallelism
-                = static_cast<float>(num_parallel_work) < 1.5f * bgmmc.nthr;
+        const bool low_parallelism = static_cast<float>(num_parallel_work)
+                < 1.5f * static_cast<float>(bgmmc.nthr);
         const bool maybe_low_blocking
                 = is_amx_int8 && bm_conf_utils.maybe_low_brg_blocking();
-        const int min_M_blk = !bgmmc.is_runtime_M
+        const dim_t min_M_blk = !bgmmc.is_runtime_M
                         && (maybe_low_blocking || low_parallelism)
                         && bgmmc.M_blk > 32
                 ? div_up(bgmmc.M_blk, 2)
                 : bgmmc.M_blk;
-        const int min_N_blk = !bgmmc.is_runtime_N && low_parallelism
+        const dim_t min_N_blk = !bgmmc.is_runtime_N && low_parallelism
                         && is_amx_xf16 && !bm_conf_utils.check_n_blk_fixed()
                         && bgmmc.N_blk > 32 && !runtime_dims
                         && !bgmmc.transposed_B // Transposed copy B kernel doesn't support adjusting N_blk
                 ? 32
                 : bgmmc.N_blk;
-        const int desired_M_chunk = bgmmc.is_runtime_M
+        const dim_t desired_M_chunk = bgmmc.is_runtime_M
                 ? runtime_M_chunk
-                : nstl::min(4, num_M_blk);
-        const int desired_N_chunk = bgmmc.is_runtime_N
+                : nstl::min<dim_t>(4, num_M_blk);
+        const dim_t desired_N_chunk = bgmmc.is_runtime_N
                 ? runtime_N_chunk
-                : nstl::min(a_lot_of_parallel_work_lvl2 ? 6 : 4, num_N_blk);
+                : nstl::min<dim_t>(
+                          a_lot_of_parallel_work_lvl2 ? 6 : 4, num_N_blk);
 
-        std::unordered_set<int> mblk_candidates;
-        for (int m_blk = bgmmc.M_blk; m_blk >= min_M_blk;
+        std::unordered_set<dim_t> mblk_candidates;
+        for (dim_t m_blk = bgmmc.M_blk; m_blk >= min_M_blk;
                 m_blk = m_blk > 1 ? div_up(m_blk, 2) : m_blk - 1) {
             if (IMPLICATION(maybe_low_blocking, m_blk != bgmmc.M_blk))
                 mblk_candidates.insert(m_blk);
@@ -1325,20 +1348,20 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
 
         if (!bgmmc.is_runtime_M && bgmmc.M > 16) {
             // Add multiple of 16 M block sizes for consideration
-            const int mul16_m_blk_max
-                    = nstl::min(rnd_dn(static_cast<int>(bgmmc.M), 16), 64);
-            const int mul16_m_blk_min = rnd_up(min_M_blk, 16);
-            for (int m_blk = mul16_m_blk_max; m_blk >= mul16_m_blk_min;
+            const dim_t mul16_m_blk_max
+                    = nstl::min<dim_t>(rnd_dn(bgmmc.M, (dim_t)16), 64);
+            const dim_t mul16_m_blk_min = rnd_up(min_M_blk, (dim_t)16);
+            for (dim_t m_blk = mul16_m_blk_max; m_blk >= mul16_m_blk_min;
                     m_blk -= 16) {
                 mblk_candidates.insert(m_blk);
             }
         }
 
         bool found_best_blocking = false;
-        for_(int n_blk = bgmmc.N_blk; n_blk >= min_N_blk; n_blk -= 16)
-        for_(int m_blk : mblk_candidates)
-        for_(int n_ch_sz = desired_N_chunk; n_ch_sz >= 1; n_ch_sz--)
-        for (int m_ch_sz = desired_M_chunk; m_ch_sz >= 1; m_ch_sz--, iter++) {
+        for_(dim_t n_blk = bgmmc.N_blk; n_blk >= min_N_blk; n_blk -= 16)
+        for_(dim_t m_blk : mblk_candidates)
+        for_(dim_t n_ch_sz = desired_N_chunk; n_ch_sz >= 1; n_ch_sz--)
+        for (dim_t m_ch_sz = desired_M_chunk; m_ch_sz >= 1; m_ch_sz--, iter++) {
             current_blocking.set_blocking_parameters(
                     nthr_k, n_blk, n_ch_sz, m_blk, m_ch_sz);
 
@@ -1348,11 +1371,11 @@ void matmul_amx_blocking_params_micro_t::find_best_blocking(
             // TODO: Verify whether using a chunk count of 1 for runtime M and N is optimal for
             // this heuristic. The previous implementation inadvertently used DNNL_RUNTIME_DIM_VAL
             // for M and N in arithmetic, producing incorrect work_amount values.
-            int m_chunks
+            dim_t m_chunks
                     = bgmmc.is_runtime_M ? 1 : div_up(bgmmc.M, m_blk * m_ch_sz);
-            int n_chunks
+            dim_t n_chunks
                     = bgmmc.is_runtime_N ? 1 : div_up(bgmmc.N, n_blk * n_ch_sz);
-            int work_amount = bgmmc.batch * m_chunks * n_chunks;
+            dim_t work_amount = bgmmc.batch * m_chunks * n_chunks;
 
             bool skip_config = work_amount < nthr_bmn * 3
                     && work_amount % nthr_bmn != 0 && max_nthr_k == 1;
@@ -1381,8 +1404,8 @@ void matmul_amx_blocking_params_micro_t::update_k_blocking_dependent_params() {
     need_buf_c_ = is_buffer_c_required();
 }
 
-void matmul_amx_blocking_params_micro_t::set_blocking_parameters(
-        int nthr_k, int n_blk, int n_chunk_size, int m_blk, int m_chunk_size) {
+void matmul_amx_blocking_params_micro_t::set_blocking_parameters(int nthr_k,
+        dim_t n_blk, dim_t n_chunk_size, dim_t m_blk, dim_t m_chunk_size) {
     nthr_k_ = nstl::max(1, nthr_k);
     nthr_mnb_ = nthr / nthr_k_;
     nthr_ = nthr_mnb_ * nthr_k_;
@@ -1475,26 +1498,33 @@ float matmul_amx_blocking_params_micro_t::get_thread_balance_scores() const {
     assert(!(is_runtime_M && is_runtime_N)
             && "single runtime dim is supported");
     // Ignore M sizes in thread balance computation as actual M size is unknown
-    if (is_runtime_M) return (float)N / rnd_up(N, n_chunk_elems_);
+    if (is_runtime_M)
+        return static_cast<float>(N)
+                / static_cast<float>(rnd_up(N, n_chunk_elems_));
     // Ignore N sizes in thread balance computation as actual N size is unknown
-    if (is_runtime_N) return (float)M / rnd_up(M, m_chunk_elems_);
+    if (is_runtime_N)
+        return static_cast<float>(M)
+                / static_cast<float>(rnd_up(M, m_chunk_elems_));
 
     const dim_t num_M_chunks = div_up(M, m_chunk_elems_);
     const dim_t num_N_chunks = div_up(N, n_chunk_elems_);
-    float mnb_parallel_score = batch * ((float)M / m_chunk_elems_)
-            * ((float)N / n_chunk_elems_)
-            / rnd_up(batch * num_M_chunks * num_N_chunks, nthr_mnb_)
-            * nthr_mnb_;
+    float mnb_parallel_score = static_cast<float>(batch)
+            * (static_cast<float>(M) / static_cast<float>(m_chunk_elems_))
+            * (static_cast<float>(N) / static_cast<float>(n_chunk_elems_))
+            / static_cast<float>(
+                    rnd_up(batch * num_M_chunks * num_N_chunks, nthr_mnb_))
+            * static_cast<float>(nthr_mnb_);
     float k_parallel_score = 1.0f;
     if (nthr_k_ > 1) {
         const dim_t num_K_chunks = div_up(K, k_chunk_elems_);
         const float parallel_reduction_penalty = 0.8f;
         k_parallel_score = parallel_reduction_penalty
-                * ((float)K / k_chunk_elems_) / rnd_up(num_K_chunks, nthr_k_)
-                * nthr_k_;
+                * (static_cast<float>(K) / static_cast<float>(k_chunk_elems_))
+                / static_cast<float>(rnd_up(num_K_chunks, nthr_k_))
+                * static_cast<float>(nthr_k_);
     }
 
-    return mnb_parallel_score * k_parallel_score / nthr;
+    return mnb_parallel_score * k_parallel_score / static_cast<float>(nthr);
 }
 
 // Returns score for current blocking parameters' values in range [0, 1]
@@ -1509,10 +1539,12 @@ float matmul_amx_blocking_params_micro_t::get_copied_data_reusage_scores()
     const dim_t desired_N_chunk_size = is_runtime_N
             ? effective_n_chunk_sz
             : nstl::min(N, effective_n_chunk_sz);
-    const float coef_M = nstl::min(
-            static_cast<float>(m_chunk_elems_) / desired_M_chunk_size, 1.0f);
-    const float coef_N = nstl::min(
-            static_cast<float>(n_chunk_elems_) / desired_N_chunk_size, 1.0f);
+    const float coef_M = nstl::min(static_cast<float>(m_chunk_elems_)
+                    / static_cast<float>(desired_M_chunk_size),
+            1.0f);
+    const float coef_N = nstl::min(static_cast<float>(n_chunk_elems_)
+                    / static_cast<float>(desired_N_chunk_size),
+            1.0f);
     return 0.5f * (coef_M + coef_N);
 }
 
@@ -1520,8 +1552,10 @@ float matmul_amx_blocking_params_micro_t::get_copied_data_reusage_scores()
 // for L2 utilization
 float matmul_amx_blocking_params_micro_t::get_L2_utilization_scores() const {
     const float relative_difference_with_L2
-            = fabsf((float)L2_threshold() - blocking_chunk_mem_size_)
-            / nstl::max(L2_threshold(), blocking_chunk_mem_size_);
+            = fabsf((float)L2_threshold()
+                      - static_cast<float>(blocking_chunk_mem_size_))
+            / static_cast<float>(
+                    nstl::max(L2_threshold(), blocking_chunk_mem_size_));
     return 1.0f - relative_difference_with_L2;
 }
 
@@ -1535,7 +1569,7 @@ float matmul_amx_blocking_params_micro_t::calculate_blocking_scores() const {
                 brgemm_batch_size_))
         return 0.0f;
 
-    const float nthr_coeff = nstl::min(nthr, 100);
+    const float nthr_coeff = static_cast<float>(nstl::min(nthr, 100));
     const float reusage_factor = 1.0f;
     // For runtume M the actual size is unknown, use independent on num_threads
     // balance factors

--- a/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
+++ b/src/cpu/x64/matmul/amx_blocking_heuristics.hpp
@@ -34,7 +34,7 @@ struct layer_perf_characteristics_t {
             nt_mat_l1_miss {0};
     float l1_reuse {0};
     float num_postop_cache_lines {0};
-    int num_cycles_per_tmul {0};
+    dim_t num_cycles_per_tmul {0};
 
     bool strip1_b_tranform_h {false};
     bool strips_b_tranform_v {false};
@@ -48,7 +48,9 @@ class bw_map_t {
 public:
     bw_map_t() = default;
 
-    float get_bw(int x) const { return linear_interpolation(multicore_bw, x); }
+    float get_bw(int x) const {
+        return linear_interpolation(multicore_bw, static_cast<float>(x));
+    }
 
     // All the following bandwidth measurements were taken on an
     // EMR machine with two NUMA domains, each containing 32 cores.
@@ -73,7 +75,7 @@ private:
     float linear_interpolation(
             const std::map<int, float> &points, float x) const {
         // Find the interval [x0, x1] where x0 <= x <= x1
-        auto it = points.lower_bound(x);
+        auto it = points.lower_bound(static_cast<int>(x));
         if (it == points.end()) {
             return points.rbegin()
                     ->second; // x is greater than the largest x in the map
@@ -91,7 +93,9 @@ private:
         float y1 = it1->second;
 
         // Perform linear interpolation
-        return y0 + (y1 - y0) * (x - x0) / (x1 - x0);
+        return y0
+                + (y1 - y0) * (x - static_cast<float>(x0))
+                / static_cast<float>(x1 - x0);
     }
 };
 
@@ -99,10 +103,10 @@ class matmul_amx_blocking_params_t : public brgemm_matmul_conf_t {
 public:
     matmul_amx_blocking_params_t(const brgemm_matmul_conf_t &bgmmc)
         : brgemm_matmul_conf_t(bgmmc)
-        , nthr_m_(nstl::max(nthr_m, 1))
-        , nthr_n_(nstl::max(nthr_n, 1))
-        , nthr_k_(nstl::max(nthr_k, 1))
-        , nthr_b_(nstl::max(nthr_b, 1))
+        , nthr_m_(nstl::max<int>(nthr_m, 1))
+        , nthr_n_(nstl::max<int>(nthr_n, 1))
+        , nthr_k_(nstl::max<int>(nthr_k, 1))
+        , nthr_b_(nstl::max<int>(nthr_b, 1))
         , nthr_mnb_(nthr / nthr_k_)
         , nthr_(nthr_mnb_ * nthr_k_)
         , n_blk_(N_blk)
@@ -140,7 +144,7 @@ protected:
     virtual dim_t get_actual_lda() const;
 
     // Num threads for parallelism wrt K dimension
-    size_t nthr_m_ {0}, nthr_n_ {0}, nthr_k_ {0}, nthr_b_ {0};
+    int nthr_m_ {0}, nthr_n_ {0}, nthr_k_ {0}, nthr_b_ {0};
     // Num threads for parallelism wrt M, N and batch dimensions
     int nthr_mnb_ {0};
     int nthr_ {0};
@@ -218,9 +222,9 @@ private:
     size_t l2_matrix_and_c_usage(size_t k_chunk_size, size_t m_or_n_blk,
             size_t k_blk, bool is_horizontal) const;
     void set_core_divs(int nthr_b, int nthr_m, int nthr_k, int nthr_n);
-    int bw(size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk,
+    size_t bw(size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk,
             bool is_horizontal) const;
-    int compute(size_t m_blk, size_t k_chunk_size, size_t k_blk,
+    size_t compute(size_t m_blk, size_t k_chunk_size, size_t k_blk,
             size_t n_blk) const;
     float ratio(size_t m_blk, size_t k_chunk_size, size_t k_blk, size_t n_blk,
             bool is_horizontal) const;
@@ -260,8 +264,8 @@ public:
     matmul_amx_blocking_params_micro_t(const brgemm_matmul_conf_t &bgmmc)
         : matmul_amx_blocking_params_t(bgmmc) {}
 
-    void set_blocking_parameters(int nthr_k, int n_blk, int n_chunk_size,
-            int m_blk, int m_chunk_size);
+    void set_blocking_parameters(int nthr_k, dim_t n_blk, dim_t n_chunk_size,
+            dim_t m_blk, dim_t m_chunk_size);
 
     static void find_best_blocking(const brgemm_matmul_conf_t &bgmmc,
             const brgemm_matmul_conf_utils_t &bm_conf_utils,

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -47,7 +47,7 @@ using namespace nstl;
 using namespace data_type;
 namespace {
 
-int get_brg_batchsize(
+dim_t get_brg_batchsize(
         const brgemm_matmul_conf_t &bgmmc, bool is_bs_tail, bool is_K_tail) {
     auto bs = is_K_tail  ? 1
             : is_bs_tail ? bgmmc.brgemm_batch_tail_size
@@ -57,7 +57,7 @@ int get_brg_batchsize(
 
 int get_brg_kernel_index(const brgemm_matmul_conf_t &bgmmc, bool is_bs_tail,
         bool do_initialization, int m_ker_idx, int n_ker_idx, bool is_K_tail,
-        int bs, bool is_prefetching) {
+        dim_t bs, bool is_prefetching) {
     const int max_m_ker_idx
             = bgmmc.is_runtime_M ? max_num_dynamic_m_tails + 1 : 2;
     if (m_ker_idx >= max_m_ker_idx) return -1;
@@ -129,7 +129,7 @@ template <cpu_isa_t isa>
 int brgemm_matmul_t<isa>::pd_t::get_brg_kernel_idx(bool is_bs_tail,
         bool do_initialization, int m_ker_idx, int n_ker_idx, bool is_K_tail,
         bool is_prefetching) const {
-    int bs = get_brg_batchsize(bgmmc_, is_bs_tail, is_K_tail);
+    dim_t bs = get_brg_batchsize(bgmmc_, is_bs_tail, is_K_tail);
     return get_brg_kernel_index(bgmmc_, is_bs_tail, do_initialization,
             m_ker_idx, n_ker_idx, is_K_tail, bs, is_prefetching);
 }
@@ -399,7 +399,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                                                     : bgmmc_.N_tail);
         auto vK = (i_K) ? bgmmc_.K_tail : bgmmc_.K_blk;
 
-        int bs = get_brg_batchsize(bgmmc_, i_bs, i_K);
+        dim_t bs = get_brg_batchsize(bgmmc_, i_bs, i_K);
         int idx = get_brg_kernel_idx(i_bs, i_init, i_M, i_N, i_K, prefetching);
         if (idx < 0) continue;
 
@@ -501,7 +501,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
         CHECK(brgemm_desc_finalize(&brg));
 
-        bgmmc_.wsp_tile_per_thr_bytes = nstl::max(
+        bgmmc_.wsp_tile_per_thr_bytes = nstl::max<dim_t>(
                 brg.get_wsp_buffer_size(), bgmmc_.wsp_tile_per_thr_bytes);
     }
 
@@ -589,8 +589,8 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
 }
 
 template <cpu_isa_t isa>
-bool brgemm_matmul_t<isa>::determine_prefetch(const int mb, const int m_end,
-        const int nb, const int n_end, const brgemm_matmul_conf_t &bgmmc,
+bool brgemm_matmul_t<isa>::determine_prefetch(const dim_t mb, const dim_t m_end,
+        const dim_t nb, const dim_t n_end, const brgemm_matmul_conf_t &bgmmc,
         const brg_matmul_exec_ctx_t &brgmm_ctx) const {
     // Prefetch if not the last BRGEMM in the chunk and
     // if the next BRGEMM is identical to the current one.
@@ -633,26 +633,26 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
         const bool use_buffer_a
                 = bgmmc.use_buffer_a || bgmmc.use_buffer_a_tail_only;
         const bool is_amx = is_superset(isa, avx512_core_amx);
-        const int M_chunks = brgmm_ctx.get_M_chunks();
-        const int M_chunk_size = brgmm_ctx.get_M_chunk_size();
-        const int M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
+        const dim_t M_chunks = brgmm_ctx.get_M_chunks();
+        const dim_t M_chunk_size = brgmm_ctx.get_M_chunk_size();
+        const dim_t M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
 
-        const int K_chunks = brgmm_ctx.get_K_chunks();
-        const int K_chunk_size = brgmm_ctx.get_K_chunk_size();
-        const int K_chunk_tail = brgmm_ctx.get_K_chunk_tail();
+        const dim_t K_chunks = brgmm_ctx.get_K_chunks();
+        const dim_t K_chunk_size = brgmm_ctx.get_K_chunk_size();
+        const dim_t K_chunk_tail = brgmm_ctx.get_K_chunk_tail();
 
-        const int N_chunks = brgmm_ctx.get_N_chunks();
-        const int N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
+        const dim_t N_chunks = brgmm_ctx.get_N_chunks();
+        const dim_t N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
 
         const int ithr_bmn = brgmm_ctx.get_thread_idx_for_bmn_gemm(ithr);
         const int ithr_k = brgmm_ctx.get_thread_idx_for_k(ithr);
         if (ithr_bmn < 0 || ithr_k < 0) return;
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(brgmm_ctx.get_parallel_work_amount_gemm(),
                 brgmm_ctx.get_num_threads_for_bmn(), ithr_bmn, start, end);
-        int kc_start {0}, kc_end {bgmmc.K_chunks};
+        dim_t kc_start {0}, kc_end {bgmmc.K_chunks};
         if (brgmm_ctx.parallel_reduction_is_used())
-            balance211((int)bgmmc.K_chunks, brgmm_ctx.get_num_threads_for_k(),
+            balance211(bgmmc.K_chunks, brgmm_ctx.get_num_threads_for_k(),
                     ithr_k, kc_start, kc_end);
 
         int prev_ker_idx = -1;
@@ -667,11 +667,11 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
+        dim_t b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
                 bt {0}, mt {0}, nt {0};
-        int m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
-        int n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
-        int batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
+        dim_t m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
+        dim_t n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
+        dim_t batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
         if (brgmm_ctx.is_chunks_horizontal_process_order())
             nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
                     bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
@@ -699,9 +699,9 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
             b = bt * batch_per_thread + b_per_t;
         };
 
-        int mc_prev = -1;
-        int nb_prev = -1;
-        int b_prev = -1;
+        dim_t mc_prev = -1;
+        dim_t nb_prev = -1;
+        dim_t b_prev = -1;
         const char *a_batch_ptr = nullptr;
         const char *b_batch_ptr = nullptr;
 
@@ -718,12 +718,12 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
             const bool n_chunk_tail = nc == N_chunks - 1 && N_chunk_tail > 0;
             auto n_end = n_start
                     + (n_chunk_tail ? N_chunk_tail : bgmmc.N_chunk_size);
-            int kc_prev = -1;
+            dim_t kc_prev = -1;
             if (b != b_prev) {
                 a_batch_ptr = brgmm_ctx.get_data_A_batch_ptr(b);
                 b_batch_ptr = brgmm_ctx.get_data_B_batch_ptr(b);
             }
-            for_(int kc = kc_start; kc < kc_end; kc++)
+            for_(dim_t kc = kc_start; kc < kc_end; kc++)
             {
                 const bool k_chunk_tail
                         = kc == K_chunks - 1 && K_chunk_tail > 0;
@@ -731,7 +731,7 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
                 auto kb_end = kb_start
                         + (k_chunk_tail ? K_chunk_tail : K_chunk_size);
 
-                for (int nb = n_start; nb < n_end; nb++) {
+                for (dim_t nb = n_start; nb < n_end; nb++) {
                     const bool bcast_across_all_batch_dims
                             = bgmmc.bcast_B_desc.bcast_across_all_batch_dims;
                     const bool skip_copy_b
@@ -740,14 +740,14 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
                                               || bcast_across_all_batch_dims))
                             && !bgmmc.packed_sparse_weights;
 
-                    for (int mb = m_start; mb < m_end; mb++) {
+                    for (dim_t mb = m_start; mb < m_end; mb++) {
                         const bool skip_copy_a = mc_prev == mc && kc_prev == kc
                                 && (b_prev == b
                                         || bgmmc.bcast_A_desc
                                                    .bcast_across_all_batch_dims);
                         bool prefetch = determine_prefetch(
                                 mb, m_end, nb, n_end, bgmmc, brgmm_ctx);
-                        for (int kb = kb_start; kb < kb_end; kb++) {
+                        for (dim_t kb = kb_start; kb < kb_end; kb++) {
 
                             if (bgmmc.use_buffer_b && mb == m_start
                                     && !skip_copy_b)
@@ -785,8 +785,8 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::compute_kernel(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *A_data_batch_ptr,
-        const char *B_data_batch_ptr, int ithr, int b_idx, int m_blk_idx,
-        int n_blk_idx, int k_blk_idx, bool do_init, int &prev_ker_idx,
+        const char *B_data_batch_ptr, int ithr, dim_t b_idx, dim_t m_blk_idx,
+        dim_t n_blk_idx, dim_t k_blk_idx, bool do_init, int &prev_ker_idx,
         bool prefetch) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
     const auto addr_batch = brgmm_ctx.get_batch_elem_ptr(ithr);
@@ -801,8 +801,8 @@ void brgemm_matmul_t<isa>::compute_kernel(
     const int n_ker_idx = brgmm_ctx.get_N_kernel_idx(n_blk_idx);
     const bool is_last_K_blk = brgmm_ctx.is_last_K_blk(k_blk_idx);
 
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
-    const int remaining_k_blks
+    const dim_t gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
+    const dim_t remaining_k_blks
             = (bgmmc.use_buffer_a ? utils::rnd_up(bgmmc.K, bgmmc.K_blk)
                                   : bgmmc.K)
             - k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
@@ -834,7 +834,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
     brgmm_ctx.maybe_backup_dst_values_to_buffer(
             ithr, b_idx, m_blk_idx, n_blk_idx);
 
-    auto is_brg_amx = [&](const int brg_idx) {
+    auto is_brg_amx = [&](const dim_t brg_idx) {
         return is_superset(
                 pd()->get_brg_desc(brg_idx).isa_impl, avx512_core_amx);
     };
@@ -844,8 +844,8 @@ void brgemm_matmul_t<isa>::compute_kernel(
     // compensation and the final-block epilogue go through the post-ops API.
     // The `do_only_*` flags map to {do_post_ops, do_apply_comp} as {0,1} (comp
     // only) and {1,1} (epilogue).
-    auto execute_brgemm = [&](const brgemm_kernel_t *kernel, const int brg_idx,
-                                  const int bs, const bool need_postops,
+    auto execute_brgemm = [&](const brgemm_kernel_t *kernel, const dim_t brg_idx,
+                                  const dim_t bs, const bool need_postops,
                                   const bool is_tail) {
         const bool per_k_scales = bgmmc.is_src_scale_per_k
                 || (bgmmc.is_wei_scale_per_k
@@ -987,10 +987,10 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::fill_per_mn_compensation(
-        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, int b_idx,
-        int m_blk_idx, int n_blk_idx, const char *A_data_batch_ptr,
-        const char *B_data_batch_ptr, int m_kernel_size, int n_kernel_size,
-        int k_blk_idx, bool is_tail) const {
+        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, dim_t b_idx,
+        dim_t m_blk_idx, dim_t n_blk_idx, const char *A_data_batch_ptr,
+        const char *B_data_batch_ptr, dim_t m_kernel_size, dim_t n_kernel_size,
+        dim_t k_blk_idx, bool is_tail) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
     if (!bgmmc.with_per_mn_compensation) return;
     assert(per_mn_comp_kernel_ != nullptr);
@@ -1095,8 +1095,8 @@ void brgemm_matmul_t<isa>::fill_per_mn_compensation(
 
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::maybe_reduce_A(
-        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, int gemm_batch,
-        int m_blk_idx, int n_blk_idx, int k_chunk_idx, bool do_init,
+        const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr, dim_t gemm_batch,
+        dim_t m_blk_idx, dim_t n_blk_idx, dim_t k_chunk_idx, bool do_init,
         bool has_K_tail, bool do_K_tail) const {
 
     if (!pd()->with_reduce()) return;
@@ -1124,7 +1124,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_A(
         const int m_ker_idx = brgmm_ctx.get_M_kernel_idx(m_blk_idx);
 
         if (!do_K_tail) {
-            for (int gb = 0; gb < gemm_batch; gb++) {
+            for (dim_t gb = 0; gb < gemm_batch; gb++) {
                 p.ptr_in = (void *)addr_batch[gb].ptr.A;
 
                 const bool is_first = do_init && gb == 0;
@@ -1212,9 +1212,9 @@ void brgemm_matmul_t<isa>::maybe_reduce_and_convert_partial_results_A(
         const int ithr_k = brgmm_ctx.get_thread_idx_for_k(ithr);
         if (ithr_bmn < 0 || ithr_k < 0) return;
 
-        const int M_chunks = brgmm_ctx.get_M_chunks();
+        const dim_t M_chunks = brgmm_ctx.get_M_chunks();
 
-        int start_mc {0}, end_mc {0};
+        dim_t start_mc {0}, end_mc {0};
         balance211(M_chunks, brgmm_ctx.get_num_threads_for_bmn(), ithr_bmn,
                 start_mc, end_mc);
         if (start_mc != end_mc && ithr_k == 0) {
@@ -1276,24 +1276,24 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
         const int ithr_k = brgmm_ctx.get_thread_idx_for_k(ithr);
         if (ithr_bmn < 0 || ithr_k < 0) return;
 
-        const int num_reduction_buffers = nstl::min(nthr_k, bgmmc.K_chunks);
+        const dim_t num_reduction_buffers = nstl::min<dim_t>(nthr_k, bgmmc.K_chunks);
         brgemm_dynamic_values_t leading_dimensions(
                 bgmmc.LDA, bgmmc.LDB, brgmm_ctx.get_LDC(), brgmm_ctx.get_LDD());
         const dim_t M = brgmm_ctx.get_M();
-        const int M_chunks = brgmm_ctx.get_M_chunks();
-        const int M_chunk_size = brgmm_ctx.get_M_chunk_size();
-        const int M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
-        const int N_chunks = brgmm_ctx.get_N_chunks();
-        const int N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
+        const dim_t M_chunks = brgmm_ctx.get_M_chunks();
+        const dim_t M_chunk_size = brgmm_ctx.get_M_chunk_size();
+        const dim_t M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
+        const dim_t N_chunks = brgmm_ctx.get_N_chunks();
+        const dim_t N_chunk_tail = brgmm_ctx.get_N_chunk_tail();
 
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(brgmm_ctx.get_parallel_work_amount_gemm(),
                 brgmm_ctx.get_num_threads_for_bmn(), ithr_bmn, start, end);
-        int b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
+        dim_t b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
                 bt {0}, mt {0}, nt {0};
-        int m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
-        int n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
-        int batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
+        dim_t m_chunks_per_thread = div_up(M_chunks, bgmmc.nthr_m);
+        dim_t n_chunks_per_thread = div_up(N_chunks, bgmmc.nthr_n);
+        dim_t batch_per_thread = div_up(bgmmc.batch, bgmmc.nthr_b);
         if (brgmm_ctx.is_chunks_horizontal_process_order())
             nd_iterator_init(start, bt, bgmmc.nthr_b, mt, bgmmc.nthr_m, nt,
                     bgmmc.nthr_n, b_per_t, batch_per_thread, mc_per_t,
@@ -1337,21 +1337,21 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
             auto nb_end_total = nb_start_total
                     + (n_chunk_tail ? N_chunk_tail : bgmmc.N_chunk_size);
 
-            int total_m_work = mb_end_total - mb_start_total;
-            int total_n_work = nb_end_total - nb_start_total;
-            int mn_start, mn_end;
+            dim_t total_m_work = mb_end_total - mb_start_total;
+            dim_t total_n_work = nb_end_total - nb_start_total;
+            dim_t mn_start, mn_end;
             balance211(total_m_work * total_n_work, bgmmc.nthr_k, ithr_k,
                     mn_start, mn_end);
 
-            int mb_in_chunk, nb_in_chunk;
+            dim_t mb_in_chunk, nb_in_chunk;
             nd_iterator_init(mn_start, mb_in_chunk, total_m_work, nb_in_chunk,
                     total_n_work);
             while (mn_start < mn_end) {
-                int mb = mc * M_chunk_size + mb_in_chunk;
-                int nb = nc * bgmmc.N_chunk_size + nb_in_chunk;
-                const int curr_M_blk = brgmm_ctx.get_M_kernel_size(mb);
+                dim_t mb = mc * M_chunk_size + mb_in_chunk;
+                dim_t nb = nc * bgmmc.N_chunk_size + nb_in_chunk;
+                const dim_t curr_M_blk = brgmm_ctx.get_M_kernel_size(mb);
                 const int m_ker_idx = brgmm_ctx.get_M_kernel_idx(mb);
-                const int curr_N_blk = brgmm_ctx.get_N_kernel_size(nb);
+                const dim_t curr_N_blk = brgmm_ctx.get_N_kernel_size(nb);
                 char *buf_reduced_base
                         = brgmm_ctx.get_buf_C_par_reduction_ptr(0, mb, nb);
 
@@ -1434,7 +1434,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *A_data_batch_ptr,
-        int ithr, int m_blk_idx, int k_blk_idx) const {
+        int ithr, dim_t m_blk_idx, dim_t k_blk_idx) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
 
     auto ctx = jit_brgemm_matmul_copy_a_t::ctx_t();
@@ -1442,8 +1442,8 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
     const bool is_K_tail
             = brgmm_ctx.is_last_K_blk(k_blk_idx) && bgmmc.K_tail > 0;
 
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
-    const int gemm_batch_iters = bgmmc.use_buffer_a_tail_only ? 0 : gemm_batch;
+    const dim_t gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
+    const dim_t gemm_batch_iters = bgmmc.use_buffer_a_tail_only ? 0 : gemm_batch;
 
     const dim_t m = brgmm_ctx.get_M_idx(m_blk_idx, true);
 
@@ -1463,11 +1463,11 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
             = !bgmmc.with_wei_decompression && !bgmmc.with_per_mn_compensation;
     int32_t neg_zp_b = use_legacy_zp_a_path ? brgmm_ctx.get_neg_zp_b() : 0;
     int32_t neg_zp_ab_comp
-            = use_legacy_zp_a_path ? bgmmc.K * brgmm_ctx.get_neg_zp_a() : 0;
+            = static_cast<int32_t>(use_legacy_zp_a_path ? bgmmc.K * brgmm_ctx.get_neg_zp_a() : 0);
     ctx.zp_b_neg_val_ptr = &neg_zp_b;
     ctx.zp_ab_comp_ptr = &neg_zp_ab_comp;
 
-    for (int gb = 0; gb < gemm_batch_iters; gb++) {
+    for (dim_t gb = 0; gb < gemm_batch_iters; gb++) {
         const dim_t k = k_start + gb * bgmmc.K_blk;
         ctx.src = (void *)brgmm_ctx.get_data_A_mk_ptr(A_data_batch_ptr, m, k);
         ctx.tr_src = (void *)brgmm_ctx.get_buf_A_ptr(
@@ -1493,18 +1493,18 @@ void brgemm_matmul_t<isa>::copy_a_chunk_in_buffer(
 template <cpu_isa_t isa>
 void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
         const brg_matmul_exec_ctx_t &brgmm_ctx, const char *B_data_batch_ptr,
-        int ithr, int b_idx, int n_blk_idx, int k_blk_idx) const {
+        int ithr, dim_t b_idx, dim_t n_blk_idx, dim_t k_blk_idx) const {
     const auto &bgmmc = pd()->get_brgemm_matmul_conf();
 
     const dim_t k_start = k_blk_idx * bgmmc.K_blk * bgmmc.brgemm_batch_size;
     const bool is_K_tail
             = brgmm_ctx.is_last_K_blk(k_blk_idx) && bgmmc.K_tail > 0;
-    const int gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
+    const dim_t gemm_batch = brgmm_ctx.get_brgemm_batch_size(k_blk_idx);
 
     const dim_t n = brgmm_ctx.get_N_idx(n_blk_idx, true);
 
     if (brgmm_ctx.packed_sparse_weights()) {
-        for (int gb = 0; gb < gemm_batch + is_K_tail; gb++) {
+        for (dim_t gb = 0; gb < gemm_batch + is_K_tail; gb++) {
             const dim_t k = k_start + gb * bgmmc.K_blk;
             auto p = jit_avx512_sparse_decompress_kernel_t::call_params_t();
             const char *B_data_ptr
@@ -1539,7 +1539,7 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
     // For the grouped Zero points/scales need to vary k-block size
     // For this case need to call copy kernel with unaligned (k, k_iters)
     auto call_copy_kernel
-            = [&](dim_t k, int k_iters, int gb, bool aligned_blocks = false) {
+            = [&](dim_t k, dim_t k_iters, dim_t gb, bool aligned_blocks = false) {
         ctx.src = (void *)brgmm_ctx.get_data_B_kn_ptr(B_data_batch_ptr, k, n);
         // Use k for buffer locating only when the block is unaligned
         if (aligned_blocks)
@@ -1598,7 +1598,7 @@ void brgemm_matmul_t<isa>::copy_b_chunk_in_buffer(
             call_copy_kernel(k, k_end - k, gb);
         }
     } else { // Default case with k_blk blocking
-        for (int gb = 0; gb < gemm_batch; ++gb) {
+        for (dim_t gb = 0; gb < gemm_batch; ++gb) {
             const auto k = k_start + gb * bgmmc.K_blk;
             const auto k_iters = nstl::min(bgmmc.K_blk, bgmmc.K);
             call_copy_kernel(k, k_iters, gb, /*aligned_blocks=*/true);
@@ -1781,7 +1781,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             M_ = helper.M();
             M_chunks_ = M_ / bgmmc.M_chunk_elems;
             M_chunk_tail_elements_ = M_ % bgmmc.M_chunk_elems;
-            int tail = M_chunk_tail_elements_;
+            dim_t tail = M_chunk_tail_elements_;
             dim_t m_idx = M_ - tail;
             int tail_idx = 0;
             dim_t m_c_buf_idx = 0;
@@ -1806,7 +1806,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                     tail_idx++;
                     continue;
                 }
-                int kernel_m_shift = nstl::max(tail_ker_size - tail, 0);
+                dim_t kernel_m_shift = nstl::max<dim_t>(tail_ker_size - tail, 0);
 
                 m_tail_processing_.push_back({m_idx, ker_idx, tail_ker_size,
                         kernel_m_shift, m_c_buf_idx});
@@ -1845,7 +1845,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             N_ = helper.N();
             N_chunks_ = N_ / bgmmc.N_chunk_elems;
             N_chunk_tail_elems_ = N_ % bgmmc.N_chunk_elems;
-            int tail = N_chunk_tail_elems_;
+            dim_t tail = N_chunk_tail_elems_;
             dim_t n_idx = N_ - tail;
             int tail_idx = 0;
             dim_t n_c_buf_idx = 0;
@@ -1870,7 +1870,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                     tail_idx++;
                     continue;
                 }
-                int kernel_n_shift = nstl::max(tail_ker_size - tail, 0);
+                dim_t kernel_n_shift = nstl::max<dim_t>(tail_ker_size - tail, 0);
 
                 n_tail_processing_.push_back({n_idx, ker_idx, tail_ker_size,
                         kernel_n_shift, n_c_buf_idx});
@@ -1918,9 +1918,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         // create parallel work of amount that is divisible by nthr_m and nthr_n,
         // the chunks that do not exist will be ignored in gemm execution
         // In case of micro heuristics, nthr_m==nthr_n==nthr_b==1 (round up has no effect)
-        int m_chunks_per_thread = rnd_up(M_chunks_, bgmmc.nthr_m);
-        int n_chunks_per_thread = rnd_up(N_chunks_, bgmmc.nthr_n);
-        int b_per_thread = rnd_up(bgmmc.batch, bgmmc.nthr_b);
+        dim_t m_chunks_per_thread = rnd_up(M_chunks_, bgmmc.nthr_m);
+        dim_t n_chunks_per_thread = rnd_up(N_chunks_, bgmmc.nthr_n);
+        dim_t b_per_thread = rnd_up(bgmmc.batch, bgmmc.nthr_b);
         parallel_work_amount_gemm_
                 = b_per_thread * m_chunks_per_thread * n_chunks_per_thread;
 
@@ -1950,7 +1950,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         // For Eigen threadpool there is significant advantage to not spawn
         // useless threads.
         if (!dnnl_thr_syncable()) {
-            nthr_bmn_ = nstl::min(nthr_bmn_, parallel_work_amount_);
+            nthr_bmn_ = static_cast<int>(nstl::min<dim_t>(nthr_bmn_, parallel_work_amount_));
         }
 
         num_threads_used_ = nthr_k_ * nthr_bmn_;
@@ -1964,15 +1964,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     // NOTE: gb --> generalized batch, bb --> broadcast batch
-    int get_bb_idx(int gb_idx, const brgemm_matmul_bcast_desc_t &bd) const {
+    dim_t get_bb_idx(dim_t gb_idx, const brgemm_matmul_bcast_desc_t &bd) const {
         if (!bd.bcast_mask) // no broadcast
             return gb_idx;
 
         if (bd.bcast_across_all_batch_dims) return 0;
 
-        int gb_off_before_bcast = utils::rnd_dn(
+        dim_t gb_off_before_bcast = utils::rnd_dn(
                 gb_idx, bd.first_bcast_dim_to_last_batch_dim_prod);
-        int bb_idx = gb_off_before_bcast / (bd.bcast_dims_prod);
+        dim_t bb_idx = gb_off_before_bcast / (bd.bcast_dims_prod);
 
         dim_t cur_bcast_dims_prod = bd.bcast_dims_prod;
         int mask = 1 << (bgmmc_.batch_ndims - bd.first_bcast_dim - 1);
@@ -1980,7 +1980,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             if (bd.bcast_mask & mask) // broadcast
                 cur_bcast_dims_prod /= bd.batch_dims[d];
             else {
-                int cur_b = (gb_idx / bd.gb_off[d]) % bd.batch_dims[d];
+                dim_t cur_b = (gb_idx / bd.gb_off[d]) % bd.batch_dims[d];
                 bb_idx += cur_b * (bd.gb_off[d] / cur_bcast_dims_prod);
             }
             mask >>= 1;
@@ -1991,9 +1991,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Note: Minimize the calls to `X_batch_ptr` to reduce overhead.
     // Call it once the batch changes, later use get_data_mk_off
-    const char *get_data_A_batch_ptr(int b_idx) const {
+    const char *get_data_A_batch_ptr(dim_t b_idx) const {
         using namespace format_tag;
-        const int b = get_bb_idx(b_idx, bgmmc_.bcast_A_desc);
+        const dim_t b = get_bb_idx(b_idx, bgmmc_.bcast_A_desc);
         dim_t b_off = 0;
         if (one_of(bgmmc_.src_tag, acbd, adbc)
                 /* this is a special case when src can be represented
@@ -2022,11 +2022,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_data_B_kn_off(dim_t k, dim_t n) const {
-        const int wei_k_blk = bgmmc_.is_bf32 || bgmmc_.is_xf16_fp8
+        const dim_t wei_k_blk = bgmmc_.is_bf32 || bgmmc_.is_xf16_fp8
                 ? get_wei_k_blk(bgmmc_.orig_wei_dt)
                 : bgmmc_.wei_k_blk;
-        const int k_idx = bgmmc_.blocked_B ? k / wei_k_blk : k;
-        const int n_idx = bgmmc_.blocked_B ? n / bgmmc_.wei_n_blk : n;
+        const dim_t k_idx = bgmmc_.blocked_B ? k / wei_k_blk : k;
+        const dim_t n_idx = bgmmc_.blocked_B ? n / bgmmc_.wei_n_blk : n;
         const int int4_fac = bgmmc_.is_int4_weights ? 2 : 1;
         return (B_strides_[1] * k_idx + B_strides_[0] * n_idx
                        + get_data_B_off_within_block(k, n))
@@ -2045,7 +2045,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return b_ptr;
     }
 
-    dim_t get_data_B_batch_off(int b) const {
+    dim_t get_data_B_batch_off(dim_t b) const {
         using namespace format_tag;
         dim_t b_off = 0;
         if (one_of(bgmmc_.wei_tag, acbd, adbc)
@@ -2069,12 +2069,12 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return b_off;
     }
 
-    const char *get_data_B_batch_ptr(int b_idx) const {
-        const int b = get_bb_idx(b_idx, bgmmc_.bcast_B_desc);
+    const char *get_data_B_batch_ptr(dim_t b_idx) const {
+        const dim_t b = get_bb_idx(b_idx, bgmmc_.bcast_B_desc);
         return data_B_ptr_ + get_data_B_batch_off(b);
     }
 
-    const char *get_data_B_bitmask_ptr(int b, dim_t k, dim_t n) const {
+    const char *get_data_B_bitmask_ptr(dim_t b, dim_t k, dim_t n) const {
         assert(bgmmc_.packed_sparse_weights);
         const dim_t cur_data_B_off
                 = get_data_B_batch_off(b) + get_data_B_kn_off(k, n);
@@ -2082,7 +2082,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return data_B_bitmask_ptr_ + bitmask_off;
     }
 
-    char *get_data_C_ptr(int b, dim_t m, dim_t n) const {
+    char *get_data_C_ptr(dim_t b, dim_t m, dim_t n) const {
         return data_C_ptr_ + get_data_C_off(b, m, n);
     }
 
@@ -2091,17 +2091,17 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                 + ithr * bgmmc_.brgemm_batch_element_per_thr_sz;
     }
 
-    void init_brgemm_batch_elements_values(int ithr, int brg_batch_start,
-            int brg_batch_iters, const char *A_data_batch_ptr,
-            const char *B_data_batch_ptr, int b_idx, int m_blk_idx,
-            int k_blk_idx, int n_blk_idx) const {
+    void init_brgemm_batch_elements_values(int ithr, dim_t brg_batch_start,
+            dim_t brg_batch_iters, const char *A_data_batch_ptr,
+            const char *B_data_batch_ptr, dim_t b_idx, dim_t m_blk_idx,
+            dim_t k_blk_idx, dim_t n_blk_idx) const {
         auto addr_batch = get_batch_elem_ptr(ithr);
 
         const dim_t m = get_M_idx(m_blk_idx, true);
         const dim_t n = n_blk_idx * bgmmc_.N_blk;
 
         for (int b_iter = 0; b_iter < brg_batch_iters; b_iter++) {
-            const int brg_batch_idx = brg_batch_start + b_iter;
+            const dim_t brg_batch_idx = brg_batch_start + b_iter;
             const dim_t k = k_blk_idx * bgmmc_.K_blk * bgmmc_.brgemm_batch_size
                     + brg_batch_idx * bgmmc_.K_blk;
             addr_batch[b_iter].ptr.A = bgmmc_.use_buffer_a
@@ -2116,22 +2116,22 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         }
     }
 
-    char *get_buf_A_ptr(int ithr, int m_blk_idx, int k_blk_idx, int gb) const {
+    char *get_buf_A_ptr(int ithr, dim_t m_blk_idx, dim_t k_blk_idx, dim_t gb) const {
         if (!bgmmc_.use_buffer_a && !bgmmc_.use_buffer_a_tail_only)
             return nullptr;
 
-        int k_blk_local = bgmmc_.use_buffer_a_tail_only ? 0 : k_blk_idx;
+        dim_t k_blk_local = bgmmc_.use_buffer_a_tail_only ? 0 : k_blk_idx;
         k_blk_local = k_blk_local % get_K_chunk_size();
         if (is_runtime_M_tail_chunk(m_blk_idx)) {
-            const int tail_idx = get_M_tail_block_idx(m_blk_idx);
-            const int curr_m_block_size
+            const dim_t tail_idx = get_M_tail_block_idx(m_blk_idx);
+            const dim_t curr_m_block_size
                     = m_tail_processing_[tail_idx].kernel_size;
             const dim_t curr_m_buf_shift
                     = m_tail_processing_[tail_idx].buf_dim_idx;
             const dim_t ld = bgmmc_.tr_a_dt_sz
                     * (bgmmc_.use_buffer_a_tail_only ? bgmmc_.wei_k_blk
                                                      : bgmmc_.LDA);
-            const int batch = bgmmc_.use_buffer_a_tail_only
+            const dim_t batch = bgmmc_.use_buffer_a_tail_only
                     ? 1
                     : bgmmc_.brgemm_batch_size;
             const dim_t offset = ithr * bgmmc_.buffer_a_per_thread_sz
@@ -2141,7 +2141,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             return buf_A_ptr_ + offset;
         }
 
-        const int m_blk_local = m_blk_idx % get_M_chunk_size();
+        const dim_t m_blk_local = m_blk_idx % get_M_chunk_size();
         return buf_A_ptr_ + ithr * bgmmc_.buffer_a_per_thread_sz
                 + m_blk_local * bgmmc_.buffer_a_m_stride
                 + k_blk_local * bgmmc_.buffer_a_k_stride
@@ -2155,10 +2155,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     //     a block of memory per thread.
     //   `gb` defines an offset to a specific block over K inside a portion of
     //     blocks.
-    char *get_buf_B_ptr(int ithr, int k_blk_idx, int n_blk_idx, int gb) const {
+    char *get_buf_B_ptr(int ithr, dim_t k_blk_idx, dim_t n_blk_idx, dim_t gb) const {
         UNUSED(n_blk_idx);
         if (!bgmmc_.use_buffer_b) return nullptr;
-        int k_blk_local = k_blk_idx % get_K_chunk_size();
+        dim_t k_blk_local = k_blk_idx % get_K_chunk_size();
         const auto offset = ithr * bgmmc_.buffer_b_per_thread_sz
                 + k_blk_local * bgmmc_.buffer_b_k_brg_stride
                 + gb * bgmmc_.buffer_b_gb_stride;
@@ -2187,7 +2187,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return buf_B_ptr_ + offset;
     }
 
-    char *get_buf_C_ptr(int ithr, int m_blk_idx, int n_blk_idx) const {
+    char *get_buf_C_ptr(int ithr, dim_t m_blk_idx, dim_t n_blk_idx) const {
         if (!bgmmc_.use_buffer_c) return nullptr;
 
         if (bgmmc_.nthr_k > 1) {
@@ -2197,8 +2197,8 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         char *buf_C_ptr_local
                 = buf_C_ptr_ + ithr * bgmmc_.buffer_c_per_thread_sz;
 
-        int n_blk_local = 0;
-        int m_blk_local = 0;
+        dim_t n_blk_local = 0;
+        dim_t m_blk_local = 0;
 
         if (bgmmc_.is_runtime_N || bgmmc_.is_runtime_M
                 || bgmmc_.K_chunk_elems < bgmmc_.K) {
@@ -2210,7 +2210,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         const bool runtime_N_tail = is_runtime_N_tail_chunk(n_blk_idx);
 
         if (runtime_M_tail || runtime_N_tail) {
-            const int curr_m_block_size = get_M_kernel_size(m_blk_idx);
+            const dim_t curr_m_block_size = get_M_kernel_size(m_blk_idx);
             const dim_t curr_m_buf_shift = runtime_M_tail
                     ? m_tail_processing_[get_M_tail_block_idx(m_blk_idx)]
                               .buf_dim_idx
@@ -2237,7 +2237,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     char *get_buf_C_par_reduction_ptr(
-            int ithr_k, int m_blk_idx, int n_blk_idx) const {
+            int ithr_k, dim_t m_blk_idx, dim_t n_blk_idx) const {
         if (bgmmc_.nthr_k <= 1) return nullptr;
 
         const dim_t m = m_blk_idx * bgmmc_.M_blk;
@@ -2256,12 +2256,12 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
         if (!bgmmc_.blocked_B) return 0;
 
-        const int orig_wei_k_blk = bgmmc_.is_xf16_fp8
+        const dim_t orig_wei_k_blk = bgmmc_.is_xf16_fp8
                 ? get_wei_k_blk(bgmmc_.orig_wei_dt)
                 : bgmmc_.wei_k_blk;
         dim_t x0 = k % orig_wei_k_blk;
         dim_t x1 = n % bgmmc_.wei_n_blk;
-        const int orig_vnni_factor = bgmmc_.is_xf16_fp8
+        const dim_t orig_vnni_factor = bgmmc_.is_xf16_fp8
                 ? data_type_vnni_granularity(bgmmc_.orig_wei_dt)
                 : vnni_factor;
         dim_t offset
@@ -2270,7 +2270,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return bgmmc_.b_dt_sz * offset;
     }
 
-    dim_t get_data_C_off(int b, dim_t m, dim_t n) const {
+    dim_t get_data_C_off(dim_t b, dim_t m, dim_t n) const {
         using namespace format_tag;
         assert(bgmmc_.dst_tag != adbc);
         dim_t off = 0;
@@ -2293,14 +2293,14 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Returns a pointer to the user-provided reduce buffer, shifted by
     // the specified offset @p off.
-    char *get_data_reduce_ptr(int off) const {
+    char *get_data_reduce_ptr(dim_t off) const {
         if (!bgmmc_.with_reduce) return nullptr;
         return data_reduce_ptr_ + off * bgmmc_.reduce_dt_sz;
     }
 
     // Returns a pointer to the scratchpad reduce buffer for the
     // corresponding @p ithr, shifted by the specified offset @p off.
-    char *get_buf_reduce_ptr(int ithr, int off) const {
+    char *get_buf_reduce_ptr(int ithr, dim_t off) const {
         if (!bgmmc_.with_reduce) return nullptr;
         assert(bgmmc_.acc_dt == f32);
         const int ithr_k = get_thread_idx_for_k(ithr);
@@ -2315,7 +2315,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     // Returns a pointer to the scratchpad reduce buffer for the
     // corresponding index @p ibuf, shifted by the specified offset @p off.
-    char *get_buf_reduce_ptr_by_index(int ibuf, int off) const {
+    char *get_buf_reduce_ptr_by_index(int ibuf, dim_t off) const {
         if (!bgmmc_.with_reduce) return nullptr;
         const size_t _off = bgmmc_.M * ibuf + off;
         return buf_reduce_ptr_ + _off * bgmmc_.acc_dt_sz;
@@ -2327,10 +2327,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return bias_ptr_ + n * bgmmc_.bias_dt_sz;
     }
 
-    int32_t *get_s8s8_comp_ptr(int ithr, int b, int n_blk_idx) const {
+    int32_t *get_s8s8_comp_ptr(int ithr, dim_t b, dim_t n_blk_idx) const {
         if (!bgmmc_.s8s8_compensation_required) return nullptr;
 
-        const int n_blk_local = bgmmc_.use_buffer_b
+        const dim_t n_blk_local = bgmmc_.use_buffer_b
                 ? n_blk_idx % bgmmc_.N_chunk_size
                 : n_blk_idx;
         assert(!is_runtime_value(bgmmc_.s8s8_comp_b_str));
@@ -2490,10 +2490,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     int32_t *get_zp_a_compensation_ptr(
-            int ithr, int b_idx, int n_blk_idx) const {
+            int ithr, dim_t b_idx, dim_t n_blk_idx) const {
         if (!bgmmc_.has_zero_point_a) return nullptr;
 
-        const int n_blk_local = n_blk_idx % bgmmc_.N_chunk_size;
+        const dim_t n_blk_local = n_blk_idx % bgmmc_.N_chunk_size;
         int32_t *zp_comp = zero_point_a_compensations_ptr_
                 + ithr * bgmmc_.zp_a_comp_elems_per_thr
                 + n_blk_local * bgmmc_.zp_a_comp_shift_n;
@@ -2503,20 +2503,20 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
             // locally just before usage. Using the single global scaling before
             // parallel section might produce significant overhead for small
             // problems running in multitreaded execution mode
-            const int base_offset = get_bb_idx(b_idx, bgmmc_.bcast_B_desc)
+            const dim_t base_offset = get_bb_idx(b_idx, bgmmc_.bcast_B_desc)
                             * rnd_up(bgmmc_.N, bgmmc_.wei_n_blk)
                     + n_blk_idx * bgmmc_.N_blk;
 
-            int curr_N_blk = get_N_kernel_size(n_blk_idx);
+            const dim_t curr_N_blk = get_N_kernel_size(n_blk_idx);
             PRAGMA_OMP_SIMD()
-            for (int b = 0; b < curr_N_blk; b++)
+            for (dim_t b = 0; b < curr_N_blk; b++)
                 zp_comp[b] = -get_neg_zp_a()
                         * reorder_zp_a_comp_ptr_[base_offset + b];
         }
         return zp_comp;
     }
 
-    int32_t *get_zp_b_compensation_result_ptr(int ithr, int m_blk_idx) const {
+    int32_t *get_zp_b_compensation_result_ptr(int ithr, dim_t m_blk_idx) const {
         if (!bgmmc_.has_zero_point_b) return nullptr;
 
         if (is_runtime_M_tail_chunk(m_blk_idx)) {
@@ -2527,13 +2527,13 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                     + ithr * bgmmc_.zp_b_comp_elems_per_thr + curr_m_buf_shift;
         }
 
-        const int m_blk_local = m_blk_idx % get_M_chunk_size();
+        const dim_t m_blk_local = m_blk_idx % get_M_chunk_size();
         return zero_point_b_compensations_ptr_
                 + ithr * bgmmc_.zp_b_comp_elems_per_thr
                 + m_blk_local * bgmmc_.zp_b_comp_result_shift_m;
     }
 
-    int32_t *get_zp_b_compensation_buffer_ptr(int ithr, int m_blk_idx) const {
+    int32_t *get_zp_b_compensation_buffer_ptr(int ithr, dim_t m_blk_idx) const {
         if (!bgmmc_.has_zero_point_b) return nullptr;
 
         if (is_runtime_M_tail_chunk(m_blk_idx)) {
@@ -2544,7 +2544,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                     + bgmmc_.zp_b_comp_buffer_start + curr_m_buf_shift;
         }
 
-        const int m_blk_local = m_blk_idx % get_M_chunk_size();
+        const dim_t m_blk_local = m_blk_idx % get_M_chunk_size();
         return get_zp_b_compensation_result_ptr(ithr, 0)
                 + bgmmc_.zp_b_comp_buffer_start
                 + m_blk_local * bgmmc_.zp_b_comp_buffer_shift_m;
@@ -2561,17 +2561,17 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     int get_base_brgemm_kernel_idx() const { return base_brg_ker_idx_; }
 
-    bool is_last_K_blk(int k_blk_idx) const {
+    bool is_last_K_blk(dim_t k_blk_idx) const {
         return k_blk_idx == bgmmc_.num_K_blocks - 1;
     }
 
-    int get_brgemm_batch_size(int k_chunk_idx) const {
+    dim_t get_brgemm_batch_size(dim_t k_chunk_idx) const {
         return is_last_K_blk(k_chunk_idx) ? last_brgemm_batch_size_
                                           : bgmmc_.brgemm_batch_size;
     }
 
-    int get_parallel_work_amount() const { return parallel_work_amount_; }
-    int get_parallel_work_amount_gemm() const {
+    dim_t get_parallel_work_amount() const { return parallel_work_amount_; }
+    dim_t get_parallel_work_amount_gemm() const {
         return parallel_work_amount_gemm_;
     }
     int get_num_threads_for_k() const { return nthr_k_; }
@@ -2602,15 +2602,15 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return num_threads_used_;
     }
     dim_t get_M() const { return M_; }
-    int get_M_chunks() const { return M_chunks_; }
-    int get_M_chunk_size() const { return bgmmc_.M_chunk_size; }
-    int get_M_chunk_tail() const { return M_chunk_tail_; }
+    dim_t get_M_chunks() const { return M_chunks_; }
+    dim_t get_M_chunk_size() const { return bgmmc_.M_chunk_size; }
+    dim_t get_M_chunk_tail() const { return M_chunk_tail_; }
 
-    int get_K_chunks() const { return K_chunks_; }
-    int get_K_chunk_size() const { return bgmmc_.K_chunk_size; }
-    int get_K_chunk_tail() const { return K_chunk_tail_; }
+    dim_t get_K_chunks() const { return K_chunks_; }
+    dim_t get_K_chunk_size() const { return bgmmc_.K_chunk_size; }
+    dim_t get_K_chunk_tail() const { return K_chunk_tail_; }
 
-    int get_M_kernel_idx(int m_block_idx) const {
+    int get_M_kernel_idx(dim_t m_block_idx) const {
         if (!is_M_tail_processing(m_block_idx))
             return 0;
         else if (!bgmmc_.is_runtime_M)
@@ -2621,7 +2621,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return m_tail_processing_[get_M_tail_block_idx(m_block_idx)].kernel_idx;
     }
 
-    int get_M_kernel_size(int m_block_idx) const {
+    dim_t get_M_kernel_size(dim_t m_block_idx) const {
         if (!is_M_tail_processing(m_block_idx))
             return bgmmc_.M_blk;
         else if (!bgmmc_.is_runtime_M)
@@ -2634,10 +2634,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_M_idx(
-            int m_block_idx, bool adjust_for_kernel_overlap = false) const {
+            dim_t m_block_idx, bool adjust_for_kernel_overlap = false) const {
         if (is_runtime_M_tail_chunk(m_block_idx)) {
-            const int tail_idx = get_M_tail_block_idx(m_block_idx);
-            const int shift = adjust_for_kernel_overlap
+            const dim_t tail_idx = get_M_tail_block_idx(m_block_idx);
+            const dim_t shift = adjust_for_kernel_overlap
                     ? m_tail_processing_[tail_idx].shift
                     : 0;
             return m_tail_processing_[tail_idx].idx - shift;
@@ -2646,11 +2646,11 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_N() const { return N_; }
-    int get_N_chunks() const { return N_chunks_; }
-    int get_N_chunk_tail() const { return N_chunk_tail_; }
-    int get_N_chunk_tail_elems() const { return N_chunk_tail_elems_; }
+    dim_t get_N_chunks() const { return N_chunks_; }
+    dim_t get_N_chunk_tail() const { return N_chunk_tail_; }
+    dim_t get_N_chunk_tail_elems() const { return N_chunk_tail_elems_; }
 
-    int get_N_kernel_idx(int n_block_idx) const {
+    int get_N_kernel_idx(dim_t n_block_idx) const {
         if (!is_N_tail_processing(n_block_idx))
             return 0;
         else if (!bgmmc_.is_runtime_N)
@@ -2661,7 +2661,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
         return n_tail_processing_[get_N_tail_block_idx(n_block_idx)].kernel_idx;
     }
 
-    int get_N_kernel_size(int n_block_idx) const {
+    dim_t get_N_kernel_size(dim_t n_block_idx) const {
         if (!is_N_tail_processing(n_block_idx))
             return bgmmc_.N_blk;
         else if (!bgmmc_.is_runtime_N)
@@ -2674,10 +2674,10 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     dim_t get_N_idx(
-            int n_block_idx, bool adjust_for_kernel_overlap = false) const {
+            dim_t n_block_idx, bool adjust_for_kernel_overlap = false) const {
         if (is_runtime_N_tail_chunk(n_block_idx)) {
-            const int tail_idx = get_N_tail_block_idx(n_block_idx);
-            const int shift = adjust_for_kernel_overlap
+            const dim_t tail_idx = get_N_tail_block_idx(n_block_idx);
+            const dim_t shift = adjust_for_kernel_overlap
                     ? n_tail_processing_[tail_idx].shift
                     : 0;
             return n_tail_processing_[tail_idx].idx - shift;
@@ -2692,20 +2692,20 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     // compute dst values for the same area. We need to backup/restore values
     // for overlapped area to avoid correctness issues.
     void maybe_backup_dst_values_to_buffer(
-            int ithr, int b_idx, int m_blk_idx, int n_blk_idx) const {
+            int ithr, dim_t b_idx, dim_t m_blk_idx, dim_t n_blk_idx) const {
         if (!copy_d_required(m_blk_idx, n_blk_idx)) return;
 
         const bool m_tail_overlapping = is_m_tail_overlap(m_blk_idx);
         dim_t m_start = m_tail_overlapping ? get_M_idx(m_blk_idx, true)
                                            : get_M_idx(m_blk_idx);
-        const int rows_to_copy = m_tail_overlapping
+        const dim_t rows_to_copy = m_tail_overlapping
                 ? m_tail_processing_[get_M_tail_block_idx(m_blk_idx)].shift
                 : get_M_kernel_size(m_blk_idx);
 
         const bool n_tail_overlapping = is_n_tail_overlap(n_blk_idx);
         dim_t n_start = n_tail_overlapping ? get_N_idx(n_blk_idx, true)
                                            : get_N_idx(n_blk_idx);
-        const int row_elems = n_tail_overlapping
+        const dim_t row_elems = n_tail_overlapping
                 ? n_tail_processing_[get_N_tail_block_idx(n_blk_idx)].shift
                 : get_N_kernel_size(n_blk_idx);
         const dim_t bytes_to_copy = bgmmc_.c_dt_sz * row_elems;
@@ -2724,20 +2724,20 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
     }
 
     void maybe_restore_dst_values_from_buffer(
-            int ithr, int b_idx, int m_blk_idx, int n_blk_idx) const {
+            int ithr, dim_t b_idx, dim_t m_blk_idx, dim_t n_blk_idx) const {
         if (!copy_d_required(m_blk_idx, n_blk_idx)) return;
 
         const bool m_tail_overlapping = is_m_tail_overlap(m_blk_idx);
         dim_t m_start = m_tail_overlapping ? get_M_idx(m_blk_idx, true)
                                            : get_M_idx(m_blk_idx);
-        const int rows_to_copy = m_tail_overlapping
+        const dim_t rows_to_copy = m_tail_overlapping
                 ? m_tail_processing_[get_M_tail_block_idx(m_blk_idx)].shift
                 : get_M_kernel_size(m_blk_idx);
 
         const bool n_tail_overlapping = is_n_tail_overlap(n_blk_idx);
         dim_t n_start = n_tail_overlapping ? get_N_idx(n_blk_idx, true)
                                            : get_N_idx(n_blk_idx);
-        const int row_elems = n_tail_overlapping
+        const dim_t row_elems = n_tail_overlapping
                 ? n_tail_processing_[get_N_tail_block_idx(n_blk_idx)].shift
                 : get_N_kernel_size(n_blk_idx);
         const dim_t bytes_to_copy = bgmmc_.c_dt_sz * row_elems;
@@ -2768,7 +2768,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     bool packed_sparse_weights() const { return bgmmc_.packed_sparse_weights; }
 
-    int get_current_K_pad(int current_K_iters) const {
+    dim_t get_current_K_pad(dim_t current_K_iters) const {
         if (bgmmc_.is_wei_zp_per_k || bgmmc_.is_wei_scale_per_k) return 0;
         if (current_K_iters % bgmmc_.wei_k_blk == 0) return 0;
         return (bgmmc_.extendable_k || bgmmc_.use_fused_copy_a)
@@ -2785,10 +2785,10 @@ private:
         // index of tail processing kernel, 0 is reserved for main block
         int kernel_idx;
         // block size of tail kernel
-        int kernel_size;
+        dim_t kernel_size;
         // shift wrt dimension index when kernel is applied w/ computational
         // overlapping with other kernel, dim_idx_to_apply_kernel = idx - shift
-        int shift;
+        dim_t shift;
         // if shift > 0 (computational overlapping case) we have to use buffer
         // for kernel dst to avoid result values spoiling, this value
         // represents dimensional idx for dst buffer
@@ -2811,7 +2811,7 @@ private:
     const char *data_B_bitmask_ptr_;
     // The size of a packed saprse block. E.g. the block
     // for a tag 'BA16a64b4a' is 4096.
-    int B_packed_sparse_block_size_;
+    dim_t B_packed_sparse_block_size_;
 
     char *data_C_ptr_;
     char *data_reduce_ptr_;
@@ -2844,33 +2844,33 @@ private:
     std::vector<const void *> post_ops_binary_rhs_arg_vec_;
 
     int base_brg_ker_idx_;
-    int vnni_factor;
+    dim_t vnni_factor;
 
     // parallelization parameters
-    int parallel_work_amount_;
-    int parallel_work_amount_gemm_;
+    dim_t parallel_work_amount_;
+    dim_t parallel_work_amount_gemm_;
     int nthr_, nthr_k_, nthr_bmn_, num_threads_used_;
     // Horizontal order means first process N (load) dim then M (bcast) dim.
     bool is_thread_chunks_exec_order_horizontal_;
-    int last_brgemm_batch_size_;
+    dim_t last_brgemm_batch_size_;
 
     dim_t M_;
-    int M_chunks_;
-    int M_chunk_tail_;
-    int M_chunk_tail_elements_;
-    int M_tail_block_start_;
+    dim_t M_chunks_;
+    dim_t M_chunk_tail_;
+    dim_t M_chunk_tail_elements_;
+    dim_t M_tail_block_start_;
 
     dim_t K_;
-    int K_chunks_;
-    int K_chunk_tail_;
-    int K_chunk_tail_elements_;
+    dim_t K_chunks_;
+    dim_t K_chunk_tail_;
+    dim_t K_chunk_tail_elements_;
 
     dim_t N_;
-    int N_chunks_;
-    int N_chunk_tail_;
-    int N_chunk_tail_elems_;
+    dim_t N_chunks_;
+    dim_t N_chunk_tail_;
+    dim_t N_chunk_tail_elems_;
 
-    int N_tail_block_start_;
+    dim_t N_tail_block_start_;
     dim_t A_strides_[3];
     dim_t A_ptr_shift_b_;
     dim_t copy_A_src_stride_;
@@ -2887,44 +2887,44 @@ private:
         return buf_D_ptr_ + bgmmc_.c_dt_sz * bgmmc_.M_blk * bgmmc_.N_blk * ithr;
     }
 
-    int get_M_tail_block_idx(int m_block_idx) const {
-        const int tail_idx = m_block_idx - M_tail_block_start_;
+    dim_t get_M_tail_block_idx(dim_t m_block_idx) const {
+        const dim_t tail_idx = m_block_idx - M_tail_block_start_;
         if (!bgmmc_.is_runtime_M) return tail_idx;
-        return tail_idx < (int)m_tail_processing_.size() ? tail_idx : -1;
+        return tail_idx < (dim_t)m_tail_processing_.size() ? tail_idx : -1;
     }
-    bool is_M_tail_processing(int m_block_idx) const {
+    bool is_M_tail_processing(dim_t m_block_idx) const {
         return get_M_tail_block_idx(m_block_idx) >= 0;
     }
-    bool is_runtime_M_tail_chunk(int m_block_idx) const {
+    bool is_runtime_M_tail_chunk(dim_t m_block_idx) const {
         return bgmmc_.is_runtime_M && is_M_tail_processing(m_block_idx);
     }
 
-    bool is_m_tail_overlap(int m_block_idx) const {
+    bool is_m_tail_overlap(dim_t m_block_idx) const {
         return is_runtime_M_tail_chunk(m_block_idx)
                 && m_tail_processing_[get_M_tail_block_idx(m_block_idx)].shift
                 > 0;
     }
 
-    int get_N_tail_block_idx(int n_block_idx) const {
-        const int tail_idx = n_block_idx - N_tail_block_start_;
+    dim_t get_N_tail_block_idx(dim_t n_block_idx) const {
+        const dim_t tail_idx = n_block_idx - N_tail_block_start_;
         if (!bgmmc_.is_runtime_N) return tail_idx;
-        return tail_idx < (int)n_tail_processing_.size() ? tail_idx : -1;
+        return tail_idx < (dim_t)n_tail_processing_.size() ? tail_idx : -1;
     }
-    bool is_N_tail_processing(int n_block_idx) const {
+    bool is_N_tail_processing(dim_t n_block_idx) const {
         return get_N_tail_block_idx(n_block_idx) >= 0;
     }
 
-    bool is_runtime_N_tail_chunk(int n_block_idx) const {
+    bool is_runtime_N_tail_chunk(dim_t n_block_idx) const {
         return bgmmc_.is_runtime_N && is_N_tail_processing(n_block_idx);
     }
 
-    bool is_n_tail_overlap(int n_block_idx) const {
+    bool is_n_tail_overlap(dim_t n_block_idx) const {
         return is_runtime_N_tail_chunk(n_block_idx)
                 && n_tail_processing_[get_N_tail_block_idx(n_block_idx)].shift
                 > 0;
     }
 
-    bool copy_d_required(int m_block_idx, int n_block_idx) const {
+    bool copy_d_required(dim_t m_block_idx, dim_t n_block_idx) const {
         if (!bgmmc_.with_sum) return false;
         return is_m_tail_overlap(m_block_idx) || is_n_tail_overlap(n_block_idx);
     }

--- a/src/cpu/x64/matmul/brgemm_matmul.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.hpp
@@ -63,7 +63,7 @@ struct brgemm_matmul_t : public primitive_t {
         int get_brg_kernel_idx(bool is_bs_tail, bool do_initialization,
                 int m_ker_idx, int n_ker_idx, bool is_K_tail,
                 bool is_prefetching) const;
-        const brgemm_desc_t &get_brg_desc(int idx) const {
+        const brgemm_desc_t &get_brg_desc(dim_t idx) const {
             return brg_descs_[idx];
         }
         const brgemm_matmul_conf_t &get_brgemm_matmul_conf() const {
@@ -91,28 +91,29 @@ private:
     status_t execute_body(const exec_ctx_t &ctx) const;
     void compute_kernel(const brg_matmul_exec_ctx_t &brgmm_ctx,
             const char *A_data_batch_ptr, const char *B_data_batch_ptr,
-            int ithr, int b_idx, int m_blk_idx, int n_blk_idx, int k_blk_idx,
-            bool do_init, int &prev_ker_idx, bool prefetch) const;
+            int ithr, dim_t b_idx, dim_t m_blk_idx, dim_t n_blk_idx,
+            dim_t k_blk_idx, bool do_init, int &prev_ker_idx,
+            bool prefetch) const;
     void fill_per_mn_compensation(const brg_matmul_exec_ctx_t &brgmm_ctx,
-            int ithr, int b_idx, int m_blk_idx, int n_blk_idx,
+            int ithr, dim_t b_idx, dim_t m_blk_idx, dim_t n_blk_idx,
             const char *A_data_batch_ptr, const char *B_data_batch_ptr,
-            int m_kernel_size, int n_kernel_size, int k_blk_idx,
+            dim_t m_kernel_size, dim_t n_kernel_size, dim_t k_blk_idx,
             bool is_tail) const;
 
-    bool determine_prefetch(const int mc, const int m_end, const int nc,
-            const int n_end, const brgemm_matmul_conf_t &bgmmc,
+    bool determine_prefetch(const dim_t mc, const dim_t m_end, const dim_t nc,
+            const dim_t n_end, const brgemm_matmul_conf_t &bgmmc,
             const brg_matmul_exec_ctx_t &brgmm_ctx) const;
 
     void copy_a_chunk_in_buffer(const brg_matmul_exec_ctx_t &brgmm_ctx,
-            const char *A_data_batch_ptr, int ithr, int m_blk_idx,
-            int k_blk_idx) const;
+            const char *A_data_batch_ptr, int ithr, dim_t m_blk_idx,
+            dim_t k_blk_idx) const;
     void copy_b_chunk_in_buffer(const brg_matmul_exec_ctx_t &brgmm_ctx,
-            const char *B_data_batch_ptr, int ithr, int b_idx, int n_blk_idx,
-            int k_blk_idx) const;
+            const char *B_data_batch_ptr, int ithr, dim_t b_idx, dim_t n_blk_idx,
+            dim_t k_blk_idx) const;
     void maybe_reduce_partial_results_and_apply_postops(
             const std::shared_ptr<brg_matmul_exec_ctx_t> &brgmm_ctx_ptr) const;
     void maybe_reduce_A(const brg_matmul_exec_ctx_t &brgmm_ctx, int ithr,
-            int gemm_batch, int m_blk_idx, int n_blk_idx, int k_chunk_idx,
+            dim_t gemm_batch, dim_t m_blk_idx, dim_t n_blk_idx, dim_t k_chunk_idx,
             bool do_init, bool has_K_tail, bool do_K_tail) const;
     void maybe_reduce_and_convert_partial_results_A(
             const std::shared_ptr<brg_matmul_exec_ctx_t> &brgmm_ctx_ptr) const;

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -43,9 +43,10 @@ struct jit_brgemm_matmul_copy_a_impl_t : public jit_brgemm_matmul_copy_a_t,
     jit_brgemm_matmul_copy_a_impl_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_a_t(conf)
         , jit_generator_t(jit_name())
-        , typesize_(conf_->a_dt_sz)
-        , tr_typesize_(conf_->tr_a_dt_sz)
-        , vnni_granularity_(data_type_vnni_granularity(conf_->src_dt))
+        , typesize_(static_cast<int>(conf_->a_dt_sz))
+        , tr_typesize_(static_cast<int>(conf_->tr_a_dt_sz))
+        , vnni_granularity_(
+                  static_cast<int>(data_type_vnni_granularity(conf_->src_dt)))
         , k_step_(vlen_ / nstl::max(typesize_, tr_typesize_))
         , src_stride_(conf_->copy_A_src_stride)
         , tr_src_stride_((conf_->use_buffer_a_tail_only
@@ -265,8 +266,9 @@ void jit_brgemm_matmul_copy_a_impl_t<
 template <typename Vmm>
 void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
         bool is_K_tail, bool is_first_K_iter, bool is_last_K_iter) {
-    const int K_blk = is_K_tail ? conf_->K % conf_->K_blk
-                                : nstl::min(conf_->K, conf_->K_blk);
+    const int K_blk = static_cast<int>(is_K_tail
+                    ? conf_->K % conf_->K_blk
+                    : nstl::min<dim_t>(conf_->K, conf_->K_blk));
     const int k_tail = K_blk % k_step_;
     const int num_k_iters = K_blk / k_step_;
     const int num_acc = utils::saturate(1, (int)num_comp_acc_, num_k_iters);
@@ -295,7 +297,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
             const int k_idx = kb * k_loop_unroll_ + k;
             const size_t offset
                     = static_cast<size_t>(k_idx) * k_step_ * typesize_;
-            load_vmm(k, offset);
+            load_vmm(k, static_cast<int>(offset));
             maybe_compute_compensation(k_idx, get_vmm_copy(k));
         }
         if (allow_input_shift_for_s8s8 && conf_->s8s8_compensation_required) {
@@ -330,7 +332,7 @@ void jit_brgemm_matmul_copy_a_impl_t<Vmm>::copy_K_loop(
                 const size_t offset
                         = (static_cast<size_t>(kb) * k_loop_unroll_ + k)
                         * k_step_ * tr_typesize_;
-                store_vmm(k, offset);
+                store_vmm(k, static_cast<int>(offset));
             }
         }
     }
@@ -3547,7 +3549,7 @@ private:
 
     Xbyak::Ymm get_ymm(int idx) { return get_vmm(0, idx); }
 
-    void load_ymm(int ymm_idx, size_t offset, bool is_tail, size_t tail_sz) {
+    void load_ymm(int ymm_idx, size_t offset, bool is_tail, int tail_sz) {
         Xbyak::Ymm vmm_src = Xbyak::Ymm(ymm_idx);
         if (is_tail) {
             load_bytes(vmm_src, reg_src, offset, tail_sz);
@@ -3566,8 +3568,8 @@ private:
             if (pass == 0 && ncolumns >= simd_w_) mov(reg_src_backup, reg_src);
             assert(one_of(pass, 0, 1));
             const dim_t tr_src_off_base = k * tr_src_stride_;
-            const int set_1_tr_src_offset
-                    = tr_src_off_base + pass * 2 * n_blk_step_;
+            const int set_1_tr_src_offset = static_cast<int>(
+                    tr_src_off_base + pass * 2 * n_blk_step_);
             const int row_start = k * k_blk_step_;
             const int row_end = nstl::min(row_start + k_blk_step_, nrows);
             if (!zeropad) {
@@ -3743,7 +3745,8 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         if (!is_dynamic_N_) mov(reg_N_blk, ncolumns);
 
         if (do_compute_compensation_) {
-            int n_iters = div_up(conf_->wei_n_blk, 16) * (is_ymm_ ? 2 : 1);
+            int n_iters = static_cast<int>(
+                    div_up(conf_->wei_n_blk, 16) * (is_ymm_ ? 2 : 1));
             for (int i = 0; i < n_iters; i++)
                 uni_vpxor(get_comp_acc(i), get_comp_acc(i), get_comp_acc(i));
             mov(reg_tmp, 1);
@@ -3771,7 +3774,7 @@ void jit_brgemm_matmul_copy_b_int8_t<Vmm>::generate() {
         if (do_compute_compensation_) {
             const bool req_s8s8_comp = conf_->s8s8_compensation_required;
             const bool req_zp_comp = conf_->has_zero_point_a;
-            int n_iters = div_up(conf_->wei_n_blk, 16);
+            int n_iters = static_cast<int>(div_up(conf_->wei_n_blk, 16));
             assert(IMPLICATION(req_zp_comp,
                     conf_->src_zp_type == brgemm_broadcast_t::per_tensor));
 
@@ -3965,9 +3968,9 @@ struct jit_brgemm_matmul_copy_b_bf16_t
 
     jit_brgemm_matmul_copy_b_bf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize(conf->b_dt_sz)
-        , tr_typesize(conf->tr_b_dt_sz)
-        , wei_scales_typesize(conf->wei_scales_dt_sz)
+        , typesize(static_cast<int>(conf->b_dt_sz))
+        , tr_typesize(static_cast<int>(conf->tr_b_dt_sz))
+        , wei_scales_typesize(static_cast<int>(conf->wei_scales_dt_sz))
         , src_stride(conf->copy_B_wei_stride)
         , tr_src_stride(conf_->LDB * k_blk_step * tr_typesize)
         , is_src_int4(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
@@ -4197,7 +4200,7 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_2x32(
     if (is_dynamic_N || do_N_loop) {
         n_iters = ncolumns;
     } else {
-        n_iters = conf_->wei_n_blk;
+        n_iters = static_cast<int>(conf_->wei_n_blk);
     }
 
     for_(int k = 0; k < nrows; k += k_blk_step)
@@ -4315,7 +4318,8 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::copy_block(
     mov(ptr[rsp + reg_tr_src_offs], reg_tr_src);
     xor_(reg_copy_block_n_shift, reg_copy_block_n_shift);
 
-    int current_n_blk_step = do_N_loop ? conf_->LDB : n_blk_step;
+    int current_n_blk_step
+            = do_N_loop ? static_cast<int>(conf_->LDB) : n_blk_step;
 
     Label loop_row_start, loop_row_tail, loop_row_done;
     cmp(reg_dynamic_tail, current_n_blk_step);
@@ -4417,8 +4421,8 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
         // Otherwise default K-loop is used
         if (is_wei_grouped_over_k) {
             const int k_group_size = conf_->is_wei_zp_per_k
-                    ? conf_->wei_zp_k_gsize
-                    : conf_->wei_scales_k_gsize;
+                    ? static_cast<int>(conf_->wei_zp_k_gsize)
+                    : static_cast<int>(conf_->wei_scales_k_gsize);
             if (k_group_size < k_blk_step) {
                 if (zeropad) return;
                 copy_block(
@@ -4472,7 +4476,8 @@ void jit_brgemm_matmul_copy_b_bf16_t<Vmm>::generate() {
     };
 
     auto compute_K_loop = [&](bool is_N_tail) {
-        int ncolumns = is_N_tail ? conf_->N_tail : conf_->N_blk;
+        int ncolumns = is_N_tail ? static_cast<int>(conf_->N_tail)
+                                 : static_cast<int>(conf_->N_blk);
         // 'param1' register (rcx on Windows) re-written in compute_K_loop_body
         // so we need to read and keep 'current_K_pad' parameter in stack before
         // the call
@@ -4600,7 +4605,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
                 (k * src_stride_ + n * typesize_in_) / src_elems_per_byte_);
         if (is_tail && !isa_has_masks(conf_->isa)) {
             load_bytes(src_vmm, addr,
-                    (ncolumns % simd_w_) * typesize_in_ / src_elems_per_byte_);
+                    static_cast<int>((ncolumns % simd_w_) * typesize_in_
+                            / src_elems_per_byte_));
             load_value(src_vmm, src_vmm, vmm_permd, conf_->orig_wei_dt, false);
         } else
             load_value(src_vmm, addr, vmm_permd, conf_->orig_wei_dt, is_tail);
@@ -4624,7 +4630,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
         const auto addr = maybe_EVEX_compress_addr(reg_zp_ptr, offset);
         if (is_tail && !isa_has_masks(conf_->isa)) {
             load_bytes(vmm_zp_b_shift, addr,
-                    (ncolumns % simd_w_) * zp_dt_sz / elems_per_byte);
+                    static_cast<int>(
+                            (ncolumns % simd_w_) * zp_dt_sz / elems_per_byte));
             load_value(vmm_zp_b_shift, vmm_zp_b_shift, vmm_permd, zp_dt, false);
         } else
             load_value(vmm_zp_b_shift, addr, vmm_permd, zp_dt, is_tail);
@@ -4643,8 +4650,8 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::copy_16_x_n_block(
         const auto offset = n * scales_dt_sz;
         const auto addr = maybe_EVEX_compress_addr(reg_wei_scales, offset);
         if (is_tail && !isa_has_masks(conf_->isa)) {
-            load_bytes(
-                    vmm_wei_scales, addr, (ncolumns % simd_w_) * scales_dt_sz);
+            load_bytes(vmm_wei_scales, addr,
+                    static_cast<int>((ncolumns % simd_w_) * scales_dt_sz));
             load_scale_value(vmm_wei_scales, vmm_wei_scales, scales_dt, false);
         } else
             load_scale_value(vmm_wei_scales, addr, scales_dt, is_tail);
@@ -4698,7 +4705,9 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::compute_k_loop(int ncolumns) {
         jl(K_end_label, T_NEAR);
 
         copy_16_x_n_block(unroll, ncolumns);
-        add(reg_src, (unroll * src_stride_) / src_elems_per_byte_);
+        add(reg_src,
+                static_cast<dim_t>(
+                        (unroll * src_stride_) / src_elems_per_byte_));
         add(reg_tr_src, unroll * tr_src_stride_);
 
         sub(reg_K_iters, unroll);
@@ -4769,13 +4778,13 @@ void jit_brgemm_matmul_copy_b_f32_t<Vmm>::generate() {
         Label not_N_tail;
         cmp(reg_N_blk, conf_->N_tail);
         jne(not_N_tail, T_NEAR);
-        compute_k_loop(conf_->N_tail);
+        compute_k_loop(static_cast<int>(conf_->N_tail));
         jmp(done, T_NEAR);
 
         L(not_N_tail);
     }
 
-    compute_k_loop(conf_->N_blk);
+    compute_k_loop(static_cast<int>(conf_->N_blk));
     L(done);
 
     postamble();
@@ -4791,10 +4800,11 @@ struct jit_brgemm_matmul_copy_b_transposed_t
 
     jit_brgemm_matmul_copy_b_transposed_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize_(conf_->b_dt_sz)
-        , tr_typesize_(conf_->tr_b_dt_sz)
-        , wei_scales_typesize_(conf_->wei_scales_dt_sz)
-        , vnni_granularity_(data_type_vnni_granularity(conf_->wei_dt))
+        , typesize_(static_cast<int>(conf_->b_dt_sz))
+        , tr_typesize_(static_cast<int>(conf_->tr_b_dt_sz))
+        , wei_scales_typesize_(static_cast<int>(conf_->wei_scales_dt_sz))
+        , vnni_granularity_(
+                  static_cast<int>(data_type_vnni_granularity(conf_->wei_dt)))
         , k_blk_step_(vlen_ / tr_typesize_)
         , is_wei_grouped_over_k_(
                   conf_->is_wei_zp_per_k || conf_->is_wei_scale_per_k)
@@ -5354,7 +5364,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::init_tail_mask(
                 ? size_t(((size_t)1 << div_up(dt_step * columns_tail, 2)) - 1)
                 : size_t(((size_t)1 << dt_step * columns_tail) - 1);
         if (req_cvtps2xf16_)
-            kmovw(kTail, tail_mask);
+            kmovw(kTail, static_cast<uint32_t>(tail_mask));
         else
             kmovq(kTail, tail_mask);
     }
@@ -6048,7 +6058,7 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_N_loop(
     if (conf_->is_wei_scale_per_n) {
         const auto &scales_dt_sz = conf_->wei_scales_dt_sz;
         const auto offset = n_blk_step_ * scales_dt_sz;
-        add(reg_wei_scales, offset);
+        add(reg_wei_scales, static_cast<dim_t>(offset));
     }
 
     if (conf_->is_wei_zp_per_n) {
@@ -6064,9 +6074,9 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::compute_N_loop(
         // compensation pointer. Only the stack-saved ZP pointer needs to
         // advance per N-block in that case.
         if (req_int8_zp_b_shift_)
-            add(qword[rsp + reg_zp_b_ptr_offs_], offset);
+            add(qword[rsp + reg_zp_b_ptr_offs_], static_cast<dim_t>(offset));
         else
-            add(reg_zp_ptr, offset);
+            add(reg_zp_ptr, static_cast<dim_t>(offset));
     }
 
     if (req_zp_comp_) add(reg_zp_comp_ptr, comp_shift_);
@@ -6214,7 +6224,8 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
         }
 
         if (is_wei_grouped_over_k_ && grouped_k < k_blk_step_) {
-            compute_N_loop(grouped_k, is_first_K_iter, is_last_K_iter);
+            compute_N_loop(static_cast<int>(grouped_k), is_first_K_iter,
+                    is_last_K_iter);
             return;
         }
 
@@ -6223,13 +6234,15 @@ void jit_brgemm_matmul_copy_b_transposed_t<Vmm>::generate() {
             Label not_K_tail;
             cmp(reg_K_iters, k_blk);
             je(not_K_tail, T_NEAR);
-            compute_N_loop(K_tail_tail, is_first_K_iter, is_last_K_iter);
+            compute_N_loop(static_cast<int>(K_tail_tail), is_first_K_iter,
+                    is_last_K_iter);
             jmp(compute_body_done, T_NEAR);
 
             L(not_K_tail);
         }
 
-        compute_N_loop(K_blk_tail, is_first_K_iter, is_last_K_iter);
+        compute_N_loop(
+                static_cast<int>(K_blk_tail), is_first_K_iter, is_last_K_iter);
         L(compute_body_done);
     };
 
@@ -6290,9 +6303,9 @@ struct jit_brgemm_matmul_copy_b_cvt_bf16_t
 
     jit_brgemm_matmul_copy_b_cvt_bf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_common_t(conf)
-        , typesize_(conf->b_dt_sz)
-        , tr_typesize_(conf->tr_b_dt_sz)
-        , wei_scales_typesize_(conf_->wei_scales_dt_sz)
+        , typesize_(static_cast<int>(conf->b_dt_sz))
+        , tr_typesize_(static_cast<int>(conf->tr_b_dt_sz))
+        , wei_scales_typesize_(static_cast<int>(conf_->wei_scales_dt_sz))
         , is_src_int4_(one_of(conf->orig_wei_dt, data_type::s4, data_type::u4))
         , src_elems_per_byte_(is_src_int4_ ? 2 : 1)
         , src_stride_(
@@ -6592,8 +6605,8 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
         // Otherwise default K-loop is used
         if (is_wei_grouped_over_k_) {
             const int k_group_size = conf_->is_wei_zp_per_k
-                    ? conf_->wei_zp_k_gsize
-                    : conf_->wei_scales_k_gsize;
+                    ? static_cast<int>(conf_->wei_zp_k_gsize)
+                    : static_cast<int>(conf_->wei_scales_k_gsize);
             if (k_group_size == 1) {
                 if (zeropad) return;
                 copy_block(k_group_size, ncolumns, /*zeropad= */ false);
@@ -6659,7 +6672,7 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
 
     if (conf_->LDB2 != 0) {
         Label main_N_loop, main_N_loop_tail;
-        int tail = conf_->N % conf_->LDB;
+        int tail = static_cast<int>(conf_->N % conf_->LDB);
 
         if (tail != 0) {
             cmp(reg_N_blk, conf_->LDB);
@@ -6667,7 +6680,7 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
         }
 
         L(main_N_loop);
-        compute_K_loop(conf_->LDB);
+        compute_K_loop(static_cast<int>(conf_->LDB));
         add(reg_src, conf_->LDB2 * typesize_);
         add(reg_tr_src, conf_->LDB2 * tr_typesize_);
 
@@ -6687,13 +6700,13 @@ void jit_brgemm_matmul_copy_b_cvt_bf16_t<Vmm>::generate() {
             Label main_N_blk;
             cmp(reg_N_blk, conf_->N_blk);
             je(main_N_blk, T_NEAR);
-            compute_K_loop(conf_->N_tail);
+            compute_K_loop(static_cast<int>(conf_->N_tail));
             jmp(done, T_NEAR);
 
             L(main_N_blk);
         }
 
-        compute_K_loop(conf_->N_blk);
+        compute_K_loop(static_cast<int>(conf_->N_blk));
     }
     L(done);
     postamble();
@@ -6761,8 +6774,8 @@ struct jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t
     jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t(const brgemm_matmul_conf_t *conf)
         : jit_brgemm_matmul_copy_b_t(conf)
         , jit_generator_t(jit_name())
-        , typesize_(conf->b_dt_sz)
-        , tr_typesize_(conf->tr_b_dt_sz)
+        , typesize_(static_cast<int>(conf->b_dt_sz))
+        , tr_typesize_(static_cast<int>(conf->tr_b_dt_sz))
         , src_stride_(conf->LDB * k_blk_step * typesize_)
         , tr_src_stride_(conf->LDB * tr_k_blk_step * tr_typesize_)
         , cvt_helper_(this, conf) {}
@@ -6956,7 +6969,7 @@ private:
         assert(conf_->LDB2 != 0);
 
         Label main_N_loop, main_N_loop_tail;
-        int tail = conf_->N % conf_->LDB;
+        int tail = static_cast<int>(conf_->N % conf_->LDB);
 
         if (tail != 0) {
             cmp(reg_N_blk, conf_->LDB);
@@ -6964,7 +6977,7 @@ private:
         }
 
         L(main_N_loop);
-        compute_K_loop(conf_->LDB);
+        compute_K_loop(static_cast<int>(conf_->LDB));
         add(reg_src, conf_->B_strides[0]);
         add(reg_tr_src, conf_->LDB2 * tr_typesize_);
 

--- a/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_reorders.cpp
@@ -72,7 +72,7 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
     // drop all unit dims as they they will break the calculations. Removing
     // unit dims will not change the physical memory reorder problem.
     dims_t non_unit_dims {};
-    dim_t non_unit_dim = 0;
+    int non_unit_dim = 0;
     for (dim_t i = 0; i < src_md.ndims; i++) {
         if (src_md.dims[i] == 1) continue;
         non_unit_dims[non_unit_dim++] = src_md.dims[i];
@@ -147,8 +147,8 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
 
     // find first umatching stride by division
     dim_t lm_idx = -1;
-    int prev_M_src = src_over_dst[l_idx],
-        prev_1_over_M_dst = dst_over_src[l_idx];
+    dim_t prev_M_src = src_over_dst[l_idx],
+          prev_1_over_M_dst = dst_over_src[l_idx];
     // here we are checking to make sure all indexes are the same in src/dst
     // and dst/src arrays (comparing with prev_h_src and prev_h_dst). If its
     // different, then both src/dst and dst/src arrays should be different. In
@@ -175,8 +175,8 @@ status_t calculate_plain_transpose_blocks(dim_t &batch, dim_t &M, dim_t &K,
     // Only case this might be possible is unit strides after batch.
     VDISPATCH_REORDER_IC(lm_idx != -1, VERBOSE_UNSUPPORTED_MEM_STRIDE);
 
-    int prev_1_over_K_src = src_over_dst[lm_idx],
-        prev_K_dst = dst_over_src[lm_idx];
+    dim_t prev_1_over_K_src = src_over_dst[lm_idx],
+          prev_K_dst = dst_over_src[lm_idx];
     // Here we make sure the last strides divs are the same. If not, then this
     // means that one of the l+m, l+m+1, ..., l+m+n indexes is not in the same
     // order as in src. For example in src, looking at memory view, it can be

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -83,12 +83,12 @@ int get_n_block_from_tag(format_tag_t matrix_b_tag) {
     }
 }
 
-int get_wei_k_blk(data_type_t wei_dt) {
+dim_t get_wei_k_blk(data_type_t wei_dt) {
     // Fixed outer block size.
-    const int k_outer_block = 16;
+    const dim_t k_outer_block = 16;
 
     // VNNI granularity determines the inner block size along K.
-    const int k_inner_block = data_type_vnni_granularity(wei_dt);
+    const dim_t k_inner_block = data_type_vnni_granularity(wei_dt);
 
     return k_outer_block * k_inner_block;
 }
@@ -627,7 +627,7 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
             VCONDCHECK_BG(
                     IMPLICATION(bgmmc.is_xf16_fp8, blocked_B_layouts_allowed),
                     VERBOSE_UNSUPPORTED_TAG)
-            const int default_n_block = init_n_tag
+            const dim_t default_n_block = init_n_tag
                     ? get_default_n_block(format_tag::undef)
                     : bgmmc.N_blk;
             bgmmc.wei_tag = blocked_B_layouts_allowed && !bgmmc.is_runtime_N
@@ -708,7 +708,7 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(memory_desc_t &B_md,
 }
 
 status_t brgemm_matmul_conf_utils_t::update_and_check_B_tag(memory_desc_t &B_md,
-        int n_blk_size, const matmul_helper_t &helper) const {
+        dim_t n_blk_size, const matmul_helper_t &helper) const {
     if (n_blk_fixed && n_blk_size != bgmmc.wei_n_blk)
         return status::unimplemented;
 
@@ -844,7 +844,7 @@ status_t brgemm_matmul_conf_utils_t::set_B_flags(memory_desc_t &B_md) const {
 }
 
 format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
-        int n_blk) const {
+        dim_t n_blk) const {
 
     if (bgmmc.ndims > 3) return format_tag::undef;
 
@@ -937,14 +937,14 @@ struct matmul_avx512_blocking_params_t {
     }
 
     const matmul_params_t &mp;
-    int m_chunks, m_blk, m_tail;
-    int n_chunks, n_blk, n_tail;
-    int batch_size, k_blk, k_tail;
+    dim_t m_chunks, m_blk, m_tail;
+    dim_t n_chunks, n_blk, n_tail;
+    dim_t batch_size, k_blk, k_tail;
     int nthr_k;
     const int nthr;
 
-    void update_params(int m_chunks_, int m_blk_, int n_chunks_, int n_blk_,
-            int batch_size_, int k_blk_, int nthr_k_) {
+    void update_params(dim_t m_chunks_, dim_t m_blk_, dim_t n_chunks_,
+            dim_t n_blk_, dim_t batch_size_, dim_t k_blk_, int nthr_k_) {
         m_chunks = m_chunks_;
         m_blk = m_blk_;
         m_tail = mp.M % m_blk;
@@ -962,7 +962,7 @@ struct matmul_avx512_blocking_params_t {
         size_t scalar = work < thread_block
                 ? thread_block - mod
                 : nstl::min(thread_block - mod, mod);
-        return static_cast<float>(scalar) / thread_block;
+        return static_cast<float>(scalar) / static_cast<float>(thread_block);
     }
 
     float get_imbalance() const {
@@ -973,20 +973,25 @@ struct matmul_avx512_blocking_params_t {
                 = calculate_spatial_disbalance(parallel_work, cur_nthr);
 
         const auto m_work = (m_blk * div_up(mp.M, m_blk)) % mp.M;
-        const float m_blk_disbalance = static_cast<float>(m_work) / mp.M;
+        const float m_blk_disbalance
+                = static_cast<float>(m_work) / static_cast<float>(mp.M);
 
         const auto num_n_blk = div_up(mp.N, n_blk);
         const auto par_n_chunks = div_up(num_n_blk, n_chunks);
         const float n_chunk_disbalance
-                = (static_cast<float>(par_n_chunks) * n_chunks - num_n_blk)
-                / num_n_blk;
+                = (static_cast<float>(par_n_chunks)
+                                  * static_cast<float>(n_chunks)
+                          - static_cast<float>(num_n_blk))
+                / static_cast<float>(num_n_blk);
 
         const float disbalance_nthr_k
                 = calculate_spatial_disbalance(mp.K, nthr_k * k_blk);
 
         const float thread_allocation_disb
                 = (cur_nthr * nthr_k) != static_cast<size_t>(nthr)
-                ? (static_cast<float>(nthr) - cur_nthr * nthr_k) / nthr
+                ? (static_cast<float>(nthr)
+                          - static_cast<float>(cur_nthr * nthr_k))
+                        / static_cast<float>(nthr)
                 : 0;
 
         const float score
@@ -1152,7 +1157,7 @@ void compute_gemv_k_blocking(dim_t K, int &k_blk, int &batch_size) {
 // only select m_blk >= min_m_blk.
 bool is_gemv_k_split_needed(const brgemm_matmul_conf_t &bgmmc,
         const matmul_avx512_blocking_params_t::matmul_params_t &matmul,
-        int min_m_blk, int nthr) {
+        dim_t min_m_blk, int nthr) {
     if (!bgmmc.is_gemv) return false;
     if (!one_of(bgmmc.gemv_strategy, gemv_strategy_t::n1_A_trans,
                 gemv_strategy_t::m1_B_plain))
@@ -1192,7 +1197,7 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
 
     dim_t min_m_chunks = div_up(matmul.M, max_m_blk);
 
-    int n_blk = bgmmc.N_blk;
+    dim_t n_blk = bgmmc.N_blk;
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1261,15 +1266,15 @@ float compute_blocking_heuristic_avx512(brgemm_matmul_conf_t &bgmmc,
         use_k_partitioning = use_k_partitioning && bm_conf_utils.is_f32();
 
         if (use_k_partitioning) {
-            auto least_prime_factor = [](int n) {
+            auto least_prime_factor = [](dim_t n) {
                 assert(n > 0);
-                if (n == 1) return 1;
-                for (int factor = 2; factor < n; factor++)
+                if (n == 1) return (dim_t)1;
+                for (dim_t factor = 2; factor < n; factor++)
                     if (n % factor == 0) return factor;
                 return n;
             };
 
-            int nthr_bmn = max_div(max_bmn_parallel, nthr);
+            int nthr_bmn = static_cast<int>(max_div(max_bmn_parallel, nthr));
             int nthr_k = nstl::max(nthr / nthr_bmn, 1);
             int nthr_remainder = nthr % nthr_bmn;
 
@@ -1374,7 +1379,7 @@ float compute_blocking_heuristic_avx2(brgemm_matmul_conf_t &bgmmc,
     int min_m_blk
             = static_cast<int>(nstl::min((dim_t)32, matmul.M)); // max_m_blk
 
-    int n_blk = bgmmc.N_blk;
+    dim_t n_blk = bgmmc.N_blk;
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1431,7 +1436,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     dim_t max_m_blk = nstl::min((dim_t)256, matmul.M);
     dim_t min_m_blk = nstl::min((dim_t)32, matmul.M);
 
-    int n_blk = bgmmc.N_blk;
+    dim_t n_blk = bgmmc.N_blk;
     const dim_t n_chunks = div_up(matmul.N, n_blk);
     const dim_t max_n_chunks = bgmmc.use_buffer_a ? 16 : 1;
     const int n_chunks_start
@@ -1446,10 +1451,12 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     // for cases with low parallel work, reduce 'min_m_blk' to
     // increase potential parallelization balance.
     size_t max_parallel = matmul.batch * n_chunks;
-    const float req_additional_parallel = nthr / max_parallel;
+    const float req_additional_parallel
+            = static_cast<float>(nthr) / static_cast<float>(max_parallel);
     if (req_additional_parallel > 1) {
         min_m_blk = saturate<dim_t>(nstl::min((dim_t)16, max_m_blk), max_m_blk,
-                matmul.M / req_additional_parallel);
+                static_cast<dim_t>(static_cast<float>(matmul.M)
+                        / req_additional_parallel));
         max_parallel *= div_up(matmul.M, min_m_blk);
     } else if (bm_conf_utils.check_is_transposed(bgmmc.src_tag)
             && matmul.K >= 4096) {
@@ -1457,7 +1464,8 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     }
 
     bool low_parallel_work = max_parallel % nthr != 0
-            && (static_cast<float>(max_parallel) / nthr) < 2;
+            && (static_cast<float>(max_parallel) / static_cast<float>(nthr))
+                    < 2;
     if (low_parallel_work) {
         // Reduce n_blk size to increase parallel space
         // note: over reduction of n_blk size on 2d shapes when n_chunks == 1
@@ -1471,7 +1479,7 @@ float compute_blocking_heuristic_avx2_f32(brgemm_matmul_conf_t &bgmmc,
     max_m_blk = nstl::max(max_m_blk, min_m_blk);
     for_(int nthr_k = start_nthr_k; nthr_k >= 1; --nthr_k)
     for_(int n_chunk_size = n_chunks_start; n_chunk_size >= 1; --n_chunk_size)
-    for (int m_blk = max_m_blk; m_blk >= min_m_blk; --m_blk) {
+    for (dim_t m_blk = max_m_blk; m_blk >= min_m_blk; --m_blk) {
         matmul_avx512_blocking_params_t cur_params(matmul, nthr);
         cur_params.update_params(
                 1, m_blk, n_chunk_size, n_blk, brgemm_bs, k_blk, nthr_k);
@@ -2609,7 +2617,7 @@ void init_aux_values(brgemm_matmul_conf_t &bgmmc,
             ? runtime_value_for(bgmmc.num_K_blocks)
             : div_up(bgmmc.K, bgmmc.K_blk * bgmmc.brgemm_batch_size);
 
-    const int last_chunck_batch_size
+    const dim_t last_chunck_batch_size
             = (nstl::max(bgmmc.K, bgmmc.K_blk)
                       - (bgmmc.K_chunks - 1) * bgmmc.K_chunk_elems)
             / bgmmc.K_blk;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -118,14 +118,14 @@ struct brgemm_matmul_conf_t {
     int ndims, batch_ndims;
     dim_t M, N, K, batch, batch_without_first_dim;
     dim_t M_blk, N_blk, K_blk, M_tail, N_tail, K_tail;
-    int M_chunk_size, N_chunk_size, K_chunk_size;
+    dim_t M_chunk_size, N_chunk_size, K_chunk_size;
     bool is_a_nt, is_b_nt, set_nt;
     bool need_prefetch_a, need_prefetch_b;
     bool use_fused_copy_a;
     dim_t LDA, LDB, LDC, LDD;
     dim_t LDB2;
-    int brgemm_batch_size, brgemm_batch_tail_size;
-    int wei_n_blk, wei_k_blk;
+    dim_t brgemm_batch_size, brgemm_batch_tail_size;
+    dim_t wei_n_blk, wei_k_blk;
     brgemm_batch_kind_t brg_type;
     bool is_macro_heuristics;
 
@@ -179,12 +179,12 @@ struct brgemm_matmul_conf_t {
     // from FP32 implementation)
     dim_t tr_a_dt_sz, tr_b_dt_sz;
 
-    int M_chunks;
-    int N_chunks;
-    int K_chunks;
-    int num_M_blocks;
-    int num_N_blocks;
-    int num_K_blocks;
+    dim_t M_chunks;
+    dim_t N_chunks;
+    dim_t K_chunks;
+    dim_t num_M_blocks;
+    dim_t num_N_blocks;
+    dim_t num_K_blocks;
     dim_t M_chunk_elems;
     dim_t N_chunk_elems;
     dim_t K_chunk_elems;
@@ -229,11 +229,11 @@ struct brgemm_matmul_conf_t {
     // were changed.
     bool adjust_a_strides = false;
 
-    int wsp_tile_per_thr_bytes;
-    int brgemm_batch_element_per_thr_sz;
+    dim_t wsp_tile_per_thr_bytes;
+    dim_t brgemm_batch_element_per_thr_sz;
     bool is_amx;
 
-    int required_k_granularity;
+    dim_t required_k_granularity;
     bool is_bf32 = false;
     bool is_bf16_with_int_wei = false;
     bool is_f16_with_int_wei = false;
@@ -491,13 +491,13 @@ struct brgemm_matmul_conf_utils_t {
     status_t set_or_check_B_tag(memory_desc_t &B_md,
             const dnnl::impl::cpu::matmul::matmul_helper_t &helper,
             bool init_n_tag = true) const;
-    status_t update_and_check_B_tag(memory_desc_t &B_md, int n_blk_size,
+    status_t update_and_check_B_tag(memory_desc_t &B_md, dim_t n_blk_size,
             const dnnl::impl::cpu::matmul::matmul_helper_t &helper) const;
     status_t set_or_check_tags(memory_desc_t &A_md, memory_desc_t &C_md,
             memory_desc_t &bias_md,
             const dnnl::impl::cpu::matmul::matmul_helper_t &helper) const;
     status_t set_B_flags(memory_desc_t &B_md) const;
-    format_tag_t pick_blocked_B_layout(int n_blk) const;
+    format_tag_t pick_blocked_B_layout(dim_t n_blk) const;
 
     format_tag_t get_gemv_A_tag(const memory_desc_t &A_md) const;
     format_tag_t get_gemv_B_tag(const memory_desc_t &B_md) const;
@@ -568,7 +568,7 @@ bool dims_adjacent(const memory_desc_wrapper &mdw, const int outer_dim,
  *
  * @return The total K dimension block size.
  */
-int get_wei_k_blk(data_type_t wei_dt);
+dim_t get_wei_k_blk(data_type_t wei_dt);
 
 } // namespace matmul
 } // namespace x64

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_per_mn_comp.cpp
@@ -655,7 +655,8 @@ private:
                     const dim_t off
                             = c * simd_w * types::data_type_size(wei_zp_dt_);
                     const int tail_bytes = has_tail
-                            ? rem * types::data_type_size(wei_zp_dt_)
+                            ? static_cast<int>(
+                                      rem * types::data_type_size(wei_zp_dt_))
                             : 0;
                     load_vec_zps_f32(vmm_zw(), wei_zp_dt_, ptr[reg_tmp + off],
                             has_tail, tail_bytes);

--- a/src/cpu/x64/matmul/jit_brgemm_matmul_reduce.cpp
+++ b/src/cpu/x64/matmul/jit_brgemm_matmul_reduce.cpp
@@ -47,9 +47,9 @@ jit_brgemm_kernel_reduce_t<Vmm>::jit_brgemm_kernel_reduce_t(
     // MatMul `reduce` buffer.
     , out_dt_(bgmmc.reduce_dt)
     , acc_dt_(bgmmc.acc_dt)
-    , in_typesize_(types::data_type_size(in_dt_))
-    , out_typesize_(types::data_type_size(out_dt_))
-    , acc_typesize_(types::data_type_size(acc_dt_)) {
+    , in_typesize_(static_cast<int>(types::data_type_size(in_dt_)))
+    , out_typesize_(static_cast<int>(types::data_type_size(out_dt_)))
+    , acc_typesize_(static_cast<int>(types::data_type_size(acc_dt_))) {
     // This kernel must be called after the copy A routine because it assumes
     // that fp16 data has already been upconverted to f32.
     // Only reduction for `src` is supported.

--- a/src/cpu/x64/matmul/jit_uni_sparse_matmul.cpp
+++ b/src/cpu/x64/matmul/jit_uni_sparse_matmul.cpp
@@ -68,11 +68,11 @@ struct sparse_matmul_kernel_t : public jit_generator_t {
     int data_type_size() const { return sizeof(float); }
     int index_type_size() const { return sizeof(int32_t); }
 
-    int block_size() const { return vlen(); }
+    int block_size() const { return static_cast<int>(vlen()); }
 
     int unroll_factor() const { return 2; }
 
-    int N() const { return N_; }
+    int N() const { return static_cast<int>(N_); }
 
 protected:
     size_t N_;
@@ -173,17 +173,17 @@ struct jit_uni_sparse_matmul_kernel_t : public sparse_matmul_kernel_t {
 
     Vmm get_wei_reg(int index, bool is_tail_block) {
         // Vmm(0) is reserved for mask.
-        const int nloads = is_tail_block
-                ? utils::div_up(tail_block_size(), simd_w())
-                : block_size() / simd_w();
+        const int nloads = static_cast<int>(is_tail_block
+                        ? utils::div_up(tail_block_size(), simd_w())
+                        : block_size() / simd_w());
         return Vmm(nloads + index + 1);
     }
 
     void loop_within_block_row(
             Vmm vreg_src_val, Reg64 reg_src_col_idx, bool is_tail_block) {
-        const int nloads = is_tail_block
-                ? utils::div_up(tail_block_size(), simd_w())
-                : block_size() / simd_w();
+        const int nloads = static_cast<int>(is_tail_block
+                        ? utils::div_up(tail_block_size(), simd_w())
+                        : block_size() / simd_w());
         for (int i_load = 0; i_load < nloads; i_load++) {
             Vmm vreg_tmp_wei = get_wei_reg(i_load, is_tail_block);
             // Load a row of weights.
@@ -254,15 +254,15 @@ struct jit_uni_sparse_matmul_kernel_t : public sparse_matmul_kernel_t {
         Label loop_over_blocks_begin, loop_over_blocks_end;
         L(loop_over_blocks_begin);
         {
-            cmp(reg_blocks_count, nblocks);
+            cmp(reg_blocks_count, static_cast<dim_t>(nblocks));
             je(loop_over_blocks_end, T_NEAR);
 
             mov(reg_block_offset, reg_blocks_count);
             shl(reg_block_offset, math::ilog2q(block_size()));
 
-            const int nloads = is_tail_block
-                    ? utils::div_up(tail_block_size(), simd_w())
-                    : block_size() / simd_w();
+            const int nloads = static_cast<int>(is_tail_block
+                            ? utils::div_up(tail_block_size(), simd_w())
+                            : block_size() / simd_w());
             std::vector<Vmm> vregs_dst(nloads);
             for (int i_load = 0; i_load < nloads; i_load++) {
                 vregs_dst[i_load] = get_dst_reg(i_load);

--- a/src/cpu/x64/matmul/postops_estimator.hpp
+++ b/src/cpu/x64/matmul/postops_estimator.hpp
@@ -44,9 +44,12 @@ public:
         if (res != status::success) return res;
 
         size_t code_size = post_ops_gen.getSize();
-        size_t estimated_vec_code_size = (size_t)nstl::max(
-                (int)code_size - (int)mean_none_vec_code_bytes, 0);
-        estimated_vec_insts = estimated_vec_code_size / mean_vec_inst_bytes;
+        const size_t estimated_vec_code_size
+                = code_size > mean_none_vec_code_bytes
+                ? code_size - mean_none_vec_code_bytes
+                : 0;
+        estimated_vec_insts = static_cast<int>(
+                estimated_vec_code_size / mean_vec_inst_bytes);
         return status::success;
     }
 
@@ -60,10 +63,10 @@ private:
         : jit_generator_t("dummy_generator") {
         auto dsc = memory_desc_wrapper(dst_md);
         const dnnl::impl::cpu::x64::binary_injector::rhs_arg_static_params_t
-                rhs_sp(static_cast<size_t>(Xbyak::Zmm(1).getIdx()), this->r14,
-                        this->r15, this->r13, false, false,
-                        static_cast<size_t>(0), static_cast<size_t>(0), dsc,
-                        static_cast<size_t>(0), Xbyak::Opmask(0), false);
+                rhs_sp(Xbyak::Zmm(1).getIdx(), this->r14, this->r15, this->r13,
+                        false, false, static_cast<size_t>(0),
+                        static_cast<size_t>(0), dsc, static_cast<size_t>(0),
+                        Xbyak::Opmask(0), false);
 
         const dnnl::impl::cpu::x64::binary_injector::static_params_t bsp(
                 this->param1,

--- a/src/cpu/x64/prelu/jit_prelu_backward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_backward.cpp
@@ -217,7 +217,7 @@ status_t jit_prelu_bwd_t::execute(const exec_ctx_t &ctx) const {
                 weights_diff_scratchpad, C_cache_line_aligned, nthr);
 
         if (bcast == prelu::bcast::per_oc_blocked) {
-            const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+            const dim_t C_blocks = utils::div_up(C, simd_w);
             work_amount = MB * C_blocks;
             parallel_nd_ext(nthr, MB, C_blocks,
                     [=](int ithr, int, dim_t mb, dim_t c_blk) {
@@ -283,7 +283,7 @@ void jit_prelu_bwd_t::scratchpad_to_diff_weights_reduction(float *scratchpad,
     const auto reduction_kernel = reduction_kernel_.get();
     const auto &simd_w = reduction_kernel_->simd_w();
     const bool tail_exists = C % simd_w;
-    const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+    const dim_t C_blocks = utils::div_up(C, simd_w);
 
     parallel_nd(C_blocks, [=](dim_t c_blk) {
         const auto blk_offset = c_blk * simd_w;

--- a/src/cpu/x64/prelu/jit_prelu_forward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_forward.cpp
@@ -181,7 +181,7 @@ status_t jit_prelu_fwd_t::execute(const exec_ctx_t &ctx) const {
             });
         } else if (bcast == prelu::bcast::per_oc_blocked) {
             const auto simd_w = kernel->simd_w();
-            const dim_t C_blocks = std::ceil(static_cast<float>(C) / simd_w);
+            const dim_t C_blocks = utils::div_up(C, simd_w);
 
             parallel_nd(MB, C_blocks, [=](dim_t mb, dim_t c_blk) {
                 jit_prelu_forward_kernel_t::call_params_t params;

--- a/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
@@ -99,11 +99,11 @@ template <typename weights_t, typename scratch_t, typename gemm_acc_t>
 void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::execute()
         const {
     if (rnn_.is_cell_amx()) {
-        parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
             this->kernel_amx(ithr, nthr);
         });
     } else {
-        parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
             this->kernel(ithr, nthr);
         });
     }
@@ -111,12 +111,12 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::execute()
 
 template <typename weights_t, typename scratch_t, typename gemm_acc_t>
 void brgemm_diff_src_layer_iter_t<weights_t, scratch_t,
-        gemm_acc_t>::kernel_amx_compute_iter(const int m_block_id,
-        const int n_block_id, const int gates_start, const int gates_end,
+        gemm_acc_t>::kernel_amx_compute_iter(const dim_t m_block_id,
+        const dim_t n_block_id, const int gates_start, const int gates_end,
         thread_exec_ctx_t &ctx) const {
 
-    const int m = m_block_id * rnn_.diff_src_brgemm.m_block;
-    const int n = n_block_id * rnn_.diff_src_brgemm.n_block;
+    const dim_t m = m_block_id * rnn_.diff_src_brgemm.m_block;
+    const dim_t n = n_block_id * rnn_.diff_src_brgemm.n_block;
     const int num_gates = gates_end - gates_start;
     const scratch_t *const A_m = A_ + m * LDA_;
     const auto B_n_offset = n_block_id * B_nb_offset_;
@@ -253,21 +253,23 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel_amx(
         const int ithr, const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int mn_start = 0, mn_end = 0;
+    dim_t mn_start = 0, mn_end = 0;
     balance211(work_amount_, nthr, ithr, mn_start, mn_end);
 
-    int n_block_id = 0, m_block_id = 0;
+    dim_t n_block_id = 0, m_block_id = 0;
     const auto n_gates = rnn_.n_gates;
-    const int gates_block_size = rnn_.diff_src_brgemm.gates_block;
+    const dim_t gates_block_size = rnn_.diff_src_brgemm.gates_block;
     thread_exec_ctx_t ctx;
     ctx.addr_batch = addr_batch_global_ + ithr * (k_blocks_n_gates_ + 1);
     ctx.amx_buffer = amx_scratchpad_
             + rnn_.diff_src_brgemm.m_block * rnn_.diff_src_brgemm.n_block
                     * ithr;
 
-    for (int gate_idx = 0; gate_idx < n_gates; gate_idx += gates_block_size) {
-        const int gates_start = gate_idx;
-        const int gates_end = nstl::min(gate_idx + gates_block_size, n_gates);
+    for (dim_t gate_idx = 0; gate_idx < n_gates;
+            gate_idx += gates_block_size) {
+        const int gates_start = static_cast<int>(gate_idx);
+        const int gates_end = static_cast<int>(
+                nstl::min<dim_t>(gate_idx + gates_block_size, n_gates));
 
         switch (rnn_.diff_src_brgemm.loop_order) {
             case brgemm_rnn_execute_loop_order_t::mblk_nblk:
@@ -280,7 +282,7 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel_amx(
                 break;
             default: assert(!"unsupported loop order");
         }
-        int mn_idx = mn_start;
+        dim_t mn_idx = mn_start;
         while (mn_idx < mn_end) {
             kernel_amx_compute_iter(
                     m_block_id, n_block_id, gates_start, gates_end, ctx);
@@ -303,10 +305,10 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel_amx(
 template <typename weights_t, typename scratch_t, typename gemm_acc_t>
 void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
-    int n_block_id = 0, m_block_id = 0;
+    dim_t n_block_id = 0, m_block_id = 0;
     nd_iterator_init(start, n_block_id, n_blocking_, m_block_id, m_blocking_);
 
     x64::brgemm_batch_element_t *const addr_batch
@@ -314,8 +316,8 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel(
     const auto n_gates = rnn_.n_gates;
 
     while (start < end) {
-        const int m = m_block_id * rnn_.diff_src_brgemm.m_block;
-        const int n = n_block_id * rnn_.diff_src_brgemm.n_block;
+        const dim_t m = m_block_id * rnn_.diff_src_brgemm.m_block;
+        const dim_t n = n_block_id * rnn_.diff_src_brgemm.n_block;
         const scratch_t *const A_m = A_ + m * LDA_;
         const auto B_n_offset = n_block_id * B_nb_offset_;
         const weights_t *const B_wei_iter_n = B_wei_iter_ + B_n_offset;
@@ -491,11 +493,11 @@ template <typename src_layer_t, typename src_iter_t, typename scratch_t,
 void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
         gemm_acc_t>::execute() const {
     if (is_amx_) {
-        parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
             this->kernel_amx(ithr, nthr);
         });
     } else {
-        parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
             this->kernel(ithr, nthr);
         });
     }
@@ -537,11 +539,11 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
             : A_layer_transposed_scratch_
                     + ithr * rnn_.diff_wei_brgemm.Kpadded * m_layer_block_;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
-    int n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
-        last_m_block_id = -1;
+    dim_t n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
+          last_m_block_id = -1;
 
     nd_iterator_init(start, n_block_id, n_blocking_, m_block_id, m_blocking_);
 
@@ -555,8 +557,8 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
         const bool should_transpose_src = transpose_needed && !global_transpose
                 && (last_m_block_id != m_block_id);
 
-        const int m_iter = m_block_id * m_iter_block_;
-        const int m_layer = m_block_id * m_layer_block_;
+        const dim_t m_iter = m_block_id * m_iter_block_;
+        const dim_t m_layer = m_block_id * m_layer_block_;
         const src_iter_t *const A_iter_m = global_transpose
                 ? A_iter_transposed_ithr + m_iter * LDA_iter_
                 : A_iter_ + m_iter;
@@ -573,7 +575,7 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
                 ? const_cast<src_layer_t *>(A_layer_m)
                 : A_layer_transposed_ithr;
 
-        const int n = n_block_id * rnn_.diff_wei_brgemm.n_block;
+        const dim_t n = n_block_id * rnn_.diff_wei_brgemm.n_block;
         const scratch_t *const B_n = B_ + n;
         const auto C_iter_offset = m_iter * LDC_iter_ + n;
         const auto C_layer_offset = m_layer * LDC_layer_ + n;
@@ -670,11 +672,11 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
 
     const bool global_transpose = rnn_.diff_wei_brgemm.global_transpose;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
-    int n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
-        last_m_block_id = -1;
+    dim_t n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
+          last_m_block_id = -1;
     switch (rnn_.diff_wei_brgemm.loop_order) {
         case brgemm_rnn_execute_loop_order_t::mblk_nblk:
             nd_iterator_init(
@@ -713,8 +715,8 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
         const bool should_transpose_src
                 = !global_transpose && last_m_block_id != m_block_id;
 
-        const int m_iter = m_block_id * m_iter_block_;
-        const int m_layer = m_block_id * m_layer_block_;
+        const dim_t m_iter = m_block_id * m_iter_block_;
+        const dim_t m_layer = m_block_id * m_layer_block_;
         const src_iter_t *const A_iter_m = global_transpose
                 ? A_iter_transposed_ithr + m_iter * LDA_iter_
                 : A_iter_ + m_iter;
@@ -729,7 +731,7 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
                 ? const_cast<src_layer_t *>(A_layer_m)
                 : A_layer_transposed_ithr;
 
-        const int n = n_block_id * rnn_.diff_wei_brgemm.n_block;
+        const dim_t n = n_block_id * rnn_.diff_wei_brgemm.n_block;
         const scratch_t *const B_n = B_ + n;
         const auto C_iter_offset = m_iter * LDC_iter_ + n;
         const auto C_layer_offset = m_layer * LDC_layer_ + n;
@@ -885,10 +887,10 @@ template <typename scratch_t>
 void brgemm_diff_wei_peep_t<scratch_t>::kernel(
         const int ithr, const int nthr) const {
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
-    int g = 0, dhc_block_id = 0;
+    dim_t g = 0, dhc_block_id = 0;
 
     nd_iterator_init(
             start, g, n_gates_, dhc_block_id, rnn_.dhc_blocks_peephole);

--- a/src/cpu/x64/rnn/brgemm_cell_common_bwd.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_bwd.hpp
@@ -70,7 +70,7 @@ private:
     };
 
     void kernel_amx(const int ithr, const int nthr) const;
-    void kernel_amx_compute_iter(const int m_block_id, const int n_block_id,
+    void kernel_amx_compute_iter(const dim_t m_block_id, const dim_t n_block_id,
             const int gates_start, const int gates_end,
             thread_exec_ctx_t &ctx) const;
     void kernel(const int ithr, const int nthr) const;
@@ -97,7 +97,7 @@ private:
     const dim_t max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const dim_t max_n_layer_blocks_;
     const dim_t max_n_iter_blocks_;
     const bool gemm_layer_needed_;
@@ -195,7 +195,7 @@ private:
     const dim_t B_kb_offset_;
     const dim_t B_k_tail_offset_;
     const dim_t B_k_tail_offset_blocked_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const brgemm_kernel_t *const kernel_iter_full_blocks_;
     const brgemm_kernel_t *const kernel_iter_n_tail_;
     const brgemm_kernel_t *const kernel_iter_k_tail_;
@@ -241,9 +241,9 @@ private:
     const void *src_iter_c_;
     const void *dst_iter_c_;
     float *diff_weights_peephole_;
-    const int work_amount_;
-    const int dst_iter_c_ld_;
-    const int src_iter_c_ld_;
+    const dim_t work_amount_;
+    const dim_t dst_iter_c_ld_;
+    const dim_t src_iter_c_ld_;
     const jit_diff_weights_peephole_t *const kernel_;
     const jit_diff_weights_peephole_t *const kernel_tail_;
 };

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
@@ -110,11 +110,11 @@ template <typename src_t, typename weights_t, typename scratch_t,
 void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::execute()
         const {
     if (is_fused_layer_iter_brgemm_) {
-        parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
             this->kernel_fused_iter_layer(ithr, nthr);
         });
     } else {
-        parallel(max_nthr_, [this](const int ithr, const int nthr) {
+        parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
             this->kernel(ithr, nthr);
         });
     }
@@ -158,14 +158,14 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+    const dim_t max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
             nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * max_K_Block;
@@ -245,7 +245,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         }
 
         for (int g = 0; g < n_gates_; g++) {
-            const int lg = g + g_unfused;
+            const dim_t lg = g + g_unfused;
             const auto *const Bl_g = Bl_n + lg * Bl_g_offset_;
             const auto *const Bi_g = Bi_n + lg * Bi_g_offset_;
             auto *C_g = C_n + lg * rnn_.N;
@@ -274,7 +274,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             if (is_amx) load_cfg_if_needed(pallete_buff_layer_k_tail);
 
             for (int g = 0; g < n_gates_; g++) {
-                const int lg = g + g_unfused;
+                const dim_t lg = g + g_unfused;
                 const auto *const Bl_g = Bl_n + lg * Bl_g_offset_;
                 auto *const C_g = C_n + lg * rnn_.N;
 
@@ -289,7 +289,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             if (is_amx) load_cfg_if_needed(pallete_buff_iter_k_tail);
 
             for (int g = 0; g < n_gates_; g++) {
-                const int lg = g + g_unfused;
+                const dim_t lg = g + g_unfused;
                 const auto *const Bi_g = Bi_n + lg * Bi_g_offset_;
                 auto *C_g = C_n + lg * rnn_.N;
                 if (rnn_.is_lbr && g == n_gates_ - 1) C_g = C_cell_i;
@@ -326,14 +326,14 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = 2
+    const dim_t max_K_Block = 2
             * nstl::max(rnn_.KB1_blocks + 1,
                     nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     brgemm_batch_element_t *const addr_batch
@@ -398,7 +398,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         }
 
         for (int g = 0; g < n_gates_; g++) {
-            const int lg = g + g_unfused;
+            const dim_t lg = g + g_unfused;
             const auto *const Bl_g = Bl_n + lg * B_g_offset;
             const auto *const Bi_g = Bi_n + lg * B_g_offset;
             auto *const C_g = C_n + lg * rnn_.N;
@@ -427,7 +427,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
 
         if (rnn_.k2_tail) {
             for (int g = 0; g < n_gates_; g++) {
-                const int lg = g + g_unfused;
+                const dim_t lg = g + g_unfused;
                 auto *const C_g = C_n + lg * rnn_.N;
 
                 int batch_idx = 0;
@@ -501,7 +501,7 @@ brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::brgemm_dst_proj_t(
 
 template <typename src_t, typename weights_t, typename gemm_acc_t>
 void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::execute() const {
-    parallel(max_nthr_, [this](const int ithr, const int nthr) {
+    parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
         this->kernel(ithr, nthr);
     });
 }
@@ -511,10 +511,10 @@ void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_proj_, nthr, ithr, start, end);
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
-    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+    const dim_t max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
             nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     auto *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
@@ -525,7 +525,7 @@ void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::kernel(
 
     if (is_amx) load_cfg_if_needed(rnn_brgemm_.pallete_buff_proj_);
 
-    int nb = 0, mb = 0;
+    dim_t nb = 0, mb = 0;
     switch (rnn_.loop_order) {
         case brgemm_rnn_execute_loop_order_t::mblk_nblk:
             nd_iterator_init(start, mb, rnn_.M_blocks, nb, rnn_.Nproj_blocks);
@@ -537,10 +537,10 @@ void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::kernel(
     }
 
     while (start < end) {
-        const int n = nb * rnn_.n_block;
-        const int m = mb * rnn_.m_block;
+        const dim_t n = nb * rnn_.n_block;
+        const dim_t m = mb * rnn_.m_block;
         const bool do_n_tail = (n + rnn_.n_block) > rnn_.Nproj;
-        const int block_step = ((do_n_tail) ? rnn_.nproj_tail : rnn_.n_block)
+        const dim_t block_step = ((do_n_tail) ? rnn_.nproj_tail : rnn_.n_block)
                 * sizeof(src_t);
 
         const auto *const Ap_m = A_ + m * rnn_.LDAproj;
@@ -704,7 +704,7 @@ template <typename src_t, typename weights_t, typename scratch_t,
         typename gemm_acc_t>
 void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::execute() const {
     assert(is_fused_layer_iter_brgemm_);
-    parallel(max_nthr_, [this](const int ithr, const int nthr) {
+    parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
         this->kernel(ithr, nthr);
     });
 }
@@ -713,14 +713,14 @@ template <typename src_t, typename weights_t, typename scratch_t,
         typename gemm_acc_t>
 void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+    const dim_t max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
             nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * max_K_Block;
@@ -974,7 +974,7 @@ template <typename src_t, typename weights_t, typename scratch_t,
         typename gemm_acc_t>
 void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::execute()
         const {
-    parallel(max_nthr_, [this](const int ithr, const int nthr) {
+    parallel(static_cast<int>(max_nthr_), [this](const int ithr, const int nthr) {
         this->kernel(ithr, nthr);
     });
 }
@@ -985,7 +985,7 @@ void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
@@ -993,7 +993,7 @@ void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = rnn_.KB1_blocks + 1;
+    const dim_t max_K_Block = rnn_.KB1_blocks + 1;
     brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * max_K_Block;
 

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
@@ -33,7 +33,7 @@ class brgemm_dst_layer_iter_t {
 public:
     using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
     using postgemm_fused_t = std::function<void(
-            dim_t, dim_t, dim_t, const src_t *, scratch_t *, scratch_t *, int)>;
+            dim_t, dim_t, dim_t, const src_t *, scratch_t *, scratch_t *, dim_t)>;
     brgemm_dst_layer_iter_t(const ref_rnn_brgemm_t &rnn_brgemm_,
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, const src_t *src_iter,
@@ -64,7 +64,7 @@ private:
     const dim_t LDAi_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const dim_t Bl_n_offset_;
     const dim_t Bi_n_offset_;
     const dim_t Bl_g_offset_;
@@ -108,7 +108,7 @@ class brgemm_dst_proj_t {
 public:
     using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
     using postgemm_fused_t
-            = std::function<void(dim_t, dim_t, gemm_acc_t *, int)>;
+            = std::function<void(dim_t, dim_t, gemm_acc_t *, dim_t)>;
     brgemm_dst_proj_t(const ref_rnn_brgemm_t &rnn_brgemm_,
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, const src_t *proj_ht,
@@ -124,13 +124,13 @@ private:
 
     const ref_rnn_brgemm_t &rnn_brgemm_;
     const rnn_utils::rnn_conf_t &rnn_;
-    const int proj_desc_idx_;
+    const dim_t proj_desc_idx_;
     const src_t *const A_;
     const weights_t *const B_;
     gemm_acc_t *const C_;
     const dim_t LDC_;
     const dim_t max_nthr_;
-    const int work_amount_proj_;
+    const dim_t work_amount_proj_;
     const dim_t B_n_offset_;
     const dim_t Bp_kb_offset_;
     gemm_acc_t *const amx_scratchpad_;
@@ -149,7 +149,7 @@ class brgemm_gru_t {
 public:
     using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
     using postgemm_fused_t = std::function<void(
-            dim_t, dim_t, dim_t, const src_t *, scratch_t *, scratch_t *, int)>;
+            dim_t, dim_t, dim_t, const src_t *, scratch_t *, scratch_t *, dim_t)>;
     brgemm_gru_t(const ref_rnn_brgemm_t &rnn_brgemm_,
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, const src_t *src_iter,
@@ -184,7 +184,7 @@ private:
     const dim_t max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const dim_t Bl_n_offset_;
     const dim_t Bi_n_offset_;
     const dim_t Bl_g_offset_;
@@ -253,7 +253,7 @@ private:
     const dim_t max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const dim_t Bl_n_offset_;
     const dim_t Bl_g_offset_;
     const dim_t Al_k_tail_offset_;

--- a/src/cpu/x64/rnn/brgemm_cell_common_reorders.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_reorders.cpp
@@ -23,8 +23,8 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-src_layer_iter_transpose_t::src_layer_iter_transpose_t(const int src_ld,
-        const int dst_ld, const int rows, const int cols,
+src_layer_iter_transpose_t::src_layer_iter_transpose_t(const dim_t src_ld,
+        const dim_t dst_ld, const dim_t rows, const dim_t cols,
         jit_brgemm_trans_src_t *const kernel_transpose)
     : src_ld_(src_ld)
     , dst_ld_(dst_ld)
@@ -34,7 +34,7 @@ src_layer_iter_transpose_t::src_layer_iter_transpose_t(const int src_ld,
 
 template <typename Dt>
 void src_layer_iter_transpose_t::execute(const Dt *src, Dt *dst) const {
-    static constexpr int block_size = 16;
+    static constexpr dim_t block_size = 16;
     const auto rows_div = std::div(src_rows_, block_size);
     const auto rows_tail = rows_div.rem;
     const auto rows_blks = rows_div.quot + (rows_tail > 0 ? 1 : 0);

--- a/src/cpu/x64/rnn/brgemm_cell_common_reorders.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_reorders.hpp
@@ -29,18 +29,18 @@ struct rnn_conf_t;
 }
 namespace x64 {
 struct src_layer_iter_transpose_t {
-    src_layer_iter_transpose_t(const int src_ld, const int dst_ld,
-            const int rows, const int cols,
+    src_layer_iter_transpose_t(const dim_t src_ld, const dim_t dst_ld,
+            const dim_t rows, const dim_t cols,
             jit_brgemm_trans_src_t *const kernel_transpose);
 
     template <typename Dt>
     void execute(const Dt *src, Dt *dst) const;
 
 private:
-    const int src_ld_;
-    const int dst_ld_;
-    const int src_rows_;
-    const int src_cols_;
+    const dim_t src_ld_;
+    const dim_t dst_ld_;
+    const dim_t src_rows_;
+    const dim_t src_cols_;
     jit_brgemm_trans_src_t *const kernel_transpose_;
 };
 

--- a/src/cpu/x64/rnn/jit_brgemm_transpose_single_row.cpp
+++ b/src/cpu/x64/rnn/jit_brgemm_transpose_single_row.cpp
@@ -51,22 +51,24 @@ void jit_brgemm_transpose_single_row_t::compute(
         const dim_t unrolling, const bool is_tail) {
 
     if (is_tail) {
-        mov(reg_tmp_.cvt32(), std::pow(2, tail_) - 1);
+        mov(reg_tmp_.cvt32(), static_cast<uint32_t>(std::pow(2, tail_) - 1));
         kmovd(tail_mask_, reg_tmp_.cvt32());
     }
 
-    for (int k = unrolling - 1; k >= 0; k--) {
-        const auto read_vmm
-                = is_tail ? Xbyak::Zmm(k) | tail_mask_ | T_z : Xbyak::Zmm(k);
-        const auto src_off = k * simd_w_ * sizeof(bfloat16_t);
-        vpmovzxwd(read_vmm, ptr[reg_src_ + src_off]);
+    for (dim_t k = unrolling - 1; k >= 0; k--) {
+        const auto read_vmm = is_tail
+                ? Xbyak::Zmm(static_cast<int>(k)) | tail_mask_ | T_z
+                : Xbyak::Zmm(static_cast<int>(k));
+        const size_t src_off = k * simd_w_ * sizeof(bfloat16_t);
+        vpmovzxwd(read_vmm, ptr[reg_src_ + static_cast<uint32_t>(src_off)]);
     }
 
-    for (int k = unrolling - 1; k >= 0; k--) {
-        const auto store_vmm
-                = is_tail ? Xbyak::Zmm(k) | tail_mask_ : Xbyak::Zmm(k);
-        const auto dst_off = k * simd_w_ * sizeof(float);
-        uni_vmovups(ptr[reg_dst_ + dst_off], store_vmm);
+    for (dim_t k = unrolling - 1; k >= 0; k--) {
+        const auto store_vmm = is_tail
+                ? Xbyak::Zmm(static_cast<int>(k)) | tail_mask_
+                : Xbyak::Zmm(static_cast<int>(k));
+        const size_t dst_off = k * simd_w_ * sizeof(float);
+        uni_vmovups(ptr[reg_dst_ + static_cast<uint32_t>(dst_off)], store_vmm);
     }
 }
 
@@ -98,8 +100,8 @@ void jit_brgemm_transpose_single_row_t::compute_loop() {
     const int k_blocks_left = k_blocks_nb_ - full_loop_iters_ * vmms_available_;
     if (k_blocks_left > 0) {
         const auto off = k_blocks_left * simd_w_;
-        const auto src_off = off * sizeof(bfloat16_t);
-        const auto dst_off = off * sizeof(float);
+        const dim_t src_off = off * sizeof(bfloat16_t);
+        const dim_t dst_off = off * sizeof(float);
 
         compute(k_blocks_left, false);
         add(reg_src_, src_off);

--- a/src/cpu/x64/rnn/jit_brgemm_transpose_src.cpp
+++ b/src/cpu/x64/rnn/jit_brgemm_transpose_src.cpp
@@ -379,7 +379,7 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
     // rows -> sp, cols -> ic
     // M -> ic, K -> sp
     assert(conf_->ic_block % transpose_size == 0);
-    const int os_block = conf_->os_block;
+    const int os_block = static_cast<int>(conf_->os_block);
     const int last_os_block_tail = conf_->K_tail % os_block;
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize;
@@ -708,10 +708,11 @@ void jit_brgemm_trans_m_k_bf16_t::generate() {
     constexpr int amx_xf16_granularity = 2;
     const bool last_row_padded = is_superset(conf_->isa, avx512_core_amx)
             && conf_->os % amx_xf16_granularity != 0;
-    const int eff_K_tail = conf_->K_tail - (last_row_padded ? 1 : 0);
+    const dim_t eff_K_tail = conf_->K_tail - (last_row_padded ? 1 : 0);
 
-    const int os_block = conf_->os_block;
-    const int last_os_block_tail = eff_K_tail % transpose_size;
+    const int os_block = static_cast<int>(conf_->os_block);
+    const int last_os_block_tail
+            = static_cast<int>(eff_K_tail % transpose_size);
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize;
     tr_src_stride = conf_->LDA * typesize;
@@ -1036,7 +1037,7 @@ void jit_brgemm_trans_m_k_f16_t::transpose_16x16(int nrows, int ncolumns) {
 void jit_brgemm_trans_m_k_f16_t::generate() {
     preamble();
     assert(conf_->ic_block % transpose_size == 0);
-    const int os_block = conf_->os_block;
+    const int os_block = static_cast<int>(conf_->os_block);
     const int last_os_block_tail = conf_->K_tail % transpose_size;
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize_in;

--- a/src/cpu/x64/rnn/jit_diff_weights_peephole.cpp
+++ b/src/cpu/x64/rnn/jit_diff_weights_peephole.cpp
@@ -70,8 +70,8 @@ void jit_diff_weights_peephole_t::compute_loop() {
     mov(loop_cnt_, compute_block_size_);
     xor_(reg_offset_, reg_offset_);
 
-    const size_t offt_max = max_unrolling * simd_w_;
-    const size_t full_unroling_steps = compute_block_size_ / offt_max;
+    const dim_t offt_max = max_unrolling * simd_w_;
+    const dim_t full_unroling_steps = compute_block_size_ / offt_max;
 
     if (full_unroling_steps) {
         L(unroll_loop);
@@ -86,16 +86,16 @@ void jit_diff_weights_peephole_t::compute_loop() {
         }
     }
 
-    const size_t full_blocks_left = (compute_block_size_ - tail_size_
+    const dim_t full_blocks_left = (compute_block_size_ - tail_size_
                                             - (full_unroling_steps * offt_max))
             / simd_w_;
 
     L(unroll_loop_tail);
     {
         if (full_blocks_left) {
-            compute_dst(full_blocks_left, false /*tail*/);
+            compute_dst(static_cast<int>(full_blocks_left), false /*tail*/);
             if (tail_size_) {
-                const size_t offt = full_blocks_left * simd_w_;
+                const dim_t offt = full_blocks_left * simd_w_;
                 add(reg_offset_, offt);
             }
         }
@@ -104,29 +104,31 @@ void jit_diff_weights_peephole_t::compute_loop() {
 }
 
 void jit_diff_weights_peephole_t::compute_dst(
-        size_t unrolling_factor, bool tail) {
+        int unrolling_factor, bool tail) {
 
-    static constexpr dim_t number_vmm_single_compute = 3;
+    static constexpr int number_vmm_single_compute = 3;
 
-    const auto get_compute_zmm = [=](size_t base_idx, size_t unroll_group) {
+    const auto get_compute_zmm = [=](int base_idx, int unroll_group) {
         return Xbyak::Zmm(base_idx + unroll_group * number_vmm_single_compute);
     };
 
     const auto get_addr = [&](const Xbyak::Reg64 &reg_base, const dim_t offt,
                                   const data_type_t dt) {
-        const auto dt_size = types::data_type_size(dt);
-        return ptr[reg_base + reg_offset_ * dt_size + offt * dt_size];
+        const dim_t dt_size = types::data_type_size(dt);
+        return ptr[reg_base + reg_offset_
+                        * static_cast<uint32_t>(dt_size)
+                + static_cast<uint32_t>(offt * dt_size)];
     };
 
-    static constexpr size_t dst_idx = 0;
-    static constexpr size_t scratch_idx = 1;
-    static constexpr size_t c_states_idx = 2;
+    static constexpr int dst_idx = 0;
+    static constexpr int scratch_idx = 1;
+    static constexpr int c_states_idx = 2;
 
     const auto io_dst = io_.at(dst_dt_);
     const auto io_scratch = io_.at(scratch_dt_);
     const auto io_c_states = io_.at(c_states_dt_);
 
-    for (size_t unroll_group = 0; unroll_group < unrolling_factor;
+    for (int unroll_group = 0; unroll_group < unrolling_factor;
             ++unroll_group) {
 
         const auto dst_zmm = get_compute_zmm(dst_idx, unroll_group);

--- a/src/cpu/x64/rnn/jit_diff_weights_peephole.hpp
+++ b/src/cpu/x64/rnn/jit_diff_weights_peephole.hpp
@@ -52,7 +52,7 @@ private:
     void load_addresses();
     void init();
     void compute_loop();
-    void compute_dst(size_t unrolling, bool tail);
+    void compute_dst(int unrolling, bool tail);
 
     static constexpr dim_t simd_w_ = 16;
     static constexpr dim_t max_unrolling = 10;

--- a/src/cpu/x64/rnn/jit_gates_reduction.cpp
+++ b/src/cpu/x64/rnn/jit_gates_reduction.cpp
@@ -33,9 +33,9 @@ jit_gates_reduction_t::jit_gates_reduction_t(
                           : rnn_.diff_wei_brgemm.n_block)
     , n_simd_w_blks_(n_block_ / simd_w_)
     , n_tail_(n_block_ % simd_w_)
-    , bf16_ones_(rnn_.is_bf16_conf() ? reserve_vmm() : 0)
-    , f16_tmp_vreg_(rnn_.is_f16_conf() ? reserve_vmm() : 0)
-    , f16_vperm_vreg_(rnn_.is_f16_conf() ? reserve_vmm() : 0)
+    , bf16_ones_(rnn_.is_bf16_conf() ? static_cast<int>(reserve_vmm()) : 0)
+    , f16_tmp_vreg_(rnn_.is_f16_conf() ? static_cast<int>(reserve_vmm()) : 0)
+    , f16_vperm_vreg_(rnn_.is_f16_conf() ? static_cast<int>(reserve_vmm()) : 0)
     , acc_regs_(reserve_acc_regs()) {}
 
 void jit_gates_reduction_t::generate() {
@@ -148,17 +148,18 @@ void jit_gates_reduction_t::compute_step(
 
 void jit_gates_reduction_t::compute(dim_t unrolling) {
 
-    const int n_block_off = rnn_.diff_wei_brgemm.n_block * sizeof(float);
+    const size_t n_block_off = rnn_.diff_wei_brgemm.n_block * sizeof(float);
 
     for (dim_t k = 0; k < unrolling; ++k) {
-        const int k_offset = -1 * (k + 1) * n_block_off;
-        const int first_reversed_block = acc_regs_.size() - 1;
+        const dim_t k_offset = -1 * (k + 1) * n_block_off;
+        const dim_t first_reversed_block = acc_regs_.size() - 1;
 
-        for (int n_block = first_reversed_block; n_block >= 0; --n_block) {
+        for (dim_t n_block = first_reversed_block; n_block >= 0; --n_block) {
             const bool tail = static_cast<bool>(n_tail_)
                     && n_block == first_reversed_block;
             const auto &acc_zmm = acc_regs_[n_block];
-            const int nk_offset = k_offset + n_block * simd_w_ * sizeof(float);
+            const dim_t nk_offset
+                    = k_offset + n_block * simd_w_ * sizeof(float);
             compute_step(acc_zmm, ptr[reg_src_ + reg_loop_ + nk_offset], tail);
         }
     }
@@ -169,7 +170,7 @@ void jit_gates_reduction_t::compute_loop() {
     const dim_t k_pack = rnn_.is_xf16_conf() ? 2 : 1;
     const dim_t k = rnn_.diff_wei_brgemm.Kpadded;
     const auto res = std::div(k, k_block);
-    const int n_block_off = rnn_.diff_wei_brgemm.n_block
+    const size_t n_block_off = rnn_.diff_wei_brgemm.n_block
             * (rnn_.is_xf16_conf() ? sizeof(bfloat16_t) : sizeof(float));
     const auto &num_k_blks = res.quot;
     const auto &k_tail = res.rem;

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
@@ -43,12 +43,16 @@ struct jit_uni_gru_cell_postgemm_part1_bwd : public jit_uni_rnn_postgemm_t {
 protected:
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    const size_t vlen_scratch
-            = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
-    static constexpr size_t hstate_dt_size = sizeof(float);
-    const size_t gate_dt_size = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    static constexpr dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+    const dim_t vlen_scratch = vlen
+            / (sizeof(float)
+                    / static_cast<dim_t>(
+                            types::data_type_size(scratch_data_t)));
+    static constexpr dim_t hstate_dt_size = sizeof(float);
+    const dim_t gate_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
+    const dim_t scratch_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;
@@ -100,26 +104,29 @@ protected:
 #endif
 
         // helper lambda to address the gates and biases
-        const auto sg_addr = [&](int i) {
+        const auto sg_addr = [&](dim_t i) {
             return ptr[addr_scratch_gates_reg + i * rnn_.dhc * scratch_dt_size];
         };
-        const auto wg_addr = [&](int i) {
+        const auto wg_addr = [&](dim_t i) {
             return ptr[addr_ws_gates_reg + i * rnn_.dhc * gate_dt_size];
         };
 
         // initialize registers with addresses and constants
         mov(table_reg, table_label);
-        init_regs(vlen);
+        init_regs(static_cast<size_t>(vlen));
+        const int vlen_int = static_cast<int>(vlen);
+        const int hstate_dt_size_int = static_cast<int>(hstate_dt_size);
         uni_vmovups(one_vmm, one_addr);
 
         if (is_augru) {
             uni_vpxor(
                     Vmm(dattn_acc_idx), Vmm(dattn_acc_idx), Vmm(dattn_acc_idx));
             const Xmm attn1s(attn_idx);
-            to_float(attn1s, ptr[addr_attn_reg], src_data_t, hstate_dt_size);
+            to_float(attn1s, ptr[addr_attn_reg], src_data_t,
+                    hstate_dt_size_int);
         }
 
-        mov(loop_cnt, rnn_.dhc * scratch_dt_size);
+        mov(loop_cnt, static_cast<uint64_t>(rnn_.dhc * scratch_dt_size));
         cmp(loop_cnt, vlen_scratch);
         jl(vector_loop_end_label, Xbyak::CodeGenerator::T_NEAR);
 
@@ -135,8 +142,8 @@ protected:
                     dHt(dHt_idx), tmp1(tmp1_idx), tmp2(tmp2_idx), h(h_idx),
                     diff_attn_acc(dattn_acc_idx), attn(attn_idx);
 
-            to_float(G0, wg_addr(0), src_data_t, vlen);
-            to_float(G2, wg_addr(2), src_data_t, vlen);
+            to_float(G0, wg_addr(0), src_data_t, vlen_int);
+            to_float(G2, wg_addr(2), src_data_t, vlen_int);
 
             // compute dHt
             uni_vmovups(dHt, ptr[addr_diff_states_tp1_l_reg]);
@@ -145,7 +152,7 @@ protected:
             uni_vaddps(dHt, dHt, tmp1);
 
             // compute dG0
-            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t, vlen);
+            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t, vlen_int);
             uni_vmovups(dG0, G0);
             uni_vmovups(tmp1, G0);
             uni_vfnmadd231ps(dG0, tmp1, tmp1); // (G0 - G0^2)
@@ -176,8 +183,8 @@ protected:
             uni_vmovups(ptr[addr_diff_states_t_l_reg], dHt);
 
             // downconvert and write data
-            to_src(sg_addr(0), dG0, scratch_data_t, vlen);
-            to_src(sg_addr(2), dG2, scratch_data_t, vlen);
+            to_src(sg_addr(0), dG0, scratch_data_t, vlen_int);
+            to_src(sg_addr(2), dG2, scratch_data_t, vlen_int);
 
             // increment address pointers
             add(addr_ws_gates_reg, vlen_scratch);
@@ -186,7 +193,7 @@ protected:
             add(addr_diff_states_tp1_l_reg, vlen);
             add(addr_diff_states_t_l_reg, vlen);
             add(addr_states_tm1_l_reg, vlen_scratch);
-            inc_regs(vlen);
+            inc_regs(static_cast<size_t>(vlen));
 
             // increment loop counter
             sub(loop_cnt, vlen_scratch);
@@ -223,8 +230,8 @@ protected:
                     dHt(dHt_idx), tmp1(tmp1_idx), tmp2(tmp2_idx), h(h_idx),
                     diff_attn_acc(dattn_acc_idx), attn(attn_idx);
 
-            to_float(G0, wg_addr(0), src_data_t, hstate_dt_size);
-            to_float(G2, wg_addr(2), src_data_t, hstate_dt_size);
+            to_float(G0, wg_addr(0), src_data_t, hstate_dt_size_int);
+            to_float(G2, wg_addr(2), src_data_t, hstate_dt_size_int);
 
             // compute dHt
             uni_vmovss(dHt, ptr[addr_diff_states_tp1_l_reg]);
@@ -233,7 +240,8 @@ protected:
             uni_vaddss(dHt, dHt, tmp1);
 
             // compute dG0
-            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t, hstate_dt_size);
+            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t,
+                    hstate_dt_size_int);
             uni_vmovss(dG0, G0);
             uni_vmovss(tmp1, G0);
             uni_vfnmadd231ps(dG0, tmp1, tmp1); // (G0 - G0^2)
@@ -268,8 +276,8 @@ protected:
             uni_vmovss(ptr[addr_diff_states_t_l_reg], dHt);
 
             // downconvert and write data
-            to_src(sg_addr(0), dG0, scratch_data_t, hstate_dt_size);
-            to_src(sg_addr(2), dG2, scratch_data_t, hstate_dt_size);
+            to_src(sg_addr(0), dG0, scratch_data_t, hstate_dt_size_int);
+            to_src(sg_addr(2), dG2, scratch_data_t, hstate_dt_size_int);
 
             // increment address pointers
             add(addr_ws_gates_reg, scratch_dt_size);
@@ -278,7 +286,7 @@ protected:
             add(addr_diff_states_tp1_l_reg, hstate_dt_size);
             add(addr_diff_states_t_l_reg, hstate_dt_size);
             add(addr_states_tm1_l_reg, scratch_dt_size);
-            inc_regs(hstate_dt_size);
+            inc_regs(static_cast<size_t>(hstate_dt_size));
 
             // increment loop counter
             sub(loop_cnt, scratch_dt_size);
@@ -302,7 +310,7 @@ protected:
 
         postamble();
 
-        init_table(vlen);
+        init_table(static_cast<size_t>(vlen));
         L(table_label);
         {
             for (size_t i = 0; i < vlen / sizeof(float); i++)

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
@@ -56,26 +56,32 @@ protected:
 
     // register size in bytes
     using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t qscale_dt_size = sizeof(float);
-    const size_t vlen_dst
-            = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias_ = vlen / (sizeof(float) / bias_dt_size_);
-    const size_t hstate_dt_size = types::data_type_size(src_data_t);
-    const size_t gate_dt_size = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
-    const size_t vlen_qscale = vlen / qscale_dt_size;
-    const size_t vlen_elems = vlen / scratch_dt_size;
+    static constexpr dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t qscale_dt_size = sizeof(float);
+    const dim_t vlen_dst = vlen
+            / (sizeof(float)
+                    / static_cast<dim_t>(
+                            types::data_type_size(src_data_t)));
+    const dim_t vlen_bias_ = vlen
+            / (sizeof(float) / static_cast<dim_t>(bias_dt_size_));
+    const dim_t hstate_dt_size
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t gate_dt_size
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t scratch_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
+    const dim_t vlen_qscale = vlen / qscale_dt_size;
+    const dim_t vlen_elems = vlen / scratch_dt_size;
 
     const int loop_ur_max = 4;
     // We skip vmm0 as it can be used by the injector for masks on sse4.1
-    int G0_idx(int i) {
-        const int idx = 1 + i;
+    int G0_idx(dim_t i) {
+        const int idx = static_cast<int>(1 + i);
         assert(idx < loop_ur_max + 1);
         return idx;
     }
-    int G1_idx(int i) {
-        const int idx = loop_ur_max + 1 + i;
+    int G1_idx(dim_t i) {
+        const int idx = static_cast<int>(loop_ur_max + 1 + i);
         assert(idx < 2 * loop_ur_max + 1);
         return idx;
     }
@@ -115,28 +121,31 @@ protected:
         const auto addr_states_tm1_l_reg = abi_param6;
 #endif
         // helper lambda to address the gates and biases
-        const auto sg_addr = [&](int i, int j) {
+        const auto sg_addr = [&](dim_t i, dim_t j) {
             return ptr[addr_scratch_gates_reg + i * rnn_.dhc * scratch_dt_size
                     + j * vlen];
         };
-        const auto wg_addr = [&](int i, int j) {
+        const auto wg_addr = [&](dim_t i, dim_t j) {
             return ptr[addr_ws_gates_reg + i * rnn_.dhc * gate_dt_size
                     + j * vlen_dst];
         };
-        const auto B_addr = [&](int i, int j) {
-            return ptr[addr_bias_reg + i * rnn_.dhc * bias_dt_size_ + j * vlen];
+        const auto B_addr = [&](dim_t i, dim_t j) {
+            return ptr[addr_bias_reg
+                    + i * rnn_.dhc * static_cast<dim_t>(bias_dt_size_)
+                    + j * vlen];
         };
 
-        const size_t loop_len = rnn_.dhc;
-        const size_t loop_tail = loop_len % vlen_elems;
+        const dim_t loop_len = rnn_.dhc;
+        const dim_t loop_tail = loop_len % vlen_elems;
         // initialize registers with addresses and constants
-        init_regs(weights_scales, vlen, loop_tail);
+        init_regs(weights_scales, static_cast<size_t>(vlen),
+                static_cast<size_t>(loop_tail));
 
         // both sigmoid and tanh use the same table so load address just once in rax
         sigmoid_injector_->load_table_addr();
 
-        const size_t nb_loop_len = loop_len / vlen_elems;
-        size_t loop_ur_val = 1;
+        const dim_t nb_loop_len = loop_len / vlen_elems;
+        dim_t loop_ur_val = 1;
         const bool is_brgemm = rnn_.is_brgemm && !rnn_.unfused_post_gemm;
         if (is_brgemm) {
 #ifdef _WIN32
@@ -152,17 +161,18 @@ protected:
             for (loop_ur_val = loop_ur_max; loop_ur_val > 1; --loop_ur_val)
                 if (nb_loop_len % loop_ur_val == 0) break;
 
-            mov(loop_cnt, loop_len);
+            mov(loop_cnt, static_cast<uint64_t>(loop_len));
         }
-        const size_t loop_ur = loop_ur_val;
+        const dim_t loop_ur = loop_ur_val;
 
         auto compute_loop
-                = [&](size_t current_vlen_elem, size_t current_loop_unroll) {
+                = [&](dim_t current_vlen_elem, dim_t current_loop_unroll) {
             const auto current_vlen = current_vlen_elem * scratch_dt_size;
+            const int vlen_int = static_cast<int>(current_vlen);
             Label loop_start_label;
             L(loop_start_label);
             {
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (dim_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     const Vmm G0(G0_idx(loop_ur_idx));
                     const Vmm G1(G1_idx(loop_ur_idx));
@@ -171,61 +181,59 @@ protected:
                     //      Compute gate 1: G1 = sigmoid(G1 + b1)
 
                     // load gates from scratchpad
-                    load(G0, sg_addr(0, loop_ur_idx), scratch_data_t,
-                            current_vlen);
-                    load(G1, sg_addr(1, loop_ur_idx), scratch_data_t,
-                            current_vlen);
+                    load(G0, sg_addr(0, loop_ur_idx), scratch_data_t, vlen_int);
+                    load(G1, sg_addr(1, loop_ur_idx), scratch_data_t, vlen_int);
 
                     // dequantize gates from s32 to f32 if needed
                     deq_w(src_data_t, G0, tmp1_vmm, tmp2_vmm,
                             0 * rnn_.dhc + loop_ur_idx * vlen_qscale, mask,
-                            current_vlen);
+                            vlen_int);
                     deq_w(src_data_t, G1, tmp1_vmm, tmp2_vmm,
                             1 * rnn_.dhc + loop_ur_idx * vlen_qscale, mask,
-                            current_vlen);
+                            vlen_int);
 
                     // apply bias
                     to_float(tmp1_vmm, B_addr(0, loop_ur_idx), rnn_.bias_dt,
-                            current_vlen);
-                    compute_vaddps(G0, G0, tmp1_vmm, current_vlen);
+                            vlen_int);
+                    compute_vaddps(G0, G0, tmp1_vmm, vlen_int);
                     to_float(tmp2_vmm, B_addr(1, loop_ur_idx), rnn_.bias_dt,
-                            current_vlen);
-                    compute_vaddps(G1, G1, tmp2_vmm, current_vlen);
+                            vlen_int);
+                    compute_vaddps(G1, G1, tmp2_vmm, vlen_int);
                 }
 
                 // Compute sigmoid of unrolled G0 and G1 regs together
                 // (this allows to not save any registers during eltwise)
                 injector_utils::vmm_index_set_t vmm_idxs;
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (dim_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     vmm_idxs.emplace(G0_idx(loop_ur_idx));
                     vmm_idxs.emplace(G1_idx(loop_ur_idx));
                 }
                 sigmoid_injector_->compute_vector_range(vmm_idxs);
 
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (dim_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     const Vmm G0(G0_idx(loop_ur_idx));
                     const Vmm G1(G1_idx(loop_ur_idx));
                     // store G0 for use in postgemm_part2
                     store(sg_addr(0, loop_ur_idx), G0, scratch_data_t,
-                            current_vlen);
+                            vlen_int);
 
                     // if training we write back the gates
                     if (is_training) {
                         to_src(wg_addr(1, loop_ur_idx), G1, src_data_t,
-                                current_vlen);
+                                vlen_int);
                         to_src(wg_addr(0, loop_ur_idx), G0, src_data_t,
-                                current_vlen);
+                                vlen_int);
                     }
 
                     // states_t_l = states_tm1_l * G1
                     to_float(tmp1_vmm,
                             ptr[addr_states_tm1_l_reg + loop_ur_idx * vlen_dst],
-                            src_data_t, current_vlen);
-                    compute_vmulps(G1, G1, tmp1_vmm, current_vlen);
+                            src_data_t, vlen_int);
+                    compute_vmulps(G1, G1, tmp1_vmm, vlen_int);
                     to_src(ptr[addr_states_t_l_reg + loop_ur_idx * vlen_dst],
-                            G1, src_data_t, current_vlen);
+                            G1, src_data_t, vlen_int);
                     // if states_t_l_copy is a non null ptr, we write the output
                     // to both tensors
                     Label loop_inc_regs;
@@ -236,7 +244,7 @@ protected:
                     // write_only=false for the same Vmm
                     to_src(ptr[addr_states_t_l_copy_reg
                                    + loop_ur_idx * vlen_dst],
-                            G1, src_data_t, current_vlen, true);
+                            G1, src_data_t, vlen_int, true);
                     L(loop_inc_regs);
                 }
 
@@ -254,15 +262,15 @@ protected:
                     add(addr_bias_reg,
                             current_vlen == vlen
                                     ? vlen_bias_ * current_loop_unroll
-                                    : bias_dt_size_);
+                                    : static_cast<dim_t>(bias_dt_size_));
                     add(addr_states_t_l_reg, current_states_size);
                     add(addr_states_t_l_copy_reg, current_states_size);
                     add(addr_states_tm1_l_reg, current_states_size);
                     if (is_training) add(addr_ws_gates_reg, current_gate_size);
-                    inc_regs(mask,
-                            current_vlen == vlen
-                                    ? current_vlen * current_loop_unroll
-                                    : qscale_dt_size);
+                    const dim_t qscale_shift = current_vlen == vlen
+                            ? current_vlen * current_loop_unroll
+                            : qscale_dt_size;
+                    inc_regs(mask, static_cast<size_t>(qscale_shift));
 
                     // increment loop counter
                     sub(loop_cnt, current_vlen_elem * current_loop_unroll);
@@ -299,7 +307,7 @@ protected:
 
         // Again, only one table is needed and shared between sigmoid and tanh
         sigmoid_injector_->prepare_table(true);
-        init_table(vlen);
+        init_table(static_cast<size_t>(vlen));
     }
 };
 

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
@@ -43,12 +43,16 @@ struct jit_uni_gru_cell_postgemm_part2_bwd : public jit_uni_rnn_postgemm_t {
 protected:
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t hstate_dt_size = sizeof(float);
-    const size_t vlen_scratch
-            = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
-    const size_t gate_dt_size = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    static constexpr dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t hstate_dt_size = sizeof(float);
+    const dim_t vlen_scratch = vlen
+            / (sizeof(float)
+                    / static_cast<dim_t>(
+                            types::data_type_size(scratch_data_t)));
+    const dim_t gate_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
+    const dim_t scratch_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;
@@ -105,17 +109,19 @@ protected:
 #endif
 
         // helper lambda to address the gates and biases
-        const auto sg_addr = [&](int i) {
+        const auto sg_addr = [&](dim_t i) {
             return ptr[addr_scratch_gates_reg + i * rnn_.dhc * scratch_dt_size];
         };
-        const auto wg_addr = [&](int i) {
+        const auto wg_addr = [&](dim_t i) {
             return ptr[addr_ws_gates_reg + i * rnn_.dhc * gate_dt_size];
         };
 
         // initialize registers with addresses and constants
-        init_regs(vlen);
+        init_regs(static_cast<size_t>(vlen));
+        const int vlen_int = static_cast<int>(vlen);
+        const int hstate_dt_size_int = static_cast<int>(hstate_dt_size);
 
-        mov(loop_cnt, rnn_.dhc * scratch_dt_size);
+        mov(loop_cnt, static_cast<uint64_t>(rnn_.dhc * scratch_dt_size));
         cmp(loop_cnt, vlen_scratch);
         jl(vector_loop_end_label, Xbyak::CodeGenerator::T_NEAR);
 
@@ -124,8 +130,8 @@ protected:
             const Vmm dG1(dG1_idx), dhG1(dhG1_idx), hG1(hG1_idx), G1(G1_idx),
                     dH(dH_idx), tmp1(tmp1_idx), h(h_idx);
 
-            to_float(G1, wg_addr(1), src_data_t, vlen);
-            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t, vlen);
+            to_float(G1, wg_addr(1), src_data_t, vlen_int);
+            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t, vlen_int);
 
             // compute dG1
             uni_vmovups(dG1, G1);
@@ -144,8 +150,8 @@ protected:
             uni_vfmadd231ps(dH, dhG1, G1);
 
             // downconvert and write data
-            to_src(sg_addr(1), dG1, scratch_data_t, vlen);
-            to_src(ptr[addr_scratch_cell_reg], hG1, scratch_data_t, vlen);
+            to_src(sg_addr(1), dG1, scratch_data_t, vlen_int);
+            to_src(ptr[addr_scratch_cell_reg], hG1, scratch_data_t, vlen_int);
             uni_vmovups(ptr[addr_diff_states_t_l_reg], dH);
 
             // increment address pointers
@@ -155,7 +161,7 @@ protected:
             add(addr_diff_states_t_l_reg, vlen);
             add(addr_states_tm1_l_reg, vlen_scratch);
             add(addr_scratch_cell_reg, vlen_scratch);
-            inc_regs(vlen);
+            inc_regs(static_cast<size_t>(vlen));
 
             // increment loop counter
             sub(loop_cnt, vlen_scratch);
@@ -173,8 +179,9 @@ protected:
             const Xmm dG1(dG1_idx), dhG1(dhG1_idx), hG1(hG1_idx), G1(G1_idx),
                     dH(dH_idx), tmp1(tmp1_idx), h(h_idx);
 
-            to_float(G1, wg_addr(1), src_data_t, hstate_dt_size);
-            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t, hstate_dt_size);
+            to_float(G1, wg_addr(1), src_data_t, hstate_dt_size_int);
+            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t,
+                    hstate_dt_size_int);
 
             // compute dG1
             uni_vmovss(dG1, G1);
@@ -193,9 +200,9 @@ protected:
             uni_vfmadd231ps(dH, dhG1, G1);
 
             // downconvert and write data
-            to_src(sg_addr(1), dG1, scratch_data_t, hstate_dt_size);
+            to_src(sg_addr(1), dG1, scratch_data_t, hstate_dt_size_int);
             to_src(ptr[addr_scratch_cell_reg], hG1, scratch_data_t,
-                    hstate_dt_size);
+                    hstate_dt_size_int);
             uni_vmovss(ptr[addr_diff_states_t_l_reg], dH);
 
             // increment address pointers
@@ -205,7 +212,7 @@ protected:
             add(addr_diff_states_t_l_reg, hstate_dt_size);
             add(addr_states_tm1_l_reg, scratch_dt_size);
             add(addr_scratch_cell_reg, scratch_dt_size);
-            inc_regs(hstate_dt_size);
+            inc_regs(static_cast<size_t>(hstate_dt_size));
 
             // increment loop counter
             sub(loop_cnt, scratch_dt_size);
@@ -216,7 +223,7 @@ protected:
 
         postamble();
 
-        init_table(vlen);
+        init_table(static_cast<size_t>(vlen));
     }
 };
 

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
@@ -56,26 +56,31 @@ protected:
 
     // register size in bytes
     using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t qscale_dt_size = sizeof(float);
-    const size_t vlen_dst
-            = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
-    const size_t hstate_dt_size = types::data_type_size(src_data_t);
-    const size_t gate_dt_size = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
-    const size_t vlen_qscale = vlen / qscale_dt_size;
-    const size_t vlen_elems = vlen / scratch_dt_size;
+    static constexpr dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t qscale_dt_size = sizeof(float);
+    const dim_t vlen_dst = vlen
+            / (sizeof(float)
+                    / static_cast<dim_t>(types::data_type_size(src_data_t)));
+    const dim_t vlen_bias
+            = vlen / (sizeof(float) / static_cast<dim_t>(bias_dt_size_));
+    const dim_t hstate_dt_size
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t gate_dt_size
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t scratch_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
+    const dim_t vlen_qscale = vlen / qscale_dt_size;
+    const dim_t vlen_elems = vlen / scratch_dt_size;
 
-    const int loop_ur_max = 4;
+    static constexpr int loop_ur_max = 4;
     // We skip vmm0 as it can be used by the injector for masks on sse4.1
-    Vmm G0(int i) {
-        const int idx = 1 + i;
+    Vmm G0(dim_t i) {
+        const int idx = static_cast<int>(1 + i);
         assert(idx < loop_ur_max + 1);
         return Vmm(idx); // max of vmm4
     }
-    Vmm G2(int i) {
-        const int idx = loop_ur_max + 1 + i;
+    Vmm G2(dim_t i) {
+        const int idx = static_cast<int>(loop_ur_max + 1 + i);
         assert(idx < 2 * loop_ur_max + 1);
         return Vmm(idx); // max of vmm8
     }
@@ -130,29 +135,31 @@ protected:
 #endif
 
         // helper lambda to address the gates and biases
-        const auto sg_addr = [&](int i, int j) {
+        const auto sg_addr = [&](dim_t i, dim_t j) {
             return ptr[addr_scratch_gates_reg + i * rnn_.dhc * scratch_dt_size
                     + j * vlen];
         };
-        const auto wg_addr = [&](int i, int j) {
+        const auto wg_addr = [&](dim_t i, dim_t j) {
             return ptr[addr_ws_gates_reg + i * rnn_.dhc * gate_dt_size
                     + j * vlen_dst];
         };
-        const auto B_addr = [&](int i, int j) {
-            return ptr[addr_bias_reg + i * rnn_.dhc * bias_dt_size_
+        const auto B_addr = [&](dim_t i, dim_t j) {
+            return ptr[addr_bias_reg
+                    + i * rnn_.dhc * static_cast<dim_t>(bias_dt_size_)
                     + j * vlen_bias];
         };
 
-        const size_t loop_len = rnn_.dhc;
-        const size_t loop_tail = loop_len % vlen_elems;
+        const dim_t loop_len = rnn_.dhc;
+        const dim_t loop_tail = loop_len % vlen_elems;
 
         // initialize registers with addresses and constants
         mov(table_reg, table_label);
         tanh_injector_->load_table_addr();
-        init_regs(weights_scales, vlen, loop_tail);
+        init_regs(weights_scales, static_cast<size_t>(vlen),
+                static_cast<size_t>(loop_tail));
 
-        const size_t nb_loop_len = loop_len / vlen_elems;
-        size_t loop_ur_val = 1;
+        const dim_t nb_loop_len = loop_len / vlen_elems;
+        dim_t loop_ur_val = 1;
         const bool is_brgemm = rnn_.is_brgemm && !rnn_.unfused_post_gemm;
         if (is_brgemm) {
 #ifdef _WIN32
@@ -168,90 +175,91 @@ protected:
             for (loop_ur_val = loop_ur_max; loop_ur_val > 1; --loop_ur_val)
                 if (nb_loop_len % loop_ur_val == 0) break;
 
-            mov(loop_cnt, loop_len);
+            mov(loop_cnt, static_cast<uint64_t>(loop_len));
         }
-        const size_t loop_ur = loop_ur_val;
+        const dim_t loop_ur = loop_ur_val;
 
         auto compute_loop
-                = [&](size_t current_vlen_elem, size_t current_loop_unroll) {
+                = [&](dim_t current_vlen_elem, dim_t current_loop_unroll) {
             const auto current_vlen = current_vlen_elem * scratch_dt_size;
+            const int vlen_int = static_cast<int>(current_vlen);
             Label loop_start_label;
             L(loop_start_label);
             {
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (dim_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     // Compute gate 2: G2 = tanh(G2 + b2)
                     load(G2(loop_ur_idx), sg_addr(2, loop_ur_idx),
-                            scratch_data_t, current_vlen);
+                            scratch_data_t, vlen_int);
                     // dequantize gate from s32 to f32 if needed
                     deq_w(src_data_t, G2(loop_ur_idx), tmp1_vmm, tmp2_vmm,
                             2 * rnn_.dhc + loop_ur_idx * vlen_qscale, mask,
-                            current_vlen);
+                            vlen_int);
                     to_float(tmp1_vmm, B_addr(2, loop_ur_idx), rnn_.bias_dt,
-                            current_vlen);
+                            vlen_int);
                     compute_vaddps(G2(loop_ur_idx), G2(loop_ur_idx), tmp1_vmm,
-                            current_vlen);
+                            vlen_int);
                 }
 
                 // Compute tanh of unrolled G2 regs together
                 // (this allows to not save any registers during eltwise)
                 injector_utils::vmm_index_set_t vmm_idxs;
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (dim_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     vmm_idxs.emplace(G2(loop_ur_idx).getIdx());
                 }
                 tanh_injector_->compute_vector_range(vmm_idxs);
 
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (dim_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     // if training we write back the gates
                     if (is_training)
                         to_src(wg_addr(2, loop_ur_idx), G2(loop_ur_idx),
-                                src_data_t, current_vlen);
+                                src_data_t, vlen_int);
 
                     load(G0(loop_ur_idx), sg_addr(0, loop_ur_idx),
-                            scratch_data_t, current_vlen);
-                    load(tmp1_vmm, one_addr, scratch_data_t, current_vlen);
+                            scratch_data_t, vlen_int);
+                    load(tmp1_vmm, one_addr, scratch_data_t, vlen_int);
                     if (is_augru) {
                         // for augru there is additional step G01 = (1 - a) * G0
                         // states_t_l = states_tm1_l * G01 + (1 - G01) * G2
                         const Xmm tmp2s_vmm(tmp2_vmm.getIdx());
                         to_float(tmp2s_vmm, ptr[addr_attn_reg], src_data_t,
-                                scratch_dt_size);
+                                static_cast<int>(scratch_dt_size));
                         uni_vbroadcastss(tmp2_vmm, tmp2s_vmm);
                         // G01 = (1 - a) * G0
                         compute_vsubps(tmp2_vmm, tmp1_vmm, tmp2_vmm, tmp3_vmm,
-                                current_vlen);
+                                vlen_int);
                         compute_vmulps(G0(loop_ur_idx), G0(loop_ur_idx),
-                                tmp2_vmm, current_vlen);
+                                tmp2_vmm, vlen_int);
                         to_float(tmp2_vmm,
                                 ptr[addr_states_tm1_l_reg
                                         + loop_ur_idx * vlen_dst],
-                                src_data_t, current_vlen);
+                                src_data_t, vlen_int);
                         // tmp1 = 1 - G01
-                        compute_vsubps(tmp1_vmm, tmp1_vmm, G0(loop_ur_idx),
-                                current_vlen);
+                        compute_vsubps(
+                                tmp1_vmm, tmp1_vmm, G0(loop_ur_idx), vlen_int);
                         // tmp1 = G2 * tmp1
                         compute_vmulps(tmp1_vmm, G2(loop_ur_idx), tmp1_vmm,
-                                tmp3_vmm, current_vlen);
+                                tmp3_vmm, vlen_int);
                         // states_t_l = G01 * states_tm1_l + tmp1
-                        compute_vfmadd213ps(G0(loop_ur_idx), tmp2_vmm, tmp1_vmm,
-                                current_vlen);
+                        compute_vfmadd213ps(
+                                G0(loop_ur_idx), tmp2_vmm, tmp1_vmm, vlen_int);
                     } else {
                         // states_t_l = states_tm1_l * G0 + (1 - G0) * G2
-                        compute_vsubps(tmp1_vmm, tmp1_vmm, G0(loop_ur_idx),
-                                current_vlen);
+                        compute_vsubps(
+                                tmp1_vmm, tmp1_vmm, G0(loop_ur_idx), vlen_int);
                         to_float(tmp2_vmm,
                                 ptr[addr_states_tm1_l_reg
                                         + loop_ur_idx * vlen_dst],
-                                src_data_t, current_vlen);
+                                src_data_t, vlen_int);
                         compute_vmulps(G0(loop_ur_idx), G0(loop_ur_idx),
-                                tmp2_vmm, current_vlen);
+                                tmp2_vmm, vlen_int);
                         compute_vfmadd231ps(G0(loop_ur_idx), tmp1_vmm,
-                                G2(loop_ur_idx), current_vlen);
+                                G2(loop_ur_idx), vlen_int);
                     }
                     to_src(ptr[addr_states_t_l_reg + loop_ur_idx * vlen_dst],
-                            G0(loop_ur_idx), src_data_t, current_vlen);
+                            G0(loop_ur_idx), src_data_t, vlen_int);
                     // if states_t_l_copy is a non null ptr, we write the output
                     // to both tensors
                     Label loop_inc_regs;
@@ -262,16 +270,16 @@ protected:
                     // write_only=false for the same Vmm
                     to_src(ptr[addr_states_t_l_copy_reg
                                    + loop_ur_idx * vlen_dst],
-                            G0(loop_ur_idx), src_data_t, current_vlen, true);
+                            G0(loop_ur_idx), src_data_t, vlen_int, true);
                     L(loop_inc_regs);
                 }
 
                 if (current_vlen_elem != loop_tail) {
                     // increment address pointers
-                    const auto current_gate_size = current_vlen == vlen
+                    const dim_t current_gate_size = current_vlen == vlen
                             ? vlen_dst * current_loop_unroll
                             : gate_dt_size;
-                    const auto current_states_size = current_vlen == vlen
+                    const dim_t current_states_size = current_vlen == vlen
                             ? vlen_dst * current_loop_unroll
                             : hstate_dt_size;
 
@@ -280,15 +288,15 @@ protected:
                     add(addr_bias_reg,
                             current_vlen == vlen
                                     ? vlen_bias * current_loop_unroll
-                                    : bias_dt_size_);
+                                    : static_cast<dim_t>(bias_dt_size_));
                     add(addr_states_t_l_reg, current_states_size);
                     add(addr_states_t_l_copy_reg, current_states_size);
                     add(addr_states_tm1_l_reg, current_states_size);
                     if (is_training) add(addr_ws_gates_reg, current_gate_size);
                     inc_regs(mask,
-                            current_vlen == vlen
-                                    ? current_vlen * current_loop_unroll
-                                    : qscale_dt_size);
+                            static_cast<size_t>(current_vlen == vlen
+                                            ? current_vlen * current_loop_unroll
+                                            : qscale_dt_size));
 
                     // increment loop counter
                     sub(loop_cnt, current_vlen_elem * current_loop_unroll);
@@ -324,10 +332,10 @@ protected:
         postamble();
 
         tanh_injector_->prepare_table(true);
-        init_table(vlen);
+        init_table(static_cast<size_t>(vlen));
         L(table_label);
         {
-            for (size_t i = 0; i < vlen / sizeof(float); i++)
+            for (dim_t i = 0; i < vlen / static_cast<dim_t>(sizeof(float)); i++)
                 dd(float2int(1.0f));
         }
     }

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_bwd.hpp
@@ -43,12 +43,16 @@ struct jit_uni_gru_lbr_cell_postgemm_bwd : public jit_uni_rnn_postgemm_t {
 protected:
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t hstate_dt_size = sizeof(float);
-    const size_t vlen_scratch
-            = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
-    const size_t gate_dt_size = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    static constexpr dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t hstate_dt_size = sizeof(float);
+    const dim_t vlen_scratch = vlen
+            / (hstate_dt_size
+                    / static_cast<dim_t>(
+                            types::data_type_size(scratch_data_t)));
+    const dim_t gate_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
+    const dim_t scratch_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;
@@ -121,17 +125,18 @@ protected:
 
         // initialize registers with addresses and constants
         mov(table_reg, table_label);
-        init_regs(vlen);
+        init_regs(static_cast<size_t>(vlen));
         uni_vmovups(one_vmm, one_addr);
 
         if (is_augru) {
             uni_vpxor(
                     Vmm(dattn_acc_idx), Vmm(dattn_acc_idx), Vmm(dattn_acc_idx));
             const Xmm attn1s(attn_idx);
-            to_float(attn1s, ptr[addr_attn_reg], src_data_t, hstate_dt_size);
+            to_float(attn1s, ptr[addr_attn_reg], src_data_t,
+                    static_cast<int>(hstate_dt_size));
         }
 
-        mov(loop_cnt, rnn_.dhc * scratch_dt_size);
+        mov(loop_cnt, static_cast<uint64_t>(rnn_.dhc * scratch_dt_size));
         cmp(loop_cnt, vlen_scratch);
         jl(vector_loop_end_label, Xbyak::CodeGenerator::T_NEAR);
 
@@ -148,9 +153,9 @@ protected:
                     tmp2(tmp2_idx), h(h_idx), diff_attn_acc(dattn_acc_idx),
                     attn(attn_idx);
 
-            to_float(G0, wg_addr(0), src_data_t, vlen);
-            to_float(G1, wg_addr(1), src_data_t, vlen);
-            to_float(G2, wg_addr(2), src_data_t, vlen);
+            to_float(G0, wg_addr(0), src_data_t, static_cast<int>(vlen));
+            to_float(G1, wg_addr(1), src_data_t, static_cast<int>(vlen));
+            to_float(G2, wg_addr(2), src_data_t, static_cast<int>(vlen));
 
             // compute dHt
             uni_vmovups(dHt, ptr[addr_diff_states_tp1_l_reg]);
@@ -159,7 +164,8 @@ protected:
             uni_vaddps(dHt, dHt, tmp1);
 
             // compute dG0
-            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t, vlen);
+            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t,
+                    static_cast<int>(vlen));
             uni_vmovups(dG0, G0);
             uni_vmovups(tmp1, G0);
             uni_vfnmadd231ps(dG0, tmp1, tmp1); // (G0 - G0^2)
@@ -185,7 +191,8 @@ protected:
             uni_vmulps(dG2, dG2, dHt); //(1 - G0) * (1 - G2^2) * dHt
 
             // compute dG1
-            to_float(tmp1, ptr[addr_ws_grid_reg], src_data_t, vlen);
+            to_float(tmp1, ptr[addr_ws_grid_reg], src_data_t,
+                    static_cast<int>(vlen));
             uni_vmovups(dG1, G1);
             uni_vmovups(tmp2, G1);
             uni_vfnmadd231ps(dG1, tmp2, tmp2); // (G1 - G1^2)
@@ -201,20 +208,22 @@ protected:
             uni_vmulps(tmp1, tmp1, G1);
 
             // downconvert and write data
-            to_src(sc_addr(0), dG0, scratch_data_t, vlen);
+            to_src(sc_addr(0), dG0, scratch_data_t, static_cast<int>(vlen));
             // As to_src is called with write_only=true it's important for xf16
             // src_dt to execute just after to_src method with write_only=false
             // for the same Vmm
-            to_src(sg_addr(0), dG0, scratch_data_t, vlen, true);
+            to_src(sg_addr(0), dG0, scratch_data_t, static_cast<int>(vlen),
+                    true);
 
-            to_src(sc_addr(1), dG1, scratch_data_t, vlen);
+            to_src(sc_addr(1), dG1, scratch_data_t, static_cast<int>(vlen));
             // As to_src is called with write_only=true it's important for xf16
             // src_dt to execute just after to_src method with write_only=false
             // for the same Vmm
-            to_src(sg_addr(1), dG1, scratch_data_t, vlen, true);
+            to_src(sg_addr(1), dG1, scratch_data_t, static_cast<int>(vlen),
+                    true);
 
-            to_src(sc_addr(2), tmp1, scratch_data_t, vlen);
-            to_src(sg_addr(2), dG2, scratch_data_t, vlen);
+            to_src(sc_addr(2), tmp1, scratch_data_t, static_cast<int>(vlen));
+            to_src(sg_addr(2), dG2, scratch_data_t, static_cast<int>(vlen));
 
             // increment address pointers
             add(addr_ws_gates_reg, vlen_scratch);
@@ -225,7 +234,7 @@ protected:
             add(addr_states_tm1_l_reg, vlen_scratch);
             add(addr_scratch_cell_reg, vlen_scratch);
             add(addr_ws_grid_reg, vlen_scratch);
-            inc_regs(vlen);
+            inc_regs(static_cast<size_t>(vlen));
 
             // increment loop counter
             sub(loop_cnt, vlen_scratch);
@@ -263,9 +272,12 @@ protected:
                     tmp2(tmp2_idx), h(h_idx), diff_attn_acc(dattn_acc_idx),
                     attn(attn_idx);
 
-            to_float(G0, wg_addr(0), src_data_t, hstate_dt_size);
-            to_float(G1, wg_addr(1), src_data_t, hstate_dt_size);
-            to_float(G2, wg_addr(2), src_data_t, hstate_dt_size);
+            to_float(G0, wg_addr(0), src_data_t,
+                    static_cast<int>(hstate_dt_size));
+            to_float(G1, wg_addr(1), src_data_t,
+                    static_cast<int>(hstate_dt_size));
+            to_float(G2, wg_addr(2), src_data_t,
+                    static_cast<int>(hstate_dt_size));
 
             // compute dHt
             uni_vmovss(dHt, ptr[addr_diff_states_tp1_l_reg]);
@@ -274,7 +286,8 @@ protected:
             uni_vaddss(dHt, dHt, tmp1);
 
             // compute dG0
-            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t, hstate_dt_size);
+            to_float(h, ptr[addr_states_tm1_l_reg], src_data_t,
+                    static_cast<int>(hstate_dt_size));
             uni_vmovss(dG0, G0);
             uni_vmovss(tmp1, dG0);
             uni_vfnmadd231ps(dG0, tmp1, tmp1); // (G0 - G0^2)
@@ -306,7 +319,8 @@ protected:
             uni_vmulss(dG2, dG2, dHt); //(1 - G0) * (1 - G2^2) * dHt
 
             // compute dG1
-            to_float(tmp1, ptr[addr_ws_grid_reg], src_data_t, hstate_dt_size);
+            to_float(tmp1, ptr[addr_ws_grid_reg], src_data_t,
+                    static_cast<int>(hstate_dt_size));
             uni_vmovss(dG1, G1);
             uni_vmovss(tmp2, G1);
             uni_vfnmadd231ps(dG1, tmp2, tmp2); // (G1 - G1^2)
@@ -322,20 +336,26 @@ protected:
             uni_vmulss(tmp1, tmp1, G1);
 
             // downconvert and write data
-            to_src(sc_addr(0), dG0, scratch_data_t, hstate_dt_size);
+            to_src(sc_addr(0), dG0, scratch_data_t,
+                    static_cast<int>(hstate_dt_size));
             // As to_src is called with write_only=true it's important for xf16
             // src_dt to execute just after to_src method with write_only=false
             // for the same Vmm
-            to_src(sg_addr(0), dG0, scratch_data_t, hstate_dt_size, true);
+            to_src(sg_addr(0), dG0, scratch_data_t,
+                    static_cast<int>(hstate_dt_size), true);
 
-            to_src(sc_addr(1), dG1, scratch_data_t, hstate_dt_size);
+            to_src(sc_addr(1), dG1, scratch_data_t,
+                    static_cast<int>(hstate_dt_size));
             // As to_src is called with write_only=true it's important for xf16
             // src_dt to execute just after to_src method with write_only=false
             // for the same Vmm
-            to_src(sg_addr(1), dG1, scratch_data_t, hstate_dt_size, true);
+            to_src(sg_addr(1), dG1, scratch_data_t,
+                    static_cast<int>(hstate_dt_size), true);
 
-            to_src(sc_addr(2), tmp1, scratch_data_t, hstate_dt_size);
-            to_src(sg_addr(2), dG2, scratch_data_t, hstate_dt_size);
+            to_src(sc_addr(2), tmp1, scratch_data_t,
+                    static_cast<int>(hstate_dt_size));
+            to_src(sg_addr(2), dG2, scratch_data_t,
+                    static_cast<int>(hstate_dt_size));
 
             // increment address pointers
             add(addr_ws_gates_reg, scratch_dt_size);
@@ -346,7 +366,7 @@ protected:
             add(addr_states_tm1_l_reg, scratch_dt_size);
             add(addr_scratch_cell_reg, scratch_dt_size);
             add(addr_ws_grid_reg, scratch_dt_size);
-            inc_regs(hstate_dt_size);
+            inc_regs(static_cast<size_t>(hstate_dt_size));
 
             // increment loop counter
             sub(loop_cnt, scratch_dt_size);
@@ -371,11 +391,12 @@ protected:
 
         postamble();
 
-        init_table(vlen);
+        init_table(static_cast<size_t>(vlen));
         L(table_label);
         {
-            for (size_t i = 0; i < vlen / sizeof(float); i++)
-                dd(float2int(1.0f));
+            for (size_t i = 0;
+                    i < static_cast<size_t>(vlen) / sizeof(float); i++)
+                dd(static_cast<uint32_t>(float2int(1.0f)));
         }
     }
 }; // namespace cpu

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
@@ -57,17 +57,24 @@ protected:
 
     // register size in bytes
     using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t f32_dt_size = sizeof(float);
 
-    const size_t vlen_dst
-            = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias_ = vlen / (sizeof(float) / bias_dt_size_);
-    const size_t hstate_dt_size = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
-    const size_t gate_dt_size = types::data_type_size(src_data_t);
-    const size_t vlen_elems = vlen / scratch_dt_size;
-    const size_t loop_len = rnn_.dhc;
-    const size_t loop_tail = loop_len % nstl::max(size_t(1), vlen_elems);
+    const dim_t vlen_dst = vlen
+            / (f32_dt_size
+                    / static_cast<dim_t>(types::data_type_size(src_data_t)));
+    const dim_t vlen_bias_ = vlen
+            / (f32_dt_size / static_cast<dim_t>(bias_dt_size_));
+    const dim_t hstate_dt_size
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t scratch_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
+    const dim_t gate_dt_size
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t vlen_elems = vlen / scratch_dt_size;
+    const dim_t bias_dt_size = static_cast<dim_t>(bias_dt_size_);
+    const dim_t loop_len = rnn_.dhc;
+    const dim_t loop_tail = loop_len % nstl::max<dim_t>(1, vlen_elems);
 
     void generate() override {
         using namespace Xbyak;
@@ -132,95 +139,106 @@ protected:
             return ptr[addr_ws_gates_reg + i * rnn_.dhc * gate_dt_size];
         };
         const auto B_addr = [&](int i) {
-            return ptr[addr_bias_reg + i * rnn_.dhc * bias_dt_size_];
+            return ptr[addr_bias_reg + i * rnn_.dhc * bias_dt_size];
         };
         const auto sc_addr = [&](int i) {
             return ptr[addr_scratch_cell_reg + i * rnn_.dhc * scratch_dt_size];
         };
 
-        auto compute_loop = [&](size_t current_vlen_elems) {
-            const auto current_vlen = current_vlen_elems * scratch_dt_size;
+        auto compute_loop = [&](dim_t current_vlen_elems) {
+            const dim_t current_vlen = current_vlen_elems * scratch_dt_size;
+            const int current_vlen_int = static_cast<int>(current_vlen);
             Label loop_start_label, loop_inc_regs_or_finish;
             L(loop_start_label);
             {
-                load(G0, sg_addr(0), scratch_data_t, current_vlen);
-                to_float(tmp1_vmm, B_addr(0), rnn_.bias_dt, current_vlen);
-                compute_vaddps(G0, G0, tmp1_vmm, current_vlen);
+                load(G0, sg_addr(0), scratch_data_t, current_vlen_int);
+                to_float(tmp1_vmm, B_addr(0), rnn_.bias_dt, current_vlen_int);
+                compute_vaddps(G0, G0, tmp1_vmm, current_vlen_int);
                 if (!rnn_.is_brgemm) {
-                    load(tmp1_vmm, sc_addr(0), scratch_data_t, current_vlen);
-                    compute_vaddps(G0, G0, tmp1_vmm, current_vlen);
+                    load(tmp1_vmm, sc_addr(0), scratch_data_t,
+                            current_vlen_int);
+                    compute_vaddps(G0, G0, tmp1_vmm, current_vlen_int);
                 }
                 sigmoid_injector_->load_table_addr();
                 sigmoid_injector_->compute_vector(G0.getIdx());
                 // if training we write back the gates
                 if (is_training)
-                    to_src(wg_addr(0), G0, src_data_t, current_vlen);
+                    to_src(wg_addr(0), G0, src_data_t, current_vlen_int);
 
                 // Compute gate 1
-                load(G1, sg_addr(1), scratch_data_t, current_vlen);
-                to_float(tmp1_vmm, B_addr(1), rnn_.bias_dt, current_vlen);
-                compute_vaddps(G1, G1, tmp1_vmm, current_vlen);
+                load(G1, sg_addr(1), scratch_data_t, current_vlen_int);
+                to_float(tmp1_vmm, B_addr(1), rnn_.bias_dt, current_vlen_int);
+                compute_vaddps(G1, G1, tmp1_vmm, current_vlen_int);
                 if (!rnn_.is_brgemm) {
-                    load(tmp1_vmm, sc_addr(1), scratch_data_t, current_vlen);
-                    compute_vaddps(G1, G1, tmp1_vmm, current_vlen);
+                    load(tmp1_vmm, sc_addr(1), scratch_data_t,
+                            current_vlen_int);
+                    compute_vaddps(G1, G1, tmp1_vmm, current_vlen_int);
                 }
                 sigmoid_injector_->load_table_addr();
                 sigmoid_injector_->compute_vector(G1.getIdx());
                 // if training we write back the gates
                 if (is_training)
-                    to_src(wg_addr(1), G1, src_data_t, current_vlen);
+                    to_src(wg_addr(1), G1, src_data_t, current_vlen_int);
 
                 // compute last gate
                 const auto wh_b_addr = sc_addr(rnn_.is_brgemm ? 0 : 2);
                 const auto ws_h_addr = ptr[addr_ws_h_reg];
-                load(tmp1_vmm, wh_b_addr, scratch_data_t, current_vlen);
-                to_float(tmp2_vmm, B_addr(3), rnn_.bias_dt, current_vlen);
-                compute_vaddps(tmp1_vmm, tmp1_vmm, tmp2_vmm, current_vlen);
+                load(tmp1_vmm, wh_b_addr, scratch_data_t, current_vlen_int);
+                to_float(tmp2_vmm, B_addr(3), rnn_.bias_dt, current_vlen_int);
+                compute_vaddps(
+                        tmp1_vmm, tmp1_vmm, tmp2_vmm, current_vlen_int);
                 if (is_training)
-                    to_src(ws_h_addr, tmp1_vmm, src_data_t, current_vlen);
-                load(G2, sg_addr(2), scratch_data_t, current_vlen);
-                to_float(tmp2_vmm, B_addr(2), rnn_.bias_dt, current_vlen);
-                compute_vaddps(G2, G2, tmp2_vmm, current_vlen);
-                compute_vfmadd231ps(G2, G1, tmp1_vmm, current_vlen);
+                    to_src(ws_h_addr, tmp1_vmm, src_data_t, current_vlen_int);
+                load(G2, sg_addr(2), scratch_data_t, current_vlen_int);
+                to_float(tmp2_vmm, B_addr(2), rnn_.bias_dt, current_vlen_int);
+                compute_vaddps(G2, G2, tmp2_vmm, current_vlen_int);
+                compute_vfmadd231ps(G2, G1, tmp1_vmm, current_vlen_int);
                 tanh_injector_->load_table_addr();
                 tanh_injector_->compute_vector(G2.getIdx());
                 // if training we write back the gates
                 if (is_training)
-                    to_src(wg_addr(2), G2, src_data_t, current_vlen);
+                    to_src(wg_addr(2), G2, src_data_t, current_vlen_int);
 
                 if (is_augru) {
-                    load(tmp1_vmm, one_addr, scratch_data_t, current_vlen);
+                    load(tmp1_vmm, one_addr, scratch_data_t, current_vlen_int);
                     // for augru there is additional step G01 = (1 - a) * G0
                     // states_t_l = states_tm1_l * G01 + (1 - G01) * G2
                     const Xmm tmp2s_vmm(tmp2_vmm.getIdx());
                     to_float(tmp2s_vmm, ptr[addr_attn_reg], src_data_t,
-                            scratch_dt_size);
+                            static_cast<int>(scratch_dt_size));
                     uni_vbroadcastss(tmp2_vmm, tmp2s_vmm);
                     // G01 = (1 - a) * G0
                     compute_vsubps(tmp2_vmm, tmp1_vmm, tmp2_vmm, tmp3_vmm,
-                            current_vlen);
-                    compute_vmulps(G0, G0, tmp2_vmm, current_vlen);
+                            current_vlen_int);
+                    compute_vmulps(G0, G0, tmp2_vmm, current_vlen_int);
                     // tmp1 = 1 - G01
-                    compute_vsubps(tmp1_vmm, tmp1_vmm, G0, current_vlen);
+                    compute_vsubps(
+                            tmp1_vmm, tmp1_vmm, G0, current_vlen_int);
                     // tmp1 = G2 * tmp1
                     compute_vmulps(
-                            tmp1_vmm, G2, tmp1_vmm, tmp3_vmm, current_vlen);
+                            tmp1_vmm, G2, tmp1_vmm, tmp3_vmm,
+                            current_vlen_int);
                     // states_t_l = G01 * states_tm1_l + tmp2
                     to_float(tmp2_vmm, ptr[addr_states_tm1_l_reg], src_data_t,
-                            current_vlen);
-                    compute_vfmadd213ps(G0, tmp2_vmm, tmp1_vmm, current_vlen);
+                            current_vlen_int);
+                    compute_vfmadd213ps(
+                            G0, tmp2_vmm, tmp1_vmm, current_vlen_int);
                 } else {
                     // states_t_l = states_tm1_l * G0 + (1 - G0) * G2
-                    load(tmp1_vmm, one_addr, scratch_data_t, current_vlen);
-                    compute_vsubps(tmp1_vmm, tmp1_vmm, G0, current_vlen);
+                    load(tmp1_vmm, one_addr, scratch_data_t,
+                            current_vlen_int);
+                    compute_vsubps(
+                            tmp1_vmm, tmp1_vmm, G0, current_vlen_int);
                     to_float(tmp2_vmm, ptr[addr_states_tm1_l_reg], src_data_t,
-                            current_vlen);
-                    compute_vmulps(G0, G0, tmp2_vmm, current_vlen);
-                    compute_vfmadd231ps(G0, tmp1_vmm, G2, current_vlen);
+                            current_vlen_int);
+                    compute_vmulps(G0, G0, tmp2_vmm, current_vlen_int);
+                    compute_vfmadd231ps(
+                            G0, tmp1_vmm, G2, current_vlen_int);
                 }
 
                 // write back the result
-                to_src(ptr[addr_states_t_l_reg], G0, src_data_t, current_vlen);
+                to_src(ptr[addr_states_t_l_reg], G0, src_data_t,
+                        current_vlen_int);
                 // if states_t_l_copy is a non null ptr, we write the output to
                 // both tensors
                 cmp(addr_states_t_l_copy_reg, rnn_.dhc * hstate_dt_size);
@@ -229,18 +247,18 @@ protected:
                 // xf16 src_dt to execute just after to_src method with
                 // write_only=false for the same Vmm
                 to_src(ptr[addr_states_t_l_copy_reg], G0, src_data_t,
-                        current_vlen, true);
+                        current_vlen_int, true);
                 // increment address pointers
                 L(loop_inc_regs_or_finish);
                 if (current_vlen_elems != loop_tail) {
                     const auto current_gate_size
                             = current_vlen == vlen ? vlen_dst : gate_dt_size;
-                    const auto current_states_size
+                    const dim_t current_states_size
                             = current_vlen == vlen ? vlen_dst : hstate_dt_size;
                     add(addr_scratch_gates_reg, current_vlen);
                     add(addr_ws_h_reg, current_gate_size);
                     add(addr_bias_reg,
-                            current_vlen == vlen ? vlen_bias_ : bias_dt_size_);
+                            current_vlen == vlen ? vlen_bias_ : bias_dt_size);
                     add(addr_states_t_l_reg, current_states_size);
                     add(addr_states_t_l_copy_reg, current_states_size);
                     add(addr_states_tm1_l_reg, current_states_size);
@@ -257,7 +275,7 @@ protected:
 
         // initialize registers with addresses and constants
         mov(table_reg, table_label);
-        init_regs(vlen, loop_tail);
+        init_regs(static_cast<size_t>(vlen), static_cast<size_t>(loop_tail));
         if (rnn_.is_brgemm) {
 #ifdef _WIN32
             mov(loop_cnt, ptr[base_args + 40]);
@@ -269,7 +287,7 @@ protected:
             mov(loop_cnt, ptr[base_args + 24]);
 #endif
         } else {
-            mov(loop_cnt, loop_len);
+            mov(loop_cnt, static_cast<uint64_t>(loop_len));
         }
 
         if (loop_tail > 0) {
@@ -284,7 +302,7 @@ protected:
             Label exit_label;
             cmp(loop_cnt, 0);
             jle(exit_label, T_NEAR);
-            compute_loop(is_avx512 ? loop_tail : 1);
+            compute_loop(is_avx512 ? loop_tail : dim_t(1));
             L(exit_label);
         }
 
@@ -292,12 +310,13 @@ protected:
 
         sigmoid_injector_->prepare_table(true);
         tanh_injector_->prepare_table(true);
-        init_table(vlen);
+        init_table(static_cast<size_t>(vlen));
 
         L(table_label);
         {
-            for (size_t i = 0; i < vlen / sizeof(float); i++)
-                dd(float2int(1.0f));
+            for (size_t i = 0;
+                    i < static_cast<size_t>(vlen) / sizeof(float); i++)
+                dd(static_cast<uint32_t>(float2int(1.0f)));
         }
     }
 }; // namespace cpu

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
@@ -64,17 +64,17 @@ protected:
     std::unique_ptr<injector_t> tanh_injector_;
 
     // register size in bytes
-    static constexpr size_t vlen_ = cpu_isa_traits_t<isa>::vlen;
-    const size_t vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
+    static constexpr dim_t vlen_ = cpu_isa_traits_t<isa>::vlen;
+    const dim_t vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
 
-    static constexpr size_t diff_cstate_dt_size_ = sizeof(float);
-    static constexpr size_t hstate_dt_size_ = sizeof(float);
-    static constexpr size_t weights_peephole_dt_size_ = sizeof(float);
+    static constexpr dim_t diff_cstate_dt_size_ = sizeof(float);
+    static constexpr dim_t hstate_dt_size_ = sizeof(float);
+    static constexpr dim_t weights_peephole_dt_size_ = sizeof(float);
 
-    const size_t vlen_scratch_
+    const dim_t vlen_scratch_
             = vlen_ / (sizeof(float) / types::data_type_size(scratch_data_t));
-    const size_t gate_dt_size_ = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size_ = types::data_type_size(scratch_data_t);
+    const dim_t gate_dt_size_ = types::data_type_size(scratch_data_t);
+    const dim_t scratch_dt_size_ = types::data_type_size(scratch_data_t);
 
     void generate() override {
         using namespace Xbyak;

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
@@ -69,16 +69,19 @@ protected:
     std::unique_ptr<injector_t> tanh_injector_;
 
     // register size in bytes
-    static constexpr size_t vlen_ = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t qscale_dt_size = sizeof(float);
-    static constexpr size_t weights_peephole_dt_size_ = sizeof(float);
-    const size_t vlen_dst_
+    static constexpr dim_t vlen_ = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t qscale_dt_size = sizeof(float);
+    static constexpr dim_t weights_peephole_dt_size_ = sizeof(float);
+    const dim_t vlen_dst_
             = vlen_ / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias_ = vlen_ / (sizeof(float) / bias_dt_size_);
-    const size_t vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
-    const size_t hstate_dt_size_ = types::data_type_size(src_data_t);
-    const size_t gate_dt_size_ = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size_ = types::data_type_size(scratch_data_t);
+    const dim_t vlen_bias_ = vlen_ / (sizeof(float) / bias_dt_size_);
+    const dim_t vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
+    const dim_t hstate_dt_size_
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t gate_dt_size_
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t scratch_dt_size_
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
     int get_vmm_idx(int unroll_idx, int type_shift) const {
         const int preserved_vmm_start_idx = 1;
         // G0, G1, G2, G3, c_states;
@@ -101,7 +104,7 @@ protected:
     }
 
     dim_t scale_off(int gate_idx, int unroll_idx) const {
-        const size_t vlen_qscale_elem = vlen_ / qscale_dt_size;
+        const dim_t vlen_qscale_elem = vlen_ / qscale_dt_size;
         return gate_idx * rnn_.dhc + unroll_idx * vlen_qscale_elem;
     }
 
@@ -172,11 +175,12 @@ protected:
                     + i * rnn_.dhc * weights_peephole_dt_size_ + j * vlen_];
         };
 
-        const auto loop_len = rnn_.dhc * scratch_dt_size_;
-        const auto loop_tail = loop_len % vlen_;
+        const dim_t loop_len = rnn_.dhc * scratch_dt_size_;
+        const dim_t loop_tail = loop_len % vlen_;
 
         // initialize registers with addresses and constants
-        init_regs(weights_scales, vlen_, loop_tail / scratch_dt_size_);
+        init_regs(weights_scales, static_cast<size_t>(vlen_),
+                static_cast<size_t>(loop_tail / scratch_dt_size_));
         sigmoid_injector_->load_table_addr();
         tanh_injector_->load_table_addr();
         if (rnn_.is_brgemm && !rnn_.unfused_post_gemm)
@@ -207,7 +211,8 @@ protected:
                 loop_unroll_tail = 1;
         }
 
-        auto compute_loop = [&](size_t current_vlen, int current_unroll_len) {
+        auto compute_loop = [&](dim_t current_vlen, int current_unroll_len) {
+            const int vlen_int = static_cast<int>(current_vlen);
             this->reset_tmp_vmm_idx_range(
                     get_last_preserved_vmm_idx(current_unroll_len) + 1,
                     this->get_max_allowed_tmp_vmm_allowed_idx());
@@ -217,7 +222,7 @@ protected:
             const bool single_tail_loop_iter
                     = current_vlen < vlen_ && current_vlen == loop_tail;
             const bool need_increment_regs = !single_tail_loop_iter;
-            const auto iter_size = current_unroll_len * current_vlen;
+            const dim_t iter_size = current_unroll_len * current_vlen;
 
             Label loop_start_label, loop_skip_label;
             cmp(loop_cnt, iter_size);
@@ -230,56 +235,56 @@ protected:
                             G2(G2_idx(ur_idx)), G3(G3_idx(ur_idx)),
                             tmp_c_states(c_states_idx(ur_idx));
                     // load G0 G1 G2 G3
-                    load(G0, sg_addr(0, ur_idx), scratch_data_t, current_vlen);
-                    load(G1, sg_addr(1, ur_idx), scratch_data_t, current_vlen);
-                    load(G2, sg_addr(2, ur_idx), scratch_data_t, current_vlen);
-                    load(G3, sg_addr(3, ur_idx), scratch_data_t, current_vlen);
+                    load(G0, sg_addr(0, ur_idx), scratch_data_t, vlen_int);
+                    load(G1, sg_addr(1, ur_idx), scratch_data_t, vlen_int);
+                    load(G2, sg_addr(2, ur_idx), scratch_data_t, vlen_int);
+                    load(G3, sg_addr(3, ur_idx), scratch_data_t, vlen_int);
 
                     // dequantize the gates from s32 to f32 if needed, add bias
                     deq_w(src_data_t, G0, this->get_next_tmp_vmm(),
                             this->get_next_tmp_vmm(), scale_off(0, ur_idx),
-                            mask, current_vlen);
+                            mask, vlen_int);
                     const auto bias_g0_vmm = this->get_next_tmp_vmm();
                     to_float(bias_g0_vmm, B_addr(0, ur_idx), rnn_.bias_dt,
-                            current_vlen);
-                    compute_vaddps(G0, G0, bias_g0_vmm, current_vlen);
+                            vlen_int);
+                    compute_vaddps(G0, G0, bias_g0_vmm, vlen_int);
 
                     deq_w(src_data_t, G1, this->get_next_tmp_vmm(),
                             this->get_next_tmp_vmm(), scale_off(1, ur_idx),
-                            mask, current_vlen);
+                            mask, vlen_int);
                     const auto bias_g1_vmm = this->get_next_tmp_vmm();
                     to_float(bias_g1_vmm, B_addr(1, ur_idx), rnn_.bias_dt,
-                            current_vlen);
-                    compute_vaddps(G1, G1, bias_g1_vmm, current_vlen);
+                            vlen_int);
+                    compute_vaddps(G1, G1, bias_g1_vmm, vlen_int);
 
                     deq_w(src_data_t, G2, this->get_next_tmp_vmm(),
                             this->get_next_tmp_vmm(), scale_off(2, ur_idx),
-                            mask, current_vlen);
+                            mask, vlen_int);
                     const auto bias_g2_vmm = this->get_next_tmp_vmm();
                     to_float(bias_g2_vmm, B_addr(2, ur_idx), rnn_.bias_dt,
-                            current_vlen);
-                    compute_vaddps(G2, G2, bias_g2_vmm, current_vlen);
+                            vlen_int);
+                    compute_vaddps(G2, G2, bias_g2_vmm, vlen_int);
 
                     deq_w(src_data_t, G3, this->get_next_tmp_vmm(),
                             this->get_next_tmp_vmm(), scale_off(3, ur_idx),
-                            mask, current_vlen);
+                            mask, vlen_int);
                     const auto bias_g3_vmm = this->get_next_tmp_vmm();
                     to_float(bias_g3_vmm, B_addr(3, ur_idx), rnn_.bias_dt,
-                            current_vlen);
-                    compute_vaddps(G3, G3, bias_g3_vmm, current_vlen);
+                            vlen_int);
+                    compute_vaddps(G3, G3, bias_g3_vmm, vlen_int);
 
                     to_float(tmp_c_states,
                             ptr[addr_c_states_tm1_l_reg
                                     + ur_idx * vlen_c_states_],
-                            rnn_.src_iter_c_dt, current_vlen);
+                            rnn_.src_iter_c_dt, vlen_int);
 
                     // add peephole
                     if (rnn_.is_lstm_peephole) {
                         compute_vfmadd231ps(G0, tmp_c_states,
-                                weights_peephole_addr(0, ur_idx), current_vlen,
+                                weights_peephole_addr(0, ur_idx), vlen_int,
                                 this->maybe_get_next_tmp_vmm_for_below_avx2_isa());
                         compute_vfmadd231ps(G1, tmp_c_states,
-                                weights_peephole_addr(1, ur_idx), current_vlen,
+                                weights_peephole_addr(1, ur_idx), vlen_int,
                                 this->maybe_get_next_tmp_vmm_for_below_avx2_isa());
                     }
 
@@ -297,12 +302,12 @@ protected:
                     for (int ur_idx = 0; ur_idx < current_unroll_len;
                             ur_idx++) {
                         to_src(wg_addr(0, ur_idx), Vmm(G0_idx(ur_idx)),
-                                src_data_t, current_vlen);
+                                src_data_t, vlen_int);
                         to_src(wg_addr(1, ur_idx), Vmm(G1_idx(ur_idx)),
-                                src_data_t, current_vlen);
+                                src_data_t, vlen_int);
                         if (!rnn_.is_lstm_peephole)
                             to_src(wg_addr(3, ur_idx), Vmm(G3_idx(ur_idx)),
-                                    src_data_t, current_vlen);
+                                    src_data_t, vlen_int);
                     }
                 }
                 for (int ur_idx = 0; ur_idx < current_unroll_len; ur_idx++) {
@@ -317,17 +322,15 @@ protected:
                             G2(G2_idx(ur_idx)),
                             tmp_c_states(c_states_idx(ur_idx));
                     if (is_training) {
-                        to_src(wg_addr(2, ur_idx), G2, src_data_t,
-                                current_vlen);
+                        to_src(wg_addr(2, ur_idx), G2, src_data_t, vlen_int);
                     }
 
                     // compute c_states_t_l = G1 * c_tm1_l + G0 * G2
-                    compute_vmulps(
-                            tmp_c_states, tmp_c_states, G1, current_vlen);
-                    compute_vfmadd231ps(tmp_c_states, this->vmm_backup(G0), G2,
-                            current_vlen);
+                    compute_vmulps(tmp_c_states, tmp_c_states, G1, vlen_int);
+                    compute_vfmadd231ps(
+                            tmp_c_states, this->vmm_backup(G0), G2, vlen_int);
                     to_src(ptr[addr_c_states_t_l_reg + ur_idx * vlen_c_states_],
-                            tmp_c_states, rnn_.dst_iter_c_dt, current_vlen);
+                            tmp_c_states, rnn_.dst_iter_c_dt, vlen_int);
                 }
 
                 // add peephole
@@ -337,7 +340,7 @@ protected:
                         const int cur_g3_idx = G3_idx(ur_idx);
                         compute_vfmadd231ps(Vmm(cur_g3_idx),
                                 Vmm(c_states_idx(ur_idx)),
-                                weights_peephole_addr(2, ur_idx), current_vlen,
+                                weights_peephole_addr(2, ur_idx), vlen_int,
                                 this->maybe_get_next_tmp_vmm_for_below_avx2_isa());
                         vmm_idxs.emplace(cur_g3_idx);
                     }
@@ -350,7 +353,7 @@ protected:
                         for (int ur_idx = 0; ur_idx < current_unroll_len;
                                 ur_idx++) {
                             to_src(wg_addr(3, ur_idx), Vmm(G3_idx(ur_idx)),
-                                    src_data_t, current_vlen);
+                                    src_data_t, vlen_int);
                         }
                     }
                 }
@@ -366,8 +369,7 @@ protected:
                 for (int ur_idx = 0; ur_idx < current_unroll_len; ur_idx++) {
                     const Vmm G3(G3_idx(ur_idx)),
                             tmp_c_states(c_states_idx(ur_idx));
-                    compute_vmulps(
-                            tmp_c_states, tmp_c_states, G3, current_vlen);
+                    compute_vmulps(tmp_c_states, tmp_c_states, G3, vlen_int);
                 }
 
                 // downconvert/quantize and write back the state
@@ -380,60 +382,60 @@ protected:
                 for (int ur_idx = 0; ur_idx < current_unroll_len; ur_idx++) {
                     const Vmm tmp_c_states(c_states_idx(ur_idx));
                     to_src(ptr[addr_states_t_l_reg + ur_idx * vlen_dst_],
-                            tmp_c_states, src_data_t, current_vlen);
+                            tmp_c_states, src_data_t, vlen_int);
                     // As to_src is called with write_only=true it's important
                     // for xf16 src_dt to execute just after to_src method with
                     // write_only=false for the same Vmm
                     to_src(ptr[addr_states_t_l_copy_reg + ur_idx * vlen_dst_],
-                            tmp_c_states, src_data_t, current_vlen, true);
+                            tmp_c_states, src_data_t, vlen_int, true);
                 }
-                const size_t hstate_shift = current_vlen < vlen_
+                const dim_t hstate_shift = current_vlen < vlen_
                         ? hstate_dt_size_
                         : current_unroll_len * vlen_dst_;
                 if (need_increment_regs)
-                    add(addr_states_t_l_copy_reg, hstate_shift);
+                    add(addr_states_t_l_copy_reg,
+                            hstate_shift);
                 jmp(loop_inc_regs_label, T_NEAR);
 
                 L_aligned(update_single_states_tensor_only_label);
                 for (int ur_idx = 0; ur_idx < current_unroll_len; ur_idx++) {
                     to_src(ptr[addr_states_t_l_reg + ur_idx * vlen_dst_],
-                            Vmm(c_states_idx(ur_idx)), src_data_t,
-                            current_vlen);
+                            Vmm(c_states_idx(ur_idx)), src_data_t, vlen_int);
                 }
 
                 // increment address pointers
                 L_aligned(loop_inc_regs_label);
                 if (need_increment_regs) {
-                    const size_t scratch_shift = current_vlen < vlen_
+                    const dim_t scratch_shift = current_vlen < vlen_
                             ? scratch_dt_size_
                             : current_unroll_len * vlen_;
                     add(addr_scratch_gates_reg, scratch_shift);
                     if (rnn_.is_lstm_peephole) {
-                        const size_t wpeephole_shift = current_vlen < vlen_
+                        const dim_t wpeephole_shift = current_vlen < vlen_
                                 ? weights_peephole_dt_size_
                                 : current_unroll_len * vlen_;
                         add(addr_weights_peephole_reg, wpeephole_shift);
                     }
-                    const size_t bias_shift = current_vlen < vlen_
+                    const dim_t bias_shift = current_vlen < vlen_
                             ? bias_dt_size_
                             : current_unroll_len * vlen_bias_;
                     add(addr_bias_reg, bias_shift);
                     add(addr_states_t_l_reg, hstate_shift);
-                    const size_t cstate_shift = current_vlen < vlen_
+                    const dim_t cstate_shift = current_vlen < vlen_
                             ? cstate_dt_size_
                             : current_unroll_len * vlen_c_states_;
                     add(addr_c_states_tm1_l_reg, cstate_shift);
                     add(addr_c_states_t_l_reg, cstate_shift);
                     if (is_training) {
-                        const size_t gate_shift = current_vlen < vlen_
+                        const dim_t gate_shift = current_vlen < vlen_
                                 ? gate_dt_size_
                                 : current_unroll_len * vlen_dst_;
                         add(addr_ws_gates_reg, gate_shift);
                     }
-                    const size_t qscale_shift = current_vlen < vlen_
+                    const dim_t qscale_shift = current_vlen < vlen_
                             ? qscale_dt_size
                             : current_unroll_len * vlen_;
-                    inc_regs(mask, qscale_shift);
+                    inc_regs(mask, static_cast<size_t>(qscale_shift));
                 }
 
                 // increment loop counter
@@ -464,7 +466,7 @@ protected:
         sigmoid_injector_->prepare_table(true);
         tanh_injector_->prepare_table(true);
 
-        init_table(vlen_);
+        init_table(static_cast<size_t>(vlen_));
     }
 };
 

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
@@ -43,12 +43,14 @@ struct jit_uni_rnn_cell_postgemm_bwd : public jit_uni_rnn_postgemm_t {
 protected:
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t hstate_dt_size = sizeof(float);
-    const size_t vlen_scratch
+    static constexpr dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t hstate_dt_size = sizeof(float);
+    const dim_t vlen_scratch
             = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
-    const size_t gate_dt_size = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    const dim_t gate_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
+    const dim_t scratch_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;
@@ -98,7 +100,7 @@ protected:
         // };
 
         // initialize registers with addresses and constants
-        init_regs(vlen);
+        init_regs(static_cast<size_t>(vlen));
 
         mov(table_reg, table_one_label);
         uni_vmovups(Vmm(one_idx), ptr[table_reg]);
@@ -119,7 +121,7 @@ protected:
             const Vmm G(G_idx), dG(dG_idx), dHt(dHt_idx), tmp1(tmp1_idx),
                     one(one_idx), zero(zero_idx), alpha(alpha_idx);
 
-            to_float(G, wg_addr(0), src_data_t, vlen);
+            to_float(G, wg_addr(0), src_data_t, static_cast<int>(vlen));
 
             // compute dHt
             uni_vmovups(dHt, ptr[addr_diff_states_tp1_l_reg]);
@@ -156,14 +158,14 @@ protected:
             uni_vmulps(dG, dG, dHt);
 
             // downconvert and write data
-            to_src(sg_addr(0), dG, scratch_data_t, vlen);
+            to_src(sg_addr(0), dG, scratch_data_t, static_cast<int>(vlen));
 
             // increment address pointers
             add(addr_ws_gates_reg, vlen_scratch);
             add(addr_scratch_gates_reg, vlen_scratch);
             add(addr_diff_states_t_lp1_reg, vlen);
             add(addr_diff_states_tp1_l_reg, vlen);
-            inc_regs(vlen);
+            inc_regs(static_cast<size_t>(vlen));
 
             // increment loop counter
             sub(loop_cnt, vlen_scratch);
@@ -181,7 +183,8 @@ protected:
             const Xmm G(G_idx), dG(dG_idx), dHt(dHt_idx), tmp1(tmp1_idx),
                     one(one_idx), zero(zero_idx), alpha(alpha_idx);
 
-            to_float(G, wg_addr(0), src_data_t, hstate_dt_size);
+            to_float(G, wg_addr(0), src_data_t,
+                    static_cast<int>(hstate_dt_size));
 
             // compute dHt
             uni_vmovss(dHt, ptr[addr_diff_states_tp1_l_reg]);
@@ -213,14 +216,15 @@ protected:
             uni_vmulps(dG, dG, dHt);
 
             // downconvert and write data
-            to_src(sg_addr(0), dG, scratch_data_t, hstate_dt_size);
+            to_src(sg_addr(0), dG, scratch_data_t,
+                    static_cast<int>(hstate_dt_size));
 
             // increment address pointers
             add(addr_ws_gates_reg, scratch_dt_size);
             add(addr_scratch_gates_reg, scratch_dt_size);
             add(addr_diff_states_t_lp1_reg, hstate_dt_size);
             add(addr_diff_states_tp1_l_reg, hstate_dt_size);
-            inc_regs(hstate_dt_size);
+            inc_regs(static_cast<size_t>(hstate_dt_size));
 
             // increment loop counter
             sub(loop_cnt, scratch_dt_size);
@@ -232,7 +236,7 @@ protected:
         postamble();
 
         // inject the constant table for the activation
-        init_table(vlen);
+        init_table(static_cast<size_t>(vlen));
         L(table_one_label);
         {
             for (size_t i = 0; i < vlen / sizeof(float); i++)

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
@@ -52,16 +52,19 @@ protected:
 
     // register size in bytes
     using Vmm = typename jit_uni_eltwise_injector_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t cstate_dt_size = sizeof(float);
-    static constexpr size_t qscale_dt_size = sizeof(float);
+    static constexpr dim_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr dim_t cstate_dt_size = sizeof(float);
+    static constexpr dim_t qscale_dt_size = sizeof(float);
 
-    const size_t vlen_dst
+    const dim_t vlen_dst
             = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
-    const size_t hstate_dt_size = types::data_type_size(src_data_t);
-    const size_t gate_dt_size = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    const dim_t vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
+    const dim_t hstate_dt_size
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t gate_dt_size
+            = static_cast<dim_t>(types::data_type_size(src_data_t));
+    const dim_t scratch_dt_size
+            = static_cast<dim_t>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;
@@ -116,7 +119,7 @@ protected:
         const auto B_addr = ptr[addr_bias_reg + 0 * rnn_.dhc * bias_dt_size_];
 
         // initialize registers with addresses and constants
-        init_regs(weights_scales, vlen);
+        init_regs(weights_scales, static_cast<size_t>(vlen));
         injector_->load_table_addr();
 
         if (rnn_.is_brgemm && !rnn_.unfused_post_gemm)
@@ -133,19 +136,22 @@ protected:
             uni_vmovups(G, sg_addr);
 
             // dequantize the gates from s32 to f32 if needed
-            deq_w(src_data_t, G, tmp1_vmm, tmp2_vmm, 0, mask, vlen);
+            deq_w(src_data_t, G, tmp1_vmm, tmp2_vmm, 0, mask,
+                    static_cast<int>(vlen));
 
             // add biases
-            to_float(tmp1_vmm, B_addr, rnn_.bias_dt, vlen);
+            to_float(tmp1_vmm, B_addr, rnn_.bias_dt, static_cast<int>(vlen));
             uni_vaddps(G, G, tmp1_vmm);
 
             // inject eltwise code
             injector_->compute_vector(G.getIdx());
 
             // if training we write back the gates
-            if (is_training) to_src(wg_addr, G, src_data_t, vlen);
+            if (is_training)
+                to_src(wg_addr, G, src_data_t, static_cast<int>(vlen));
 
-            to_src(ptr[addr_states_t_l_reg], G, src_data_t, vlen);
+            to_src(ptr[addr_states_t_l_reg], G, src_data_t,
+                    static_cast<int>(vlen));
             // if states_t_l_copy is a non null ptr, we write the output to both
             // tensors
             cmp(addr_states_t_l_copy_reg, rnn_.dhc * hstate_dt_size);
@@ -153,7 +159,8 @@ protected:
             // As to_src is called with write_only=true it's important for xf16
             // src_dt to execute just after to_src method with write_only=false
             // for the same Vmm
-            to_src(ptr[addr_states_t_l_copy_reg], G, src_data_t, vlen, true);
+            to_src(ptr[addr_states_t_l_copy_reg], G, src_data_t,
+                    static_cast<int>(vlen), true);
 
             // increment address pointers
             L(vector_loop_inc_regs);
@@ -162,7 +169,7 @@ protected:
             add(addr_states_t_l_reg, vlen_dst);
             add(addr_states_t_l_copy_reg, vlen_dst);
             if (is_training) add(addr_ws_gates_reg, vlen_dst);
-            inc_regs(mask, vlen);
+            inc_regs(mask, static_cast<size_t>(vlen));
 
             // increment loop counter
             sub(loop_cnt, vlen);
@@ -185,19 +192,24 @@ protected:
             uni_vmovss(Gs, sg_addr);
 
             // dequantize the gates from s32 to f32 if needed
-            deq_w(src_data_t, G, tmp1_vmm, tmp2_vmm, 0, mask, scratch_dt_size);
+            deq_w(src_data_t, G, tmp1_vmm, tmp2_vmm, 0, mask,
+                    static_cast<int>(scratch_dt_size));
 
             // add biases
-            to_float(tmp1_vmm, B_addr, rnn_.bias_dt, sizeof(float));
+            to_float(tmp1_vmm, B_addr, rnn_.bias_dt,
+                    static_cast<int>(sizeof(float)));
             uni_vaddps(Gs, Gs, tmp1s_vmm);
 
             // inject eltwise code
             injector_->compute_vector(Gs.getIdx());
 
             // if training we write back the gates
-            if (is_training) to_src(wg_addr, G, src_data_t, scratch_dt_size);
+            if (is_training)
+                to_src(wg_addr, G, src_data_t,
+                        static_cast<int>(scratch_dt_size));
 
-            to_src(ptr[addr_states_t_l_reg], G, src_data_t, scratch_dt_size);
+            to_src(ptr[addr_states_t_l_reg], G, src_data_t,
+                    static_cast<int>(scratch_dt_size));
             // if states_t_l_copy is a non null ptr, we write the output to both
             // tensors
             cmp(addr_states_t_l_copy_reg, rnn_.dhc * hstate_dt_size);
@@ -206,16 +218,16 @@ protected:
             // src_dt to execute just after to_src method with write_only=false
             // for the same Vmm
             to_src(ptr[addr_states_t_l_copy_reg], G, src_data_t,
-                    scratch_dt_size, true);
+                    static_cast<int>(scratch_dt_size), true);
 
             // increment address pointers
             L(rem_loop_inc_regs);
             add(addr_scratch_gates_reg, scratch_dt_size);
-            add(addr_bias_reg, bias_dt_size_);
+            add(addr_bias_reg, static_cast<uint32_t>(bias_dt_size_));
             add(addr_states_t_l_reg, hstate_dt_size);
             add(addr_states_t_l_copy_reg, hstate_dt_size);
             if (is_training) add(addr_ws_gates_reg, gate_dt_size);
-            inc_regs(mask, qscale_dt_size);
+            inc_regs(mask, static_cast<size_t>(qscale_dt_size));
 
             // increment loop counter
             sub(loop_cnt, scratch_dt_size);
@@ -228,7 +240,7 @@ protected:
 
         // inject the constant table for the activation
         injector_->prepare_table();
-        init_table(vlen);
+        init_table(static_cast<size_t>(vlen));
     }
 };
 

--- a/src/cpu/x64/rnn/jit_uni_rnn_common_postgemm.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_common_postgemm.hpp
@@ -126,14 +126,14 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
 
     template <typename dst_layer_t, typename dst_iter_t, typename src_iter_t,
             typename gates_t, typename scratch_t>
-    inline void postgemm_fwd_call(int m, const rnn_utils::rnn_conf_t &rnn,
+    inline void postgemm_fwd_call(dim_t m, const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, gates_t *ws_gates_,
             scratch_t *scratch_gates_, const dst_layer_t *augru_attention_,
             dst_layer_t *dst_layer_, void *dst_iter_c_,
             const src_iter_t *src_iter_, const void *src_iter_c_,
             const float *weights_peephole_, const void *bias_,
             gates_t *ws_grid_, scratch_t *scratch_cell_, dst_iter_t *dst_iter_,
-            float *weights_scales_, int block_step) const {
+            float *weights_scales_, dim_t block_step) const {
         const rnn_utils::ws_gates_aoc_t<gates_t> ws_gates(rnn, ws_gates_);
         const rnn_utils::scratch_gates_aoc_t<scratch_t> scratch_gates(
                 rnn, scratch_gates_);
@@ -143,11 +143,11 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
                 bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
 
         const auto src_iter_ld = rnn.src_iter_ld(cell_position);
-        const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+        const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
         const auto dst_layer_ld
                 = rnn.dst_layer_ld(cell_position, is_projection());
         const auto dst_iter_ld = rnn.dst_iter_ld(cell_position);
-        const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+        const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
 
         const rnn_utils::ws_states_layer_aoc_t<dst_layer_t> dst_layer(
                 rnn, dst_layer_, dst_layer_ld);
@@ -227,8 +227,8 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
             typename gemm_acc_t, typename gates_t, typename scratch_t>
     rnn_postgemm_sig(execute_bwd) {
         using namespace rnn_utils;
-        const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
-        const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+        const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+        const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
         const auto src_iter_ld = rnn.src_iter_ld(cell_position);
 
         const rnn_utils::weights_peephole_aoc_t<const float> weights_peephole(
@@ -475,7 +475,7 @@ protected:
 
     void inc_regs(int mask, size_t vlen) {
         if (pd_->weights_md()->data_type == data_type::s8) {
-            if (mask != 0) add(weights_scales_reg, vlen);
+            if (mask != 0) add(weights_scales_reg, static_cast<uint32_t>(vlen));
         }
     }
     void inc_regs(size_t vlen) {
@@ -885,7 +885,7 @@ protected:
     bool projection_;
     bf16_emulation_t *bf16_emu_ = nullptr;
     const size_t bias_dt_size_;
-    const size_t cstate_dt_size_;
+    const dim_t cstate_dt_size_;
     const bool is_avx512;
     const bool is_avx2;
 

--- a/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
@@ -153,8 +153,9 @@ std::pair<dim_t, dim_t> brgemm_calc_k_block_vanilla_rnn(dim_t K1, dim_t K2,
     dim_t k2_block = K2;
 
     if (should_adjust_by_l2) {
-        int block_size = (l2_cache_size * l2_occupancy)
-                / ((M + n_block) * src_layer_type_size);
+        int block_size = static_cast<int>(
+                (static_cast<float>(l2_cache_size) * l2_occupancy)
+                / static_cast<float>((M + n_block) * src_layer_type_size));
 
         if (is_xf16) {
             // due to weights format ldgOI32o2i block_size should be even
@@ -210,8 +211,8 @@ dim_t brgemm_calc_m_block_vanilla_rnn(dim_t nthr, dim_t M, dim_t N_blocks,
                 m_block_it--) {
             if (M % m_block_it == 0) {
                 const auto m_blocks = M / m_block_it;
-                const auto work_by_MN
-                        = static_cast<float>(m_blocks * N_blocks) / nthr;
+                const auto work_by_MN = static_cast<float>(m_blocks * N_blocks)
+                        / static_cast<float>(nthr);
 
                 const float work_by_MN_decimal
                         = work_by_MN - std::floor(work_by_MN);
@@ -357,7 +358,7 @@ void rnn_brgemm_base_t::init_scratchpad(const cpu::rnn_utils::rnn_conf_t &rnn,
                 rnn.n_iter * rnn.mb * sizeof(bfloat16_t), 64);
     }
 
-    const int max_K_Block
+    const dim_t max_K_Block
             = nstl::max(rnn.KB1_blocks + 1,
                       nstl::max(rnn.KBproj_blocks + 1, rnn.KB2_blocks + 1))
             * (rnn.brgemm_fwd_iter_layer_fuse_possible ? 2 : 1);
@@ -550,7 +551,7 @@ status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
         rnn.merge_gemm_layer = true;
 
         // required adjustment if mlc_m_dim_adjustment_not_required = false
-        const int n_iters_to_merge = rnn.n_iter;
+        const dim_t n_iters_to_merge = rnn.n_iter;
         rnn.Mlayermerged = rnn.mb * n_iters_to_merge;
         rnn.mlayermerged_block = brgemm_calc_m_block(cell_kind,
                 prop_kind::forward, rnn.nthr, rnn.Mlayermerged, rnn.N_blocks,
@@ -638,8 +639,8 @@ status_t rnn_brgemm_t<prop_kind::forward>::init_kernels(
                 K, LDA, LDB, LDC, beta, max_bs);
     };
 
-    const int brgemm_n = nstl::min(rnn.N, rnn.n_block);
-    const int brgemm_n_tail = nstl::min(rnn.N, rnn.n_tail);
+    const dim_t brgemm_n = nstl::min(rnn.N, rnn.n_block);
+    const dim_t brgemm_n_tail = nstl::min(rnn.N, rnn.n_tail);
     const int max_bs_factor = rnn.brgemm_fwd_iter_layer_fuse_possible ? 2 : 1;
 
     for (int i = 0; i < num_base_kernels_; i++) {
@@ -1141,10 +1142,10 @@ static status_t init_kernels_diff_src(rnn_diff_src_brgemm_t &diff_src,
     };
 
     const auto &diff_src_conf = rnn.diff_src_brgemm;
-    const int n_diff_src = nstl::min(diff_src_conf.N, diff_src_conf.n_block);
-    const int n_diff_src_iter_tail
+    const dim_t n_diff_src = nstl::min(diff_src_conf.N, diff_src_conf.n_block);
+    const dim_t n_diff_src_iter_tail
             = nstl::min(diff_src_conf.N_iter, diff_src_conf.n_iter_tail);
-    const int n_diff_src_layer_tail
+    const dim_t n_diff_src_layer_tail
             = nstl::min(diff_src_conf.N_layer, diff_src_conf.n_layer_tail);
     const auto K_batch_size = rnn.n_gates * diff_src_conf.K_blocks;
     const auto split_gates_computation
@@ -1364,8 +1365,11 @@ static status_t init_kernels_diff_wei(rnn_diff_wei_brgemm_t &diff_wei,
     tmp_matmul_conf_for_reorder.wei_tag = format_tag::ab;
     tmp_matmul_conf_for_reorder.N = rnn.scratch_gates_ld;
     tmp_matmul_conf_for_reorder.K = rnn.mb;
-    tmp_matmul_conf_for_reorder.wei_n_blk = tmp_matmul_conf_for_reorder.N_blk
-            = diff_wei_conf.n_block;
+    tmp_matmul_conf_for_reorder.N_blk = diff_wei_conf.n_block;
+    // wei_n_blk is a bounded block-size value (int), while N_blk/n_block are
+    // dim_t; cast explicitly at this int-typed field boundary.
+    tmp_matmul_conf_for_reorder.wei_n_blk
+            = static_cast<int>(diff_wei_conf.n_block);
     tmp_matmul_conf_for_reorder.N_tail = diff_wei_conf.n_tail;
     tmp_matmul_conf_for_reorder.LDB = diff_wei_conf.LDB;
     tmp_matmul_conf_for_reorder.src_dt = tmp_matmul_conf_for_reorder.wei_dt
@@ -1417,14 +1421,14 @@ status_t rnn_brgemm_t<prop_kind::backward>::init_kernels(
 
             kernel_transpose_single_row_iter_
                     = utils::make_unique<jit_brgemm_transpose_single_row_t>(
-                            m_block_iter);
+                            static_cast<int>(m_block_iter));
             CHECK(kernel_transpose_single_row_iter_->create_kernel());
 
             if (!is_m_block_equal) {
                 const auto m_block_layer = rnn.diff_wei_brgemm.M_layer;
                 kernel_transpose_single_row_layer_
                         = utils::make_unique<jit_brgemm_transpose_single_row_t>(
-                                m_block_layer);
+                                static_cast<int>(m_block_layer));
                 CHECK(kernel_transpose_single_row_layer_->create_kernel());
             }
         }
@@ -1445,7 +1449,7 @@ status_t rnn_brgemm_t<prop_kind::backward>::init_kernels(
         trans_conf.LDA = os_padded; // dst's leading dim
         trans_conf.K_tail = rnn.mb % blk_size; // src's rows tail
 
-        const int LDA_iter[]
+        const dim_t LDA_iter[]
                 = {rnn.src_iter_ld_, rnn.dst_layer_ld_, rnn.ws_states_iter_ld};
         trans_conf.M_tail = rnn.sic % blk_size; // src's cols tail
         for (int i = 0; i < num_base_kernels_; i++) {
@@ -1454,7 +1458,7 @@ status_t rnn_brgemm_t<prop_kind::backward>::init_kernels(
                     kernel_transpose_iter_[i], &trans_conf));
         }
 
-        const int LDA_layer[]
+        const dim_t LDA_layer[]
                 = {rnn.src_layer_ld_, rnn.dst_iter_ld_, rnn.ws_states_layer_ld};
         trans_conf.M_tail = rnn.slc % blk_size; // src's cols tail
         for (int i = 0; i < num_base_kernels_; i++) {

--- a/src/cpu/x64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle.cpp
@@ -148,10 +148,12 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
     const auto &conf = pd()->get_conf();
     assert(conf.tag_kind == jit_memory_tag_kind_t::blocked);
 
-    const int transpose_row = pd()->is_fwd() ? conf.group_size
-                                             : conf.axis_size / conf.group_size;
-    const int transpose_col = pd()->is_fwd() ? conf.axis_size / conf.group_size
-                                             : conf.group_size;
+    const dim_t transpose_row = pd()->is_fwd()
+            ? conf.group_size
+            : conf.axis_size / conf.group_size;
+    const dim_t transpose_col = pd()->is_fwd()
+            ? conf.axis_size / conf.group_size
+            : conf.group_size;
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
     auto scratchpad_ptr = scratchpad.template get<int>(
@@ -159,7 +161,8 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
 
     // Precompute transposed axis helper array
     parallel_nd(transpose_col, transpose_row, [=](dim_t i, dim_t j) {
-        scratchpad_ptr[j * transpose_col + i] = i * transpose_row + j;
+        scratchpad_ptr[j * transpose_col + i]
+                = static_cast<int>(i * transpose_row + j);
     });
 
     const dim_t CB = utils::div_up(conf.c, conf.blk_size);
@@ -167,17 +170,17 @@ status_t jit_uni_shuffle_t<isa>::execute(const exec_ctx_t &ctx) const {
 
     // Precompute input offsets using transposed axis
     parallel_nd(CB, [=](dim_t cb) {
-        const int blk_end
+        const dim_t blk_end
                 = nstl::min(conf.blk_size, conf.c - cb * conf.blk_size);
         PRAGMA_OMP_SIMD()
-        for (int cc = 0; cc < blk_end; ++cc) {
-            const int off = cb * conf.blk_size + cc;
-            int input_c = scratchpad_ptr[off];
+        for (dim_t cc = 0; cc < blk_end; ++cc) {
+            const dim_t off = cb * conf.blk_size + cc;
+            const dim_t input_c = scratchpad_ptr[off];
             // Re-write transposed axis data.
-            scratchpad_ptr[off]
-                    = (input_c / conf.blk_size * conf.sp * conf.blk_size
-                              + input_c % conf.blk_size)
-                    * conf.dt_size;
+            scratchpad_ptr[off] = static_cast<int>(
+                    (input_c / conf.blk_size * conf.sp * conf.blk_size
+                            + input_c % conf.blk_size)
+                    * conf.dt_size);
         }
     });
 

--- a/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.cpp
@@ -78,34 +78,35 @@ void jit_uni_shuffle_kernel_t<avx512_core>::emu_gather_data(
     constexpr unsigned xmm_size_elem = 8; //bf16
     constexpr unsigned xmm_size_elem_half = xmm_size_elem / 2;
 
-    const unsigned number_of_xmms = is_tail
+    const dim_t number_of_xmms = is_tail
             ? utils::div_up(conf_.simd_tail, xmm_size_elem)
             : utils::div_up(conf_.simd_w, xmm_size_elem);
 
     for (unsigned i = 0; i < number_of_xmms; i++) {
-        const unsigned number_of_xmm_halfs = is_tail && i == number_of_xmms - 1
+        const dim_t number_of_xmm_halfs = is_tail && i == number_of_xmms - 1
                 ? utils::div_up(conf_.simd_tail,
                           xmm_size_elem_half + i * xmm_size_elem)
                 : 2;
 
         for (unsigned j = 0; j < number_of_xmm_halfs; j++) {
             const unsigned rem = conf_.simd_tail % xmm_size_elem_half;
-            const unsigned number_of_values_to_load = is_tail
+            const dim_t number_of_values_to_load = is_tail
                             && i == number_of_xmms - 1
                             && j == number_of_xmm_halfs - 1 && rem
                     ? rem
                     : xmm_size_elem_half;
 
-            vextractf32x4(xmm_tmp, Zmm(indices_idx), j + i * 2);
+            vextractf32x4(xmm_tmp, Zmm(indices_idx), to_imm_uint8_t(j + i * 2));
             for (unsigned k = 0; k < number_of_values_to_load; k++) {
-                vpextrd(reg_tmp_.cvt32(), xmm_tmp, k + j * xmm_size_elem_half);
+                vpextrd(reg_tmp_.cvt32(), xmm_tmp,
+                        to_imm_uint8_t(k + j * xmm_size_elem_half));
                 add(reg_src_addr, reg_tmp_);
                 vpinsrw(xmm_dst, xmm_dst, ptr[reg_src_addr],
-                        k + j * xmm_size_elem_half);
+                        to_imm_uint8_t(k + j * xmm_size_elem_half));
                 mov(reg_src_addr, reg_tmp1_);
             }
         }
-        vinsertf128(Ymm(data_idx), Ymm(data_idx), xmm_dst, i);
+        vinsertf128(Ymm(data_idx), Ymm(data_idx), xmm_dst, to_imm_uint8_t(i));
     }
 }
 
@@ -120,24 +121,24 @@ void jit_uni_shuffle_kernel_t<avx>::emu_gather_data(const Reg64 &reg_src_addr,
 
     constexpr unsigned xmm_size_elem = 4;
 
-    const unsigned number_of_xmms = is_tail
+    const dim_t number_of_xmms = is_tail
             ? utils::div_up(conf_.simd_tail, xmm_size_elem)
             : utils::div_up(conf_.simd_w, xmm_size_elem);
     for (unsigned i = 0; i < number_of_xmms; i++) {
-        vextractf128(xmm_tmp, Ymm(indices_idx), i);
+        vextractf128(xmm_tmp, Ymm(indices_idx), to_imm_uint8_t(i));
 
-        const unsigned number_of_values_to_load = i == number_of_xmms - 1
+        const dim_t number_of_values_to_load = i == number_of_xmms - 1
                         && is_tail && conf_.simd_tail % xmm_size_elem != 0
                 ? conf_.simd_tail % xmm_size_elem
                 : xmm_size_elem;
         for (unsigned j = 0; j < number_of_values_to_load; j++) {
-            vpextrd(reg_tmp_.cvt32(), xmm_tmp, j);
+            vpextrd(reg_tmp_.cvt32(), xmm_tmp, to_imm_uint8_t(j));
             add(reg_src_addr, reg_tmp_);
-            vpinsrd(xmm_dst, xmm_dst, ptr[reg_src_addr], j);
+            vpinsrd(xmm_dst, xmm_dst, ptr[reg_src_addr], to_imm_uint8_t(j));
             mov(reg_src_addr, reg_tmp1_);
         }
 
-        vinsertf128(Ymm(data_idx), Ymm(data_idx), xmm_dst, i);
+        vinsertf128(Ymm(data_idx), Ymm(data_idx), xmm_dst, to_imm_uint8_t(i));
     }
 }
 
@@ -149,12 +150,12 @@ void jit_uni_shuffle_kernel_t<sse41>::emu_gather_data(const Reg64 &reg_src_addr,
 
     constexpr unsigned xmm_size_elem = 4;
 
-    const unsigned number_of_values_to_load
+    const dim_t number_of_values_to_load
             = is_tail ? conf_.simd_tail : xmm_size_elem;
     for (unsigned j = 0; j < number_of_values_to_load; j++) {
-        pextrd(reg_tmp_.cvt32(), Xmm(indices_idx), j);
+        pextrd(reg_tmp_.cvt32(), Xmm(indices_idx), to_imm_uint8_t(j));
         add(reg_src_addr, reg_tmp_);
-        pinsrd(Xmm(data_idx), ptr[reg_src_addr], j);
+        pinsrd(Xmm(data_idx), ptr[reg_src_addr], to_imm_uint8_t(j));
         mov(reg_src_addr, reg_tmp1_);
     }
 }
@@ -276,7 +277,7 @@ void jit_uni_shuffle_kernel_t<sse41>::store_data(const int data_idx,
     if (is_tail)
         for (unsigned i = 0; i < conf_.simd_tail; i++) {
             pextrd(ptr[reg_dst_addr + offset + i * conf_.dt_size],
-                    Xmm(data_idx), i);
+                    Xmm(data_idx), to_imm_uint8_t(i));
         }
     else
         movups(ptr[reg_dst_addr + offset], Vmm(data_idx));
@@ -291,13 +292,13 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
     const Reg64 &reg_cb_loop_size = reg_tmp4_;
     const Reg64 &reg_blk_tail = reg_tmp5_;
     const Reg64 &reg_src_save = reg_tmp6_;
-    const int simd_in_blk = conf_.blk_size / conf_.simd_w;
-    const int simd_in_tail_blk
+    const dim_t simd_in_blk = conf_.blk_size / conf_.simd_w;
+    const dim_t simd_in_tail_blk
             = utils::div_up(conf_.c % conf_.blk_size, conf_.simd_w);
     const Vmm vmm_tmp[4] = {Vmm(5), Vmm(6), Vmm(7), Vmm(8)};
 
     auto load_indices = ([&](bool is_blk_tail) {
-        const int simd_to_process
+        const dim_t simd_to_process
                 = is_blk_tail ? simd_in_tail_blk : simd_in_blk;
         for (int i = 0; i < simd_to_process; ++i)
             uni_vmovdqu(vmm_tmp[i],
@@ -306,7 +307,7 @@ void jit_uni_shuffle_kernel_t<isa>::shuffle_blocked_format() {
     });
 
     auto shuffle = ([&](bool is_blk_tail) {
-        const int simd_to_process
+        const dim_t simd_to_process
                 = is_blk_tail ? simd_in_tail_blk : simd_in_blk;
         for (int i = 0; i < simd_to_process; ++i) {
             const bool simd_tail_condition = is_blk_tail && conf_.simd_tail > 0

--- a/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.hpp
+++ b/src/cpu/x64/shuffle/jit_uni_shuffle_kernel.hpp
@@ -74,6 +74,13 @@ struct jit_uni_shuffle_kernel_t : public jit_generator_t {
 
     void generate() override;
 
+    // Narrows a small, fixed-range value (SIMD lane/element index) to the
+    // XByak 8-bit immediate at the single instruction-emit boundary.
+    static uint8_t to_imm_uint8_t(dim_t v) noexcept {
+        assert(v >= 0 && v <= UINT8_MAX);
+        return static_cast<uint8_t>(v);
+    }
+
     const Vmm vmm_tail_mask_ = Vmm(0);
     // Used only for avx
     // Vgatherdps always gets data using a conditional mask

--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -310,30 +310,35 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
     // For f16 we do not need such interleaving.
     const int xmm_size_elem = (data_type_ == data_type::f16) ? 8 : 4;
     const int number_of_xmms = tail
-            ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
-            : utils::div_up(gather_conf_->simd_w_, xmm_size_elem);
+            ? static_cast<int>(
+                      utils::div_up(tail_conf_->tail_size_, xmm_size_elem))
+            : static_cast<int>(
+                      utils::div_up(gather_conf_->simd_w_, xmm_size_elem));
     const int num_indices_in_xmm = 16 / sizeof(int);
     for (int i = 0, idx = 0; i < number_of_xmms; i++) {
 
         const int number_of_values_to_load = i == number_of_xmms - 1 && tail
                         && tail_conf_->tail_size_ % xmm_size_elem != 0
-                ? tail_conf_->tail_size_ % xmm_size_elem
+                ? static_cast<int>(tail_conf_->tail_size_ % xmm_size_elem)
                 : xmm_size_elem;
         for (int j = 0; j < number_of_values_to_load; j++) {
 
             if (j % num_indices_in_xmm == 0)
-                host_->vextractf32x4(xmm_tmp, indices_vmm, idx++);
-            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
+                host_->vextractf32x4(
+                        xmm_tmp, indices_vmm, static_cast<uint8_t>(idx++));
+            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp,
+                    static_cast<uint8_t>(j));
             host_->add(src_reg, gather_conf_->reg_tmp_);
             switch (data_type_) {
                 case data_type::f16:
                     assert(f16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg], j);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            static_cast<uint8_t>(j));
                     break;
                 case data_type::bf16:
                     assert(bf16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(
-                            xmm_dst, xmm_dst, host_->ptr[src_reg], j * 2);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            static_cast<uint8_t>(j * 2));
                     break;
                 case data_type::s8:
                 case data_type::u8:
@@ -345,7 +350,7 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                    fp8_supported_)
                             && "Unsupported data type.");
                     host_->vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            static_cast<uint8_t>(i * xmm_size_elem + j));
                     break;
                 }
                 default: assert(!"Unsupported data type.");
@@ -353,10 +358,12 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
             host_->mov(src_reg, gather_conf_->reg_tmp1_);
         }
         if (data_type_ == data_type::bf16) {
-            host_->vinsertf32x4(dst_vmm, dst_vmm, xmm_dst, i);
+            host_->vinsertf32x4(
+                    dst_vmm, dst_vmm, xmm_dst, static_cast<uint8_t>(i));
             host_->vpxord(xmm_dst, xmm_dst, xmm_dst);
         } else if (data_type_ == data_type::f16) {
-            host_->vinsertf32x4(dst_ymm, dst_ymm, xmm_dst, i);
+            host_->vinsertf32x4(
+                    dst_ymm, dst_ymm, xmm_dst, static_cast<uint8_t>(i));
             host_->vpxord(xmm_dst, xmm_dst, xmm_dst);
         }
     }
@@ -392,33 +399,37 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
     // For f16 we do not need such interleaving.
     const int xmm_size_elem = 4;
     const int number_of_xmms = tail
-            ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
-            : utils::div_up(gather_conf_->simd_w_, xmm_size_elem);
+            ? static_cast<int>(
+                      utils::div_up(tail_conf_->tail_size_, xmm_size_elem))
+            : static_cast<int>(
+                      utils::div_up(gather_conf_->simd_w_, xmm_size_elem));
     for (int i = 0; i < number_of_xmms; i++) {
-        host_->vextractf128(xmm_tmp, indices_vmm, i);
+        host_->vextractf128(xmm_tmp, indices_vmm, static_cast<uint8_t>(i));
 
         const int number_of_values_to_load = i == number_of_xmms - 1 && tail
                         && tail_conf_->tail_size_ % xmm_size_elem != 0
-                ? tail_conf_->tail_size_ % xmm_size_elem
+                ? static_cast<int>(tail_conf_->tail_size_ % xmm_size_elem)
                 : xmm_size_elem;
         for (int j = 0; j < number_of_values_to_load; j++) {
-            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
+            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp,
+                    static_cast<uint8_t>(j));
             host_->add(src_reg, gather_conf_->reg_tmp_);
             switch (data_type_) {
                 case data_type::f32:
                 case data_type::s32: {
-                    host_->vpinsrd(xmm_dst, xmm_dst, host_->ptr[src_reg], j);
+                    host_->vpinsrd(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            static_cast<uint8_t>(j));
                     break;
                 }
                 case data_type::f16:
                     assert(f16_supported_ && "Unsupported data type.");
                     host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            static_cast<uint8_t>(i * xmm_size_elem + j));
                     break;
                 case data_type::bf16:
                     assert(bf16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(
-                            xmm_dst, xmm_dst, host_->ptr[src_reg], j * 2);
+                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                            static_cast<uint8_t>(j * 2));
                     break;
                 case data_type::s8:
                 case data_type::u8:
@@ -430,7 +441,7 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                    fp8_supported_)
                             && "Unsupported data type.");
                     host_->vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
-                            i * xmm_size_elem + j);
+                            static_cast<uint8_t>(i * xmm_size_elem + j));
                     break;
                 }
                 default: assert(!"Unsupported data type.");
@@ -440,7 +451,8 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
 
         if (utils::one_of(data_type_, data_type::f32, data_type::s32,
                     data_type::bf16))
-            host_->vinsertf128(dst_vmm, dst_vmm, xmm_dst, i);
+            host_->vinsertf128(
+                    dst_vmm, dst_vmm, xmm_dst, static_cast<uint8_t>(i));
     }
 
     if (data_type_ == data_type::s32 || data_type_ == data_type::bf16)
@@ -462,24 +474,28 @@ void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
     host_->mov(gather_conf_->reg_tmp1_, src_reg);
 
     const unsigned xmm_size_elem = 4;
-    const unsigned number_of_values_to_load
-            = tail ? tail_conf_->tail_size_ : xmm_size_elem;
-    for (unsigned j = 0; j < number_of_values_to_load; j++) {
-        host_->pextrd(gather_conf_->reg_tmp_.cvt32(), indices_vmm, j);
+    const int number_of_values_to_load
+            = tail ? static_cast<int>(tail_conf_->tail_size_) : xmm_size_elem;
+    for (int j = 0; j < number_of_values_to_load; j++) {
+        host_->pextrd(gather_conf_->reg_tmp_.cvt32(), indices_vmm,
+                static_cast<uint8_t>(j));
         host_->add(src_reg, gather_conf_->reg_tmp_);
         switch (data_type_) {
             case data_type::f32:
             case data_type::s32: {
-                host_->pinsrd(dst_vmm, host_->ptr[src_reg], j);
+                host_->pinsrd(
+                        dst_vmm, host_->ptr[src_reg], static_cast<uint8_t>(j));
                 break;
             }
             case data_type::f16:
                 assert(f16_supported_ && "Unsupported data type.");
-                host_->pinsrw(dst_vmm, host_->ptr[src_reg], j);
+                host_->pinsrw(
+                        dst_vmm, host_->ptr[src_reg], static_cast<uint8_t>(j));
                 break;
             case data_type::bf16:
                 assert(bf16_supported_ && "Unsupported data type.");
-                host_->pinsrw(dst_vmm, host_->ptr[src_reg], j * 2);
+                host_->pinsrw(dst_vmm, host_->ptr[src_reg],
+                        static_cast<uint8_t>(j * 2));
                 break;
             case data_type::s8:
             case data_type::u8:
@@ -489,7 +505,8 @@ void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                            data_type::f8_e5m2),
                                fp8_supported_)
                         && "Unsupported data type.");
-                host_->pinsrb(dst_vmm, host_->ptr[src_reg], j);
+                host_->pinsrb(
+                        dst_vmm, host_->ptr[src_reg], static_cast<uint8_t>(j));
                 break;
             }
             default: assert(!"Unsupported data type.");
@@ -626,7 +643,8 @@ void jit_io_helper_t<Vmm>::load(const Xbyak::Address &src_addr,
                     || (!is_tail_load_supported && (is_i8 || is_xf16)));
 
     if (can_load_byte_by_byte) {
-        load_byte_by_byte(src_addr, dst_vmm, tail_conf_->tail_size_);
+        load_byte_by_byte(
+                src_addr, dst_vmm, static_cast<int>(tail_conf_->tail_size_));
     } else {
         switch (data_type_) {
             case data_type::f32: load_f32(src_addr, dst_vmm, tail); break;
@@ -785,7 +803,7 @@ void jit_io_helper_t<Vmm>::store(const Vmm &src_raw_vmm,
                 = vreg_traits_t<Xbyak::Xmm>::vlen / sizeof(int32_t);
         const size_t store_size = (tail ? tail_conf_->tail_size_ : xmm_length)
                 * types::data_type_size(data_type_);
-        store_byte_by_byte(src_vmm, dst_addr, store_size);
+        store_byte_by_byte(src_vmm, dst_addr, static_cast<int>(store_size));
     } else {
         switch (data_type_) {
             case data_type::f32:


### PR DESCRIPTION
## Summary

Full `dim_t` narrowing-conversion cleanup across the x64 CPU JIT stack (BRGEMM infra, JIT kernel internals, injectors, BRGEMM, matmul, inner product, RNN, softmax, all conv variants, GEMM, reorder, xf16/fp8 conversion). This is the umbrella branch containing the full 27-commit linear history; the work has been split into stacked, individually reviewable PRs listed below (in dependency order).

**Note**: this branch does not yet include @inteldimitrius narrowing-conversion fixes for the areas assigned to him (batch/group/layer normalization, LRN, pooling, PReLU, shuffle, resampling, reduction, binary) — those are being tracked and delivered separately, will be added to this branch soon. Added 2 temporary commits at the end, because build was failing because of dependencies.

## Stacked PRs (in order)

1. #5547 — x64: brgemm: widen infrastructure types to dim_t
2. #5565 — x64: brgemm: widen JIT kernel internals to dim_t
3. #5646 — x64: injectors: eliminate implicit narrowing conversions
4. #5640 — x64: brgemm: other: eliminate implicit narrowing conversions
5. #5637 — x64: matmul: eliminate implicit narrowing conversions
6. #5639 — x64: inner product: eliminate implicit narrowing conversions
7. #5638 — cpu: rnn: eliminate implicit narrowing conversions
8. #5655 — x64: softmax: eliminate implicit narrowing conversions
9. #5661 — cpu: conv: AVX512 common: eliminate implicit narrowing conversions
10. #5662 — cpu: conv: AMX: eliminate implicit narrowing conversions
11. #5663 — cpu: conv: BF16: eliminate implicit narrowing conversions
12. #5664 — cpu: conv: depthwise: eliminate implicit narrowing conversions
13. #5665 — cpu: conv: AVX512 x8s8s32x: eliminate implicit narrowing conversions
14. #5666 — cpu: conv: AVX2: eliminate implicit narrowing conversions
15. #5667 — cpu: conv: SSE41: eliminate implicit narrowing conversions
16. #5668 — cpu: conv: universal x8s8s32x: eliminate implicit narrowing conversions
17. #5669 — cpu: conv: GEMM and reference: eliminate implicit narrowing conversions
18. #5670 — cpu: conv: BRGEMM: eliminate implicit narrowing conversions
19. #5671 — x64: GEMM: eliminate implicit narrowing conversions
20. #5672 — x64: reorder: eliminate implicit narrowing conversions
21. #5673 — x64: xf16/fp8 conversion kernels: eliminate implicit narrowing conversions

Each PR is based on the previous one in this list, forming a fully linear chain that matches this branch's real commit history exactly (no synthetic/cherry-pick reconstruction) — merging them in order is equivalent to merging this branch.

## Verification

- Full build (`cmake --build --target dnnl -j56`, clang, Release): **0 errors, 0 warnings**.
- Strict 5-flag scan across all src/cpu files (368 CPU translation units) (`-Wshorten-64-to-32 -Wimplicit-int-conversion -Wfloat-conversion -Wimplicit-float-conversion -Wsign-compare`, `-ferror-limit=0`): 34 files show hits, but every one is either:
  - Confirmed @inteldimitrius -owned (batch/group/layer normalization, LRN, pooling, PReLU, shuffle, resampling, reduction, generic binary), or
  - A pre-existing warnings (`int32_t↔float`/`float→bool` quantization idioms in `ref_softmax.cpp` and `ref_deconvolution.cpp`) — confirmed via diff that my commits there only touched `int`/`dim_t` signature narrowing and never touched these lines, no decision made yet on this.
- CI not tested yet.

