### PR TITLE
cpu: matmul: support transposed dst in f32 gemm

### DIFF
--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -109,8 +109,21 @@ status_t gemm_f32_matmul_t::pd_t::init(const engine_t *engine) {
     VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
     // Should be followed by `set_default_formats`.
     VDISPATCH_MATMUL(check_attr_post_ops(), VERBOSE_UNSUPPORTED_POSTOP);
-    VDISPATCH_MATMUL(gemm_based::check_gemm_compatible_formats(*this),
-            VERBOSE_INCOMPATIBLE_GEMM_FMT);
+#if DNNL_X64
+    const memory_desc_wrapper dst_d(dst_md());
+    const bool is_transposed_dst_2d = ndims() == 2
+            && !has_runtime_dims_or_strides() && !with_bias()
+            && attr()->has_default_values()
+            && dst_d.matches_tag(format_tag::ba);
+#else
+    const bool is_transposed_dst_2d = false;
+#endif
+    const bool compatible_formats
+            = gemm_based::check_gemm_compatible_formats(*this)
+            || (is_transposed_dst_2d
+                    && gemm_based::check_gemm_input_format(*src_md())
+                    && gemm_based::check_gemm_input_format(*weights_md()));
+    VDISPATCH_MATMUL(compatible_formats, VERBOSE_INCOMPATIBLE_GEMM_FMT);
 
     bool po_format_ok = attr_.set_default_formats(dst_md(0)) == status::success;
     VDISPATCH_MATMUL(po_format_ok, VERBOSE_UNSUPPORTED_POSTOP);
@@ -160,10 +173,12 @@ status_t gemm_f32_matmul_t::pd_t::configure_attributes() {
             && utils::one_of(po.entry_[sum_idx].sum.dt, dst_md()->data_type,
                     data_type::undef);
 
-    // `C_is_abx` limitation comes from `extended_sgemm`.
-    const bool C_is_abx
-            = !is_runtime_value(helper.ldc()) && helper.ldc() >= helper.N();
-    params_.dst_is_acc_ = C_is_abx
+    // The required leading dimension depends on whether extended_sgemm writes
+    // C or its transposition.
+    const dim_t min_ldc = helper.transC() == 'N' ? helper.N() : helper.M();
+    const bool C_is_gemm_compatible
+            = !is_runtime_value(helper.ldc()) && helper.ldc() >= min_ldc;
+    params_.dst_is_acc_ = C_is_gemm_compatible
             && IMPLICATION(attr()->post_ops_.find(primitive_kind::sum) != -1,
                     sum_po_via_gemm_beta);
 
@@ -254,10 +269,10 @@ status_t gemm_f32_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
         need_free_acc = true;
     }
 
-    // `ldc` is the destination row stride. When `M == 1`, a degenerate stride
-    // (e.g. `acb` gives `ldc == 1`) can violate the `ldc >= N` requirement.
-    // Clamp `ldc` to `N`. This is safe for `M == 1` and has no effect for `M > 1`.
-    const dim_t acc_ldc = dst_is_acc ? nstl::max(ldc, N) : N;
+    // A degenerate stride can violate the extended_sgemm leading-dimension
+    // requirement. Clamp it to the number of physical rows in the output.
+    const dim_t min_acc_ldc = helper.transC() == 'N' ? N : M;
+    const dim_t acc_ldc = dst_is_acc ? nstl::max(ldc, min_acc_ldc) : N;
     const int scale_idx_mult
             = this->pd()->attr()->scales_.get_mask(DNNL_ARG_WEIGHTS)
             == (1 << (ndims - 1));
@@ -370,8 +385,19 @@ status_t gemm_f32_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
         // collapse batch into M, if weights batch dimensions are broadcasted.
         M = batch * M;
 
-        st = extended_sgemm(&transB, &transA, &N, &M, &K, &alpha, weights, &ldb,
-                src, &lda, &beta, acc, &acc_ldc, nullptr, false);
+        if (helper.transC() == 'N') {
+            st = extended_sgemm(&transB, &transA, &N, &M, &K, &alpha, weights,
+                    &ldb, src, &lda, &beta, acc, &acc_ldc, nullptr, false);
+        } else {
+            // A row-major input is a transposed column-major matrix and vice
+            // versa. Compute C directly using the column-major identity rather
+            // than materializing an output transposition.
+            const char trans_src = transA == 'N' ? 'T' : 'N';
+            const char trans_weights = transB == 'N' ? 'T' : 'N';
+            st = extended_sgemm(&trans_src, &trans_weights, &M, &N, &K, &alpha,
+                    src, &lda, weights, &ldb, &beta, acc, &acc_ldc, nullptr,
+                    false);
+        }
 
         if (st == status::success && params.has_pp_kernel_) {
             const bool force_sequential = pp_kernel_->sequential_kernel();

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -389,6 +389,22 @@ HANDLE_EXCEPTIONS_FOR_TEST_P(
     ASSERT_EQ(impl_info_no_postops, impl_info_with_postops);
 }
 
+TEST(Matmul, TransposedDstUsesOptimizedImplementation) {
+    const auto engine_kind = get_test_engine_kind();
+    SKIP_IF(!DNNL_X64 || engine_kind != engine::kind::cpu,
+            "Optimized transposed destination is specific to x64 CPU");
+
+    engine e {engine_kind, 0};
+    const auto src_md = memory::desc({63, 40}, memory::data_type::f32, tag::ba);
+    const auto weights_md
+            = memory::desc({40, 2}, memory::data_type::f32, tag::ba);
+    const auto dst_md = memory::desc({63, 2}, memory::data_type::f32, tag::ba);
+    const auto matmul_pd
+            = matmul::primitive_desc(e, src_md, weights_md, dst_md);
+
+    ASSERT_NE(std::string(matmul_pd.impl_info_str()), "ref:any");
+}
+
 /********************************* TEST CASES *********************************/
 
 using iface = matmul_iface_test_t;
@@ -535,6 +551,18 @@ static auto cases_f = [](memory::data_type dt) {
     cases.push_back({{{{10, 2}, dt, tag::ab}, {{2, 20}, dt, tag::ab},
                              {{10, 20}, dt, tag::ab}, data_type::undef},
             {}});
+    if (dt == data_type::f32) {
+        // Transposed destination with small N (regression for issue #1667).
+        cases.push_back({{{{63, 40}, dt, tag::ba}, {{40, 2}, dt, tag::ba},
+                                 {{63, 2}, dt, tag::ba}, data_type::undef},
+                {}});
+        // The optimized path must preserve valid input leading dimensions.
+        cases.push_back(
+                {{{{63, 40}, dt, tag::ba, P::SRC | P::LEADING_DIM},
+                         {{40, 2}, dt, tag::ba, P::WEIGHTS | P::LEADING_DIM},
+                         {{63, 2}, dt, tag::ba}, data_type::undef},
+                        {}});
+    }
     // simple case + leading dimensions
     cases.push_back(
             {{{{10, 1}, dt, tag::ab, P::SRC | P::LEADING_DIM},


### PR DESCRIPTION
# Description

Fixes #1667.

For f32 matmul with a plain transposed (`ba`) destination, the f32 GEMM path could compute the correct destination offsets but rejected the memory descriptor during implementation selection. Dispatch consequently fell back to `ref:any`.

This change:

- allows the existing f32 GEMM matmul implementation to accept the supported plain transposed destination layout;
- derives the destination leading dimension from the destination strides;
- preserves the existing handling of post-ops and scratchpad storage;
- adds a regression test that checks both correctness and optimised implementation selection.

The normal `ab` destination path remains on `brg_matmul:avx2`.

## Performance

Tested on:

- Intel Core i9-13905H
- Windows 11
- AVX2
- OpenMP runtime
- MSVC 19.41
- one thread pinned to CPU 2, a P-core
- tested upstream baseline: `e9b276201917f3f8023499345fd440fc7c8977ea`

For the original `ba/ba/ba` reproducer:

| Version | Implementation | Median |
| --- | --- | ---: |
| Baseline | `ref:any` | 892.477 ms |
| Candidate | `gemm:jit:f32` | 23.754 ms |

This is a 37.57x speedup, or approximately 97.34% lower latency.

The candidate remains approximately 2.39x slower than the corresponding normal `ab` destination case, so this does not claim complete layout parity.

Additional measurements:

- Six P-cores: 235.894 ms -> 4.513 ms, 52.28x
- All logical processors: 185.384 ms -> 4.166 ms, 44.50x

The all-logical-processor candidate measurement was noisy, including a 38.497 ms outlier, so the pinned single-thread result is the primary comparison.

Hardware PMU counters were not available in this Windows/WSL environment.

## Validation

- Focused Debug regression tests: 10/10 passed
- Full Debug CTest: 205/205 passed
- Release matmul gtest: 50 passed, 17 unsupported datatype skips, 0 failures
- benchdnn matmul smoke: 112 passed, 96 unsupported datatype skips, 0 failures
- ASan+UBSan matmul gtest: 49 passed, 17 unsupported skips, 0 failures
- Original reproducer passed under ASan+UBSan
- No sanitiser or leak reports
- No scratchpad growth was observed
- JIT inspection confirmed AVX2 YMM/FMA code generation

Full Release CTest completed 202/205. The following three batch-normalisation failures reproduce with the archived baseline DLL and appear unrelated to this change:

- `cpu-primitives-batch-normalization-cpp`
- `test_batch_normalization`
- `test_graph_unit_dnnl_batch_norm_cpu`

## Checklist

### General

- [ ] All unit and benchdnn tests pass locally for each commit
  - Debug is fully green and the relevant Release/benchdnn tests pass.
  - Three unrelated Release batch-normalisation failures reproduce on the baseline, as documented above.
- [x] The changed C++ files have been formatted with `clang-format -style=file`.

### Performance improvements

- [x] Performance data, test configuration, baseline commit, and observed variability are included above.

### Bug fixes

- [x] The original problem and reproducer have been described.
- [x] A relevant regression test has been added.


