### PR TITLE
cpu: rv64: add u8u8 suport for rv64 gemm kernel

### DIFF
--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.cpp
@@ -31,11 +31,13 @@ using namespace Xbyak_riscv;
 using namespace dnnl::impl::utils;
 
 jit_rvv_gemm_s8_kernel_t::jit_rvv_gemm_s8_kernel_t(dim_t n_cols, bool isTransA,
-        bool isTransB, bool b_signed, data_type_t dst_dt, bool has_bias)
+        bool isTransB, bool a_signed, bool b_signed, data_type_t dst_dt,
+        bool has_bias)
     : jit_generator_t("rv64_gemm_kernel_s8_jit")
     , n_cols_(n_cols)
     , isTransA_(isTransA)
     , isTransB_(isTransB)
+    , a_signed_(a_signed)
     , b_signed_(b_signed)
     , dst_dt_(dst_dt)
     , has_bias_(has_bias) {
@@ -138,9 +140,16 @@ void jit_rvv_gemm_s8_kernel_t::generate() {
     };
 
     auto emit_extend_a = [&]() {
-        // Sign-extend v_a_e8 (e8 LMUL=m1) to v_a_e16 (e16 LMUL=m2).
+        // Widen v_a_e8 (e8 LMUL=m1) to v_a_e16 (e16 LMUL=m2). Sign-extend
+        // for s8 A (vwmul.vx by 1) or zero-extend for u8 A (vwmulu.vx by 1).
+        // vsext.vf2 / vzext.vf2 trap on SG2044, so the widening-multiply
+        // idiom is used instead (see jit_rvv_inner_product_kernel_t).
         li(reg_tmp0, 1);
-        vwmul_vx(v_a_e16, v_a_e8, reg_tmp0);
+        if (a_signed_) {
+            vwmul_vx(v_a_e16, v_a_e8, reg_tmp0);
+        } else {
+            vwmulu_vx(v_a_e16, v_a_e8, reg_tmp0);
+        }
     };
 
     auto emit_load_b_consecutive = [&]() {
@@ -467,9 +476,9 @@ int dst_kind_index(data_type_t dst_dt) {
     return -1;
 }
 
-// One (transA, transB, b_signed) combination's worth of kernel storage:
-// for each supported dst, an array of (n_cols -> unique_ptr<kernel>) for
-// both the no-bias (nb) and with-bias (b) variants. The [kNumDstKinds]
+// One (transA, transB, a_signed, b_signed) combination's worth of kernel
+// storage: for each supported dst, an array of (n_cols -> unique_ptr<kernel>)
+// for both the no-bias (nb) and with-bias (b) variants. The [kNumDstKinds]
 // outer dimension and the [8] inner dimension (with [0] and [7] unused
 // because n_cols ∈ [1, 6]) mirror the f32 GEMM dispatcher's shape so the
 // patterns read consistently across kernels in this directory.
@@ -482,7 +491,7 @@ struct jit_rvv_gemm_s8_kernel_storage_t {
             b;
 };
 
-template <bool isTransA, bool isTransB, bool b_signed>
+template <bool isTransA, bool isTransB, bool a_signed, bool b_signed>
 const jit_rvv_gemm_s8_kernel_storage_t &get_jit_rvv_gemm_s8_kernel_storage() {
     static jit_rvv_gemm_s8_kernel_storage_t storage;
     static std::once_flag initialized;
@@ -491,48 +500,58 @@ const jit_rvv_gemm_s8_kernel_storage_t &get_jit_rvv_gemm_s8_kernel_storage() {
         for (int dt = 0; dt < kNumDstKinds; ++dt) {
             const data_type_t dst_dt = dts[dt];
             for (dim_t n_cols = 1; n_cols <= 6; n_cols++) {
-                storage.nb[dt][n_cols].reset(new jit_rvv_gemm_s8_kernel_t(
-                        n_cols, isTransA, isTransB, b_signed, dst_dt, false));
-                storage.b[dt][n_cols].reset(new jit_rvv_gemm_s8_kernel_t(
-                        n_cols, isTransA, isTransB, b_signed, dst_dt, true));
+                storage.nb[dt][n_cols].reset(
+                        new jit_rvv_gemm_s8_kernel_t(n_cols, isTransA, isTransB,
+                                a_signed, b_signed, dst_dt, false));
+                storage.b[dt][n_cols].reset(new jit_rvv_gemm_s8_kernel_t(n_cols,
+                        isTransA, isTransB, a_signed, b_signed, dst_dt, true));
             }
         }
     });
     return storage;
 }
 
-// Pick the per-(transA, transB, b_signed) storage. Exhaustive over the 8
-// combinations; aborts on a combination the dispatcher macro doesn't
+// Pick the per-(transA, transB, a_signed, b_signed) storage. Exhaustive over
+// the 16 combinations; aborts on a combination the dispatcher macro doesn't
 // cover rather than silently picking a wrong kernel.
 const jit_rvv_gemm_s8_kernel_storage_t &pick_jit_rvv_gemm_s8_kernel_storage(
-        bool isTransA, bool isTransB, bool b_signed) {
-#define DISPATCH(SA, SB, BS) \
-    if (isTransA == (SA) && isTransB == (SB) && b_signed == (BS)) { \
-        return get_jit_rvv_gemm_s8_kernel_storage<SA, SB, BS>(); \
+        bool isTransA, bool isTransB, bool a_signed, bool b_signed) {
+#define DISPATCH(SA, SB, AS, BS) \
+    if (isTransA == (SA) && isTransB == (SB) && a_signed == (AS) \
+            && b_signed == (BS)) { \
+        return get_jit_rvv_gemm_s8_kernel_storage<SA, SB, AS, BS>(); \
     }
-    DISPATCH(false, false, true)
-    DISPATCH(false, false, false)
-    DISPATCH(false, true, true)
-    DISPATCH(false, true, false)
-    DISPATCH(true, false, true)
-    DISPATCH(true, false, false)
-    DISPATCH(true, true, true)
-    DISPATCH(true, true, false)
+    DISPATCH(false, false, true, true)
+    DISPATCH(false, false, true, false)
+    DISPATCH(false, false, false, true)
+    DISPATCH(false, false, false, false)
+    DISPATCH(false, true, true, true)
+    DISPATCH(false, true, true, false)
+    DISPATCH(false, true, false, true)
+    DISPATCH(false, true, false, false)
+    DISPATCH(true, false, true, true)
+    DISPATCH(true, false, true, false)
+    DISPATCH(true, false, false, true)
+    DISPATCH(true, false, false, false)
+    DISPATCH(true, true, true, true)
+    DISPATCH(true, true, true, false)
+    DISPATCH(true, true, false, true)
+    DISPATCH(true, true, false, false)
 #undef DISPATCH
-    assert(!"unsupported (transA, transB, b_signed) combination");
+    assert(!"unsupported (transA, transB, a_signed, b_signed) combination");
     // The assert above only fires in debug builds. In release, abort
     // rather than silently picking a wrong kernel (the previous fallback
     // returned the s32 table, which would write s32 values for any
     // dst_dt — exactly the class of bug we want to surface).
     std::abort();
     // unreachable; satisfies the compiler's control-flow analysis.
-    return get_jit_rvv_gemm_s8_kernel_storage<false, false, true>();
+    return get_jit_rvv_gemm_s8_kernel_storage<false, false, true, true>();
 }
 
 } // namespace
 
-jit_rvv_gemm_s8_kernel_table_t get_jit_rvv_gemm_s8_kernel_table(
-        bool isTransA, bool isTransB, bool b_signed, data_type_t dst_dt) {
+jit_rvv_gemm_s8_kernel_table_t get_jit_rvv_gemm_s8_kernel_table(bool isTransA,
+        bool isTransB, bool a_signed, bool b_signed, data_type_t dst_dt) {
     // Map the request to a dst index. Abort on an unsupported dst_dt
     // rather than silently substituting a different dst's kernel (the
     // previous code's s32 fallback had this exact hazard).
@@ -542,8 +561,8 @@ jit_rvv_gemm_s8_kernel_table_t get_jit_rvv_gemm_s8_kernel_table(
         std::abort();
     }
 
-    const auto &storage
-            = pick_jit_rvv_gemm_s8_kernel_storage(isTransA, isTransB, b_signed);
+    const auto &storage = pick_jit_rvv_gemm_s8_kernel_storage(
+            isTransA, isTransB, a_signed, b_signed);
 
     // Build the per-n_cols lookup by reading pointers out of the
     // function-local-static storage. The `unique_ptr`s are populated once

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_s8_kernel.hpp
@@ -33,6 +33,11 @@ namespace gemm_utils {
 //   C[0:m, 0:n_cols] = sum_k A[0:m, 0:K] * B[0:K, 0:n_cols]
 //                    + (has_bias ? bias[0:m] : 0)
 //
+// A (GEMM A axis) and B (GEMM B axis) are each independently s8 or u8,
+// selected by a_signed / b_signed: A is widened with vwmul.vx (sign-extend)
+// or vwmulu.vx (zero-extend); B scalars are loaded with lb (s8) or lbu (u8).
+// All four {s8,u8}x{s8,u8} combinations are therefore correct.
+//
 // dst_dt (data_type_t) selects the C element type and epilogue strategy.
 // The driver (rvv_gemm_s8s8s32) enforces the alpha/beta contract for each
 // destination before invoking the kernel, so this table only needs to
@@ -74,7 +79,7 @@ namespace gemm_utils {
 //   v28..v31  bias loader (f32, e32 LMUL=m4)
 struct jit_rvv_gemm_s8_kernel_t : public jit_generator_t {
     struct call_params_t {
-        const void *A; // weights, s8 (M x K GEMM A axis)
+        const void *A; // weights, s8 or u8 (M x K GEMM A axis)
         const void *B; // src, s8 or u8 (K x N GEMM B axis)
         void *C; // dst, see dst_dt above
         dim_t lda;
@@ -98,7 +103,7 @@ struct jit_rvv_gemm_s8_kernel_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_s8_kernel_t)
 
     jit_rvv_gemm_s8_kernel_t(dim_t n_cols, bool isTransA, bool isTransB,
-            bool b_signed, data_type_t dst_dt, bool has_bias);
+            bool a_signed, bool b_signed, data_type_t dst_dt, bool has_bias);
 
     void operator()(const call_params_t *p) const {
         jit_generator_t::operator()(p);
@@ -111,6 +116,7 @@ private:
     dim_t n_cols_;
     bool isTransA_;
     bool isTransB_;
+    bool a_signed_; // true: A is s8 (sign-extend); false: A is u8 (zero-extend)
     bool b_signed_; // true: B is s8; false: B is u8
     // dst_dt selects the C element type and epilogue strategy. Mirrors the
     // public data_type_t enum (see common/c_types_map.hpp) so the JIT kernel
@@ -122,22 +128,22 @@ private:
 
 // Per-n_cols lookup table of (with/without-bias) kernel pointers. The
 // kernel pointers reference kernels owned by the per-(transA, transB,
-// b_signed) function-local-static storage inside jit_rvv_gemm_s8_kernel.cpp;
-// they remain valid for the program's lifetime (the storage is built once
-// under std::call_once and never destroyed).
+// a_signed, b_signed) function-local-static storage inside
+// jit_rvv_gemm_s8_kernel.cpp; they remain valid for the program's lifetime
+// (the storage is built once under std::call_once and never destroyed).
 struct jit_rvv_gemm_s8_kernel_table_t {
     std::array<const jit_rvv_gemm_s8_kernel_t *, 8> nb {};
     std::array<const jit_rvv_gemm_s8_kernel_t *, 8> b {};
 };
 
 // Returns the per-n_cols lookup table of JIT kernels specialized for the
-// given (transA, transB, B-signedness, dst_dt) combination. dst_dt must be
-// one of {s32, f32, s8, u8, f16, bf16}; rvv_gemm_s8s8s32() guards that set
-// before calling. The result is built on the fly (twelve pointer copies)
-// from the owned kernels, so callers should cache the returned value at
-// the dispatch site rather than calling per-tile.
-jit_rvv_gemm_s8_kernel_table_t get_jit_rvv_gemm_s8_kernel_table(
-        bool isTransA, bool isTransB, bool b_signed, data_type_t dst_dt);
+// given (transA, transB, A-signedness, B-signedness, dst_dt) combination.
+// dst_dt must be one of {s32, f32, s8, u8, f16, bf16}; rvv_gemm_s8s8s32()
+// guards that set before calling. The result is built on the fly (twelve
+// pointer copies) from the owned kernels, so callers should cache the
+// returned value at the dispatch site rather than calling per-tile.
+jit_rvv_gemm_s8_kernel_table_t get_jit_rvv_gemm_s8_kernel_table(bool isTransA,
+        bool isTransB, bool a_signed, bool b_signed, data_type_t dst_dt);
 
 } // namespace gemm_utils
 } // namespace rv64

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.cpp
@@ -49,11 +49,12 @@ static bool dst_supports_k_split(data_type_t dt) {
     return one_of(dt, data_type::s32, data_type::f32);
 }
 
-// Scalar copy of A (s8 weights) into a cache-friendly workspace. After copy,
-// ws holds K blocks of m_unroll contiguous s8 values:
+// Scalar copy of A (s8/u8 weights) into a cache-friendly workspace. After
+// copy, ws holds K blocks of m_unroll contiguous byte values:
 //   ws[k * m_unroll + i] = A_logical[i, k]
-void copy_A_s8(bool isTransA, dim_t K, const int8_t *A, dim_t lda, int8_t *ws,
-        dim_t m) {
+// The copy is byte-wise, so it is agnostic to A's signedness.
+void copy_A_i8(
+        bool isTransA, dim_t K, const char *A, dim_t lda, int8_t *ws, dim_t m) {
     for (dim_t k = 0; k < K; k++) {
         if (isTransA) {
             for (dim_t i = 0; i < m; i++)
@@ -66,7 +67,7 @@ void copy_A_s8(bool isTransA, dim_t K, const int8_t *A, dim_t lda, int8_t *ws,
 }
 
 template <bool isTransA, bool isTransB>
-void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
+void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const char *A,
         const dim_t lda, const void *B, const dim_t ldb, void *C,
         const dim_t ldc, const float alpha, const float beta, int8_t *ws,
         bool do_copy, int ithr, const float *bias, bool bias_is_scalar,
@@ -106,7 +107,7 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
     };
 
     auto invoke_kernel
-            = [&](const int8_t *a_orig, const void *b, void *c, dim_t tile_m,
+            = [&](const char *a_orig, const void *b, void *c, dim_t tile_m,
                       dim_t tile_n, dim_t j_col, const float *bias_tile) {
         const void *a_eff;
         dim_t lda_eff;
@@ -114,7 +115,7 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
 
         if (do_copy && tile_m == m_unroll) {
             if (j_col == 0) {
-                copy_A_s8(isTransA, K, a_orig, lda, ws, m_unroll);
+                copy_A_i8(isTransA, K, a_orig, lda, ws, m_unroll);
             }
             a_eff = ws;
             lda_eff = m_unroll;
@@ -132,7 +133,7 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
     };
 
     for (dim_t i = 0; i < Mu; i += m_unroll) {
-        const int8_t *a = isTransA ? &A[i * lda] : &A[i];
+        const char *a = isTransA ? &A[i * lda] : &A[i];
         // Scalar bias broadcasts over M: every tile reads the same base float.
         const float *bias_tile
                 = bias ? (bias_is_scalar ? bias : bias + i) : nullptr;
@@ -154,7 +155,7 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
     }
 
     if (m_tail > 0) {
-        const int8_t *a_tail = isTransA ? &A[Mu * lda] : &A[Mu];
+        const char *a_tail = isTransA ? &A[Mu * lda] : &A[Mu];
         const float *bias_tile
                 = bias ? (bias_is_scalar ? bias : bias + Mu) : nullptr;
 
@@ -182,7 +183,7 @@ void block_ker_s8(const dim_t M, const dim_t N, const dim_t K, const int8_t *A,
 
 template <bool isTransA, bool isTransB>
 void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
-        const float alpha, const int8_t *A, const dim_t lda, const void *B,
+        const float alpha, const char *A, const dim_t lda, const void *B,
         const dim_t ldb, const float beta, void *C, const dim_t ldc,
         bool do_copy, int8_t *ws, int ithr, const float *bias,
         bool bias_is_scalar, const dim_t m_unroll, bool b_signed,
@@ -197,7 +198,7 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
             ? K
             : gemm_traits_t<float, isTransA, isTransB>::BK;
 
-    const int8_t *curA;
+    const char *curA;
     const void *curB;
     char *curC;
 
@@ -293,9 +294,9 @@ void gemm_ithr_s8(const dim_t M, const dim_t N, const dim_t K,
 
 status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
         const dim_t *M_, const dim_t *N_, const dim_t *K_, const float *alpha_,
-        const int8_t *A, const dim_t *lda_, const void *B, const dim_t *ldb_,
+        const void *A, const dim_t *lda_, const void *B, const dim_t *ldb_,
         const float *beta_, void *C, const dim_t *ldc_, const float *bias,
-        bool b_signed, data_type_t dst_dt, int32_t *c_buffers_in,
+        bool a_signed, bool b_signed, data_type_t dst_dt, int32_t *c_buffers_in,
         int8_t *ws_buffers_in, bool bias_is_scalar,
         const gemm_partition_t *part) {
 
@@ -400,9 +401,9 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
     // inner work fns reuse a single 12-pointer struct rather than
     // rebuilding it per tile.
     const auto trans_a_table = get_jit_rvv_gemm_s8_kernel_table(
-            isTransA, isTransB, b_signed, dst_dt);
+            isTransA, isTransB, a_signed, b_signed, dst_dt);
     const auto nontrans_a_table = get_jit_rvv_gemm_s8_kernel_table(
-            false, isTransB, b_signed, dst_dt);
+            false, isTransB, a_signed, b_signed, dst_dt);
 
     auto get_thr_block = [&](dim_t &from, dim_t &to, dim_t &myN, dim_t NB,
                                  dim_t N, int ithr) {
@@ -446,8 +447,9 @@ status_t rvv_gemm_s8s8s32(const char *transa_, const char *transb_,
                 myBeta = 0.0f;
                 ld = MB;
             }
-            const int8_t *myA = isTransA ? &(A[k_from + m_from * lda])
-                                         : &(A[m_from + k_from * lda]);
+            const char *A_bytes = static_cast<const char *>(A);
+            const char *myA = isTransA ? &A_bytes[k_from + m_from * lda]
+                                       : &A_bytes[m_from + k_from * lda];
             const char *B_bytes = static_cast<const char *>(B);
             const void *myB = isTransB
                     ? static_cast<const void *>(B_bytes + n_from + k_from * ldb)

--- a/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp
@@ -26,9 +26,9 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
-// RVV int8 GEMM driver. Mirrors rvv_gemm_f32() in structure but accepts s8
-// weights, s8/u8 src, and a wider set of dst types: s32, f32, s8, u8, f16,
-// bf16. The dst element width is no longer uniform (1, 2 or 4 bytes), so
+// RVV int8 GEMM driver. Mirrors rvv_gemm_f32() in structure but accepts
+// s8/u8 weights, s8/u8 src, and a wider set of dst types: s32, f32, s8, u8,
+// f16, bf16. The dst element width is no longer uniform (1, 2 or 4 bytes), so
 // `dst_dt` selects both the type and the element size; `dst_dt_sz` is derived
 // internally.
 //
@@ -45,8 +45,9 @@ namespace rv64 {
 //   - bf16  : any alpha; beta must be 0. K-split forced off. Requires
 //             Zvfbfwma; caller gates on mayiuse(zvfbfwma).
 //
-// b_signed selects between s8 and u8 on the B (src) axis; A (weights) is
-// always s8.
+// a_signed selects between s8 and u8 on the A (weights) axis; b_signed
+// selects between s8 and u8 on the B (src) axis. All four {s8,u8}x{s8,u8}
+// combinations are supported.
 //
 // `bias` is an optional f32 vector of length M, broadcast across the N axis.
 // When non-null it is fused into the JIT kernel's C-update phase, matching the
@@ -76,10 +77,11 @@ namespace rv64 {
 // before passing them through.
 status_t rvv_gemm_s8s8s32(const char *transa, const char *transb,
         const dim_t *M, const dim_t *N, const dim_t *K, const float *alpha,
-        const int8_t *A, const dim_t *lda, const void *B, const dim_t *ldb,
+        const void *A, const dim_t *lda, const void *B, const dim_t *ldb,
         const float *beta, void *C, const dim_t *ldc, const float *bias,
-        bool b_signed, data_type_t dst_dt, int32_t *c_buffers = nullptr,
-        int8_t *ws_buffers = nullptr, bool bias_is_scalar = false,
+        bool a_signed, bool b_signed, data_type_t dst_dt,
+        int32_t *c_buffers = nullptr, int8_t *ws_buffers = nullptr,
+        bool bias_is_scalar = false,
         const gemm_utils::gemm_partition_t *part = nullptr);
 
 } // namespace rv64

--- a/src/cpu/rv64/rvv_matmul.cpp
+++ b/src/cpu/rv64/rvv_matmul.cpp
@@ -171,12 +171,11 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     const dim_t wei_matrix_stride = K_dim * N_dim;
 
     if (pd()->is_int8_path_) {
-        // Int8 dispatch: s8 weights * (s8|u8) src -> (s32|f32|s8|u8|f16|bf16)
-        // dst. No post-ops or scales (those attrs are rejected in
-        // pd_t::init), so the only epilogue work is the optional fused bias
-        // inside the GEMM kernel itself.
-        const int8_t *weights = static_cast<const int8_t *>(
-                CTX_IN_MEM(const void *, DNNL_ARG_WEIGHTS));
+        // Int8 dispatch: (s8|u8) weights * (s8|u8) src ->
+        // (s32|f32|s8|u8|f16|bf16) dst. No post-ops or scales (those attrs are
+        // rejected in pd_t::init), so the only epilogue work is the optional
+        // fused bias inside the GEMM kernel itself.
+        const void *weights = CTX_IN_MEM(const void *, DNNL_ARG_WEIGHTS);
         const void *src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
         void *dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
         const float *bias = bias_d.is_zero()
@@ -186,6 +185,9 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
         // kernel to splat one float instead of reading a full vector.
         const bool bias_is_scalar = bias && bias_d.nelems() == 1;
 
+        // A axis = weights, B axis = src (see the GEMM mapping comment
+        // below). Each operand is independently s8/u8.
+        const bool a_signed = weights_d.data_type() == data_type::s8;
         const bool b_signed = src_d.data_type() == data_type::s8;
         const data_type_t dst_dt = dst_d.data_type();
 
@@ -210,8 +212,9 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
 
             status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &M_gemm_all,
                     &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src,
-                    &g.ldb, &beta, dst, &g.ldc, /*bias=*/bias, b_signed, dst_dt,
-                    c_buffer, ws_buffer, bias_is_scalar, &part);
+                    &g.ldb, &beta, dst, &g.ldc, /*bias=*/bias, a_signed,
+                    b_signed, dst_dt, c_buffer, ws_buffer, bias_is_scalar,
+                    &part);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);
         } else {
@@ -242,14 +245,14 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
                     }
                 }
 
-                const int8_t *wei_base
-                        = weights + weight_batch_index * wei_matrix_stride;
+                const char *wei_base = static_cast<const char *>(weights)
+                        + weight_batch_index * wei_matrix_stride;
 
                 status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &g.M_gemm,
                         &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda,
                         src_base, &g.ldb, &beta, dst_base, &g.ldc,
-                        /*bias=*/bias, b_signed, dst_dt, c_buffer, ws_buffer,
-                        bias_is_scalar, &part);
+                        /*bias=*/bias, a_signed, b_signed, dst_dt, c_buffer,
+                        ws_buffer, bias_is_scalar, &part);
                 assert(st == status::success || st == status::unimplemented);
                 MAYBE_UNUSED(st);
             }

--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -64,9 +64,9 @@ struct rvv_matmul_t : public primitive_t {
                     VERBOSE_UNSUPPORTED_TAG);
 
             // Determine which dispatch path this pd serves. f32 stays on the
-            // existing f32 GEMM kernel; int8 src + s8 weights + a dst in the
-            // int8-supported set (s32|f32|s8|u8|f16|bf16) runs through the s8
-            // GEMM kernel. f16 and bf16 additionally require Zvfh /
+            // existing f32 GEMM kernel; (s8|u8) src + (s8|u8) weights + a dst
+            // in the int8-supported set (s32|f32|s8|u8|f16|bf16) runs through
+            // the int8 GEMM kernel. f16 and bf16 additionally require Zvfh /
             // Zvfbfwma, which we gate below.
             const auto src_dt = src_mdw.data_type();
             const auto wei_dt = weights_mdw.data_type();
@@ -76,8 +76,9 @@ struct rvv_matmul_t : public primitive_t {
                     && acc_dt == f32;
             const bool dst_in_int8_set
                     = utils::one_of(dst_dt, s32, f32, s8, u8, f16, bf16);
-            is_int8_path_ = utils::one_of(src_dt, s8, u8) && wei_dt == s8
-                    && dst_in_int8_set && acc_dt == s32;
+            is_int8_path_ = utils::one_of(src_dt, s8, u8)
+                    && utils::one_of(wei_dt, s8, u8) && dst_in_int8_set
+                    && acc_dt == s32;
             VDISPATCH_MATMUL(
                     is_f32_path_ || is_int8_path_, VERBOSE_UNSUPPORTED_DT);
             // Half-precision dst requires the corresponding vector fp
@@ -248,9 +249,9 @@ struct rvv_matmul_t : public primitive_t {
         bool weights_are_broadcast_ = false;
         bool weights_col_major_ = false;
         // Dispatch path selected in init(). is_f32_path_ keeps the historical
-        // behavior; is_int8_path_ routes (s8|u8):s8:(s32|f32|s8|u8|f16|bf16)
-        // through the s8 GEMM kernel and rejects non-default attrs except bias
-        // (and scales/zero-points/post-ops).
+        // behavior; is_int8_path_ routes (s8|u8):(s8|u8):(s32|f32|s8|u8|f16|bf16)
+        // through the int8 GEMM kernel and rejects non-default attrs except
+        // bias (and scales/zero-points/post-ops).
         bool is_f32_path_ = false;
         bool is_int8_path_ = false;
 


### PR DESCRIPTION
# Description

This PR extends the RISC-V (RV64) int8 GEMM kernel and `rvv_matmul_t` dispatch to support `u8` on the weights (GEMM A) axis, adding the missing `u8:u8` source combination and, as a side effect of the symmetric implementation, the `s8:u8` combination. Previously the int8 matmul path accepted only `(s8|u8):s8` sources, so any `u8:u8` workload fell through to the scalar `ref_int8:any` reference. With this change the path accepts all four `{s8,u8}x{s8,u8}` source combinations for the six supported destination types `s32`, `f32`, `s8`, `u8`, `f16` (Zvfh) and `bf16` (Zvfbfwma).

This version provides:

1. A new `a_signed` specialization knob on the `jit_rvv_gemm_s8_kernel_t` micro-kernel, parallel to the existing `b_signed` knob. The A (weights) row is widened with `vwmul.vx` (sign-extend) for `s8` or `vwmulu.vx` (zero-extend) for `u8`, while the B (src) scalars keep the existing `lb`/`lbu` choice. The signed `vwmacc.vx` accumulation is correct for every combination because a zero-extended `u8` value stays non-negative in `e16`.
2. Threading of `a_signed` through the `rvv_gemm_s8s8s32()` driver, with the A operand generalized from `const int8_t *` to `const void *`/`const char *` so byte-level pointer arithmetic is sign-agnostic, matching how the B operand is already handled.
3. A one-line relaxation in `rvv_matmul_t::pd_t::init()` from `wei_dt == s8` to `utils::one_of(wei_dt, s8, u8)`, which makes `u8` weights dispatch through the JIT int8 path and computes `a_signed = (weights_dt == s8)` at execute time.

## Key Features

- **RVV int8 GEMM kernel**: the A-axis widening is selected at JIT-create time by `a_signed`, so each `(transA, transB, a_signed, b_signed, dst_dt)` combination is its own specialized kernel in the static table (16 transpose/signedness combinations instead of the previous 8). `vsext.vf2`/`vzext.vf2` are avoided because they trap on SG2044; the widening-multiply idiom (`vwmul.vx`/`vwmulu.vx` by 1) is reused, consistent with `jit_rvv_inner_product_kernel_t`.
- **Data Types**: `s8:s8`, `u8:s8`, `s8:u8` and `u8:u8` sources into `s32`, `f32`, `s8`, `u8`, `f16` (Zvfh) and `bf16` (Zvfbfwma) destinations. The `u8:u8` combination is the target of this PR; `s8:u8` comes for free because RVV widens each operand independently and has no ISA restriction analogous to aarch64's missing `summla`.
- **Memory Layouts**: row-major src and dst, row- or column-major weights (the existing trans-A / non-trans-A GEMM kernel paths), unchanged from the prior int8 path.
- **Fused Bias / Post-Ops**: unchanged — optional `f32` bias is still fused inside the JIT epilogue; scales, zero-points and post-ops are still rejected (consistent with the existing int8 path's strict attr mask).

# Checklist

## General

- [x] Do all unit and benchdnn tests pass? (verified `tests/benchdnn/benchdnn --matmul --dt=<src:wei:dst> --batch=tests/benchdnn/inputs/matmul/shapes_2d` passes 10/10 for `u8:u8:{s32,f32,s8,u8}`, the new `s8:u8:s32` combination, and the existing `u8:s8:s32` and `s8:s8:s32` combinations — no regressions)
- [x] Have you formatted the code using clang-format-18? (verified `clang-format-18 --dry-run --Werror` returns no diff on all 6 changed files)

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on the SG2044 platform with VLEN=128 using RISC-V GNU toolchain 14.2. We draw comparisons among:

1. **baseline (upstream `main`)**: the int8 matmul path requires `wei_dt == s8`, so `u8:u8` matmul dispatches to `ref_int8:any` (the scalar reference).
2. **this PR**: built from the current branch; the int8 matmul path additionally accepts `u8` weights, so `u8:u8` matmul dispatches to `jit:rvv`.

The comparison is on `u8:u8:s32` (the canonical int8 accumulator output). The GEMM core is shared across all destination types, so the speedup pattern is representative for `f32`/`s8`/`u8`/`f16`/`bf16` destinations as well. Minimum latency (`min_time`, the `%-time%` benchdnn column) is reported.

### Single-Core Performance (1 thread, `u8:u8:s32`)

| Dataset / Layer | Shape | baseline `ref_int8:any` (ms) | this PR `jit:rvv` (ms) | Speedup |
|---|---|---|---|---|
| GNMT:0*1 | 64x512:512x512 | 442.78 | 1.56 | **285x** |
| GNMT:1*1 | 64x1024:1024x1024 | 1759.89 | 6.24 | **282x** |
| resnet:ip1*1 | 112x2048:2048x1000 | 6026.20 | 20.67 | **292x** |
| resnet_sparse:ip1*1 | 64x2048:2048x1000 | 3442.57 | 13.20 | **261x** |
| transformer | 16x40x64:16x64x40 | 48.86 | 0.23 | **209x** |
| transformer | 16x40x40:16x40x64 | 50.76 | 0.21 | **239x** |
| transformer | 2048x40x64:2048x64x40 | 6247.83 | 34.56 | **181x** |
| transformer | 2048x40x40:2048x40x64 | 6306.76 | 35.76 | **176x** |

**Summary:**
- The new `jit:rvv` path replaces the scalar `ref_int8:any` reference for `u8:u8`, delivering 176x-292x speedup on GNMT, ResNet inner-product and transformer matmul shapes.
- Single-thread throughput on the ResNet inner-product layer reaches ~22 GFLOPS, consistent with the existing `(s8|u8):s8` kernel that shares the same micro-kernel core.

### 8-Core Performance (8 threads, `u8:u8:s32`)

| Dataset / Layer | Shape | baseline `ref_int8:any` (ms) | this PR `jit:rvv` (ms) | Speedup |
|---|---|---|---|---|
| GNMT:0*1 | 64x512:512x512 | 55.70 | 0.26 | **216x** |
| GNMT:1*1 | 64x1024:1024x1024 | 221.84 | 0.98 | **226x** |
| resnet:ip1*1 | 112x2048:2048x1000 | 755.44 | 4.03 | **187x** |
| resnet_sparse:ip1*1 | 64x2048:2048x1000 | 435.75 | 2.09 | **208x** |
| transformer | 16x40x64:16x64x40 | 6.17 | 0.11 | **54x** |
| transformer | 16x40x40:16x40x64 | 6.27 | 0.11 | **59x** |
| transformer | 2048x40x64:2048x64x40 | 788.57 | 15.72 | **50x** |
| transformer | 2048x40x40:2048x40x64 | 809.66 | 16.17 | **50x** |

**Summary:**
- 8-thread scaling preserves the speedup pattern (50x-226x over `ref_int8:any`). The smaller transformer shapes scale less because their per-problem work is tiny relative to thread overhead, so the absolute `jit:rvv` latency (0.1 ms) is already near the noise floor.
- 8-thread throughput on the ResNet inner-product layer reaches ~114 GFLOPS, ~5x the single-thread throughput, consistent with the GEMM kernel's M/N tiling and K-split on multi-core.

# Future Plans

1. Software-pipeline the A load (double-buffer `v_a_e8`) to hide `vle8.v` + widening-multiply latency in the K loop, benefiting all four source combinations.
2. Collapse the `a_signed`/`b_signed` storage tables where they differ by only one opcode (e.g. the A `vwmul`/`vwmulu` choice or the B `lb`/`lbu` choice), reducing the 16 transpose/signedness static tables toward one per `(transA, transB, dst)`.
3. Accept `s32` bias and add per-oc / per-tensor scales and zero-points so `u8:u8` can serve fully quantized workloads end-to-end.
