### PR TITLE
TF32 support removal

### DIFF
--- a/doc/programming_model/attributes_fpmath_mode.md
+++ b/doc/programming_model/attributes_fpmath_mode.md
@@ -29,6 +29,11 @@ The @ref dnnl::fpmath_mode primitive attribute can take 3 types of values:
 This attribute is ignored if a primitive computation data-type is
 integral.
 
+@note
+The `tf32` mode is accelerated on Intel GPUs only. Intel CPUs do not implement
+`tf32` arithmetic; setting `tf32` on a CPU engine is accepted but has no effect,
+and computations are performed in `f32`.
+
 ## Enforcing the floating-point math mode to an integral primitive.
 
 A user can enforce an integral primitive to comply with the floating-point math

--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -97,8 +97,6 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
         {{forward, "f32:xf:*"}, {
             CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_X64(ip_convolution_fwd_t)
-            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
-            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>)
             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
             CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_1x1_convolution_fwd_t<avx512_core>)
@@ -218,9 +216,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
         // BWD_D fp
         {{backward_data, "*:xf:f32"}, REG_BWD_D_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_data_t)
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx10_2_amx_2>)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx512_core_amx>)
-            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx10_2_amx_2>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_t<avx512_core>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)
             CPU_INSTANCE_AVX512(jit_avx512_common_dw_convolution_bwd_data_t)

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -228,8 +228,7 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_b, bool transA, bool transB,
         brgemm_layout_t layout, float alpha, float beta, dim_t LDA, dim_t LDB,
-        dim_t LDC, dim_t M, dim_t N, dim_t K, const brgemm_strides_t *strides,
-        bool is_tf32) {
+        dim_t LDC, dim_t M, dim_t N, dim_t K, const brgemm_strides_t *strides) {
     /*
     m - number of rows of the matrix op(A) and number of rows of the matrix C
     n - number of columns of the matrix op(B) and number of columns of the matrix C
@@ -251,8 +250,7 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
         return status::invalid_arguments;
 
     CHECK(brgemm_utils::init_brgemm_conf(brg, isa, type, dt_a, dt_b, layout,
-            alpha, beta, LDA, LDB, LDC, M, N, K, strides, false /* is_bf32 */,
-            is_tf32));
+            alpha, beta, LDA, LDB, LDC, M, N, K, strides, false /* is_bf32 */));
 
     if (utils::one_of(true, brg->is_runtime_lda, brg->is_runtime_ldb))
         return status::unimplemented;
@@ -301,8 +299,7 @@ status_t brgemv_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->is_gemv = true;
 
     CHECK(brgemm_desc_init(brg, isa, type, dt_a, dt_x, false, false,
-            brgemm_row_major, alpha, beta, LDA, 1, INCY, M, 1, N, nullptr,
-            false));
+            brgemm_row_major, alpha, beta, LDA, 1, INCY, M, 1, N, nullptr));
 
     // Initialize transA here because `brgemm_desc_init` would otherwise return
     // unimplemented since brgemm doesn't support this case and we don't pass

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -67,7 +67,7 @@ status_t DNNL_API brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
         impl::data_type_t dt_b, bool transA, bool transB,
         brgemm_layout_t layout, float alpha, float beta, dim_t LDA, dim_t LDB,
         dim_t LDC, dim_t M, dim_t N, dim_t K,
-        const brgemm_strides_t *strides = nullptr, bool is_tf32 = false);
+        const brgemm_strides_t *strides = nullptr);
 
 /// Initializes a BRGEMM descriptor configured for batched matrix-vector
 /// multiplication.

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -359,7 +359,6 @@ struct brgemm_desc_t {
     bool is_f16 = false, is_f16_tmm = false;
     bool is_f32 = false;
     bool is_bf32 = false;
-    bool is_tf32 = false;
 
     bool has_int8_vnni = false;
 
@@ -683,12 +682,8 @@ struct brgemm_desc_t {
     bool reduce_by_words() const {
         return is_bf16_tmm || is_f16_tmm || is_input_convert();
     }
-    int max_rd_block() const {
-        return is_tf32 ? 16 : reduce_by_words() ? 32 : 64;
-    }
-    int rd_block_step() const {
-        return is_tf32 ? 1 : (reduce_by_words() && !is_fp8) ? 2 : 4;
-    }
+    int max_rd_block() const { return reduce_by_words() ? 32 : 64; }
+    int rd_block_step() const { return (reduce_by_words() && !is_fp8) ? 2 : 4; }
 
     bool amx_may_extend_k() const {
         return (is_superset(isa_impl, avx512_core_amx) && brgattr.extendable_k

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -138,9 +138,7 @@ void set_isa_impl(brgemm_desc_t *brg) {
         return;
     }
 
-    if (brg->is_tf32) {
-        brg->isa_impl = avx10_2_amx_2;
-    } else if (brg->is_bf32) {
+    if (brg->is_bf32) {
         brg->isa_impl = avx512_core_amx;
     } else if (brg->is_f32) {
         brg->isa_impl = utils::map(true, isa_undef,
@@ -203,7 +201,7 @@ void set_isa_impl(brgemm_desc_t *brg) {
 
 void set_brg_vmm(brgemm_desc_t *brg) {
     brg->is_tmm = brg->is_int8_tmm || brg->is_bf16_tmm || brg->is_f16_tmm
-            || brg->is_bf32 || brg->is_fp8_tmm || brg->is_tf32;
+            || brg->is_bf32 || brg->is_fp8_tmm;
     brg->is_zmm = !brg->is_tmm && mayiuse(avx512_core)
             && is_superset(brg->isa_impl, avx512_core);
     brg->is_ymm
@@ -682,16 +680,16 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     // dimension)
     // TODO: these checks do not work for fp8-f16 and f16-fp8 cfgs
     if (!IMPLICATION(brg->rdb > 0 && brg->rdb_tail,
-                brg->is_tf32 || brg->is_input_convert()
-                        || brg->amx_wary_k_tail() || brg->fused_copy_a)) {
+                brg->is_input_convert() || brg->amx_wary_k_tail()
+                        || brg->fused_copy_a)) {
         return status::unimplemented;
     }
 
     if (!IMPLICATION((brg->rdb_tail
                              % ((brg->is_bf16_tmm || brg->is_f16_tmm) ? 2 : 4))
                         != 0,
-                brg->is_tf32 || brg->is_input_convert()
-                        || brg->amx_wary_k_tail() || brg->fused_copy_a)) {
+                brg->is_input_convert() || brg->amx_wary_k_tail()
+                        || brg->fused_copy_a)) {
         return status::unimplemented;
     }
 
@@ -1062,7 +1060,7 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_b, brgemm_layout_t layout, float alpha, float beta,
         dim_t LDA, dim_t LDB, dim_t LDC, dim_t M, dim_t N, dim_t K,
-        const brgemm_strides_t *strides, bool is_bf32, bool is_tf32) {
+        const brgemm_strides_t *strides, bool is_bf32) {
 
     init_common_conf(brg, type, alpha, beta, strides);
 
@@ -1083,9 +1081,6 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
 
     brg->isa_user = isa;
 
-    brg->is_tf32 = is_tf32
-            && utils::one_of(brg->isa_user, isa_undef, avx10_2_amx_2)
-            && mayiuse(avx10_2_amx_2);
     brg->is_bf32 = is_bf32
             && utils::one_of(brg->isa_user, isa_undef, avx512_core_amx)
             && mayiuse(avx512_core_amx);

--- a/src/cpu/x64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.hpp
@@ -50,8 +50,7 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_b, brgemm_layout_t layout, float alpha, float beta,
         dim_t LDA, dim_t LDB, dim_t LDC, dim_t M, dim_t N, dim_t K,
-        const brgemm_strides_t *strides = nullptr, bool is_bf32 = false,
-        bool is_tf32 = false);
+        const brgemm_strides_t *strides = nullptr, bool is_bf32 = false);
 
 /* The purpose of this function is to enable initialization of brgemm values
  * and then call additional functions like blocking heuristics without

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -2161,9 +2161,7 @@ void jit_brgemm_amx_uker_base_t::tdpbxxd(brgemm_iteration_t &bi, int bdb_idx,
     const Tmm &x3 = Tmm(brg.get_B_tensor(ldb_idx, bi.ldi->is_tail(ldb_idx)));
 
     using namespace data_type;
-    if (brg.is_tf32) {
-        tmmultf32ps(x1, x2, x3);
-    } else if (brg.is_bf32 || (brg.dt_a == bf16 && brg.dt_b == bf16)) {
+    if (brg.is_bf32 || (brg.dt_a == bf16 && brg.dt_b == bf16)) {
         tdpbf16ps(x1, x2, x3);
     } else if (brg.dt_a == f16 && brg.dt_b == f16) {
         tdpfp16ps(x1, x2, x3);

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2774,9 +2774,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
         bool last_bdb) {
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
         using namespace data_type;
-        if (brg.is_tf32) {
-            tmmultf32ps(x1, x2, x3);
-        } else if (brg.is_fp8 && brg.is_fp8_via_convert()) {
+        if (brg.is_fp8 && brg.is_fp8_via_convert()) {
             tdpfp16ps(x1, x2, x3);
         } else if (brg.dt_a == f8_e5m2 && brg.dt_b == f8_e5m2) {
             tdpbf8ps(x1, x2, x3);

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -192,7 +192,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
                 = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
         CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, src_type, wei_type,
                 false, false, brgemm_row_major, alpha, vbeta, LDA, jcp_.LDB,
-                jcp_.LDC, vM, vN, vK, strides_ptr, jcp_.is_tf32));
+                jcp_.LDC, vM, vN, vK, strides_ptr));
 
         brgemm_attr_t brgattr;
         brgattr.max_bs = jcp_.gemm_batch_size;

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -276,7 +276,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
             = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
     CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, src_type, wei_type, false,
             false, brgemm_row_major, alpha, vbeta, jcp_.LDA, jcp_.LDB, jcp_.LDC,
-            vbrgM, vN, vK, strides_ptr, jcp_.is_tf32));
+            vbrgM, vN, vK, strides_ptr));
     brgattr.use_uker = jcp_.use_uker;
     brgattr.use_interleave_stores = jcp_.use_interleave_stores;
     brgattr.hint_prefetching = jcp_.hint_prefetching;
@@ -950,7 +950,6 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         ajcp.nb_ic_int = 1;
         ajcp.is_nspc = true;
         ajcp.is_bf32 = jcp.is_bf32;
-        ajcp.is_tf32 = jcp.is_tf32;
         ajcp.typesize_in = jcp.src_dsz;
         ajcp.ic_block_int = jcp.amx_w;
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -330,7 +330,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
             = (jcp_.brg_type == brgemm_strd) ? &brg_strides : nullptr;
     CHECK(brgemm_desc_init(&brg, isa, jcp_.brg_type, jcp_.src_dt, jcp_.wei_dt,
             false, false, brgemm_row_major, alpha, vbeta, jcp_.LDA, jcp_.LDB,
-            jcp_.LDC, vM, vN, vK, strides_ptr, jcp_.is_tf32));
+            jcp_.LDC, vM, vN, vK, strides_ptr));
 
     brgemm_attr_t brgattr;
     brgattr.use_uker = jcp_.use_uker;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -591,7 +591,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     brgemm_desc_t brg;
     CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
-            is_bf32, is_tf32));
+            is_bf32));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
     ur = brg.bd_block * nstl::max(1, brg.bd_block2);
@@ -601,7 +601,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
         brgemm_desc_t brg_sp_tail;
         CHECK(brgemm_utils::init_brgemm_conf(&brg_sp_tail, isa, brgemm_addr,
                 src_dt, wei_dt, brgemm_row_major, alpha, beta, LDA, LDB, LDC,
-                M_tail, vN, vK, nullptr, is_bf32, is_tf32));
+                M_tail, vN, vK, nullptr, is_bf32));
         CHECK(brgemm_utils::brgemm_blocking(&brg_sp_tail));
         ur_block_tail = brg_sp_tail.bd_block;
     } else {
@@ -648,8 +648,7 @@ status_t brg_blocking_t::get_brgemm_ur(
                             : nullptr;
                     CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brg_type,
                             src_dt, wei_dt, brgemm_row_major, alpha, vbeta, LDA,
-                            LDB, LDC, vM, vN, vK, strides_ptr, is_bf32,
-                            is_tf32));
+                            LDB, LDC, vM, vN, vK, strides_ptr, is_bf32));
                     CHECK(brgemm_utils::brgemm_blocking(&brg));
 
                     brgemm_attr_t brgattr;
@@ -1512,9 +1511,6 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = everyone_is(f32, jcp.src_dt, jcp.dst_dt) && jcp.wei_dt == bf16;
     jcp.is_f32_f16
             = everyone_is(f32, jcp.src_dt, jcp.dst_dt) && jcp.wei_dt == f16;
-    jcp.is_tf32 = everyone_is(f32, jcp.src_dt, jcp.wei_dt)
-            && one_of(attr.fpmath_.mode_, fpmath_mode::tf32, fpmath_mode::any)
-            && is_superset(isa, avx10_2_amx_2);
 
     VDISPATCH_CONV_IC(!jcp.is_bf32, VERBOSE_UNSUPPORTED_DT);
 
@@ -1623,8 +1619,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                                       || is_superset(jcp.isa, avx2_vnni_2)),
             VERBOSE_ISA_DT_MISMATCH);
 
-    VDISPATCH_CONV_IC(
-            IMPLICATION(is_f32, one_of(isa, avx512_core, avx2) || jcp.is_tf32),
+    VDISPATCH_CONV_IC(IMPLICATION(is_f32, one_of(isa, avx512_core, avx2)),
             VERBOSE_ISA_DT_MISMATCH);
 
     VDISPATCH_CONV_IC(

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -448,13 +448,12 @@ float brg_blocking_t::io_k(const loop_t loop, const array_in_loop_t arr,
 void brg_blocking_t::select_ic_block() {
     if (is_1x1 && is_amx(isa)) {
         // TODO: merge with non-1x1 code block below
-        const bool is_xf32 = is_bf32 || is_tf32;
         const int ic_padded_block = 16 * vnni_block;
 
         MAYBE_UNUSED(ic_padded_block);
-        // Note: bf32 and tf32 require ic_block be less than 64, otherwise it results
+        // Note: bf32 requires ic_block be less than 64, otherwise it results
         // in incorrect output.
-        ic_block = is_xf32 && (!is_rtus) ? nstl::min(64, ic) : ic;
+        ic_block = is_bf32 && (!is_rtus) ? nstl::min(64, ic) : ic;
         nb_ic = utils::div_up(ic, ic_block); // trivially 1 for now
         inp_ic_block = ic_block;
         return;
@@ -623,21 +622,20 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
 
     N = oc >= oc_block ? oc_block : 0;
     N_tail = oc % oc_block;
-    const bool is_xf32 = is_bf32 || is_tf32;
     if (is_relo()) {
         K = (ic >= ic_block) ? rnd_up(kh_koef * kw * inp_ic_block, vnni_block)
                              : 0;
         if (vnni_block > 1 && K > simd_w) K = rnd_up(K, simd_w);
 
         K_tail = rnd_up(kh_koef * kw
-                        * (!is_xf32 ? inp_ic_block
+                        * (!is_bf32 ? inp_ic_block
                                     : rnd_up(ic % ic_block, vnni_block)),
                 vnni_block);
         if (vnni_block > 1 && K_tail > simd_w) K_tail = rnd_up(K_tail, simd_w);
     } else {
         K = kh_koef * (ic >= ic_block ? ic_block : 0);
         const auto ic_ceil
-                = exec_type == exec_trans && ic_block % simd_w == 0 && !is_xf32
+                = exec_type == exec_trans && ic_block % simd_w == 0 && !is_bf32
                 ? simd_w
                 : vnni_block;
         K_tail = kh_koef
@@ -654,7 +652,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     brgemm_desc_t brg;
     CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
-            is_bf32, is_tf32));
+            is_bf32));
     if (exec_type == exec_vpad) {
         brg.zp_type_a = src_zero_point ? brgemm_broadcast_t::per_tensor
                                        : brgemm_broadcast_t::none;
@@ -676,7 +674,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
 
         CHECK(brgemm_utils::init_brgemm_conf(&brg_sp_tail, isa, brgemm_addr,
                 src_dt, wei_dt, brgemm_row_major, alpha, beta, LDA, LDB, LDC,
-                M_tail, vN, vK, nullptr, is_bf32, is_tf32));
+                M_tail, vN, vK, nullptr, is_bf32));
         if (exec_type == exec_vpad) {
             brg_sp_tail.zp_type_a = src_zero_point
                     ? brgemm_broadcast_t::per_tensor
@@ -758,7 +756,7 @@ status_t brg_blocking_t::get_brgemm_ur(
                 = (brg_type == brgemm_strd) ? &brg_strides : nullptr;
         CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brg_type, src_dt,
                 wei_dt, brgemm_row_major, alpha, vbeta, LDA, LDB, LDC, vM, vN,
-                vK, strides_ptr, is_bf32, is_tf32));
+                vK, strides_ptr, is_bf32));
 
         brgemm_attr_t brgattr;
         brgattr.use_uker = use_uker;
@@ -1772,9 +1770,6 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.is_bf32 = everyone_is(f32, jcp.src_dt, jcp.wei_dt)
             && one_of(attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any)
             && isa == avx512_core_amx;
-    jcp.is_tf32 = everyone_is(f32, jcp.src_dt, jcp.wei_dt)
-            && one_of(attr.fpmath_.mode_, fpmath_mode::tf32, fpmath_mode::any)
-            && is_superset(isa, avx10_2_amx_2);
     jcp.wei_plain = everyone_is(true, jcp.wei_dt == data_type::f32,
             is_superset(isa, avx512_core), weights_d.is_plain());
     if (jcp.wei_plain)
@@ -1894,9 +1889,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             VERBOSE_ISA_DT_MISMATCH);
     const bool is_f32
             = utils::everyone_is(f32, jcp.src_dt, jcp.wei_dt, jcp.dst_dt);
-    VDISPATCH_CONV_IC(IMPLICATION(is_f32,
-                              one_of(isa, avx512_core, avx2) || jcp.is_bf32
-                                      || jcp.is_tf32),
+    VDISPATCH_CONV_IC(
+            IMPLICATION(is_f32, one_of(isa, avx512_core, avx2) || jcp.is_bf32),
             VERBOSE_ISA_DT_MISMATCH);
     VDISPATCH_CONV_IC(
             IMPLICATION(jcp.is_f32_f16, one_of(isa, avx512_core, avx2)),
@@ -2509,16 +2503,13 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         const int ic_block
                 = nstl::min(jcp.acc_simd_w, n_vnni_blocks) * jcp.vnni_block;
 
-        jcp.extendable_k
-                = !jcp.is_tf32 && jcp.ic > jcp.simd_w && jcp.ic % jcp.simd_w;
+        jcp.extendable_k = jcp.ic > jcp.simd_w && jcp.ic % jcp.simd_w;
 
-        const bool do_zeropad = !(jcp.is_bf32 || jcp.is_tf32)
-                && !jcp.extendable_k
+        const bool do_zeropad = !jcp.is_bf32 && !jcp.extendable_k
                 && (jcp.ic % jcp.vnni_block != 0 || jcp.ic > ic_block);
         if (do_zeropad) jcp.ic = utils::rnd_up(jcp.ic, ic_block);
         const auto ic_padded_block = jcp.simd_w;
-        jcp.is_rd_padded_to_block
-                = jcp.ic > ic_padded_block && !(jcp.is_bf32 || jcp.is_tf32);
+        jcp.is_rd_padded_to_block = jcp.ic > ic_padded_block && !jcp.is_bf32;
 
         // try to choose optimal loop order
         // TODO: incorporate loop order into smart blocking selection

--- a/src/cpu/x64/jit_brgemm_primitive_conf.hpp
+++ b/src/cpu/x64/jit_brgemm_primitive_conf.hpp
@@ -66,7 +66,6 @@ struct jit_brgemm_primitive_conf_t {
     bool use_buffer_a;
     bool use_buffer_b;
     bool is_bf32;
-    bool is_tf32;
 
     bool with_src_scales;
     bool with_wei_scales;

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -167,7 +167,6 @@ struct jit_conv_conf_t {
     data_type_t dsrc_dt;
     data_type_t dwei_dt;
     bool is_bf32 {false};
-    bool is_tf32 {false};
     bool expl_bcast;
     bool large_spatial, large_w_filter;
     int is_ic_scale, is_oc_scale;
@@ -867,7 +866,6 @@ struct jit_brgemm_conv_conf_t {
     bool req_brg_comp_pad;
     bool req_cal_comp_pad;
     bool is_bf32 {false};
-    bool is_tf32 {false};
     bool is_fp8 {false};
     bool is_fp8_convert {false};
     bool is_f32_f16 {false};

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -442,7 +442,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
             CHECK(brgemm_desc_init(&brg, kernel_isa, bgmmc_.brg_type,
                     bgmmc_.src_dt, bgmmc_.wei_dt, false, false,
                     brgemm_row_major, alpha, vbeta, LDA, bgmmc_.LDB, bgmmc_.LDC,
-                    vM, vN, vK, nullptr, bgmmc_.is_tf32));
+                    vM, vN, vK, nullptr));
         }
 
         auto LDD = bgmmc_.LDD;

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -247,8 +247,7 @@ status_t check_isa_with_datatype(
         const cpu_isa_t isa, const brgemm_matmul_conf_utils_t &bm_conf_utils) {
     const bool ok
             = IMPLICATION(bm_conf_utils.is_f32(),
-                      one_of(isa, avx512_core, avx2) || bm_conf_utils.is_bf32()
-                              || bm_conf_utils.is_tf32())
+                      one_of(isa, avx512_core, avx2) || bm_conf_utils.is_bf32())
             && IMPLICATION(bm_conf_utils.is_int8()
                             || bm_conf_utils.with_int8_grouped_quantization(),
                     is_superset(isa, avx512_core)
@@ -318,7 +317,6 @@ status_t check_datatype_cfg(const brgemm_matmul_conf_utils_t &bm_conf_utils) {
                       bm_conf_utils.is_f32_bf16(), bm_conf_utils.is_bf32(),
                       bm_conf_utils.is_f8(), bm_conf_utils.is_int8(),
                       bm_conf_utils.is_f4_via_convert(),
-                      bm_conf_utils.is_tf32(),
                       bm_conf_utils.is_bf16_with_int_wei(),
                       bm_conf_utils.is_bf16_fp8(), bm_conf_utils.is_f16_fp8(),
                       bm_conf_utils.is_f16_with_int_wei(),
@@ -353,9 +351,6 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
     , bf32_dt(f32_dt
               && one_of(attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any)
               && isa == avx512_core_amx)
-    , tf32_dt(f32_dt
-              && one_of(attr.fpmath_.mode_, fpmath_mode::tf32, fpmath_mode::any)
-              && isa == avx10_2_amx_2)
     , weights_decompression_support(one_of(bgmmc.wei_dt, u8, s8, u4, s4)
               && one_of(attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::f16,
                       fpmath_mode::strict, fpmath_mode::any)
@@ -742,7 +737,7 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_tags(memory_desc_t &A_md,
                     || this->is_bf16() || this->is_f32() || this->is_bf32()
                     || this->is_f16() || this->is_f32_f16()
                     || this->is_f32_bf16() || this->is_bf16_with_int_wei()
-                    || this->is_f16_with_int_wei() || this->is_tf32()
+                    || this->is_f16_with_int_wei()
                     || this->is_f32_with_int_wei() || this->is_bf16_fp8()
                     || this->is_f16_fp8();
             bgmmc.src_tag = is_adbc_allowed
@@ -877,7 +872,7 @@ format_tag_t brgemm_matmul_conf_utils_t::pick_blocked_B_layout(
 
     // Note: bf32 assumes f32 blocking
     if (is_f32() || is_bf32() || is_f16() || is_f32_f16() || is_f32_bf16()
-            || is_f16_with_int_wei() || is_tf32() || is_f32_with_int_wei()) {
+            || is_f16_with_int_wei() || is_f32_with_int_wei()) {
         switch (n_blk) {
             case 64: return bgmmc.ndims == 3 ? aCB16b64c : BA16a64b;
             case 48: return bgmmc.ndims == 3 ? aCB16b48c : BA16a48b;
@@ -1723,7 +1718,6 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         VCONDCHECK_BG(bgmmc.wei_dt == s8, VERBOSE_UNSUPPORTED_DT);
     }
     bgmmc.is_bf32 = bm_conf_utils.is_bf32();
-    bgmmc.is_tf32 = bm_conf_utils.is_tf32();
     bgmmc.is_bf16_with_int_wei = bm_conf_utils.is_bf16_with_int_wei();
     bgmmc.is_f16_with_int_wei = bm_conf_utils.is_f16_with_int_wei();
     bgmmc.is_f32_with_int_wei = bm_conf_utils.is_f32_with_int_wei();
@@ -2238,8 +2232,7 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     }
 
     const bool is_copy_a_required = !bgmmc.is_gemv
-            && ((bgmmc.is_amx
-                        && (bm_conf_utils.is_bf32() || bm_conf_utils.is_tf32()))
+            && ((bgmmc.is_amx && bm_conf_utils.is_bf32())
                     || ((bm_conf_utils.is_f16()
                                 || bm_conf_utils.is_f16_with_int_wei())
                             && isa == avx512_core_fp16)

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -243,7 +243,6 @@ struct brgemm_matmul_conf_t {
     bool is_xf16_fp8 = false;
     bool is_int4_weights = false;
     bool is_f4_via_convert = false;
-    bool is_tf32 = false;
     bool with_int8_grouped_quantization = false;
     // Enables the driver-side per-(M, N) f32 compensation tile that captures
     // the symmetric src/wei zero-point + 128-shift correction in the grouped
@@ -375,7 +374,6 @@ struct brgemm_matmul_conf_utils_t {
             // use b_buffer for AMX when:
             // - not bf32 && using non-blocked weights
             // - is bf32
-            // - is tf32
             return IMPLICATION(!wei_down_convert_to_vnni(), !bgmmc.blocked_B)
                     || bgmmc.packed_sparse_weights;
 
@@ -451,8 +449,6 @@ struct brgemm_matmul_conf_utils_t {
 
     inline bool is_bf32() const { return bf32_dt; }
 
-    inline bool is_tf32() const { return tf32_dt; }
-
     inline bool is_bf16_with_int_wei() const { return bf16_with_int_wei_dt; }
 
     inline bool is_f32_f16() const { return f32_f16_dt; }
@@ -478,8 +474,7 @@ struct brgemm_matmul_conf_utils_t {
     }
 
     inline bool wei_down_convert_to_vnni() const {
-        return (bf32_dt || tf32_dt || f16_with_int_wei_dt
-                       || bf16_with_int_wei_dt)
+        return (bf32_dt || f16_with_int_wei_dt || bf16_with_int_wei_dt)
                 && get_blocked_B();
     }
 
@@ -509,7 +504,7 @@ private:
     brgemm_matmul_conf_t &bgmmc;
 
     const bool f32_dt, bf16_dt, f16_dt, f4_via_convert_dt, f8_dt, bf8_dt,
-            int8_dt, bf32_dt, tf32_dt;
+            int8_dt, bf32_dt;
     const bool weights_decompression_support, bf16_with_int_wei_dt, f32_f16_dt,
             f32_bf16_dt, f16_with_int_wei_dt, f32_with_int_wei_dt,
             int8_grouped_quantization_dt, bf16_fp8_dt, f16_fp8_dt;


### PR DESCRIPTION
This implements MFDNN-15401.

The tf32-AMX path was added in anticipation of tf32 support on DMR.
It was decided not to support tf32, so the path is removed. It was
dispatched for f32 problems when `fpmath_mode=tf32` (or `any`) was set.

CPU-only removal: `fpmath_mode::tf32` stays in the public API and on GPU.

On x64 CPU `fpmath_mode::tf32` is now ignored and the computation runs
in f32. The mode is still accepted, so there is no API change and no
new error. `fpmath_mode::any` on `avx10_2_amx_2` hardware would now
pick bf32 instead of tf32.

The tf32 cases in the benchdnn inputs are kept as is, so conv, deconv, matmul
and rnn still validate the mode after the removal.