### PR TITLE
xe: sdpa: reduce bwd SLM usage

### DIFF
--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -751,41 +751,46 @@ static std::vector<bwd_config_record_t> sorted_bwd_configs = []() {
     // clang-format off
     std::vector<bwd_config_record_t> configs = {
         // xe_hpc
-        {{compute::gpu_arch_t::xe_hpc, 32},  { 16, 16, 16, 16, 16, 16, 2, 16, 2, 2, 2, 16 }},
-        {{compute::gpu_arch_t::xe_hpc, 32, 128},  { 16, 16, 16, 16, 16, 16, 2, 4, 2, 2, 2, 4 }},
+        {{compute::gpu_arch_t::xe_hpc, 32},      { 16, 16, 16, 16, 16, 16, 2, 2, 2, 2, 2, 2 }},
+        {{compute::gpu_arch_t::xe_hpc, 32, 128}, { 16, 16, 16, 16, 16, 16, 2, 8, 2, 2, 2, 8 }},
+        {{compute::gpu_arch_t::xe_hpc, 32, 256}, { 16, 16, 16, 16, 16, 16, 2, 8, 2, 2, 2, 8 }},
 
-        {{compute::gpu_arch_t::xe_hpc, 64},  { 16, 32, 16, 16, 32, 32, 2, 16, 4, 2, 2, 16 }},
-        {{compute::gpu_arch_t::xe_hpc, 64, 64},   { 16, 16, 16, 16, 16, 32, 2, 4, 4, 2, 4, 2 }},
-        {{compute::gpu_arch_t::xe_hpc, 64, 77},   { 16, 16, 16, 16, 32, 32, 1, 8, 4, 1, 2, 4 }},
-        {{compute::gpu_arch_t::xe_hpc, 64, 128},  { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
+        {{compute::gpu_arch_t::xe_hpc, 64},      { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
+        {{compute::gpu_arch_t::xe_hpc, 64, 49},  { 16, 16, 16, 16, 16, 16, 4, 8, 4, 4, 4, 8 }},
+        {{compute::gpu_arch_t::xe_hpc, 64, 256}, { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
 
-        {{compute::gpu_arch_t::xe_hpc, 128}, { 16, 16, 16, 16, 32, 32, 2, 8, 8, 2, 4, 4 }},
-        //{{compute::gpu_arch_t::xe_hpc, 256}, {  16, 32, 16, 16, 32, 32, 4, 8, 8, 4, 4, 8 }},
+        {{compute::gpu_arch_t::xe_hpc, 88},      { 16, 16, 16, 16, 16, 32, 4, 8, 8, 4, 8, 4 }},
+
+        {{compute::gpu_arch_t::xe_hpc, 128},      { 16, 16, 16, 16, 16, 32, 4, 8, 8, 4, 8, 4 }},
+        {{compute::gpu_arch_t::xe_hpc, 128, 256}, { 16, 16, 16, 32, 32, 32, 2, 4, 8, 1, 4, 2 }},
+        {{compute::gpu_arch_t::xe_hpc, 128, 320}, { 16, 16, 32, 16, 32, 16, 4, 4, 4, 4, 4, 4 }},
 
         {{compute::gpu_arch_t::xe_hpc, 32, second_token},  { 16, 16, 16, 16, 32, 16, 1, 2, 2, 1, 1, 2 }},
         {{compute::gpu_arch_t::xe_hpc, 64, second_token},  { 32, 16, 16, 32, 32, 32, 1, 4, 4, 1, 2, 2 }},
         {{compute::gpu_arch_t::xe_hpc, 128, second_token}, { 16, 16, 16, 16, 32, 32, 2, 8, 8, 2, 4, 4 }},
-        //{{compute::gpu_arch_t::xe_hpc, 256, second_token}, {  16, 16, 16, 16, 32, 32, 2, 8, 8, 2, 4, 4 }},
 
         {{compute::gpu_arch_t::xe_hpc,  32, f32 | fma},  { 32, 32, 16, 16, 32, 32, 1, 4, 2, 2, 1, 4 }},
         {{compute::gpu_arch_t::xe_hpc,  64, f32 | fma},  { 16, 32, 16, 16, 16, 32, 4, 4, 4, 4, 4, 4 }},
         {{compute::gpu_arch_t::xe_hpc, 128, f32 | fma},  { 16, 16, 16, 32, 32, 32, 2, 4, 8, 1, 4, 2 }},
 
+        // xe2
+        {{compute::gpu_arch_t::xe2, 32},       { 16, 16, 16, 16, 16, 16, 2, 4, 2, 2, 2, 4 }},
+        {{compute::gpu_arch_t::xe2, 32, 128},  { 16, 16, 16, 16, 16, 16, 2, 4, 2, 2, 2, 4 }},
+
+        {{compute::gpu_arch_t::xe2, 64},       { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
+        {{compute::gpu_arch_t::xe2, 64, 64},   { 16, 16, 16, 32, 16, 32, 2, 2, 4, 1, 4, 1 }},
+        {{compute::gpu_arch_t::xe2, 64, 128},  { 16, 16, 16, 16, 16, 32, 2, 4, 4, 2, 4, 2 }},
+        {{compute::gpu_arch_t::xe2, 64, 320},  { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
+
+        {{compute::gpu_arch_t::xe2, 88},       { 16, 16, 16, 32, 32, 32, 2, 4, 8, 1, 4, 2 }},
+
+        {{compute::gpu_arch_t::xe2, 128},      { 16, 16, 32, 16, 32, 32, 2, 4, 4, 2, 4, 2 }},
+        {{compute::gpu_arch_t::xe2, 128, 256}, { 16, 16, 16, 32, 32, 32, 2, 8, 8, 1, 4, 4 }},
+
         {{compute::gpu_arch_t::xe2, 32, integrated},  { 16, 64, 16, 16, 32, 32, 2, 2, 2, 2, 1, 4 }},
         {{compute::gpu_arch_t::xe2, 64, integrated},  { 16, 32, 16, 16, 32, 32, 2, 4, 4, 2, 2, 4 }},
         {{compute::gpu_arch_t::xe2, 128, integrated}, { 16, 32, 16, 16, 32, 32, 4, 8, 8, 4, 4, 8 }},
 
-        {{compute::gpu_arch_t::xe2, 32},       { 16, 64, 16, 16, 32, 32, 2, 2, 2, 2, 1, 4 }},
-        {{compute::gpu_arch_t::xe2, 32, 128},  { 16, 16, 16, 16, 16, 16, 4, 4, 2, 4, 2, 4 }},
-        {{compute::gpu_arch_t::xe2, 32, 196},  { 16, 16, 16, 16, 16, 32, 1, 2, 2, 1, 2, 1 }},
-        {{compute::gpu_arch_t::xe2, 64},  { 16, 32, 16, 16, 32, 32, 2, 4, 4, 2, 2, 4 }},
-        {{compute::gpu_arch_t::xe2, 64, 50},   { 16, 16, 16, 16, 32, 32, 1, 4, 4, 1, 2, 2 }},
-        {{compute::gpu_arch_t::xe2, 64, 64},   { 16, 16, 16, 32, 32, 32, 2, 4, 4, 1, 2, 2}},
-        {{compute::gpu_arch_t::xe2, 64, 65},   { 16, 16, 16, 16, 16, 32, 2, 4, 4, 2, 4, 2 }},
-        {{compute::gpu_arch_t::xe2, 64, 128},  { 16, 16, 32, 32, 16, 16, 4, 4, 2, 2, 4, 4 }},
-        {{compute::gpu_arch_t::xe2, 64, 512},  { 16, 16, 16, 32, 16, 16, 4, 4, 4, 2, 4, 4 }},
-        {{compute::gpu_arch_t::xe2, 88},  { 16, 16, 16, 32, 32, 32, 2, 8, 8, 1, 4, 4 }},
-        {{compute::gpu_arch_t::xe2, 128}, { 16, 16, 16, 16, 32, 32, 2, 8, 8, 2, 4, 4 }},
     };
     // clang-format on
 
@@ -796,15 +801,21 @@ static std::vector<bwd_config_record_t> sorted_bwd_configs = []() {
 
 bwd_config_t *choose_bwd_config(compute::gpu_arch_t arch, dim_t head_size,
         dim_t qry, dim_t seq, bool is_thin_q, bool is_quantized,
-        bool is_integrated, bool is_fma, bool is_f32) {
+        bool is_integrated, bool is_fma, bool is_f32, bool is_causal) {
     // limit configs to tuned architectures and problem sizes
     if (arch >= compute::gpu_arch_t::xe3) return nullptr;
     if (compute::gpu_arch_t::xe2 == arch && is_integrated) return nullptr;
-    if (compute::gpu_arch_t::xe2 == arch
-            && (seq == qry && seq <= 128 && head_size >= 64)) {
+
+    if (compute::gpu_arch_t::xe2 == arch && !is_causal
+            && (head_size >= 64 && std::min(qry, seq) <= head_size)) {
         return nullptr;
     }
-    if (arch == compute::gpu_arch_t::xe_hpc && (qry < 256 && head_size > 32)) {
+
+    // primitives based bwd pass is empirically faster below this qry * seq area
+    // the fused kernel wins in all cases for head_size <= 32
+    static constexpr dim_t xe_hpc_bwd_min_fused_area = 128 * 192;
+    if (arch == compute::gpu_arch_t::xe_hpc && !is_causal && head_size > 32
+            && qry * seq < xe_hpc_bwd_min_fused_area) {
         return nullptr;
     }
 

--- a/src/gpu/intel/sdpa/configs.cpp
+++ b/src/gpu/intel/sdpa/configs.cpp
@@ -756,7 +756,7 @@ static std::vector<bwd_config_record_t> sorted_bwd_configs = []() {
         {{compute::gpu_arch_t::xe_hpc, 32, 256}, { 16, 16, 16, 16, 16, 16, 2, 8, 2, 2, 2, 8 }},
 
         {{compute::gpu_arch_t::xe_hpc, 64},      { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
-        {{compute::gpu_arch_t::xe_hpc, 64, 49},  { 16, 16, 16, 16, 16, 16, 4, 8, 4, 4, 4, 8 }},
+        {{compute::gpu_arch_t::xe_hpc, 64, 49},  { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
         {{compute::gpu_arch_t::xe_hpc, 64, 256}, { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
 
         {{compute::gpu_arch_t::xe_hpc, 88},      { 16, 16, 16, 16, 16, 32, 4, 8, 8, 4, 8, 4 }},
@@ -778,7 +778,7 @@ static std::vector<bwd_config_record_t> sorted_bwd_configs = []() {
         {{compute::gpu_arch_t::xe2, 32, 128},  { 16, 16, 16, 16, 16, 16, 2, 4, 2, 2, 2, 4 }},
 
         {{compute::gpu_arch_t::xe2, 64},       { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
-        {{compute::gpu_arch_t::xe2, 64, 64},   { 16, 16, 16, 32, 16, 32, 2, 2, 4, 1, 4, 1 }},
+        {{compute::gpu_arch_t::xe2, 64, 64},   { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
         {{compute::gpu_arch_t::xe2, 64, 128},  { 16, 16, 16, 16, 16, 32, 2, 4, 4, 2, 4, 2 }},
         {{compute::gpu_arch_t::xe2, 64, 320},  { 16, 16, 16, 16, 16, 16, 4, 4, 4, 4, 4, 4 }},
 
@@ -800,22 +800,15 @@ static std::vector<bwd_config_record_t> sorted_bwd_configs = []() {
 }();
 
 bwd_config_t *choose_bwd_config(compute::gpu_arch_t arch, dim_t head_size,
-        dim_t qry, dim_t seq, bool is_thin_q, bool is_quantized,
-        bool is_integrated, bool is_fma, bool is_f32, bool is_causal) {
+        dim_t qry, dim_t seq, dim_t batch_heads, bool is_thin_q,
+        bool is_quantized, bool is_integrated, bool is_fma, bool is_f32,
+        bool is_causal) {
     // limit configs to tuned architectures and problem sizes
     if (arch >= compute::gpu_arch_t::xe3) return nullptr;
     if (compute::gpu_arch_t::xe2 == arch && is_integrated) return nullptr;
 
     if (compute::gpu_arch_t::xe2 == arch && !is_causal
             && (head_size >= 64 && std::min(qry, seq) <= head_size)) {
-        return nullptr;
-    }
-
-    // primitives based bwd pass is empirically faster below this qry * seq area
-    // the fused kernel wins in all cases for head_size <= 32
-    static constexpr dim_t xe_hpc_bwd_min_fused_area = 128 * 192;
-    if (arch == compute::gpu_arch_t::xe_hpc && !is_causal && head_size > 32
-            && qry * seq < xe_hpc_bwd_min_fused_area) {
         return nullptr;
     }
 
@@ -827,6 +820,32 @@ bwd_config_t *choose_bwd_config(compute::gpu_arch_t arch, dim_t head_size,
             static_cast<int>(seq), query_properties);
     auto it = find(begin(sorted_bwd_configs), end(sorted_bwd_configs), query);
     if (it != end(sorted_bwd_configs)) {
+        // Primitive-based backward is generally faster for small problems.
+        // Direct dQ and fully occupied tiles lower that crossover for
+        // sufficiently parallel Xe HPC configurations.
+        static constexpr dim_t xe_hpc_bwd_min_fused_area = 128 * 192;
+        static constexpr dim_t xe_hpc_bwd_min_batch_heads = 256;
+        static constexpr dim_t xe_hpc_bwd_min_main_wgs = 2048;
+        if (arch == compute::gpu_arch_t::xe_hpc && head_size > 32) {
+            const auto &config = it->config;
+            const dim_t tile_k = config.unroll_m_BcBr * config.wg_m_BcBr;
+            const dim_t tile_q = config.unroll_n_BcBr * config.wg_n_BcBr;
+            const dim_t tile_d = config.unroll_m_DBc * config.wg_m_DBc;
+            const bool large_problem = qry * seq >= xe_hpc_bwd_min_fused_area;
+            const bool full_d64 = head_size <= 64 && head_size == tile_d;
+            const bool efficient_direct_dq = full_d64 && !is_thin_q
+                    && seq <= tile_k && tile_q <= 64
+                    && batch_heads >= xe_hpc_bwd_min_batch_heads;
+            const dim_t key_blocks = utils::div_up(seq, tile_k);
+            const bool efficient_full_tiles = full_d64 && !is_thin_q
+                    && seq % tile_k == 0 && qry % tile_q == 0
+                    && batch_heads * key_blocks >= xe_hpc_bwd_min_main_wgs;
+            const bool efficient_small_problem = is_causal
+                    ? !is_thin_q
+                    : efficient_direct_dq || efficient_full_tiles;
+            if (!large_problem && !efficient_small_problem) return nullptr;
+        }
+
         VDEBUGINFO(4, primitive, sdpa,
                 "bwd config search: {query %s} -> {%s config:%s},",
                 to_string(query).c_str(), to_string(it->criteria).c_str(),

--- a/src/gpu/intel/sdpa/configs.hpp
+++ b/src/gpu/intel/sdpa/configs.hpp
@@ -123,8 +123,9 @@ fwd_config_t *choose_config(compute::gpu_arch_t arch, dim_t head_size,
         dim_t seq, bool is_thin_q, bool is_quantized, bool is_integrated,
         bool is_fma, bool is_f32, bool is_f16_accumulate);
 bwd_config_t *choose_bwd_config(compute::gpu_arch_t arch, dim_t head_size,
-        dim_t qry, dim_t seq, bool is_thin_q, bool is_quantized,
-        bool is_integrated, bool is_fma, bool is_f32, bool is_causal);
+        dim_t qry, dim_t seq, dim_t batch_heads, bool is_thin_q,
+        bool is_quantized, bool is_integrated, bool is_fma, bool is_f32,
+        bool is_causal);
 dim_t round_up_seq_interval(dim_t seq, compute::gpu_arch_t arch);
 
 dim_t nearest_conf_seq_interval(compute::gpu_arch_t arch, dim_t head_size,

--- a/src/gpu/intel/sdpa/configs.hpp
+++ b/src/gpu/intel/sdpa/configs.hpp
@@ -124,7 +124,7 @@ fwd_config_t *choose_config(compute::gpu_arch_t arch, dim_t head_size,
         bool is_fma, bool is_f32, bool is_f16_accumulate);
 bwd_config_t *choose_bwd_config(compute::gpu_arch_t arch, dim_t head_size,
         dim_t qry, dim_t seq, bool is_thin_q, bool is_quantized,
-        bool is_integrated, bool is_fma, bool is_f32);
+        bool is_integrated, bool is_fma, bool is_f32, bool is_causal);
 dim_t round_up_seq_interval(dim_t seq, compute::gpu_arch_t arch);
 
 dim_t nearest_conf_seq_interval(compute::gpu_arch_t arch, dim_t head_size,

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -446,9 +446,10 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(
     bool is_f32 = (desc()->qry_md()->data_type == data_type::f32);
 
     bool use_fma_config = !use_systolic_ukernel_;
+    const dim_t batch_heads = d->batch() * d->num_q_heads();
     config = choose_bwd_config(arch_, d->head_size(), d->queries(), d->keys(),
-            thin_q, quantized, is_integrated, use_fma_config, is_f32,
-            with_causal_mask());
+            batch_heads, thin_q, quantized, is_integrated, use_fma_config,
+            is_f32, with_causal_mask());
 
     VDISPATCH_SDPA(config != nullptr,
             "No suitable kernel configuration found for the given problem "
@@ -1025,6 +1026,14 @@ status_t micro_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
         conf.block_dV = (ldv % 4 == 0) && (dv_full);
     }
 
+    // check if dQ can be computed without atomics
+    {
+        const memory_desc_wrapper diff_qry_mdw(desc()->diff_qry_md());
+        const bool single_k_block = (desc()->keys() <= tile_k);
+        conf.direct_dQ = single_k_block && diff_qry_mdw.is_plain()
+                && diff_qry_mdw.strides()[3] == 1;
+    }
+
     return status::success;
 }
 
@@ -1035,7 +1044,7 @@ status_t micro_bwd_t::pd_t::init_scratchpad(const impl::engine_t *engine) {
     size_t wspace_size = memory_desc_wrapper(desc()->diff_qry_md()).nelems();
     // f32 can directly atomic add to output
     // others need intermediate scratchpad before conversion
-    if (conf.data_t != data_type::f32) {
+    if (conf.data_t != data_type::f32 && !conf.direct_dQ) {
         scratchpad.book(memory_tracking::names::key_sdpa_dQ_reduction,
                 wspace_size, sizeof(float), gpu_align);
     }
@@ -1326,6 +1335,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     kernel_ctx.define_int("BLOCK_DV", block_dV);
     kernel_ctx.define_int("BLOCK_K", block_k);
     kernel_ctx.define_int("K_IN_SLM", k_in_slm);
+    kernel_ctx.define_int("DIRECT_DQ", direct_dQ);
 
     kernel_ctx.define_int("USE_SYSTOLIC_UKERNEL", use_systolic_ukernel);
     kernel_ctx.define_int("WITH_DROPOUT", dropout);
@@ -1744,10 +1754,16 @@ status_t micro_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
     const dim_t D = pd()->desc()->head_size();
 
     const data_type_t data_t = pd()->dst_md()->data_type;
-    const bool needs_intermediate_dQ = (data_t != data_type::f32);
+    const bool direct_dQ = pd()->conf.direct_dQ;
+    const bool needs_intermediate_dQ = (data_t != data_type::f32) && !direct_dQ;
     const bool needs_intermediate_dKV
             = (kv_group_size > 1 && data_t != data_type::f32);
     const bool needs_zero_dKV = (kv_group_size > 1);
+
+    const bool all_q_visited
+            = (pd()->desc()->mask_type != attn_mask_type::bottom_right)
+            || (Q <= K);
+    const bool needs_zero_dQ = !direct_dQ || !all_q_visited;
 
     const auto &conf = pd()->conf;
 
@@ -1886,7 +1902,6 @@ status_t micro_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
 
     auto *d = pd()->desc();
     // zero f32 intermediates before atomic adds in the main kernel
-    // dQ always needs atomics, dK/dV only for GQA cases
     {
         auto compute_stream = utils::downcast<intel::stream_t *>(ctx.stream());
         auto &fill_deps = compute_stream->ctx().get_deps();
@@ -1900,12 +1915,14 @@ status_t micro_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
             return compute_stream->fill(buf, 0, bytes, fill_deps, fill_deps);
         };
 
-        // always zero dQ
-        auto &dQ_buf = needs_intermediate_dQ ? *diff_q_scratch : diff_q;
-        const size_t dQ_bytes = needs_intermediate_dQ
-                ? size_t(batch * num_q_heads * Q * D) * sizeof(float)
-                : diff_qry_mdw.size();
-        CHECK(zero_fill(dQ_buf, dQ_bytes));
+        // zero dQ
+        if (needs_zero_dQ) {
+            auto &dQ_buf = needs_intermediate_dQ ? *diff_q_scratch : diff_q;
+            const size_t dQ_bytes = needs_intermediate_dQ
+                    ? size_t(batch * num_q_heads * Q * D) * sizeof(float)
+                    : diff_qry_mdw.size();
+            CHECK(zero_fill(dQ_buf, dQ_bytes));
+        }
 
         // zero dK/dV for GQA cases
         if (needs_zero_dKV) {

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -447,7 +447,8 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(
 
     bool use_fma_config = !use_systolic_ukernel_;
     config = choose_bwd_config(arch_, d->head_size(), d->queries(), d->keys(),
-            thin_q, quantized, is_integrated, use_fma_config, is_f32);
+            thin_q, quantized, is_integrated, use_fma_config, is_f32,
+            with_causal_mask());
 
     VDISPATCH_SDPA(config != nullptr,
             "No suitable kernel configuration found for the given problem "
@@ -595,11 +596,19 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(
             gemm_desc_t::get_ld(*desc()->key_md()) * key_mdw.data_type_size());
     auto ldq = static_cast<int>(
             gemm_desc_t::get_ld(*desc()->qry_md()) * qry_mdw.data_type_size());
-    problem_kq.A.setAlignment(64); // Q is packed in VNNI format in SLM
-    if (use_systolic_ukernel()) {
-        problem_kq.A.crosspack = 2;
-        problem_kq.A.tileR = into<uint16_t>(sg_size_);
-        problem_kq.A.tileC = into<uint16_t>(d_max());
+
+    conf.k_in_slm = !utils::one_of(
+            arch_, compute::gpu_arch_t::xe_hpc, compute::gpu_arch_t::xe2);
+    if (conf.k_in_slm) {
+        problem_kq.A.setAlignment(64); // K is packed in VNNI format in SLM
+        if (use_systolic_ukernel()) {
+            problem_kq.A.crosspack = 2;
+            problem_kq.A.tileR = into<uint16_t>(sg_size_);
+            problem_kq.A.tileC = into<uint16_t>(d_max());
+        }
+    } else {
+        problem_kq.A.layout = convert_dnnl_to_kernel_layout(desc()->key_md());
+        problem_kq.A.setAlignment(micro::alignmentForLD(int(ldk)));
     }
     problem_kq.B.setAlignment(micro::alignmentForLD(int(ldq)));
 
@@ -607,7 +616,7 @@ status_t micro_bwd_t::pd_t::init_conf_microkernels(
 
     /* Set up microkernel options */
     micro::GEMMOptions opts_kq;
-    opts_kq.localA = true;
+    opts_kq.localA = conf.k_in_slm;
     opts_kq.slmPtr = true;
     opts_kq.scaleA = false;
     opts_kq.offsetA = false;
@@ -1003,7 +1012,7 @@ status_t micro_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
     if (d_full) {
         bool can_block_load_k
                 = (ldk % 4 == 0) && (desc()->keys() % tile_k == 0);
-        conf.block_k = can_block_load_k;
+        conf.block_k = can_block_load_k && conf.k_in_slm;
         if (conf.transpose_k) {
             // tile_store_dK_t uses lddk = max(DK_S2, DK_S3)
             const memory_desc_wrapper dk_mdw(desc()->diff_key_md());
@@ -1313,9 +1322,10 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     kernel_ctx.define_int("SUBGROUP_SIZE", subgroup_size);
     kernel_ctx.define_int("D_MAX", d_max);
 
-    kernel_ctx.define_int("BLOCK_K", block_k);
     kernel_ctx.define_int("BLOCK_DK", block_dK);
     kernel_ctx.define_int("BLOCK_DV", block_dV);
+    kernel_ctx.define_int("BLOCK_K", block_k);
+    kernel_ctx.define_int("K_IN_SLM", k_in_slm);
 
     kernel_ctx.define_int("USE_SYSTOLIC_UKERNEL", use_systolic_ukernel);
     kernel_ctx.define_int("WITH_DROPOUT", dropout);

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -1025,6 +1025,14 @@ status_t micro_bwd_t::pd_t::init_conf(const impl::engine_t *engine) {
         conf.block_dV = (ldv % 4 == 0) && (dv_full);
     }
 
+    // check if dQ can be computed without atomics
+    {
+        const memory_desc_wrapper diff_qry_mdw(desc()->diff_qry_md());
+        const bool single_k_block = (desc()->keys() <= tile_k);
+        conf.direct_dQ = single_k_block && diff_qry_mdw.is_plain()
+                && diff_qry_mdw.strides()[3] == 1;
+    }
+
     return status::success;
 }
 
@@ -1035,7 +1043,7 @@ status_t micro_bwd_t::pd_t::init_scratchpad(const impl::engine_t *engine) {
     size_t wspace_size = memory_desc_wrapper(desc()->diff_qry_md()).nelems();
     // f32 can directly atomic add to output
     // others need intermediate scratchpad before conversion
-    if (conf.data_t != data_type::f32) {
+    if (conf.data_t != data_type::f32 && !conf.direct_dQ) {
         scratchpad.book(memory_tracking::names::key_sdpa_dQ_reduction,
                 wspace_size, sizeof(float), gpu_align);
     }
@@ -1326,6 +1334,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     kernel_ctx.define_int("BLOCK_DV", block_dV);
     kernel_ctx.define_int("BLOCK_K", block_k);
     kernel_ctx.define_int("K_IN_SLM", k_in_slm);
+    kernel_ctx.define_int("DIRECT_DQ", direct_dQ);
 
     kernel_ctx.define_int("USE_SYSTOLIC_UKERNEL", use_systolic_ukernel);
     kernel_ctx.define_int("WITH_DROPOUT", dropout);
@@ -1744,10 +1753,16 @@ status_t micro_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
     const dim_t D = pd()->desc()->head_size();
 
     const data_type_t data_t = pd()->dst_md()->data_type;
-    const bool needs_intermediate_dQ = (data_t != data_type::f32);
+    const bool direct_dQ = pd()->conf.direct_dQ;
+    const bool needs_intermediate_dQ = (data_t != data_type::f32) && !direct_dQ;
     const bool needs_intermediate_dKV
             = (kv_group_size > 1 && data_t != data_type::f32);
     const bool needs_zero_dKV = (kv_group_size > 1);
+
+    const bool all_q_visited
+            = (pd()->desc()->mask_type != attn_mask_type::bottom_right)
+            || (Q <= K);
+    const bool needs_zero_dQ = !direct_dQ || !all_q_visited;
 
     const auto &conf = pd()->conf;
 
@@ -1886,7 +1901,6 @@ status_t micro_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
 
     auto *d = pd()->desc();
     // zero f32 intermediates before atomic adds in the main kernel
-    // dQ always needs atomics, dK/dV only for GQA cases
     {
         auto compute_stream = utils::downcast<intel::stream_t *>(ctx.stream());
         auto &fill_deps = compute_stream->ctx().get_deps();
@@ -1900,12 +1914,14 @@ status_t micro_bwd_t::execute_backward(const exec_ctx_t &ctx) const {
             return compute_stream->fill(buf, 0, bytes, fill_deps, fill_deps);
         };
 
-        // always zero dQ
-        auto &dQ_buf = needs_intermediate_dQ ? *diff_q_scratch : diff_q;
-        const size_t dQ_bytes = needs_intermediate_dQ
-                ? size_t(batch * num_q_heads * Q * D) * sizeof(float)
-                : diff_qry_mdw.size();
-        CHECK(zero_fill(dQ_buf, dQ_bytes));
+        // zero dQ
+        if (needs_zero_dQ) {
+            auto &dQ_buf = needs_intermediate_dQ ? *diff_q_scratch : diff_q;
+            const size_t dQ_bytes = needs_intermediate_dQ
+                    ? size_t(batch * num_q_heads * Q * D) * sizeof(float)
+                    : diff_qry_mdw.size();
+            CHECK(zero_fill(dQ_buf, dQ_bytes));
+        }
 
         // zero dK/dV for GQA cases
         if (needs_zero_dKV) {

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -151,7 +151,8 @@ struct micro_bwd_params_t : trivially_serializable_t<micro_bwd_params_t> {
     bool require_stateless_addressing;
     bool dropout, dropout_output_mask, dropout_offset, dropout_host_scalars;
     bool k_in_slm;
-    uint8_t padding2[2] = {0};
+    bool direct_dQ;
+    uint8_t padding2[1] = {0};
 
     micro_bwd_ukernel_params_t ukernel_config;
 };

--- a/src/gpu/intel/sdpa/micro.hpp
+++ b/src/gpu/intel/sdpa/micro.hpp
@@ -150,7 +150,8 @@ struct micro_bwd_params_t : trivially_serializable_t<micro_bwd_params_t> {
     bool with_dS;
     bool require_stateless_addressing;
     bool dropout, dropout_output_mask, dropout_offset, dropout_host_scalars;
-    uint8_t padding2[3] = {0};
+    bool k_in_slm;
+    uint8_t padding2[2] = {0};
 
     micro_bwd_ukernel_params_t ukernel_config;
 };

--- a/src/gpu/intel/sdpa/micro_bwd.cl
+++ b/src/gpu/intel/sdpa/micro_bwd.cl
@@ -182,6 +182,7 @@ DECLARE_2D_TILE_COPY_REBLOCK(q_tile_type, SUBGROUP_SIZE, D_MAX, 1, 1,
         q_tile_sg_n, dq_tile_type, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n,
         CONVERT_TILE_FLOAT_FMA_T)
 
+#if K_IN_SLM
 #if TRANSPOSE_K
 
 #define k_tile_t_sg_n DIV_UP(ugemm_kq_wg_tile_m, sg_per_wg)
@@ -200,6 +201,7 @@ DECLARE_2D_TILE(k_tile_type, FMA_TYPE, SUBGROUP_SIZE, ugemm_kq_wg_tile_m, 1, 1,
 #if BLOCK_K
 DECLARE_2D_TILE_BLOCK_OPS(k_tile_type, FMA_TYPE, SUBGROUP_SIZE,
         ugemm_kq_wg_tile_m, 1, 1, dmax_tile_sg_n)
+#endif
 #endif
 #endif
 
@@ -296,6 +298,16 @@ DECLARE_2D_TILE_COPY_REBLOCK(s_tile_type, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
         ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
         ugemm_kq_c_type_nblock1, s_tile_type_reblock, SUBGROUP_SIZE,
         ugemm_kq_sg_tile_m, 1, 1, ugemm_kq_sg_tile_n, CONVERT_TILE_FMA_T)
+
+#define CONVERT_TILE_IDENT(v) (v)
+DECLARE_2D_TILE_COPY_REBLOCK(s_tile_type, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
+        ugemm_kq_c_type_block1, ugemm_kq_c_type_nblock0,
+        ugemm_kq_c_type_nblock1, p_tile_type, SUBGROUP_SIZE,
+        ugemm_vtdA_c_type_block0, ugemm_vtdA_c_type_block1,
+        ugemm_vtdA_c_type_nblock0, ugemm_vtdA_c_type_nblock1,
+        CONVERT_TILE_IDENT)
+#undef CONVERT_TILE_IDENT
+
 DECLARE_2D_TILE_COPY_REBLOCK(p_tile_type, SUBGROUP_SIZE,
         ugemm_vtdA_c_type_block0, ugemm_vtdA_c_type_block1,
         ugemm_vtdA_c_type_nblock0, ugemm_vtdA_c_type_nblock1,
@@ -377,6 +389,7 @@ DECLARE_2D_TILE_SLM_ADD_T(a_tile_type, float, SUBGROUP_SIZE,
 
 #define binary_add(x, y) ((x) + (y))
 
+#if K_IN_SLM
 inline void tile_load_k(k_tile_type *K_tile, const global KEY_DATA_T *K,
         int seq_len, int head_size, int ldk, int seq_off, int sg_ij,
         int load_rem) {
@@ -433,6 +446,7 @@ inline void tile_store_k_slm(
 
 #endif
 }
+#endif
 
 #if KV_GROUP_SIZE > 1
 #define IS_GQA 1
@@ -646,17 +660,20 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     uint sg_j_ktq = sg_ij / ugemm_ktq_sg_per_wg_m;
 
     /* SLM allocations -- place in one array to work around compiler bug */
+#if K_IN_SLM
 #define K_slm_size (ugemm_kq_wg_tile_m * D_MAX * sizeof(KEY_DATA_T))
-#define S_slm_size (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * sizeof(FMA_TYPE))
-#if USE_SYSTOLIC_UKERNEL || WITH_DROPOUT
-#define S2_f32_slm_size \
-    (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * sizeof(float))
 #else
-#define S2_f32_slm_size 0
+#define K_slm_size 0
+#endif
+#define S_slm_size (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * sizeof(FMA_TYPE))
+#if USE_SYSTOLIC_UKERNEL
+#define dSt_slm_size \
+    (ugemm_kq_wg_tile_m * ugemm_kq_wg_tile_n * sizeof(FMA_TYPE))
+#else
+#define dSt_slm_size 0
 #endif
 
 #define dK_slm_size (ugemm_kq_wg_tile_m * D_MAX * sizeof(float))
-#define dV_slm_size (ugemm_kq_wg_tile_m * D_MAX * sizeof(float))
 
 #define ugemm_slm_size \
     MAX(MAX(MAX(MAX(ugemm_kq_slm_size, ugemm_vs_slm_size), \
@@ -664,28 +681,26 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                 ugemm_qdSt_slm_size), \
             ugemm_ktq_slm_size)
 
-    local char slm[K_slm_size + S_slm_size + S2_f32_slm_size + ugemm_slm_size
-            + dK_slm_size + dV_slm_size];
+    local char slm[K_slm_size + S_slm_size + dSt_slm_size + ugemm_slm_size
+            + dK_slm_size];
 
+#if K_IN_SLM
     local KEY_DATA_T *K_slm = (local KEY_DATA_T *)&slm[0];
+#endif
 
     // S_slm, softmax for ugemm_vs also reused for dS
     local FMA_TYPE *S_slm = (local FMA_TYPE *)&slm[K_slm_size];
-#if USE_SYSTOLIC_UKERNEL || WITH_DROPOUT
-    // f32 softmax cache, reused for dS^t (systolic only)
-    // and un-dropped P for dS computation
-    local float *S2_f32_slm = (local float *)&slm[K_slm_size + S_slm_size];
+#if USE_SYSTOLIC_UKERNEL
+    local FMA_TYPE *dSt_slm = (local FMA_TYPE *)&slm[K_slm_size + S_slm_size];
 #endif
 
     // ugemm scratch space
     local uint *ugemm_slm
-            = (local uint *)&slm[K_slm_size + S_slm_size + S2_f32_slm_size];
+            = (local uint *)&slm[K_slm_size + S_slm_size + dSt_slm_size];
 
-    // used for accumulation of dV, dK across q-loop
+    // used for accumulation of dK across q-loop (dV accumulates in registers)
     local float *dK_slm = (local float *)&slm[K_slm_size + S_slm_size
-            + S2_f32_slm_size + ugemm_slm_size];
-    local float *dV_slm = (local float *)&slm[K_slm_size + S_slm_size
-            + S2_f32_slm_size + ugemm_slm_size + dK_slm_size];
+            + dSt_slm_size + ugemm_slm_size];
 
     const size_t k_offset = KEY_BATCH(b1, b0_kv);
     const size_t v_offset = VAL_BATCH(b1, b0_kv);
@@ -719,6 +734,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
             && mask_aligned;
 #endif
 
+#if K_IN_SLM
     if (qdiag0 < q0end) {
         /* Load K tile, destined for SLM */
         k_tile_type K_tile;
@@ -729,6 +745,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         /* Store K tile to SLM */
         tile_store_k_slm(&K_tile, K_slm, sg_ij);
     }
+#endif
 
     /* Load scale */
     float scale = 1.f;
@@ -773,8 +790,10 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     for (int i = get_local_id(0); i < ugemm_kq_wg_tile_m * D_MAX;
             i += get_local_size(0)) {
         dK_slm[i] = 0.f;
-        dV_slm[i] = 0.f;
     }
+
+    dv_tile_type dV_acc;
+    tile_fill(dV_acc, 0.0f);
 
     uint sg_i0_kq = sg_i_kq * ugemm_kq_sg_tile_m;
     uint sg_j0_kq = sg_j_kq * ugemm_kq_sg_tile_n;
@@ -794,9 +813,20 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         int q_nchunk = min(q0end - q0, ugemm_kq_wg_tile_n);
         /* Calculate S = (K^T) * Q */
 #if DO_MM
+#if K_IN_SLM
         s_tile_type S_tile = ugemm_kq(AS_KEY_SLM_TILE_PTR(K_slm), D_MAX,
                 AS_QRY_TILE_PTR(Q + q0 * ldq), ldq, k_chunk, q_nchunk, d, 0, 0,
                 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
+#else
+        s_tile_type S_tile = ugemm_kq(
+#if TRANSPOSE_K
+                AS_KEY_TILE_PTR(K + k0 * ldk),
+#else
+                AS_KEY_TILE_PTR(K + k0),
+#endif
+                ldk, AS_QRY_TILE_PTR(Q + q0 * ldq), ldq, k_chunk, q_nchunk, d,
+                0, 0, 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
+#endif
 #else
         s_tile_type S_tile;
 #endif
@@ -876,13 +906,10 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         tile_elementwise(S_tile, scaled_exp);
 #undef scaled_exp
 
+        s_tile_type S_stash;
         barrier(CLK_LOCAL_MEM_FENCE);
         {
-#if USE_SYSTOLIC_UKERNEL || WITH_DROPOUT
-            // store softmax in f32 for S2 reload (systolic only)
-            tile_store(S_tile, S2_f32_slm, ugemm_kq_wg_tile_m,
-                    ugemm_kq_wg_tile_n, ugemm_kq_wg_tile_m, sg_i0_kq, sg_j0_kq);
-#endif
+            S_stash = S_tile;
 
 #if WITH_DROPOUT
             /* P_dropped = P (dot) Z, used for dV GEMM */
@@ -924,7 +951,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 
             // accumulate dv tile to slm
             if (sg_ij < sg_per_wg_BcD) {
-                tile_slm_add(dV_tile1, dV_slm, D_MAX, sg_i0_vs, sg_j0_vs);
+                tile_binary(dV_acc, dV_tile1, binary_add);
             }
         }
 
@@ -949,20 +976,9 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         tile_hbroadcast_sub(&dP_tile,
                 D_i); // needs output to be transposed from vtdA layout.C = N
 
-        // reload softmax since ugemm_vtdA() clobbers registers
         {
             p_tile_type S2_tile;
-#if USE_SYSTOLIC_UKERNEL || WITH_DROPOUT
-            /* S2_f32_slm holds un-dropped P (stored before dropout). */
-            tile_load(&S2_tile, S2_f32_slm, ugemm_kq_wg_tile_m,
-                    ugemm_kq_wg_tile_n, ugemm_kq_wg_tile_m, sg_i0_kq, sg_j0_kq);
-#else
-            // reload from packed S_slm (or no dropout)
-            p_tile_type_reblock S2_tile_reblock;
-            tile_load_packed_src1(&S2_tile_reblock, S_slm, ugemm_vs_sg_tile_n,
-                    ugemm_kq_wg_tile_n, sg_i0_kq, sg_j0_kq);
-            tile_copy_reblock(S2_tile_reblock, &S2_tile);
-#endif
+            tile_copy_reblock(S_stash, &S2_tile);
             intel_work_group_barrier_arrive(CLK_LOCAL_MEM_FENCE);
 
 #define binary_mul_scale(x, y) ((x) * (y) * scale)
@@ -978,9 +994,6 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #undef gte_k
         }
 
-#if USE_SYSTOLIC_UKERNEL
-        local FMA_TYPE *dSt_slm = (local FMA_TYPE *)S2_f32_slm;
-#endif
         {
             p_tile_type_reblock P_tile_reblock;
             tile_copy_reblock(dP_tile, &P_tile_reblock);
@@ -1076,12 +1089,8 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     // ensure all loops done writing to SLM
     barrier(CLK_LOCAL_MEM_FENCE);
 
-    dv_tile_type dV_tile_slm;
-
     if (sg_ij < sg_per_wg_BcD) {
-        tile_load(&dV_tile_slm, dV_slm, D_MAX, ugemm_kq_wg_tile_m, D_MAX,
-                sg_i0_vs, sg_j0_vs);
-        tile_store_dV(&dV_tile_slm, dV, d, k, lddv, sg_i0_vs, wg_i0 + sg_j0_vs,
+        tile_store_dV(&dV_acc, dV, d, k, lddv, sg_i0_vs, wg_i0 + sg_j0_vs,
                 remainder_k);
     }
     // /update dV

--- a/src/gpu/intel/sdpa/micro_bwd.cl
+++ b/src/gpu/intel/sdpa/micro_bwd.cl
@@ -467,6 +467,13 @@ inline void tile_store_k_slm(
 #define DST_DATA_T_DKDV DST_DATA_T
 #endif
 
+#if DIRECT_DQ
+#define DST_DATA_T_DQ DST_DATA_T
+#else
+// needs intermediate f32 output before postprocess_dQ
+#define DST_DATA_T_DQ float
+#endif
+
 // round f32 intermediate values to DST_DATA_T precision before GQA atomic
 // accumulation. Although less accurate, it matches the unfused path
 // where each query group matmul output passes through DST_DATA_T
@@ -554,7 +561,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #if WITH_DS
         global DST_DATA_T *dS, // expensive, optional intermediate
 #endif
-        global DST_DATA_T_DKDV *dK, global float *dQ,
+        global DST_DATA_T_DKDV *dK, global DST_DATA_T_DQ *dQ,
         global DST_DATA_T_DKDV *dV,
 #if WITH_HOST_SCALE
         float scalar_scale, float inv_scalar_scale,
@@ -1060,9 +1067,8 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #endif
 
         {
-#if DO_MM
             ktq_tile_type dQ_tile;
-
+#if DO_MM
             dQ_tile = ugemm_ktq(
 #if TRANSPOSE_K
                     AS_KEY_TILE_PTR(K + k0 * ldk),
@@ -1071,14 +1077,20 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #endif
                     ldk, dSt_slm, ugemm_kq_wg_tile_m, d, q_nchunk, k_chunk, 0,
                     0, 0, sg_i_ktq, sg_j_ktq, (local char *)ugemm_slm);
-#else
-            ktq_tile_type dQ_tile;
 #endif
             uint sg_i0_dq = sg_i_ktq * ugemm_ktq_sg_tile_m;
             uint sg_j0_dq = sg_j_ktq * ugemm_ktq_sg_tile_n + q0;
 
+#if DIRECT_DQ
+            dq_tile_type_dst dQ_tile_dst;
+            tile_copy_reblock(dQ_tile, &dQ_tile_dst);
+            if (sg_ij < sg_per_wg_BrD)
+                tile_store(dQ_tile_dst, (global DST_TILE_DATA_T *)dQ, d, q,
+                        lddq, sg_i0_dq, sg_j0_dq);
+#else
             if (sg_ij < sg_per_wg_BrD)
                 tile_atomic_add(dQ_tile, dQ, d, q, lddq, sg_i0_dq, sg_j0_dq);
+#endif
         }
     }
 
@@ -1225,11 +1237,19 @@ postprocess_dQ(global DST_DATA_T *dst, global const float *src, int nelems,
     src += src_offset;
     dst += dst_offset;
     size_t idx = get_global_id(0);
-    if (idx < nelems) {
-        size_t row = idx / QRY_D3;
-        size_t col = idx % QRY_D3;
-        size_t src_idx = (size_t)row * DQ_S2 + col * DQ_S3;
-        size_t dst_idx = (size_t)row * QRY_S2 + col * QRY_S3;
+    if (idx >= (size_t)nelems) return;
+
+    const bool dense = (DQ_S3 == 1) && (QRY_S3 == 1) && (DQ_S2 == QRY_D3)
+            && (QRY_S2 == QRY_D3);
+    if (dense) {
+        dst[idx] = TO_DATA_T(src[idx]);
+    } else {
+        uint lin = (uint)idx;
+        uint ncols = (uint)QRY_D3;
+        uint row = lin / ncols;
+        uint col = lin - row * ncols;
+        size_t src_idx = (size_t)row * DQ_S2 + (size_t)col * DQ_S3;
+        size_t dst_idx = (size_t)row * QRY_S2 + (size_t)col * QRY_S3;
         dst[dst_idx] = TO_DATA_T(src[src_idx]);
     }
 }


### PR DESCRIPTION
# Description
This PR improves SDPA backwards performance though the reduction of SLM usage leading to better occupancy.  

PR #5434 removed the non-deterministic clobbering of registers now allowing tile lifetime to span multiple microkernel calls.
* For the backwards pass, this allows us to directly accumulate the dV tile in registers. 
* Also, the softmax tile doesn't need to be cached in SLM before reuse for the dS calculation since the V^t *dA microkernel won't clobber it anymore. 
*  SLM usage was further decreased by reloading the K tile in the first KQ-gemm directly from global memory. Although this tile was previously shared between all iterations of the q-loop the improved occupancy would make the reloads faster. 

Lowering the SLM resource demands then required re-evaluating previously inefficient configs against the new SLM budget, ultimately improving performance for a set of requested shapes as follows in the truncated table:
```
| problem | mintime_main | mintime_PR | Speedup |
| --- | --- | --- | --- |
| --mode=F --graph --engine=gpu --in-shapes=8:128x12x197x1+10:128x12x197x64+100:128x12x197x64+101:128x12x197x64+104:128x12x197x64+105:128x12x197x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 9.25456 | 1.69808 | 5.450014134 |
| --mode=F --graph --engine=gpu --in-shapes=8:256x4x197x1+10:256x4x197x64+100:256x4x197x64+101:256x4x197x64+104:256x4x197x64+105:256x4x197x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 5.8664 | 1.136 | 5.164084507 |
| --mode=F --graph --engine=gpu --in-shapes=8:64x12x198x1+10:64x12x198x64+100:64x12x198x64+101:64x12x198x64+104:64x12x198x64+105:64x12x198x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 4.28352 | 0.85232 | 5.02571804 |
| --mode=F --graph --engine=gpu --in-shapes=8:128x3x197x1+10:128x3x197x64+100:128x3x197x64+101:128x3x197x64+104:128x3x197x64+105:128x3x197x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 2.09328 | 0.456 | 4.590526316 |
| --mode=F --graph --engine=gpu --in-shapes=8:256x4x256x1+10:256x4x256x36+100:256x4x256x36+101:256x4x256x36+104:256x4x256x36+105:256x4x256x36 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 5.53424 | 1.24592 | 4.44189033 |
| --mode=F --graph --engine=gpu --in-shapes=8:32x6x197x1+10:32x6x197x64+100:32x6x197x64+101:32x6x197x64+104:32x6x197x64+105:32x6x197x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 1.06592 | 0.26464 | 4.027811366 |
| --mode=F --graph --engine=gpu --in-shapes=8:128x12x256x1+10:128x12x256x64+100:128x12x256x64+101:128x12x256x64+104:128x12x256x64+105:128x12x256x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 7.49104 | 1.9176 | 3.906466416 |
| --mode=F --graph --engine=gpu --in-shapes=8:256x4x256x1+10:256x4x256x36+100:256x4x256x36+101:256x4x256x36+103:1x1x256x256+104:256x4x256x36+105:256x4x256x36 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 6.06256 | 1.672 | 3.625933014 |
| --mode=F --graph --engine=gpu --in-shapes=8:64x16x128x1+10:64x16x128x64+100:64x16x128x64+101:64x16x128x64+104:64x16x128x64+105:64x16x128x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 1.67584 | 0.54112 | 3.096984033 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+103:f16+104:f16+105:f16 --in-shapes=8:256x4x256x1+10:256x4x256x36+100:256x4x256x36+101:256x4x256x36+103:1x1x256x256+104:256x4x256x36+105:256x4x256x36 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 5.85984 | 1.67136 | 3.506031017 |
| --mode=F --graph --engine=gpu --in-shapes=8:64x8x257x1+10:64x8x257x64+100:64x8x257x64+101:64x8x257x64+104:64x8x257x64+105:64x8x257x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 2.53152 | 0.77472 | 3.267657993 |
| --mode=F --graph --engine=gpu --in-shapes=8:128x12x256x1+10:128x12x256x64+100:128x12x256x64+101:128x12x256x64+103:1x1x256x256+104:128x12x256x64+105:128x12x256x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 8.46128 | 2.58944 | 3.267609985 |
| --mode=F --graph --engine=gpu --in-shapes=8:8x64x512x1+10:8x64x512x64+100:8x64x512x64+101:8x64x512x64+104:8x64x512x64+105:8x64x512x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 4.98416 | 1.58672 | 3.141171725 |
| --mode=F --graph --engine=gpu --in-shapes=8:4x64x512x1+10:4x64x512x64+100:4x64x512x64+101:4x64x512x64+104:4x64x512x64+105:4x64x512x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 2.4352 | 0.80016 | 3.043391322 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+103:f16+104:f16+105:f16 --in-shapes=8:128x12x256x1+10:128x12x256x64+100:128x12x256x64+101:128x12x256x64+103:1x1x256x256+104:128x12x256x64+105:128x12x256x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 7.99872 | 2.60064 | 3.07567368 |
| --mode=F --graph --engine=gpu --in-shapes=8:8x12x512x1+10:8x12x512x64+100:8x12x512x64+101:8x12x512x64+104:8x12x512x64+105:8x12x512x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 0.964 | 0.35488 | 2.716411181 |
| --mode=F --graph --engine=gpu --in-shapes=8:128x12x1370x1+10:128x12x1370x64+100:128x12x1370x64+101:128x12x1370x64+104:128x12x1370x64+105:128x12x1370x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 61.3648 | 23.0776 | 2.659063334 |
| --mode=F --graph --engine=gpu --in-shapes=8:64x4x962x1+10:64x4x962x64+100:64x4x962x64+101:64x4x962x64+104:64x4x962x64+105:64x4x962x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 5.89712 | 2.26048 | 2.608791053 |
| --mode=F --graph --engine=gpu --in-shapes=8:64x8x257x1+10:64x8x257x64+100:64x8x257x64+101:64x8x257x64+103:1x1x257x257+104:64x8x257x64+105:64x8x257x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 2.94816 | 1.16112 | 2.53906573 |
| --mode=F --graph --engine=gpu --in-shapes=8:4x16x1024x1+10:4x16x1024x64+100:4x16x1024x64+101:4x16x1024x64+104:4x16x1024x64+105:4x16x1024x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 1.56752 | 0.63408 | 2.472117083 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+104:f16+105:f16 --in-shapes=8:4x16x1024x1+10:4x16x1024x64+100:4x16x1024x64+101:4x16x1024x64+104:4x16x1024x64+105:4x16x1024x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 1.58096 | 0.6328 | 2.498356511 |
| --mode=F --graph --engine=gpu --in-shapes=8:256x4x401x1+10:256x4x401x32+100:256x4x401x32+101:256x4x401x32+104:256x4x401x32+105:256x4x401x32 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 3.42992 | 1.3928 | 2.462607697 |
| --mode=F --graph --engine=gpu --in-shapes=8:8x6x1500x1+10:8x6x1500x64+100:8x6x1500x64+101:8x6x1500x64+104:8x6x1500x64+105:8x6x1500x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 2.1752 | 0.91264 | 2.383415147 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+104:f16+105:f16 --in-shapes=8:32x16x128x1+10:32x16x128x64+100:32x16x128x64+101:32x16x128x64+104:32x16x128x64+105:32x16x128x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 0.67472 | 0.30352 | 2.222983658 |
| --mode=F --graph --engine=gpu --in-shapes=8:32x16x128x1+10:32x16x128x64+100:32x16x128x64+101:32x16x128x64+104:32x16x128x64+105:32x16x128x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 0.68128 | 0.30208 | 2.25529661 |
| --mode=F --graph --engine=gpu --in-shapes=8:1x32x1000x1+10:1x32x1000x64+100:1x32x1000x64+101:1x32x1000x64+104:1x32x1000x64+105:1x32x1000x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 0.82864 | 0.39136 | 2.117334424 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+104:f16+105:f16 --in-shapes=8:2x12x2048x1+10:2x12x2048x64+100:2x12x2048x64+101:2x12x2048x64+104:2x12x2048x64+105:2x12x2048x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 1.70848 | 0.80176 | 2.130911994 |
| --mode=F --graph --engine=gpu --in-shapes=8:2x12x2048x1+10:2x12x2048x64+100:2x12x2048x64+101:2x12x2048x64+104:2x12x2048x64+105:2x12x2048x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 1.69776 | 0.8088 | 2.099109792 |
| --mode=F --graph --engine=gpu --in-shapes=8:128x12x1370x1+10:128x12x1370x64+100:128x12x1370x64+101:128x12x1370x64+103:1x1x1370x1370+104:128x12x1370x64+105:128x12x1370x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 108.084 | 52.4147 | 2.062093268 |
| --mode=F --graph --engine=gpu --in-shapes=8:4x64x512x1+10:4x64x512x64+100:4x64x512x64+101:4x64x512x64+103:1x1x512x512+104:4x64x512x64+105:4x64x512x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 2.90048 | 1.41632 | 2.04789878 |
| --mode=F --graph --engine=gpu --in-shapes=8:8x64x512x1+10:8x64x512x64+100:8x64x512x64+101:8x64x512x64+103:1x1x512x512+104:8x64x512x64+105:8x64x512x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 5.87872 | 2.91312 | 2.018015049 |
| --mode=F --graph --engine=gpu --in-shapes=8:8x12x512x1+10:8x12x512x64+100:8x12x512x64+101:8x12x512x64+103:1x1x512x512+104:8x12x512x64+105:8x12x512x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 1.1352 | 0.56256 | 2.017918089 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+103:f16+104:f16+105:f16 --in-shapes=8:128x12x1370x1+10:128x12x1370x64+100:128x12x1370x64+101:128x12x1370x64+103:1x1x1370x1370+104:128x12x1370x64+105:128x12x1370x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 107.502 | 52.939 | 2.030676817 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+103:f16+104:f16+105:f16 --in-shapes=8:4x64x512x1+10:4x64x512x64+100:4x64x512x64+101:4x64x512x64+103:1x1x512x512+104:4x64x512x64+105:4x64x512x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 2.83824 | 1.42448 | 1.992474447 |
| --mode=F --graph --engine=gpu --in-shapes=8:1x32x1000x1+10:1x32x1000x64+100:1x32x1000x64+101:1x32x1000x64+103:1x1x1000x1000+104:1x32x1000x64+105:1x32x1000x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 1.28 | 0.65344 | 1.958863859 |
| --mode=F --graph --engine=gpu --in-shapes=8:128x12x197x1+10:128x12x197x64+100:128x12x197x64+101:128x12x197x64+103:1x1x197x197+104:128x12x197x64+105:128x12x197x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 4.61296 | 2.27408 | 2.02849504 |
| --mode=F --graph --engine=gpu --in-shapes=8:64x4x962x1+10:64x4x962x64+100:64x4x962x64+101:64x4x962x64+103:1x1x962x962+104:64x4x962x64+105:64x4x962x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 8.89072 | 4.77424 | 1.862227286 |
| --mode=F --graph --engine=gpu --in-shapes=8:256x4x197x1+10:256x4x197x64+100:256x4x197x64+101:256x4x197x64+103:1x1x197x197+104:256x4x197x64+105:256x4x197x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 2.79168 | 1.51232 | 1.845958527 |
| --mode=F --graph --engine=gpu --in-shapes=8:32x8x77x1+10:32x8x77x64+100:32x8x77x64+101:32x8x77x64+104:32x8x77x64+105:32x8x77x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 0.28496 | 0.16096 | 1.770377734 |
| --mode=F --graph --engine=gpu --in-shapes=8:4x16x1024x1+10:4x16x1024x64+100:4x16x1024x64+101:4x16x1024x64+103:1x1x1024x1024+104:4x16x1024x64+105:4x16x1024x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 2.27552 | 1.21808 | 1.868120321 |
| --mode=F --graph --engine=gpu --in-shapes=8:128x1x3136x1+10:128x1x3136x64+100:128x1x3136x64+101:128x1x49x64+103:1x1x3136x49+104:128x1x49x64+105:128x1x3136x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 2.29552 | 1.2456 | 1.842903019 |
| --mode=F --graph --engine=gpu --in-shapes=8:8x6x1500x1+10:8x6x1500x64+100:8x6x1500x64+101:8x6x1500x64+103:1x1x1500x1500+104:8x6x1500x64+105:8x6x1500x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 3.7952 | 2.06112 | 1.841328986 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+104:f16+105:f16 --in-shapes=8:32x8x77x1+10:32x8x77x64+100:32x8x77x64+101:32x8x77x64+104:32x8x77x64+105:32x8x77x64 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 0.27904 | 0.16288 | 1.713163065 |
| --mode=F --graph --engine=gpu --dt=10:f16+12:f16+13:f16+28:f16+29:f16+31:f16+100:f16+101:f16+102:f16+103:f16+104:f16+105:f16 --in-shapes=8:64x12x198x1+10:64x12x198x64+100:64x12x198x64+101:64x12x198x64+103:1x1x198x198+104:64x12x198x64+105:64x12x198x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 1.99728 | 1.15008 | 1.736644407 |
| --mode=F --graph --engine=gpu --in-shapes=8:64x12x198x1+10:64x12x198x64+100:64x12x198x64+101:64x12x198x64+103:1x1x198x198+104:64x12x198x64+105:64x12x198x64 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 1.91728 | 1.13904 | 1.683242028 |
| --mode=F --graph --engine=gpu --in-shapes=8:256x4x401x1+10:256x4x401x32+100:256x4x401x32+101:256x4x401x32+103:1x1x401x401+104:256x4x401x32+105:256x4x401x32 --case=complex_fusion/mha/sdpa-plain-training-backward-bf16-f32.json | 5.19776 | 2.93056 | 1.773640533 |
| --mode=F --graph --engine=gpu --in-shapes=8:128x12x196x1+10:128x12x196x32+100:128x12x196x32+101:128x12x196x32+104:128x12x196x32+105:128x12x196x32 --case=complex_fusion/mha/sdpa-plain-training-backward-implicit-causal-mask-bf16-f32.json | 2.22176 | 1.27008 | 1.74930713 |
```

Addresses MFDNN-14965.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [X] Have you formatted the code using clang-format?

## Performance improvements

- [X] Have you submitted performance data that demonstrates performance improvements?

