### PR TITLE
graph: backend: dnnl: kernels: add decomp kernel for sdpa training fwd

### DIFF
--- a/src/graph/backend/dnnl/kernels/sdp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp.hpp
@@ -26,6 +26,7 @@
 #include "graph/backend/dnnl/kernels/kernel_base.hpp"
 #include "graph/backend/dnnl/kernels/large_partition.hpp"
 #include "graph/backend/dnnl/kernels/sdp_decomp.hpp"
+#include "graph/backend/dnnl/kernels/sdp_decomp_training.hpp"
 #include "graph/backend/dnnl/kernels/sdp_primitive.hpp"
 
 #include "graph/backend/dnnl/dnnl_partition_impl.hpp"
@@ -65,11 +66,18 @@ public:
                 ret = kernel->compile_impl(part, eng, inputs, outputs);
             }
 
+            // TODO(xxx): merge with the decomp kernel above.
+            if (ret != status::success) {
+                kernel = std::make_shared<sdp_decomp_training_kernel_t>();
+                ret = kernel->compile_impl(part, eng, inputs, outputs);
+            }
+
             if (ret != status::success) {
                 kernel = std::make_shared<larger_partition_kernel_t>();
                 ret = kernel->compile_impl(part, eng, inputs, outputs);
             }
         }
+
         if (ret == status::success)
             VDISPATCH_GRAPH_SDP(
                     "sdpa is dispatched to %s", kernel->str().c_str());

--- a/src/graph/backend/dnnl/kernels/sdp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp.hpp
@@ -26,6 +26,7 @@
 #include "graph/backend/dnnl/kernels/kernel_base.hpp"
 #include "graph/backend/dnnl/kernels/large_partition.hpp"
 #include "graph/backend/dnnl/kernels/sdp_decomp.hpp"
+#include "graph/backend/dnnl/kernels/sdp_decomp_training.hpp"
 #include "graph/backend/dnnl/kernels/sdp_primitive.hpp"
 
 #include "graph/backend/dnnl/dnnl_partition_impl.hpp"
@@ -71,6 +72,12 @@ public:
 
         if (ret != status::success && enable_decomp) {
             kernel = std::make_shared<sdp_decomp_kernel_t<quantized, dt>>();
+            ret = kernel->compile_impl(part, eng, inputs, outputs);
+        }
+
+        // TODO(xxx): merge with the above decomp kernel.
+        if (ret != status::success && enable_decomp && !quantized) {
+            kernel = std::make_shared<sdp_decomp_training_kernel_t>();
             ret = kernel->compile_impl(part, eng, inputs, outputs);
         }
 

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training.cpp
@@ -1,0 +1,299 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/compiler_workarounds.hpp"
+
+#include "graph/backend/dnnl/kernels/sdp_decomp_training.hpp"
+
+#include "graph/backend/dnnl/passes/insert_ops.hpp"
+#include "graph/backend/dnnl/passes/layout_propagation.hpp"
+#include "graph/backend/dnnl/passes/lower.hpp"
+#include "graph/backend/dnnl/passes/transform.hpp"
+#include "graph/backend/dnnl/passes/utils.hpp"
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "cpu/cpu_stream.hpp"
+#endif
+
+#define VCHECK_SDP_DECOMP_TRAIN(cond, status, msg, ...) \
+    VCONDCHECK(graph, create, check, sdp_decomp_training_kernel_t, (cond), \
+            status, msg, ##__VA_ARGS__);
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+status_t sdp_decomp_training_kernel_t::compile_impl(
+        const dnnl_partition_impl_t *part, engine_t *eng,
+        const std::vector<logical_tensor_t> &inputs,
+        const std::vector<logical_tensor_t> &outputs) {
+    VCHECK_SDP_DECOMP_TRAIN(eng->kind() == engine_kind::cpu,
+            status::unimplemented, "supports cpu only");
+
+#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_OMP \
+        && DNNL_CPU_RUNTIME != DNNL_RUNTIME_THREADPOOL
+    UNUSED(part);
+    UNUSED(inputs);
+    UNUSED(outputs);
+    VCHECK_SDP_DECOMP_TRAIN(false, status::unimplemented,
+            "supports OMP or Threadpool runtime only");
+#else
+
+    p_engine_ = make_dnnl_engine(*eng);
+
+    subgraph_ = std::make_shared<subgraph_t>(
+            part->get_ops(), p_engine_, part->get_fpmath_mode(), false, true);
+    BACKEND_DNNL_CHECK(set_given_inputs_outputs(subgraph_, inputs, outputs));
+
+    // Check if supported by training decomposition kernel
+    if (!sdp_cfg_.initial_check(subgraph_, inputs, outputs))
+        return status::unimplemented;
+
+    subgraph_visualizer_t vis(part->id(), [this](const value_t *val) {
+        return this->memory_planner_.get_memory_info(val);
+    });
+    pass_pipeline_t pipeline = pass_pipeline_t(vis);
+    BACKEND_DNNL_ADD_PASS(pipeline, lower_down);
+    BACKEND_DNNL_ADD_PASS(pipeline, insert_host_scalar);
+    BACKEND_DNNL_ADD_PASS(pipeline, fuse_reshape_for_gqa);
+    BACKEND_DNNL_ADD_PASS(pipeline, binary_canonicalization);
+    BACKEND_DNNL_ADD_PASS(pipeline, sdp_fuse_post_ops);
+    BACKEND_DNNL_ADD_PASS(pipeline, insert_permute_for_matmul);
+    pipeline.reset_visualize_arg(true, false);
+    BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_transpose_to_predecessor);
+    BACKEND_DNNL_ADD_PASS(pipeline, layout_propagation);
+
+    // Run the added passes
+    BACKEND_DNNL_CHECK(pipeline.run(subgraph_));
+
+    // Fill information for inputs logical tensors
+    for (size_t i = 0; i < inputs.size(); i++) {
+        auto &in = const_cast<logical_tensor_t &>(inputs[i]);
+        in = subgraph_->ins_[i];
+    }
+
+    // Fill information for outputs logical tensors
+    for (size_t i = 0; i < outputs.size(); i++) {
+        auto &out = const_cast<logical_tensor_t &>(outputs[i]);
+        out = subgraph_->outs_[i];
+    }
+
+    resource_ctor_
+            = [this]() { return std::make_shared<sdp_args_set_t>(this); };
+
+    return sdp_cfg_.construct_params(
+            subgraph_, sdp_registry_, p_engine_, inputs, outputs);
+#endif
+}
+
+void sdp_decomp_training_kernel_t::prepare_sub_args(
+        const grantor_t &var_grantor, const int id, const size_t block_size,
+        std::unordered_map<dnnl_memory_t, std::vector<memory>> &mem_map) {
+    auto size_offset = id * block_size;
+
+    // Set data handle for memories that are in execution args
+    auto set_handle = [&](const memory &m) {
+        auto it = mem_map.find(m.get());
+        if (it != mem_map.end()) {
+            it->second[id].set_data_handle(
+                    var_grantor.get(sdp_cfg_.mem_key_map.at(m.get()))
+                    + size_offset);
+        }
+    };
+
+    // Memories used in primitive args
+    set_handle(sdp_cfg_.sub_mm1_src);
+    set_handle(sdp_cfg_.sub_mm1_wei);
+    set_handle(sdp_cfg_.sub_mm1_dst);
+    set_handle(sdp_cfg_.sub_softmax_out);
+    if (sdp_cfg_.needs_softmax_reorder) { set_handle(sdp_cfg_.sub_mm2_src); }
+    set_handle(sdp_cfg_.sub_mm2_wei);
+    set_handle(sdp_cfg_.sub_mm2_dst);
+    set_handle(sdp_cfg_.sub_scratchpad);
+
+    set_handle(sdp_cfg_.sub_log_max_P);
+    set_handle(sdp_cfg_.sub_stats);
+}
+
+status_t sdp_decomp_training_kernel_t::execute_impl(stream_t *strm,
+        const std::vector<tensor_t> &inputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    auto *tp_stream
+            = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
+                    strm);
+#endif
+
+    thread_local_cache_t<sdp_args_set_t> res_cache;
+    sdp_args_set_t *res = res_cache.get_or_add(
+            reinterpret_cast<size_t>(this), resource_ctor_);
+
+    dim_t MBO = sdp_cfg_.batch_size, MBI = sdp_cfg_.num_head_q;
+
+    char *src1_user_pointer = static_cast<char *>(
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_training_config_t::mm1_src]]
+                    .get_data_handle());
+    char *wei1_user_pointer = static_cast<char *>(
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_training_config_t::mm1_wei]]
+                    .get_data_handle());
+    char *wei2_user_pointer = static_cast<char *>(
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_training_config_t::mm2_wei]]
+                    .get_data_handle());
+    char *dst_user_pointer = static_cast<char *>(
+            outputs[sdp_cfg_.attn_out_index].get_data_handle());
+    char *stats_user_pointer = static_cast<char *>(
+            outputs[sdp_cfg_.stats_out_index].get_data_handle());
+
+    size_t block_size = sdp_registry_.size();
+    auto scratchpad = std::make_shared<scratchpad_t>(
+            scratchpad_buf, block_size * sdp_cfg_.nthr, p_engine_);
+    grantor_t var_grantor = sdp_registry_.grantor(scratchpad->get_buffer());
+
+    const auto get_mem_dt_size = [](const memory &m) -> size_t {
+        return memory::data_type_size(m.get_desc().get_data_type());
+    };
+
+    const auto loop
+            = [= COMPAT_THIS_CAPTURE](int tid, int nthr, dim_t bo, dim_t bi) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+        threadpool_utils::deactivate_threadpool();
+#endif
+
+        // Prepare execution args and allocate real memory
+        prepare_sub_args(var_grantor, tid, block_size, res->mem_map);
+
+        // reorder0: set Q pointer
+        auto &sub_src1_tid = res->mem_map[sdp_cfg_.sub_src1.get()][tid];
+        const size_t sub_src1_offset = (bo * sdp_cfg_.src1_strides[0]
+                                               + bi * sdp_cfg_.src1_strides[1])
+                * get_mem_dt_size(sub_src1_tid);
+        sub_src1_tid.set_data_handle(src1_user_pointer + sub_src1_offset);
+
+        // reorder1: set K pointer
+        auto &sub_wei1_user_tid
+                = res->mem_map[sdp_cfg_.sub_wei1_user.get()][tid];
+        const size_t sub_wei1_offset = (bo * sdp_cfg_.wei1_strides[0]
+                                               + bi * sdp_cfg_.wei1_strides[1])
+                * get_mem_dt_size(sub_wei1_user_tid);
+        sub_wei1_user_tid.set_data_handle(wei1_user_pointer + sub_wei1_offset);
+
+        // mm1 post-ops: scale
+        if (sdp_cfg_.has_scale) {
+            auto &sub_mm1_post_scale_tid
+                    = res->mem_map[sdp_cfg_.sub_mm1_post_mem[0].get()][tid];
+            sub_mm1_post_scale_tid.set_data_handle(
+                    inputs[sdp_cfg_.graph_inport
+                                    [sdp_decomp_training_config_t::mm1_scale]]
+                            .get_data_handle());
+        }
+
+        // reorder2: set V pointer
+        auto &sub_wei2_user_tid
+                = res->mem_map[sdp_cfg_.sub_wei2_user.get()][tid];
+        const size_t sub_wei2_offset = (bo * sdp_cfg_.wei2_strides[0]
+                                               + bi * sdp_cfg_.wei2_strides[1])
+                * get_mem_dt_size(sub_wei2_user_tid);
+        sub_wei2_user_tid.set_data_handle(wei2_user_pointer + sub_wei2_offset);
+
+        // reorder3: set output pointer
+        auto &sub_dst_user_tid = res->mem_map[sdp_cfg_.sub_dst_user.get()][tid];
+        auto &sub_mm2_dst_tid = res->mem_map[sdp_cfg_.sub_mm2_dst.get()][tid];
+        const size_t sub_dst_user_offset
+                = (bo * sdp_cfg_.dst_strides[0] + bi * sdp_cfg_.dst_strides[1])
+                * get_mem_dt_size(sub_dst_user_tid);
+        sub_dst_user_tid.set_data_handle(
+                dst_user_pointer + sub_dst_user_offset);
+
+        if (sdp_cfg_.sub_reorder3.get_inplace()) {
+            sub_mm2_dst_tid.set_data_handle(
+                    dst_user_pointer + sub_dst_user_offset);
+        }
+
+        // Execute pipeline: reorder0 -> reorder1 -> mm1
+        sdp_cfg_.sub_reorder0.execute(p_stream, res->sub_reorder0_args[tid]);
+        sdp_cfg_.sub_reorder1.execute(p_stream, res->sub_reorder1_args[tid]);
+        dnnl_primitive_execute_without_tp_hook(
+                sdp_cfg_.sub_mm1_prim, p_stream, res->sub_mm1_args[tid]);
+
+        // Softmax: scores -> P
+        dnnl_primitive_execute_without_tp_hook(sdp_cfg_.sub_softmax_prim,
+                p_stream, res->sub_softmax_args[tid]);
+
+        // Compute stats: logsumexp = reduce_max(scores) - log(reduce_max(P))
+        {
+            auto &sub_stats_user_tid
+                    = res->mem_map[sdp_cfg_.sub_stats_user.get()][tid];
+            sub_stats_user_tid.set_data_handle(stats_user_pointer
+                    + (bo * sdp_cfg_.stats_dst_strides[0]
+                              + bi * sdp_cfg_.stats_dst_strides[1])
+                            * sizeof(float));
+
+            if (sdp_cfg_.sub_reorder_stats.get_inplace()) {
+                auto &sub_stats_tid
+                        = res->mem_map[sdp_cfg_.sub_stats.get()][tid];
+                sub_stats_tid.set_data_handle(
+                        sub_stats_user_tid.get_data_handle());
+            }
+
+            dnnl_primitive_execute_without_tp_hook(
+                    sdp_cfg_.sub_reduce_max_P_prim, p_stream,
+                    res->sub_reduce_max_P_args[tid]);
+            dnnl_primitive_execute_without_tp_hook(
+                    sdp_cfg_.sub_reduce_max_src_prim, p_stream,
+                    res->sub_reduce_max_src_args[tid]);
+            sdp_cfg_.sub_reorder_stats.execute(
+                    p_stream, res->sub_reorder_stats_args[tid]);
+        }
+
+        // reorder_softmax: f32 P -> xf16 for mm2
+        if (sdp_cfg_.needs_softmax_reorder) {
+            sdp_cfg_.sub_reorder_softmax.execute(
+                    p_stream, res->sub_reorder_softmax_args[tid]);
+        }
+        // reorder2 -> mm2 -> reorder3
+        sdp_cfg_.sub_reorder2.execute(p_stream, res->sub_reorder2_args[tid]);
+        dnnl_primitive_execute_without_tp_hook(
+                sdp_cfg_.sub_mm2_prim, p_stream, res->sub_mm2_args[tid]);
+        sdp_cfg_.sub_reorder3.execute(p_stream, res->sub_reorder3_args[tid]);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+        auto tp = threadpool_utils::get_active_threadpool();
+        threadpool_utils::activate_threadpool(tp);
+#endif
+    };
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    tp_stream->before_exec_hook();
+#endif
+
+    parallel_nd_ext(sdp_cfg_.nthr, MBO, MBI, loop);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    tp_stream->after_exec_hook();
+#endif
+
+    prolong_scratchpad_lifetime(strm, scratchpad);
+
+    return status::success;
+}
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training.cpp
@@ -1,0 +1,276 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "common/compiler_workarounds.hpp"
+
+#include "graph/backend/dnnl/kernels/sdp_decomp_training.hpp"
+
+#include "graph/backend/dnnl/passes/insert_ops.hpp"
+#include "graph/backend/dnnl/passes/layout_propagation.hpp"
+#include "graph/backend/dnnl/passes/lower.hpp"
+#include "graph/backend/dnnl/passes/transform.hpp"
+#include "graph/backend/dnnl/passes/utils.hpp"
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "cpu/cpu_stream.hpp"
+#endif
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+status_t sdp_decomp_training_kernel_t::compile_impl(
+        const dnnl_partition_impl_t *part, engine_t *eng,
+        const std::vector<logical_tensor_t> &inputs,
+        const std::vector<logical_tensor_t> &outputs) {
+    p_engine_ = make_dnnl_engine(*eng);
+
+    subgraph_ = std::make_shared<subgraph_t>(
+            part->get_ops(), p_engine_, part->get_fpmath_mode(), false, true);
+    BACKEND_DNNL_CHECK(set_given_inputs_outputs(subgraph_, inputs, outputs));
+
+    // Check if supported by training decomposition kernel
+    if (!sdp_cfg_.initial_check(subgraph_, inputs, outputs))
+        return status::unimplemented;
+
+    subgraph_visualizer_t vis(part->id(), [this](const value_t *val) {
+        return this->memory_planner_.get_memory_info(val);
+    });
+    pass_pipeline_t pipeline = pass_pipeline_t(vis);
+    BACKEND_DNNL_ADD_PASS(pipeline, lower_down);
+    BACKEND_DNNL_ADD_PASS(pipeline, insert_host_scalar);
+    BACKEND_DNNL_ADD_PASS(pipeline, fuse_reshape_for_gqa);
+    BACKEND_DNNL_ADD_PASS(pipeline, binary_canonicalization);
+    BACKEND_DNNL_ADD_PASS(pipeline, sdp_fuse_post_ops);
+    BACKEND_DNNL_ADD_PASS(pipeline, insert_permute_for_matmul);
+    pipeline.reset_visualize_arg(true, false);
+    BACKEND_DNNL_ADD_PASS(pipeline, fuse_dst_transpose_to_predecessor);
+    BACKEND_DNNL_ADD_PASS(pipeline, layout_propagation);
+
+    // Run the added passes
+    BACKEND_DNNL_CHECK(pipeline.run(subgraph_));
+
+    // Fill information for inputs logical tensors
+    for (size_t i = 0; i < inputs.size(); i++) {
+        auto &in = const_cast<logical_tensor_t &>(inputs[i]);
+        in = subgraph_->ins_[i];
+    }
+
+    // Fill information for outputs logical tensors
+    for (size_t i = 0; i < outputs.size(); i++) {
+        auto &out = const_cast<logical_tensor_t &>(outputs[i]);
+        out = subgraph_->outs_[i];
+    }
+
+    resource_ctor_
+            = [this]() { return std::make_shared<sdp_args_set_t>(this); };
+
+    return sdp_cfg_.construct_params(
+            subgraph_, sdp_registry_, p_engine_, inputs);
+}
+
+void sdp_decomp_training_kernel_t::prepare_sub_args(
+        const grantor_t &var_grantor, const int id, const size_t block_size,
+        std::unordered_map<dnnl_memory_t, std::vector<memory>> &mem_map) {
+    auto size_offset = id * block_size;
+
+    // Set data handle for memories that are in execution args
+    auto set_handle = [&](const memory &m) {
+        auto it = mem_map.find(m.get());
+        if (it != mem_map.end()) {
+            it->second[id].set_data_handle(
+                    var_grantor.get(sdp_cfg_.mem_key_map.at(m.get()))
+                    + size_offset);
+        }
+    };
+
+    // Memories used in primitive args
+    set_handle(sdp_cfg_.sub_mm1_src);
+    set_handle(sdp_cfg_.sub_mm1_wei);
+    set_handle(sdp_cfg_.sub_mm1_dst);
+    set_handle(sdp_cfg_.sub_softmax_out);
+    if (sdp_cfg_.needs_softmax_reorder) { set_handle(sdp_cfg_.sub_mm2_src); }
+    set_handle(sdp_cfg_.sub_mm2_wei);
+    set_handle(sdp_cfg_.sub_mm2_dst);
+    set_handle(sdp_cfg_.sub_scratchpad);
+
+    set_handle(sdp_cfg_.sub_log_max_P);
+}
+
+status_t sdp_decomp_training_kernel_t::execute_impl(stream_t *strm,
+        const std::vector<tensor_t> &inputs,
+        const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf) {
+    dnnl::stream p_stream = make_dnnl_stream(*strm);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    auto *tp_stream
+            = dnnl::impl::utils::downcast<dnnl::impl::cpu::cpu_stream_t *>(
+                    strm);
+#endif
+
+    thread_local_cache_t<sdp_args_set_t> res_cache;
+    sdp_args_set_t *res = res_cache.get_or_add(
+            reinterpret_cast<size_t>(this), resource_ctor_);
+
+    dim_t MBO = sdp_cfg_.batch_size, MBI = sdp_cfg_.num_head_q;
+
+    char *src1_user_pointer = static_cast<char *>(
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_training_config_t::mm1_src]]
+                    .get_data_handle());
+    char *wei1_user_pointer = static_cast<char *>(
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_training_config_t::mm1_wei]]
+                    .get_data_handle());
+    char *wei2_user_pointer = static_cast<char *>(
+            inputs[sdp_cfg_.graph_inport[sdp_decomp_training_config_t::mm2_wei]]
+                    .get_data_handle());
+    char *dst_user_pointer = static_cast<char *>(
+            outputs[sdp_cfg_.attn_out_index].get_data_handle());
+    char *stats_user_pointer = static_cast<char *>(
+            outputs[sdp_cfg_.stats_out_index].get_data_handle());
+
+    size_t block_size = sdp_registry_.size();
+    auto scratchpad = std::make_shared<scratchpad_t>(
+            scratchpad_buf, block_size * sdp_cfg_.nthr, p_engine_);
+    grantor_t var_grantor = sdp_registry_.grantor(scratchpad->get_buffer());
+
+    const auto get_mem_dt_size = [](const memory &m) -> size_t {
+        return memory::data_type_size(m.get_desc().get_data_type());
+    };
+
+    const auto loop
+            = [= COMPAT_THIS_CAPTURE](int tid, int nthr, dim_t bo, dim_t bi) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+        threadpool_utils::deactivate_threadpool();
+#endif
+
+        // Prepare execution args and allocate real memory
+        prepare_sub_args(var_grantor, tid, block_size, res->mem_map);
+
+        const size_t group_head = sdp_cfg_.num_head_q / sdp_cfg_.num_head_kv;
+        const size_t wei_head_offset = bi / group_head;
+
+        // reorder0: set Q pointer
+        auto &sub_src1_tid = res->mem_map[sdp_cfg_.sub_src1.get()][tid];
+        const size_t sub_src1_offset = (bo * sdp_cfg_.src1_strides[0]
+                                               + bi * sdp_cfg_.src1_strides[1])
+                * get_mem_dt_size(sub_src1_tid);
+        sub_src1_tid.set_data_handle(src1_user_pointer + sub_src1_offset);
+
+        // reorder1: set K pointer
+        auto &sub_wei1_user_tid
+                = res->mem_map[sdp_cfg_.sub_wei1_user.get()][tid];
+        const size_t sub_wei1_offset
+                = (bo * sdp_cfg_.wei1_strides[0]
+                          + wei_head_offset * sdp_cfg_.wei1_strides[1])
+                * get_mem_dt_size(sub_wei1_user_tid);
+        sub_wei1_user_tid.set_data_handle(wei1_user_pointer + sub_wei1_offset);
+
+        // mm1 post-ops: scale
+        if (sdp_cfg_.has_scale) {
+            auto &sub_mm1_post_scale_tid
+                    = res->mem_map[sdp_cfg_.sub_mm1_post_mem[0].get()][tid];
+            sub_mm1_post_scale_tid.set_data_handle(
+                    inputs[sdp_cfg_.graph_inport
+                                    [sdp_decomp_training_config_t::mm1_scale]]
+                            .get_data_handle());
+        }
+
+        // reorder2: set V pointer
+        auto &sub_wei2_user_tid
+                = res->mem_map[sdp_cfg_.sub_wei2_user.get()][tid];
+        const size_t sub_wei2_offset
+                = (bo * sdp_cfg_.wei2_strides[0]
+                          + wei_head_offset * sdp_cfg_.wei2_strides[1])
+                * get_mem_dt_size(sub_wei2_user_tid);
+        sub_wei2_user_tid.set_data_handle(wei2_user_pointer + sub_wei2_offset);
+
+        // reorder3: set output pointer
+        auto &sub_dst_user_tid = res->mem_map[sdp_cfg_.sub_dst_user.get()][tid];
+        auto &sub_mm2_dst_tid = res->mem_map[sdp_cfg_.sub_mm2_dst.get()][tid];
+        const size_t sub_dst_user_offset
+                = (bo * sdp_cfg_.dst_strides[0] + bi * sdp_cfg_.dst_strides[1])
+                * get_mem_dt_size(sub_dst_user_tid);
+        sub_dst_user_tid.set_data_handle(
+                dst_user_pointer + sub_dst_user_offset);
+
+        if (sdp_cfg_.sub_reorder3.get_inplace()) {
+            sub_mm2_dst_tid.set_data_handle(
+                    dst_user_pointer + sub_dst_user_offset);
+        }
+
+        // Execute pipeline: reorder0 -> reorder1 -> mm1
+        sdp_cfg_.sub_reorder0.execute(p_stream, res->sub_reorder0_args[tid]);
+        sdp_cfg_.sub_reorder1.execute(p_stream, res->sub_reorder1_args[tid]);
+        dnnl_primitive_execute_without_tp_hook(
+                sdp_cfg_.sub_mm1_prim, p_stream, res->sub_mm1_args[tid]);
+
+        // Softmax: scores -> P
+        dnnl_primitive_execute_without_tp_hook(sdp_cfg_.sub_softmax_prim,
+                p_stream, res->sub_softmax_args[tid]);
+
+        // Compute stats: logsumexp = reduce_max(scores) - log(reduce_max(P))
+        {
+            auto &sub_stats_tid = res->mem_map[sdp_cfg_.sub_stats.get()][tid];
+            sub_stats_tid.set_data_handle(stats_user_pointer
+                    + (bo * sdp_cfg_.stats_dst_strides[0]
+                              + bi * sdp_cfg_.stats_dst_strides[1])
+                            * sizeof(float));
+
+            dnnl_primitive_execute_without_tp_hook(
+                    sdp_cfg_.sub_reduce_max_P_prim, p_stream,
+                    res->sub_reduce_max_P_args[tid]);
+            dnnl_primitive_execute_without_tp_hook(
+                    sdp_cfg_.sub_reduce_max_src_prim, p_stream,
+                    res->sub_reduce_max_src_args[tid]);
+        }
+
+        // reorder_softmax: f32 P -> xf16 for mm2
+        if (sdp_cfg_.needs_softmax_reorder) {
+            sdp_cfg_.sub_reorder_softmax.execute(
+                    p_stream, res->sub_reorder_softmax_args[tid]);
+        }
+        // reorder2 -> mm2 -> reorder3
+        sdp_cfg_.sub_reorder2.execute(p_stream, res->sub_reorder2_args[tid]);
+        dnnl_primitive_execute_without_tp_hook(
+                sdp_cfg_.sub_mm2_prim, p_stream, res->sub_mm2_args[tid]);
+        sdp_cfg_.sub_reorder3.execute(p_stream, res->sub_reorder3_args[tid]);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+        auto tp = threadpool_utils::get_active_threadpool();
+        threadpool_utils::activate_threadpool(tp);
+#endif
+    };
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    tp_stream->before_exec_hook();
+#endif
+
+    parallel_nd_ext(sdp_cfg_.nthr, MBO, MBI, loop);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    tp_stream->after_exec_hook();
+#endif
+
+    prolong_scratchpad_lifetime(strm, scratchpad);
+
+    return status::success;
+}
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training.hpp
@@ -1,0 +1,182 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GRAPH_BACKEND_DNNL_KERNELS_SDP_DECOMP_TRAINING_HPP
+#define GRAPH_BACKEND_DNNL_KERNELS_SDP_DECOMP_TRAINING_HPP
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "graph/backend/dnnl/kernels/kernel_base.hpp"
+#include "graph/backend/dnnl/kernels/sdp_decomp_training_config.hpp"
+
+#include "graph/backend/dnnl/dnnl_partition_impl.hpp"
+#include "graph/backend/dnnl/scratchpad.hpp"
+#include "graph/backend/dnnl/subgraph.hpp"
+#include "graph/backend/dnnl/thread_local_cache.hpp"
+
+#include "graph/backend/dnnl/passes/memory_planning.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+struct sdp_decomp_training_kernel_t : public kernel_base_t {
+private:
+    registry_t sdp_registry_;
+    std::shared_ptr<subgraph_t> subgraph_;
+    memory_planner_t memory_planner_;
+    sdp_decomp_training_config_t sdp_cfg_;
+
+public:
+    sdp_decomp_training_kernel_t() {
+        thread_local_cache_t<sdp_args_set_t> res_cache;
+        res_cache.retain();
+    }
+
+    ~sdp_decomp_training_kernel_t() override {
+        thread_local_cache_t<sdp_args_set_t> res_cache;
+        res_cache.remove_if_exist(reinterpret_cast<size_t>(this));
+        res_cache.release();
+    }
+
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
+            const std::vector<logical_tensor_t> &inputs,
+            const std::vector<logical_tensor_t> &outputs) override;
+
+    void prepare_sub_args(const grantor_t &var_grantor, const int id,
+            const size_t block_size,
+            std::unordered_map<dnnl_memory_t, std::vector<memory>> &mem_map);
+
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
+
+    std::string str() const override { return "sdp_decomp_training_kernel_t"; }
+
+    size_t get_scratchpad_size() const override {
+        return sdp_registry_.size() * sdp_cfg_.nthr;
+    }
+
+#ifdef DNNL_WITH_SYCL
+    status_t sycl_execute_impl(stream_t *strm,
+            const std::vector<tensor_t> &inputs,
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
+            const std::vector<::sycl::event> &sycl_deps,
+            ::sycl::event *sycl_event) override {
+        UNUSED(strm);
+        UNUSED(inputs);
+        UNUSED(outputs);
+        UNUSED(sycl_deps);
+        UNUSED(sycl_event);
+        return status::unimplemented;
+    }
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    status_t ocl_execute_impl(stream_t *strm,
+            const std::vector<tensor_t> &inputs,
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
+            const std::vector<ocl_event_t> &ocl_deps,
+            ocl_event_t &ocl_event) override {
+        UNUSED(strm);
+        UNUSED(inputs);
+        UNUSED(outputs);
+        UNUSED(ocl_deps);
+        UNUSED(ocl_event);
+        return status::unimplemented;
+    }
+#endif
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(sdp_decomp_training_kernel_t)
+
+    class sdp_args_set_t {
+    public:
+        sdp_args_set_t(sdp_decomp_training_kernel_t *sdp_kernel) {
+            int nthr = sdp_kernel->sdp_cfg_.nthr;
+            auto args_ctor
+                    = [this, nthr](
+                              const std::unordered_map<int, memory> &ori_args,
+                              std::vector<std::unordered_map<int, memory>>
+                                      &args) {
+                args.resize(nthr);
+                for (const auto &iter : ori_args) {
+                    memory ori_mem = iter.second;
+                    if (mem_map.count(ori_mem.get()) == 0) {
+                        mem_map[ori_mem.get()] = std::vector<memory>(nthr);
+                        for (int tid = 0; tid < nthr; tid++) {
+                            mem_map[ori_mem.get()][tid]
+                                    = memory(ori_mem.get_desc(),
+                                            ori_mem.get_engine(), nullptr);
+                            if (iter.first >= DNNL_ARG_ATTR_SCALES) {
+                                mem_map[ori_mem.get()][tid].set_data_handle(
+                                        ori_mem.get_data_handle());
+                            }
+                        }
+                    }
+                    for (int tid = 0; tid < nthr; tid++) {
+                        args[tid].insert(
+                                {iter.first, mem_map[ori_mem.get()][tid]});
+                    }
+                }
+            };
+            args_ctor(
+                    sdp_kernel->sdp_cfg_.sub_reorder0_args, sub_reorder0_args);
+            args_ctor(
+                    sdp_kernel->sdp_cfg_.sub_reorder1_args, sub_reorder1_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_mm1_args, sub_mm1_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_softmax_args, sub_softmax_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_reduce_max_P_args,
+                    sub_reduce_max_P_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_reduce_max_src_args,
+                    sub_reduce_max_src_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_reorder_stats_args,
+                    sub_reorder_stats_args);
+            if (sdp_kernel->sdp_cfg_.needs_softmax_reorder) {
+                args_ctor(sdp_kernel->sdp_cfg_.sub_reorder_softmax_args,
+                        sub_reorder_softmax_args);
+            }
+            args_ctor(
+                    sdp_kernel->sdp_cfg_.sub_reorder2_args, sub_reorder2_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_mm2_args, sub_mm2_args);
+            args_ctor(
+                    sdp_kernel->sdp_cfg_.sub_reorder3_args, sub_reorder3_args);
+        }
+
+        std::unordered_map<dnnl_memory_t, std::vector<memory>> mem_map;
+        std::vector<std::unordered_map<int, memory>> sub_reorder0_args,
+                sub_reorder1_args, sub_mm1_args, sub_reorder2_args,
+                sub_mm2_args, sub_reorder3_args;
+        std::vector<std::unordered_map<int, memory>> sub_softmax_args;
+        std::vector<std::unordered_map<int, memory>> sub_reorder_softmax_args;
+        std::vector<std::unordered_map<int, memory>> sub_reduce_max_P_args,
+                sub_reduce_max_src_args;
+        std::vector<std::unordered_map<int, memory>> sub_reorder_stats_args;
+    };
+
+    std::function<std::shared_ptr<sdp_args_set_t>()> resource_ctor_;
+};
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training.hpp
@@ -1,0 +1,179 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GRAPH_BACKEND_DNNL_KERNELS_SDP_DECOMP_TRAINING_HPP
+#define GRAPH_BACKEND_DNNL_KERNELS_SDP_DECOMP_TRAINING_HPP
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "graph/backend/dnnl/kernels/kernel_base.hpp"
+#include "graph/backend/dnnl/kernels/sdp_decomp_training_config.hpp"
+
+#include "graph/backend/dnnl/dnnl_partition_impl.hpp"
+#include "graph/backend/dnnl/scratchpad.hpp"
+#include "graph/backend/dnnl/subgraph.hpp"
+#include "graph/backend/dnnl/thread_local_cache.hpp"
+
+#include "graph/backend/dnnl/passes/memory_planning.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+struct sdp_decomp_training_kernel_t : public kernel_base_t {
+private:
+    registry_t sdp_registry_;
+    std::shared_ptr<subgraph_t> subgraph_;
+    memory_planner_t memory_planner_;
+    sdp_decomp_training_config_t sdp_cfg_;
+
+public:
+    sdp_decomp_training_kernel_t() {
+        thread_local_cache_t<sdp_args_set_t> res_cache;
+        res_cache.retain();
+    }
+
+    ~sdp_decomp_training_kernel_t() override {
+        thread_local_cache_t<sdp_args_set_t> res_cache;
+        res_cache.remove_if_exist(reinterpret_cast<size_t>(this));
+        res_cache.release();
+    }
+
+    status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
+            const std::vector<logical_tensor_t> &inputs,
+            const std::vector<logical_tensor_t> &outputs) override;
+
+    void prepare_sub_args(const grantor_t &var_grantor, const int id,
+            const size_t block_size,
+            std::unordered_map<dnnl_memory_t, std::vector<memory>> &mem_map);
+
+    status_t execute_impl(stream_t *strm, const std::vector<tensor_t> &inputs,
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf) override;
+
+    std::string str() const override { return "sdp_decomp_training_kernel_t"; }
+
+    size_t get_scratchpad_size() const override {
+        return sdp_registry_.size() * sdp_cfg_.nthr;
+    }
+
+#ifdef DNNL_WITH_SYCL
+    status_t sycl_execute_impl(stream_t *strm,
+            const std::vector<tensor_t> &inputs,
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
+            const std::vector<::sycl::event> &sycl_deps,
+            ::sycl::event *sycl_event) override {
+        UNUSED(strm);
+        UNUSED(inputs);
+        UNUSED(outputs);
+        UNUSED(sycl_deps);
+        UNUSED(sycl_event);
+        return status::unimplemented;
+    }
+#endif
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+    status_t ocl_execute_impl(stream_t *strm,
+            const std::vector<tensor_t> &inputs,
+            const std::vector<tensor_t> &outputs,
+            const tensor_t *scratchpad_buf,
+            const std::vector<cl_event> &cl_deps,
+            cl_event *ret_event) override {
+        UNUSED(strm);
+        UNUSED(inputs);
+        UNUSED(outputs);
+        UNUSED(cl_deps);
+        UNUSED(ret_event);
+        return status::unimplemented;
+    }
+#endif
+
+    DNNL_DISALLOW_COPY_AND_ASSIGN(sdp_decomp_training_kernel_t)
+
+    class sdp_args_set_t {
+    public:
+        sdp_args_set_t(sdp_decomp_training_kernel_t *sdp_kernel) {
+            int nthr = sdp_kernel->sdp_cfg_.nthr;
+            auto args_ctor
+                    = [this, nthr](
+                              const std::unordered_map<int, memory> &ori_args,
+                              std::vector<std::unordered_map<int, memory>>
+                                      &args) {
+                args.resize(nthr);
+                for (const auto &iter : ori_args) {
+                    memory ori_mem = iter.second;
+                    if (mem_map.count(ori_mem.get()) == 0) {
+                        mem_map[ori_mem.get()] = std::vector<memory>(nthr);
+                        for (int tid = 0; tid < nthr; tid++) {
+                            mem_map[ori_mem.get()][tid]
+                                    = memory(ori_mem.get_desc(),
+                                            ori_mem.get_engine(), nullptr);
+                            if (iter.first >= DNNL_ARG_ATTR_SCALES) {
+                                mem_map[ori_mem.get()][tid].set_data_handle(
+                                        ori_mem.get_data_handle());
+                            }
+                        }
+                    }
+                    for (int tid = 0; tid < nthr; tid++) {
+                        args[tid].insert(
+                                {iter.first, mem_map[ori_mem.get()][tid]});
+                    }
+                }
+            };
+            args_ctor(
+                    sdp_kernel->sdp_cfg_.sub_reorder0_args, sub_reorder0_args);
+            args_ctor(
+                    sdp_kernel->sdp_cfg_.sub_reorder1_args, sub_reorder1_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_mm1_args, sub_mm1_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_softmax_args, sub_softmax_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_reduce_max_P_args,
+                    sub_reduce_max_P_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_reduce_max_src_args,
+                    sub_reduce_max_src_args);
+            if (sdp_kernel->sdp_cfg_.needs_softmax_reorder) {
+                args_ctor(sdp_kernel->sdp_cfg_.sub_reorder_softmax_args,
+                        sub_reorder_softmax_args);
+            }
+            args_ctor(
+                    sdp_kernel->sdp_cfg_.sub_reorder2_args, sub_reorder2_args);
+            args_ctor(sdp_kernel->sdp_cfg_.sub_mm2_args, sub_mm2_args);
+            args_ctor(
+                    sdp_kernel->sdp_cfg_.sub_reorder3_args, sub_reorder3_args);
+        }
+
+        std::unordered_map<dnnl_memory_t, std::vector<memory>> mem_map;
+        std::vector<std::unordered_map<int, memory>> sub_reorder0_args,
+                sub_reorder1_args, sub_mm1_args, sub_reorder2_args,
+                sub_mm2_args, sub_reorder3_args;
+        std::vector<std::unordered_map<int, memory>> sub_softmax_args;
+        std::vector<std::unordered_map<int, memory>> sub_reorder_softmax_args;
+        std::vector<std::unordered_map<int, memory>> sub_reduce_max_P_args,
+                sub_reduce_max_src_args;
+    };
+
+    std::function<std::shared_ptr<sdp_args_set_t>()> resource_ctor_;
+};
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.cpp
@@ -1,0 +1,647 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "graph/backend/dnnl/kernels/sdp_decomp_training_config.hpp"
+
+#include "graph/backend/dnnl/common.hpp"
+#include "graph/backend/dnnl/fusion_info.hpp"
+
+#define VCHECK_SDP_TRAIN(cond, status, msg, ...) \
+    VCONDCHECK(graph, create, check, sdp_decomp_training_kernel_t, (cond), \
+            status, msg, ##__VA_ARGS__);
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+bool sdp_decomp_training_config_t::initial_check(
+        const std::shared_ptr<subgraph_t> &sg,
+        const std::vector<logical_tensor_t> &inputs,
+        const std::vector<logical_tensor_t> &outputs) {
+    // Record the input offset
+    CHECK_BOOL(record_input_offset(sg, inputs));
+
+    dims src1_user_dims = ltw(inputs[graph_inport[mm1_src]]).vdims();
+    ndims = src1_user_dims.size();
+    // TODO: support 5D GQA inputs (needs dimension extraction + offset logic)
+    VCHECK_SDP_TRAIN(ndims == 4, false,
+            "Training decomp only supports 4D input, but got %zu ndims",
+            src1_user_dims.size());
+
+    // Require 2 outputs: attention output + stats (logsumexp)
+    VCHECK_SDP_TRAIN(outputs.size() == 2, false,
+            "Training decomp requires 2 outputs (attn + stats), but got %zu",
+            outputs.size());
+
+    // Initialize SDP input dimensions
+    batch_size = src1_user_dims[0];
+    num_head_q = src1_user_dims[1];
+    seq_len_q = src1_user_dims[2];
+    head_size_qk = src1_user_dims[3];
+
+    dims wei1_user_dims = ltw(inputs[graph_inport[mm1_wei]]).vdims();
+    dims wei2_user_dims = ltw(inputs[graph_inport[mm2_wei]]).vdims();
+    VCHECK_SDP_TRAIN(wei1_user_dims[1] == wei2_user_dims[1], false,
+            "kv head number mismatch");
+    // Without GQA, Q/K/V must have the same number of heads
+    VCHECK_SDP_TRAIN(num_head_q == wei1_user_dims[1], false,
+            "GQA not supported: num_head_q != num_head_kv");
+
+    VCHECK_SDP_TRAIN(
+            batch_size == wei1_user_dims[0] && batch_size == wei2_user_dims[0],
+            false, "Batch size mismatch");
+
+    seq_len_kv = wei1_user_dims[3]; // K shape: [batch, head, head_size, seq_kv]
+    head_size_v = wei2_user_dims[3];
+
+    // Check scale size
+    if (graph_inport[mm1_scale] != -1) {
+        auto scale_sz = ltw(inputs[graph_inport[mm1_scale]]).nelems();
+        VCHECK_SDP_TRAIN(scale_sz == 1, false,
+                "Only supports single scale value, but got %ld",
+                static_cast<long int>(scale_sz));
+    }
+
+    // Reject quantized ops
+    for (const auto &cur_op : sg->get_ops()) {
+        const auto &op_kind = cur_op->get_kind();
+        VCHECK_SDP_TRAIN(op_kind != graph::op_kind::Quantize
+                        && op_kind != graph::op_kind::Dequantize
+                        && op_kind != graph::op_kind::DynamicDequantize,
+                false, "Training decomp does not support quantization");
+        // Reject dropout
+        VCHECK_SDP_TRAIN(op_kind != graph::op_kind::Dropout, false,
+                "Training decomp does not support dropout yet");
+        // Reject inf_as_zero mode softmax
+        if (op_kind == graph::op_kind::SoftMax
+                && cur_op->has_attr(op_attr::mode)) {
+            const auto &mode = cur_op->get_attr<std::string>(op_attr::mode);
+            VCHECK_SDP_TRAIN(mode != "inf_as_zero", false,
+                    "Training decomp does not support inf_as_zero mode");
+        }
+    }
+
+    // Check data types - only f32/bf16/f16
+    auto src_dt = ltw(inputs[graph_inport[mm1_src]]).data_type();
+    VCHECK_SDP_TRAIN(src_dt == graph::data_type::f32
+                    || src_dt == graph::data_type::bf16
+                    || src_dt == graph::data_type::f16,
+            false, "Only supports f32/bf16/f16 data types");
+
+    // K and V must have the same data type
+    VCHECK_SDP_TRAIN(ltw(inputs[graph_inport[mm1_wei]]).data_type()
+                    == ltw(inputs[graph_inport[mm2_wei]]).data_type(),
+            false, "Key and value should have the same data type");
+
+    // Initialize nthr with max threads num
+    nthr = dnnl_get_max_threads();
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    constexpr dim_t ratio = 2;
+    VCHECK_SDP_TRAIN(batch_size * num_head_q > ratio * nthr, false,
+            "Doesn't meet condition for decompose: batch_size * num_head_q "
+            "should be larger than ratio * nthr");
+#endif
+    return true;
+}
+
+impl::status_t sdp_decomp_training_config_t::construct_params(
+        std::shared_ptr<subgraph_t> &sg, registry_t &sdp_registry,
+        const dnnl::engine &p_engine,
+        const std::vector<logical_tensor_t> &inputs,
+        const std::vector<logical_tensor_t> &outputs) {
+    // Determine which output index is attention output vs stats.
+    // Stats has last dim = 1, attention output has last dim = head_size_v.
+    {
+        dims out0_dims = ltw(outputs[0]).vdims();
+        dims out1_dims = ltw(outputs[1]).vdims();
+        if (out0_dims.back() == 1) {
+            stats_out_index = 0;
+            attn_out_index = 1;
+        } else {
+            stats_out_index = 1;
+            attn_out_index = 0;
+        }
+    }
+
+    CHECK(record_sdp_ops(sg));
+    const dim_t last_dim = ndims - 1, second_last_dim = ndims - 2;
+
+    // Update seq_len_kv from the actual weight shape after passes
+    const auto &lt_wei = sdp_op[0]->get_input_logical_tensor(1);
+    const ltw ltw_wei(lt_wei);
+    seq_len_kv = ltw_wei.vdims()[last_dim];
+
+    // Acquire data type
+    memory::data_type dt_src_user = static_cast<memory::data_type>(
+            ltw(inputs[graph_inport[mm1_src]]).data_type());
+    // For training, intermediate computation (scores, softmax) uses f32
+    // for numerical precision. User-facing I/O (Q, K, V, output, P) stays
+    // in dt_src_user (e.g., bf16).
+    memory::data_type dt_inter = memory::data_type::f32;
+
+    ////////////////////////////////////////////////////////////////////////
+    ////////////// Start Creating primitives ///////////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(1);
+#endif
+
+    // Memory descriptors
+    memory::desc sub_src1_md, sub_wei1_user_md, sub_wei1_md, sub_mm1_src_md,
+            sub_mm1_wei_md, sub_mm1_dst_md, sub_wei2_user_md, sub_mm2_wei_md,
+            sub_mm2_dst_md, sub_dst_md, sub_dst_user_md;
+    std::vector<memory::desc> sub_mm1_post_md;
+
+    // reorder0: src1 strided -> dense
+    primitive_attr sub_reorder0_attr;
+    sub_reorder0_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    dims sub_src1_dims = {seq_len_q, head_size_qk};
+    src1_strides = ltw(inputs[graph_inport[mm1_src]]).vstrides();
+    sub_src1_md = memory::desc(sub_src1_dims, dt_src_user,
+            {src1_strides[second_last_dim], src1_strides[last_dim]});
+    auto sub_src1_d_md
+            = memory::desc(sub_src1_dims, dt_src_user, format_tag::ab);
+    auto sub_reorder0_pd = reorder::primitive_desc(
+            p_engine, sub_src1_md, p_engine, sub_src1_d_md, sub_reorder0_attr);
+    sub_reorder0.init(sub_reorder0_pd);
+
+    // reorder1: key strided -> transposed dense
+    primitive_attr sub_reorder1_attr;
+    sub_reorder1_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    dims sub_wei1_dims = {head_size_qk, seq_len_kv};
+    auto wei_md = make_dnnl_memory_desc(sdp_op[0]->get_input_logical_tensor(1));
+    wei1_strides = wei_md.get_strides();
+    sub_wei1_user_md = memory::desc(sub_wei1_dims, dt_src_user,
+            {wei1_strides[second_last_dim], wei1_strides[last_dim]});
+    sub_wei1_md = memory::desc(sub_wei1_dims, dt_src_user, format_tag::ba);
+    auto sub_reorder1_pd = reorder::primitive_desc(p_engine, sub_wei1_user_md,
+            p_engine, sub_wei1_md, sub_reorder1_attr);
+    sub_reorder1.init(sub_reorder1_pd);
+
+    // MatMul1: Q × K^T -> f32 scores
+    dnnl::primitive_attr sub_matmul1_attr = make_primitive_attr(sdp_op[0]);
+    dims sub_mm1_src_dims = {seq_len_q, head_size_qk};
+    dims sub_mm1_wei_dims = {head_size_qk, seq_len_kv};
+    dims sub_mm1_dst_dims = {seq_len_q, seq_len_kv};
+
+    sub_mm1_src_md
+            = memory::desc(sub_mm1_src_dims, dt_src_user, format_tag::ab);
+    sub_mm1_wei_md
+            = memory::desc(sub_mm1_wei_dims, dt_src_user, format_tag::ba);
+    // mm1 output is f32 for numerical precision in softmax computation
+    sub_mm1_dst_md = memory::desc(sub_mm1_dst_dims, dt_inter, format_tag::ab);
+
+    // Handle post-ops for mm1 (scale, mask)
+    dnnl::post_ops dnnl_pops;
+    auto mm1_ori_dnnl_pops = sub_matmul1_attr.get_post_ops();
+    for (int i = 0; i < mm1_ori_dnnl_pops.get()->len(); i++) {
+        if (mm1_ori_dnnl_pops.get()->entry_[i].is_binary()) {
+            auto alg = static_cast<algorithm>(
+                    mm1_ori_dnnl_pops.get()->entry_[i].binary.alg);
+            const dnnl::impl::memory_desc_t &ori_desc
+                    = mm1_ori_dnnl_pops.get()->entry_[i].binary.user_src1_desc;
+            auto post_shape = ori_desc.dims;
+            auto post_stride = ori_desc.format_desc.blocking.strides;
+            auto post_dt
+                    = static_cast<dnnl::memory::data_type>(ori_desc.data_type);
+            auto new_sub_md = memory::desc(
+                    {post_shape[second_last_dim], post_shape[last_dim]},
+                    post_dt,
+                    {post_stride[second_last_dim], post_stride[last_dim]});
+            sub_mm1_post_md.emplace_back(new_sub_md);
+            dnnl_pops.append_binary(alg, new_sub_md);
+        } else if (mm1_ori_dnnl_pops.get()->entry_[i].is_eltwise()) {
+            auto alg = static_cast<algorithm>(
+                    mm1_ori_dnnl_pops.get()->entry_[i].eltwise.alg);
+            auto alpha = mm1_ori_dnnl_pops.get()->entry_[i].eltwise.alpha;
+            auto beta = mm1_ori_dnnl_pops.get()->entry_[i].eltwise.beta;
+            dnnl_pops.append_eltwise(alg, alpha, beta);
+        }
+    }
+    sub_matmul1_attr.set_post_ops(dnnl_pops);
+    auto sub_mm1_pd = matmul::primitive_desc(p_engine, sub_mm1_src_md,
+            sub_mm1_wei_md, sub_mm1_dst_md, sub_matmul1_attr);
+    sub_mm1_prim = matmul(sub_mm1_pd);
+
+    // Softmax primitive: scores -> P
+    dims scores_dims = {seq_len_q, seq_len_kv};
+    dims stats_dims = {seq_len_q, 1};
+    auto scores_md = memory::desc(scores_dims, dt_inter, format_tag::ab);
+    auto stats_md = memory::desc(stats_dims, dt_inter, format_tag::ab);
+    auto softmax_out_md = memory::desc(scores_dims, dt_inter, format_tag::ab);
+
+    primitive_attr softmax_attr;
+    softmax_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    auto sub_softmax_pd = softmax_forward::primitive_desc(p_engine,
+            prop_kind::forward_inference, algorithm::softmax_accurate,
+            sub_mm1_dst_md, softmax_out_md,
+            /*axis=*/sub_mm1_dst_md.get_ndims() - 1, softmax_attr);
+    sub_softmax_prim = softmax_forward(sub_softmax_pd);
+
+    // Stats computation: logsumexp = reduce_max(src) - log(reduce_max(P))
+    // Fused into 2 primitives using post-ops:
+    //   1) reduce_max(P) [log post-op] -> log_max_P
+    //   2) reduce_max(scores) [binary_sub(log_max_P) post-op] -> stats
+    memory::desc sub_reduce_max_P_scratchpad_md;
+    memory::desc sub_reduce_max_src_scratchpad_md;
+    {
+        // reduce_max(P) with log post-op -> log_max_P
+        primitive_attr reduce_max_P_attr;
+        reduce_max_P_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+        post_ops reduce_max_P_po;
+        reduce_max_P_po.append_eltwise(algorithm::eltwise_log, 0.f, 0.f);
+        reduce_max_P_attr.set_post_ops(reduce_max_P_po);
+        auto sub_reduce_max_P_pd
+                = reduction::primitive_desc(p_engine, algorithm::reduction_max,
+                        softmax_out_md, stats_md, 0.f, 0.f, reduce_max_P_attr);
+        sub_reduce_max_P_prim = reduction(sub_reduce_max_P_pd);
+        sub_reduce_max_P_scratchpad_md = sub_reduce_max_P_pd.scratchpad_desc();
+
+        // reduce_max(scores) with binary_sub(log_max_P) post-op -> stats
+        primitive_attr reduce_max_src_attr;
+        reduce_max_src_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+        post_ops reduce_max_src_po;
+        reduce_max_src_po.append_binary(algorithm::binary_sub, stats_md);
+        reduce_max_src_attr.set_post_ops(reduce_max_src_po);
+        auto sub_reduce_max_src_pd = reduction::primitive_desc(p_engine,
+                algorithm::reduction_max, sub_mm1_dst_md, stats_md, 0.f, 0.f,
+                reduce_max_src_attr);
+        sub_reduce_max_src_prim = reduction(sub_reduce_max_src_pd);
+        sub_reduce_max_src_scratchpad_md
+                = sub_reduce_max_src_pd.scratchpad_desc();
+
+        // Stats memories
+        sub_log_max_P = memory(stats_md, p_engine, nullptr);
+        sub_stats = memory(stats_md, p_engine, nullptr);
+    }
+
+    // reorder_stats: dense stats -> user layout
+    primitive_attr sub_reorder_stats_attr;
+    sub_reorder_stats_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    // Extract stats strides now that shape inference has filled outputs
+    stats_dst_strides = ltw(sdp_op[1]->get_output_logical_tensor(2)).vstrides();
+    auto sub_stats_user_md = memory::desc(stats_dims, dt_inter,
+            {stats_dst_strides[second_last_dim], stats_dst_strides[last_dim]});
+    auto sub_reorder_stats_pd = reorder::primitive_desc(p_engine, stats_md,
+            p_engine, sub_stats_user_md, sub_reorder_stats_attr);
+    sub_reorder_stats.init(sub_reorder_stats_pd);
+    sub_stats_user = memory(sub_stats_user_md, p_engine, nullptr);
+
+    // reorder2: value strided -> dense
+    primitive_attr sub_reorder2_attr;
+    sub_reorder2_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    dims sub_wei2_dims = {seq_len_kv, head_size_v};
+    wei2_strides = ltw(inputs[graph_inport[mm2_wei]]).vstrides();
+    sub_wei2_user_md = memory::desc(sub_wei2_dims, dt_src_user,
+            {wei2_strides[second_last_dim], wei2_strides[last_dim]});
+    auto sub_wei2_md = memory::desc(sub_wei2_dims, dt_src_user, format_tag::ab);
+    auto sub_reorder2_pd = reorder::primitive_desc(p_engine, sub_wei2_user_md,
+            p_engine, sub_wei2_md, sub_reorder2_attr);
+    sub_reorder2.init(sub_reorder2_pd);
+
+    // MatMul2: P x V
+    // When softmax output is f32 but mm2 expects lower precision (bf16/f16),
+    // add a reorder. For pure f32 SDPA, no reorder needed.
+    needs_softmax_reorder = (dt_inter != dt_src_user);
+    memory::desc sub_reorder_softmax_scratchpad_md;
+    dnnl::primitive_attr sub_matmul2_attr = make_primitive_attr(sdp_op[2]);
+    dims sub_mm2_src_dims = {seq_len_q, seq_len_kv};
+    dims sub_mm2_wei_dims = {seq_len_kv, head_size_v};
+    dims sub_mm2_dst_dims = {seq_len_q, head_size_v};
+    auto sub_mm2_src_md
+            = memory::desc(sub_mm2_src_dims, dt_src_user, format_tag::ab);
+
+    if (needs_softmax_reorder) {
+        // Reorder f32 softmax output -> bf16/f16 for mm2
+        primitive_attr sub_reorder_softmax_attr;
+        sub_reorder_softmax_attr.set_scratchpad_mode(
+                dnnl::scratchpad_mode::user);
+        auto sub_reorder_softmax_pd
+                = reorder::primitive_desc(p_engine, softmax_out_md, p_engine,
+                        sub_mm2_src_md, sub_reorder_softmax_attr);
+        sub_reorder_softmax.init(sub_reorder_softmax_pd);
+        sub_reorder_softmax_scratchpad_md
+                = sub_reorder_softmax_pd.scratchpad_desc();
+        sub_mm2_src = memory(sub_mm2_src_md, p_engine, nullptr);
+    }
+
+    sub_mm2_wei_md
+            = memory::desc(sub_mm2_wei_dims, dt_src_user, format_tag::ab);
+    sub_mm2_dst_md
+            = memory::desc(sub_mm2_dst_dims, dt_src_user, format_tag::ab);
+    auto sub_mm2_pd = matmul::primitive_desc(p_engine, sub_mm2_src_md,
+            sub_mm2_wei_md, sub_mm2_dst_md, sub_matmul2_attr);
+    sub_mm2_prim = matmul(sub_mm2_pd);
+
+    // reorder3: output dense -> strided
+    primitive_attr sub_reorder3_attr;
+    sub_reorder3_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    dims sub_dst_dims = {seq_len_q, head_size_v};
+    auto out_lt = sdp_op[2]->get_output_logical_tensor(0);
+    dst_strides = ltw(out_lt).vstrides();
+    sub_dst_md = memory::desc(sub_dst_dims, dt_src_user, format_tag::ab);
+    sub_dst_user_md = memory::desc(sub_dst_dims, dt_src_user,
+            {dst_strides[second_last_dim], dst_strides[last_dim]});
+    auto sub_reorder3_pd = reorder::primitive_desc(
+            p_engine, sub_dst_md, p_engine, sub_dst_user_md, sub_reorder3_attr);
+    sub_reorder3.init(sub_reorder3_pd);
+
+    ////////////////////////////////////////////////////////////////////////
+    /////////////// End Creating primitives ////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+
+    ////////////////////////////////////////////////////////////////////////
+    /////////////// Start Constructing exec args ///////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+
+    // Find max scratchpad size
+    size_t max_scratchpad_size = 0;
+    memory::desc max_scratchpad_md;
+    std::vector<memory::desc> scratchpads {
+            sub_reorder0_pd.scratchpad_desc(),
+            sub_reorder1_pd.scratchpad_desc(),
+            sub_mm1_pd.scratchpad_desc(),
+            sub_softmax_pd.scratchpad_desc(),
+            sub_reorder2_pd.scratchpad_desc(),
+            sub_mm2_pd.scratchpad_desc(),
+            sub_reorder3_pd.scratchpad_desc(),
+    };
+    if (needs_softmax_reorder) {
+        scratchpads.push_back(sub_reorder_softmax_scratchpad_md);
+    }
+    scratchpads.push_back(sub_reduce_max_src_scratchpad_md);
+    scratchpads.push_back(sub_reduce_max_P_scratchpad_md);
+    scratchpads.push_back(sub_reorder_stats_pd.scratchpad_desc());
+    for (auto &sp : scratchpads) {
+        const size_t size = sp.get_size();
+        if (size > max_scratchpad_size) {
+            max_scratchpad_size = size;
+            max_scratchpad_md = sp;
+        }
+    }
+
+    // Initialize memory objects
+    sub_src1 = memory(sub_src1_md, p_engine, nullptr);
+    sub_wei1_user = memory(sub_wei1_user_md, p_engine, nullptr);
+    sub_mm1_src = memory(sub_mm1_src_md, p_engine, nullptr);
+    sub_mm1_wei = memory(sub_wei1_md, p_engine, nullptr);
+    sub_mm1_dst = memory(sub_mm1_dst_md, p_engine, nullptr);
+
+    for (size_t i = 0; i < sub_mm1_post_md.size(); i++) {
+        sub_mm1_post_mem.emplace_back(sub_mm1_post_md[i], p_engine, nullptr);
+    }
+
+    // Softmax output P is f32 (dt_inter); reorder to dt_src_user is applied before mm2 when needed.
+    sub_softmax_out = memory(softmax_out_md, p_engine, nullptr);
+
+    // mm2 memories
+    sub_wei2_user = memory(sub_wei2_user_md, p_engine, nullptr);
+    sub_mm2_wei = memory(sub_wei2_md, p_engine, nullptr);
+    sub_mm2_dst = memory(sub_mm2_dst_md, p_engine, nullptr);
+    sub_dst_user = memory(sub_dst_user_md, p_engine, nullptr);
+
+    // scratchpad
+    sub_scratchpad = memory(max_scratchpad_md, p_engine, nullptr);
+
+    // Construct execution args
+    sub_reorder0_args = {{DNNL_ARG_SRC, sub_src1}, {DNNL_ARG_DST, sub_mm1_src},
+            {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    sub_reorder1_args = {{DNNL_ARG_SRC, sub_wei1_user},
+            {DNNL_ARG_DST, sub_mm1_wei}, {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+
+    sub_mm1_args = {{DNNL_ARG_SRC, sub_mm1_src},
+            {DNNL_ARG_WEIGHTS, sub_mm1_wei}, {DNNL_ARG_DST, sub_mm1_dst},
+            {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    for (int i = 0; i < mm1_ori_dnnl_pops.get()->len(); i++) {
+        if (mm1_ori_dnnl_pops.get()->entry_[i].is_binary()) {
+            sub_mm1_args.insert(
+                    {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1,
+                            sub_mm1_post_mem[i]});
+        }
+    }
+
+    // Softmax args
+    sub_softmax_args
+            = {{DNNL_ARG_SRC, sub_mm1_dst}, {DNNL_ARG_DST, sub_softmax_out},
+                    {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+
+    // Stats args (fused: reduce_max_P[log] runs first, then reduce_max_src[sub])
+    sub_reduce_max_P_args
+            = {{DNNL_ARG_SRC, sub_softmax_out}, {DNNL_ARG_DST, sub_log_max_P},
+                    {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    sub_reduce_max_src_args = {{DNNL_ARG_SRC, sub_mm1_dst},
+            {DNNL_ARG_DST, sub_stats},
+            {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, sub_log_max_P},
+            {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    sub_reorder_stats_args
+            = {{DNNL_ARG_SRC, sub_stats}, {DNNL_ARG_DST, sub_stats_user},
+                    {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+
+    // Reorder f32 softmax_out -> bf16/f16 mm2_src.
+    if (needs_softmax_reorder) {
+        sub_reorder_softmax_args
+                = {{DNNL_ARG_SRC, sub_softmax_out}, {DNNL_ARG_DST, sub_mm2_src},
+                        {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    }
+
+    sub_reorder2_args = {{DNNL_ARG_SRC, sub_wei2_user},
+            {DNNL_ARG_DST, sub_mm2_wei}, {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    // mm2 src: bf16 sub_mm2_src if reordered, else f32 sub_softmax_out
+    auto &mm2_src_mem = needs_softmax_reorder ? sub_mm2_src : sub_softmax_out;
+    sub_mm2_args = {{DNNL_ARG_SRC, mm2_src_mem},
+            {DNNL_ARG_WEIGHTS, sub_mm2_wei}, {DNNL_ARG_DST, sub_mm2_dst},
+            {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    sub_reorder3_args
+            = {{DNNL_ARG_SRC, sub_mm2_dst}, {DNNL_ARG_DST, sub_dst_user},
+                    {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+
+    ////////////////////////////////////////////////////////////////////////
+    /////////////// End Constructing exec args /////////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+
+    // Memory planning
+    memory_planning(sdp_registry);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(nthr);
+#endif
+    return status::success;
+}
+
+op_ptr sdp_decomp_training_config_t::get_post_op(const op_ptr &op) const {
+    const auto out_val = op->get_output_value(0);
+    const auto &consumers = out_val->get_consumers();
+    if (consumers.size() != 1) return nullptr;
+    return consumers[0].get_op().shared_from_this();
+}
+
+impl::status_t sdp_decomp_training_config_t::record_input_offset(
+        const std::shared_ptr<subgraph_t> &sg,
+        const std::vector<logical_tensor_t> &inputs) {
+    auto find_graph_inport = [&](std::shared_ptr<value_t> val) {
+        if (val->get_consumers()[0].get_op().get_kind()
+                        == graph::op_kind::MatMul
+                || (val->has_producer()
+                        && val->get_producer().get_kind()
+                                == graph::op_kind::StaticReshape)) {
+            while (val->has_producer()) {
+                val = val->get_producer().get_input_value(0);
+            }
+        }
+        for (int i = 0; i < (int)inputs.size(); i++) {
+            if (val->get_logical_tensor().id == inputs[i].id) { return i; }
+        }
+        return -1;
+    };
+
+    op_ptr mm1 = nullptr, mm2 = nullptr, scale = nullptr;
+    const std::unordered_set<graph::op_kind_t> post_op_kind
+            = {graph::op_kind::Divide, graph::op_kind::Multiply,
+                    graph::op_kind::Add, graph::op_kind::SoftMax};
+
+    for (const auto &cur_op : sg->get_ops()) {
+        if (mm1 && mm2) break;
+        if (cur_op->get_kind() != graph::op_kind::MatMul) continue;
+
+        auto post_op = get_post_op(cur_op);
+        if (post_op && post_op_kind.count(post_op->get_kind())) {
+            mm1 = cur_op;
+            if (post_op->get_kind() == graph::op_kind::Divide
+                    || post_op->get_kind() == graph::op_kind::Multiply) {
+                has_scale = true;
+                scale = post_op;
+                post_op = get_post_op(post_op);
+            }
+            // Reject attention mask (Add or Select) for now
+            if (post_op
+                    && (post_op->get_kind() == graph::op_kind::Add
+                            || post_op->get_kind() == graph::op_kind::Select)) {
+                return status::unimplemented;
+            }
+        } else {
+            mm2 = cur_op;
+        }
+    }
+
+    VCHECK_SDP_TRAIN(mm1 != nullptr && mm2 != nullptr, status::invalid_graph,
+            "Failed to find matmul1 or matmul2");
+
+    graph_inport.emplace_back(find_graph_inport(mm1->get_input_value(0)));
+    graph_inport.emplace_back(find_graph_inport(mm1->get_input_value(1)));
+    graph_inport.emplace_back(find_graph_inport(mm2->get_input_value(1)));
+
+    if (has_scale) {
+        int scale_id = find_graph_inport(scale->get_input_value(1));
+        if (scale_id == -1)
+            scale_id = find_graph_inport(scale->get_input_value(0));
+        graph_inport.emplace_back(scale_id);
+    } else {
+        graph_inport.emplace_back(-1);
+    }
+
+    return status::success;
+}
+
+impl::status_t sdp_decomp_training_config_t::record_sdp_ops(
+        std::shared_ptr<subgraph_t> &sg) {
+    for (const auto &cur_op : sg->get_ops()) {
+        if (!cur_op || cur_op->get_kind() != op_kind::_matmul) continue;
+        auto post_op = get_post_op(cur_op);
+        if (!post_op || post_op->get_kind() != op_kind::_softmax) continue;
+        auto ppost_op = get_post_op(post_op);
+        VCHECK_SDP_TRAIN(ppost_op != nullptr, status::invalid_graph,
+                "Failed to find mm2 after softmax");
+        // sdp_op = [mm1, softmax, mm2]
+        this->sdp_op = {cur_op, post_op, ppost_op};
+        break;
+    }
+    VCHECK_SDP_TRAIN(
+            sdp_op.size() == 3, status::invalid_graph, "Failed to record ops");
+    return status::success;
+}
+
+void sdp_decomp_training_config_t::memory_planning(registry_t &sdp_registry) {
+    registrar_t temporary_registrar = sdp_registry.registrar();
+
+    // Memory reuse based on non-overlapping lifetimes:
+    // key 0: mm1_src [seq_q, d_qk] then softmax_out [seq_q, seq_kv]
+    // key 1: mm1_wei [d_qk, seq_kv]
+    // key 2: mm1_dst [seq_q, seq_kv] then mm2_wei [seq_kv, d_v]
+    // key 3: mm2_dst [seq_q, d_v]
+    // key 4: scratchpad (shared across all primitives)
+
+    // TODO(xxx): The memory planning can be further optimized if the user
+    // inputs are already in dense format, then we don't need to allocate
+    // separate memory for sub_mm1_src, sub_mm1_wei, and sub_mm2_wei.
+    auto scores_size = sub_mm1_dst.get_desc().get_size();
+    auto mm1_src_size = sub_mm1_src.get_desc().get_size();
+    auto softmax_out_size = sub_softmax_out.get_desc().get_size();
+    auto mm2_wei_size = sub_mm2_wei.get_desc().get_size();
+
+    size_t key0_size = std::max(mm1_src_size, softmax_out_size);
+    size_t key2_size = std::max(scores_size, mm2_wei_size);
+
+    mem_key_map = {
+            {sub_mm1_src.get(), 0},
+            {sub_softmax_out.get(), 0},
+            {sub_mm1_wei.get(), 1},
+            {sub_mm1_dst.get(), 2},
+            {sub_mm2_wei.get(), 2},
+            {sub_mm2_dst.get(), 3},
+            {sub_scratchpad.get(), 4},
+    };
+
+    temporary_registrar.book(0, key0_size);
+    temporary_registrar.book(1, sub_mm1_wei.get_desc().get_size());
+    temporary_registrar.book(2, key2_size);
+    temporary_registrar.book(3, sub_mm2_dst.get_desc().get_size());
+    temporary_registrar.book(4, sub_scratchpad.get_desc().get_size());
+
+    int next_key = 5;
+    if (needs_softmax_reorder) {
+        mem_key_map[sub_mm2_src.get()] = next_key;
+        temporary_registrar.book(next_key, sub_mm2_src.get_desc().get_size());
+        next_key++;
+    }
+
+    mem_key_map[sub_log_max_P.get()] = next_key;
+    temporary_registrar.book(next_key, sub_log_max_P.get_desc().get_size());
+    next_key++;
+
+    mem_key_map[sub_stats.get()] = next_key;
+    temporary_registrar.book(next_key, sub_stats.get_desc().get_size());
+    next_key++;
+}
+
+dnnl::primitive_attr sdp_decomp_training_config_t::make_primitive_attr(
+        std::shared_ptr<op_t> &op) {
+    dnnl::primitive_attr attr;
+    if (op && op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        attr = make_dnnl_primitive_attr(op, fusion_info);
+    }
+    attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    return attr;
+}
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.cpp
@@ -122,8 +122,8 @@ bool sdp_decomp_training_config_t::initial_check(
     // Initialize nthr with max threads num
     nthr = dnnl_get_max_threads();
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
-#define RATIO 2
-    VCHECK_SDP_TRAIN(batch_size * num_head_q > RATIO * nthr, false,
+    constexpr dim_t ratio = 2;
+    VCHECK_SDP_TRAIN(batch_size * num_head_q > ratio * nthr, false,
             "Doesn't meet condition for decompose: batch_size * num_head_q "
             "should be larger than ratio * nthr");
 #endif

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.cpp
@@ -392,7 +392,7 @@ impl::status_t sdp_decomp_training_config_t::construct_params(
         sub_mm1_post_mem.emplace_back(sub_mm1_post_md[i], p_engine, nullptr);
     }
 
-    // Softmax output P is in dt_src_user (bf16) for mm2 consumption
+    // Softmax output P is f32 (dt_inter); reorder to dt_src_user is applied before mm2 when needed.
     sub_softmax_out = memory(softmax_out_md, p_engine, nullptr);
 
     // mm2 memories

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.cpp
@@ -1,0 +1,619 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "graph/backend/dnnl/kernels/sdp_decomp_training_config.hpp"
+
+#include "graph/backend/dnnl/common.hpp"
+#include "graph/backend/dnnl/fusion_info.hpp"
+
+#define VCHECK_SDP_TRAIN(cond, status, msg, ...) \
+    VCONDCHECK(graph, create, check, sdp_decomp_training_kernel_t, (cond), \
+            status, msg, ##__VA_ARGS__);
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+bool sdp_decomp_training_config_t::initial_check(
+        const std::shared_ptr<subgraph_t> &sg,
+        const std::vector<logical_tensor_t> &inputs,
+        const std::vector<logical_tensor_t> &outputs) {
+    // Record the input offset
+    CHECK_BOOL(record_input_offset(sg, inputs));
+
+    dims src1_user_dims = ltw(inputs[graph_inport[mm1_src]]).vdims();
+    ndims = src1_user_dims.size();
+    VCHECK_SDP_TRAIN(ndims == 4, false,
+            "Training decomp only supports 4D input, but got %zu ndims",
+            src1_user_dims.size());
+
+    // Require 2 outputs: attention output + stats (logsumexp)
+    VCHECK_SDP_TRAIN(outputs.size() == 2, false,
+            "Training decomp requires 2 outputs (attn + stats), but got %zu",
+            outputs.size());
+
+    // Determine which output index is attention output vs stats
+    // Stats has last dim = 1, attention output has last dim = head_size_v
+    {
+        dims out0_dims = ltw(outputs[0]).vdims();
+        dims out1_dims = ltw(outputs[1]).vdims();
+        if (out0_dims.back() == 1) {
+            stats_out_index = 0;
+            attn_out_index = 1;
+        } else {
+            stats_out_index = 1;
+            attn_out_index = 0;
+        }
+        stats_dst_strides = ltw(outputs[stats_out_index]).vstrides();
+    }
+
+    // Initialize SDP input dimensions
+    batch_size = src1_user_dims[0];
+    num_head_q = src1_user_dims[1];
+    seq_len_q = src1_user_dims[2];
+    head_size_qk = src1_user_dims[3];
+
+    dims wei1_user_dims = ltw(inputs[graph_inport[mm1_wei]]).vdims();
+    dims wei2_user_dims = ltw(inputs[graph_inport[mm2_wei]]).vdims();
+    num_head_kv = wei1_user_dims[1];
+    VCHECK_SDP_TRAIN(
+            num_head_kv == wei2_user_dims[1], false, "kv head number mismatch");
+
+    VCHECK_SDP_TRAIN(
+            batch_size == wei1_user_dims[0] && batch_size == wei2_user_dims[0],
+            false, "Batch size mismatch");
+
+    seq_len_kv = wei1_user_dims[3]; // K shape: [batch, head, head_size, seq_kv]
+    head_size_v = wei2_user_dims[3];
+
+    // Check scale size
+    if (graph_inport[mm1_scale] != -1) {
+        auto scale_sz = ltw(inputs[graph_inport[mm1_scale]]).nelems();
+        VCHECK_SDP_TRAIN(scale_sz == 1, false,
+                "Only supports single scale value, but got %ld",
+                static_cast<long int>(scale_sz));
+    }
+
+    // Reject quantized ops
+    for (const auto &cur_op : sg->get_ops()) {
+        const auto &op_kind = cur_op->get_kind();
+        VCHECK_SDP_TRAIN(op_kind != graph::op_kind::Quantize
+                        && op_kind != graph::op_kind::Dequantize
+                        && op_kind != graph::op_kind::DynamicDequantize,
+                false, "Training decomp does not support quantization");
+        // Reject dropout
+        VCHECK_SDP_TRAIN(op_kind != graph::op_kind::Dropout, false,
+                "Training decomp does not support dropout yet");
+        // Reject inf_as_zero mode softmax
+        if (op_kind == graph::op_kind::SoftMax
+                && cur_op->has_attr(op_attr::mode)) {
+            const auto &mode = cur_op->get_attr<std::string>(op_attr::mode);
+            VCHECK_SDP_TRAIN(mode != "inf_as_zero", false,
+                    "Training decomp does not support inf_as_zero mode");
+        }
+    }
+
+    // Check data types - only f32/bf16/f16
+    auto src_dt = ltw(inputs[graph_inport[mm1_src]]).data_type();
+    VCHECK_SDP_TRAIN(src_dt == graph::data_type::f32
+                    || src_dt == graph::data_type::bf16
+                    || src_dt == graph::data_type::f16,
+            false, "Only supports f32/bf16/f16 data types");
+
+    // K and V must have the same data type
+    VCHECK_SDP_TRAIN(ltw(inputs[graph_inport[mm1_wei]]).data_type()
+                    == ltw(inputs[graph_inport[mm2_wei]]).data_type(),
+            false, "Key and value should have the same data type");
+
+    // Initialize nthr with max threads num
+    nthr = dnnl_get_max_threads();
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+#define RATIO 2
+    VCHECK_SDP_TRAIN(batch_size * num_head_q > RATIO * nthr, false,
+            "Doesn't meet condition for decompose: batch_size * num_head_q "
+            "should be larger than ratio * nthr");
+#endif
+    return true;
+}
+
+impl::status_t sdp_decomp_training_config_t::construct_params(
+        std::shared_ptr<subgraph_t> &sg, registry_t &sdp_registry,
+        const dnnl::engine &p_engine,
+        const std::vector<logical_tensor_t> &inputs) {
+
+    CHECK(record_sdp_ops(sg));
+    const dim_t last_dim = ndims - 1, second_last_dim = ndims - 2;
+
+    // Update seq_len_kv from the actual weight shape after passes
+    const auto &lt_wei = sdp_op[0]->get_input_logical_tensor(1);
+    const ltw ltw_wei(lt_wei);
+    seq_len_kv = ltw_wei.vdims()[last_dim];
+
+    // Acquire data type
+    memory::data_type dt_src_user = static_cast<memory::data_type>(
+            ltw(inputs[graph_inport[mm1_src]]).data_type());
+    // For training, intermediate computation (scores, softmax) uses f32
+    // for numerical precision. User-facing I/O (Q, K, V, output, P) stays
+    // in dt_src_user (e.g., bf16).
+    memory::data_type dt_inter = memory::data_type::f32;
+
+    ////////////////////////////////////////////////////////////////////////
+    ////////////// Start Creating primitives ///////////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(1);
+#endif
+
+    // Memory descriptors
+    memory::desc sub_src1_md, sub_wei1_user_md, sub_wei1_md, sub_mm1_src_md,
+            sub_mm1_wei_md, sub_mm1_dst_md, sub_wei2_user_md, sub_mm2_wei_md,
+            sub_mm2_dst_md, sub_dst_md, sub_dst_user_md;
+    std::vector<memory::desc> sub_mm1_post_md;
+
+    // reorder0: src1 strided -> dense
+    primitive_attr sub_reorder0_attr;
+    sub_reorder0_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    dims sub_src1_dims = {seq_len_q, head_size_qk};
+    src1_strides = ltw(inputs[graph_inport[mm1_src]]).vstrides();
+    sub_src1_md = memory::desc(sub_src1_dims, dt_src_user,
+            {src1_strides[second_last_dim], src1_strides[last_dim]});
+    auto sub_src1_d_md
+            = memory::desc(sub_src1_dims, dt_src_user, format_tag::ab);
+    auto sub_reorder0_pd = reorder::primitive_desc(
+            p_engine, sub_src1_md, p_engine, sub_src1_d_md, sub_reorder0_attr);
+    sub_reorder0.init(sub_reorder0_pd);
+
+    // reorder1: key strided -> transposed dense
+    primitive_attr sub_reorder1_attr;
+    sub_reorder1_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+
+    dims sub_wei1_dims = {head_size_qk, seq_len_kv};
+    auto wei_md = make_dnnl_memory_desc(sdp_op[0]->get_input_logical_tensor(1));
+    wei1_strides = wei_md.get_strides();
+    sub_wei1_user_md = memory::desc(sub_wei1_dims, dt_src_user,
+            {wei1_strides[second_last_dim], wei1_strides[last_dim]});
+    sub_wei1_md = memory::desc(sub_wei1_dims, dt_src_user, format_tag::ba);
+    auto sub_reorder1_pd = reorder::primitive_desc(p_engine, sub_wei1_user_md,
+            p_engine, sub_wei1_md, sub_reorder1_attr);
+    sub_reorder1.init(sub_reorder1_pd);
+
+    // MatMul1: Q × K^T -> f32 scores
+    dnnl::primitive_attr sub_matmul1_attr = make_primitive_attr(sdp_op[0]);
+    dims sub_mm1_src_dims = {seq_len_q, head_size_qk};
+    dims sub_mm1_wei_dims = {head_size_qk, seq_len_kv};
+    dims sub_mm1_dst_dims = {seq_len_q, seq_len_kv};
+
+    sub_mm1_src_md
+            = memory::desc(sub_mm1_src_dims, dt_src_user, format_tag::ab);
+    sub_mm1_wei_md
+            = memory::desc(sub_mm1_wei_dims, dt_src_user, format_tag::ba);
+    // mm1 output is f32 for numerical precision in softmax computation
+    sub_mm1_dst_md = memory::desc(sub_mm1_dst_dims, dt_inter, format_tag::ab);
+
+    // Handle post-ops for mm1 (scale, mask)
+    dnnl::post_ops dnnl_pops;
+    auto mm1_ori_dnnl_pops = sub_matmul1_attr.get_post_ops();
+    for (int i = 0; i < mm1_ori_dnnl_pops.get()->len(); i++) {
+        if (mm1_ori_dnnl_pops.get()->entry_[i].is_binary()) {
+            auto alg = static_cast<algorithm>(
+                    mm1_ori_dnnl_pops.get()->entry_[i].binary.alg);
+            const dnnl::impl::memory_desc_t &ori_desc
+                    = mm1_ori_dnnl_pops.get()->entry_[i].binary.user_src1_desc;
+            auto post_shape = ori_desc.dims;
+            auto post_stride = ori_desc.format_desc.blocking.strides;
+            auto post_dt
+                    = static_cast<dnnl::memory::data_type>(ori_desc.data_type);
+            auto new_sub_md = memory::desc(
+                    {post_shape[second_last_dim], post_shape[last_dim]},
+                    post_dt,
+                    {post_stride[second_last_dim], post_stride[last_dim]});
+            sub_mm1_post_md.emplace_back(new_sub_md);
+            dnnl_pops.append_binary(alg, new_sub_md);
+        } else if (mm1_ori_dnnl_pops.get()->entry_[i].is_eltwise()) {
+            auto alg = static_cast<algorithm>(
+                    mm1_ori_dnnl_pops.get()->entry_[i].eltwise.alg);
+            auto alpha = mm1_ori_dnnl_pops.get()->entry_[i].eltwise.alpha;
+            auto beta = mm1_ori_dnnl_pops.get()->entry_[i].eltwise.beta;
+            dnnl_pops.append_eltwise(alg, alpha, beta);
+        }
+    }
+    sub_matmul1_attr.set_post_ops(dnnl_pops);
+    auto sub_mm1_pd = matmul::primitive_desc(p_engine, sub_mm1_src_md,
+            sub_mm1_wei_md, sub_mm1_dst_md, sub_matmul1_attr);
+    sub_mm1_prim = matmul(sub_mm1_pd);
+
+    // Softmax primitive: scores -> P
+    dims scores_dims = {seq_len_q, seq_len_kv};
+    dims stats_dims = {seq_len_q, 1};
+    auto scores_md = memory::desc(scores_dims, dt_inter, format_tag::ab);
+    auto stats_md = memory::desc(stats_dims, dt_inter, format_tag::ab);
+    auto softmax_out_md = memory::desc(scores_dims, dt_inter, format_tag::ab);
+
+    primitive_attr softmax_attr;
+    softmax_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    auto sub_softmax_pd = softmax_forward::primitive_desc(p_engine,
+            prop_kind::forward_inference, algorithm::softmax_accurate,
+            sub_mm1_dst_md, softmax_out_md,
+            /*axis=*/sub_mm1_dst_md.get_ndims() - 1, softmax_attr);
+    sub_softmax_prim = softmax_forward(sub_softmax_pd);
+
+    // Stats computation: logsumexp = reduce_max(src) - log(reduce_max(P))
+    // Fused into 2 primitives using post-ops:
+    //   1) reduce_max(P) [log post-op] -> log_max_P
+    //   2) reduce_max(scores) [binary_sub(log_max_P) post-op] -> stats
+    memory::desc sub_reduce_max_P_scratchpad_md;
+    memory::desc sub_reduce_max_src_scratchpad_md;
+    {
+        // reduce_max(P) with log post-op -> log_max_P
+        primitive_attr reduce_max_P_attr;
+        reduce_max_P_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+        post_ops reduce_max_P_po;
+        reduce_max_P_po.append_eltwise(algorithm::eltwise_log, 0.f, 0.f);
+        reduce_max_P_attr.set_post_ops(reduce_max_P_po);
+        auto sub_reduce_max_P_pd
+                = reduction::primitive_desc(p_engine, algorithm::reduction_max,
+                        softmax_out_md, stats_md, 0.f, 0.f, reduce_max_P_attr);
+        sub_reduce_max_P_prim = reduction(sub_reduce_max_P_pd);
+        sub_reduce_max_P_scratchpad_md = sub_reduce_max_P_pd.scratchpad_desc();
+
+        // reduce_max(scores) with binary_sub(log_max_P) post-op -> stats
+        primitive_attr reduce_max_src_attr;
+        reduce_max_src_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+        post_ops reduce_max_src_po;
+        reduce_max_src_po.append_binary(algorithm::binary_sub, stats_md);
+        reduce_max_src_attr.set_post_ops(reduce_max_src_po);
+        auto sub_reduce_max_src_pd = reduction::primitive_desc(p_engine,
+                algorithm::reduction_max, sub_mm1_dst_md, stats_md, 0.f, 0.f,
+                reduce_max_src_attr);
+        sub_reduce_max_src_prim = reduction(sub_reduce_max_src_pd);
+        sub_reduce_max_src_scratchpad_md
+                = sub_reduce_max_src_pd.scratchpad_desc();
+
+        // Stats memories
+        sub_log_max_P = memory(stats_md, p_engine, nullptr);
+        sub_stats = memory(stats_md, p_engine, nullptr);
+    }
+
+    // reorder2: value strided -> dense
+    primitive_attr sub_reorder2_attr;
+    sub_reorder2_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    dims sub_wei2_dims = {seq_len_kv, head_size_v};
+    wei2_strides = ltw(inputs[graph_inport[mm2_wei]]).vstrides();
+    sub_wei2_user_md = memory::desc(sub_wei2_dims, dt_src_user,
+            {wei2_strides[second_last_dim], wei2_strides[last_dim]});
+    auto sub_wei2_md = memory::desc(sub_wei2_dims, dt_src_user, format_tag::ab);
+    auto sub_reorder2_pd = reorder::primitive_desc(p_engine, sub_wei2_user_md,
+            p_engine, sub_wei2_md, sub_reorder2_attr);
+    sub_reorder2.init(sub_reorder2_pd);
+
+    // MatMul2: P x V
+    // When softmax output is f32 but mm2 expects lower precision (bf16/f16),
+    // add a reorder. For pure f32 SDPA, no reorder needed.
+    needs_softmax_reorder = (dt_inter != dt_src_user);
+    memory::desc sub_reorder_softmax_scratchpad_md;
+    dnnl::primitive_attr sub_matmul2_attr = make_primitive_attr(sdp_op[2]);
+    dims sub_mm2_src_dims = {seq_len_q, seq_len_kv};
+    dims sub_mm2_wei_dims = {seq_len_kv, head_size_v};
+    dims sub_mm2_dst_dims = {seq_len_q, head_size_v};
+    auto sub_mm2_src_md
+            = memory::desc(sub_mm2_src_dims, dt_src_user, format_tag::ab);
+
+    if (needs_softmax_reorder) {
+        // Reorder f32 softmax output -> bf16/f16 for mm2
+        primitive_attr sub_reorder_softmax_attr;
+        sub_reorder_softmax_attr.set_scratchpad_mode(
+                dnnl::scratchpad_mode::user);
+        auto sub_reorder_softmax_pd
+                = reorder::primitive_desc(p_engine, softmax_out_md, p_engine,
+                        sub_mm2_src_md, sub_reorder_softmax_attr);
+        sub_reorder_softmax.init(sub_reorder_softmax_pd);
+        sub_reorder_softmax_scratchpad_md
+                = sub_reorder_softmax_pd.scratchpad_desc();
+        sub_mm2_src = memory(sub_mm2_src_md, p_engine, nullptr);
+    }
+
+    sub_mm2_wei_md
+            = memory::desc(sub_mm2_wei_dims, dt_src_user, format_tag::ab);
+    sub_mm2_dst_md
+            = memory::desc(sub_mm2_dst_dims, dt_src_user, format_tag::ab);
+    auto sub_mm2_pd = matmul::primitive_desc(p_engine, sub_mm2_src_md,
+            sub_mm2_wei_md, sub_mm2_dst_md, sub_matmul2_attr);
+    sub_mm2_prim = matmul(sub_mm2_pd);
+
+    // reorder3: output dense -> strided
+    primitive_attr sub_reorder3_attr;
+    sub_reorder3_attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    dims sub_dst_dims = {seq_len_q, head_size_v};
+    auto out_lt = sdp_op[2]->get_output_logical_tensor(0);
+    dst_strides = ltw(out_lt).vstrides();
+    sub_dst_md = memory::desc(sub_dst_dims, dt_src_user, format_tag::ab);
+    sub_dst_user_md = memory::desc(sub_dst_dims, dt_src_user,
+            {dst_strides[second_last_dim], dst_strides[last_dim]});
+    auto sub_reorder3_pd = reorder::primitive_desc(
+            p_engine, sub_dst_md, p_engine, sub_dst_user_md, sub_reorder3_attr);
+    sub_reorder3.init(sub_reorder3_pd);
+
+    ////////////////////////////////////////////////////////////////////////
+    /////////////// End Creating primitives ////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+
+    ////////////////////////////////////////////////////////////////////////
+    /////////////// Start Constructing exec args ///////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+
+    // Find max scratchpad size
+    size_t max_scratchpad_size = 0;
+    memory::desc max_scratchpad_md;
+    std::vector<memory::desc> scratchpads {
+            sub_reorder0_pd.scratchpad_desc(),
+            sub_reorder1_pd.scratchpad_desc(),
+            sub_mm1_pd.scratchpad_desc(),
+            sub_softmax_pd.scratchpad_desc(),
+            sub_reorder2_pd.scratchpad_desc(),
+            sub_mm2_pd.scratchpad_desc(),
+            sub_reorder3_pd.scratchpad_desc(),
+    };
+    if (needs_softmax_reorder) {
+        scratchpads.push_back(sub_reorder_softmax_scratchpad_md);
+    }
+    scratchpads.push_back(sub_reduce_max_src_scratchpad_md);
+    scratchpads.push_back(sub_reduce_max_P_scratchpad_md);
+    for (auto &sp : scratchpads) {
+        const size_t size = sp.get_size();
+        if (size > max_scratchpad_size) {
+            max_scratchpad_size = size;
+            max_scratchpad_md = sp;
+        }
+    }
+
+    // Initialize memory objects
+    sub_src1 = memory(sub_src1_md, p_engine, nullptr);
+    sub_wei1_user = memory(sub_wei1_user_md, p_engine, nullptr);
+    sub_mm1_src = memory(sub_mm1_src_md, p_engine, nullptr);
+    sub_mm1_wei = memory(sub_wei1_md, p_engine, nullptr);
+    sub_mm1_dst = memory(sub_mm1_dst_md, p_engine, nullptr);
+
+    for (size_t i = 0; i < sub_mm1_post_md.size(); i++) {
+        sub_mm1_post_mem.emplace_back(sub_mm1_post_md[i], p_engine, nullptr);
+    }
+
+    // Softmax output P is in dt_src_user (bf16) for mm2 consumption
+    sub_softmax_out = memory(softmax_out_md, p_engine, nullptr);
+
+    // mm2 memories
+    sub_wei2_user = memory(sub_wei2_user_md, p_engine, nullptr);
+    sub_mm2_wei = memory(sub_wei2_md, p_engine, nullptr);
+    sub_mm2_dst = memory(sub_mm2_dst_md, p_engine, nullptr);
+    sub_dst_user = memory(sub_dst_user_md, p_engine, nullptr);
+
+    // scratchpad
+    sub_scratchpad = memory(max_scratchpad_md, p_engine, nullptr);
+
+    // Construct execution args
+    sub_reorder0_args = {{DNNL_ARG_SRC, sub_src1}, {DNNL_ARG_DST, sub_mm1_src},
+            {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    sub_reorder1_args = {{DNNL_ARG_SRC, sub_wei1_user},
+            {DNNL_ARG_DST, sub_mm1_wei}, {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+
+    sub_mm1_args = {{DNNL_ARG_SRC, sub_mm1_src},
+            {DNNL_ARG_WEIGHTS, sub_mm1_wei}, {DNNL_ARG_DST, sub_mm1_dst},
+            {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    for (int i = 0; i < mm1_ori_dnnl_pops.get()->len(); i++) {
+        if (mm1_ori_dnnl_pops.get()->entry_[i].is_binary()) {
+            sub_mm1_args.insert(
+                    {DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1,
+                            sub_mm1_post_mem[i]});
+        }
+    }
+
+    // Softmax args
+    sub_softmax_args
+            = {{DNNL_ARG_SRC, sub_mm1_dst}, {DNNL_ARG_DST, sub_softmax_out},
+                    {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+
+    // Stats args (fused: reduce_max_P[log] runs first, then reduce_max_src[sub])
+    sub_reduce_max_P_args
+            = {{DNNL_ARG_SRC, sub_softmax_out}, {DNNL_ARG_DST, sub_log_max_P},
+                    {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    sub_reduce_max_src_args = {{DNNL_ARG_SRC, sub_mm1_dst},
+            {DNNL_ARG_DST, sub_stats},
+            {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1, sub_log_max_P},
+            {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+
+    // Reorder f32 softmax_out -> bf16/f16 mm2_src.
+    if (needs_softmax_reorder) {
+        sub_reorder_softmax_args
+                = {{DNNL_ARG_SRC, sub_softmax_out}, {DNNL_ARG_DST, sub_mm2_src},
+                        {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    }
+
+    sub_reorder2_args = {{DNNL_ARG_SRC, sub_wei2_user},
+            {DNNL_ARG_DST, sub_mm2_wei}, {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    // mm2 src: bf16 sub_mm2_src if reordered, else f32 sub_softmax_out
+    auto &mm2_src_mem = needs_softmax_reorder ? sub_mm2_src : sub_softmax_out;
+    sub_mm2_args = {{DNNL_ARG_SRC, mm2_src_mem},
+            {DNNL_ARG_WEIGHTS, sub_mm2_wei}, {DNNL_ARG_DST, sub_mm2_dst},
+            {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+    sub_reorder3_args
+            = {{DNNL_ARG_SRC, sub_mm2_dst}, {DNNL_ARG_DST, sub_dst_user},
+                    {DNNL_ARG_SCRATCHPAD, sub_scratchpad}};
+
+    ////////////////////////////////////////////////////////////////////////
+    /////////////// End Constructing exec args /////////////////////////////
+    ////////////////////////////////////////////////////////////////////////
+
+    // Memory planning
+    memory_planning(sdp_registry);
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    omp_set_num_threads(nthr);
+#endif
+    return status::success;
+}
+
+op_ptr sdp_decomp_training_config_t::get_post_op(const op_ptr &op) const {
+    const auto out_val = op->get_output_value(0);
+    const auto &consumers = out_val->get_consumers();
+    if (consumers.size() != 1) return nullptr;
+    return consumers[0].get_op().shared_from_this();
+}
+
+impl::status_t sdp_decomp_training_config_t::record_input_offset(
+        const std::shared_ptr<subgraph_t> &sg,
+        const std::vector<logical_tensor_t> &inputs) {
+    auto find_graph_inport = [&](std::shared_ptr<value_t> val) {
+        if (val->get_consumers()[0].get_op().get_kind()
+                        == graph::op_kind::MatMul
+                || (val->has_producer()
+                        && val->get_producer().get_kind()
+                                == graph::op_kind::StaticReshape)) {
+            while (val->has_producer()) {
+                val = val->get_producer().get_input_value(0);
+            }
+        }
+        for (int i = 0; i < (int)inputs.size(); i++) {
+            if (val->get_logical_tensor().id == inputs[i].id) { return i; }
+        }
+        return -1;
+    };
+
+    op_ptr mm1 = nullptr, mm2 = nullptr, scale = nullptr;
+    const std::unordered_set<graph::op_kind_t> post_op_kind
+            = {graph::op_kind::Divide, graph::op_kind::Multiply,
+                    graph::op_kind::Add, graph::op_kind::SoftMax};
+
+    for (const auto &cur_op : sg->get_ops()) {
+        if (mm1 && mm2) break;
+        if (cur_op->get_kind() != graph::op_kind::MatMul) continue;
+
+        auto post_op = get_post_op(cur_op);
+        if (post_op && post_op_kind.count(post_op->get_kind())) {
+            mm1 = cur_op;
+            if (post_op->get_kind() == graph::op_kind::Divide
+                    || post_op->get_kind() == graph::op_kind::Multiply) {
+                has_scale = true;
+                scale = post_op;
+                post_op = get_post_op(post_op);
+            }
+            // Reject attention mask for now
+            if (post_op && post_op->get_kind() == graph::op_kind::Add) {
+                return status::unimplemented;
+            }
+        } else {
+            mm2 = cur_op;
+        }
+    }
+
+    VCHECK_SDP_TRAIN(mm1 != nullptr && mm2 != nullptr, status::invalid_graph,
+            "Failed to find matmul1 or matmul2");
+
+    graph_inport.emplace_back(find_graph_inport(mm1->get_input_value(0)));
+    graph_inport.emplace_back(find_graph_inport(mm1->get_input_value(1)));
+    graph_inport.emplace_back(find_graph_inport(mm2->get_input_value(1)));
+
+    if (has_scale) {
+        int scale_id = find_graph_inport(scale->get_input_value(1));
+        if (scale_id == -1)
+            scale_id = find_graph_inport(scale->get_input_value(0));
+        graph_inport.emplace_back(scale_id);
+    } else {
+        graph_inport.emplace_back(-1);
+    }
+
+    return status::success;
+}
+
+impl::status_t sdp_decomp_training_config_t::record_sdp_ops(
+        std::shared_ptr<subgraph_t> &sg) {
+    for (const auto &cur_op : sg->get_ops()) {
+        if (!cur_op || cur_op->get_kind() != op_kind::_matmul) continue;
+        auto post_op = get_post_op(cur_op);
+        if (!post_op || post_op->get_kind() != op_kind::_softmax) continue;
+        auto ppost_op = get_post_op(post_op);
+        VCHECK_SDP_TRAIN(ppost_op != nullptr, status::invalid_graph,
+                "Failed to find mm2 after softmax");
+        // sdp_op = [mm1, softmax, mm2]
+        this->sdp_op = {cur_op, post_op, ppost_op};
+        break;
+    }
+    VCHECK_SDP_TRAIN(
+            sdp_op.size() == 3, status::invalid_graph, "Failed to record ops");
+    return status::success;
+}
+
+void sdp_decomp_training_config_t::memory_planning(registry_t &sdp_registry) {
+    registrar_t temporary_registrar = sdp_registry.registrar();
+
+    // Memory reuse based on non-overlapping lifetimes:
+    // key 0: mm1_src [seq_q, d_qk] then softmax_out [seq_q, seq_kv]
+    // key 1: mm1_wei [d_qk, seq_kv]
+    // key 2: mm1_dst [seq_q, seq_kv] then mm2_wei [seq_kv, d_v]
+    // key 3: mm2_dst [seq_q, d_v]
+    // key 4: scratchpad (shared across all primitives)
+
+    // TODO(xxx): The memory planning can be further optimized if the user
+    // inputs are already in dense format, then we don't need to allocate
+    // separate memory for sub_mm1_src, sub_mm1_wei, and sub_mm2_wei.
+    auto scores_size = sub_mm1_dst.get_desc().get_size();
+    auto mm1_src_size = sub_mm1_src.get_desc().get_size();
+    auto softmax_out_size = sub_softmax_out.get_desc().get_size();
+    auto mm2_wei_size = sub_mm2_wei.get_desc().get_size();
+
+    size_t key0_size = std::max(mm1_src_size, softmax_out_size);
+    size_t key2_size = std::max(scores_size, mm2_wei_size);
+
+    mem_key_map = {
+            {sub_mm1_src.get(), 0},
+            {sub_softmax_out.get(), 0},
+            {sub_mm1_wei.get(), 1},
+            {sub_mm1_dst.get(), 2},
+            {sub_mm2_wei.get(), 2},
+            {sub_mm2_dst.get(), 3},
+            {sub_scratchpad.get(), 4},
+    };
+
+    temporary_registrar.book(0, key0_size);
+    temporary_registrar.book(1, sub_mm1_wei.get_desc().get_size());
+    temporary_registrar.book(2, key2_size);
+    temporary_registrar.book(3, sub_mm2_dst.get_desc().get_size());
+    temporary_registrar.book(4, sub_scratchpad.get_desc().get_size());
+
+    int next_key = 5;
+    if (needs_softmax_reorder) { mem_key_map[sub_mm2_src.get()] = 0; }
+
+    mem_key_map[sub_log_max_P.get()] = next_key;
+    temporary_registrar.book(next_key, sub_log_max_P.get_desc().get_size());
+    next_key++;
+}
+
+dnnl::primitive_attr sdp_decomp_training_config_t::make_primitive_attr(
+        std::shared_ptr<op_t> &op) {
+    dnnl::primitive_attr attr;
+    if (op && op->has_attr(op_attr::fusion_info)) {
+        const fusion_info_t &fusion_info
+                = op->get_attr<fusion_info_t>(op_attr::fusion_info);
+        attr = make_dnnl_primitive_attr(op, fusion_info);
+    }
+    attr.set_scratchpad_mode(dnnl::scratchpad_mode::user);
+    return attr;
+}
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.hpp
@@ -1,0 +1,151 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GRAPH_BACKEND_DNNL_KERNELS_SDP_DECOMP_TRAINING_CONFIG_HPP
+#define GRAPH_BACKEND_DNNL_KERNELS_SDP_DECOMP_TRAINING_CONFIG_HPP
+
+#include <memory>
+#include <vector>
+
+#include "oneapi/dnnl/dnnl.hpp"
+
+#include "graph/interface/c_types_map.hpp"
+
+#include "graph/backend/dnnl/kernels/sdp_decomp_config.hpp"
+#include "graph/backend/dnnl/scratchpad.hpp"
+#include "graph/backend/dnnl/subgraph.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+struct sdp_decomp_training_config_t {
+public:
+    sdp_decomp_training_config_t() = default;
+
+    // SDP input dimension
+    dim_t ndims, batch_size, num_head_q, seq_len_q, seq_len_kv;
+    dim_t head_size_qk, head_size_v;
+
+    // SDP input and output strides
+    dims src1_strides, wei1_strides, wei2_strides, dst_strides,
+            stats_dst_strides;
+
+    // Thread nums during the workflow
+    int nthr = 0;
+
+    // Used to record the exact input offset in subgraph
+    // [mm1_src, mm1_wei, mm2_wei, mm1_scale]
+    std::vector<int> graph_inport;
+    enum input_index_t {
+        mm1_src = 0,
+        mm1_wei,
+        mm2_wei,
+        mm1_scale,
+    };
+
+    // Primitives for the execution pipeline
+    sdp_reorder_t sub_reorder0, sub_reorder1, sub_reorder2, sub_reorder3;
+    primitive sub_mm1_prim, sub_mm2_prim;
+
+    // Softmax primitive: scores -> P (f32)
+    primitive sub_softmax_prim;
+    // f32 softmax_out -> xf16 for mm2
+    sdp_reorder_t sub_reorder_softmax;
+
+    // Stats computation primitives (logsumexp = max(src) - log(max(P)))
+    primitive sub_reduce_max_P_prim;
+    primitive sub_reduce_max_src_prim;
+    // dense stats -> user layout
+    sdp_reorder_t sub_reorder_stats;
+
+    // Args used in execution of primitives
+    std::unordered_map<int, memory> sub_reorder0_args, sub_reorder1_args,
+            sub_mm1_args, sub_reorder2_args, sub_mm2_args, sub_reorder3_args;
+    std::unordered_map<int, memory> sub_softmax_args;
+    std::unordered_map<int, memory> sub_reorder_softmax_args;
+    std::unordered_map<int, memory> sub_reduce_max_P_args,
+            sub_reduce_max_src_args;
+    std::unordered_map<int, memory> sub_reorder_stats_args;
+
+    // A map from memory to registry key
+    std::unordered_map<dnnl_memory_t, registry_key> mem_key_map;
+
+    // Internal memory objects
+    // reorder0
+    memory sub_src1;
+    // reorder1
+    memory sub_wei1_user;
+    // mm1
+    memory sub_mm1_src, sub_mm1_wei, sub_mm1_dst;
+    // mm1 post-ops memories (scale, mask)
+    std::vector<memory> sub_mm1_post_mem;
+    // softmax output
+    memory sub_softmax_out;
+    // stats
+    memory sub_log_max_P;
+    memory sub_stats;
+    memory sub_stats_user;
+    // reorder2
+    memory sub_wei2_user;
+    // mm2
+    memory sub_mm2_src;
+    memory sub_mm2_wei, sub_mm2_dst;
+    // reorder3
+    memory sub_dst_user;
+    // scratchpad
+    memory sub_scratchpad;
+
+    bool has_scale = false;
+    bool needs_softmax_reorder = false;
+    int attn_out_index = 0;
+    int stats_out_index = 1;
+
+private:
+    std::vector<op_ptr> sdp_op;
+
+public:
+    // Check if configuration is supported
+    bool initial_check(const std::shared_ptr<subgraph_t> &sg,
+            const std::vector<logical_tensor_t> &inputs,
+            const std::vector<logical_tensor_t> &outputs);
+
+    // Construct all params needed for execution
+    impl::status_t construct_params(std::shared_ptr<subgraph_t> &sg,
+            registry_t &sdp_registry, const dnnl::engine &p_engine,
+            const std::vector<logical_tensor_t> &inputs,
+            const std::vector<logical_tensor_t> &outputs);
+
+private:
+    op_ptr get_post_op(const op_ptr &op) const;
+
+    impl::status_t record_input_offset(const std::shared_ptr<subgraph_t> &sg,
+            const std::vector<logical_tensor_t> &inputs);
+
+    impl::status_t record_sdp_ops(std::shared_ptr<subgraph_t> &sg);
+
+    void memory_planning(registry_t &sdp_registry);
+
+    dnnl::primitive_attr make_primitive_attr(std::shared_ptr<op_t> &op);
+};
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_training_config.hpp
@@ -1,0 +1,146 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GRAPH_BACKEND_DNNL_KERNELS_SDP_DECOMP_TRAINING_CONFIG_HPP
+#define GRAPH_BACKEND_DNNL_KERNELS_SDP_DECOMP_TRAINING_CONFIG_HPP
+
+#include <memory>
+#include <vector>
+
+#include "oneapi/dnnl/dnnl.hpp"
+
+#include "graph/interface/c_types_map.hpp"
+
+#include "graph/backend/dnnl/kernels/sdp_decomp_config.hpp"
+#include "graph/backend/dnnl/scratchpad.hpp"
+#include "graph/backend/dnnl/subgraph.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace graph {
+namespace dnnl_impl {
+
+struct sdp_decomp_training_config_t {
+public:
+    sdp_decomp_training_config_t() = default;
+
+    // SDP input dimension
+    dim_t ndims, batch_size, num_head_q, num_head_kv, seq_len_q, seq_len_kv;
+    dim_t head_size_qk, head_size_v;
+
+    // SDP input and output strides
+    dims src1_strides, wei1_strides, wei2_strides, dst_strides,
+            stats_dst_strides;
+
+    // Thread nums during the workflow
+    int nthr = 0;
+
+    // Used to record the exact input offset in subgraph
+    // [mm1_src, mm1_wei, mm2_wei, mm1_scale]
+    std::vector<int> graph_inport;
+    enum input_index_t {
+        mm1_src = 0,
+        mm1_wei,
+        mm2_wei,
+        mm1_scale,
+    };
+
+    // Primitives for the execution pipeline
+    sdp_reorder_t sub_reorder0, sub_reorder1, sub_reorder2, sub_reorder3;
+    primitive sub_mm1_prim, sub_mm2_prim;
+
+    // Softmax primitive: scores -> P (f32)
+    primitive sub_softmax_prim;
+    // f32 softmax_out -> xf16 for mm2
+    sdp_reorder_t sub_reorder_softmax;
+
+    // Stats computation primitives (logsumexp = max(src) - log(max(P)))
+    primitive sub_reduce_max_P_prim;
+    primitive sub_reduce_max_src_prim;
+
+    // Args used in execution of primitives
+    std::unordered_map<int, memory> sub_reorder0_args, sub_reorder1_args,
+            sub_mm1_args, sub_reorder2_args, sub_mm2_args, sub_reorder3_args;
+    std::unordered_map<int, memory> sub_softmax_args;
+    std::unordered_map<int, memory> sub_reorder_softmax_args;
+    std::unordered_map<int, memory> sub_reduce_max_P_args,
+            sub_reduce_max_src_args;
+
+    // A map from memory to registry key
+    std::unordered_map<dnnl_memory_t, registry_key> mem_key_map;
+
+    // Internal memory objects
+    // reorder0
+    memory sub_src1;
+    // reorder1
+    memory sub_wei1_user;
+    // mm1
+    memory sub_mm1_src, sub_mm1_wei, sub_mm1_dst;
+    // mm1 post-ops memories (scale, mask)
+    std::vector<memory> sub_mm1_post_mem;
+    // softmax output
+    memory sub_softmax_out;
+    // stats
+    memory sub_log_max_P;
+    memory sub_stats;
+    // reorder2
+    memory sub_wei2_user;
+    // mm2
+    memory sub_mm2_src;
+    memory sub_mm2_wei, sub_mm2_dst;
+    // reorder3
+    memory sub_dst_user;
+    // scratchpad
+    memory sub_scratchpad;
+
+    bool has_scale = false;
+    bool needs_softmax_reorder = false;
+    int attn_out_index = 0;
+    int stats_out_index = 1;
+
+private:
+    std::vector<op_ptr> sdp_op;
+
+public:
+    // Check if configuration is supported
+    bool initial_check(const std::shared_ptr<subgraph_t> &sg,
+            const std::vector<logical_tensor_t> &inputs,
+            const std::vector<logical_tensor_t> &outputs);
+
+    // Construct all params needed for execution
+    impl::status_t construct_params(std::shared_ptr<subgraph_t> &sg,
+            registry_t &sdp_registry, const dnnl::engine &p_engine,
+            const std::vector<logical_tensor_t> &inputs);
+
+private:
+    op_ptr get_post_op(const op_ptr &op) const;
+
+    impl::status_t record_input_offset(const std::shared_ptr<subgraph_t> &sg,
+            const std::vector<logical_tensor_t> &inputs);
+
+    impl::status_t record_sdp_ops(std::shared_ptr<subgraph_t> &sg);
+
+    void memory_planning(registry_t &sdp_registry);
+
+    dnnl::primitive_attr make_primitive_attr(std::shared_ptr<op_t> &op);
+};
+
+} // namespace dnnl_impl
+} // namespace graph
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -35,6 +35,7 @@
 --reset --in-shapes=0:2x1x1024x128*131072x128x128x1+1:2x1x1024x128*131072x128x128x1+2:1*1+5:2x1x1024x128*131072x128x128x1 --case=complex_fusion/mha/sdpa-training-fwd-no-mask-f16-f32.json
 --reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+104:f16+10:f16+28:f16+29:f16+31:f16 --case=complex_fusion/mha/sdpa-plain-training-backward-w-dmask-bf16-f32.json
 --reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+15:f16+104:f16+10:f16+30:f16+33:f16+31:f16+35:f16 --case=complex_fusion/mha/gqa-plain-training-backward-w-dmask-bf16-f32.json
+--reset --dt=0:f16+1:f16+2:f16+12:f16+14:f16 --case=complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
 
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --op-kind=1:Multiply,1:Divide --dt=1:bf16+2:bf16+3:bf16+5:bf16+6:bf16+104:bf16 --tensor-property=4:undef,4:host_scalar --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
@@ -54,6 +55,7 @@
 --reset --dt=0:bf16+1:bf16+7:bf16+8:bf16+9:bf16 --op-kind=1:undef,2:undef --case=complex_fusion/mha/sdpa-plain-simplified-f32.json
 --reset --case=complex_fusion/mha/sdpa-plain-training-backward-w-dmask-bf16-f32.json
 --reset --case=complex_fusion/mha/gqa-plain-training-backward-w-dmask-bf16-f32.json
+--reset --case=complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
 
 # int8 graphs
 --reset --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -37,6 +37,7 @@
 --reset --in-shapes=0:2x1x1024x128*131072x128x128x1+1:2x1x1024x128*131072x128x128x1+2:1*1+5:2x1x1024x128*131072x128x128x1 --case=complex_fusion/mha/sdpa-training-fwd-no-mask-f16-f32.json
 --reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+104:f16+10:f16+28:f16+29:f16+31:f16 --case=complex_fusion/mha/sdpa-plain-training-backward-w-dmask-bf16-f32.json
 --reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+15:f16+104:f16+10:f16+30:f16+33:f16+31:f16+35:f16 --case=complex_fusion/mha/gqa-plain-training-backward-w-dmask-bf16-f32.json
+--reset --dt=0:f16+1:f16+2:f16+12:f16+14:f16 --case=complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
 
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --op-kind=1:Multiply,1:Divide --dt=1:bf16+2:bf16+3:bf16+5:bf16+6:bf16+104:bf16 --tensor-property=4:undef,4:host_scalar --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
@@ -57,6 +58,7 @@
 --reset --dt=0:bf16+1:bf16+7:bf16+8:bf16+9:bf16 --case=complex_fusion/mha/sdpa-plain-wo-scale-f32.json
 --reset --case=complex_fusion/mha/sdpa-plain-training-backward-w-dmask-bf16-f32.json
 --reset --case=complex_fusion/mha/gqa-plain-training-backward-w-dmask-bf16-f32.json
+--reset --case=complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
 
 # int8 graphs
 --reset --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
@@ -40,6 +40,7 @@
 --reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+15:f16+104:f16+10:f16+30:f16+33:f16+31:f16+35:f16
         --tensor-property=205:undef+206:undef+207:undef,205:host_scalar+206:host_scalar+207:host_scalar
         --case=complex_fusion/mha/gqa-plain-training-bwd-w-dropout-bf16-f32.json
+--reset --dt=0:f16+1:f16+2:f16+12:f16+14:f16 --case=complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
 
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --op-kind=1:Multiply,1:Divide --dt=1:bf16+2:bf16+3:bf16+5:bf16+6:bf16+104:bf16 --tensor-property=4:undef,4:host_scalar --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
@@ -61,6 +62,7 @@
 --reset --case=complex_fusion/mha/gqa-plain-training-backward-w-dmask-bf16-f32.json
 --reset --tensor-property=205:undef+206:undef+207:undef,205:host_scalar+206:host_scalar+207:host_scalar --case=complex_fusion/mha/gqa-plain-training-fwd-w-dropout-bf16-f32.json
 --reset --tensor-property=205:undef+206:undef+207:undef,205:host_scalar+206:host_scalar+207:host_scalar --case=complex_fusion/mha/gqa-plain-training-bwd-w-dropout-bf16-f32.json
+--reset --case=complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
 
 # int8 graphs
 --reset --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_ci
@@ -42,6 +42,7 @@
 --reset --dt=100:f16+101:f16+102:f16+103:f16+12:f16+105:f16+13:f16+15:f16+104:f16+10:f16+30:f16+33:f16+31:f16+35:f16
         --tensor-property=205:undef+206:undef+207:undef,205:host_scalar+206:host_scalar+207:host_scalar
         --case=complex_fusion/mha/gqa-plain-training-bwd-w-dropout-bf16-f32.json
+--reset --dt=0:f16+1:f16+2:f16+12:f16+14:f16 --case=complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
 
 # bf16 inputs + f32 intermediates + bf16 outputs
 --reset --op-kind=1:Multiply,1:Divide --dt=1:bf16+2:bf16+3:bf16+5:bf16+6:bf16+104:bf16 --tensor-property=4:undef,4:host_scalar --case=complex_fusion/mha/sdpa-plain-simplified-f16-f32.json
@@ -64,6 +65,7 @@
 --reset --case=complex_fusion/mha/gqa-plain-training-backward-w-dmask-bf16-f32.json
 --reset --tensor-property=205:undef+206:undef+207:undef,205:host_scalar+206:host_scalar+207:host_scalar --case=complex_fusion/mha/gqa-plain-training-fwd-w-dropout-bf16-f32.json
 --reset --tensor-property=205:undef+206:undef+207:undef,205:host_scalar+206:host_scalar+207:host_scalar --case=complex_fusion/mha/gqa-plain-training-bwd-w-dropout-bf16-f32.json
+--reset --case=complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
 
 # int8 graphs
 --reset --case=complex_fusion/mha/MHA-GPT-inf-int8-bs1.json

--- a/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
+++ b/tests/benchdnn/inputs/graph/complex_fusion/mha/sdpa-vit-training-fwd-no-mask-bf16-f32.json
@@ -1,0 +1,309 @@
+{
+  "version": "3.11.3",
+  "engine_kind": "cpu",
+  "fpmath_mode": "strict",
+  "fpmath_mode_apply_to_int": "false",
+  "input_ports": [
+    0,
+    1,
+    3,
+    2
+  ],
+  "output_ports": [
+    13,
+    14
+  ],
+  "graph": [
+    {
+      "id": 0,
+      "name": "matmul_qk",
+      "kind": "MatMul",
+      "attrs": {
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        }
+      },
+      "inputs": [
+        {
+          "id": 0,
+          "dtype": "bf16",
+          "shape": [
+            128,
+            12,
+            197,
+            64
+          ],
+          "stride": [
+            151296,
+            12608,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 1,
+          "dtype": "bf16",
+          "shape": [
+            128,
+            12,
+            64,
+            197
+          ],
+          "stride": [
+            151296,
+            12608,
+            197,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            128,
+            12,
+            197,
+            197
+          ],
+          "stride": [
+            465708,
+            38809,
+            197,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "scale",
+      "kind": "Multiply",
+      "attrs": {
+        "auto_broadcast": {
+          "type": "string",
+          "value": "numpy"
+        }
+      },
+      "inputs": [
+        {
+          "id": 7,
+          "dtype": "f32",
+          "shape": [
+            128,
+            12,
+            197,
+            197
+          ],
+          "stride": [
+            465708,
+            38809,
+            197,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 3,
+          "dtype": "f32",
+          "shape": [
+            1
+          ],
+          "stride": [
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "constant"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 8,
+          "dtype": "f32",
+          "shape": [
+            128,
+            12,
+            197,
+            197
+          ],
+          "stride": [
+            465708,
+            38809,
+            197,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "name": "softmax",
+      "kind": "SoftMax",
+      "attrs": {
+        "mode": {
+          "type": "string",
+          "value": "none"
+        },
+        "axis": {
+          "type": "s64",
+          "value": -1
+        }
+      },
+      "inputs": [
+        {
+          "id": 8,
+          "dtype": "f32",
+          "shape": [
+            128,
+            12,
+            197,
+            197
+          ],
+          "stride": [
+            465708,
+            38809,
+            197,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 12,
+          "dtype": "bf16",
+          "shape": [
+            128,
+            12,
+            197,
+            197
+          ],
+          "stride": [
+            465708,
+            38809,
+            197,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 13,
+          "dtype": "f32",
+          "shape": [
+            128,
+            12,
+            197,
+            1
+          ],
+          "stride": [
+            2364,
+            197,
+            1,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "name": "matmul_av",
+      "kind": "MatMul",
+      "attrs": {
+        "accumulation_mode": {
+          "type": "string",
+          "value": "strict"
+        },
+        "transpose_b": {
+          "type": "bool",
+          "value": 0
+        },
+        "transpose_a": {
+          "type": "bool",
+          "value": 0
+        }
+      },
+      "inputs": [
+        {
+          "id": 12,
+          "dtype": "bf16",
+          "shape": [
+            128,
+            12,
+            197,
+            197
+          ],
+          "stride": [
+            465708,
+            38809,
+            197,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        },
+        {
+          "id": 2,
+          "dtype": "bf16",
+          "shape": [
+            128,
+            12,
+            197,
+            64
+          ],
+          "stride": [
+            151296,
+            12608,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ],
+      "outputs": [
+        {
+          "id": 14,
+          "dtype": "bf16",
+          "shape": [
+            128,
+            12,
+            197,
+            64
+          ],
+          "stride": [
+            151296,
+            12608,
+            64,
+            1
+          ],
+          "layout_type": "strided",
+          "property_type": "undef"
+        }
+      ]
+    }
+  ]
+}
+


### PR DESCRIPTION
Optimize SDPA training forward (with softmax stats output) with the primitive decomposition kernel.

Support status as below. Fallback to larger_partition_kernel_t for unsupported cases.

- Platform: CPU only, with OMP, thread pool, TBB runtimes.
- Data type: f32, bf16, f16. (no quantized data types).
- Softmax requires stats output.
- No attention mask.
- No softmax `inf_as_zero` mode.
- No dropout.
- No GQA.

Fixes MFDNN-14757