### PR TITLE
graph: backend: dnnl: manage cl_event with wrapper_t

### DIFF
--- a/src/graph/backend/dnnl/dnnl_partition_impl.hpp
+++ b/src/graph/backend/dnnl/dnnl_partition_impl.hpp
@@ -70,8 +70,8 @@ public:
     status_t execute_ocl(stream_t *strm, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &ocl_deps,
-            cl_event *ocl_event) override {
+            const std::vector<ocl_event_t> &ocl_deps,
+            ocl_event_t &ocl_event) override {
         return kernel_->execute_ocl(
                 strm, inputs, outputs, scratchpad_buf, ocl_deps, ocl_event);
     }

--- a/src/graph/backend/dnnl/executables/base.hpp
+++ b/src/graph/backend/dnnl/executables/base.hpp
@@ -36,6 +36,7 @@
 #include "graph/utils/ocl_usm_utils.hpp"
 
 #include "xpu/ocl/usm_utils.hpp"
+#include "xpu/ocl/utils.hpp"
 
 #include "oneapi/dnnl/dnnl_ocl.hpp"
 #endif
@@ -62,6 +63,10 @@ namespace dnnl {
 namespace impl {
 namespace graph {
 namespace dnnl_impl {
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+using ocl_event_t = xpu::ocl::wrapper_t<cl_event>;
+#endif
 
 struct indices_t {
     // the type_t is used to indicate the indices is for input or output
@@ -134,9 +139,15 @@ struct op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    virtual cl_event execute_ocl(const stream &stream,
+    // The returned event is used to indicate when the execution is finished.
+    // The caller can use the event to build dependency for later execution. To
+    // avoid memory leaks and safely manage the lifetime of the returned
+    // `cl_event`, we use `wrapper_t<cl_event>` to wrap it. The
+    // `wrapper_t<cl_event>` is a RAII wrapper for `cl_event`, which will
+    // automatically release the `cl_event` when it goes out of scope.
+    virtual ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const
+            const std::vector<ocl_event_t> &deps) const
             = 0;
 #endif
 };
@@ -227,12 +238,12 @@ struct dummy_impl_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
+            const std::vector<ocl_event_t> &deps) const override {
         UNUSED(stream);
 
-        // Fast path: if no event, return an immediate event.
+        // Fast path: if no event, return an empty wrapper.
         if (deps.empty()) return {};
 
         // Fast path: if only one event, return it.
@@ -240,12 +251,13 @@ struct dummy_impl_t : public op_executable_t {
 
         // Otherwise, gather all dependencies.
         auto q = dnnl::ocl_interop::get_command_queue(stream);
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
         cl_event e;
         auto err = xpu::ocl::clEnqueueMarkerWithWaitList(
-                q, static_cast<cl_uint>(deps.size()), deps.data(), &e);
+                q, static_cast<cl_uint>(raw_deps.size()), raw_deps.data(), &e);
         assert(err == CL_SUCCESS);
         MAYBE_UNUSED(err);
-        return e;
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/batch_norm.cpp
+++ b/src/graph/backend/dnnl/executables/batch_norm.cpp
@@ -265,9 +265,9 @@ std::optional<::sycl::event> bn_folding_t::execute_sycl(const stream &stream,
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event bn_folding_t::execute_ocl(const stream &stream,
+ocl_event_t bn_folding_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     UNUSED(args);
 
     auto weights = args.find(DNNL_ARG_WEIGHTS)->second;
@@ -307,11 +307,13 @@ cl_event bn_folding_t::execute_ocl(const stream &stream,
     xpu::ocl::usm::memcpy(stream.get(), epsilon_mem.get_data_handle(),
             &desc_.epsilon_, epsilon_mem.get_desc().get_size(), 0, nullptr, &e);
     xpu::ocl::clWaitForEvents(1, &e);
+    xpu::ocl::clReleaseEvent(e);
 
-    auto ocl_deps = dnnl::ocl_interop::execute(add_prim_, stream,
+    std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+    ocl_event_t ocl_deps(dnnl::ocl_interop::execute(add_prim_, stream,
             {{DNNL_ARG_SRC_0, variance}, {DNNL_ARG_SRC_1, epsilon_mem},
                     {DNNL_ARG_DST, sqrt_variance}},
-            deps);
+            raw_deps));
 
     // 2. updated_weight = weights * scale / sqrt_variance
     memory new_scale = dnnl::ocl_interop::make_memory(desc_.new_scale_desc_,
@@ -322,12 +324,12 @@ cl_event bn_folding_t::execute_ocl(const stream &stream,
             dnnl::ocl_interop::memory_kind::usm,
             sqrt_variance.get_data_handle());
 
-    auto ocl_deps2 = dnnl::ocl_interop::execute(mul_prim_, stream,
+    ocl_event_t ocl_deps2(dnnl::ocl_interop::execute(mul_prim_, stream,
             {{DNNL_ARG_SRC_0, weights}, {DNNL_ARG_SRC_1, new_scale},
                     {DNNL_ARG_DST, updated_weights},
                     {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
                             new_sqrt_variance}},
-            {ocl_deps});
+            {ocl_deps.get()}));
 
     // 3. updated_bias = (bias - mean) * scale / sqrt_variance + shift
     if (bias.get(true) == nullptr || bias.get_data_handle() == nullptr) {
@@ -337,6 +339,7 @@ cl_event bn_folding_t::execute_ocl(const stream &stream,
         xpu::ocl::usm::memcpy(stream.get(), valid_bias.get_data_handle(),
                 zero.data(), valid_bias.get_desc().get_size(), 0, nullptr, &e);
         xpu::ocl::clWaitForEvents(1, &e);
+        xpu::ocl::clReleaseEvent(e);
 
         auto ocl_deps3 = dnnl::ocl_interop::execute(sub_prim_, stream,
                 {{DNNL_ARG_SRC_0, valid_bias}, {DNNL_ARG_SRC_1, mean},
@@ -347,8 +350,8 @@ cl_event bn_folding_t::execute_ocl(const stream &stream,
                                 sqrt_variance},
                         {DNNL_ARG_ATTR_MULTIPLE_POST_OP(2) | DNNL_ARG_SRC_1,
                                 shift}},
-                {ocl_deps2});
-        return ocl_deps3;
+                {ocl_deps2.get()});
+        return ocl_event_t(ocl_deps3);
     }
 
     auto ocl_deps3 = dnnl::ocl_interop::execute(sub_prim_, stream,
@@ -359,8 +362,8 @@ cl_event bn_folding_t::execute_ocl(const stream &stream,
                             sqrt_variance},
                     {DNNL_ARG_ATTR_MULTIPLE_POST_OP(2) | DNNL_ARG_SRC_1,
                             shift}},
-            {ocl_deps2});
-    return ocl_deps3;
+            {ocl_deps2.get()});
+    return ocl_event_t(ocl_deps3);
 }
 #endif
 
@@ -705,12 +708,13 @@ std::optional<::sycl::event> batchnorm_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event batchnorm_executable_t::execute_ocl(const stream &stream,
+ocl_event_t batchnorm_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
+    std::vector<cl_event> raw_deps(deps.begin(), deps.end());
     if (!is_training_) {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 
     std::unordered_map<int, memory> exe_args = args;
@@ -719,7 +723,8 @@ cl_event batchnorm_executable_t::execute_ocl(const stream &stream,
     exe_args.erase(DNNL_ARG_DST_1);
     exe_args.erase(DNNL_ARG_DST_2);
 
-    auto e0 = dnnl::ocl_interop::execute(prim_, stream, exe_args, deps);
+    ocl_event_t e0(
+            dnnl::ocl_interop::execute(prim_, stream, exe_args, raw_deps));
 
     // calculate running_mean and running_variance
     auto batch_mean = args.find(DNNL_ARG_MEAN)->second;
@@ -734,20 +739,20 @@ cl_event batchnorm_executable_t::execute_ocl(const stream &stream,
     //                                      (1 - momentum) * batch_mean
     auto sum_prim_0 = dnnl::sum({p_engine, scales_,
             {old_running_mean.get_desc(), batch_mean.get_desc()}});
-    auto e1 = dnnl::ocl_interop::execute(sum_prim_0, stream,
+    ocl_event_t e1(dnnl::ocl_interop::execute(sum_prim_0, stream,
             {{DNNL_ARG_MULTIPLE_SRC, old_running_mean},
                     {DNNL_ARG_MULTIPLE_SRC + 1, batch_mean},
                     {DNNL_ARG_DST, new_running_mean}},
-            {e0});
+            {e0.get()}));
     // new_running_variance = momentum * old_running_variance +
     //                                  (1 - momentum) * batch_variance
     auto sum_prim_1 = dnnl::sum({p_engine, scales_,
             {old_running_variance.get_desc(), batch_variance.get_desc()}});
-    auto e2 = dnnl::ocl_interop::execute(sum_prim_1, stream,
+    ocl_event_t e2(dnnl::ocl_interop::execute(sum_prim_1, stream,
             {{DNNL_ARG_MULTIPLE_SRC, old_running_variance},
                     {DNNL_ARG_MULTIPLE_SRC + 1, batch_variance},
                     {DNNL_ARG_DST, new_running_variance}},
-            {e1});
+            {e1.get()}));
     return e2;
 }
 #endif

--- a/src/graph/backend/dnnl/executables/batch_norm.hpp
+++ b/src/graph/backend/dnnl/executables/batch_norm.hpp
@@ -75,9 +75,9 @@ struct bn_folding_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override {
@@ -129,9 +129,9 @@ struct batchnorm_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }
@@ -171,11 +171,12 @@ struct batchnorm_bwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/concat.hpp
+++ b/src/graph/backend/dnnl/executables/concat.hpp
@@ -52,11 +52,12 @@ struct concat_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/const_memory_filler.hpp
+++ b/src/graph/backend/dnnl/executables/const_memory_filler.hpp
@@ -86,22 +86,23 @@ struct const_memory_filler_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
+            const std::vector<ocl_event_t> &deps) const override {
         void *data_handle = static_cast<void *>(
                 const_cast<target_dt *>(attr_data_.data()));
         const memory &dst_mem = args.find(DNNL_ARG_TO)->second;
         assert(deps.size() <= 1);
         // Passing the empty event to memcpy below causes failure.
-        const bool empty = deps.empty() || deps[0] == nullptr;
-        const cl_uint num = empty ? 0 : static_cast<cl_uint>(deps.size());
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        const bool empty = raw_deps.empty() || raw_deps[0] == nullptr;
+        const cl_uint num = empty ? 0 : static_cast<cl_uint>(raw_deps.size());
         cl_event e;
         UNUSED_STATUS(
                 xpu::ocl::usm::memcpy(stream.get(), dst_mem.get_data_handle(),
                         data_handle, dst_mem.get_desc().get_size(), num,
-                        empty ? nullptr : deps.data(), &e));
-        return e;
+                        empty ? nullptr : raw_deps.data(), &e));
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/conv.cpp
+++ b/src/graph/backend/dnnl/executables/conv.cpp
@@ -118,10 +118,11 @@ std::optional<::sycl::event> conv_fwd_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event conv_fwd_executable_t::execute_ocl(const stream &stream,
+ocl_event_t conv_fwd_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
-    auto ocl_deps = deps;
+        const std::vector<ocl_event_t> &deps) const {
+    std::vector<cl_event> ocl_deps(deps.begin(), deps.end());
+    ocl_event_t reorder_event;
     if (with_sum_) {
         const memory &psrc_mem = args.find(DNNL_GRAPH_ARG_POST_SRC)->second;
         const memory &dst_mem = args.find(DNNL_ARG_DST)->second;
@@ -158,23 +159,25 @@ cl_event conv_fwd_executable_t::execute_ocl(const stream &stream,
                                           dst_mem.get_data_handle()));
 
                 auto prim = dnnl::reorder(psrc_mem, to_mem);
-                auto e = dnnl::ocl_interop::execute(prim, stream,
+                reorder_event = ocl_event_t(dnnl::ocl_interop::execute(prim,
+                        stream,
                         {{DNNL_ARG_FROM, const_cast<memory &>(psrc_mem)},
                                 {DNNL_ARG_TO, const_cast<memory &>(to_mem)}},
-                        ocl_deps);
-                ocl_deps = {e};
+                        ocl_deps));
+                ocl_deps = {reorder_event.get()};
             } else {
                 auto prim = dnnl::reorder(psrc_mem, dst_mem);
-                auto e = dnnl::ocl_interop::execute(prim, stream,
+                reorder_event = ocl_event_t(dnnl::ocl_interop::execute(prim,
+                        stream,
                         {{DNNL_ARG_FROM, const_cast<memory &>(psrc_mem)},
                                 {DNNL_ARG_TO, const_cast<memory &>(dst_mem)}},
-                        ocl_deps);
-                ocl_deps = {e};
+                        ocl_deps));
+                ocl_deps = {reorder_event.get()};
             }
         }
     }
     auto e = dnnl::ocl_interop::execute(prim_, stream, args, ocl_deps);
-    return e;
+    return ocl_event_t(e);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/conv.hpp
+++ b/src/graph/backend/dnnl/executables/conv.hpp
@@ -48,9 +48,9 @@ struct conv_fwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }
@@ -89,11 +89,12 @@ struct conv_bwd_data_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 
@@ -132,11 +133,12 @@ struct conv_bwd_weights_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/deconv.cpp
+++ b/src/graph/backend/dnnl/executables/deconv.cpp
@@ -62,25 +62,25 @@ std::optional<::sycl::event> deconv_fwd_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event deconv_fwd_executable_t::execute_ocl(const stream &stream,
+ocl_event_t deconv_fwd_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
-    auto ocl_deps = deps;
+        const std::vector<ocl_event_t> &deps) const {
+    std::vector<cl_event> ocl_deps(deps.begin(), deps.end());
+    ocl_event_t reorder_event;
     if (with_sum_) {
         const memory &psrc_mem = args.find(DNNL_GRAPH_ARG_POST_SRC)->second;
         const memory &dst_mem = args.find(DNNL_ARG_DST)->second;
         if (psrc_mem.get_data_handle() != dst_mem.get_data_handle()) {
             auto prim = dnnl::reorder(psrc_mem, dst_mem);
-            auto e = dnnl::ocl_interop::execute(prim, stream,
+            reorder_event = ocl_event_t(dnnl::ocl_interop::execute(prim, stream,
                     {{DNNL_ARG_FROM, const_cast<memory &>(psrc_mem)},
                             {DNNL_ARG_TO, const_cast<memory &>(dst_mem)}},
-                    deps);
-            // WA: ocl_deps = {e}; may cause compiler warining with GCC 13+.
-            ocl_deps.assign(1, e);
+                    ocl_deps));
+            ocl_deps.assign(1, reorder_event.get());
         }
     }
     auto e = dnnl::ocl_interop::execute(prim_, stream, args, ocl_deps);
-    return e;
+    return ocl_event_t(e);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/deconv.hpp
+++ b/src/graph/backend/dnnl/executables/deconv.hpp
@@ -48,9 +48,9 @@ struct deconv_fwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }
@@ -89,11 +89,12 @@ struct deconv_bwd_data_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 
@@ -132,11 +133,12 @@ struct deconv_bwd_weights_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/eltwise.cpp
+++ b/src/graph/backend/dnnl/executables/eltwise.cpp
@@ -171,12 +171,13 @@ std::optional<::sycl::event> binary_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event binary_executable_t::execute_ocl(const stream &stream,
+ocl_event_t binary_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     if (is_dummy_) { return dummy_impl_.execute_ocl(stream, args, deps); }
 
-    auto ocl_deps = deps;
+    std::vector<cl_event> ocl_deps(deps.begin(), deps.end());
+    ocl_event_t reorder_event;
     if (with_sum_) {
         auto it_dst = args.find(DNNL_ARG_DST);
         auto it_src = args.find(DNNL_GRAPH_ARG_POST_SRC);
@@ -190,16 +191,15 @@ cl_event binary_executable_t::execute_ocl(const stream &stream,
 
         if (psrc_mem.get_data_handle() != dst_mem.get_data_handle()) {
             auto prim = dnnl::reorder(psrc_mem, dst_mem);
-            auto e = dnnl::ocl_interop::execute(prim, stream,
+            reorder_event = ocl_event_t(dnnl::ocl_interop::execute(prim, stream,
                     {{DNNL_ARG_FROM, const_cast<memory &>(psrc_mem)},
                             {DNNL_ARG_TO, const_cast<memory &>(dst_mem)}},
-                    deps);
-            // WA: ocl_deps = {e}; may cause compiler warining with GCC 13+.
-            ocl_deps.assign(1, e);
+                    ocl_deps));
+            ocl_deps.assign(1, reorder_event.get());
         }
     }
     auto e = dnnl::ocl_interop::execute(prim_, stream, args, ocl_deps);
-    return e;
+    return ocl_event_t(e);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/eltwise.hpp
+++ b/src/graph/backend/dnnl/executables/eltwise.hpp
@@ -51,11 +51,12 @@ struct eltwise_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 
@@ -93,11 +94,12 @@ struct eltwise_bwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 
@@ -141,9 +143,9 @@ struct binary_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }
@@ -183,11 +185,12 @@ struct prelu_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 
@@ -225,11 +228,12 @@ struct prelu_bwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/gated_mlp.cpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.cpp
@@ -103,24 +103,25 @@ std::optional<::sycl::event> gated_mlp_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event gated_mlp_executable_t::execute_ocl(const stream &stream,
+ocl_event_t gated_mlp_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     std::vector<dnnl_exec_arg_t> c_args;
     c_args.reserve(args.size());
     for (const auto &a : args)
         c_args.push_back({a.first, a.second.get()});
 
-    const cl_event *c_deps = deps.empty() ? nullptr : deps.data();
+    std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+    const cl_event *c_deps = raw_deps.empty() ? nullptr : raw_deps.data();
 
     cl_event return_event = nullptr;
     auto ret = dnnl_ocl_interop_primitive_execute(prim_.get(), stream.get(),
             static_cast<int>(c_args.size()), c_args.data(), c_deps,
-            static_cast<int>(deps.size()), &return_event);
+            static_cast<int>(raw_deps.size()), &return_event);
     dnnl::error::wrap_c_api(
             ret, "could not execute gated mlp primitive with ocl runtime");
 
-    return return_event;
+    return ocl_event_t(return_event);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/executables/gated_mlp.hpp
@@ -44,9 +44,9 @@ struct gated_mlp_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }

--- a/src/graph/backend/dnnl/executables/gen_index.cpp
+++ b/src/graph/backend/dnnl/executables/gen_index.cpp
@@ -177,9 +177,9 @@ std::optional<::sycl::event> genindex_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event genindex_executable_t::execute_ocl_impl(const stream &stream,
+ocl_event_t genindex_executable_t::execute_ocl_impl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
 #if DNNL_GPU_VENDOR == DNNL_VENDOR_INTEL
     double start_ms = dnnl::impl::get_msec();
     auto compute_stream
@@ -198,10 +198,8 @@ cl_event genindex_executable_t::execute_ocl_impl(const stream &stream,
     ocl_stream->before_exec_hook();
 
     if (!deps.empty()) {
-        std::vector<xpu::ocl::wrapper_t<cl_event>> events(deps.size());
-        for (size_t i = 0; i < deps.size(); i++)
-            events[i] = xpu::ocl::wrapper_t<cl_event>(deps[i], true);
-        ocl_stream->ocl_ctx().set_deps(events);
+        ocl_stream->ocl_ctx().set_deps(
+                std::vector<ocl_event_t>(deps.begin(), deps.end()));
     }
 
     kernel_.parallel_for(*compute_stream, nd_range, arg_list,
@@ -215,7 +213,7 @@ cl_event genindex_executable_t::execute_ocl_impl(const stream &stream,
     if (ocl_stream->is_verbose_profiler_enabled())
         ocl_stream->run_verbose_profiler(info_, start_ms);
     ocl_stream->after_exec_hook();
-    return return_event;
+    return ocl_event_t(return_event);
 #else
     assertm(false,
             "genindex opexcutable is only implemented for intel vendor "
@@ -224,9 +222,9 @@ cl_event genindex_executable_t::execute_ocl_impl(const stream &stream,
 #endif
 }
 
-cl_event genindex_executable_t::execute_ocl(const stream &stream,
+ocl_event_t genindex_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
         if (!stream.get()->is_verbose_profiler_enabled()) {
@@ -240,7 +238,7 @@ cl_event genindex_executable_t::execute_ocl(const stream &stream,
         } else {
             execute_ocl_impl(stream, args, deps);
         }
-        return nullptr; // no event returned in profiling mode
+        return {};
     } else {
         return execute_ocl_impl(stream, args, deps);
     }

--- a/src/graph/backend/dnnl/executables/gen_index.hpp
+++ b/src/graph/backend/dnnl/executables/gen_index.hpp
@@ -51,12 +51,12 @@ struct genindex_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
-    cl_event execute_ocl_impl(const stream &stream,
+            const std::vector<ocl_event_t> &deps) const override;
+    ocl_event_t execute_ocl_impl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const;
+            const std::vector<ocl_event_t> &deps) const;
 #endif
 
     bool is_initialized() const override {

--- a/src/graph/backend/dnnl/executables/group_norm.hpp
+++ b/src/graph/backend/dnnl/executables/group_norm.hpp
@@ -53,11 +53,12 @@ struct groupnorm_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/host_scalar.cpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.cpp
@@ -72,9 +72,9 @@ std::optional<::sycl::event> host_scalar_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event host_scalar_executable_t::execute_ocl(const stream &stream,
+ocl_event_t host_scalar_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     auto it_src = args.find(DNNL_ARG_FROM);
     auto it_dst = args.find(DNNL_ARG_TO);
 
@@ -88,8 +88,9 @@ cl_event host_scalar_executable_t::execute_ocl(const stream &stream,
 
     assert(deps.size() <= 1);
     // Passing the empty event to memcpy below causes failure.
-    const bool empty = deps.empty() || deps[0] == nullptr;
-    const cl_uint num = empty ? 0 : static_cast<cl_uint>(deps.size());
+    std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+    const bool empty = raw_deps.empty() || raw_deps[0] == nullptr;
+    const cl_uint num = empty ? 0 : static_cast<cl_uint>(raw_deps.size());
     const size_t size = src_mem.get_desc().get_size();
     const auto dt = src_mem.get_desc().get_data_type();
     assert(size == types::data_type_size(static_cast<impl::data_type_t>(dt)));
@@ -98,11 +99,11 @@ cl_event host_scalar_executable_t::execute_ocl(const stream &stream,
         const DType val = src_mem.get_host_scalar_value<DType>();
         UNUSED_STATUS(xpu::ocl::usm::memcpy(stream.get(),
                 dst_mem.get_data_handle(), static_cast<const void *>(&val),
-                size, num, empty ? nullptr : deps.data(), &e));
+                size, num, empty ? nullptr : raw_deps.data(), &e));
         xpu::ocl::clWaitForEvents(1, &e);
         xpu::ocl::clReleaseEvent(e);
     });
-    return nullptr;
+    return {};
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/host_scalar.hpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.hpp
@@ -47,9 +47,9 @@ struct host_scalar_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return true; }

--- a/src/graph/backend/dnnl/executables/layer_norm.hpp
+++ b/src/graph/backend/dnnl/executables/layer_norm.hpp
@@ -53,11 +53,12 @@ struct layernorm_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 
@@ -96,11 +97,12 @@ struct layernorm_bwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/matmul.cpp
+++ b/src/graph/backend/dnnl/executables/matmul.cpp
@@ -119,12 +119,13 @@ std::optional<::sycl::event> matmul_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event matmul_executable_t::execute_ocl(const stream &stream,
+ocl_event_t matmul_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     if (is_dummy_) { return dummy_impl_.execute_ocl(stream, args, deps); }
 
-    auto ocl_deps = deps;
+    std::vector<cl_event> ocl_deps(deps.begin(), deps.end());
+    ocl_event_t reorder_event;
     if (with_sum_) {
         auto it_dst = args.find(DNNL_ARG_DST);
         auto it_src = args.find(DNNL_GRAPH_ARG_POST_SRC);
@@ -138,16 +139,15 @@ cl_event matmul_executable_t::execute_ocl(const stream &stream,
 
         if (psrc_mem.get_data_handle() != dst_mem.get_data_handle()) {
             auto prim = dnnl::reorder(psrc_mem, dst_mem);
-            auto e = dnnl::ocl_interop::execute(prim, stream,
+            reorder_event = ocl_event_t(dnnl::ocl_interop::execute(prim, stream,
                     {{DNNL_ARG_FROM, const_cast<memory &>(psrc_mem)},
                             {DNNL_ARG_TO, const_cast<memory &>(dst_mem)}},
-                    deps);
-            // WA: ocl_deps = {e}; may cause compiler warining with GCC 13+.
-            ocl_deps.assign(1, e);
+                    ocl_deps));
+            ocl_deps.assign(1, reorder_event.get());
         }
     }
     auto e = dnnl::ocl_interop::execute(prim_, stream, args, ocl_deps);
-    return e;
+    return ocl_event_t(e);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/matmul.hpp
+++ b/src/graph/backend/dnnl/executables/matmul.hpp
@@ -42,9 +42,9 @@ struct matmul_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }

--- a/src/graph/backend/dnnl/executables/memory_reparser.cpp
+++ b/src/graph/backend/dnnl/executables/memory_reparser.cpp
@@ -67,9 +67,9 @@ std::optional<::sycl::event> memory_reparser_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event memory_reparser_t::execute_ocl(const stream &stream,
+ocl_event_t memory_reparser_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     auto from = args.find(DNNL_ARG_FROM);
     auto to = args.find(DNNL_ARG_TO);
     if (from == args.end() || to == args.end()) return {};
@@ -81,14 +81,15 @@ cl_event memory_reparser_t::execute_ocl(const stream &stream,
         const memory &dst_mem = to->second;
         assert(deps.size() <= 1);
         // Passing the empty event to memcpy below causes failure.
-        const bool empty = deps.empty() || deps[0] == nullptr;
-        const cl_uint num = empty ? 0 : static_cast<cl_uint>(deps.size());
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        const bool empty = raw_deps.empty() || raw_deps[0] == nullptr;
+        const cl_uint num = empty ? 0 : static_cast<cl_uint>(raw_deps.size());
         cl_event e;
         UNUSED_STATUS(xpu::ocl::usm::memcpy(stream.get(),
                 dst_mem.get_data_handle(), src_mem.get_data_handle(),
                 dst_mem.get_desc().get_size(), num,
-                empty ? nullptr : deps.data(), &e));
-        return e;
+                empty ? nullptr : raw_deps.data(), &e));
+        return ocl_event_t(e);
     }
 }
 #endif

--- a/src/graph/backend/dnnl/executables/memory_reparser.hpp
+++ b/src/graph/backend/dnnl/executables/memory_reparser.hpp
@@ -47,9 +47,9 @@ struct memory_reparser_t : public dummy_impl_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 };
 

--- a/src/graph/backend/dnnl/executables/pool.hpp
+++ b/src/graph/backend/dnnl/executables/pool.hpp
@@ -51,11 +51,12 @@ struct pool_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 
@@ -93,11 +94,12 @@ struct pool_bwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/reduction.cpp
+++ b/src/graph/backend/dnnl/executables/reduction.cpp
@@ -61,26 +61,26 @@ std::optional<::sycl::event> reduction_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event reduction_executable_t::execute_ocl(const stream &stream,
+ocl_event_t reduction_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
-    auto ocl_deps = deps;
+        const std::vector<ocl_event_t> &deps) const {
+    std::vector<cl_event> ocl_deps(deps.begin(), deps.end());
+    ocl_event_t reorder_event;
     if (with_sum_) {
         const memory &psrc_mem = args.find(DNNL_GRAPH_ARG_POST_SRC)->second;
         const memory &dst_mem = args.find(DNNL_ARG_DST)->second;
         if (psrc_mem.get_data_handle() != dst_mem.get_data_handle()) {
             auto prim = dnnl::reorder(psrc_mem, dst_mem);
-            auto e = dnnl::ocl_interop::execute(prim, stream,
+            reorder_event = ocl_event_t(dnnl::ocl_interop::execute(prim, stream,
                     {{DNNL_ARG_FROM, const_cast<memory &>(psrc_mem)},
                             {DNNL_ARG_TO, const_cast<memory &>(dst_mem)}},
-                    deps);
-            // WA: ocl_deps = {e}; may cause compiler warining with GCC 13+.
-            ocl_deps.assign(1, e);
+                    ocl_deps));
+            ocl_deps.assign(1, reorder_event.get());
         }
     }
 
     auto e = dnnl::ocl_interop::execute(prim_, stream, args, ocl_deps);
-    return e;
+    return ocl_event_t(e);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/reduction.hpp
+++ b/src/graph/backend/dnnl/executables/reduction.hpp
@@ -49,9 +49,9 @@ struct reduction_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }

--- a/src/graph/backend/dnnl/executables/reorder.cpp
+++ b/src/graph/backend/dnnl/executables/reorder.cpp
@@ -75,10 +75,11 @@ std::optional<::sycl::event> reorder_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event reorder_executable_t::execute_ocl(const stream &stream,
+ocl_event_t reorder_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
-    auto ocl_deps = deps;
+        const std::vector<ocl_event_t> &deps) const {
+    std::vector<cl_event> ocl_deps(deps.begin(), deps.end());
+    ocl_event_t reorder_event;
     if (with_sum_) {
         auto it_dst = args.find(DNNL_ARG_DST);
         auto it_src = args.find(DNNL_GRAPH_ARG_POST_SRC);
@@ -91,16 +92,15 @@ cl_event reorder_executable_t::execute_ocl(const stream &stream,
         const memory &dst_mem = it_dst->second;
         if (psrc_mem.get_data_handle() != dst_mem.get_data_handle()) {
             auto prim = dnnl::reorder(psrc_mem, dst_mem);
-            auto e = dnnl::ocl_interop::execute(prim, stream,
+            reorder_event = ocl_event_t(dnnl::ocl_interop::execute(prim, stream,
                     {{DNNL_ARG_FROM, const_cast<memory &>(psrc_mem)},
                             {DNNL_ARG_TO, const_cast<memory &>(dst_mem)}},
-                    deps);
-            // WA: ocl_deps = {e}; may cause compiler warining with GCC 13+.
-            ocl_deps.assign(1, e);
+                    ocl_deps));
+            ocl_deps.assign(1, reorder_event.get());
         }
     }
     auto e = dnnl::ocl_interop::execute(prim_, stream, args, ocl_deps);
-    return e;
+    return ocl_event_t(e);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/reorder.hpp
+++ b/src/graph/backend/dnnl/executables/reorder.hpp
@@ -48,9 +48,9 @@ struct reorder_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }

--- a/src/graph/backend/dnnl/executables/resampling.cpp
+++ b/src/graph/backend/dnnl/executables/resampling.cpp
@@ -66,25 +66,25 @@ std::optional<::sycl::event> resampling_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event resampling_executable_t::execute_ocl(const stream &stream,
+ocl_event_t resampling_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
-    auto ocl_deps = deps;
+        const std::vector<ocl_event_t> &deps) const {
+    std::vector<cl_event> ocl_deps(deps.begin(), deps.end());
+    ocl_event_t reorder_event;
     if (with_sum_) {
         const memory &psrc_mem = args.find(DNNL_GRAPH_ARG_POST_SRC)->second;
         const memory &dst_mem = args.find(DNNL_ARG_DST)->second;
         if (psrc_mem.get_data_handle() != dst_mem.get_data_handle()) {
             auto prim = dnnl::reorder(psrc_mem, dst_mem);
-            auto e = dnnl::ocl_interop::execute(prim, stream,
+            reorder_event = ocl_event_t(dnnl::ocl_interop::execute(prim, stream,
                     {{DNNL_ARG_FROM, const_cast<memory &>(psrc_mem)},
                             {DNNL_ARG_TO, const_cast<memory &>(dst_mem)}},
-                    deps);
-            // WA: ocl_deps = {e}; may cause compiler warining with GCC 13+.
-            ocl_deps.assign(1, e);
+                    ocl_deps));
+            ocl_deps.assign(1, reorder_event.get());
         }
     }
     auto e = dnnl::ocl_interop::execute(prim_, stream, args, ocl_deps);
-    return e;
+    return ocl_event_t(e);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/resampling.hpp
+++ b/src/graph/backend/dnnl/executables/resampling.hpp
@@ -48,9 +48,9 @@ struct resampling_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return bool(prim_); }
@@ -88,11 +88,12 @@ struct resampling_bwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/sdpa.cpp
+++ b/src/graph/backend/dnnl/executables/sdpa.cpp
@@ -136,24 +136,25 @@ std::optional<::sycl::event> sdpa_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event sdpa_executable_t::execute_ocl(const stream &stream,
+ocl_event_t sdpa_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     std::vector<dnnl_exec_arg_t> c_args;
     c_args.reserve(args.size());
     for (const auto &a : args)
         c_args.push_back({a.first, a.second.get()});
 
-    const cl_event *c_deps = deps.empty() ? nullptr : deps.data();
+    std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+    const cl_event *c_deps = raw_deps.empty() ? nullptr : raw_deps.data();
 
     cl_event return_event = nullptr;
     auto ret = dnnl_ocl_interop_primitive_execute(prim_.get(), stream.get(),
             static_cast<int>(c_args.size()), c_args.data(), c_deps,
-            static_cast<int>(deps.size()), &return_event);
+            static_cast<int>(raw_deps.size()), &return_event);
     dnnl::error::wrap_c_api(
             ret, "could not execute sdpa primitive with ocl runtime");
 
-    return return_event;
+    return ocl_event_t(return_event);
 }
 #endif
 
@@ -339,22 +340,23 @@ std::optional<::sycl::event> sdpa_bwd_executable_t::execute_sycl(
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-cl_event sdpa_bwd_executable_t::execute_ocl(const stream &stream,
+ocl_event_t sdpa_bwd_executable_t::execute_ocl(const stream &stream,
         const std::unordered_map<int, memory> &args,
-        const std::vector<cl_event> &deps) const {
+        const std::vector<ocl_event_t> &deps) const {
     std::vector<dnnl_exec_arg_t> c_args;
     c_args.reserve(args.size());
     for (const auto &a : args)
         c_args.push_back({a.first, a.second.get()});
 
-    const cl_event *c_deps = deps.empty() ? nullptr : deps.data();
+    std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+    const cl_event *c_deps = raw_deps.empty() ? nullptr : raw_deps.data();
     cl_event return_event = nullptr;
     auto ret = dnnl_ocl_interop_primitive_execute(prim_.get(), stream.get(),
             static_cast<int>(c_args.size()), c_args.data(), c_deps,
-            static_cast<int>(deps.size()), &return_event);
+            static_cast<int>(raw_deps.size()), &return_event);
     dnnl::error::wrap_c_api(
             ret, "could not execute sdpa backward with ocl runtime");
-    return return_event;
+    return ocl_event_t(return_event);
 }
 #endif
 

--- a/src/graph/backend/dnnl/executables/sdpa.hpp
+++ b/src/graph/backend/dnnl/executables/sdpa.hpp
@@ -44,9 +44,9 @@ struct sdpa_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return pd_ && prim_; }
@@ -80,9 +80,9 @@ struct sdpa_bwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override;
+            const std::vector<ocl_event_t> &deps) const override;
 #endif
 
     bool is_initialized() const override { return hint_pd_ && pd_ && prim_; }

--- a/src/graph/backend/dnnl/executables/shuffle.hpp
+++ b/src/graph/backend/dnnl/executables/shuffle.hpp
@@ -52,11 +52,12 @@ struct shuffle_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/softmax.hpp
+++ b/src/graph/backend/dnnl/executables/softmax.hpp
@@ -52,11 +52,12 @@ struct softmax_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 
@@ -94,11 +95,12 @@ struct softmax_bwd_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/executables/sum.hpp
+++ b/src/graph/backend/dnnl/executables/sum.hpp
@@ -52,11 +52,12 @@ struct sum_executable_t : public op_executable_t {
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event execute_ocl(const stream &stream,
+    ocl_event_t execute_ocl(const stream &stream,
             const std::unordered_map<int, memory> &args,
-            const std::vector<cl_event> &deps) const override {
-        auto e = dnnl::ocl_interop::execute(prim_, stream, args, deps);
-        return e;
+            const std::vector<ocl_event_t> &deps) const override {
+        std::vector<cl_event> raw_deps(deps.begin(), deps.end());
+        auto e = dnnl::ocl_interop::execute(prim_, stream, args, raw_deps);
+        return ocl_event_t(e);
     }
 #endif
 

--- a/src/graph/backend/dnnl/kernels/batch_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.cpp
@@ -255,10 +255,10 @@ status_t batch_norm_fwd_t::sycl_execute_impl(stream_t *strm,
 status_t batch_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -317,8 +317,8 @@ status_t batch_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }
@@ -451,10 +451,10 @@ status_t batch_norm_bwd_t::sycl_execute_impl(stream_t *strm,
 status_t batch_norm_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -473,8 +473,8 @@ status_t batch_norm_bwd_t::ocl_execute_impl(stream_t *strm,
         deps.assign(1, returned_event);
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/batch_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/batch_norm.hpp
@@ -85,7 +85,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(batch_norm_fwd_t)
@@ -140,7 +141,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(batch_norm_bwd_t)

--- a/src/graph/backend/dnnl/kernels/binary.cpp
+++ b/src/graph/backend/dnnl/kernels/binary.cpp
@@ -170,10 +170,10 @@ status_t binary_t::sycl_execute_impl(stream_t *strm,
 status_t binary_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
+        const std::vector<ocl_event_t> &ocl_deps, ocl_event_t &ocl_event) {
 
     auto deps = ocl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -192,8 +192,8 @@ status_t binary_t::ocl_execute_impl(stream_t *strm,
         deps.assign(1, returned_event);
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ocl_event) *ocl_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ocl_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/binary.hpp
+++ b/src/graph/backend/dnnl/kernels/binary.hpp
@@ -96,8 +96,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &ocl_deps,
-            cl_event *ocl_event) override;
+            const std::vector<ocl_event_t> &ocl_deps,
+            ocl_event_t &ocl_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(binary_t)

--- a/src/graph/backend/dnnl/kernels/concat.cpp
+++ b/src/graph/backend/dnnl/kernels/concat.cpp
@@ -165,10 +165,10 @@ template <bool quantized>
 status_t concat_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -185,8 +185,8 @@ status_t concat_t<quantized>::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/concat.hpp
+++ b/src/graph/backend/dnnl/kernels/concat.hpp
@@ -85,7 +85,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(concat_t)

--- a/src/graph/backend/dnnl/kernels/conv_base.cpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.cpp
@@ -185,10 +185,10 @@ status_t conv_base_t::sycl_execute_impl(stream_t *strm,
 status_t conv_base_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
+        const std::vector<ocl_event_t> &ocl_deps, ocl_event_t &ocl_event) {
 
     auto deps = ocl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -247,8 +247,8 @@ status_t conv_base_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ocl_event) *ocl_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ocl_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/conv_base.hpp
+++ b/src/graph/backend/dnnl/kernels/conv_base.hpp
@@ -82,8 +82,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &ocl_deps,
-            cl_event *ocl_event) override;
+            const std::vector<ocl_event_t> &ocl_deps,
+            ocl_event_t &ocl_event) override;
 #endif
 
     DNNL_DISALLOW_COPY_AND_ASSIGN(conv_base_t)

--- a/src/graph/backend/dnnl/kernels/dummy.cpp
+++ b/src/graph/backend/dnnl/kernels/dummy.cpp
@@ -94,22 +94,25 @@ status_t dummy_kernel_t::sycl_execute_impl(stream_t *strm,
 status_t dummy_kernel_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
-    if (ret_event) {
-        // Fast path: if only one event, return it.
+    ret_event = {};
+    if (!cl_deps.empty()) {
+        // Fast path: if only one event, return it (copy retains).
         if (cl_deps.size() == 1) {
-            *ret_event = cl_deps[0];
+            ret_event = cl_deps[0];
         } else {
             // Otherwise, gather all dependencies.
             auto q = dnnl::ocl_interop::get_command_queue(p_stream);
+            std::vector<cl_event> raw_deps(cl_deps.begin(), cl_deps.end());
+            cl_event e;
             auto err = xpu::ocl::clEnqueueMarkerWithWaitList(q,
-                    static_cast<cl_uint>(cl_deps.size()), cl_deps.data(),
-                    ret_event);
+                    static_cast<cl_uint>(raw_deps.size()), raw_deps.data(), &e);
             assert(err == CL_SUCCESS);
             if (err != CL_SUCCESS) return status::runtime_error;
+            ret_event = ocl_event_t(e);
         }
     }
 

--- a/src/graph/backend/dnnl/kernels/dummy.hpp
+++ b/src/graph/backend/dnnl/kernels/dummy.hpp
@@ -64,7 +64,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     size_t get_scratchpad_size() const override { return 0; }

--- a/src/graph/backend/dnnl/kernels/eltwise.cpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.cpp
@@ -273,10 +273,10 @@ template <bool quantized>
 status_t eltwise_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -335,8 +335,8 @@ status_t eltwise_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }
@@ -463,10 +463,10 @@ status_t eltwise_bwd_t::sycl_execute_impl(stream_t *strm,
 status_t eltwise_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -483,8 +483,8 @@ status_t eltwise_bwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/eltwise.hpp
+++ b/src/graph/backend/dnnl/kernels/eltwise.hpp
@@ -95,7 +95,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(eltwise_fwd_t)
@@ -153,7 +154,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(eltwise_bwd_t)

--- a/src/graph/backend/dnnl/kernels/gated_mlp.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp.hpp
@@ -100,8 +100,8 @@ public:
     status_t ocl_execute_impl(stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
-            cl_event *event) override {
+            const tensor_t *scratchpad_buf,
+            const std::vector<ocl_event_t> &deps, ocl_event_t &event) override {
         return kernel->ocl_execute_impl(
                 stream, inputs, outputs, scratchpad_buf, deps, event);
     }

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.cpp
@@ -204,9 +204,9 @@ template <bool quantized>
 status_t gated_mlp_primitive_kernel_t<quantized>::ocl_execute_impl(
         stream_t *stream, const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &ocl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &ocl_deps, ocl_event_t &ret_event) {
     auto deps = ocl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
 
     dnnl::stream p_stream = make_dnnl_stream(*stream);
 
@@ -222,11 +222,11 @@ status_t gated_mlp_primitive_kernel_t<quantized>::ocl_execute_impl(
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/gated_mlp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/gated_mlp_primitive.hpp
@@ -83,8 +83,9 @@ public:
     status_t ocl_execute_impl(stream_t *stream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
-            cl_event *ret_event) override;
+            const tensor_t *scratchpad_buf,
+            const std::vector<ocl_event_t> &deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(gated_mlp_primitive_kernel_t)

--- a/src/graph/backend/dnnl/kernels/gen_index.cpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.cpp
@@ -165,9 +165,9 @@ status_t genindex_t::sycl_execute_impl(stream_t *strm,
 status_t genindex_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
+        const std::vector<ocl_event_t> &ocl_deps, ocl_event_t &ocl_event) {
     auto deps = ocl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -181,10 +181,10 @@ status_t genindex_t::ocl_execute_impl(stream_t *strm,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    if (ocl_event) *ocl_event = returned_event;
+    ocl_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/gen_index.hpp
+++ b/src/graph/backend/dnnl/kernels/gen_index.hpp
@@ -75,8 +75,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &ocl_deps,
-            cl_event *ocl_event) override;
+            const std::vector<ocl_event_t> &ocl_deps,
+            ocl_event_t &ocl_event) override;
 #endif
     DEF_KERNEL_METHOD_STR(genindex_t)
     DEF_KERNEL_METHOD_SCRATCHPAD_SIZE()

--- a/src/graph/backend/dnnl/kernels/group_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.cpp
@@ -263,10 +263,10 @@ status_t group_norm_fwd_t::sycl_execute_impl(stream_t *strm,
 status_t group_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -325,8 +325,8 @@ status_t group_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/group_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/group_norm.hpp
@@ -87,7 +87,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(group_norm_fwd_t)

--- a/src/graph/backend/dnnl/kernels/kernel_base.hpp
+++ b/src/graph/backend/dnnl/kernels/kernel_base.hpp
@@ -31,10 +31,18 @@
 #include "oneapi/dnnl/dnnl_sycl.hpp"
 #endif
 
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+#include "xpu/ocl/utils.hpp"
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace graph {
 namespace dnnl_impl {
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+using ocl_event_t = xpu::ocl::wrapper_t<cl_event>;
+#endif
 
 class dnnl_partition_impl_t;
 
@@ -86,7 +94,7 @@ struct kernel_base_t {
     status_t execute_ocl(stream_t *astream, const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) {
+            const std::vector<ocl_event_t> &ocl_deps, ocl_event_t &ocl_event) {
         return ocl_execute_impl(
                 astream, inputs, outputs, scratchpad_buf, ocl_deps, ocl_event);
     }
@@ -95,7 +103,7 @@ struct kernel_base_t {
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &ocl_deps, cl_event *ocl_event)
+            const std::vector<ocl_event_t> &ocl_deps, ocl_event_t &ocl_event)
             = 0;
 #endif
 

--- a/src/graph/backend/dnnl/kernels/large_partition.cpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.cpp
@@ -389,9 +389,9 @@ status_t larger_partition_kernel_t::sycl_execute_impl(stream_t *strm,
 status_t larger_partition_kernel_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &ocl_deps, cl_event *event) {
+        const std::vector<ocl_event_t> &ocl_deps, ocl_event_t &event) {
     auto deps = ocl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -435,7 +435,7 @@ status_t larger_partition_kernel_t::ocl_execute_impl(stream_t *strm,
                 if (!subgraph_->is_constant_[i]) continue;
                 returned_event = subgraph_->execs_[i]->execute_ocl(
                         p_stream, res->get_exec_args()[i], deps);
-                deps.assign(1, returned_event);
+                deps = {returned_event};
             }
 
             c_promise.set_value(c_buffer);
@@ -446,11 +446,11 @@ status_t larger_partition_kernel_t::ocl_execute_impl(stream_t *strm,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (event) *event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/large_partition.hpp
+++ b/src/graph/backend/dnnl/kernels/large_partition.hpp
@@ -102,7 +102,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &ocl_deps, cl_event *event) override;
+            const std::vector<ocl_event_t> &ocl_deps,
+            ocl_event_t &event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(larger_partition_kernel_t)

--- a/src/graph/backend/dnnl/kernels/layer_norm.cpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.cpp
@@ -260,10 +260,10 @@ status_t layer_norm_fwd_t::sycl_execute_impl(stream_t *strm,
 status_t layer_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -322,8 +322,8 @@ status_t layer_norm_fwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }
@@ -449,10 +449,10 @@ status_t layer_norm_bwd_t::sycl_execute_impl(stream_t *strm,
 status_t layer_norm_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -466,11 +466,11 @@ status_t layer_norm_bwd_t::ocl_execute_impl(stream_t *strm,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/layer_norm.hpp
+++ b/src/graph/backend/dnnl/kernels/layer_norm.hpp
@@ -86,7 +86,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(layer_norm_fwd_t)
@@ -141,7 +142,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     status_t prepare_inplace_pairs_impl() override {

--- a/src/graph/backend/dnnl/kernels/log_softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.cpp
@@ -152,10 +152,10 @@ status_t logsoftmax_fwd_t::sycl_execute_impl(stream_t *strm,
 status_t logsoftmax_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -173,8 +173,8 @@ status_t logsoftmax_fwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }
@@ -305,10 +305,10 @@ status_t logsoftmax_bwd_t::sycl_execute_impl(stream_t *strm,
 status_t logsoftmax_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -326,8 +326,8 @@ status_t logsoftmax_bwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/log_softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/log_softmax.hpp
@@ -89,7 +89,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(logsoftmax_fwd_t)
@@ -144,7 +145,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     status_t prepare_inplace_pairs_impl() override {

--- a/src/graph/backend/dnnl/kernels/matmul.cpp
+++ b/src/graph/backend/dnnl/kernels/matmul.cpp
@@ -333,10 +333,10 @@ template <bool quantized>
 status_t matmul_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -395,8 +395,8 @@ status_t matmul_t<quantized>::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/matmul.hpp
+++ b/src/graph/backend/dnnl/kernels/matmul.hpp
@@ -88,7 +88,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     status_t prepare_inplace_pairs_impl() override {

--- a/src/graph/backend/dnnl/kernels/mqa.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa.hpp
@@ -98,8 +98,8 @@ public:
     status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
-            cl_event *event) override {
+            const tensor_t *scratchpad_buf,
+            const std::vector<ocl_event_t> &deps, ocl_event_t &event) override {
         return kernel->ocl_execute_impl(
                 strm, inputs, outputs, scratchpad_buf, deps, event);
     }

--- a/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp.hpp
@@ -152,8 +152,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps,
-            cl_event *ret_event) override {
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override {
         UNUSED(strm);
         UNUSED(inputs);
         UNUSED(outputs);

--- a/src/graph/backend/dnnl/kernels/pool.cpp
+++ b/src/graph/backend/dnnl/kernels/pool.cpp
@@ -292,10 +292,10 @@ template <bool quantized>
 status_t pooling_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -354,8 +354,8 @@ status_t pooling_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }
@@ -498,10 +498,10 @@ status_t pooling_bwd_t::sycl_execute_impl(stream_t *strm,
 status_t pooling_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -520,8 +520,8 @@ status_t pooling_bwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/pool.hpp
+++ b/src/graph/backend/dnnl/kernels/pool.hpp
@@ -88,7 +88,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(pooling_fwd_t)
@@ -146,7 +147,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(pooling_bwd_t)

--- a/src/graph/backend/dnnl/kernels/prelu.cpp
+++ b/src/graph/backend/dnnl/kernels/prelu.cpp
@@ -170,10 +170,10 @@ template <bool quantized>
 status_t prelu_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -188,11 +188,11 @@ status_t prelu_fwd_t<quantized>::ocl_execute_impl(stream_t *strm,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }
@@ -325,10 +325,10 @@ status_t prelu_bwd_t::sycl_execute_impl(stream_t *strm,
 status_t prelu_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -343,11 +343,11 @@ status_t prelu_bwd_t::ocl_execute_impl(stream_t *strm,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/prelu.hpp
+++ b/src/graph/backend/dnnl/kernels/prelu.hpp
@@ -86,7 +86,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(prelu_fwd_t)
@@ -143,7 +144,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(prelu_bwd_t)

--- a/src/graph/backend/dnnl/kernels/quantize.cpp
+++ b/src/graph/backend/dnnl/kernels/quantize.cpp
@@ -259,10 +259,10 @@ status_t quantize_dequantize_t::sycl_execute_impl(stream_t *strm,
 status_t quantize_dequantize_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -321,8 +321,8 @@ status_t quantize_dequantize_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/quantize.hpp
+++ b/src/graph/backend/dnnl/kernels/quantize.hpp
@@ -88,7 +88,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(quantize_dequantize_t)

--- a/src/graph/backend/dnnl/kernels/reduction.cpp
+++ b/src/graph/backend/dnnl/kernels/reduction.cpp
@@ -168,10 +168,10 @@ template <bool quantized>
 status_t reduction_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -188,8 +188,8 @@ status_t reduction_t<quantized>::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/reduction.hpp
+++ b/src/graph/backend/dnnl/kernels/reduction.hpp
@@ -86,7 +86,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     status_t prepare_inplace_pairs_impl() override {

--- a/src/graph/backend/dnnl/kernels/reorder.cpp
+++ b/src/graph/backend/dnnl/kernels/reorder.cpp
@@ -275,10 +275,10 @@ template <bool quantized>
 status_t reorder_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -337,8 +337,8 @@ status_t reorder_t<quantized>::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/reorder.hpp
+++ b/src/graph/backend/dnnl/kernels/reorder.hpp
@@ -88,7 +88,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     status_t prepare_inplace_pairs_impl() override {

--- a/src/graph/backend/dnnl/kernels/resampling.cpp
+++ b/src/graph/backend/dnnl/kernels/resampling.cpp
@@ -169,10 +169,10 @@ status_t resampling_fwd_t::sycl_execute_impl(stream_t *strm,
 status_t resampling_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -189,8 +189,8 @@ status_t resampling_fwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }
@@ -318,10 +318,10 @@ status_t resampling_bwd_t::sycl_execute_impl(stream_t *strm,
 status_t resampling_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -338,8 +338,8 @@ status_t resampling_bwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/resampling.hpp
+++ b/src/graph/backend/dnnl/kernels/resampling.hpp
@@ -90,7 +90,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(resampling_fwd_t)
@@ -145,7 +146,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(resampling_bwd_t)

--- a/src/graph/backend/dnnl/kernels/sdp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp.hpp
@@ -132,8 +132,8 @@ public:
     status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
-            cl_event *event) override {
+            const tensor_t *scratchpad_buf,
+            const std::vector<ocl_event_t> &deps, ocl_event_t &event) override {
         return kernel->ocl_execute_impl(
                 strm, inputs, outputs, scratchpad_buf, deps, event);
     }

--- a/src/graph/backend/dnnl/kernels/sdp_bwd.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd.hpp
@@ -105,8 +105,8 @@ public:
     status_t ocl_execute_impl(stream_t *strm,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
-            const tensor_t *scratchpad_buf, const std::vector<cl_event> &deps,
-            cl_event *event) override {
+            const tensor_t *scratchpad_buf,
+            const std::vector<ocl_event_t> &deps, ocl_event_t &event) override {
         return kernel->ocl_execute_impl(
                 strm, inputs, outputs, scratchpad_buf, deps, event);
     }

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.cpp
@@ -213,9 +213,9 @@ status_t sdp_bwd_primitive_kernel_t::sycl_execute_impl(stream_t *strm,
 status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
 
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
@@ -231,11 +231,11 @@ status_t sdp_bwd_primitive_kernel_t::ocl_execute_impl(stream_t *strm,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_bwd_primitive.hpp
@@ -83,7 +83,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     static status_t initial_check(const std::shared_ptr<subgraph_t> &sg,

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.hpp
@@ -159,8 +159,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps,
-            cl_event *ret_event) override {
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override {
         UNUSED(strm);
         UNUSED(inputs);
         UNUSED(outputs);

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.cpp
@@ -223,9 +223,9 @@ template <bool quantized>
 status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
 
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
@@ -245,8 +245,8 @@ status_t sdp_primitive_kernel_t<quantized>::ocl_execute_impl(stream_t *strm,
         deps.assign(1, returned_event);
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive.hpp
@@ -88,7 +88,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(sdp_primitive_kernel_t)

--- a/src/graph/backend/dnnl/kernels/shuffle.cpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.cpp
@@ -167,10 +167,10 @@ status_t shuffle_fwd_t::sycl_execute_impl(stream_t *strm,
 status_t shuffle_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     thread_local_cache_t<execution_args_set_t> res_cache;
@@ -185,11 +185,11 @@ status_t shuffle_fwd_t::ocl_execute_impl(stream_t *strm,
         if (subgraph_->is_constant_[i]) continue;
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/shuffle.hpp
+++ b/src/graph/backend/dnnl/kernels/shuffle.hpp
@@ -85,7 +85,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(shuffle_fwd_t)

--- a/src/graph/backend/dnnl/kernels/softmax.cpp
+++ b/src/graph/backend/dnnl/kernels/softmax.cpp
@@ -258,10 +258,10 @@ status_t softmax_fwd_t::sycl_execute_impl(stream_t *strm,
 status_t softmax_fwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -320,8 +320,8 @@ status_t softmax_fwd_t::ocl_execute_impl(stream_t *strm,
         deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }
@@ -452,10 +452,10 @@ status_t softmax_bwd_t::sycl_execute_impl(stream_t *strm,
 status_t softmax_bwd_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -470,11 +470,11 @@ status_t softmax_bwd_t::ocl_execute_impl(stream_t *strm,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/softmax.hpp
+++ b/src/graph/backend/dnnl/kernels/softmax.hpp
@@ -91,7 +91,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(softmax_fwd_t)
@@ -146,7 +147,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     status_t prepare_inplace_pairs_impl() override {

--- a/src/graph/backend/dnnl/kernels/sum.cpp
+++ b/src/graph/backend/dnnl/kernels/sum.cpp
@@ -167,10 +167,10 @@ status_t sum_t::sycl_execute_impl(stream_t *strm,
 status_t sum_t::ocl_execute_impl(stream_t *strm,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad_buf,
-        const std::vector<cl_event> &cl_deps, cl_event *ret_event) {
+        const std::vector<ocl_event_t> &cl_deps, ocl_event_t &ret_event) {
 
     auto deps = cl_deps;
-    cl_event returned_event {};
+    ocl_event_t returned_event;
     dnnl::stream p_stream = make_dnnl_stream(*strm);
 
     // each thread's own local resource
@@ -185,11 +185,11 @@ status_t sum_t::ocl_execute_impl(stream_t *strm,
     for (size_t i = 0; i < subgraph_->execs_.size(); i++) {
         returned_event = subgraph_->execs_[i]->execute_ocl(
                 p_stream, res->get_exec_args()[i], deps);
-        deps.assign(1, returned_event);
+        deps = {returned_event};
     }
 
-    scratchpad->set_deps(returned_event);
-    if (ret_event) *ret_event = returned_event;
+    scratchpad->set_deps(returned_event.get());
+    ret_event = std::move(returned_event);
 
     return status::success;
 }

--- a/src/graph/backend/dnnl/kernels/sum.hpp
+++ b/src/graph/backend/dnnl/kernels/sum.hpp
@@ -86,7 +86,8 @@ public:
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs,
             const tensor_t *scratchpad_buf,
-            const std::vector<cl_event> &cl_deps, cl_event *ret_event) override;
+            const std::vector<ocl_event_t> &cl_deps,
+            ocl_event_t &ret_event) override;
 #endif
 
     DEF_KERNEL_METHOD_STR(sum_t)

--- a/src/graph/backend/dnnl/scratchpad.cpp
+++ b/src/graph/backend/dnnl/scratchpad.cpp
@@ -36,11 +36,7 @@ scratchpad_t::scratchpad_t(
     : buffer_(nullptr)
     , size_(size)
     , user_managed_(user_buf != nullptr)
-    , eng_(eng.get())
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    , ocl_e_(nullptr)
-#endif
-{
+    , eng_(eng.get()) {
     if (user_buf) {
         buffer_ = reinterpret_cast<char *>(user_buf->get_data_handle());
     } else if (size > 0) {

--- a/src/graph/backend/dnnl/scratchpad.hpp
+++ b/src/graph/backend/dnnl/scratchpad.hpp
@@ -30,10 +30,18 @@
 #include "oneapi/dnnl/dnnl_sycl.hpp"
 #endif
 
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+#include "xpu/ocl/utils.hpp"
+#endif
+
 namespace dnnl {
 namespace impl {
 namespace graph {
 namespace dnnl_impl {
+
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+using ocl_event_t = xpu::ocl::wrapper_t<cl_event>;
+#endif
 
 // Unified scratchpad class that handles both library-managed (temporary) and
 // user-provided buffer modes. When user_buf is non-null, the buffer lifecycle
@@ -61,7 +69,7 @@ public:
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
     void set_deps(cl_event event) {
-        if (!user_managed_) ocl_e_ = event;
+        if (!user_managed_) { ocl_e_ = ocl_event_t(event, true); }
     }
 #endif
 
@@ -75,7 +83,7 @@ private:
 #endif
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-    cl_event ocl_e_;
+    ocl_event_t ocl_e_;
 #endif
 };
 

--- a/src/graph/interface/partition.cpp
+++ b/src/graph/interface/partition.cpp
@@ -434,6 +434,8 @@ status_t DNNL_API dnnl_graph_sycl_interop_compiled_partition_execute_v2(
 }
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
+using ocl_event_t = dnnl::impl::xpu::ocl::wrapper_t<cl_event>;
+
 status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute(
         const compiled_partition_t *compiled_partition, stream_t *stream,
         size_t num_inputs, const tensor_t **inputs, size_t num_outputs,
@@ -465,32 +467,35 @@ status_t DNNL_API dnnl_graph_ocl_interop_compiled_partition_execute_v2(
         outs.emplace_back(**(outputs + i));
     }
 
+    // Wrap raw user deps with retain.
+    std::vector<ocl_event_t> wrapped_deps;
+    if (deps != nullptr) {
+        if (ndeps < 0) return status::invalid_arguments;
+        wrapped_deps.reserve(static_cast<size_t>(ndeps));
+        for (int i = 0; i < ndeps; i++)
+            wrapped_deps.emplace_back(deps[i], true);
+    }
+
+    ocl_event_t ret_event;
+
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
         stream->wait();
         double start_ms = dnnl::impl::get_msec();
-        if (deps != nullptr) {
-            std::vector<cl_event> ocl_deps(deps, deps + ndeps);
-            CHECK(compiled_partition->execute_ocl(
-                    stream, ins, outs, scratchpad, ocl_deps, ocl_event));
-        } else {
-            CHECK(compiled_partition->execute_ocl(
-                    stream, ins, outs, scratchpad, {}, ocl_event));
-        }
+        CHECK(compiled_partition->execute_ocl(
+                stream, ins, outs, scratchpad, wrapped_deps, ret_event));
+        // Transfer ownership to caller.
+        if (ocl_event) *ocl_event = ret_event.release();
         stream->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
         auto info = compiled_partition->exec_info(scratchpad != nullptr);
         VPROF(start_ms, graph, exec, VERBOSE_profile, info.c_str(),
                 duration_ms);
     } else {
-        if (deps != nullptr) {
-            std::vector<cl_event> ocl_deps(deps, deps + ndeps);
-            CHECK(compiled_partition->execute_ocl(
-                    stream, ins, outs, scratchpad, ocl_deps, ocl_event));
-        } else {
-            CHECK(compiled_partition->execute_ocl(
-                    stream, ins, outs, scratchpad, {}, ocl_event));
-        }
+        CHECK(compiled_partition->execute_ocl(
+                stream, ins, outs, scratchpad, wrapped_deps, ret_event));
+        // Transfer ownership to caller.
+        if (ocl_event) *ocl_event = ret_event.release();
     }
 
     return status::success;
@@ -751,7 +756,9 @@ status_t dnnl_graph_compiled_partition::execute(stream_t *astream,
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
         return execute_sycl(astream, inputs, outputs, scratchpad, {}, nullptr);
 #elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        return execute_ocl(astream, inputs, outputs, scratchpad, {}, nullptr);
+        ocl_event_t unused_event;
+        return execute_ocl(
+                astream, inputs, outputs, scratchpad, {}, unused_event);
 #else
         return status::runtime_error;
 #endif
@@ -812,7 +819,8 @@ status_t dnnl_graph_compiled_partition::execute_sycl(stream_t *astream,
 status_t dnnl_graph_compiled_partition::execute_ocl(stream_t *astream,
         const std::vector<tensor_t> &inputs,
         const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
-        const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) const {
+        const std::vector<ocl_event_t> &ocl_deps,
+        ocl_event_t &ocl_event) const {
     if (!astream || (astream->engine()->kind() != pimpl_->get_engine()->kind()))
         return status::invalid_arguments;
 

--- a/src/graph/interface/partition.hpp
+++ b/src/graph/interface/partition.hpp
@@ -39,6 +39,8 @@
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include <CL/cl.h>
+
+#include "xpu/ocl/utils.hpp"
 #endif
 
 namespace dnnl {
@@ -195,7 +197,9 @@ public:
             const std::vector<graph::tensor_t> &inputs,
             const std::vector<graph::tensor_t> &outputs,
             const graph::tensor_t *scratchpad,
-            const std::vector<cl_event> &ocl_deps, cl_event *ocl_event) const;
+            const std::vector<dnnl::impl::xpu::ocl::wrapper_t<cl_event>>
+                    &ocl_deps,
+            dnnl::impl::xpu::ocl::wrapper_t<cl_event> &ocl_event) const;
 #endif
 
     size_t get_scratchpad_size() const {

--- a/src/graph/interface/partition_impl.hpp
+++ b/src/graph/interface/partition_impl.hpp
@@ -43,6 +43,8 @@
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include <CL/cl.h>
+
+#include "xpu/ocl/utils.hpp"
 #endif
 
 namespace std {
@@ -367,7 +369,8 @@ public:
     virtual status_t execute_ocl(stream_t *astream,
             const std::vector<tensor_t> &inputs,
             const std::vector<tensor_t> &outputs, const tensor_t *scratchpad,
-            const std::vector<cl_event> &ocl_deps, cl_event *ocl_event)
+            const std::vector<xpu::ocl::wrapper_t<cl_event>> &ocl_deps,
+            xpu::ocl::wrapper_t<cl_event> &ocl_event)
             = 0;
 #endif
 


### PR DESCRIPTION
To avoid memory leaks and safely manage the lifetime of `cl_event`, we switch to `wrapper_t<cl_event>` which is a RAII wrapper for `cl_event`. It's already defined and widely used in the GPU backend to manage OpenCL objects.

The PR touches almost every file of kernels and executables in the backend with the same change pattern:
- the input deps arguments: from `std::vector<cl_event>` to `std::vector<wrapper_t<cl_event>>`.
- the returned event: from `cl_event` to `wrapper_t<cl_event>`.

Fixes MFDNN-15374