### PR TITLE
[GPU] Enable all eltwise algorithms in grouped GEMM

### DIFF
--- a/cmake/gen_gpu_kernel.cmake
+++ b/cmake/gen_gpu_kernel.cmake
@@ -56,7 +56,7 @@ string(REGEX REPLACE "\n" ")==\"\"\\\\n\"\nR\"==(" cl_file_lines "${cl_file_line
 
 if(cl_file_ext STREQUAL ".cl")
     set(cl_file_contents  "const char *${cl_file_name}_kernel = R\"==(${cl_file_lines})==\";")
-elseif(cl_file_ext STREQUAL ".h")
+elseif(cl_file_ext STREQUAL ".h" OR cl_file_ext STREQUAL ".hxx")
     set(cl_file_contents  "const char *${cl_file_name}_header = R\"==(${cl_file_lines})==\";")
 else()
     message(FATAL_ERROR "Unknown file extensions: ${cl_file_ext}")

--- a/src/gpu/intel/CMakeLists.txt
+++ b/src/gpu/intel/CMakeLists.txt
@@ -35,7 +35,12 @@ add_subdirectory(gemm/jit)
 include("${PROJECT_SOURCE_DIR}/cmake/gen_gpu_kernel_list.cmake")
 
 file(GLOB_RECURSE CL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cl)
-file(GLOB_RECURSE CL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+file(GLOB_RECURSE CL_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.hxx
+    )
+# gemm/jit headers are C++, not OpenCL
+list(FILTER CL_HEADERS EXCLUDE REGEX "/gemm/jit/")
 
 set(kernel_list_templ "${PROJECT_SOURCE_DIR}/src/gpu/intel/ocl_kernel_list.cpp.in")
 set(kernel_list_src "${PROJECT_BINARY_DIR}/src/gpu/intel/ocl_kernel_list.cpp")

--- a/src/gpu/intel/include/eltwise.h
+++ b/src/gpu/intel/include/eltwise.h
@@ -42,272 +42,37 @@
 #define POST_OP_LITERAL(x) x##f
 #endif
 
-POST_OP_DATA_T relu_fwd(POST_OP_DATA_T s, float alpha) {
-    return s > 0 ? s : s * alpha;
-}
-POST_OP_DATA_T relu_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {
-    return s > 0 ? dd : dd * alpha;
-}
-POST_OP_DATA_T relu_bwd_use_dst(
-        POST_OP_DATA_T dd, POST_OP_DATA_T d, float alpha) {
-    return d > 0 ? dd : dd * alpha;
+#define ELT_T POST_OP_DATA_T
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+
+#ifdef ELTWISE_VECTOR_API
+// float1 has no builtin overloads, so it defers to the scalar form.
+#include "gpu/intel/include/generic_vector_ops.h"
+
+float1 __attribute__((overloadable)) fwd_eltwise_common(
+        int eltwise_alg, float1 x, float alpha_, float beta_, float scale_) {
+    x[0] = fwd_eltwise_common(eltwise_alg, x[0], alpha_, beta_, scale_);
+    return x;
 }
 
-POST_OP_DATA_T linear_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    return alpha * s + beta;
-}
-POST_OP_DATA_T linear_bwd(POST_OP_DATA_T dd, float alpha) {
-    return dd * alpha;
-}
+#define ELT_T float2
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+#define ELT_T float4
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+#define ELT_T float8
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+#define ELT_T float16
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+#endif
 
-POST_OP_DATA_T soft_relu_fwd(POST_OP_DATA_T s, float alpha) {
-    s = alpha * s;
-    POST_OP_DATA_T v
-            = (s < log(CONVERT_POST_OP_DATA_T(DATA_MAX)) ? log1p(exp(s)) : s);
-    return v / alpha;
-}
-POST_OP_DATA_T soft_relu_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {
-    s = alpha * s;
-    return dd / (POST_OP_LITERAL(1.) + exp(-s));
-}
-
-POST_OP_DATA_T logistic_fwd(POST_OP_DATA_T s) {
-    return (POST_OP_LITERAL(1.)) / (POST_OP_LITERAL(1.) + exp(-s));
-}
-POST_OP_DATA_T logistic_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    POST_OP_DATA_T v = logistic_fwd(s);
-    return dd * v * (POST_OP_LITERAL(1.) - v);
-}
-POST_OP_DATA_T logistic_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
-    return dd * d * (POST_OP_LITERAL(1.) - d);
-}
-
-POST_OP_DATA_T square_fwd(POST_OP_DATA_T s) {
-    return s * s;
-}
-POST_OP_DATA_T square_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return dd * 2 * s;
-}
-
-POST_OP_DATA_T sqrt_fwd(POST_OP_DATA_T s) {
-    return sqrt(s);
-}
-POST_OP_DATA_T sqrt_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return dd / (POST_OP_LITERAL(2.) * sqrt(s));
-}
-POST_OP_DATA_T sqrt_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
-    return dd / (POST_OP_LITERAL(2.) * d);
-}
-
-POST_OP_DATA_T abs_fwd(POST_OP_DATA_T s) {
-    return s > 0 ? s : -s;
-}
-POST_OP_DATA_T abs_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return s > 0 ? dd : s < 0 ? -dd : 0;
-}
-
-POST_OP_DATA_T tanh_fwd(POST_OP_DATA_T s) {
-    return tanh(s);
-}
-POST_OP_DATA_T tanh_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    POST_OP_DATA_T e = tanh_fwd(s);
-    return dd * (POST_OP_LITERAL(1.) - e) * (POST_OP_LITERAL(1.) + e);
-}
-POST_OP_DATA_T tanh_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
-    return dd * (POST_OP_LITERAL(1.) - d) * (POST_OP_LITERAL(1.) + d);
-}
-
-POST_OP_DATA_T mish_fwd(POST_OP_DATA_T s) {
-    return s * tanh_fwd(soft_relu_fwd(s, POST_OP_LITERAL(1.)));
-}
-POST_OP_DATA_T mish_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    const POST_OP_DATA_T tanh = tanh_fwd(soft_relu_fwd(s, POST_OP_LITERAL(1.)));
-    const POST_OP_DATA_T srelu_bwd
-            = soft_relu_bwd(POST_OP_LITERAL(1.), s, POST_OP_LITERAL(1.));
-    const POST_OP_DATA_T derivative = tanh
-            + s * srelu_bwd
-                    * (POST_OP_LITERAL(1.) - pow(tanh, POST_OP_LITERAL(2.)));
-    return dd * derivative;
-}
-
-POST_OP_DATA_T elu_fwd(POST_OP_DATA_T s, float alpha) {
-    return s > 0 ? s : alpha * expm1(s);
-}
-POST_OP_DATA_T elu_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {
-    return dd * (s > 0 ? 1 : alpha * exp(s));
-}
-POST_OP_DATA_T elu_bwd_use_dst(
-        POST_OP_DATA_T dd, POST_OP_DATA_T d, float alpha) {
-    return dd * (d > 0 ? 1 : d + alpha);
-}
-
-POST_OP_DATA_T exp_fwd(POST_OP_DATA_T s) {
-    return exp(s);
-}
-
-POST_OP_DATA_T exp_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return dd * exp_fwd(s);
-}
-POST_OP_DATA_T exp_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
-    return dd * d;
-}
-
-POST_OP_DATA_T gelu_tanh_fwd(POST_OP_DATA_T s) {
-    const POST_OP_DATA_T g = POST_OP_LITERAL(1.5957691669464111328125) * s
-            * (POST_OP_LITERAL(1.) + POST_OP_LITERAL(0.044715) * s * s);
-    return s / (POST_OP_LITERAL(1.) + exp(-g));
-}
-POST_OP_DATA_T gelu_tanh_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    const POST_OP_DATA_T sqrt_2_over_pi
-            = POST_OP_LITERAL(0.79788458347320556640625);
-    const POST_OP_DATA_T fitting_const = POST_OP_LITERAL(0.044715);
-    const POST_OP_DATA_T g = sqrt_2_over_pi * s
-            * (POST_OP_LITERAL(1.) + fitting_const * s * s);
-    const POST_OP_DATA_T dg = sqrt_2_over_pi
-            * (POST_OP_LITERAL(1.)
-                    + POST_OP_LITERAL(3.) * fitting_const * s * s);
-    const POST_OP_DATA_T v = tanh_fwd(g);
-    return dd * POST_OP_LITERAL(0.5) * (POST_OP_LITERAL(1.) + v)
-            * (POST_OP_LITERAL(1.) + s * (POST_OP_LITERAL(1.) - v) * dg);
-}
-
-POST_OP_DATA_T swish_fwd(POST_OP_DATA_T s, float alpha) {
-    POST_OP_DATA_T w = -alpha * s;
-    return s / (POST_OP_LITERAL(1.) + exp(w));
-}
-POST_OP_DATA_T swish_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {
-    POST_OP_DATA_T v = logistic_fwd(alpha * s);
-    return dd * (v + s * alpha * v * (POST_OP_LITERAL(1.) - v));
-}
-
-POST_OP_DATA_T log_fwd(POST_OP_DATA_T s) {
-    return log(s);
-}
-POST_OP_DATA_T log_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return dd / s;
-}
-
-POST_OP_DATA_T clip_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    s = s > alpha ? s : alpha;
-    return s > beta ? beta : s;
-}
-POST_OP_DATA_T clip_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    return dd * (alpha < s && s <= beta ? 1 : 0);
-}
-
-POST_OP_DATA_T clip_v2_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    s = s > alpha ? s : alpha;
-    return s < beta ? s : beta;
-}
-POST_OP_DATA_T clip_v2_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    return dd * (alpha < s && s < beta ? 1 : 0);
-}
-POST_OP_DATA_T clip_v2_bwd_use_dst(
-        POST_OP_DATA_T dd, POST_OP_DATA_T d, float alpha, float beta) {
-    return dd * (alpha < d && d < beta ? 1 : 0);
-}
-
-POST_OP_DATA_T pow_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    return alpha * pow(s, (POST_OP_DATA_T)(beta));
-}
-POST_OP_DATA_T pow_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    if (beta == 0) return 0;
-
-    POST_OP_DATA_T v = pow_fwd(s, alpha * beta, beta - 1);
-    return dd * v;
-}
-
-POST_OP_DATA_T gelu_erf_fwd(POST_OP_DATA_T s) {
-    const POST_OP_DATA_T sqrt_2_over_2
-            = POST_OP_LITERAL(0.707106769084930419921875);
-    POST_OP_DATA_T v = s * sqrt_2_over_2;
-    return POST_OP_LITERAL(0.5) * s * (POST_OP_LITERAL(1.) + erf(v));
-}
-
-POST_OP_DATA_T gelu_erf_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    const POST_OP_DATA_T two_over_sqrt_pi
-            = POST_OP_LITERAL(1.12837922573089599609375);
-    const POST_OP_DATA_T sqrt_2_over_2
-            = POST_OP_LITERAL(0.707106769084930419921875);
-    POST_OP_DATA_T v = s * sqrt_2_over_2;
-    return dd * POST_OP_LITERAL(0.5)
-            * (POST_OP_LITERAL(1.) + erf(v)
-                    + v * two_over_sqrt_pi * exp(-v * v));
-}
-
-float round_fwd(POST_OP_DATA_T s) {
-    return (float)rint((float)s);
-}
-
-POST_OP_DATA_T hardsigmoid_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    POST_OP_DATA_T v = (POST_OP_DATA_T)alpha * s + (POST_OP_DATA_T)beta;
-    return v <= POST_OP_LITERAL(0.)    ? POST_OP_LITERAL(0.)
-            : v >= POST_OP_LITERAL(1.) ? POST_OP_LITERAL(1.)
-                                       : v;
-}
-POST_OP_DATA_T hardsigmoid_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    POST_OP_DATA_T v = alpha * s + beta;
-    return v <= 0.f ? 0.f : v >= 1.f ? 0.f : dd * alpha;
-}
-
-POST_OP_DATA_T hardswish_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    return s * hardsigmoid_fwd(s, alpha, beta);
-}
-POST_OP_DATA_T hardswish_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    POST_OP_DATA_T v = alpha * s + beta;
-    POST_OP_DATA_T w = POST_OP_LITERAL(2.) * alpha * s + beta;
-    return (v <= 0.f ? 0.f : v >= 1.f ? dd : dd * w);
-}
-
-float fwd_eltwise_common(int eltwise_alg, POST_OP_DATA_T x, float alpha_,
-        float beta_, float scale_) {
-    switch (eltwise_alg) {
-        case eltwise_relu: return scale_ * relu_fwd(x, alpha_); break;
-        case eltwise_linear:
-            return scale_ * linear_fwd(x, alpha_, beta_);
-            break;
-        case eltwise_soft_relu: return scale_ * soft_relu_fwd(x, alpha_); break;
-        case eltwise_mish: return scale_ * mish_fwd(x); break;
-        case eltwise_logistic: return scale_ * logistic_fwd(x); break;
-        case eltwise_tanh: return scale_ * tanh_fwd(x); break;
-        case eltwise_elu: return scale_ * elu_fwd(x, alpha_); break;
-        case eltwise_square: return scale_ * square_fwd(x); break;
-        case eltwise_sqrt: return scale_ * sqrt_fwd(x); break;
-        case eltwise_abs: return scale_ * abs_fwd(x); break;
-        case eltwise_exp: return scale_ * exp_fwd(x); break;
-        case eltwise_gelu_tanh: return scale_ * gelu_tanh_fwd(x); break;
-        case eltwise_swish: return scale_ * swish_fwd(x, alpha_); break;
-        case eltwise_log: return scale_ * log_fwd(x); break;
-        case eltwise_clip: return scale_ * clip_fwd(x, alpha_, beta_); break;
-        case eltwise_clip_v2:
-            return scale_ * clip_v2_fwd(x, alpha_, beta_);
-            break;
-        case eltwise_pow: return scale_ * pow_fwd(x, alpha_, beta_); break;
-        case eltwise_gelu_erf: return scale_ * gelu_erf_fwd(x); break;
-        case eltwise_round: return scale_ * round_fwd(x); break;
-        case eltwise_hardswish:
-            return scale_ * hardswish_fwd(x, alpha_, beta_);
-            break;
-        case eltwise_hardsigmoid:
-            return scale_ * hardsigmoid_fwd(x, alpha_, beta_);
-            break;
-        case eltwise_relu_dst: return scale_ * relu_fwd(x, alpha_); break;
-        case eltwise_logistic_dst: return scale_ * logistic_fwd(x); break;
-        case eltwise_tanh_dst: return scale_ * tanh_fwd(x); break;
-        case eltwise_elu_dst: return scale_ * elu_fwd(x, alpha_); break;
-        case eltwise_sqrt_dst: return scale_ * sqrt_fwd(x); break;
-        case eltwise_exp_dst: return scale_ * exp_fwd(x); break;
-        case eltwise_clip_v2_dst:
-            return scale_ * clip_v2_fwd(x, alpha_, beta_);
-            break;
-        default: return x; break;
-    }
-}
+#define ELT_T POST_OP_DATA_T
+#include "gpu/intel/include/eltwise_bwd_body.hxx"
+#undef ELT_T
 
 float fwd_eltwise(POST_OP_DATA_T x, float alpha_, float beta_, float scale_) {
 #ifdef ELTWISE_ALG

--- a/src/gpu/intel/include/eltwise.h
+++ b/src/gpu/intel/include/eltwise.h
@@ -153,12 +153,9 @@ POST_OP_DATA_T exp_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
 }
 
 POST_OP_DATA_T gelu_tanh_fwd(POST_OP_DATA_T s) {
-    const POST_OP_DATA_T sqrt_2_over_pi
-            = POST_OP_LITERAL(0.79788458347320556640625);
-    const POST_OP_DATA_T fitting_const = POST_OP_LITERAL(0.044715);
-    const POST_OP_DATA_T g = sqrt_2_over_pi * s
-            * (POST_OP_LITERAL(1.) + fitting_const * s * s);
-    return (POST_OP_LITERAL(0.5) * s * (POST_OP_LITERAL(1.) + tanh_fwd(g)));
+    const POST_OP_DATA_T g = POST_OP_LITERAL(1.5957691669464111328125) * s
+            * (POST_OP_LITERAL(1.) + POST_OP_LITERAL(0.044715) * s * s);
+    return s / (POST_OP_LITERAL(1.) + exp(-g));
 }
 POST_OP_DATA_T gelu_tanh_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
     const POST_OP_DATA_T sqrt_2_over_pi

--- a/src/gpu/intel/include/eltwise_bwd_body.hxx
+++ b/src/gpu/intel/include/eltwise_bwd_body.hxx
@@ -1,0 +1,155 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+ELT_T __attribute__((overloadable)) relu_bwd(ELT_T dd, ELT_T s, float alpha) {
+    return s > 0 ? dd : dd * alpha;
+}
+ELT_T __attribute__((overloadable)) relu_bwd_use_dst(
+        ELT_T dd, ELT_T d, float alpha) {
+    return d > 0 ? dd : dd * alpha;
+}
+
+ELT_T __attribute__((overloadable)) linear_bwd(ELT_T dd, float alpha) {
+    return dd * alpha;
+}
+
+ELT_T __attribute__((overloadable)) soft_relu_bwd(
+        ELT_T dd, ELT_T s, float alpha) {
+    s = alpha * s;
+    return dd / (POST_OP_LITERAL(1.) + exp(-s));
+}
+
+ELT_T __attribute__((overloadable)) logistic_bwd(ELT_T dd, ELT_T s) {
+    ELT_T v = logistic_fwd(s);
+    return dd * v * (POST_OP_LITERAL(1.) - v);
+}
+ELT_T __attribute__((overloadable)) logistic_bwd_use_dst(ELT_T dd, ELT_T d) {
+    return dd * d * (POST_OP_LITERAL(1.) - d);
+}
+
+ELT_T __attribute__((overloadable)) square_bwd(ELT_T dd, ELT_T s) {
+    return dd * 2 * s;
+}
+
+ELT_T __attribute__((overloadable)) sqrt_bwd(ELT_T dd, ELT_T s) {
+    return dd / (POST_OP_LITERAL(2.) * sqrt(s));
+}
+ELT_T __attribute__((overloadable)) sqrt_bwd_use_dst(ELT_T dd, ELT_T d) {
+    return dd / (POST_OP_LITERAL(2.) * d);
+}
+
+ELT_T __attribute__((overloadable)) abs_bwd(ELT_T dd, ELT_T s) {
+    return s > 0 ? dd : s < 0 ? -dd : 0;
+}
+
+ELT_T __attribute__((overloadable)) tanh_bwd(ELT_T dd, ELT_T s) {
+    ELT_T e = tanh_fwd(s);
+    return dd * (POST_OP_LITERAL(1.) - e) * (POST_OP_LITERAL(1.) + e);
+}
+ELT_T __attribute__((overloadable)) tanh_bwd_use_dst(ELT_T dd, ELT_T d) {
+    return dd * (POST_OP_LITERAL(1.) - d) * (POST_OP_LITERAL(1.) + d);
+}
+
+ELT_T __attribute__((overloadable)) mish_bwd(ELT_T dd, ELT_T s) {
+    const ELT_T tanh = tanh_fwd(soft_relu_fwd(s, POST_OP_LITERAL(1.)));
+    const ELT_T srelu_bwd
+            = soft_relu_bwd(POST_OP_LITERAL(1.), s, POST_OP_LITERAL(1.));
+    const ELT_T derivative = tanh
+            + s * srelu_bwd
+                    * (POST_OP_LITERAL(1.) - pow(tanh, POST_OP_LITERAL(2.)));
+    return dd * derivative;
+}
+
+ELT_T __attribute__((overloadable)) elu_bwd(ELT_T dd, ELT_T s, float alpha) {
+    return dd * (s > 0 ? 1 : alpha * exp(s));
+}
+ELT_T __attribute__((overloadable)) elu_bwd_use_dst(
+        ELT_T dd, ELT_T d, float alpha) {
+    return dd * (d > 0 ? 1 : d + alpha);
+}
+
+ELT_T __attribute__((overloadable)) exp_bwd(ELT_T dd, ELT_T s) {
+    return dd * exp_fwd(s);
+}
+ELT_T __attribute__((overloadable)) exp_bwd_use_dst(ELT_T dd, ELT_T d) {
+    return dd * d;
+}
+
+ELT_T __attribute__((overloadable)) gelu_tanh_bwd(ELT_T dd, ELT_T s) {
+    const ELT_T sqrt_2_over_pi = POST_OP_LITERAL(0.79788458347320556640625);
+    const ELT_T fitting_const = POST_OP_LITERAL(0.044715);
+    const ELT_T g = sqrt_2_over_pi * s
+            * (POST_OP_LITERAL(1.) + fitting_const * s * s);
+    const ELT_T dg = sqrt_2_over_pi
+            * (POST_OP_LITERAL(1.)
+                    + POST_OP_LITERAL(3.) * fitting_const * s * s);
+    const ELT_T v = tanh_fwd(g);
+    return dd * POST_OP_LITERAL(0.5) * (POST_OP_LITERAL(1.) + v)
+            * (POST_OP_LITERAL(1.) + s * (POST_OP_LITERAL(1.) - v) * dg);
+}
+
+ELT_T __attribute__((overloadable)) swish_bwd(ELT_T dd, ELT_T s, float alpha) {
+    ELT_T v = logistic_fwd(alpha * s);
+    return dd * (v + s * alpha * v * (POST_OP_LITERAL(1.) - v));
+}
+
+ELT_T __attribute__((overloadable)) log_bwd(ELT_T dd, ELT_T s) {
+    return dd / s;
+}
+
+ELT_T __attribute__((overloadable)) clip_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    return dd * (alpha < s && s <= beta ? 1 : 0);
+}
+
+ELT_T __attribute__((overloadable)) clip_v2_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    return dd * (alpha < s && s < beta ? 1 : 0);
+}
+ELT_T __attribute__((overloadable)) clip_v2_bwd_use_dst(
+        ELT_T dd, ELT_T d, float alpha, float beta) {
+    return dd * (alpha < d && d < beta ? 1 : 0);
+}
+
+ELT_T __attribute__((overloadable)) pow_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    if (beta == 0) return 0;
+
+    ELT_T v = pow_fwd(s, alpha * beta, beta - 1);
+    return dd * v;
+}
+
+ELT_T __attribute__((overloadable)) gelu_erf_bwd(ELT_T dd, ELT_T s) {
+    const ELT_T two_over_sqrt_pi = POST_OP_LITERAL(1.12837922573089599609375);
+    const ELT_T sqrt_2_over_2 = POST_OP_LITERAL(0.707106769084930419921875);
+    ELT_T v = s * sqrt_2_over_2;
+    return dd * POST_OP_LITERAL(0.5)
+            * (POST_OP_LITERAL(1.) + erf(v)
+                    + v * two_over_sqrt_pi * exp(-v * v));
+}
+
+ELT_T __attribute__((overloadable)) hardsigmoid_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    ELT_T v = alpha * s + beta;
+    return v <= 0.f ? 0.f : v >= 1.f ? 0.f : dd * alpha;
+}
+
+ELT_T __attribute__((overloadable)) hardswish_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    ELT_T v = alpha * s + beta;
+    ELT_T w = POST_OP_LITERAL(2.) * alpha * s + beta;
+    return (v <= 0.f ? 0.f : v >= 1.f ? dd : dd * w);
+}

--- a/src/gpu/intel/include/eltwise_fwd_body.hxx
+++ b/src/gpu/intel/include/eltwise_fwd_body.hxx
@@ -1,0 +1,149 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+ELT_T __attribute__((overloadable)) relu_fwd(ELT_T s, float alpha) {
+    return s > (ELT_T)0 ? s : s * alpha;
+}
+
+ELT_T __attribute__((overloadable)) linear_fwd(
+        ELT_T s, float alpha, float beta) {
+    return alpha * s + beta;
+}
+
+ELT_T __attribute__((overloadable)) soft_relu_fwd(ELT_T s, float alpha) {
+    s = alpha * s;
+    return (s < (ELT_T)log(CONVERT_POST_OP_DATA_T(DATA_MAX)) ? log1p(exp(s))
+                                                             : s)
+            / alpha;
+}
+
+ELT_T __attribute__((overloadable)) logistic_fwd(ELT_T s) {
+    return (ELT_T)POST_OP_LITERAL(1.) / (POST_OP_LITERAL(1.) + exp(-s));
+}
+
+ELT_T __attribute__((overloadable)) square_fwd(ELT_T s) {
+    return s * s;
+}
+
+ELT_T __attribute__((overloadable)) sqrt_fwd(ELT_T s) {
+    return sqrt(s);
+}
+
+ELT_T __attribute__((overloadable)) abs_fwd(ELT_T s) {
+    return s > (ELT_T)0 ? s : -s;
+}
+
+ELT_T __attribute__((overloadable)) tanh_fwd(ELT_T s) {
+    return tanh(s);
+}
+
+ELT_T __attribute__((overloadable)) mish_fwd(ELT_T s) {
+    return s * tanh_fwd(soft_relu_fwd(s, POST_OP_LITERAL(1.)));
+}
+
+ELT_T __attribute__((overloadable)) elu_fwd(ELT_T s, float alpha) {
+    return s > (ELT_T)0 ? s : alpha * expm1(s);
+}
+
+ELT_T __attribute__((overloadable)) exp_fwd(ELT_T s) {
+    return exp(s);
+}
+
+ELT_T __attribute__((overloadable)) gelu_tanh_fwd(ELT_T s) {
+    const ELT_T g = POST_OP_LITERAL(1.5957691669464111328125) * s
+            * (POST_OP_LITERAL(1.) + POST_OP_LITERAL(0.044715) * s * s);
+    return s / (POST_OP_LITERAL(1.) + exp(-g));
+}
+
+ELT_T __attribute__((overloadable)) swish_fwd(ELT_T s, float alpha) {
+    return s / (POST_OP_LITERAL(1.) + exp(-alpha * s));
+}
+
+ELT_T __attribute__((overloadable)) log_fwd(ELT_T s) {
+    return log(s);
+}
+
+ELT_T __attribute__((overloadable)) clip_fwd(ELT_T s, float alpha, float beta) {
+    return fmin(fmax(s, (ELT_T)alpha), (ELT_T)beta);
+}
+
+ELT_T __attribute__((overloadable)) clip_v2_fwd(
+        ELT_T s, float alpha, float beta) {
+    return clip_fwd(s, alpha, beta);
+}
+
+ELT_T __attribute__((overloadable)) pow_fwd(ELT_T s, float alpha, float beta) {
+    return alpha * pow(s, (ELT_T)beta);
+}
+
+ELT_T __attribute__((overloadable)) gelu_erf_fwd(ELT_T s) {
+    return POST_OP_LITERAL(0.5) * s
+            * (POST_OP_LITERAL(1.)
+                    + erf(s * POST_OP_LITERAL(0.707106769084930419921875)));
+}
+
+ELT_T __attribute__((overloadable)) round_fwd(ELT_T s) {
+    return rint(s);
+}
+
+ELT_T __attribute__((overloadable)) hardsigmoid_fwd(
+        ELT_T s, float alpha, float beta) {
+    const ELT_T v = linear_fwd(s, alpha, beta);
+    return isnan(v)
+            ? v
+            : clamp(v, (ELT_T)POST_OP_LITERAL(0.), (ELT_T)POST_OP_LITERAL(1.));
+}
+
+ELT_T __attribute__((overloadable)) hardswish_fwd(
+        ELT_T s, float alpha, float beta) {
+    return s * hardsigmoid_fwd(s, alpha, beta);
+}
+
+ELT_T __attribute__((overloadable)) fwd_eltwise_common(
+        int eltwise_alg, ELT_T x, float alpha_, float beta_, float scale_) {
+    switch (eltwise_alg) {
+        case eltwise_relu: return scale_ * relu_fwd(x, alpha_);
+        case eltwise_linear: return scale_ * linear_fwd(x, alpha_, beta_);
+        case eltwise_soft_relu: return scale_ * soft_relu_fwd(x, alpha_);
+        case eltwise_mish: return scale_ * mish_fwd(x);
+        case eltwise_logistic: return scale_ * logistic_fwd(x);
+        case eltwise_tanh: return scale_ * tanh_fwd(x);
+        case eltwise_elu: return scale_ * elu_fwd(x, alpha_);
+        case eltwise_square: return scale_ * square_fwd(x);
+        case eltwise_sqrt: return scale_ * sqrt_fwd(x);
+        case eltwise_abs: return scale_ * abs_fwd(x);
+        case eltwise_exp: return scale_ * exp_fwd(x);
+        case eltwise_gelu_tanh: return scale_ * gelu_tanh_fwd(x);
+        case eltwise_swish: return scale_ * swish_fwd(x, alpha_);
+        case eltwise_log: return scale_ * log_fwd(x);
+        case eltwise_clip: return scale_ * clip_fwd(x, alpha_, beta_);
+        case eltwise_clip_v2: return scale_ * clip_v2_fwd(x, alpha_, beta_);
+        case eltwise_pow: return scale_ * pow_fwd(x, alpha_, beta_);
+        case eltwise_gelu_erf: return scale_ * gelu_erf_fwd(x);
+        case eltwise_round: return scale_ * round_fwd(x);
+        case eltwise_hardswish: return scale_ * hardswish_fwd(x, alpha_, beta_);
+        case eltwise_hardsigmoid:
+            return scale_ * hardsigmoid_fwd(x, alpha_, beta_);
+        case eltwise_relu_dst: return scale_ * relu_fwd(x, alpha_);
+        case eltwise_logistic_dst: return scale_ * logistic_fwd(x);
+        case eltwise_tanh_dst: return scale_ * tanh_fwd(x);
+        case eltwise_elu_dst: return scale_ * elu_fwd(x, alpha_);
+        case eltwise_sqrt_dst: return scale_ * sqrt_fwd(x);
+        case eltwise_exp_dst: return scale_ * exp_fwd(x);
+        case eltwise_clip_v2_dst: return scale_ * clip_v2_fwd(x, alpha_, beta_);
+        default: return x;
+    }
+}

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cl
@@ -98,6 +98,9 @@ void load_bias(
 #endif
 
 #if WITH_POST_OP
+#define ELTWISE_VECTOR_API
+#include "gpu/intel/include/eltwise.h"
+
 #if WITH_BINARY_GROUPED_SCALE
 // One column-block of the [M,N] grouped scale, applied a block at a time.
 DECLARE_2D_TILE(binary_group_chunk_type, float, SUBGROUP_SIZE,

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cl
@@ -98,6 +98,9 @@ void load_bias(
 #endif
 
 #if WITH_POST_OP
+#define ELTWISE_VECTOR_API
+#include "gpu/intel/include/eltwise.h"
+
 #if WITH_BINARY_GROUPED_SCALE
 #if !BINARY_SCALE_GROUPED_DT_F32
 // Intermediate tile for loading non-float binary scale data before converting

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -398,6 +398,19 @@ status_t grouped_micro_gemm_t::pd_t::init(const impl::engine_t *engine) {
     VDISPATCH_MATMUL(compute::mayiuse_microkernels(intel_engine),
             VERBOSE_UNSUPPORTED_DEVICE_FEATURE, "microkernels");
 
+    // XXX: gelu_erf/gelu_tanh are miscompiled by IGC on XeHPG, fall back to
+    // reference.
+    if (dev_info->gpu_arch() == compute::gpu_arch_t::xe_hpg) {
+        for (int i = 0; i < attr()->post_ops_.len(); ++i) {
+            const auto &e = attr()->post_ops_.entry_[i];
+            VDISPATCH_MATMUL(!e.is_eltwise()
+                            || !utils::one_of(e.eltwise.alg,
+                                    alg_kind::eltwise_gelu_erf,
+                                    alg_kind::eltwise_gelu_tanh),
+                    VERBOSE_UNSUPPORTED_POSTOP);
+        }
+    }
+
     // Check for supported quantization schemes
     if (src_quant_.with_scale()) {
         VDISPATCH_MATMUL(utils::one_of(src_quant_.scale_dt(), f32, f16, bf16,

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -31,6 +31,16 @@ namespace matmul {
     VCONDCHECK(primitive, create, check, matmul, (cond), \
             status::unimplemented, msg, ##__VA_ARGS__);
 
+bool is_eltwise_alg_supported(alg_kind_t alg) {
+    using namespace alg_kind;
+    return utils::one_of(alg, eltwise_relu, eltwise_linear, eltwise_soft_relu,
+            eltwise_mish, eltwise_logistic, eltwise_tanh, eltwise_elu,
+            eltwise_square, eltwise_sqrt, eltwise_abs, eltwise_exp,
+            eltwise_gelu_tanh, eltwise_swish, eltwise_log, eltwise_clip,
+            eltwise_clip_v2, eltwise_pow, eltwise_gelu_erf, eltwise_round,
+            eltwise_hardswish, eltwise_hardsigmoid);
+}
+
 int find_po_in_chain(const po_kind_t *po_chain, po_kind_t kind) {
     for (int i = 0; i < 3; ++i) {
         if (po_chain[i] == kind) return i;
@@ -50,7 +60,7 @@ status_t check_post_op_chain(const primitive_attr_t &attr,
         VCHECK_MATMUL(
                 e.is_eltwise() || e.is_binary(), VERBOSE_UNSUPPORTED_POSTOP);
         if (e.is_eltwise()) {
-            VCHECK_MATMUL(e.eltwise.alg == alg_kind::eltwise_swish,
+            VCHECK_MATMUL(is_eltwise_alg_supported(e.eltwise.alg),
                     VERBOSE_UNSUPPORTED_POSTOP);
             po_chain[i] = po_kind_t::eltwise;
         } else if (e.is_binary()) {
@@ -149,12 +159,14 @@ inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, l
         const auto &e = po.entry_[i];
         if (e.is_eltwise()) {
             s += utils::format(R"(
-#define eltwise_apply_%d(v) ((%s) * ((v) / (1.0f + exp(-(%s) * (v)))))
+#define eltwise_apply_%d(v) fwd_eltwise_common(%d, v, %s, %s, %s)
     tile_elementwise((*c_tile), eltwise_apply_%d);
 #undef eltwise_apply_%d
                      )",
-                    i, to_ocl_float(e.eltwise.scale).c_str(),
-                    to_ocl_float(e.eltwise.alpha).c_str(), i, i);
+                    i, static_cast<int>(e.eltwise.alg),
+                    to_ocl_float(e.eltwise.alpha).c_str(),
+                    to_ocl_float(e.eltwise.beta).c_str(),
+                    to_ocl_float(e.eltwise.scale).c_str(), i, i);
         } else if (e.is_binary()) {
             if (po_chain[i] == po_kind_t::binary_grouped_scale) {
                 s += R"(

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -31,6 +31,16 @@ namespace matmul {
     VCONDCHECK(primitive, create, check, matmul, (cond), \
             status::unimplemented, msg, ##__VA_ARGS__);
 
+bool is_eltwise_alg_supported(alg_kind_t alg) {
+    using namespace alg_kind;
+    return utils::one_of(alg, eltwise_relu, eltwise_linear, eltwise_soft_relu,
+            eltwise_mish, eltwise_logistic, eltwise_tanh, eltwise_elu,
+            eltwise_square, eltwise_sqrt, eltwise_abs, eltwise_exp,
+            eltwise_gelu_tanh, eltwise_swish, eltwise_log, eltwise_clip,
+            eltwise_clip_v2, eltwise_pow, eltwise_gelu_erf, eltwise_round,
+            eltwise_hardswish, eltwise_hardsigmoid);
+}
+
 int find_po_in_chain(const po_kind_t *po_chain, po_kind_t kind) {
     for (int i = 0; i < 3; ++i) {
         if (po_chain[i] == kind) return i;
@@ -50,7 +60,7 @@ status_t check_post_op_chain(const primitive_attr_t &attr,
         VCHECK_MATMUL(
                 e.is_eltwise() || e.is_binary(), VERBOSE_UNSUPPORTED_POSTOP);
         if (e.is_eltwise()) {
-            VCHECK_MATMUL(e.eltwise.alg == alg_kind::eltwise_swish,
+            VCHECK_MATMUL(is_eltwise_alg_supported(e.eltwise.alg),
                     VERBOSE_UNSUPPORTED_POSTOP);
             po_chain[i] = po_kind_t::eltwise;
         } else if (e.is_binary()) {
@@ -149,12 +159,14 @@ inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, l
         const auto &e = po.entry_[i];
         if (e.is_eltwise()) {
             s += utils::format(R"(
-#define eltwise_apply_%d(v) ((%s) * ((v) / (1.0f + exp(-(%s) * (v)))))
+#define eltwise_apply_%d(v) fwd_eltwise_common(%d, v, %s, %s, %s)
     tile_elementwise((*c_tile), eltwise_apply_%d);
 #undef eltwise_apply_%d
                      )",
-                    i, to_ocl_float(e.eltwise.scale).c_str(),
-                    to_ocl_float(e.eltwise.alpha).c_str(), i, i);
+                    i, static_cast<int>(e.eltwise.alg),
+                    to_ocl_float(e.eltwise.alpha).c_str(),
+                    to_ocl_float(e.eltwise.beta).c_str(),
+                    to_ocl_float(e.eltwise.scale).c_str(), i, i);
         } else if (e.is_binary()) {
             if (po_chain[i] == po_kind_t::binary_grouped_scale) {
                 s += utils::format(R"(

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.hpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.hpp
@@ -41,6 +41,8 @@ enum class po_kind_t {
     binary_nvfp4_scale
 };
 
+bool is_eltwise_alg_supported(alg_kind_t alg);
+
 int find_po_in_chain(const po_kind_t *po_chain, po_kind_t kind);
 
 status_t check_post_op_chain(const primitive_attr_t &attr,

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -68,11 +68,9 @@ constexpr int host_argument_bytes_bwd = 256;
 
 // XXX: Use the adjusted argument base as a workaround to avoid performance
 // regressions in some cases.
-int host_argument_bytes_fwd_for(
-        const micro::HWInformation &hw_info, bool systolic) {
+int host_argument_bytes_fwd_for(const micro::HWInformation &hw_info) {
     auto family = ngen::npack::decodeHWIPVersion(hw_info.gmdid).family;
     if (family == ngen::ProductFamily::NVLP) return 256;
-    if (systolic && ngen::getCore(family) == ngen::HW::XeHPG) return 288;
     return host_argument_bytes_fwd;
 }
 
@@ -1195,8 +1193,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
             opts_vs, sizes_kq, sizes_vs, ukernel_config);
 
-    const micro::HostPayload host {subgroup_size,
-            host_argument_bytes_fwd_for(hw_info, use_systolic_ukernel)};
+    const micro::HostPayload host {
+            subgroup_size, host_argument_bytes_fwd_for(hw_info)};
     const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs;

--- a/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
@@ -235,6 +235,24 @@
 --attr-post-ops=mul:f32:1,mul:f16:1,mul:f32:3:grouped,mul:f16:3:grouped
 32x128:4x128x64
 
+# gelu_tanh/gelu_erf + binary_mul (grouped) with WOQ scales, both orders
+--reset
+--dt=f16:s4:f16
+--wtag=abc,acb
+--grouped=0:4:8+8+8+8,0:4:8+0+16+8
+--attr-fpmath=f16:true
+--attr-scales=wei:7:f16:32x1
+--attr-post-ops=eltwise_gelu_tanh+mul:f16:3:grouped,eltwise_gelu_erf+mul:f16:3:grouped,mul:f16:3:grouped+eltwise_gelu_tanh,mul:f16:3:grouped+eltwise_gelu_erf
+32x128:4x128x64
+
+# gelu_tanh/gelu_erf + binary_mul (grouped) - f32/bf16
+--reset
+--dt=f32:f32:f32,bf16:bf16:bf16
+--wtag=abc
+--grouped=0:4:8+8+8+8
+--attr-post-ops=eltwise_gelu_tanh+mul:f32:3:grouped,eltwise_gelu_erf+mul:f32:3:grouped
+32x64:4x64x32
+
 # Post-ops: multi-binary chains (grouped + dense, 3-op)
 --reset
 --dt=f16:f16:f16

--- a/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
@@ -235,6 +235,24 @@
 --attr-post-ops=mul:f32:1:ab,mul:f16:1:ab,mul:f32:3:grouped,mul:f16:3:grouped
 32x128:4x128x64
 
+# gelu_tanh/gelu_erf + binary_mul (grouped) with WOQ scales, both orders
+--reset
+--dt=f16:s4:f16
+--wtag=abc,acb
+--grouped=0:4:8+8+8+8,0:4:8+0+16+8
+--attr-fpmath=f16:true
+--attr-scales=wei:7:f16:32x1
+--attr-post-ops=eltwise_gelu_tanh+mul:f16:3:grouped,eltwise_gelu_erf+mul:f16:3:grouped,mul:f16:3:grouped+eltwise_gelu_tanh,mul:f16:3:grouped+eltwise_gelu_erf
+32x128:4x128x64
+
+# gelu_tanh/gelu_erf + binary_mul (grouped) - f32/bf16
+--reset
+--dt=f32:f32:f32,bf16:bf16:bf16
+--wtag=abc
+--grouped=0:4:8+8+8+8
+--attr-post-ops=eltwise_gelu_tanh+mul:f32:3:grouped,eltwise_gelu_erf+mul:f32:3:grouped
+32x64:4x64x32
+
 # Post-ops: multi-binary chains (grouped + dense, 3-op)
 --reset
 --dt=f16:f16:f16


### PR DESCRIPTION
Jira: [MFDNN-15371](https://jira.devtools.intel.com/browse/MFDNN-15371)

Changes:

- Extended `src/gpu/intel/include/eltwise.h` to support vector inputs to use with microkernels
- Switched `gelu_tanh` from `tanh` builtin to `exp` - this is ~5x faster and aligns with the nGEN eltwise injector