### PR TITLE
cpu: x64: brgemm: fix NaN leak in AMX extendable_k K-tail handling

### DIFF
--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -536,11 +536,9 @@ private:
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
 
-    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, int bdb,
-            const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
+    bool maybe_pre_process_k_tail(brgemm_iteration_t &bi, const Tmm &t1,
+            reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk, bool use_memadvice);
-
-    bool process_k_tail_only_last_tile();
 
     void pre_process_k_tail_fused_copy_a(brgemm_iteration_t &bi, int bdb,
             const Tmm &t1, reg64_t reg_base, dim_t offset_src, dim_t offset_dst,
@@ -2049,7 +2047,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
     }
 
     if (maybe_pre_process_k_tail(
-                bi, xdb, t1, reg_base, offset, reg_stride, mk, has_mem_advice))
+                bi, t1, reg_base, offset, reg_stride, mk, has_mem_advice))
         return;
 
     if (load_nt) {
@@ -2461,28 +2459,22 @@ void jit_brgemm_amx_uker_base_t::pre_process_k_tail_fused_copy_a(
     if (offset_dst) sub(reg_buf, offset_dst);
 }
 
-bool jit_brgemm_amx_uker_base_t::process_k_tail_only_last_tile() {
-    // Check whether loading from the original A matrix will cause out of bounds exception.
-    // The check is on the last tile on K dim and tile before last on M dim. If
-    // loading that tile exceeds the A matrix, then we need to process K tail
-    // on every M tile.
-    int last_bd_block = brg.bdb_tail == 0 ? brg.bd_block : brg.bdb_tail;
-    return brg.rd_block - brg.rdb_tail <= last_bd_block * brg.reduce_dim;
-}
-
 bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
-        brgemm_iteration_t &bi, int bdb, const Tmm &t1, reg64_t reg_base,
-        dim_t offset, reg64_t reg_stride, matrix_kind_t mk,
-        bool use_memadvice) {
+        brgemm_iteration_t &bi, const Tmm &t1, reg64_t reg_base, dim_t offset,
+        reg64_t reg_stride, matrix_kind_t mk, bool use_memadvice) {
     const auto &tloop = imap_[bi.apply_postops];
 
-    bool need_k_tail_processing = mk == matrix_A && brg.amx_wary_k_tail()
+    // With the extendable_k strategy matrix B is zero-padded along the K
+    // dimension, so brgemm reads the full K-tail tile from matrix A and relies
+    // on B's zeros to cancel the columns beyond the valid K range. Reading past
+    // the valid K columns of A, however, pulls in bytes that belong to adjacent
+    // rows of A. If those bytes contain NaN/Inf the identity 'NaN * 0 == 0' no
+    // longer holds and the garbage leaks into otherwise clean output rows. To
+    // avoid this the K-tail of A is copied into a zero-padded scratch buffer
+    // for every M tile (not only the last one) before it is loaded into the
+    // AMX tile.
+    const bool need_k_tail_processing = mk == matrix_A && brg.amx_wary_k_tail()
             && brg.rdb_tail != 0 && tloop.is_last_rdi(bi.rdi);
-
-    if (process_k_tail_only_last_tile()) {
-        need_k_tail_processing &= bi.bdi->idx == tloop.bdis.size() - 1
-                && bdb == bi.bdi->block2() - 1 && bi.last_bsi;
-    }
 
     if (!need_k_tail_processing) return false;
 
@@ -2492,10 +2484,7 @@ bool jit_brgemm_amx_uker_base_t::maybe_pre_process_k_tail(
     if (transform_offset) add(reg_buf, transform_offset);
     mov(reg_converted_stride, zmm_width_in_bytes);
 
-    // reuse transformed data from matrix A for ldi > 0 if using only one tile
-    if (bi.ldi->idx == 0 || !process_k_tail_only_last_tile()) {
-        copy_k_tail_to_wsp(t1, reg_base, offset, reg_stride, use_memadvice);
-    }
+    copy_k_tail_to_wsp(t1, reg_base, offset, reg_stride, use_memadvice);
     // load into tmm from the transformed data.
     tileloadd(t1, ptr[reg_buf + reg_converted_stride]);
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -467,11 +467,11 @@ private:
     void maybe_pre_process_data(matrix_kind_t matrix_kind, const Tmm &t1,
             reg64_t reg_base, dim_t offset, reg64_t reg_stride, dim_t num_rows,
             dim_t num_col_bytes, bool is_rd_tail);
-    bool maybe_pre_process_k_tail(bool last_bdb, bool is_rd_tail, const Tmm &t1,
+    bool maybe_pre_process_k_tail(bool is_rd_tail, const Tmm &t1,
             reg64_t reg_base, dim_t offset, reg64_t reg_stride,
             matrix_kind_t mk);
     void maybe_tileloadd_nt(matrix_kind_t matrix_kind, dim_t idx, dim_t offset,
-            bool is_rd_tail, bool is_tail, bool last_bdb);
+            bool is_rd_tail, bool is_tail);
     void load_scales_to_vmm(const data_type_t type_in, const Vmm &scales,
             const Xbyak::Operand &op, bool is_ld_tail, bool is_single_scale);
     void dot_product(Vmm v1, Vmm v2, Vmm v3);
@@ -480,7 +480,7 @@ private:
             dim_t rows_for_rd_tail);
     void gemv_microkernel(bool is_bdb_tail, dim_t ld_block, bool is_rd_tail);
     void gemm_microkernel_amx(dim_t bd_block2, bool is_bdb_tail,
-            dim_t ld_block2, bool is_rd_tail, bool is_ld_tail, bool last_bdb);
+            dim_t ld_block2, bool is_rd_tail, bool is_ld_tail);
 
     void bs_loop(dim_t bd_block2, bool is_bdb_tail, dim_t ld_block,
             bool is_ld_tail, bool first_bdb, bool last_bdb,
@@ -2729,7 +2729,7 @@ void jit_brgemm_kernel_t<Wmm>::maybe_pre_process_data(matrix_kind_t matrix_kind,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
-        dim_t idx, dim_t offset, bool is_rd_tail, bool is_tail, bool last_bdb) {
+        dim_t idx, dim_t offset, bool is_rd_tail, bool is_tail) {
 
     const bool is_A = matrix_kind == matrix_kind_t::matrix_A;
 
@@ -2770,8 +2770,8 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
                 is_A ? A_row : B_row, is_A ? A_col : B_col, is_rd_tail);
 
     } else {
-        if (maybe_pre_process_k_tail(last_bdb || is_tail, is_rd_tail, t1,
-                    reg_base, offset, reg_stride, matrix_kind))
+        if (maybe_pre_process_k_tail(
+                    is_rd_tail, t1, reg_base, offset, reg_stride, matrix_kind))
             return;
 
         const size_t cache_footprint = static_cast<size_t>(brg.typesize_A)
@@ -2789,13 +2789,21 @@ void jit_brgemm_kernel_t<Wmm>::maybe_tileloadd_nt(matrix_kind_t matrix_kind,
 }
 
 template <typename Wmm>
-bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool last_bdb,
-        bool is_rd_tail, const Tmm &t1, reg64_t reg_base, dim_t offset,
-        reg64_t reg_stride, matrix_kind_t mk) {
+bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool is_rd_tail,
+        const Tmm &t1, reg64_t reg_base, dim_t offset, reg64_t reg_stride,
+        matrix_kind_t mk) {
 
-    // TODO: check is it last bs to calculate need_k_tail_processing
+    // With the extendable_k strategy matrix B is zero-padded along the K
+    // dimension, so brgemm reads the full K-tail tile from matrix A and relies
+    // on B's zeros to cancel the columns beyond the valid K range. Reading past
+    // the valid K columns of A, however, pulls in bytes that belong to adjacent
+    // rows of A. If those bytes contain NaN/Inf the identity 'NaN * 0 == 0' no
+    // longer holds and the garbage leaks into otherwise clean output rows. To
+    // avoid this the K-tail of A is copied into a zero-padded scratch buffer
+    // for every M tile (not only the last one) before it is loaded into the
+    // AMX tile.
     const auto need_k_tail_processing = mk == matrix_A && brg.amx_wary_k_tail()
-            && brg.rdb_tail != 0 && last_bdb && is_rd_tail;
+            && brg.rdb_tail != 0 && is_rd_tail;
     if (!need_k_tail_processing) return false;
 
     const auto zmm_width_in_bytes = cpu_isa_traits_t<avx512_core>::vlen;
@@ -2855,8 +2863,7 @@ bool jit_brgemm_kernel_t<Wmm>::maybe_pre_process_k_tail(bool last_bdb,
 
 template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
-        bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail, bool is_ld_tail,
-        bool last_bdb) {
+        bool is_bdb_tail, dim_t ld_block2, bool is_rd_tail, bool is_ld_tail) {
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
         using namespace data_type;
         if (brg.is_tf32) {
@@ -2892,14 +2899,14 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(dim_t bd_block2,
         for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
             maybe_tileloadd_nt(matrix_kind_t::matrix_A, bdb,
                     rdb * rdb_A_offset() + A_offset(bdb, 0, true), is_rd_tail,
-                    is_bdb_tail, last_bdb && bdb == bd_block2 - 1);
+                    is_bdb_tail);
         }
         for (dim_t ldb = 0; ldb < ld_block2; ldb++) {
 
             const dim_t idx = (is_ld_tail) ? brg.ld_block2 : ldb;
             maybe_tileloadd_nt(matrix_kind_t::matrix_B, idx,
                     rdb * rdb_B_offset() + B_offset(ldb, 0, true), is_rd_tail,
-                    is_ld_tail, false);
+                    is_ld_tail);
             for (dim_t bdb = 0; bdb < bd_block2; bdb++) {
                 tdpbxxd(Tmm(brg.get_C_tensor(
                                 bdb, idx, is_bdb_tail, is_ld_tail)),
@@ -3388,7 +3395,7 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
         dim_t ld_block2, bool is_ld_tail, bool first_bdb, bool last_bdb,
         dim_t rows_for_rd_tail, bool skip_accumulation) {
 
-    auto bs_loop_body = [&](dim_t vpad, bool last_bdb) {
+    auto bs_loop_body = [&](dim_t vpad) {
         set_A_B_matrices();
 
         dim_t bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
@@ -3400,8 +3407,8 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
 
         if (brg.is_tmm) {
             const bool is_rd_tail = false;
-            gemm_microkernel_amx(bd_block2, is_bdb_tail, ld_block2, is_rd_tail,
-                    is_ld_tail, last_bdb);
+            gemm_microkernel_amx(
+                    bd_block2, is_bdb_tail, ld_block2, is_rd_tail, is_ld_tail);
         } else {
             if (brg.rdb > 0) {
                 Label rdb_loop_label;
@@ -3428,7 +3435,7 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
             const bool is_rd_tail = true;
             if (brg.is_tmm) {
                 gemm_microkernel_amx(bd_block2, is_bdb_tail, ld_block2,
-                        is_rd_tail, is_ld_tail, last_bdb);
+                        is_rd_tail, is_ld_tail);
             } else {
                 if (brg.is_gemv)
                     gemv_microkernel(is_bdb_tail, ld_block2, is_rd_tail);
@@ -3503,14 +3510,14 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(dim_t bd_block2, bool is_bdb_tail,
                     }
                     cmp(reg_aux_A_vpad, vpad);
                     jne(Vpad_loop_iter_label[label_vpad + 1], T_NEAR);
-                    bs_loop_body(real_vpad, last_bdb);
+                    bs_loop_body(real_vpad);
                     jmp(Vpad_loop_end_label, T_NEAR);
                 }
                 L(Vpad_loop_iter_label[n_vpads - 1]);
-                bs_loop_body(0, last_bdb);
+                bs_loop_body(0);
                 L(Vpad_loop_end_label);
             } else {
-                bs_loop_body(0, last_bdb);
+                bs_loop_body(0);
             }
             if (brg.brgattr.max_bs > 1) {
                 dec(reg_BS_loop);

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_regression
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_regression
@@ -1,2 +1,10 @@
 # Incorrect mask comparison in lazy hw config, need two problems to run back-to-back
 --reset --dt=bf16 128x448:448x32 42x608:608x32
+
+# NaN leak in AMX extendable_k K-tail handling on the non-uker kernel (issue
+# #5717). Forces the K-tail zero-pad path (need_k_tail_processing == true) via
+# use_uker:0 + extendable_k:1 + wary_A_k_tail_read:1 with K % 32 != 0.
+--reset --dt=bf16:bf16:bf16
+--brgemm-attr=use_uker:0+extendable_k:1+wary_A_k_tail_read:1
+64x33:33x64 48x65:65x80 16x97:97x64 32x129:129x48
+

--- a/tests/benchdnn/inputs/conv/shapes_regression_1x1
+++ b/tests/benchdnn/inputs/conv/shapes_regression_1x1
@@ -32,3 +32,8 @@ mb1_ic96oc96_ih6oh6kh1sh1dh0ph0_iw6ow6kw1sw1dw0pw0_n"1x1_with_nb_os_tail"
 # sh > 1 with sw=1: H-only stride, exec_trans path (not RTUS)
 mb1_ic32oc48_ih67oh23kh1sh3dh0ph0_iw4ow5kw1sw1dw0pw1_n"sh3_sw1_multi_oh_block"
 mb16_ic32oc139_ih111oh37kh1sh3dh0ph0_iw4ow5kw1sw1dw0pw1_n"sh3_sw1_tall_input"
+
+# mb1 small-mb 1x1 with ic not a multiple of simd_w (ic%16!=0) exercises the
+# non-uker AMX brgemm kernel with extendable_k / wary_A_k_tail_read enabled
+# (regression guard for the K-tail NaN leak, issue #5717).
+mb1_ic72oc80_ih6oh6kh1sh1dh0ph0_iw6ow6kw1sw1dw0pw0_n"1x1_extendable_k_tail:5717"


### PR DESCRIPTION
## Description

Fixes https://github.com/uxlfoundation/oneDNN/issues/5717.

With the `extendable_k` strategy matrix B is zero-padded along K, so brgemm reads
the full K-tail tile of matrix A and relies on B's zeros to cancel the columns
beyond the valid K range. Reading past the valid K columns of A pulls in bytes
that belong to adjacent rows of A. If those bytes hold NaN/Inf, the identity
`NaN * 0 == 0` no longer holds and the garbage leaks into otherwise clean output
rows.

The previous code only zero-padded the A K-tail for the **last** M tile
(`process_k_tail_only_last_tile`), leaving other M tiles exposed. The fix copies
the K-tail of A into a zero-padded scratch buffer for **every** M tile before it
is loaded into the AMX tile.

Triggers when `K > 32` and `K % 32 != 0` (bf16) on AMX
(`brg_matmul:avx10_1_512_amx`).

## Validation

- Repro from the issue (`16x32x33:16x33x64`, row 0 = 1.0, other rows NaN): row 0
  is now NaN-free.
- Dimension sweep over `D ∈ {16,17,31,32,33,34,40,47,48,49,63,64,65,95,96,97,100,127,128,129,200,255}`
  with varied M/N/batch: all pass NaN-absence and numeric-correctness checks.
- benchdnn `harness_matmul_regression_bf16`: 13/13 PASSED. `test_matmul_ci`: PASSED.

## Performance

benchdnn `--mode=P --dt=bf16:bf16:bf16 --stag=abc --wtag=acb --dtag=abc`, run on
an isolated sub-NUMA node (`numactl -C 30-59 -m1`), min over 3 repetitions.
Ratio = fixed / baseline execution time (>1 = slower).

| shape (HxMxK:HxKxN)          | ratio | notes                                    |
| ---------------------------- | ----- | ---------------------------------------- |
| 16x32x33:16x33x64            | 1.000 | issue repro                              |
| 16x32x64:16x64x64 (K%32==0)  | 1.000 | control — path not taken                 |
| 16x1024x129:16x129x256       | 1.004 |                                          |
| 16x256x129:16x129x4096       | 1.025 |                                          |
| 16x512x255:16x255x512        | 1.023 |                                          |
| 8x1024x513:8x513x1024        | 1.011 |                                          |
| 1x4096x33:1x33x4096          | 1.018 | adversarial (tiny K-tail, large M×N)     |
| **16x2048x33:16x33x2048**    | **1.047** | worst case observed                  |

- Controls (K a multiple of 32) are exactly 1.000 — the changed path is not
  taken, so no impact.
- Typical K-tail shapes are within ±2% (measurement noise floor).
- Worst case ≈ +5% on a deliberately adversarial shape (batch 16, M=2048 → 128
  M-tiles, K=33 → 1-column tail), where the added per-M-tile zero-pad copies are
  largest relative to the tiny K compute. This is an acceptable trade-off for a
  correctness fix that eliminates silent output corruption.

## Checklist

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Have you formatted the code using clang-format?
