### PR TITLE
common: validate index and kind in dnnl_post_ops_get_params_prelu

### DIFF
--- a/src/common/primitive_attr.cpp
+++ b/src/common/primitive_attr.cpp
@@ -925,8 +925,7 @@ status_t dnnl_post_ops_append_prelu(post_ops_t *post_ops, int mask) {
 
 status_t dnnl_post_ops_get_params_prelu(
         const post_ops_t *post_ops, int index, int *mask) {
-    if (post_ops == nullptr || index >= post_ops->len())
-        return invalid_arguments;
+    CHECK(simple_get_params_check(post_ops, index, primitive_kind::prelu));
 
     const auto &prelu_entry = post_ops->entry_[index].prelu;
     if (mask) *mask = prelu_entry.mask;

--- a/tests/gtests/test_iface_attr.cpp
+++ b/tests/gtests/test_iface_attr.cpp
@@ -497,6 +497,23 @@ HANDLE_EXCEPTIONS_FOR_TEST_F(attr_test_t, TestPostOps) {
     ASSERT_EQ(mask, prelu_mask);
 }
 
+TEST_F(attr_test_t, TestPostOpsPreluExpectFailure) {
+    dnnl::post_ops ops;
+    ops.append_eltwise(algorithm::eltwise_relu, 0.f, 0.f);
+
+    const int prelu_mask = 1;
+    ops.append_prelu(prelu_mask);
+
+    int mask = INT_MAX;
+    EXPECT_ANY_THROW(ops.get_params_prelu(-1, mask));
+    EXPECT_ANY_THROW(ops.get_params_prelu(ops.len(), mask));
+    // The entry at index 0 is an eltwise post-op, not a prelu one.
+    EXPECT_ANY_THROW(ops.get_params_prelu(0, mask));
+
+    EXPECT_NO_THROW(ops.get_params_prelu(1, mask));
+    ASSERT_EQ(mask, prelu_mask);
+}
+
 TEST_F(attr_test_t, TestPostOpsCheckLimit) {
     dnnl::post_ops ops_sum, ops_eltwise, ops_binary, ops_prelu;
 


### PR DESCRIPTION
# Description

dnnl_post_ops_get_params_prelu is the only post-op getter that doesn't go through simple_get_params_check: it bounds index from above but not below, and never checks the kind of the entry it reads. a negative index makes post_ops->entry_[index] read below the vector allocation, and an in-range entry of another kind is returned as a prelu mask with dnnl_success, since prelu shares a union with sum, eltwise, depthwise_conv and binary. routing it through the same helper the sum, eltwise, dw and binary getters already use keeps the behavior of valid queries unchanged.

reproduce the kind confusion by appending an eltwise post-op and calling dnnl_post_ops_get_params_prelu(po, 0, &mask): before the change it returns dnnl_success with mask = 32, the raw value of alg_kind::eltwise_relu read out of the union; after it returns invalid_arguments and leaves mask alone. for the index, append one prelu post-op and pass -1: asan reports a 4-byte out-of-bounds read at primitive_attr.cpp:932, 3176 bytes (one entry_t) before the allocation, while a debug build traps in std::vector::operator[] instead because platform.cmake turns on _LIBCPP_HARDENING_MODE and _GLIBCXX_ASSERTIONS there. the new gtest covers the negative index, the out-of-range index, the wrong-kind entry and a valid query; it aborts on the unpatched tree and passes after. test_iface_attr and test_iface_attr_quantization are green locally. the only in-tree caller, dnn_mem_t setup in benchdnn, already filters on dnnl_post_ops_get_kind before querying, so it is unaffected.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
