### PR TITLE
graph: backend: dnnl: refine sdpa dispatching logic

### DIFF
--- a/src/graph/backend/dnnl/executables/sdpa.cpp
+++ b/src/graph/backend/dnnl/executables/sdpa.cpp
@@ -111,9 +111,14 @@ sdpa_executable_t::sdpa_executable_t(std::shared_ptr<op_t> &op,
 
 void sdpa_executable_t::execute(const stream &stream,
         const std::unordered_map<int, memory> &args) const {
-    UNUSED(stream);
-    UNUSED(args);
-    assert(!"sdpa_executable_t::execute() is not implemented on cpu");
+    std::vector<dnnl_exec_arg_t> c_args;
+    c_args.reserve(args.size());
+    for (const auto &a : args)
+        c_args.push_back({a.first, a.second.get()});
+
+    auto ret = dnnl_primitive_execute(prim_.get(), stream.get(),
+            static_cast<int>(c_args.size()), c_args.data());
+    dnnl::error::wrap_c_api(ret, "could not execute sdpa primitive on cpu");
 }
 
 #ifdef DNNL_WITH_SYCL
@@ -315,9 +320,15 @@ sdpa_bwd_executable_t::sdpa_bwd_executable_t(std::shared_ptr<op_t> &op,
 
 void sdpa_bwd_executable_t::execute(const stream &stream,
         const std::unordered_map<int, memory> &args) const {
-    UNUSED(stream);
-    UNUSED(args);
-    assert(!"sdpa_bwd_executable_t::execute() is not implemented on cpu");
+    std::vector<dnnl_exec_arg_t> c_args;
+    c_args.reserve(args.size());
+    for (const auto &a : args)
+        c_args.push_back({a.first, a.second.get()});
+
+    auto ret = dnnl_primitive_execute(prim_.get(), stream.get(),
+            static_cast<int>(c_args.size()), c_args.data());
+    dnnl::error::wrap_c_api(
+            ret, "could not execute sdpa backward primitive on cpu");
 }
 
 #ifdef DNNL_WITH_SYCL

--- a/src/graph/backend/dnnl/kernels/sdp.hpp
+++ b/src/graph/backend/dnnl/kernels/sdp.hpp
@@ -49,62 +49,38 @@ public:
     status_t compile_impl(const dnnl_partition_impl_t *part, engine_t *eng,
             const std::vector<logical_tensor_t> &inputs,
             const std::vector<logical_tensor_t> &outputs) override {
-        const engine_kind_t ekind = eng->kind();
-        bool enable_decomp = false;
-        bool enable_ukernel = false;
-
-        if (ekind == engine_kind::cpu) {
-            enable_decomp = enable_decomp_kernel();
-        } else if (ekind == engine_kind::gpu) {
-            enable_ukernel = !force_primitive();
-        } else {
-            assert(!"unknown engine kind");
-            return status::invalid_arguments;
-        }
+        const bool use_larger_partition = force_larger_partition();
 
         status_t ret = status::unimplemented;
 
-        if (enable_ukernel) {
-            kernel = std::make_shared<sdp_primitive_kernel_t<quantized>>();
-            ret = kernel->compile_impl(part, eng, inputs, outputs);
-        }
-
-        if (ret != status::success && enable_decomp) {
-            kernel = std::make_shared<sdp_decomp_kernel_t<quantized, dt>>();
-            ret = kernel->compile_impl(part, eng, inputs, outputs);
-        }
-
-        if (ret != status::success) {
+        if (use_larger_partition) {
             kernel = std::make_shared<larger_partition_kernel_t>();
             ret = kernel->compile_impl(part, eng, inputs, outputs);
+        } else {
+            kernel = std::make_shared<sdp_primitive_kernel_t<quantized>>();
+            ret = kernel->compile_impl(part, eng, inputs, outputs);
+
+            if (ret != status::success) {
+                kernel = std::make_shared<sdp_decomp_kernel_t<quantized, dt>>();
+                ret = kernel->compile_impl(part, eng, inputs, outputs);
+            }
+
+            if (ret != status::success) {
+                kernel = std::make_shared<larger_partition_kernel_t>();
+                ret = kernel->compile_impl(part, eng, inputs, outputs);
+            }
         }
         if (ret == status::success)
             VDISPATCH_GRAPH_SDP(
-                    "sdpa is dispatched to (%s)", kernel->str().c_str());
+                    "sdpa is dispatched to %s", kernel->str().c_str());
         else
             VDISPATCH_GRAPH_SDP("sdpa is failed to dispatch");
         return ret;
     }
 
-    // It is used to check if enable the decomposition kernel based on user's
-    // env and params. Decomposition kernel is enabled when:
-    // - CPU runtime is OMP or THREADPOOl.
-    // - Primitive based implementation is not forced by the internal env var.
-    bool enable_decomp_kernel() const {
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP \
-        || DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
-        const bool force_prim = force_primitive();
-        return !force_prim;
-#else
-        return false;
-#endif
-    }
-
-    // An internal env var is provided to force using primitive based SDPA
-    // implementation and skipping ukernel based optimization on GPU or
-    // decomposition based optimization on CPU. Currently it's for oneDNN debug
-    // and testing only.
-    bool force_primitive() const {
+    // An internal env var is provided to force the larger-partition SDPA
+    // implementation. Currently it's for oneDNN debug and testing only.
+    bool force_larger_partition() const {
         const int force = graph::utils::getenv_int_internal(
                 "GRAPH_SDPA_FORCE_PRIMITIVE", 0);
         return force > 0;

--- a/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp.cpp
@@ -33,6 +33,10 @@
 #include "cpu/cpu_stream.hpp"
 #endif
 
+#define VCHECK_SDP_PRIMITIVE(cond, status, msg, ...) \
+    VCONDCHECK(graph, create, check, sdp_decomp_kernel_t, (cond), status, msg, \
+            ##__VA_ARGS__);
+
 namespace dnnl {
 namespace impl {
 namespace graph {
@@ -42,6 +46,18 @@ status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
         const dnnl_partition_impl_t *part, engine_t *eng,
         const std::vector<logical_tensor_t> &inputs,
         const std::vector<logical_tensor_t> &outputs) {
+    VCHECK_SDP_PRIMITIVE(eng->kind() == engine_kind::cpu, status::unimplemented,
+            "supports cpu only");
+
+#if DNNL_CPU_RUNTIME != DNNL_RUNTIME_OMP \
+        && DNNL_CPU_RUNTIME != DNNL_RUNTIME_THREADPOOL
+    UNUSED(part);
+    UNUSED(inputs);
+    UNUSED(outputs);
+    VCHECK_SDP_PRIMITIVE(false, status::unimplemented,
+            "supports OMP or Threadpool runtime only");
+#else
+
     p_engine_ = make_dnnl_engine(*eng);
 
     // get subgraph from the deep copied partition
@@ -110,6 +126,7 @@ status_t sdp_decomp_kernel_t<quantized, dt>::compile_impl(
     // Initialize and construct kernel params
     return sdp_cfg_.construct_params<quantized, dt>(
             subgraph_, sdp_registry_, p_engine_, inputs);
+#endif
 }
 
 template <bool quantized, memory::data_type dt>

--- a/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_primitive_config.cpp
@@ -43,10 +43,6 @@ status_t sdp_primitive_config_t::initial_check(
     VCHECK_SDP_PRIMITIVE(inputs.size() >= 3, status::invalid_arguments,
             "At least 3 inputs are required");
 
-    const bool is_f32 = inputs[0].data_type == data_type::f32;
-    bool has_genindex = false;
-
-    // Dispatch f32 implicit causal mask cases into the f32 ukernel impl.
     for (auto &cur_op : sg->get_ops()) {
         const auto opk = cur_op->get_kind();
         // SDPA with static quantization and dequantization is currently
@@ -55,7 +51,6 @@ status_t sdp_primitive_config_t::initial_check(
         VCHECK_SDP_PRIMITIVE(opk != graph::op_kind::Dequantize
                         && opk != graph::op_kind::Quantize,
                 status::unimplemented, "Not support quantized SDPA");
-        if (opk == graph::op_kind::GenIndex) { has_genindex = true; }
     }
 
     // step1(pattern check): Not support sdpa variants with select as mask
@@ -169,9 +164,6 @@ status_t sdp_primitive_config_t::initial_check(
 
     VCHECK_SDP_PRIMITIVE(q_id != -1 && k_id != -1 && v_id != -1,
             status::unimplemented, "Q, K, V are not found");
-
-    VCHECK_SDP_PRIMITIVE(!is_f32 || has_genindex, status::unimplemented,
-            "f32 fused sdpa supported for causal mask only");
 
     // sdp_primitive only supports single scale value.
     if (scale) {


### PR DESCRIPTION
1. Refine sdpa dispatching logic.
2. Move cpu egine and omp/threadpool runtime checks into decomposition kernel.
3. Remove genindex checks for f32 sdpa as they are the gpu implementation details. Rely on the check in sdpa's micro.cpp for dispatching.