### PR TITLE
tests: benchdnn: sdpa: fix perf path

### DIFF
--- a/tests/benchdnn/sdpa/sdpa.cpp
+++ b/tests/benchdnn/sdpa/sdpa.cpp
@@ -480,13 +480,15 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, v_prim[0], prb, res),
             WARN));
-
-    // Reference-only buffer holding the per-element conditioning magnitude
-    // sum_k prob_k*|V_k| (same layout as the reference DST). compute_ref fills
-    // it; setup_cmp reads it to size a per-element DST threshold. Forward only.
-    const auto &ref_dst = ref_mem_map.at(DNNL_ARG_DST);
-    ref_mem_map.emplace(SDPA_REF_ARG_OUT_ABSMAG,
-            dnn_mem_t(ref_dst.md_, get_cpu_engine(), /* prefill = */ false));
+    if (!has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
+        // Reference-only buffer holding the per-element conditioning magnitude
+        // sum_k prob_k*|V_k| (same layout as the reference DST). compute_ref fills
+        // it; setup_cmp reads it to size a per-element DST threshold. Forward only.
+        const auto &ref_dst = ref_mem_map.at(DNNL_ARG_DST);
+        ref_mem_map.emplace(SDPA_REF_ARG_OUT_ABSMAG,
+                dnn_mem_t(
+                        ref_dst.md_, get_cpu_engine(), /* prefill = */ false));
+    }
 
     args_t args(mem_map), ref_args(ref_mem_map);
 


### PR DESCRIPTION
# Description

Fix performance testing for SDPA, condition references to ref arguments on them actually existing, preventing invalid access. Use same condtion that prevents initialization of ref arguments in `init_ref_memory_args` : 

```
 --> ./tests/benchdnn/benchdnn --sdpa --engine=gpu --mode=f  --allow-enum-tags-only=false --dt=bf16:bf16:bf16:bf16 --qtag=abcd --ktag=abcd --vtag=abcd --dtag=abcd 4x16x1x128:4x16x128x129:4x16x129x128
terminate called after throwing an instance of 'std::out_of_range'
  what():  unordered_map::at
Aborted (core dumped)
```

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?