### PR TITLE
xe: copy plan: some optimizations + bug fix

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -223,6 +223,7 @@ void CopyInstruction::moveToIntegerPipe()
             break;
         default: break;
     }
+    dst.range = src0.range = DataType::invalid;
 }
 
 // Retrieve nGEN instruction modifiers for an instruction.

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -3480,6 +3480,17 @@ struct AllocationManager {
         release(end, flagAllocations);
     }
 
+    // Release any temporaries whose last use precedes the given phase, i.e.
+    //   whose value is no longer needed once instructions up to (but not
+    //   including) that phase have been emitted. This is necessary in
+    //   addition to release(int), as temporaries sharing the same element
+    //   range (e.g. all covering a single unbatched instruction group) can
+    //   only be distinguished by when they are last used, not by range.
+    void releasePhase(uint16_t phase) {
+        releasePhase(phase, grfAllocations);
+        releasePhase(phase, flagAllocations);
+    }
+
 private:
     template <typename AllocationType>
     void release(int end, std::vector<AllocationType> &allocs) {
@@ -3494,15 +3505,30 @@ private:
         }
     }
 
+    template <typename AllocationType>
+    void releasePhase(uint16_t phase, std::vector<AllocationType> &allocs) {
+        for (size_t i = 0; i < allocs.size();) {
+            auto &alloc = allocs[i];
+            if (alloc.phaseMax < phase) {
+                dealloc(alloc);
+                std::swap(allocs[i], allocs[allocs.size() - 1]);
+                allocs.pop_back();
+            } else
+                ++i;
+        }
+    }
+
 protected:
     struct GRFAllocation {
         GRFRange range;
         int end;
+        uint16_t phaseMax;
     };
 
     struct FlagAllocation {
         FlagRegister flag;
         int end;
+        uint16_t phaseMax;
     };
 
     void dealloc(GRFAllocation &alloc) { grfAllocator(0, alloc.range); }
@@ -3513,7 +3539,7 @@ protected:
         flagAllocator(temp.bytes, flag);
         if (!flag.isValid()) return false;
         temp.assignment = flag.index();
-        flagAllocations.push_back({flag, temp.range.end});
+        flagAllocations.push_back({flag, temp.range.end, temp.phaseMax});
         return true;
     }
 
@@ -3523,7 +3549,7 @@ protected:
         grfAllocator(grfs, range);
         if (!range.isValid()) return false;
         temp.assignment = range.getBase();
-        grfAllocations.push_back({range, temp.range.end});
+        grfAllocations.push_back({range, temp.range.end, temp.phaseMax});
         return true;
     }
 
@@ -3560,13 +3586,36 @@ void CopyPlan::materializeTemps(const GRFAllocator &grfAllocator, const FlagAllo
     // No temporaries used
     if (minPhaseTemp > maxPhaseTemp) return;
 
-    /* Check which instruction groups must be issued together */
+    /* Temporaries whose allocation cannot currently be resolved (neither by
+       phase advance nor by a range boundary) are deferred: their
+       instructions are excluded from consideration until they can be
+       retried, typically once other, currently-blocking temporaries have
+       had their instructions emitted and their registers released. A
+       temporary's range may nest inside another's (e.g. a flag that is
+       only truly needed once several disjoint sub-ranges have each been
+       fully processed) in a way that a single index/phase sweep cannot
+       always resolve on the first pass. */
+    std::vector<bool> deferred(temps.size(), false);
+
+    auto usesDeferredTemp = [&](const CopyInstruction &i) {
+        for (auto o: {&i.dst, &i.src0, &i.src1, &i.src2, &i.flag})
+            if (*o && o->temp && deferred[o->value]) return true;
+        return false;
+    };
+
+    /* Check which instruction groups must be issued together. Instructions
+       that use a currently-deferred temporary are excluded: they cannot be
+       issued yet regardless, and must not be allowed to block a range
+       boundary that would otherwise let other temporaries' registers be
+       reclaimed. */
     auto groupInstructions = [&](std::vector<bool> &joined, CopyRange &range) {
         range = {};
         joined.assign(joined.size(), false);
 
         for (auto &i: insns) {
             if (i.phase < minPhaseTemp || i.phase > maxPhaseTemp)
+                continue;
+            if (usesDeferredTemp(i))
                 continue;
             for (auto j = i.range.start; j < i.range.end; j++)
                 joined[j] = true;
@@ -3583,7 +3632,6 @@ void CopyPlan::materializeTemps(const GRFAllocator &grfAllocator, const FlagAllo
     groupInstructions(joined, range);
 
     /* Sort instructions and temporaries by element index */
-
     auto cmp = [&](int i, int j) {
         const auto &ri = temps[i].range;
         const auto &rj = temps[j].range;
@@ -3595,13 +3643,20 @@ void CopyPlan::materializeTemps(const GRFAllocator &grfAllocator, const FlagAllo
     std::iota(rangeOrder.begin(), rangeOrder.end(), 0);
     std::sort(rangeOrder.begin(), rangeOrder.end(), cmp);
 
-    auto emit = [&](const CopyRange &range, uint16_t minPhase, uint16_t maxPhase) {
+    std::vector<bool> insnEmitted(insns.size(), false);
+    auto emit = [&](const CopyRange &range, uint16_t minPhase, uint16_t maxPhase, bool skipDeferred = true) {
         bool emitted = false;
-        for (const auto &i: insns) {
+        for (size_t idx = 0; idx < insns.size(); idx++) {
+            auto &i = insns[idx];
+            if (insnEmitted[idx])
+                continue;
             if (i.phase < minPhase || i.phase > maxPhase)
                 continue;
             if (i.range.start < range.start || i.range.end > range.end)
                 continue;
+            if (skipDeferred && usesDeferredTemp(i))
+                continue;
+            insnEmitted[idx] = true;
             sortedInsns.push_back(i);
             emitted = true;
         }
@@ -3614,31 +3669,99 @@ void CopyPlan::materializeTemps(const GRFAllocator &grfAllocator, const FlagAllo
 
     auto order = rangeOrder.begin();
     const auto end = rangeOrder.end();
+
+    /* Check whether it is safe to advance the phase window across
+       [loPhase, hiPhase]: every temporary used by an instruction in that
+       phase range must already be allocated. This applies equally to
+       deferred temporaries: even though their instructions are excluded
+       from emission for now, advancing minPhaseTemp past their phase would
+       make them permanently unreachable (emit() never considers phases
+       below minPhaseTemp again), so their presence in the gap must block
+       the advance just like any other not-yet-allocated temporary. */
+    auto phaseGapSafe = [&](uint16_t loPhase, uint16_t hiPhase) {
+        for (auto &i: insns) {
+            if (i.phase < loPhase || i.phase > hiPhase)
+                continue;
+            for (auto o: {&i.dst, &i.src0, &i.src1, &i.src2, &i.flag}) {
+                if (!*o || !o->temp) continue;
+                auto &t = temps[o->value];
+                if (!t.range) continue;
+                if (t.assignment < 0) return false;
+            }
+        }
+        return true;
+    };
+
+    /* Advance the phase window up to just before temp's first use, emitting
+       any instructions that fall in the gap and releasing any temporaries
+       that are no longer needed as of the new phase. This is necessary in
+       addition to range-based back off: temporaries that happen to share
+       the same element range (e.g. because they all belong to a single,
+       unbatched instruction group) can only be distinguished -- and their
+       registers reclaimed -- by phase, not by range. Returns whether the
+       phase window was actually advanced. */
+    auto advancePhase = [&](const CopyTemporary &temp) {
+        if (temp.phaseMin <= minPhaseTemp) return false;
+        if (!phaseGapSafe(minPhaseTemp, temp.phaseMin - 1)) return false;
+        emit(range0, minPhaseTemp, temp.phaseMin - 1);
+        minPhaseTemp = temp.phaseMin;
+        manager.releasePhase(minPhaseTemp);
+        CopyRange unused;
+        groupInstructions(joined, unused);
+        return true;
+    };
+
     while (order != end) {
         for (; order != end; ++order) {
             auto &temp = temps[*order];
             // Don't allocate unused temporaries.
             if (!temp.range) continue;
-            if (!manager.allocate(temp)) {
-                range.end = temp.range.start - 1; break;
-            }
+            if (manager.allocate(temp)) continue;
+
+            /* Ran out of registers/flags. First see if any already-allocated
+               temporaries are simply dead in program order (their last use
+               precedes this temporary's first use) and can be released,
+               even if they can't be distinguished by element range. */
+            if (advancePhase(temp) && manager.allocate(temp)) continue;
+
+            range.end = temp.range.start - 1; break;
         }
 
-        /* Back off to the nearest instruction group boundary */
+        /* Back off to the nearest instruction group boundary. If no boundary
+           can be found (some instruction's range spans clear across the
+           remaining region), advance the phase window past already-emitted
+           phases and retry -- this may unjoin the region by excluding
+           instructions that no longer need to be considered -- until a
+           boundary is found or no further progress is possible. */
         while (range.end >= range.start && joined[range.end])
             range.end--;
-        if (range.end < range.start) {
-            bool emitted = false;
-            if (order != end) {
-                auto &temp = temps[*order];
-                if (temp.phaseMin > minPhaseTemp) {
-                    emitted = emit(range0, minPhaseTemp, temp.phaseMin - 1);
-                    minPhaseTemp = temp.phaseMin;
-                }
+
+        bool deferredCurrent = false;
+        while (range.end < range.start && order != end) {
+            if (!advancePhase(temps[*order])) {
+                /* Neither a phase advance nor a range boundary can resolve
+                   this temporary right now. Defer it: exclude its
+                   instructions from consideration and move on to the rest
+                   of the temporaries, retrying it later once other,
+                   currently-blocking temporaries have been fully emitted
+                   and released -- this may free up the resources it
+                   needs even though its own range doesn't allow it to be
+                   isolated via a range boundary. */
+                deferred[*order] = true;
+                CopyRange unused;
+                groupInstructions(joined, unused);
+                ++order;
+                deferredCurrent = true;
+                break;
             }
-            if (!emitted)
-                throw out_of_registers_exception();
-            groupInstructions(joined, range);
+            range.end = temps[*order].range.start - 1;
+            while (range.end >= range.start && joined[range.end])
+                range.end--;
+        }
+
+        if (deferredCurrent) {
+            range.end = range0.end;
+            continue;
         }
 
         /* Issue instructions for this batch of instruction groups */
@@ -3652,6 +3775,36 @@ void CopyPlan::materializeTemps(const GRFAllocator &grfAllocator, const FlagAllo
     /* Issue any remaining instructions */
     if (range.start <= range0.end)
         emit(range, minPhaseTemp, maxPhaseTemp);
+
+    /* The whole index range has now been swept, so every temporary that
+       was allocated (deferred or not) has had all of its range-bounded
+       instructions considered; release anything still held so that
+       deferred temporaries below have the best chance of finding a free
+       register. */
+    manager.release(range0.end + 1);
+
+    /* Retry any temporaries whose allocation was deferred earlier, now
+       that further registers may have been released. Keep retrying until
+       no more progress can be made; if any remain unresolved, we have
+       genuinely run out of registers. */
+    for (bool progress = true; progress;) {
+        progress = false;
+        for (auto ti: rangeOrder) {
+            if (!deferred[ti]) continue;
+            auto &temp = temps[ti];
+            if (manager.allocate(temp) || (advancePhase(temp) && manager.allocate(temp))) {
+                deferred[ti] = false;
+                progress = true;
+            }
+        }
+    }
+    if (std::find(deferred.begin(), deferred.end(), true) != deferred.end())
+        throw out_of_registers_exception();
+
+    /* Emit any instructions that were excluded earlier because they used a
+       temporary that has since been resolved. */
+    emit(range0, minPhaseTemp, maxPhaseTemp);
+
     if (maxPhaseTemp < 0xFFFF)
         emit(range0, maxPhaseTemp + 1, 0xFFFF);
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -2278,6 +2278,7 @@ void CopyPlan::planEmulatedHFToF4(CopyInstruction &i)
         ie[1]->src0.stride = 2;
 
         ie[2]->op = Opcode::dnscl;
+        ie[2]->ctrl = 0;
         ie[2]->simd = simd / 4;
         ie[2]->dst = t0;
         ie[2]->dst.type = y.type;
@@ -4133,7 +4134,7 @@ void CopyInstruction::dump(std::ostream &os, const CopyPlan &plan, bool sortInfo
     if (op == Opcode::shfl)
         os << "shfl.idx4";
     else if (op == Opcode::dnscl)
-        os << "dnscl";
+        os << "dnscl.mode" << (int)ctrl;
     else
         os << getMnemonic(op, HW::Gen9);
     switch (op) {

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -252,6 +252,7 @@ void CopyPlan::transform()
 
     sort(SortType::Register);
 
+    optimizeTranspose();
     optimizeSIMD();
     optimizeIntegerDownconvert();
     optimizeZip();
@@ -3112,6 +3113,73 @@ void CopyPlan::optimizeSIMD()
             ie[0]->simd = ie[2]->simd = esimd;
             ie[1]->invalidate();
             mask(*ie[0], *ie[2], flag);
+        }
+    }
+
+    mergeChanges();
+}
+
+// Optimization pass: Convert long chains of small-SIMD equal-strided movs
+// to a few larger-SIMD movs.
+// Example input:
+//    mov (2) r3.0:ub<1>      r3.0:ub<2>
+//    mov (2) r3.4:ub<1>      r3.4:ub<2>
+//    mov (2) r3.8:ub<1>      r3.8:ub<2>
+//    mov (2) r3.12:ub<1>     r3.12:ub<2>
+//    mov (2) r3.16:ub<1>     r3.16:ub<2>
+//    mov (2) r3.20:ub<1>     r3.20:ub<2>
+//    mov (2) r3.24:ub<1>     r3.24:ub<2>
+//    mov (2) r3.28:ub<1>     r3.28:ub<2>
+// Output:
+//    mov (8) r3.0:ub<4>      r3.0:ub<4>  /* removed */
+//    mov (8) r3.1:ub<4>      r3.2:ub<4>
+//
+void CopyPlan::optimizeTranspose()
+{
+    const auto grf = ngen::GRF::bytes(hw);
+    auto transposable = [grf](const CopyOperand &o1, const CopyOperand &o2, size_t offset) {
+        if (o1.kind != CopyOperand::GRF || o2.kind != CopyOperand::GRF) return false;
+        if (o1.type != o2.type || o1.stride != o2.stride) return false;
+        if (o1.temp != o2.temp) return false;
+        if (o1.temp && o1.grf != o2.grf) return false;
+
+        auto grf_diff = o1.temp ? o2.value - o1.value : o2.grf - o1.grf;
+        auto dist = bytesToElements(grf, o1.type) * grf_diff + (o2.offset - o1.offset);
+        return dist == offset;
+    };
+
+    auto ninsn = insns.size();
+    for (size_t n1 = 0; n1 < ninsn; n1++) {
+        auto &i1 = insns[n1];
+        if (i1.op != Opcode::mov || i1.simd == 0) continue;
+        int8_t dstride = bytesToElements(4, i1.dst.type);
+        int8_t sstride = bytesToElements(4, i1.src0.type);
+        int simd = 1;
+        size_t n2;
+        for (n2 = n1 + 1; n2 < ninsn; n2++, simd++) {
+            auto &i2 = insns[n2];
+            if (i1.phase != i2.phase) break;
+            if (i2.op != Opcode::mov) break;
+            if (i1.simd != i2.simd) break;
+            if (!transposable(i1.src0, i2.src0, dstride * (n2 - n1))) break;
+            if (!transposable(i1.dst, i2.dst, sstride * (n2 - n1))) break;
+        }
+
+        if (i1.simd > simd) continue;
+
+        for (size_t n = n1 + 1; n < n2; n++, n1++)
+            join(i1, insns[n]);
+
+        auto simd0 = i1.simd;
+        i1.simd = simd;
+        auto soffset = i1.src0.stride;
+        auto doffset = i1.dst.stride;
+        i1.src0.stride = sstride;
+        i1.dst.stride = dstride;
+        for (int i = 1; i < simd0; ++i) {
+            auto &i2 = split(i1, false);
+            i2.src0.offset += i * soffset;
+            i2.dst.offset += i * doffset;
         }
     }
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -159,7 +159,9 @@ RegData CopyOperand::ngen() const
 {
     if (kind == Null)
         return ngen::NullRegister().sub(offset, type)(stride);
-    if (kind != GRF || temp) stub("Invalid operation");
+    if (temp) stub("Invalid operation");
+    if (kind == Flag) return ngenFlag();
+    if (kind != GRF) stub("Invalid operation");
 
     auto sub = ngen::GRF(grf).sub(offset, type);
     RegData rd;
@@ -211,7 +213,7 @@ void CopyInstruction::moveToIntegerPipe()
         case 2: st = dt = DataType::uw; break;
         case 4: st = dt = DataType::ud; break;
         case 8:
-            if (src0.stride == 1 && dst.stride == 1) {
+            if (!flag && src0.stride == 1 && dst.stride == 1) {
                 st = dt = DataType::ud;
                 simd *= 2;
                 src0.offset *= 2;
@@ -250,6 +252,7 @@ void CopyPlan::transform()
 
     sort(SortType::Register);
 
+    optimizeSIMD();
     optimizeIntegerDownconvert();
     optimizeZip();
     optimizeZipAdjacent();
@@ -2860,7 +2863,7 @@ void CopyPlan::legalizeRegions()
             i.dst.offset *= 2;
             i.src0.stride *= 2;
             i.src0.offset *= 2;
-            if (i.dst.stride == 2) {
+            if (!i.flag && i.dst.stride == 2) {
                 /* Use 2D regioned src */
                 i.simd *= 2;
                 i.dst.stride = 1;
@@ -2966,6 +2969,155 @@ void CopyPlan::sort(SortType type)
     });
 }
 
+// Optimization pass: extend SIMD widths to avoid many small-SIMD instructions
+// Example input:
+//    mov (15)  r0.0<4>:uw   r10.0<2>:uw
+// i.e.,
+//    mov (8)  r0.0<4>:uw   r10.0<2>:uw
+//    mov (4)  r1.0<4>:uw   r10.16<2>:uw
+//    mov (2)  r1.16<4>:uw   r10.24<2>:uw
+//    mov (1)  r1.24<4>:uw   r10.28<2>:uw
+// Output:
+//    mov (1)  f0.0:uw    0x7FFF
+//    (f0.0) mov (16) r0.0<2>:uw   r10.0<1>:uw
+//
+void CopyPlan::optimizeSIMD()
+{
+    const auto grf = ngen::GRF::bytes(hw);
+
+    auto advance = [grf](CopyOperand &op, int n) {
+        if (op.kind == CopyOperand::Flag)
+            op.offset += n;
+        if (op.kind != CopyOperand::GRF) return;
+        int ne = bytesToElements(grf, op.type);
+        if (op.width) {
+            op.offset += (n / op.width) * op.vs;
+            n %= op.width;
+        }
+        op.offset += n * op.stride;
+        int grfOffset = op.offset / ne;
+        op.grf += grfOffset;
+        op.offset -= grfOffset * ne;
+    };
+
+    auto rerange = [](CopyInstruction &i, int simd) {
+        auto channels = i.range.end - i.range.start + 1;
+        i.range.end = i.range.start + channels * simd / i.simd - 1;
+        i.simd = simd;
+    };
+
+    auto predicatedMovSupported = [&](const CopyInstruction &i) {
+        if (i.simd > 32) return false;
+        if (getBits(i.dst.type) < 8) return false;
+        if (hw < HW::XeHPC) return true;
+        if (!isB(i.dst.type) || !isB(i.src0.type)) return true;
+        if (i.dst.stride != 1) return true;
+        if ((i.dst.offset & 1) == 0) return true;
+        return false;
+    };
+
+
+    bool needsMerge = false;
+    for (auto &i : insns) {
+        if (!predicatedMovSupported(i)) continue;
+        auto tail = i.simd % 32;
+        if (tail == rounddown_pow2(tail)) continue;
+        auto simd0 = i.simd - tail;
+
+        auto &i0 = i, &i1 = split(i, false);
+        advance(i1.dst, simd0);
+        advance(i1.src0, simd0);
+        advance(i1.src1, simd0);
+        advance(i1.src2, simd0);
+        rerange(i0, simd0);
+        rerange(i1, tail);
+        needsMerge = true;
+    }
+
+    if (needsMerge)
+        mergeChanges();
+
+    auto mask = [&](CopyInstruction &i0, CopyInstruction &i2, const CopyOperand &flag) {
+        auto hasConversion = (i0.op != Opcode::mov)
+                          || (i0.dst.type != i0.src0.type)
+                          || (i0.flag && i0.cmod != ConditionModifier::none);
+        auto dst = i0.dst;
+        auto tmp = i0.src0;
+
+        if (hasConversion) {
+            tmp = newTemp(dst.type, i0.simd, dst.stride);
+            i0.dst = tmp;
+        } else  {
+            i0.invalidate();
+        }
+
+        i2.op = Opcode::mov;
+        i2.flag = flag;
+        i2.dst = dst;
+        i2.src0 = tmp;
+        i2.src1 = i2.src2 = CopyOperand{};
+    };
+
+    const auto ninsns = insns.size();
+    for (size_t n1 = 0; n1 < ninsns; n1++) {
+        auto &i1 = insns[n1];
+        if (!predicatedMovSupported(i1)) continue;
+        if (rounddown_pow2(i1.simd) == i1.simd) continue;
+
+        size_t n2;
+        auto range = i1.range;
+        for (n2 = n1 + 1; n2 < ninsns; n2++) {
+            auto &i2 = insns[n2];
+            if (!predicatedMovSupported(i2)) continue;
+            if (i2.simd != i1.simd) break;
+            if (i2.flag != i1.flag) break;
+            if (i2.phase != i1.phase) break;
+            range |= i2.range;
+        }
+
+        auto simd = i1.simd;
+        auto esimd = 2 * rounddown_pow2(simd);
+        auto oflag = i1.flag;
+        auto flag = newFlag(esimd);
+        auto value = (1u << simd) - 1;
+        flag.type = esimd > 16 ? DataType::ud : DataType::uw;
+        rerange(i1, esimd);
+
+        auto ie1 = splitMultiple<3>(i1);
+        ie1[0]->simd = ie1[2]->simd = esimd;
+        auto &fi = *ie1[1];
+
+        fi.simd = 1;
+        fi.range = range;
+        fi.dst = flag;
+        if (oflag) {
+            fi.op = Opcode::or_;
+            fi.src0 = oflag;
+            fi.src1 = value;
+            fi.flag = fi.src2 = CopyOperand{};
+        } else {
+            fi.op = Opcode::mov;
+            fi.src0 = value;
+            fi.src1 = fi.src2 = CopyOperand{};
+        }
+        fi.cmod = ConditionModifier::none;
+
+        mask(*ie1[0], *ie1[2], flag);
+
+        for (size_t n = n1 + 1; n < n2; ++n, ++n1) {
+            auto &i = insns[n];
+            if (!predicatedMovSupported(i)) continue;
+            rerange(i, esimd);
+            auto ie = splitMultiple<3>(i);
+            ie[0]->simd = ie[2]->simd = esimd;
+            ie[1]->invalidate();
+            mask(*ie[0], *ie[2], flag);
+        }
+    }
+
+    mergeChanges();
+}
+
 // Optimization pass: zip together interleaved operations.
 // Requires a sorted plan.
 //
@@ -3001,7 +3153,7 @@ void CopyPlan::optimizeZip(bool zip2DSrc0)
             auto zippable = [&](const CopyOperand &o1, const CopyOperand &o2, bool zip2D = false, bool zipImm = false) {
                 if (o1.kind != o2.kind) return false;
                 if (o1.kind == CopyOperand::Immediate) return (o1.value == o2.value || zipImm);
-                if (o1.kind != CopyOperand::GRF) return true;
+                if (!one_of(o1.kind, {CopyOperand::GRF, CopyOperand::Flag})) return true;
                 if (o1.type != o2.type || o1.stride != o2.stride || o1.grf != o2.grf) return false;
                 if (o1.temp != o2.temp) return false;
                 if (o1.temp && o1.value != o2.value) return false;
@@ -3180,7 +3332,7 @@ void CopyPlan::optimizeZipAdjacent()
         auto zippable = [](const CopyOperand &o1, const CopyOperand &o2) {
             if (o1.kind != o2.kind) return false;
             if (o1.kind == CopyOperand::Immediate) return (o1.value == o2.value);
-            if (o1.kind != CopyOperand::GRF) return true;
+            if (!one_of(o1.kind, {CopyOperand::GRF, CopyOperand::Flag})) return true;
             if (o1.type != o2.type || o1.stride != o2.stride || o1.grf != o2.grf) return false;
             if (o1.temp != o2.temp) return false;
             if (o1.temp && o1.value != o2.value) return false;

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
@@ -307,6 +307,7 @@ protected:
     void optimizeSaturate();
     void optimizeMoveToIntPipe();
     void optimizeSIMD();
+    void optimizeTranspose();
 
     CopyOperand bfImmediate(uint16_t bits, bool ternary);
     CopyOperand zipImmediates(const CopyOperand &o1, const CopyOperand &o2, uint8_t stride);

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
@@ -394,11 +394,9 @@ void CopyInstruction::execute(Generator &g)
                 g.math(ngenModifiers(), fc, dst.ngen(), src0.ngen(), src1.ngen());
             break;
         }
-        case Opcode::dnscl: {
-            uint8_t mode = 0;
-            g.dnscl(ngenModifiers(), mode, RoundingType::rne, dst.ngen(), src0.ngen(), src1.ngen(), src2.ngen());
+        case Opcode::dnscl:
+            g.dnscl(ngenModifiers(), ctrl, RoundingType::rne, dst.ngen(), src0.ngen(), src1.ngen(), src2.ngen());
             break;
-	    }
         case Opcode::shfl:
             g.shfl.idx4(ngenModifiers(), dst.ngen(), src0.ngen(), src1.ngen());
             break;

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
@@ -306,6 +306,7 @@ protected:
     void optimizeIntegerDownconvert();
     void optimizeSaturate();
     void optimizeMoveToIntPipe();
+    void optimizeSIMD();
 
     CopyOperand bfImmediate(uint16_t bits, bool ternary);
     CopyOperand zipImmediates(const CopyOperand &o1, const CopyOperand &o2, uint8_t stride);

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
@@ -154,7 +154,7 @@ struct CopyTemporary
 
     int bytes = 0, align = 0, offset = 0;
     bool flag = false;
-    uint16_t phaseMin = 0xFFFF;
+    uint16_t phaseMin = 0xFFFF, phaseMax = 0x0000;
     int assignment = -1;
     CopyRange range;
 
@@ -167,6 +167,7 @@ protected:
     void usedBy(const CopyInstruction &i) {
         range |= i.range;
         phaseMin = std::min(phaseMin, i.phase);
+        phaseMax = std::max(phaseMax, i.phase);
     }
 
 private:


### PR DESCRIPTION
Bug fix:
 - Register allocation/reclamation in several cases.

Optimizations:
 - Replaces multiple SIMD2/4 instructions used in scatter send repacking with `simd - 1` (after removal of tautological `mov`) dword-strided instructions.
 - Rounds up `simd % 32` to a power of two and uses masking to avoid overwriting the destination.