### PR TITLE
gtests: graph: unit: fix omp oversubscription for mqa decomp test

### DIFF
--- a/tests/gtests/graph/unit/backend/dnnl/test_mqa_decomp.cpp
+++ b/tests/gtests/graph/unit/backend/dnnl/test_mqa_decomp.cpp
@@ -168,11 +168,19 @@ TEST(test_mqa_decomp_execute, Bf16MqaDecomp_CPU) {
 }
 
 // Test multiple thread execute
-TEST(test_mqa_decomp_execute, MultithreaMqaDecomp_CPU) {
+TEST(test_mqa_decomp_execute, MultithreadMqaDecomp_CPU) {
     graph::engine_t *eng = get_engine();
 
     SKIP_IF(eng->kind() == graph::engine_kind::gpu,
             "Skip for GPU - not supported yet.");
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_OMP
+    // 4 concurrent threads will be executed below. Limiting the number of OMP
+    // threads to avoid oversubscription.
+    const int nthr = dnnl_get_current_num_threads() / 4;
+    SKIP_IF(nthr == 0, "skip as not enough threads for test");
+    omp_set_num_threads(nthr);
+#endif
 
     int batch_size = 56;
     graph::graph_t g(eng->kind());


### PR DESCRIPTION
Noticed in GNR tests:

```
190/210 Test #190: test_graph_unit_dnnl_mqa_decomp_cpu .............................Child aborted***Exception:   3.47 sec
Note: Google Test filter = test_mqa_decomp*:-*_GPU*
[==========] Running 5 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 5 tests from test_mqa_decomp_execute
[ RUN      ] test_mqa_decomp_execute.F32MqaDecomp_CPU
[       OK ] test_mqa_decomp_execute.F32MqaDecomp_CPU (176 ms)
[ RUN      ] test_mqa_decomp_execute.Bf16MqaDecomp_CPU
[       OK ] test_mqa_decomp_execute.Bf16MqaDecomp_CPU (60 ms)
[ RUN      ] test_mqa_decomp_execute.MultithreaMqaDecomp_CPU
OMP: Error #34: System unable to allocate necessary resources for OMP thread:
OMP: System error #11: Resource temporarily unavailable
OMP: Hint Try decreasing the value of OMP_NUM_THREADS.
```

The fix was applied to another test case in #5136 .