### PR TITLE
benchdnn: matmul: drop stale select src2-broadcast notes

### DIFF
--- a/tests/benchdnn/doc/knobs_attr.md
+++ b/tests/benchdnn/doc/knobs_attr.md
@@ -336,9 +336,6 @@ the third tensor is fixed at `s8`.
 dimensions of the conditional (third) tensor, so it may be broadcast against the
 destination: `common` (`mask = 0`) is a single-value condition applied to the
 whole tensor, while unset (no `S2_MASK_INPUT`) spans the full destination shape.
-Note that a broadcast condition is only supported by the reference
-implementation; optimized implementations that cannot fuse it fall back to the
-reference path.
 
 ### Prelu
 `PRELU` post operation kind applies forward algorithm to the operations result

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -305,9 +305,6 @@ attr_t::post_ops_t str2attr_post_ops(const std::string &s) {
             // In that case, we check for the ':' delimiter that separates src1
             // and src2 args, split the string for the two tensors and parse
             // them individually.
-            // TODO: Currently, there is no broadcasting support for the src2
-            // tensor - specifying src2 mask inputs and tags therefore has no
-            // effect on the operation.
 
             if (e.is_binary_kind_with_ternary_op()) {
                 src_delim = '.';


### PR DESCRIPTION
Follow-up cleanup on top of #5530: drop two stale notes about the select src2 condition that no longer match the code — a TODO comment in parser.cpp and a library-implementation note in the knobs_attr.md doc. Doc/comment only, no functional change.