### PR TITLE
Migrate all cpu-x64 kernels to sum injector

### DIFF
--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -74,7 +74,7 @@ jit_brdgmm_kernel_base_t<Wmm>::jit_brdgmm_kernel_base_t(
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
                         this, brg.attr()->post_ops_, bsp,
-                        /* enable_native_sum = */ brg.with_sum);
+                        /* inject_sum = */ brg.with_sum);
 
         with_binary_non_scalar_bcast_
                 = binary_injector::any_binary_postop_rhs_non_scalar_broadcast(

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -73,7 +73,8 @@ jit_brdgmm_kernel_base_t<Wmm>::jit_brdgmm_kernel_base_t(
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                        this, brg.attr()->post_ops_, bsp);
+                        this, brg.attr()->post_ops_, bsp,
+                        /* enable_native_sum = */ brg.with_sum);
 
         with_binary_non_scalar_bcast_
                 = binary_injector::any_binary_postop_rhs_non_scalar_broadcast(
@@ -282,81 +283,26 @@ void jit_brdgmm_kernel_base_t<Wmm>::apply_post_ops(
         vmm_idxs_param.insert(vmm_idx);
     }
 
-    if (brg.with_binary) {
-        reg_binary_params.restore();
+    if (brg.with_binary) reg_binary_params.restore();
 
-        if (with_binary_non_scalar_bcast_) {
-
-            for_(int v_i = 0; v_i < v_substep; ++v_i)
-            for_(int m_i = 0; m_i < m_blocks; m_i++)
-            for (int n_i = 0; n_i < n_blocks; n_i++) {
-                const int substep_simd = get_substep_simd(n_i, v_i, has_n_tail);
-                if (substep_simd <= 0) continue;
-                const auto vmm_idx
-                        = accm(m_blocks, n_blocks, m_i, n_i, v_i).getIdx();
-                rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_aux_D);
-                rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
-                        vmm_idx, D_offset(m_i, n_i, v_i));
-
-                if (n_i + 1 == n_blocks && has_n_tail && substep_simd < simd_w_)
-                    rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
-            }
-        }
-    }
-
-    const auto sum_injector = [&] {
-        const float *p_sum_scale = &brg.sum_scale;
-        const int32_t *p_sum_zp = &brg.sum_zp;
-        const bool p_sum_scale_reg_set = *p_sum_scale != 1.f;
-        const bool p_sum_zp_reg_set = *p_sum_zp != 0;
-
-        const reg64_savable_guard_t register_guard_sum(
-                {{{&reg_ptr_sum_scale},
-                         with_binary_non_scalar_bcast_ && p_sum_scale_reg_set},
-                        {{&reg_ptr_sum_zp}, p_sum_zp_reg_set}});
-
-        if (p_sum_scale_reg_set)
-            mov(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
-
-        auto vmm_sum_zp = vmm_tmp(0);
-        if (p_sum_zp_reg_set) {
-            mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-            if (is_superset(brg.isa_impl, avx512_core)) {
-                vcvtdq2ps(vmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
-            } else {
-                uni_vpbroadcastd(vmm_sum_zp, ptr[reg_ptr_sum_zp]);
-                vcvtdq2ps(vmm_sum_zp, vmm_sum_zp);
-            }
-        }
-
+    // Sum post-op requires binary parameters to be set.
+    const bool set_for_binary
+            = brg.with_binary && with_binary_non_scalar_bcast_;
+    if (set_for_binary || brg.with_sum) {
+        for_(int v_i = 0; v_i < v_substep; ++v_i)
         for_(int m_i = 0; m_i < m_blocks; m_i++)
-        for_(int n_i = 0; n_i < n_blocks; n_i++)
-        for (int v_i = 0; v_i < v_substep; v_i++) {
+        for (int n_i = 0; n_i < n_blocks; n_i++) {
             const int substep_simd = get_substep_simd(n_i, v_i, has_n_tail);
             if (substep_simd <= 0) continue;
-            const auto vmm = accm(m_blocks, n_blocks, m_i, n_i, v_i);
-            const auto addr = ptr[reg_aux_D + D_offset(m_i, n_i, v_i)];
-            const auto vmm_prev_dst = vmm_tmp(1);
-            cvt2ps(brg.sum_dt, vmm_prev_dst, addr, substep_simd != simd_w_,
-                    false);
-            if (p_sum_zp_reg_set) vsubps(vmm_prev_dst, vmm_sum_zp);
-            if (!p_sum_scale_reg_set)
-                vaddps(vmm, vmm_prev_dst);
-            else {
-                if (is_superset(brg.isa_impl, avx512_core)) {
-                    vfmadd231ps(vmm, vmm_prev_dst, ptr_b[reg_ptr_sum_scale]);
-                } else {
-                    auto vmm_scale = vmm_bcast();
-                    uni_vpbroadcastd(vmm_scale, ptr[reg_ptr_sum_scale]);
-                    uni_vfmadd231ps(vmm, vmm_prev_dst, vmm_scale);
-                }
-            }
-        }
-    };
+            const auto vmm_idx
+                    = accm(m_blocks, n_blocks, m_i, n_i, v_i).getIdx();
+            rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_aux_D);
+            rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
+                    vmm_idx, D_offset(m_i, n_i, v_i));
 
-    if (brg.with_sum) {
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
+            if (n_i + 1 == n_blocks && has_n_tail && substep_simd < simd_w_)
+                rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
+        }
     }
 
     postops_injector_->compute_vector_range(vmm_idxs_param, rhs_arg_params);
@@ -1484,7 +1430,7 @@ void jit_brdgmm_kernel_base_t<Wmm>::generate() {
     add(rsp, regscratchpad_.Size());
     postamble();
 
-    if (brg.with_eltwise)
+    if (brg.with_eltwise || brg.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 
     if (is_fast_vnni_int8()) {

--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.hpp
@@ -77,12 +77,6 @@ struct jit_brdgmm_kernel_base_t : public jit_base_brgemm_kernel_t {
                 idx_vmm_zp_comp_ = aux_vmm_count_++;
                 if (!is_superset(brg.isa_impl, avx512_core))
                     idx_vmm_bcast_ = aux_vmm_count_++;
-            } else if (brg.with_sum
-                    && (!is_superset(brg.isa_impl, avx512_core))) {
-                const bool p_sum_scale_reg_set = brg.sum_scale != 1.f;
-                if (p_sum_scale_reg_set)
-                    idx_vmm_bcast_
-                            = aux_vmm_count_++; // need extra vmm for broadcast
             }
             compute_vmm_base_idx_ = aux_vmm_count_;
 
@@ -232,10 +226,6 @@ private:
     // so need to be savable or use other registers
     const injector_utils::reg64_savable_t reg_binary_params {
             regscratchpad_, abi_param1};
-    const injector_utils::reg64_savable_t reg_ptr_sum_scale {
-            regscratchpad_, r14, r27};
-    const injector_utils::reg64_savable_t reg_ptr_sum_zp {
-            regscratchpad_, rax, r28};
     const injector_utils::reg64_savable_t reg_s8s8_comp {
             regscratchpad_, r14, r29};
 

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -101,7 +101,7 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
 
             postops_injector_ = utils::make_unique<po_injector_t>(this,
                     brg.attr()->post_ops_, bsp, esp,
-                    /* enable_native_sum = */ brg.with_sum);
+                    /* inject_sum = */ brg.with_sum);
 
             using namespace dnnl::impl::cpu::binary_injector_utils;
             std::tie(with_binary_per_oc_bcast_, with_binary_per_oc_sp_bcast_,

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -99,8 +99,9 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
             esp.preserve_vmm = preserve_vmm;
             esp.preserve_p_table = false;
 
-            postops_injector_ = utils::make_unique<po_injector_t>(
-                    this, brg.attr()->post_ops_, bsp, esp);
+            postops_injector_ = utils::make_unique<po_injector_t>(this,
+                    brg.attr()->post_ops_, bsp, esp,
+                    /* enable_native_sum = */ brg.with_sum);
 
             using namespace dnnl::impl::cpu::binary_injector_utils;
             std::tie(with_binary_per_oc_bcast_, with_binary_per_oc_sp_bcast_,
@@ -180,7 +181,6 @@ private:
     const reg64_t reg_do_post_ops = rbx;
     const reg64_t reg_do_skip_accum = reg_do_post_ops;
     const reg64_t reg_tmp_gpr = rbx;
-    const reg64_t reg_ptr_sum_scale = rbx;
 
     const reg64_savable_t reg_zp_comp_a {regscratchpad_, rbx, r17};
     const reg64_savable_t reg_zp_a_values {regscratchpad_, rbx, r18};
@@ -188,7 +188,6 @@ private:
     const reg64_savable_t reg_zp_c_values {regscratchpad_, rbx, r20};
     const reg64_savable_t reg_src_scales_per_k {regscratchpad_, rbx, r21};
     const reg64_savable_t reg_per_mn_comp {regscratchpad_, rbx, r22};
-    const reg64_t reg_ptr_sum_zp = rbx;
     const reg64_t reg_converted_stride = rsi;
     const reg64_t reg_zp_comp_pad_a = rsi;
 
@@ -1049,75 +1048,25 @@ void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
     const auto ldb_pos = bi.ldi->pos(ldb);
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
 
-    if (brg.with_binary) {
-        if (handle_binary_po_offset_) {
-            for (auto bd = bd_start; bd < bd_finish; bd++) {
-                // We have no way to tell the injector to skip some vectors.
-                // Therefore, we must set parameters correctly for all registers.
-                // TODO: Make it possible to specify "skipped" vectors to injector
-                const auto idx = accm(bd).getIdx();
-                if (is_ld_tail) rhs_arg_params.vmm_tail_idx_.emplace(idx);
-                rhs_arg_params.vmm_idx_to_out_reg.emplace(idx, reg_D);
+    // Sum post-op requires binary parameters to be set.
+    const bool set_for_binary = brg.with_binary && handle_binary_po_offset_;
+    if (set_for_binary || brg.with_sum) {
+        for (auto bd = bd_start; bd < bd_finish; bd++) {
+            // We have no way to tell the injector to skip some vectors.
+            // Therefore, we must set parameters correctly for all registers.
+            // TODO: Make it possible to specify "skipped" vectors to injector
+            const auto idx = accm(bd).getIdx();
+            if (is_ld_tail) rhs_arg_params.vmm_tail_idx_.emplace(idx);
+            rhs_arg_params.vmm_idx_to_out_reg.emplace(idx, reg_D);
 
-                if (!is_out_bd(bi.bdi, bdb, bd)) continue;
+            // Rows that are not stored keep the default zero offset. Sum then
+            // reads the head of `reg_D`, which stays in bounds, and the result
+            // is dropped along with the accumulator.
+            if (!is_out_bd(bi.bdi, bdb, bd)) continue;
 
-                const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
-                rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
-                        idx, d_offset);
-            }
+            const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
+            rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(idx, d_offset);
         }
-    }
-
-    const auto sum_injector = [&] {
-        const float *p_sum_scale = &brg.sum_scale;
-        const int32_t *p_sum_zp = &brg.sum_zp;
-        const bool p_sum_scale_reg_set = *p_sum_scale != 1.f;
-        const bool p_sum_zp_reg_set = *p_sum_zp != 0;
-
-        {
-            const auto &zmm_sum_zp = zmm_tmp_2();
-            if (p_sum_zp_reg_set) {
-                mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-                vcvtdq2ps(zmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
-            }
-            if (p_sum_scale_reg_set)
-                mov(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
-
-            const auto k_mask = (!is_ld_tail) ? ld_full_mask : ld_tail_mask;
-            const auto zmm_prev_dst = Xbyak::Zmm(0);
-
-            const auto max_d_offset = [&]() {
-                dim_t result = 0;
-                for (auto bd = bd_start; bd < bd_finish; bd++) {
-                    if (!is_out_bd(bi.bdi, bdb, bd)) continue;
-                    result = nstl::max(result, D_offset(bi, bdb, bd, ldb_pos));
-                }
-                return result;
-            }();
-            reg64_savable_guard_t reg_A_guard(
-                    {&reg_long_offt}, max_d_offset > INT_MAX);
-
-            for (auto bd = bd_start; bd < bd_finish; bd++) {
-                if (!is_out_bd(bi.bdi, bdb, bd)) continue;
-
-                auto zmm = accm(bd);
-                const auto d_offset = D_offset(bi, bdb, bd, ldb_pos);
-                auto addr = EVEX_compress_addr_safe(
-                        reg_D, d_offset, reg_long_offt);
-
-                cvt2ps(brg.sum_dt, zmm_prev_dst, addr, true, false, k_mask);
-                if (p_sum_zp_reg_set) vsubps(zmm_prev_dst, zmm_sum_zp);
-                if (!p_sum_scale_reg_set)
-                    vaddps(zmm, zmm_prev_dst);
-                else
-                    vfmadd231ps(zmm, zmm_prev_dst, zword_b[reg_ptr_sum_scale]);
-            }
-        }
-    };
-
-    if (brg.with_sum) {
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
     }
 
     // Using knowledge how "accm" assign zmm registers.
@@ -3282,7 +3231,7 @@ void jit_brgemm_amx_uker_base_t::generate() {
 
     postamble();
 
-    if (brg.with_eltwise)
+    if (brg.with_eltwise || brg.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 
     if (brg.is_fp8_via_convert()) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -126,7 +126,7 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
 
             postops_injector_ = utils::make_unique<po_injector_t>(this,
                     brg.attr()->post_ops_, bsp,
-                    /* enable_native_sum = */ brg.with_sum);
+                    /* inject_sum = */ brg.with_sum);
 
             with_binary_non_scalar_bcast_ = binary_injector::
                     any_binary_postop_rhs_non_scalar_broadcast(

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -108,7 +108,9 @@ gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, post_ops, binary_static_params, eltwise_static_params);
+                // Sum is applied in the kernel's own store sequence.
+                this, post_ops, binary_static_params, eltwise_static_params,
+                /* inject_sum = */ false);
 #undef PARAM_OFF
     }
 

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -137,9 +137,11 @@ template <typename Vmm>
 jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
-        const eltwise_injector::static_params_t &eltwise_static_params)
+        const eltwise_injector::static_params_t &eltwise_static_params,
+        bool enable_native_sum)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-              eltwise_static_params, lambda_jit_injectors_t()) {}
+              eltwise_static_params, lambda_jit_injectors_t(),
+              enable_native_sum) {}
 
 template <typename Vmm>
 void jit_uni_postops_injector_t<Vmm>::compute_vector_range(size_t start_idx,

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -50,13 +50,11 @@ jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params,
-        const lambda_jit_injectors_t &lambda_jit_injectors,
-        bool enable_native_sum)
+        bool inject_sum)
     : post_ops_(post_ops)
     , host_(host)
     , binary_injector_(nullptr)
-    , lambda_jit_injectors_(lambda_jit_injectors)
-    , sum_is_native_(enable_native_sum) {
+    , inject_sum_(inject_sum) {
 
     const auto &esp = eltwise_static_params;
     bool is_like_binary = false;
@@ -92,16 +90,15 @@ jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
                 injector opmask. Otherwise eltwise injector will overwrite \
                 binary tail opmask.");
 
-    // Native sum reads the previous value through the binary injector's load
-    // path so the binary injector is created for a sum-only chain as well.
+    // The sum injector reads the previous value through the binary injector's
+    // load path so the binary injector is created for a sum-only chain as well.
     if (is_like_binary || is_sum)
         binary_injector_ = utils::make_unique<
                 binary_injector::jit_uni_binary_injector_t<Vmm>>(
                 host, binary_static_params);
 
-    // Build one sum injector per sum post-op when the caller opted in to
-    // native sum.
-    if (is_sum && sum_is_native_) {
+    // Build one sum injector per sum post-op when the caller asked for it.
+    if (is_sum && inject_sum_) {
         const auto &rhs = binary_static_params.rhs_arg_static_params;
         const auto dst_dt = rhs.dst_d.data_type();
         for (int i = 0; i < post_ops.len(); i++) {
@@ -120,28 +117,9 @@ template <typename Vmm>
 jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
         const binary_injector::static_params_t &binary_static_params,
-        bool enable_native_sum)
+        bool inject_sum)
     : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-              eltwise_injector::static_params_t(), lambda_jit_injectors_t(),
-              enable_native_sum) {}
-
-template <typename Vmm>
-jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
-        jit_generator_t *host, const post_ops_t &post_ops,
-        const binary_injector::static_params_t &binary_static_params,
-        const lambda_jit_injectors_t &lambda_jit_injectors)
-    : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-              eltwise_injector::static_params_t(), lambda_jit_injectors) {}
-
-template <typename Vmm>
-jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
-        jit_generator_t *host, const post_ops_t &post_ops,
-        const binary_injector::static_params_t &binary_static_params,
-        const eltwise_injector::static_params_t &eltwise_static_params,
-        bool enable_native_sum)
-    : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
-              eltwise_static_params, lambda_jit_injectors_t(),
-              enable_native_sum) {}
+              eltwise_injector::static_params_t(), inject_sum) {}
 
 template <typename Vmm>
 void jit_uni_postops_injector_t<Vmm>::compute_vector_range(size_t start_idx,
@@ -178,13 +156,12 @@ void jit_uni_postops_injector_t<Vmm>::compute_vector_range(
             // Ternary op handles two arguments at the same time, thus,
             // skipping one more.
             if (post_op.is_binary_with_ternary_op()) ++rhs_arg_idx;
-        } else if (sum_is_native_ && post_op.is_sum(false, false)) {
+        } else if (inject_sum_ && post_op.is_sum(false, false)) {
             idx_to_sum_injector_.at(i).compute_vector_range(
                     vmm_idxs, rhs_arg_params);
-        } else {
-            const auto lam = lambda_jit_injectors_.find(post_op.kind);
-            if (lam != lambda_jit_injectors_.end()) lam->second();
         }
+        // A sum entry falls through when `inject_sum_` is unset. The kernel
+        // applies it itself in that case.
     }
 }
 template <typename Vmm>
@@ -200,7 +177,7 @@ void jit_uni_postops_injector_t<Vmm>::prepare_table(bool gen_table) {
 
     // Sum injectors emit their scale/zero-point constants here, similar to the
     // eltwise loop above.
-    if (sum_is_native_)
+    if (inject_sum_)
         for (auto &kv : idx_to_sum_injector_)
             kv.second.prepare_table(gen_table);
 }
@@ -214,12 +191,6 @@ void jit_uni_postops_injector_t<Vmm>::compute_vector(size_t idx,
 template <typename Vmm>
 void jit_uni_postops_injector_t<Vmm>::compute_vector(size_t idx) {
     compute_vector_range({idx});
-}
-
-template <typename Vmm>
-void jit_uni_postops_injector_t<Vmm>::set_lambda_injector(
-        dnnl_primitive_kind_t kind, const std::function<void()> &jit_injector) {
-    lambda_jit_injectors_[kind] = jit_injector;
 }
 
 post_ops_ok_args_t::post_ops_ok_args_t(const cpu_isa_t isa,
@@ -253,8 +224,9 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
             = post_ops_ok_args.enabled_bcast_strategy;
 
     // Save scale and zero point of first sum postop in order to check that any
-    // subsequent sum postops have the same values. This check is necessary
-    // because there is only one lambda injector.
+    // subsequent sum postops have the same values. Callers that apply sum with
+    // a single set of constants ask for this check through
+    // `sum_requires_same_params`.
     const auto sum_idx = post_ops.find(primitive_kind::sum);
     const bool with_sum = sum_idx != -1;
     const auto &entry

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -287,6 +287,13 @@ bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
                     }
                     VCHECK_PO_INJ_BOOL(IMPLICATION(sum_at_pos_0_only, idx == 0),
                             "Unsupported sum position in post-ops");
+                    // The sum post-op reads the destination back.
+                    VCHECK_PO_INJ_BOOL(dst_d, VERBOSE_UNSUPPORTED_FORMAT_KIND);
+                    VCHECK_PO_INJ_BOOL(
+                            binary_injector::is_data_supported(isa,
+                                    post_ops.get_sum_dt(
+                                            dst_d->data_type(), idx)),
+                            VERBOSE_ISA_DT_MISMATCH);
                     return true;
                 case eltwise:
                     if (!entry.is_eltwise()) continue;

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -16,7 +16,6 @@
 #ifndef CPU_X64_INJECTORS_JIT_UNI_POSTOPS_INJECTOR_HPP
 #define CPU_X64_INJECTORS_JIT_UNI_POSTOPS_INJECTOR_HPP
 
-#include <functional>
 #include <map>
 #include <memory>
 
@@ -36,16 +35,6 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 namespace injector {
-
-/*
- * Allows specifying custom injector function for given post-op type - one
- * function per primitive. There are post-ops type (example: sum) that don't
- * have specialized injector. They heavily rely on kernel specific intrnals,
- * which makes the generalization unreasonable. As so user can prepare internal
- * kernel lambda and pass it explicitly to injector.
- */
-using lambda_jit_injectors_t
-        = std::map<dnnl_primitive_kind_t, std::function<void()>>;
 
 size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd);
 
@@ -67,35 +56,27 @@ public:
      * see: jit_uni_binary_injector.hpp for more info.
      * @param eltwise_static_params <optional> - allows user specify non default
      * params for eltwise_injector
-     * @param lambda_jit_injectors <optional> - allows user specify custom injector
-     * function for given post-op type
-     * @param enable_native_sum <optional> - handle the sum post-op inside the
-     * injector instead of through a caller-provided lambda. Native sum reads
-     * the previous value from the address supplied per accumulator in
-     * `rhs_arg_dynamic_params_t`, so the caller must provide it (as it does for
-     * binary post-ops).
+     * @param inject_sum <required> - whether the injector applies the sum
+     * post-op. Whether the chain holds a sum entry is visible in `post_ops`,
+     * but whether this kernel wants the injector to act on it is not. Some
+     * kernels apply sum manually and pass the entry along only so the rest of
+     * the chain is handled. Those must pass `false`, otherwise the value is
+     * summed twice. The argument is mandatory so that the intent is stated at
+     * every call site. When set, the injector reads the previous value from the
+     * address supplied per accumulator in `rhs_arg_dynamic_params_t`, so the
+     * caller must provide it, as it does for binary post-ops.
      */
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
-            bool enable_native_sum = false);
-    jit_uni_postops_injector_t(jit_generator_t *host,
-            const post_ops_t &post_ops,
-            const binary_injector::static_params_t &binary_static_params,
-            const lambda_jit_injectors_t &lambda_jit_injectors);
-    jit_uni_postops_injector_t(jit_generator_t *host,
-            const post_ops_t &post_ops,
-            const binary_injector::static_params_t &binary_static_params,
-            const eltwise_injector::static_params_t &eltwise_static_params,
-            bool enable_native_sum = false);
-    // This is the delegation target for the other constructors, since it owns
+            bool inject_sum);
+    // This is the delegation target for the other constructor, since it owns
     // all construction state.
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
             const eltwise_injector::static_params_t &eltwise_static_params,
-            const lambda_jit_injectors_t &lambda_jit_injectors,
-            bool enable_native_sum = false);
+            bool inject_sum);
 
     // Generates code of post_ops chain injected to host primitive. Applied to
     // ordered set of vector registers' indexes.
@@ -120,8 +101,6 @@ public:
 
     // Thin wrapper for eltwise injector specific function
     void prepare_table(bool gen_table);
-    void set_lambda_injector(lambda_jit_injectors_t::key_type,
-            const lambda_jit_injectors_t::mapped_type &jit_injector);
 
 private:
     post_ops_t post_ops_;
@@ -135,9 +114,8 @@ private:
     // do not own it. Keep `idx_to_sum_injector_` after the `binary_injector_`
     // field, just in case.
     std::map<int, jit_uni_sum_injector_t<Vmm>> idx_to_sum_injector_;
-    lambda_jit_injectors_t lambda_jit_injectors_;
-    // When set, a sum entry is handled by the sum injector instead of a lambda.
-    const bool sum_is_native_;
+    // When unset, a sum entry is skipped because the kernel applies it itself.
+    const bool inject_sum_;
 };
 
 enum post_op_type { sum = 0, eltwise, binary, prelu };

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -86,7 +86,8 @@ public:
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
             const binary_injector::static_params_t &binary_static_params,
-            const eltwise_injector::static_params_t &eltwise_static_params);
+            const eltwise_injector::static_params_t &eltwise_static_params,
+            bool enable_native_sum = false);
     // This is the delegation target for the other constructors, since it owns
     // all construction state.
     jit_uni_postops_injector_t(jit_generator_t *host,

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -38,7 +38,10 @@ template <typename Vmm>
 std::shared_ptr<void> create_injector(jit_generator_t &gen,
         const post_ops_t &post_ops,
         const binary_injector::static_params_t &bsp) {
-    return std::make_shared<injector_t<Vmm>>(&gen, post_ops, bsp);
+    // The IR path rejects a sum post-op during dispatch, so the injector
+    // never has one to apply.
+    return std::make_shared<injector_t<Vmm>>(
+            &gen, post_ops, bsp, /* inject_sum = */ false);
 }
 
 template <typename Vmm>

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -66,7 +66,8 @@ jit_avx2_1x1_conv_kernel_f32_t::jit_avx2_1x1_conv_kernel_f32_t(
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Ymm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
 }
 

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -71,7 +71,8 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Ymm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
 }
 

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -69,7 +69,8 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
 }
 

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -115,7 +115,8 @@ jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
 }
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -64,7 +64,7 @@ jit_avx512_core_amx_1x1_fwd_kernel_t::jit_avx512_core_amx_1x1_fwd_kernel_t(
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(this,
                 jcp.post_ops, static_params,
-                /* enable_native_sum = */ is_sum_via_postops());
+                /* inject_sum = */ is_sum_via_postops());
     }
 }
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -62,8 +62,9 @@ jit_avx512_core_amx_1x1_fwd_kernel_t::jit_avx512_core_amx_1x1_fwd_kernel_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, jcp.post_ops, static_params);
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(this,
+                jcp.post_ops, static_params,
+                /* enable_native_sum = */ is_sum_via_postops());
     }
 }
 
@@ -203,38 +204,12 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::cvt2ps(data_type_t type_in,
     if (utils::one_of(type_in, s32, s8, u8)) vcvtdq2ps(zmm_in, zmm_in);
 }
 
-void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_sum(const Zmm zmm_out,
-        const float *p_sum_scale, const int32_t *p_sum_zp,
-        const Xbyak::Address &addr, const bool mask_flag) {
-    if (p_sum_scale) {
-        const auto p_sum_scale_val = *p_sum_scale;
-        const auto p_sum_zp_val = *p_sum_zp;
-        const auto sum_injector
-                = [&, zmm_out, p_sum_scale_val, p_sum_zp_val, mask_flag]() {
-            cvt2ps(jcp.sum_dt, zmm_prev_dst, addr, mask_flag);
-            if (p_sum_zp_val != 0) {
-                vcvtdq2ps(zmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
-                vsubps(zmm_prev_dst, zmm_sum_zp);
-            }
-            if (p_sum_scale_val == 1.f)
-                vaddps(zmm_out, zmm_prev_dst);
-            else
-                vfmadd231ps(zmm_out, zmm_prev_dst, zword_b[reg_ptr_sum_scale]);
-        };
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-}
-
-void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_postops(const Zmm zmm_out,
-        const float *p_sum_scale, const int32_t *p_sum_zp,
-        const Xbyak::Address &addr, const size_t off, const bool mask_flag) {
-    if (jcp.with_eltwise || jcp.with_binary
-            || (jcp.with_sum && p_sum_scale != nullptr)) {
-        apply_sum(zmm_out, p_sum_scale, p_sum_zp, addr, mask_flag);
-
+void jit_avx512_core_amx_1x1_fwd_kernel_t::apply_postops(
+        const Zmm zmm_out, const size_t off, const bool mask_flag) {
+    if (jcp.with_eltwise || jcp.with_binary || is_sum_via_postops()) {
         const auto vmm_idx = zmm_out.getIdx();
-        if (jcp.with_binary) {
+        // Sum post-op requires binary parameters to be set.
+        if (jcp.with_binary || is_sum_via_postops()) {
             binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
             rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, out_ptr);
             rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(vmm_idx, off);
@@ -427,22 +402,6 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
 
     const bool mask_flag
             = last_oc_block_flag_ && ocb == (jcp.nb_oc_blocking - 1);
-    const auto &p = attr_.post_ops_;
-    const int sum_idx = p.find(primitive_kind::sum);
-    const float *p_sum_scale = nullptr;
-    const int32_t *p_sum_zp = nullptr;
-    if (sum_idx != -1) {
-        const auto &p_entry = p.entry_[sum_idx];
-        p_sum_scale = &p_entry.sum.scale;
-        p_sum_zp = &p_entry.sum.zero_point;
-    }
-
-    if (p_sum_scale) {
-        if (*p_sum_scale != 1.f)
-            mov(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
-        if (*p_sum_zp != 0)
-            mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-    }
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
@@ -481,7 +440,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
         vaddps(zmm_out_msk, zmm_out, zmm_bias);
     }
 
-    apply_postops(zmm_out, p_sum_scale, p_sum_zp, addr, off, mask_flag);
+    apply_postops(zmm_out, off, mask_flag);
 
     if (jcp.with_dst_scales) {
         mov(reg_ptr_dst_scales, ptr[param1 + GET_OFF(dst_scales)]);
@@ -593,9 +552,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_bf16(
             vaddps(zmm_mask(zmm_out, mask_flag), bias_addr);
     }
 
-    static constexpr auto skip_sum_in_injection = nullptr;
-    apply_postops(zmm_out, skip_sum_in_injection, skip_sum_in_injection, addr,
-            off, mask_flag);
+    apply_postops(zmm_out, off, mask_flag);
 
     if (jcp.dst_dt == data_type::bf16) {
         store_output_ymm_bf16(zmm_out.getIdx(), addr, mask_flag);
@@ -920,7 +877,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::generate() {
     L(label_done);
     postamble();
 
-    if (jcp.with_eltwise)
+    if (jcp.with_eltwise || is_sum_via_postops())
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
@@ -145,12 +145,13 @@ private:
 
     void update_buffer_pointers();
     void interleave_store();
-    void apply_sum(const Xbyak::Zmm zmm_out, const float *p_sum_scale,
-            const int32_t *p_sum_zp, const Xbyak::Address &addr,
-            const bool mask_flag);
-    void apply_postops(const Xbyak::Zmm zmm_out, const float *p_sum_scale,
-            const int32_t *p_sum_zp, const Xbyak::Address &addr,
-            const size_t off, const bool mask_flag);
+    // Sum goes through the post-ops injector on the int8 single-row store path
+    // only. The bf16 path folds it into the accumulator by hand, see
+    // `store_output_vector_bf16`, and the `is_fast_postops` whole-tile paths
+    // bypass the injector altogether.
+    bool is_sum_via_postops() const { return jcp.with_sum && !is_bf16(); }
+    void apply_postops(
+            const Xbyak::Zmm zmm_out, const size_t off, const bool mask_flag);
     static bool is_fast_postops(const jit_conv_conf_t &jcp);
     void store_output_vectors_int8(int ocb, int osb);
     void store_output_vector_int8(

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -2486,7 +2486,6 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const int binary_ind = p.find(primitive_kind::binary);
     const int prelu_ind = p.find(primitive_kind::prelu);
     jcp.with_binary = !everyone_is(-1, binary_ind, prelu_ind);
-    jcp.sum_dt = p.get_sum_dt(jcp.dst_dt);
 
     jcp.post_ops = p;
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1095,8 +1095,9 @@ jit_avx512_core_amx_fwd_kernel_t::jit_avx512_core_amx_fwd_kernel_t(
                 this->param1, rhs_arg_static_params};
 
         postops_injector_ = utils::make_unique<
-                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, jcp.post_ops, static_params);
+                injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(this,
+                jcp.post_ops, static_params,
+                /* enable_native_sum = */ is_sum_via_postops());
     }
     copy_to_pbuffer_
             = utils::make_unique<jit_avx512_core_amx_copy_to_pbuffer_t>(jcp);
@@ -1381,38 +1382,12 @@ void jit_avx512_core_amx_fwd_kernel_t::cvt2ps(data_type_t type_in,
         vcvtdq2ps(zmm_in, zmm_in);
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::apply_sum(const Zmm &zmm_out,
-        const float *p_sum_scale, const int32_t *p_sum_zp,
-        const Xbyak::Address &addr, const bool mask_flag) {
-    if (p_sum_scale) {
-        const float p_sum_scale_val = *p_sum_scale;
-        const int32_t p_sum_zp_val = *p_sum_zp;
-        const auto sum_injector
-                = [&, p_sum_scale_val, p_sum_zp_val, mask_flag]() {
-            cvt2ps(jcp.sum_dt, zmm_prev_dst, addr, mask_flag);
-            if (p_sum_zp_val != 0) {
-                vcvtdq2ps(zmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
-                vsubps(zmm_prev_dst, zmm_sum_zp);
-            }
-            if (p_sum_scale_val == 1.f)
-                vaddps(zmm_out, zmm_prev_dst);
-            else
-                vfmadd231ps(zmm_out, zmm_prev_dst, zword_b[reg_ptr_sum_scale]);
-        };
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-}
-
-void jit_avx512_core_amx_fwd_kernel_t::apply_postops(const Zmm &zmm_out,
-        const float *p_sum_scale, const int32_t *p_sum_zp,
-        const Xbyak::Address &addr, const size_t off, const bool mask_flag) {
-    if (jcp.with_eltwise || jcp.with_binary
-            || (jcp.with_sum && p_sum_scale != nullptr)) {
-        apply_sum(zmm_out, p_sum_scale, p_sum_zp, addr, mask_flag);
-
+void jit_avx512_core_amx_fwd_kernel_t::apply_postops(
+        const Zmm &zmm_out, const size_t off, const bool mask_flag) {
+    if (jcp.with_eltwise || jcp.with_binary || is_sum_via_postops()) {
         const auto vmm_idx = zmm_out.getIdx();
-        if (jcp.with_binary) {
+        // Sum post-op requires binary parameters to be set.
+        if (jcp.with_binary || is_sum_via_postops()) {
             binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
             rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_out_ptr);
             rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(vmm_idx, off);
@@ -1464,9 +1439,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
             vaddps(zmm_mask(zmm_out, mask_flag), bias_addr);
     }
 
-    static constexpr auto skip_sum_injection = nullptr;
-    apply_postops(zmm_out, skip_sum_injection, skip_sum_injection, addr, off,
-            mask_flag);
+    apply_postops(zmm_out, off, mask_flag);
 
     if (jcp.dst_dt == data_type::bf16) {
         store_output_ymm_bf16(zmm_out.getIdx(), addr, mask_flag);
@@ -1485,23 +1458,6 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
 
     const auto off = get_out_row_offset(h, ocb, w, jcp.typesize_out);
     auto addr = EVEX_compress_addr(reg_out_ptr, off);
-
-    const auto &p = attr_.post_ops_;
-    const int sum_idx = p.find(primitive_kind::sum);
-    const float *p_sum_scale = nullptr;
-    const int32_t *p_sum_zp = nullptr;
-    if (sum_idx != -1) {
-        const auto &p_entry = p.entry_[sum_idx];
-        p_sum_scale = &p_entry.sum.scale;
-        p_sum_zp = &p_entry.sum.zero_point;
-    }
-
-    if (p_sum_scale) {
-        if (*p_sum_scale != 1.f)
-            mov(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
-        if (*p_sum_zp != 0)
-            mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-    }
 
     if (jcp.with_bias) {
         int bias_offset = jcp.typesize_bia * ocb * oc_block;
@@ -1549,7 +1505,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_bias) vaddps(zmm_out, zmm_out, zmm_bias);
 
-    apply_postops(zmm_out, p_sum_scale, p_sum_zp, addr, off, mask_flag);
+    apply_postops(zmm_out, off, mask_flag);
 
     if (jcp.with_dst_scales) {
         mov(reg_ptr_dst_scales, ptr[param1 + GET_OFF(dst_scales)]);
@@ -2136,7 +2092,7 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
 
     postamble();
 
-    if (jcp.with_eltwise)
+    if (jcp.with_eltwise || is_sum_via_postops())
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1097,7 +1097,7 @@ jit_avx512_core_amx_fwd_kernel_t::jit_avx512_core_amx_fwd_kernel_t(
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(this,
                 jcp.post_ops, static_params,
-                /* enable_native_sum = */ is_sum_via_postops());
+                /* inject_sum = */ is_sum_via_postops());
     }
     copy_to_pbuffer_
             = utils::make_unique<jit_avx512_core_amx_copy_to_pbuffer_t>(jcp);

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -309,9 +309,7 @@ private:
     const Xbyak::Reg64 reg_ptr_src_scales = r10;
     const Xbyak::Reg64 reg_ptr_wei_scales = r10;
     const Xbyak::Reg64 reg_ptr_dst_scales = r10;
-    const Xbyak::Reg64 reg_ptr_sum_scale = r9;
-    const Xbyak::Reg64 reg_ptr_sum_zp = abi_not_param1;
-    const Xbyak::Reg64 reg_aux_saturation = reg_ptr_sum_scale;
+    const Xbyak::Reg64 reg_aux_saturation = r9;
 
     const Xbyak::Reg64 reg_inp_stride = rbx;
     const Xbyak::Reg64 reg_wei_stride = rdx;
@@ -335,7 +333,6 @@ private:
     const Xbyak::Zmm &zmm_saturation = zmm_bias;
     const Xbyak::Zmm &zmm_zero = zmm30;
     const Xbyak::Zmm &zmm_prev_dst = zmm29;
-    const Xbyak::Zmm &zmm_sum_zp = zmm26;
     /* zero-point */
     const Xbyak::Zmm &zmm_zp = zmm29;
     const Xbyak::Zmm &zmm_src_zp = zmm28;
@@ -388,12 +385,14 @@ private:
             const Xbyak::Ymm &zmm_in, bool mask_flag, bool store = false);
     Xbyak::Zmm zmm_mask(
             const Xbyak::Zmm &zmm_in, bool mask_flag, bool store = false);
-    void apply_sum(const Xbyak::Zmm &zmm_out, const float *p_sum_scale,
-            const int32_t *p_sum_zp, const Xbyak::Address &addr,
-            const bool mask_flag);
-    void apply_postops(const Xbyak::Zmm &zmm_out, const float *p_sum_scale,
-            const int32_t *p_sum_zp, const Xbyak::Address &addr,
-            const size_t off, const bool mask_flag);
+    // Sum goes through the post-ops injector on the int8 store path only. The
+    // bf16 path folds it into the accumulator by hand, see
+    // `store_output_vector_bf16`.
+    bool is_sum_via_postops() const {
+        return jcp.with_sum && jcp.src_dt != data_type::bf16;
+    }
+    void apply_postops(
+            const Xbyak::Zmm &zmm_out, const size_t off, const bool mask_flag);
     inline void store_output_ymm_bf16(
             const int idx, const Xbyak::Address &addr, const bool mask_flag);
     void store_output_vector_bf16(

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -64,7 +64,8 @@ jit_avx512_core_bf16_1x1_conv_kernel_t::jit_avx512_core_bf16_1x1_conv_kernel_t(
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
 
     if (!isa_has_bf16(jcp.isa))

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -122,7 +122,9 @@ jit_avx512_core_bf16_fwd_kernel_vmm_t<
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                        this, jcp.post_ops, static_params);
+                        // Sum is folded into accumulator initialization.
+                        this, jcp.post_ops, static_params,
+                        /* inject_sum = */ false);
     }
     if (!isa_has_bf16(jcp.isa))
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -55,7 +55,8 @@ jit_avx512_dw_conv_fwd_kernel_bf16_t::jit_avx512_dw_conv_fwd_kernel_bf16_t(
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
     if (!isa_has_bf16(jcp.isa))
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -55,7 +55,8 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
 
     const io::jit_io_multi_dt_helper_t<Xbyak::Zmm>::data_types_t data_types {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -1008,7 +1008,6 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.bia_dt = jcp.with_bias ? cd.bias_desc.data_type : data_type::undef;
     jcp.dst_dt = cd.dst_desc.data_type;
-    jcp.sum_dt = post_ops.get_sum_dt(jcp.dst_dt);
 
     jcp.ic_block = jcp.oc_block = simd_w;
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -75,7 +75,7 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
                         this, jcp.post_ops, static_params,
-                        /* enable_native_sum = */ jcp.with_sum);
+                        /* inject_sum = */ jcp.with_sum);
     }
     if (jcp.dst_dt == data_type::bf16 && !isa_has_bf16(jcp.isa))
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -74,7 +74,8 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                        this, jcp.post_ops, static_params);
+                        this, jcp.post_ops, static_params,
+                        /* enable_native_sum = */ jcp.with_sum);
     }
     if (jcp.dst_dt == data_type::bf16 && !isa_has_bf16(jcp.isa))
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,
@@ -164,11 +165,6 @@ static void iterate(const int load_loop_blk, const int ur,
     }
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur,
-        const bool last_oc_block_flag, const F &f) {
-    iterate(load_loop_blk, ur, last_oc_block_flag, false, f);
-}
-template <typename F>
 static void iterate(const int load_loop_blk, const int ur, const F &f) {
     iterate(load_loop_blk, ur, false, false, f);
 }
@@ -197,46 +193,12 @@ Vmm jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::vreg_accum(
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_sum(
-        const int load_loop_blk, const int ur, const bool mask_flag_in,
-        const float *p_sum_scale, const int32_t *p_sum_zp) {
-    if (jcp.with_sum) {
-        const float sum_scale = *p_sum_scale;
-        const int32_t sum_zp = *p_sum_zp;
-        const auto sum_injector_lam
-                = [this, sum_scale, sum_zp, load_loop_blk](const bool mask_flag,
-                          const int i_load, const int i_ur) {
-            const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
-            cvt2ps(jcp.sum_dt, vmm_prev_dst, output_ptr(i_load, i_ur),
-                    mask_flag);
-            if (sum_zp != 0) vsubps(vmm_prev_dst, vmm_tmp);
-            if (sum_scale == 1.f)
-                vaddps(r, vmm_prev_dst);
-            else
-                vfmadd231ps(r, vmm_prev_dst, zword_b[reg_ptr_sum_scale]);
-        };
-        // Capture by value has to be applied since this lambda is called from
-        // a different context when stack values are unavailable.
-        const auto sum_injector
-                = [load_loop_blk, ur, mask_flag_in, sum_injector_lam]() {
-            iterate(load_loop_blk, ur, mask_flag_in, sum_injector_lam);
-        };
-        if (sum_zp != 0) vcvtdq2ps(vmm_tmp, ptr_b[rsp + reg_ptr_sum_zp_off]);
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-}
-
-template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
-        const int load_loop_blk, const int ur, const bool mask_flag_in,
-        const float *p_sum_scale, const int32_t *p_sum_zp) {
+        const int load_loop_blk, const int ur) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-
-        apply_sum(load_loop_blk, ur, mask_flag_in, p_sum_scale, p_sum_zp);
-
         injector_utils::vmm_index_set_t vmm_idxs;
-        if (jcp.with_binary) {
+        // Sum post-op requires binary parameters to be set.
+        if (jcp.with_binary || jcp.with_sum) {
             binary_injector::rhs_arg_dynamic_params_t rhs_arg_params,
                     rhs_arg_params_tail;
             const auto mask_tail = jcp.oc_without_padding % jcp.load_block;
@@ -263,7 +225,10 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
             rhs_arg_params = rhs_arg_params_tail;
             rhs_arg_params.vmm_tail_idx_.clear();
 
-            mov(abi_param1, EVEX_compress_addr(rsp, reg_abi_param1_backup));
+            // Only the binary injector reads the rhs arguments through
+            // `abi_param1`, and only then is the backup slot filled in.
+            if (jcp.with_binary)
+                mov(abi_param1, EVEX_compress_addr(rsp, reg_abi_param1_backup));
 
             Label postops_done;
             if (mask_tail || oc_blk_is_smaller_than_vmm) {
@@ -343,28 +308,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
     };
 
     auto store = [&](const bool mask_flag_in) {
-        const auto &p = attr_.post_ops_;
-        const int sum_idx = p.find(primitive_kind::sum);
-        const float *p_sum_scale = nullptr;
-        const int32_t *p_sum_zp = nullptr;
-        if (sum_idx != -1) {
-            p_sum_scale = &p.entry_[sum_idx].sum.scale;
-            p_sum_zp = &p.entry_[sum_idx].sum.zero_point;
-        }
-        const auto p_sum_scale_val = p_sum_scale ? *p_sum_scale : 1.f;
-        const auto p_sum_zp_val = p_sum_zp ? *p_sum_zp : 0;
-        const bool is_scale_or_zp_sum
-                = p_sum_zp_val != 0 || p_sum_scale_val != 1.f;
         mov(EVEX_compress_addr(rsp, reg_bcast_data_off), reg_bcast_data);
-        if (is_scale_or_zp_sum) {
-            mov(EVEX_compress_addr(rsp, reg_load_data_off), reg_load_data);
-            if (p_sum_zp_val != 0) {
-                mov(reg_load_data, p_sum_zp_val);
-                mov(ptr[rsp + reg_ptr_sum_zp_off], reg_load_data);
-            }
-            if (p_sum_scale_val != 1.f)
-                mov(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
-        }
         if (jcp.signed_input && (!jcp.has_vnni)) {
             mov(reg_scratch, float2int(jcp.wei_adj_scale));
         }
@@ -455,7 +399,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             }
         }
 
-        apply_postops(load_loop_blk, ur, mask_flag_in, p_sum_scale, p_sum_zp);
+        apply_postops(load_loop_blk, ur);
 
         if (jcp.with_dst_scales) {
             mov(reg_dst_scales, EVEX_compress_addr(rsp, reg_dst_scales_off));
@@ -561,8 +505,6 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             }
         }
         mov(reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
-        if (is_scale_or_zp_sum)
-            mov(reg_load_data, EVEX_compress_addr(rsp, reg_load_data_off));
     };
 
     auto compute = [this](Vmm vreg_acc, Vmm vreg_wei, Vmm vreg_src) {
@@ -742,13 +684,16 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
                     (1 << (load_dim_tail + jcp.load_block)) - 1);
             kmovd(k_load_dim_tail_mask_extended, reg_tail_32.cvt32());
         }
-    } else if (jcp.with_binary)
+    } else if (jcp.with_binary || jcp.with_sum) {
+        // Native sum reads the destination through the binary injector, so it
+        // needs `postops_mask` as well.
         if (jcp.oc_block != isa_simd_width_) {
             const int mask = (1 << jcp.oc_block) - 1;
             const Reg32 reg_tail_32 = reg_load_dim_tail_mask.cvt32();
             mov(reg_tail_32, mask);
             kmovw(postops_mask, reg_tail_32);
         }
+    }
 
     auto load_loop_body = [&](int load_loop_blk) {
         if (load_dim_tail) {
@@ -861,7 +806,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
 
     postamble();
 
-    if (jcp.with_eltwise)
+    if (jcp.with_eltwise || jcp.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -60,7 +60,6 @@ private:
     const Xbyak::Reg64 reg_ptr_saturation_ubound = r8;
     const Xbyak::Reg64 reg_output_data = r9;
     const Xbyak::Reg64 reg_load_data = r10;
-    const Xbyak::Reg64 reg_ptr_sum_scale = r10;
     const Xbyak::Reg64 reg_reduce_loop_work = r11;
     const Xbyak::Reg64 reg_bias_data = r12;
     const Xbyak::Reg64 reg_comp_data = r12;
@@ -92,7 +91,6 @@ private:
     const Vmm vmm_saturation = Vmm(28);
     const Vmm vmm_one = Vmm(29);
     const Vmm vmm_zero = Vmm(30);
-    const Vmm vmm_prev_dst = Vmm(30);
     const Vmm vmm_shift = Vmm(30);
     const Vmm vmm_bcast = Vmm(31);
     /* zero-point */
@@ -114,17 +112,15 @@ private:
     constexpr static int bcast_loop_work_off = 0;
     constexpr static int reg_bias_data_off = 1 * reg64_size_;
     constexpr static int reg_bcast_data_off = 2 * reg64_size_;
-    constexpr static int reg_load_data_off = 3 * reg64_size_;
-    constexpr static int reg_src_scales_off = 4 * reg64_size_;
-    constexpr static int reg_wei_scales_off = 5 * reg64_size_;
-    constexpr static int reg_dst_scales_off = 6 * reg64_size_;
-    constexpr static int reg_ptr_sum_zp_off = 7 * reg64_size_;
-    constexpr static int reg_comp_data_off = 8 * reg64_size_;
-    constexpr static int reg_zp_compensation_off = 9 * reg64_size_;
-    constexpr static int reg_src_zero_point_off = 10 * reg64_size_;
-    constexpr static int reg_dst_zero_point_off = 11 * reg64_size_;
-    constexpr static int reg_abi_param1_backup = 12 * reg64_size_;
-    constexpr static int stack_space_needed = 13 * reg64_size_;
+    constexpr static int reg_src_scales_off = 3 * reg64_size_;
+    constexpr static int reg_wei_scales_off = 4 * reg64_size_;
+    constexpr static int reg_dst_scales_off = 5 * reg64_size_;
+    constexpr static int reg_comp_data_off = 6 * reg64_size_;
+    constexpr static int reg_zp_compensation_off = 7 * reg64_size_;
+    constexpr static int reg_src_zero_point_off = 8 * reg64_size_;
+    constexpr static int reg_dst_zero_point_off = 9 * reg64_size_;
+    constexpr static int reg_abi_param1_backup = 10 * reg64_size_;
+    constexpr static int stack_space_needed = 11 * reg64_size_;
 
     inline Vmm maybe_mask_vmm(Vmm vmm, bool mask_flag) {
         return mask_flag ? vmm | k_load_dim_mask_extended : vmm;
@@ -140,12 +136,7 @@ private:
     Xbyak::Address output_ptr(const int i_load, const int i_ur);
     int vreg_accum_idx(const int load_loop_blk, int i_load, int i_ur) const;
     Vmm vreg_accum(const int load_loop_blk, int i_load, int i_ur) const;
-    void apply_sum(const int load_loop_blk, const int ur,
-            const bool mask_flag_in, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
-    void apply_postops(const int load_loop_blk, const int ur,
-            const bool mask_flag_in, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
+    void apply_postops(const int load_loop_blk, const int ur);
     void generate() override;
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -86,7 +86,7 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
                         this, jcp.post_ops, static_params,
-                        /* enable_native_sum = */ jcp.with_sum);
+                        /* inject_sum = */ jcp.with_sum);
     }
     if (!isa_has_bf16(jcp.isa) && jcp.dst_dt == data_type::bf16)
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -1593,7 +1593,6 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     const int sum_ind = post_ops.find(primitive_kind::sum);
     jcp.with_sum = sum_ind != -1;
-    jcp.sum_dt = post_ops.get_sum_dt(jcp.dst_dt);
 
     jcp.post_ops = post_ops;
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -85,7 +85,8 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                        this, jcp.post_ops, static_params);
+                        this, jcp.post_ops, static_params,
+                        /* enable_native_sum = */ jcp.with_sum);
     }
     if (!isa_has_bf16(jcp.isa) && jcp.dst_dt == data_type::bf16)
         bf16_emu_ = utils::make_unique<bf16_emulation_t>(this,
@@ -154,63 +155,17 @@ static void iterate(const int nb_oc_block, const int ur_w,
     }
 }
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w,
-        const bool last_oc_block_flag, const F &f) {
-    iterate(nb_oc_block, ur_w, last_oc_block_flag, false, f);
-}
-template <typename F>
 static void iterate(const int nb_oc_block, const int ur_w, const F &f) {
     iterate(nb_oc_block, ur_w, false, false, f);
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_sum(int ur_w,
-        bool last_oc_block_flag, const int nb_oc_block, const int oc_block,
-        const float *p_sum_scale, const int32_t *p_sum_zp) {
-    if (jcp.with_sum) {
-        const float sum_scale = *p_sum_scale;
-        const int32_t sum_zp = *p_sum_zp;
-        const auto sum_injector_lam
-                = [this, oc_block, sum_scale, sum_zp](
-                          const bool mask_flag, const int k, const int j) {
-            int aux_output_offset = jcp.typesize_out
-                    * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
-            auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
-            Vmm vmm = vmm_out(j, k);
-            cvt2ps(jcp.sum_dt, vmm_prev_dst, addr, mask_flag);
-            if (sum_zp != 0) vsubps(vmm_prev_dst, vmm_sum_zp);
-            if (sum_scale == 1.f)
-                vaddps(vmm, vmm_prev_dst);
-            else
-                vfmadd231ps(vmm, vmm_prev_dst, zword_b[reg_ptr_sum_scale]);
-        };
-        // Capture by value has to be applied since this lambda is called from
-        // a different context when stack values are unavailable.
-        const auto sum_injector
-                = [nb_oc_block, ur_w, last_oc_block_flag, sum_injector_lam]() {
-            iterate(nb_oc_block, ur_w, last_oc_block_flag, sum_injector_lam);
-        };
-        if (sum_scale != 1.f)
-            mov(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
-        if (sum_zp != 0) {
-            mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-            vcvtdq2ps(vmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
-        }
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-}
-
-template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
-        bool last_oc_block_flag, const int nb_oc_block, const int oc_block,
-        const float *p_sum_scale, const int32_t *p_sum_zp) {
+        bool last_oc_block_flag, const int nb_oc_block, const int oc_block) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-        apply_sum(ur_w, last_oc_block_flag, nb_oc_block, oc_block, p_sum_scale,
-                p_sum_zp);
-
         injector_utils::vmm_index_set_t vmm_idxs;
-        if (jcp.with_binary) {
+        // Sum post-op requires binary parameters to be set.
+        if (jcp.with_binary || jcp.with_sum) {
             binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
             const bool oc_blk_is_smaller_than_vmm = oc_block < isa_simd_width_;
             iterate(nb_oc_block, ur_w, last_oc_block_flag,
@@ -253,16 +208,6 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
     if (jcp.src_zero_point) {
         mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
-    }
-
-    const auto &p = attr_.post_ops_;
-    const int sum_idx = p.find(primitive_kind::sum);
-    const float *p_sum_scale = nullptr;
-    const int32_t *p_sum_zp = nullptr;
-    if (sum_idx != -1) {
-        const auto &p_entry = p.entry_[sum_idx];
-        p_sum_scale = &p_entry.sum.scale;
-        p_sum_zp = &p_entry.sum.zero_point;
     }
 
     for (int k = 0; k < nb_oc_block; k++) {
@@ -345,8 +290,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         }
     }
 
-    apply_postops(ur_w, last_oc_block_flag, nb_oc_block, oc_block, p_sum_scale,
-            p_sum_zp);
+    apply_postops(ur_w, last_oc_block_flag, nb_oc_block, oc_block);
 
     if (jcp.with_dst_scales) {
         mov(reg_dst_scales, ptr[param1 + GET_OFF(dst_scales)]);
@@ -1081,13 +1025,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
             mov(regw_tmp, (1 << (tail_size + jcp.simd_w)) - 1);
             kmovd(ktail_mask_extended, regw_tmp);
         }
-    } else if (jcp.with_binary)
+    } else if (jcp.with_binary || jcp.with_sum) {
+        // Native sum reads the destination through the binary injector, so it
+        // needs `postops_mask` as well.
         if (jcp.oc_block != isa_simd_width_) {
             const int mask = (1 << jcp.oc_block) - 1;
             const Reg32 regw_tmp = reg_oi.cvt32();
             mov(regw_tmp, mask);
             kmovw(postops_mask, regw_tmp);
         }
+    }
     if (jcp.is_fast_depthwise) {
         // prepare mask register for blending weights
         mov(reg_scratch, 0x8888444422221111);
@@ -1378,7 +1325,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
 
     postamble();
 
-    if (jcp.with_eltwise)
+    if (jcp.with_eltwise || jcp.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 
     if (jcp.is_fast_depthwise) {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -75,8 +75,6 @@ private:
     const Xbyak::Reg64 reg_ker = r9;
     const Xbyak::Reg64 reg_out = r10;
     const Xbyak::Reg64 aux_reg_inp = r11;
-    const Xbyak::Reg64 reg_ptr_sum_scale = r11;
-    const Xbyak::Reg64 reg_ptr_sum_zp = abi_not_param1;
     const Xbyak::Reg64 aux_reg_ker = r12;
     const Xbyak::Reg64 reg_compensation = r14;
     const Xbyak::Reg64 aux_reg_inp_d = r13;
@@ -114,11 +112,8 @@ private:
     /* used during bias section of store_output */
     const Vmm vmm_comp = Vmm(30); // only for signed input
     const Vmm vmm_bias = Vmm(31);
-    /* used during post_op sum section of store_output */
-    const Vmm vmm_prev_dst = Vmm(31);
     /* used during write-out section of store_output */
     const Vmm vmm_saturation = Vmm(30);
-    const Vmm vmm_sum_zp = Vmm(30);
     const Vmm vmm_zero = Vmm(31);
 
     /* used in compute_ker (but set during prepare_output) */
@@ -219,12 +214,8 @@ private:
     }
 
     void prepare_output(int ur_w);
-    void apply_sum(int ur_w, bool last_oc_block_flag, const int nb_oc_block,
-            const int oc_block, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
     void apply_postops(int ur_w, bool last_oc_block_flag, const int nb_oc_block,
-            const int oc_block, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
+            const int oc_block);
     void store_output(int ur_w, bool last_oc_block_flag);
     void compute_ker_dw(int ur_w, int pad_l, int pad_r,
             ic_block_t last_ic_block_flag, bool h_padded);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -69,7 +69,7 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
                         this, jcp.post_ops, bsp,
-                        /* enable_native_sum = */ jcp.with_sum);
+                        /* inject_sum = */ jcp.with_sum);
     }
 }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -68,7 +68,8 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                        this, jcp.post_ops, bsp);
+                        this, jcp.post_ops, bsp,
+                        /* enable_native_sum = */ jcp.with_sum);
     }
 }
 
@@ -1031,43 +1032,9 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
     }
     /* Do post-ops */
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-        const auto &p = attr_.post_ops_;
-        const int sum_idx = p.find(primitive_kind::sum);
-        const float *p_sum_scale
-                = (sum_idx != -1) ? &p.entry_[sum_idx].sum.scale : nullptr;
-        if (p_sum_scale && *p_sum_scale != 1.f)
-            mov(reg_ptr_sum_scale, (size_t)p_sum_scale);
-
-        const auto sum_injector = [&]() {
-            if (p_sum_scale) { // post_op: sum
-                for (int k = 0; k < jcp.nb_oc_blocking; k++) {
-                    const bool mask_flag
-                            = last_oc_block == 1 && k == jcp.nb_oc_blocking - 1;
-                    for (int j = 0; j < ur_w; j++) {
-                        int aux_output_offset = jcp.typesize_out
-                                * (k * jcp.oc_block
-                                        + j * jcp.oc_without_padding
-                                                * jcp.ngroups);
-                        auto addr = EVEX_compress_addr(
-                                reg_dst, aux_output_offset);
-                        const Vmm vmm = vmm_out(j, k);
-                        cvt2ps(jcp.dst_dt, vmm_prev_dst, addr, mask_flag);
-                        if (*p_sum_scale == 1.f)
-                            vaddps(vmm, vmm_prev_dst);
-                        else
-                            vfmadd231ps(vmm, vmm_prev_dst,
-                                    zword_b[reg_ptr_sum_scale]);
-                    }
-                }
-            }
-        };
-
-        if (p_sum_scale)
-            postops_injector_->set_lambda_injector(
-                    primitive_kind::sum, sum_injector);
-
         binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
-        if (jcp.with_binary) {
+        // Sum post-op requires binary parameters to be set.
+        if (jcp.with_binary || jcp.with_sum) {
             for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
                 const bool mask_flag
                         = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
@@ -1432,7 +1399,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
 
     postamble();
 
-    if (jcp.with_eltwise)
+    if (jcp.with_eltwise || jcp.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -115,7 +115,6 @@ private:
 
     const Xbyak::Reg64 reg_compensation = r14;
     const Xbyak::Reg64 reg_scratch = r14;
-    const Xbyak::Reg64 reg_ptr_sum_scale = r11;
     const Xbyak::Reg64 reg_overflow = rax;
     const Xbyak::Reg64 reg_comp_strides = reg_overflow;
     const Xbyak::Reg64 reg_ker_long_offt = r15;
@@ -139,7 +138,6 @@ private:
     const Vmm vmm_comp = Vmm(30);
     const Vmm vmm_bias = Vmm(31);
     const Vmm vmm_scale_adjust = Vmm(31);
-    const Vmm vmm_prev_dst = Vmm(31);
 
     Vmm vmm_out(int i_ur, int i_oc) {
         int idx = i_ur * jcp.nb_oc_blocking + i_oc;

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -99,8 +99,9 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         const eltwise_injector::static_params_t esp {
                 save_state, reserved_eltwise_gpr, reserved_eltwise_maskr};
 
-        postops_injector_ = utils::make_unique<po_injector_t>(
-                this, attr_.post_ops_, bsp, esp);
+        postops_injector_ = utils::make_unique<po_injector_t>(this,
+                attr_.post_ops_, bsp, esp,
+                /* enable_native_sum = */ brg_.with_sum);
     }
 
     inp_dt_ = brg_.dt_c;
@@ -186,58 +187,10 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<Vmm>::cvt2ps(
 template <typename Vmm>
 void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         Vmm>::inject_attr_postops(int m_block, int n_block, int tail /*= 0*/) {
-    const auto &p = attr_.post_ops_;
-    const int sum_idx = p.find(primitive_kind::sum);
-    const auto k_mask = tail == 0 ? k_full_mask : k_tail_mask;
-    const auto sum_dt = p.get_sum_dt(out_dt_);
-
-    const auto sum_injector = [&] {
-        const float *p_sum_scale = &p.entry_[sum_idx].sum.scale;
-        const int32_t *p_sum_zp = &p.entry_[sum_idx].sum.zero_point;
-        if (*p_sum_scale != 1.f) mov(reg_ptr_sum_scale, (size_t)p_sum_scale);
-        auto vmm_sum_zp = vmm_tmp(1);
-        if (*p_sum_zp != 0) {
-            mov(reg_ptr_sum_zp, (size_t)p_sum_zp);
-            if (is_superset(brg_.isa_impl, avx512_core)) {
-                vcvtdq2ps(vmm_sum_zp, ptr_b[reg_ptr_sum_zp]);
-            } else {
-                vpbroadcastd(vmm_sum_zp, ptr[reg_ptr_sum_zp]);
-                uni_vcvtdq2ps(vmm_sum_zp, vmm_sum_zp);
-            }
-        }
-
-        for_(int m = 0; m < m_block; m++)
-        for (int n = 0; n < n_block; n++) {
-            const auto vmm = vector(m, n, n_block);
-            const auto addr = ptr[aux_reg_out
-                    + out_typesize_ * (m * brg_.LDD + n * brg_.ld_block)];
-
-            const auto vmm_prev_dst = vmm_tmp(0);
-            cvt2ps(sum_dt, vmm_prev_dst, addr, tail, false, k_mask);
-            if (*p_sum_zp != 0)
-                uni_vsubps(vmm_prev_dst, vmm_prev_dst, vmm_sum_zp);
-            if (*p_sum_scale == 1.f)
-                uni_vaddps(vmm, vmm, vmm_prev_dst);
-            else {
-                if (is_superset(brg_.isa_impl, avx512_core)) {
-                    vfmadd231ps(vmm, vmm_prev_dst, ptr_b[reg_ptr_sum_scale]);
-                } else {
-                    auto vmm_sum_scale = vmm_tmp(2);
-                    vpbroadcastd(vmm_sum_scale, ptr[reg_ptr_sum_scale]);
-                    vfmadd231ps(vmm, vmm_prev_dst, vmm_sum_scale);
-                }
-            }
-        }
-    };
-
-    if (brg_.with_sum) {
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
 
-    if (with_binary_non_scalar_bcast_) {
+    // Sum post-op requires binary parameters to be set.
+    if (with_binary_non_scalar_bcast_ || brg_.with_sum) {
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
             const auto vmm_idx = vector(m, n, n_block).getIdx();

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -101,7 +101,7 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
 
         postops_injector_ = utils::make_unique<po_injector_t>(this,
                 attr_.post_ops_, bsp, esp,
-                /* enable_native_sum = */ brg_.with_sum);
+                /* inject_sum = */ brg_.with_sum);
     }
 
     inp_dt_ = brg_.dt_c;

--- a/src/cpu/x64/jit_brgemm_post_ops.hpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.hpp
@@ -143,9 +143,6 @@ private:
     const reg64_t reg_wei_scales = r9;
     const reg64_t aux_reg_wei_scales = r8;
 
-    const reg64_t reg_ptr_sum_scale = rdx;
-    const reg64_t reg_ptr_sum_zp = rsi;
-
     const reg64_t reg_zp_c_values = rbx;
     const reg64_t aux_reg_zp_c_values = rbx;
     const reg64_t reg_zp_a_comp = rbx;

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -353,8 +353,9 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<
                         typename cpu_isa_traits_t<isa>::Vmm>>(this,
+                        // Sum is applied in the kernel's own store sequence.
                         this->post_ops_, binary_static_params,
-                        eltwise_static_params);
+                        eltwise_static_params, /* inject_sum = */ false);
 
         using namespace dnnl::impl::cpu::binary_injector_utils;
         std::tie(any_binary_postop_is_no_bcast_type_,

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -198,7 +198,8 @@ jit_pp_ker_t::jit_pp_ker_t(
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Zmm>>(
-                this, jcp_.post_ops, static_params);
+                // Sum is applied in the kernel's own store sequence.
+                this, jcp_.post_ops, static_params, /* inject_sum = */ false);
     }
 }
 

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -506,7 +506,6 @@ struct jit_1x1_conv_conf_t {
     int is_oc_scale;
     data_type_t bia_dt;
     data_type_t dst_dt;
-    data_type_t sum_dt;
     bool signed_input;
     float wei_adj_scale;
     // zero-point compensation

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -950,7 +950,6 @@ struct jit_binary_conf_t {
     bool with_eltwise = false;
     bool with_binary = false;
     bool with_postops = false;
-    float sum_scale = 0.f;
     bool use_stride_src1 = false;
     bool broadcast_src1_value = false;
     bool use_stride_rhs_postops = false;

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -1011,7 +1011,6 @@ struct jit_reduction_conf_t {
     bool with_eltwise = false;
     bool with_binary = false;
     bool with_sum = false;
-    std::queue<float> sum_scales;
 };
 
 struct jit_uni_reduction_args_t {

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -663,7 +663,6 @@ struct jit_resampling_conf_t {
     bool with_eltwise = false;
     bool with_binary = false;
     bool with_sum = false;
-    std::queue<float> sum_scales;
 };
 
 struct jit_uni_resampling_args_t {

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -59,7 +59,8 @@ jit_sse41_1x1_conv_kernel_f32_t::jit_sse41_1x1_conv_kernel_f32_t(
                 this->param1, rhs_arg_static_params};
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Xmm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
 }
 

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -59,7 +59,8 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
 
         postops_injector_ = utils::make_unique<
                 injector::jit_uni_postops_injector_t<Xbyak::Xmm>>(
-                this, jcp.post_ops, static_params);
+                // Sum is folded into accumulator initialization.
+                this, jcp.post_ops, static_params, /* inject_sum = */ false);
     }
 }
 

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -187,7 +187,6 @@ status_t jit_uni_binary_t::pd_t::init(const engine_t *engine) {
     conf_.with_binary = po.find(primitive_kind::binary) != -1;
     conf_.with_postops
             = conf_.with_binary || conf_.with_eltwise || conf_.do_sum;
-    conf_.sum_scale = conf_.do_sum ? po.entry_[sum_idx].sum.scale : 0.f;
     const auto &bcast_dims = broadcast_dims();
     conf_.bcast_type = is_tensor_op() ? bcast_t::none
                                       : get_bcast_type(src1_md_, bcast_dims);

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -150,7 +150,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::init_post_ops_injector() {
 
     postops_injector_
             = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, po, bsp, esp, /* enable_native_sum = */ conf_.do_sum);
+                    this, po, bsp, esp, /* inject_sum = */ conf_.do_sum);
 }
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -150,69 +150,14 @@ void jit_uni_binary_kernel_t<isa, Vmm>::init_post_ops_injector() {
 
     postops_injector_
             = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, po, bsp, esp);
+                    this, po, bsp, esp, /* enable_native_sum = */ conf_.do_sum);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_kernel_t<isa, Vmm>::apply_postops(int unroll, bool tail) {
-    const auto sum_ne_xf16_injector = [&]() {
-        const Vmm vreg_dst_even_tmp = conf_.is_src_different_layouts
-                ? vmm_gathered_src_
-                : Vmm(unroll + vmm_start_idx_);
-        const Vmm vreg_dst_odd_tmp = Vmm(unroll + 1 + vmm_start_idx_);
-        const Vmm vmm_aux = vreg_saturation_ubound_;
-        for (int i = 0; i < unroll; i += 2) {
-            const bool can_load_two_simdw = unroll - i >= 2;
-            const int offt_base = simd_w_ * i;
-            const Vmm vreg_tmp_even_src0 = Vmm(i + vmm_start_idx_);
-            const Vmm vreg_tmp_odd_src0 = Vmm(i + 1 + vmm_start_idx_);
-            if (can_load_two_simdw) {
-                io_.at(conf_.dst_type)
-                        ->load_two_simdw_xf16(dst_ptr(offt_base
-                                                      * types::data_type_size(
-                                                              conf_.dst_type)),
-                                vreg_dst_even_tmp, vreg_dst_odd_tmp);
-                io_.at(conf_.dst_type)
-                        ->merge_interleaved_to_plain(
-                                vreg_dst_even_tmp, vreg_dst_odd_tmp, vmm_aux);
-            } else
-                io_.at(conf_.dst_type)
-                        ->load(dst_ptr(offt_base
-                                       * types::data_type_size(conf_.dst_type)),
-                                vreg_dst_even_tmp, false);
-            uni_vfmadd231ps(
-                    vreg_tmp_even_src0, vreg_dst_even_tmp, vreg_sum_scale_);
-            if (can_load_two_simdw)
-                uni_vfmadd231ps(
-                        vreg_tmp_odd_src0, vreg_dst_odd_tmp, vreg_sum_scale_);
-        }
-    };
-
-    const auto sum_injector = [&]() {
-        for (int i = 0; i < unroll; i++) {
-            const int offt = simd_w_ * i;
-            const Vmm vreg_tmp_src0 = Vmm(i + vmm_start_idx_);
-            const Vmm vreg_tmp = conf_.is_src_different_layouts
-                    ? vmm_gathered_src_
-                    : Vmm(unroll + i + vmm_start_idx_);
-            io_.at(conf_.dst_type)
-                    ->load(dst_ptr(offt
-                                   * types::data_type_size(conf_.dst_type)),
-                            vreg_tmp, tail);
-            uni_vfmadd231ps(vreg_tmp_src0, vreg_tmp, vreg_sum_scale_);
-        }
-    };
-
-    if (conf_.do_sum) {
-        if (is_ne_xf16_supported(isa, conf_.dst_type) && !tail)
-            postops_injector_->set_lambda_injector(
-                    primitive_kind::sum, sum_ne_xf16_injector);
-        else
-            postops_injector_->set_lambda_injector(
-                    primitive_kind::sum, sum_injector);
-    }
-
-    if (conf_.with_binary) {
+    // The sum post-op reads the destination through the same rhs parameters as
+    // a binary post-op, so they have to be filled for either one.
+    if (conf_.with_binary || conf_.do_sum) {
         binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
         const Reg64 &reg_offt_dst
                 = conf_.is_i8 ? reg_offt_dst_ : reg_offt_src0_;
@@ -241,9 +186,6 @@ void jit_uni_binary_kernel_t<isa, Vmm>::apply_postops(int unroll, bool tail) {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_kernel_t<isa, Vmm>::load_kernel_params() {
-    mov(reg_tmp_, float2int(conf_.sum_scale));
-    uni_vmovq(xreg_sum_scale_, reg_tmp_);
-    uni_vbroadcastss(vreg_sum_scale_, xreg_sum_scale_);
     if (is_src1_outer_dims_tail_)
         mov(reg_outer_dims_range_,
                 ptr[reg_param_ + PARAM_OFF(spat_offt_count)]);
@@ -779,7 +721,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::generate() {
         forward();
     postamble();
 
-    if ((conf_.with_eltwise || conf_.is_i8) && postops_injector_)
+    if ((conf_.with_eltwise || conf_.is_i8 || conf_.do_sum)
+            && postops_injector_)
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -108,8 +108,6 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     const Opmask cmp_mask = k3;
     const Opmask full_mask_ = k4;
     const Vmm vmm_tail_vmask_ = Vmm(0);
-    const Vmm vreg_sum_scale_ = Vmm(is_avx512 ? 17 : 9);
-    const Xmm xreg_sum_scale_ = Xmm(9);
     const Vmm vreg_zero_ = Vmm(is_avx512 ? 18 : 10);
     const Vmm vreg_one_ = Vmm(is_avx512 ? 19 : 11);
     const Vmm vreg_saturation_ubound_ = Vmm(is_avx512 ? 20 : 12);

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -57,7 +57,9 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<
                         typename cpu_isa_traits_t<isa>::Vmm>>(
-                        this, jcp.post_ops, static_params);
+                        // Sum is folded into accumulator initialization.
+                        this, jcp.post_ops, static_params,
+                        /* inject_sum = */ false);
     }
 }
 

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -144,8 +144,9 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, pd_->attr()->post_ops_, bsp, esp);
+                    injector::jit_uni_postops_injector_t<Vmm>>(this,
+                    pd_->attr()->post_ops_, bsp, esp,
+                    /* inject_sum = */ false);
         }
         preamble();
 

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -266,7 +266,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
 
             postops_injector_ = utils::make_unique<
                     injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, jpp.post_ops, bsp);
+                    this, jpp.post_ops, bsp, /* inject_sum = */ false);
         }
     }
 };

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -134,8 +134,9 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, pd_->attr()->post_ops_, bsp, esp);
+                    injector::jit_uni_postops_injector_t<Vmm>>(this,
+                    pd_->attr()->post_ops_, bsp, esp,
+                    /* inject_sum = */ false);
         }
         preamble();
 

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -566,8 +566,9 @@ protected:
                     get_supported_bcast_strategies(dst_d_.ndims()), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, pd_->attr()->post_ops_, bsp, esp);
+                    injector::jit_uni_postops_injector_t<Vmm>>(this,
+                    pd_->attr()->post_ops_, bsp, esp,
+                    /* inject_sum = */ false);
         }
         preamble();
 

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -104,7 +104,7 @@ jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                        this, jpp.post_ops, bsp);
+                        this, jpp.post_ops, bsp, /* inject_sum = */ false);
     }
 
     io::io_tail_conf_t io_tail_conf(jpp.c_block, tail_size,

--- a/src/cpu/x64/jit_uni_reduction.cpp
+++ b/src/cpu/x64/jit_uni_reduction.cpp
@@ -108,7 +108,6 @@ status_t jit_uni_reduction_t::pd_t::init(const engine_t *engine) {
             conf_.with_binary = true;
         } else if (entry.is_sum(require_scale_one) && entry.sum.scale != 0.f) {
             conf_.with_sum = true;
-            conf_.sum_scales.push(entry.sum.scale);
         }
     }
     conf_.with_postops

--- a/src/cpu/x64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.cpp
@@ -164,8 +164,9 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::init_post_ops_injector(
             reg_param_, get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 
     postops_injector_
-            = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, conf_.post_ops, bsp, esp);
+            = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(this,
+                    conf_.post_ops, bsp, esp,
+                    /* enable_native_sum = */ conf_.with_sum);
 }
 
 template <cpu_isa_t isa, typename Vmm>
@@ -346,40 +347,11 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::load_params() {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_reduction_kernel_t<isa, Vmm>::apply_sum(const int data_idx) {
-    if (conf_.with_sum) {
-        assert(!conf_.sum_scales.empty()
-                && "No scales for sum post operation.");
-        const auto sum_injector = [this, data_idx]() {
-            const Vmm vmm_prev_dst(vmm_tmp1_.getIdx());
-            const Vmm vmm_dst(data_idx);
-
-            io_store_.load(ptr[reg_dst_], vmm_prev_dst, true);
-            const float sum_scale = sum_scales_.front();
-            if (sum_scale == 1.f)
-                uni_vaddps(vmm_dst, vmm_dst, vmm_prev_dst);
-            else {
-                const Xmm xmm_sum_scale = Xmm(vmm_sum_scale_.getIdx());
-                mov(reg_tmp1_.cvt32(), float2int(sum_scale));
-                uni_vmovd(xmm_sum_scale, reg_tmp1_.cvt32());
-                uni_vbroadcastss(vmm_sum_scale_, xmm_sum_scale);
-                uni_vfmadd231ps(vmm_dst, vmm_prev_dst, vmm_sum_scale_);
-            }
-            sum_scales_.push(sum_scale);
-            sum_scales_.pop();
-        };
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-}
-
-template <cpu_isa_t isa, typename Vmm>
 void jit_uni_reduction_kernel_t<isa, Vmm>::apply_postops(const int data_idx) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
 
-    if (conf_.with_sum) apply_sum(data_idx);
-
-    if (conf_.with_binary) {
+    // Sum post-op requires binary parameters to be set.
+    if (conf_.with_binary || conf_.with_sum) {
         rhs_arg_params.vmm_idx_to_out_reg.emplace(data_idx, reg_dst_);
         rhs_arg_params.vmm_tail_idx_.emplace(data_idx);
     }
@@ -424,7 +396,7 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::generate() {
 
     postamble();
 
-    if (conf_.with_eltwise && postops_injector_)
+    if ((conf_.with_eltwise || conf_.with_sum) && postops_injector_)
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.cpp
@@ -164,9 +164,9 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::init_post_ops_injector(
             reg_param_, get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 
     postops_injector_
-            = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(this,
-                    conf_.post_ops, bsp, esp,
-                    /* enable_native_sum = */ conf_.with_sum);
+            = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
+                    this, conf_.post_ops, bsp, esp,
+                    /* inject_sum = */ conf_.with_sum);
 }
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/jit_uni_reduction_kernel.hpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.hpp
@@ -37,16 +37,13 @@ struct jit_uni_reduction_kernel_base_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_reduction)
 
     jit_uni_reduction_kernel_base_t(const jit_reduction_conf_t &conf)
-        : jit_generator_t(jit_name(), conf.isa)
-        , conf_(conf)
-        , sum_scales_(conf_.sum_scales) {}
+        : jit_generator_t(jit_name(), conf.isa), conf_(conf) {}
     ~jit_uni_reduction_kernel_base_t() override = default;
 
     virtual std::size_t get_simd_w() = 0;
 
 protected:
     const jit_reduction_conf_t &conf_;
-    std::queue<float> sum_scales_;
 };
 
 template <cpu_isa_t isa, typename Vmm = typename cpu_isa_traits_t<isa>::Vmm>
@@ -86,7 +83,6 @@ private:
     void reduce_ne_convert_xf16();
 
     void load_params();
-    void apply_sum(const int data_idx);
     void apply_postops(const int data_idx);
     void finalize();
     void generate() override;
@@ -100,7 +96,6 @@ private:
     const Vmm vmm_tmp2_ = Vmm(6);
     const Vmm vmm_tmp3_ = Vmm(7);
     const Vmm vmm_tmp4_ = Vmm(8);
-    const Vmm vmm_sum_scale_ = Vmm(9);
     const Vmm rhs_dt_helper_vmm_ = Vmm(10);
     const Xbyak::Zmm vmm_bf16_emu_1_ = Xbyak::Zmm(28);
     const Xbyak::Zmm vmm_bf16_emu_2_ = Xbyak::Zmm(29);
@@ -115,7 +110,6 @@ private:
     const Xbyak::Reg64 reg_dst_ = rdx;
     const Xbyak::Reg64 reg_param_ = abi_param1;
     const Xbyak::Reg64 reg_tmp_ = abi_not_param1;
-    const Xbyak::Reg64 reg_tmp1_ = r13;
 
     static constexpr bool is_zmm_ = std::is_same<Vmm, Xbyak::Zmm>::value;
     static constexpr bool is_ymm_ = std::is_same<Vmm, Xbyak::Ymm>::value;

--- a/src/cpu/x64/jit_uni_resampling.cpp
+++ b/src/cpu/x64/jit_uni_resampling.cpp
@@ -160,7 +160,6 @@ status_t jit_uni_resampling_fwd_t::pd_t::init(const engine_t *engine) {
             conf_.with_binary = true;
         } else if (entry.is_sum(require_scale_one) && entry.sum.scale != 0.f) {
             conf_.with_sum = true;
-            conf_.sum_scales.push(entry.sum.scale);
         }
     }
     conf_.with_postops

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -70,7 +70,8 @@ jit_uni_resampling_kernel_t<isa, Vmm>::jit_uni_resampling_kernel_t(
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                        this, conf_.post_ops, bsp);
+                        this, conf_.post_ops, bsp,
+                        /* enable_native_sum = */ conf_.with_sum);
 
         std::tie(any_binary_postop_is_per_oc_bcast_type_,
                 any_binary_postop_is_per_oc_sp_bcast_type_)
@@ -230,52 +231,6 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding_in_post_ops(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_resampling_kernel_t<isa, Vmm>::apply_sum(
-        const int data_idx, const bool is_tail, const size_t offset) {
-    if (conf_.with_sum) {
-        assert(!conf_.sum_scales.empty()
-                && "No scales for sum post operation.");
-        const auto sum_injector = [this, data_idx, is_tail, offset]() {
-            const Vmm vmm_prev_dst(vmm_tmp_.getIdx());
-            const Vmm vmm_dst(data_idx);
-
-            // Zeroing previous dst is needed to preserve zero padding.
-            if (is_tail && conf_.tag_kind == tag_kind::blocked)
-                uni_vxorps(vmm_prev_dst, vmm_prev_dst, vmm_prev_dst);
-
-            io_.at(conf_.dst_data_type)
-                    ->load(ptr[reg_dst_ + offset], vmm_prev_dst, is_tail);
-            const float sum_scale = sum_scales_.front();
-            if (sum_scale == 1.f)
-                uni_vaddps(vmm_dst, vmm_dst, vmm_prev_dst);
-            else {
-                const Xmm xmm_sum_scale = Xmm(vmm_sum_scale_.getIdx());
-
-                // If the algorithm used is the linear algorithm, and the shape
-                // has 5 dimensions, then we have not enough gpr registers to use
-                // tmp registers. Therefore, if there is a need to use them it is
-                // needed to save their state and restore it after execution of all
-                // needed operations.
-                if (conf_.alg == alg_kind::resampling_linear
-                        && conf_.ndims == 5)
-                    push(reg_tmp1_);
-                mov(reg_tmp1_.cvt32(), float2int(sum_scale));
-                uni_vmovd(xmm_sum_scale, reg_tmp1_.cvt32());
-                if (conf_.alg == alg_kind::resampling_linear
-                        && conf_.ndims == 5)
-                    pop(reg_tmp1_);
-                uni_vbroadcastss(vmm_sum_scale_, xmm_sum_scale);
-                uni_vfmadd231ps(vmm_dst, vmm_prev_dst, vmm_sum_scale_);
-            }
-            sum_scales_.push(sum_scale);
-            sum_scales_.pop();
-        };
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-}
-
-template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::apply_postops(
         const int data_idx, const bool is_tail, const size_t offset) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
@@ -285,9 +240,8 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::apply_postops(
             && (any_binary_postop_is_per_oc_bcast_type_
                     || any_binary_postop_is_per_oc_sp_bcast_type_);
 
-    if (conf_.with_sum) apply_sum(data_idx, is_tail, offset);
-
-    if (apply_rhs_binary) {
+    // Sum post-op requires binary parameters to be set.
+    if (apply_rhs_binary || conf_.with_sum) {
         rhs_arg_params.vmm_idx_to_out_reg.emplace(data_idx, reg_dst_);
         rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(data_idx, offset);
         if (is_tail) rhs_arg_params.vmm_tail_idx_.emplace(data_idx);
@@ -909,7 +863,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::generate() {
 
     postamble();
 
-    if (conf_.with_eltwise && postops_injector_)
+    if ((conf_.with_eltwise || conf_.with_sum) && postops_injector_)
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -71,7 +71,7 @@ jit_uni_resampling_kernel_t<isa, Vmm>::jit_uni_resampling_kernel_t(
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
                         this, conf_.post_ops, bsp,
-                        /* enable_native_sum = */ conf_.with_sum);
+                        /* inject_sum = */ conf_.with_sum);
 
         std::tie(any_binary_postop_is_per_oc_bcast_type_,
                 any_binary_postop_is_per_oc_sp_bcast_type_)

--- a/src/cpu/x64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.hpp
@@ -38,9 +38,7 @@ struct jit_uni_resampling_kernel_base_t : public jit_generator_t {
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_resampling)
 
     jit_uni_resampling_kernel_base_t(const jit_resampling_conf_t &conf)
-        : jit_generator_t(jit_name(), conf.isa)
-        , conf_(conf)
-        , sum_scales_(conf_.sum_scales) {}
+        : jit_generator_t(jit_name(), conf.isa), conf_(conf) {}
 
     ~jit_uni_resampling_kernel_base_t() override = default;
 
@@ -48,7 +46,6 @@ struct jit_uni_resampling_kernel_base_t : public jit_generator_t {
 
 protected:
     const jit_resampling_conf_t &conf_;
-    std::queue<float> sum_scales_;
 };
 
 template <cpu_isa_t isa, typename Vmm>
@@ -84,8 +81,6 @@ private:
     void get_params_for_linear_in_c_oriented_format();
 
     void preserve_zero_padding_in_post_ops(int data_idx);
-    void apply_sum(
-            const int data_idx, const bool is_tail, const size_t offset = 0);
     void apply_postops(
             const int data_idx, const bool is_tail, const size_t offset = 0);
 
@@ -120,7 +115,6 @@ private:
     const Vmm vmm_weights_ = Vmm(3);
     const Vmm vmm_indices_ = Vmm(4);
     const Vmm vmm_tmp_gather_ = Vmm(5);
-    const Vmm vmm_sum_scale_ = Vmm(7);
     const Vmm vmm_tmp_ = Vmm(8);
     const Vmm vmm_post_op_helper_ = Vmm(9);
     const Vmm vmm_zero_saturation_ = isa == avx512_core ? Vmm(18) : Vmm(10);

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -966,8 +966,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, pd_->attr()->post_ops_, bsp);
+                    injector::jit_uni_postops_injector_t<Vmm>>(this,
+                    pd_->attr()->post_ops_, bsp, /* inject_sum = */ false);
         }
 #undef PARAM_OFF
 
@@ -1551,8 +1551,8 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
                     reg_param, get_supported_bcast_strategies(), rhs_sp};
 
             postops_injector_ = utils::make_unique<
-                    injector::jit_uni_postops_injector_t<Vmm>>(
-                    this, pd_->attr()->post_ops_, bsp);
+                    injector::jit_uni_postops_injector_t<Vmm>>(this,
+                    pd_->attr()->post_ops_, bsp, /* inject_sum = */ false);
         }
 #undef PARAM_OFF
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -65,9 +65,9 @@ jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa,
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<
-                        typename cpu_isa_traits_t<isa>::Vmm>>(
-                        this, jcp.post_ops, static_params,
-                        /* enable_native_sum = */ jcp.with_sum);
+                        typename cpu_isa_traits_t<isa>::Vmm>>(this,
+                        jcp.post_ops, static_params,
+                        /* inject_sum = */ jcp.with_sum);
     }
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -753,7 +753,6 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     jcp.bia_dt = jcp.with_bias ? cd.bias_desc.data_type : data_type::undef;
     jcp.dst_dt = cd.dst_desc.data_type;
-    jcp.sum_dt = post_ops.get_sum_dt(jcp.dst_dt);
 
     jcp.ic_block = jcp.oc_block = simd_w;
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -66,7 +66,8 @@ jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa,
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<
                         typename cpu_isa_traits_t<isa>::Vmm>>(
-                        this, jcp.post_ops, static_params);
+                        this, jcp.post_ops, static_params,
+                        /* enable_native_sum = */ jcp.with_sum);
     }
 }
 
@@ -147,61 +148,15 @@ void iterate(const int ur, const int load_loop_blk, const F &f) {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_sum(const int ur,
-        const int load_loop_blk, const bool mask_flag_in,
-        const float *p_sum_scale, const int32_t *p_sum_zp) {
-
-    if (jcp.with_sum) {
-        assert(!utils::any_null(p_sum_scale, p_sum_zp)
-                && "p_sum_scale or p_sum_zp = nullptr");
-        const float sum_scale = *p_sum_scale;
-        const int32_t sum_zp = *p_sum_zp;
-        const auto sum_injector_lam
-                = [this, mask_flag_in, load_loop_blk, sum_scale, sum_zp](
-                          const int i_ur, const int i_load) {
-            const bool mask_flag = mask_flag_in && i_load == load_loop_blk - 1;
-            const auto ymm_prev_dst = vmm_zero;
-
-            const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
-            cvt2ps(jcp.sum_dt, ymm_prev_dst, aux_reg_output_data,
-                    output_ptr(i_load, i_ur),
-                    mask_flag ? get_tail_size() : simd_w);
-
-            if (sum_zp != 0) {
-                uni_vbroadcastss(vmm_tmp, ptr[reg_ptr_sum_zp]);
-                uni_vcvtdq2ps(vmm_tmp, vmm_tmp);
-                uni_vsubps(vmm_prev_dst, vmm_prev_dst, vmm_tmp);
-            }
-            if (sum_scale == 1.f)
-                uni_vaddps(r, r, ymm_prev_dst);
-            else {
-                uni_vbroadcastss(vmm_tmp, ptr[reg_ptr_sum_scale]);
-                uni_vfmadd231ps(r, ymm_prev_dst, vmm_tmp);
-            }
-        };
-        const auto sum_injector
-                = [=]() { iterate(ur, load_loop_blk, sum_injector_lam); };
-        if (sum_zp != 0)
-            mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-}
-
-template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_postops(
-        const int ur, const int load_loop_blk, const bool mask_flag_in,
-        const float *p_sum_scale, const int32_t *p_sum_zp) {
+        const int ur, const int load_loop_blk, const bool mask_flag_in) {
 
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-        if (jcp.with_sum && *p_sum_zp != 0)
-            mov(ptr[rsp + reg_bcast_loop_iter_off], reg_ptr_sum_zp);
-        apply_sum(ur, load_loop_blk, mask_flag_in, p_sum_scale, p_sum_zp);
-
         binary_injector::rhs_arg_dynamic_params_t rhs_arg_params,
                 rhs_arg_params_tail;
         vmm_index_set_t vmm_idxs;
-        if (jcp.with_binary) {
+        // Sum post-op requires binary parameters to be set.
+        if (jcp.with_binary || jcp.with_sum) {
             iterate(ur, load_loop_blk, [&](const int i_ur, const int i_load) {
                 const int ur_stride
                         = jcp.oc_without_padding * jcp.ngroups * i_ur;
@@ -238,8 +193,6 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_postops(
             });
             postops_injector_->compute_vector_range(vmm_idxs, rhs_arg_params);
         }
-        if (jcp.with_sum && *p_sum_zp != 0)
-            mov(reg_ptr_sum_zp, ptr[rsp + reg_bcast_loop_iter_off]);
     }
 }
 
@@ -300,17 +253,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
     };
 
     auto store = [&](const bool mask_flag_in) {
-        const auto &p = attr_.post_ops_;
-        const int sum_idx = p.find(primitive_kind::sum);
-        const float *p_sum_scale
-                = (sum_idx != -1) ? &p.entry_[sum_idx].sum.scale : nullptr;
-        const int32_t *p_sum_zp
-                = (sum_idx != -1) ? &p.entry_[sum_idx].sum.zero_point : nullptr;
         mov(ptr[rsp + reg_bcast_data_off], reg_bcast_data);
-        if (p_sum_scale && *p_sum_scale != 1.f) {
-            mov(ptr[rsp + reg_load_data_off], reg_load_data);
-            mov(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
-        }
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[rsp + reg_zp_compensation_off]);
             mov(reg_src_zero_point, ptr[rsp + reg_src_zero_point_off]);
@@ -419,7 +362,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
             }
         }
 
-        apply_postops(ur, load_loop_blk, mask_flag_in, p_sum_scale, p_sum_zp);
+        apply_postops(ur, load_loop_blk, mask_flag_in);
 
         if (jcp.with_dst_scales) {
             mov(reg_dst_scales, ptr[rsp + reg_dst_scales_off]);
@@ -472,8 +415,6 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
             }
         }
         mov(reg_bcast_data, ptr[rsp + reg_bcast_data_off]);
-        if (p_sum_scale && *p_sum_scale != 1.f)
-            mov(reg_load_data, ptr[rsp + reg_load_data_off]);
     };
 
     auto compute = [&](Vmm vreg_acc, Vmm vreg_wei, Vmm vreg_src) {
@@ -692,7 +633,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::generate() {
     add(rsp, stack_space_needed);
     postamble();
 
-    if (jcp.with_eltwise)
+    if (jcp.with_eltwise || jcp.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -56,8 +56,6 @@ private:
     const Xbyak::Reg64 reg_scale_adjust = r8;
     const Xbyak::Reg64 reg_dst_scales = r12;
     const Xbyak::Reg64 reg_load_data = r10;
-    const Xbyak::Reg64 reg_ptr_sum_scale = r10;
-    const Xbyak::Reg64 reg_ptr_sum_zp = rdx;
     const Xbyak::Reg64 reg_reduce_loop_work = r11;
     const Xbyak::Reg64 reg_bias_data = r12;
     const Xbyak::Reg64 reg_comp_data = r12;
@@ -88,8 +86,6 @@ private:
     const Vmm vmm_scales = Vmm(1);
     const Vmm vmm_scales_tmp = Vmm(3); // Has dependency on `vmm_bias`.
     const Vmm vmm_dst_scales = Vmm(1);
-    /* used during post_op sum section of store_output */
-    const Vmm vmm_prev_dst = Vmm(1);
     /* used during bias section of store_output */
     const Vmm vmm_comp = Vmm(0); // only for signed input
     const Vmm vmm_bias = Vmm(3);
@@ -102,28 +98,22 @@ private:
     constexpr static int bcast_loop_work_off = 0;
     constexpr static int reg_bias_data_off = 1 * reg64_size;
     constexpr static int reg_bcast_data_off = 2 * reg64_size;
-    constexpr static int reg_load_data_off = 3 * reg64_size;
-    constexpr static int reg_src_scales_off = 4 * reg64_size;
-    constexpr static int reg_wei_scales_off = 5 * reg64_size;
-    constexpr static int reg_dst_scales_off = 6 * reg64_size;
-    constexpr static int reg_bcast_loop_iter_off = 7 * reg64_size;
-    constexpr static int reg_comp_data_off = 8 * reg64_size;
-    constexpr static int reg_zp_compensation_off = 9 * reg64_size;
-    constexpr static int reg_src_zero_point_off = 10 * reg64_size;
-    constexpr static int reg_dst_zero_point_off = 11 * reg64_size;
-    constexpr static int stack_space_needed = 12 * reg64_size;
+    constexpr static int reg_src_scales_off = 3 * reg64_size;
+    constexpr static int reg_wei_scales_off = 4 * reg64_size;
+    constexpr static int reg_dst_scales_off = 5 * reg64_size;
+    constexpr static int reg_comp_data_off = 6 * reg64_size;
+    constexpr static int reg_zp_compensation_off = 7 * reg64_size;
+    constexpr static int reg_src_zero_point_off = 8 * reg64_size;
+    constexpr static int reg_dst_zero_point_off = 9 * reg64_size;
+    constexpr static int stack_space_needed = 10 * reg64_size;
 
     int vreg_accum_idx(
             const int load_loop_blk, const int i_load, const int i_ur);
     Vmm vreg_accum(const int load_loop_blk, const int i_load, const int i_ur);
     int output_ptr(const int i_load, const int i_ur);
     void bcast_loop(int load_loop_blk);
-    void apply_sum(const int ur, const int load_loop_blk,
-            const bool mask_flag_in, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
-    void apply_postops(const int ur, const int load_loop_blk,
-            const bool mask_flag_in, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
+    void apply_postops(
+            const int ur, const int load_loop_blk, const bool mask_flag_in);
     void reduce_loop(int load_loop_blk, int ur, bool wraparound);
 
     void generate() override;

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -81,7 +81,8 @@ jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::jit_uni_x8s8s32x_fwd_kernel_vmm_t(
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<
                         typename cpu_isa_traits_t<isa>::Vmm>>(
-                        this, jcp.post_ops, static_params);
+                        this, jcp.post_ops, static_params,
+                        /* enable_native_sum = */ jcp.with_sum);
     }
 }
 
@@ -124,70 +125,18 @@ void iterate(const int nb_oc_block, const int ur_w,
     }
 }
 template <typename F>
-void iterate(const int nb_oc_block, const int ur_w,
-        const bool last_oc_block_flag, const F &f) {
-    iterate(nb_oc_block, ur_w, last_oc_block_flag, false, f);
-}
-template <typename F>
 void iterate(const int nb_oc_block, const int ur_w, const F &f) {
     iterate(nb_oc_block, ur_w, false, false, f);
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_sum(
-        const int nb_oc_block, const int ur_w, const bool last_oc_block_flag,
-        const int oc_block, const float *p_sum_scale, const int32_t *p_sum_zp) {
-    if (jcp.with_sum) {
-        assert(!utils::any_null(p_sum_scale, p_sum_zp)
-                && "p_sum_scale or p_sum_zp = nullptr");
-        const float sum_scale = *p_sum_scale;
-        const int32_t sum_zp = *p_sum_zp;
-        const auto sum_injector_lam
-                = [this, oc_block, sum_scale, sum_zp](
-                          const bool mask_flag, const int k, const int j) {
-            const int aux_output_offset = jcp.typesize_out
-                    * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
-            cvt2ps(jcp.sum_dt, vmm_prev_dst, reg_out, aux_output_offset,
-                    mask_flag ? get_tail_size() : get_blocking_size());
-            const Vmm vmm = vmm_out(j, k);
-            if (sum_zp != 0) {
-                uni_vbroadcastss(vmm_tmp, ptr[reg_ptr_sum_zp]);
-                uni_vcvtdq2ps(vmm_tmp, vmm_tmp);
-                uni_vsubps(vmm_prev_dst, vmm_prev_dst, vmm_tmp);
-            }
-            if (sum_scale == 1.f)
-                uni_vaddps(vmm, vmm, vmm_prev_dst);
-            else {
-                uni_vbroadcastss(vmm_tmp, ptr[reg_ptr_sum_scale]);
-                uni_vfmadd231ps(vmm, vmm_prev_dst, vmm_tmp);
-            }
-        };
-        // Capture by value has to be applied since this lambda is called from
-        // a different context when stack values are unavailable.
-        const auto sum_injector
-                = [nb_oc_block, ur_w, last_oc_block_flag, sum_injector_lam]() {
-            iterate(nb_oc_block, ur_w, last_oc_block_flag, sum_injector_lam);
-        };
-        if (*p_sum_scale != 1.f)
-            mov(reg_ptr_sum_scale, reinterpret_cast<size_t>(p_sum_scale));
-        if (*p_sum_zp != 0)
-            mov(reg_ptr_sum_zp, reinterpret_cast<size_t>(p_sum_zp));
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-    }
-}
-
-template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
         const int nb_oc_block, const int ur_w, const bool last_oc_block_flag,
-        const int oc_block, const float *p_sum_scale, const int32_t *p_sum_zp) {
+        const int oc_block) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-        if (jcp.with_sum && *p_sum_zp != 0) push(reg_ptr_sum_zp);
-        apply_sum(nb_oc_block, ur_w, last_oc_block_flag, oc_block, p_sum_scale,
-                p_sum_zp);
-
         vmm_index_set_t vmm_idxs;
-        if (jcp.with_binary) {
+        // Sum post-op requires binary parameters to be set.
+        if (jcp.with_binary || jcp.with_sum) {
             binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
             const bool oc_blk_is_smaller_than_vmm = oc_block < isa_simd_width_;
             iterate(nb_oc_block, ur_w, last_oc_block_flag,
@@ -214,7 +163,6 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
             });
             postops_injector_->compute_vector_range(vmm_idxs);
         }
-        if (jcp.with_sum && *p_sum_zp != 0) pop(reg_ptr_sum_zp);
     }
 }
 
@@ -233,16 +181,6 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
         uni_vpbroadcastd(vmm_zp, ptr[reg_src_zero_point]);
-    }
-
-    const auto &p = attr_.post_ops_;
-    const int sum_idx = p.find(primitive_kind::sum);
-    const float *p_sum_scale = nullptr;
-    const int32_t *p_sum_zp = nullptr;
-    if (sum_idx != -1) {
-        const auto &p_entry = p.entry_[sum_idx];
-        p_sum_scale = &p_entry.sum.scale;
-        p_sum_zp = &p_entry.sum.zero_point;
     }
 
     for (int k = 0; k < nb_oc_block; ++k) {
@@ -342,8 +280,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         }
     }
 
-    apply_postops(nb_oc_block, ur_w, last_oc_block_flag, oc_block, p_sum_scale,
-            p_sum_zp);
+    apply_postops(nb_oc_block, ur_w, last_oc_block_flag, oc_block);
 
     if (jcp.with_dst_scales) {
         mov(reg_dst_scales, ptr[param1 + GET_OFF(dst_scales)]);
@@ -1284,7 +1221,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
     postamble();
 
-    if (jcp.with_eltwise)
+    if (jcp.with_eltwise || jcp.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -1464,7 +1464,6 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     jcp.with_binary = !everyone_is(-1, binary_ind, prelu_ind);
     const int sum_ind = post_ops.find(primitive_kind::sum);
     jcp.with_sum = sum_ind != -1;
-    jcp.sum_dt = post_ops.get_sum_dt(jcp.dst_dt);
 
     jcp.post_ops = post_ops;
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -80,9 +80,9 @@ jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::jit_uni_x8s8s32x_fwd_kernel_vmm_t(
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<
-                        typename cpu_isa_traits_t<isa>::Vmm>>(
-                        this, jcp.post_ops, static_params,
-                        /* enable_native_sum = */ jcp.with_sum);
+                        typename cpu_isa_traits_t<isa>::Vmm>>(this,
+                        jcp.post_ops, static_params,
+                        /* inject_sum = */ jcp.with_sum);
     }
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -71,8 +71,6 @@ private:
     const Xbyak::Reg64 reg_ker = r9;
     const Xbyak::Reg64 reg_out = r10;
     const Xbyak::Reg64 aux_reg_inp = r11;
-    const Xbyak::Reg64 reg_ptr_sum_scale = r11;
-    const Xbyak::Reg64 reg_ptr_sum_zp = rdx;
     const Xbyak::Reg64 aux_reg_ker = r12;
     const Xbyak::Reg64 aux_reg_inp_d = r13;
     const Xbyak::Reg64 reg_compensation = r14;
@@ -108,8 +106,6 @@ private:
     const Vmm vmm_scales = Vmm(1);
     const Vmm vmm_scales_tmp = Vmm(0); // Has dependency on `vmm_bias`.
     const Vmm vmm_dst_scales = Vmm(0);
-    /* used during post_op sum section of store_output */
-    const Vmm vmm_prev_dst = Vmm(0);
     /* used during write-out section of store_output */
     const Vmm vmm_zero = Vmm(0);
     const Vmm vmm_saturation = Vmm(0);
@@ -182,12 +178,8 @@ private:
 
     void cvt2ps(data_type_t type_in, const Vmm &vmm_in, const Xbyak::Reg64 &reg,
             int offset, int load_size);
-    void apply_sum(const int nb_oc_block, const int ur_w,
-            const bool last_oc_block_flag, const int oc_block,
-            const float *p_sum_scale, const int32_t *p_sum_zp);
     void apply_postops(const int nb_oc_block, const int ur_w,
-            const bool last_oc_block_flag, const int oc_block,
-            const float *p_sum_scale, const int32_t *p_sum_zp);
+            const bool last_oc_block_flag, const int oc_block);
 };
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -445,7 +445,7 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
                         this, jcp_.post_ops, bsp,
-                        /* enable_native_sum = */ jcp_.with_sum);
+                        /* inject_sum = */ jcp_.with_sum);
     }
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -444,7 +444,8 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<Vmm>>(
-                        this, jcp_.post_ops, bsp);
+                        this, jcp_.post_ops, bsp,
+                        /* enable_native_sum = */ jcp_.with_sum);
     }
 }
 
@@ -1013,44 +1014,11 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::cvt2ps(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(int ur_w,
-        bool last_oc_block, const float *p_sum_scale, const int32_t *p_sum_zp) {
-    const auto sum_injector = [&]() {
-        if (p_sum_scale) { // post_op: sum
-            for (int k = 0; k < jcp_.nb_oc_blocking; k++) {
-                const bool mask_flag
-                        = last_oc_block == 1 && k == jcp_.nb_oc_blocking - 1;
-                for (int j = 0; j < ur_w; j++) {
-                    const int aux_output_offset = jcp_.typesize_out
-                            * (k * jcp_.oc_block
-                                    + j * jcp_.oc_without_padding
-                                            * jcp_.ngroups);
-                    cvt2ps(jcp_.dst_dt, vmm_prev_dst_, reg_dst_,
-                            aux_output_offset,
-                            mask_flag ? get_tail_size() : get_blocking_size());
-                    if (*p_sum_zp != 0) {
-                        uni_vbroadcastss(vmm_sum_zp_, ptr[reg_ptr_sum_zp_]);
-                        uni_vcvtdq2ps(vmm_sum_zp_, vmm_sum_zp_);
-                        uni_vsubps(vmm_prev_dst_, vmm_prev_dst_, vmm_sum_zp_);
-                    }
-                    const Vmm vmm = vmm_out(j, k);
-                    if (*p_sum_scale == 1.f)
-                        uni_vaddps(vmm, vmm, vmm_prev_dst_);
-                    else {
-                        uni_vbroadcastss(vmm_tmp_, ptr[reg_ptr_sum_scale_]);
-                        uni_vfmadd231ps(vmm, vmm_prev_dst_, vmm_tmp_);
-                    }
-                }
-            }
-        }
-    };
-
-    if (p_sum_scale)
-        postops_injector_->set_lambda_injector(
-                primitive_kind::sum, sum_injector);
-
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
+        int ur_w, bool last_oc_block) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
-    if (jcp_.with_binary) {
+    // Sum post-op requires binary parameters to be set.
+    if (jcp_.with_binary || jcp_.with_sum) {
         for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
             const bool mask_flag
                     = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
@@ -1085,13 +1053,6 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         mov(reg_zp_src_, ptr[param1_ + GET_OFF(src_zero_point)]);
         mov(reg_zp_compensation_, ptr[param1_ + GET_OFF(zp_compensation)]);
     }
-
-    const auto &p = jcp_.post_ops;
-    const int sum_idx = p.find(primitive_kind::sum);
-    const float *p_sum_scale
-            = (sum_idx != -1) ? &p.entry_[sum_idx].sum.scale : nullptr;
-    const int32_t *p_sum_zp
-            = (sum_idx != -1) ? &p.entry_[sum_idx].sum.zero_point : nullptr;
 
     if (jcp_.src_zero_point) {
         const auto &vmm_src_zp = vmm_tmp_;
@@ -1206,13 +1167,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         }
     }
 
-    if (p_sum_scale && *p_sum_scale != 1.f)
-        mov(reg_ptr_sum_scale_, reinterpret_cast<size_t>(p_sum_scale));
-    if (p_sum_zp && *p_sum_zp != 0) {
-        mov(reg_ptr_sum_zp_, reinterpret_cast<size_t>(p_sum_zp));
-    }
     if (jcp_.with_eltwise || jcp_.with_binary || jcp_.with_sum)
-        apply_postops(ur_w, last_oc_block, p_sum_scale, p_sum_zp);
+        apply_postops(ur_w, last_oc_block);
 
     if (jcp_.with_dst_scales) {
         mov(reg_dst_scales_, ptr[param1_ + GET_OFF(dst_scales)]);
@@ -1447,7 +1403,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
     postamble();
 
-    if (jcp_.with_eltwise)
+    if (jcp_.with_eltwise || jcp_.with_sum)
         postops_injector_->prepare_table(/* generate = */ true);
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -95,8 +95,6 @@ private:
 
     const reg64_t reg_compensation_ = r14;
     const reg64_t reg_scratch_ = r14;
-    const reg64_t reg_ptr_sum_scale_ = r11;
-    const reg64_t reg_ptr_sum_zp_ = r15;
     const reg64_t reg_overflow_ = rax;
     const reg64_t reg_comp_strides_ = reg_overflow_;
     const reg64_t reg_ker_long_offt_ = r15;
@@ -120,8 +118,6 @@ private:
     const Vmm vmm_shift_ = Vmm(1);
     const Vmm vmm_comp_ = Vmm(1);
     const Vmm vmm_bias_ = vmm_zero_;
-    const Vmm vmm_prev_dst_ = vmm_zero_;
-    const Vmm vmm_sum_zp_ = vmm_tmp_;
 
     Vmm vmm_out(int i_ur, int i_oc) const;
     Vmm vmm_inp(int i_ic, int nb_x_blocking) const;
@@ -132,8 +128,7 @@ private:
     int get_tail_size() const noexcept;
 
     void prepare_output(int ur_w);
-    void apply_postops(int ur_w, bool last_oc_block, const float *p_sum_scale,
-            const int32_t *p_sum_zp);
+    void apply_postops(int ur_w, bool last_oc_block);
     void store_output(int ur_w, bool last_oc_block);
     void compute_ker(int ur_w, int l_overflow, int r_overflow,
             ker_block_t last_ic_block_flag, bool h_padded = false);

--- a/src/cpu/x64/matmul/postops_estimator.hpp
+++ b/src/cpu/x64/matmul/postops_estimator.hpp
@@ -76,8 +76,10 @@ private:
         esp.preserve_vmm = false;
         esp.preserve_p_table = false;
 
-        postops_injector_ = utils::make_unique<po_injector_t>(
-                this, attr.post_ops_, bsp, esp);
+        postops_injector_ = utils::make_unique<po_injector_t>(this,
+                attr.post_ops_, bsp, esp,
+                // The estimate leaves sum out, as it always has.
+                /* inject_sum = */ false);
     }
 
     const char *name() const final {


### PR DESCRIPTION
This PR is a continuation of #5706.

**Recap:** cpu-x64 didn't really have a dedicated sum injector. Instead, each kernel had to implement its own version of the sum injector and provide it to the injector driver to control when the code was generated and applied. As a result, there was no reuse of the sum post-op code leading to significant code duplication.

The main motivation for introducing a dedicated sum injector was the IR effort, as the sum post-op cannot be supported in IR the way it was previously implemented. This PR migrates all kernels that support the sum post-op to the new sum injector, enforcing a uniform design across the codebase. The old mechanism has been removed completely. From now on, extending the sum post-op will only require modifying a single implementation.