### PR TITLE
governance: @densamoylov as maintainer for cpu-x64

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -137,6 +137,7 @@ Team: @uxlfoundation/onednn-cpu-x64
 | Name                | Github ID             | Affiliation       | Role       |
 | ------------------- | --------------------- | ----------------- | ---------- |
 | Andrey Kalinin      | @ankalinin            | Intel Corporation | Maintainer |
+| Denis Samoilov      | @densamoilov          | Intel Corporation | Maintainer |
 | Tatyana Primak      | @tprimak              | Intel Corporation | Maintainer |
 | Alexander Simonov   | @asimonov1            | Intel Corporation | Code Owner |
 | Alexey Makarevich   | @amakarev             | Intel Corporation | Code Owner |


### PR DESCRIPTION
I would like to nominate Denis Samoilov @densamoilov for the role of maintainer for x64 component. Denis is already a maintainer for Arch component and has [extensive history](https://github.com/uxlfoundation/oneDNN/pulls?q=is%3Apr+author%3Adensamoilov+label%3Aplatform%3Acpu-x64+is%3Aclosed) of contributions to x64 backend.

P.S. I was convinced that this already happened.
