### PR TITLE
third_party: ngen: fix EOT detection for sendg

### DIFF
--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -2071,6 +2071,19 @@ static inline bool isSend(Opcode op)
     }
 }
 
+static inline bool isSendg(Opcode op)
+{
+    switch (op) {
+        case Opcode::sendg:
+        case Opcode::sendgc:
+        case Opcode::sendgx:
+        case Opcode::sendgxc:
+            return true;
+        default:
+            return false;
+    }
+}
+
 static inline bool trackedByToken(HW hw, Opcode op, unsigned dstTypecode)
 {
     switch (op) {

--- a/third_party/ngen/ngen_gen12.hpp
+++ b/third_party/ngen/ngen_gen12.hpp
@@ -582,7 +582,7 @@ struct Instruction12 {
     Opcode opcode() const         { return static_cast<Opcode>(common.opcode & 0x7F); }
     SyncFunction syncFC() const   { return static_cast<SyncFunction>(binary.cmod); }
     SharedFunction sfid() const   { return static_cast<SharedFunction>(send.sfid); }
-    bool eot() const              { return (opcode() == Opcode::send || opcode() == Opcode::sendc) && send.eot; }
+    bool eot() const              { return isSend(opcode()) && (isSendg(opcode()) ? sendg.eot : send.eot); }
     bool predicated() const       { return !common.maskCtrl || (static_cast<PredCtrl>(common.predCtrl) != PredCtrl::None); }
     bool atomic() const           { return common.atomicCtrl; }
     unsigned dstTypecode() const  { return binary.dstType; }
@@ -629,17 +629,8 @@ struct InstructionXeHPC : public Instruction12 {
         return Instruction12::getCModDepRegion<EncodingTagXeHPC>(region);
     }
 
-    bool isSendg() const {
-        return (opcode() == Opcode::sendg || opcode() == Opcode::sendgc || opcode() == Opcode::sendgx || opcode() == Opcode::sendgxc);
-    }
-
-    bool eot() const {
-        if (isSendg()) return sendg.eot;
-        return Instruction12::eot();
-    }
-
     bool atomic() const {
-        if (isSendg()) return false;    /* no atomic field */
+        if (isSendg(opcode())) return false;    /* no atomic field */
         return Instruction12::atomic();
     }
 };
@@ -1736,9 +1727,8 @@ autoswsb::DestinationMask Instruction12::destinations(int &jip, int &uip) const
     using namespace autoswsb;
 
     if (!isBranch(opcode())) {
-        if (opcode() == Opcode::send || opcode() == Opcode::sendc)
-            if (send.eot && !predicated())
-                return DestNone;
+        if (eot() && !predicated())
+            return DestNone;
         return DestNextIP;
     }
 


### PR DESCRIPTION
PR fixes `Instruction12::destinations()` to properly handle the EOT message on Xe3p. Without this change, SWSB inserts redundant syncs after EOT.

Example: the kernel below produced 27 extra syncs before the fix on CRI:

```
$ export GEMM_KERNEL='gemm HH[SH] T@16N@16N 48 16 1 0 aT16#16,0{ccc}+M32,32@32{ccc} aM32#16,0{ccc}+M32,32@48{ccc} aB#16,0{ccc/ubu} wg 4x8 sys af k32 grf192 raxehpc sm sn vav di sr bf cc rr sb64 np bm16777216 bn16777216 bk16777216' 
$ ./build/tests/benchdnn/benchdnn -v5 --mode=I --engine=gpu --matmul --dt=f16 256x256:256x256
```

Assembly generator is already correct:

https://github.com/uxlfoundation/oneDNN/blob/7e37c64591a141274402c5276824672d92b3bd23/third_party/ngen/ngen_asm.hpp#L340-L341

