### PR TITLE
benchdnn: rnn: reject unsupported --flags values

### DIFF
--- a/tests/benchdnn/rnn/rnn_aux.cpp
+++ b/tests/benchdnn/rnn/rnn_aux.cpp
@@ -113,15 +113,16 @@ const char *direction2str(dnnl_rnn_direction_t direction) {
 
 flags_t str2flags(const char *str) {
     flags_t flags = NONE;
-    while (str && *str) {
-        if (*str == 'O') {
+    // Iterate with a separate cursor so `str` still points at the whole value and the
+    // error below can report what the user actually passed rather than its tail.
+    for (const char *s = str; s && *s; s++) {
+        if (*s == 'O') {
             flags |= DIFF_WEIGHTS_OVERWRITE;
         } else {
             BENCHDNN_PRINT(0, "%s \'%s\'\n",
                     "Error: --flags option doesn't support value", str);
             SAFE_V(FAIL);
         }
-        str++;
     }
     return flags;
 }

--- a/tests/benchdnn/rnn/rnn_aux.cpp
+++ b/tests/benchdnn/rnn/rnn_aux.cpp
@@ -114,9 +114,13 @@ const char *direction2str(dnnl_rnn_direction_t direction) {
 flags_t str2flags(const char *str) {
     flags_t flags = NONE;
     while (str && *str) {
-        if (*str == 'O')
+        if (*str == 'O') {
             flags |= DIFF_WEIGHTS_OVERWRITE;
-        else { BENCHDNN_PRINT(0, "%s\n", "Error: unsupported flags value."); }
+        } else {
+            BENCHDNN_PRINT(0, "%s \'%c\'\n",
+                    "Error: --flags option doesn't support value", *str);
+            SAFE_V(FAIL);
+        }
         str++;
     }
     return flags;

--- a/tests/benchdnn/rnn/rnn_aux.cpp
+++ b/tests/benchdnn/rnn/rnn_aux.cpp
@@ -117,8 +117,8 @@ flags_t str2flags(const char *str) {
         if (*str == 'O') {
             flags |= DIFF_WEIGHTS_OVERWRITE;
         } else {
-            BENCHDNN_PRINT(0, "%s \'%c\'\n",
-                    "Error: --flags option doesn't support value", *str);
+            BENCHDNN_PRINT(0, "%s \'%s\'\n",
+                    "Error: --flags option doesn't support value", str);
             SAFE_V(FAIL);
         }
         str++;


### PR DESCRIPTION
# Description

`rnn::str2flags()` in the benchdnn RNN driver printed an error for an unrecognized `--flags` character and then continued parsing. The bad character was skipped, the returned bitmask silently fell back to `NONE`, and the driver ran and reported success. A typo in `--flags` therefore validated a different configuration than the one requested, and exited 0.

Two things make it hard to notice. The error text did not name the offending character, and the `__REPRO` line does not echo `--flags` when the parsed value is `NONE`, so the log contains no record that the requested configuration was never tested.

Current behavior on `main` at 58a5a4b:

```
$ ./benchdnn --mode=I --rnn --flags=X l1t1mb1sic4slc4dhc4dic4
Error: unsupported flags value.
0:INITIALIZED (5 ms) __REPRO: --mode=I --rnn --tag=any:any:any l1t1mb1sic4slc4dhc4dic4
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
$ echo $?
0
```

The RNN driver was the only one that did this. The other three `--flags` parsers reject the bad character:

- `tests/benchdnn/bnorm/bnorm_aux.cpp:54-58`
- `tests/benchdnn/gnorm/gnorm_aux.cpp:30-34`
- `tests/benchdnn/lnorm/lnorm_aux.cpp:35-38`

So does the reorder driver's flag parser, at `tests/benchdnn/reorder/reorder_aux.cpp:40-45`. All four print the offending value and call `SAFE_V(FAIL)`. `str2desc()` in `rnn_aux.cpp` itself already returns `FAIL` for an unrecognized descriptor pattern, so `--flags` was the last option in the RNN driver that still accepted garbage.

The fix adopts the peer pattern verbatim, so all four `--flags` parsers now behave identically.

After the change:

```
$ ./benchdnn --mode=I --rnn --flags=X l1t1mb1sic4slc4dhc4dic4
Error: --flags option doesn't support value 'X'
Error: Function 'str2flags' at (tests/benchdnn/rnn/rnn_aux.cpp:122) returned '1'
$ echo $?
1
```

Valid input is unaffected:

```
$ ./benchdnn --mode=I --rnn --flags=O l1t1mb1sic4slc4dhc4dic4
0:INITIALIZED (5 ms) __REPRO: --mode=I --rnn --tag=any:any:any --flags=O l1t1mb1sic4slc4dhc4dic4
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
$ echo $?    # 0
$ ./benchdnn --mode=I --rnn l1t1mb1sic4slc4dhc4dic4
$ echo $?    # 0
```

# How this was verified

Built and run locally on macOS 15 arm64, Apple clang, `DNNL_CPU_RUNTIME=SEQ`, `DNNL_GPU_RUNTIME=NONE`, `DNNL_TEST_SET=SMOKE`.

Fail-before and pass-after were checked by swapping only this file against the base ref and rebuilding each time:

```sh
git checkout origin/main -- tests/benchdnn/rnn/rnn_aux.cpp
cmake --build build --target benchdnn -j 12
./build/tests/benchdnn/benchdnn --mode=I --rnn --flags=X l1t1mb1sic4slc4dhc4dic4; echo $?
# -> 0, run reported passed:1

git checkout HEAD -- tests/benchdnn/rnn/rnn_aux.cpp
cmake --build build --target benchdnn -j 12
./build/tests/benchdnn/benchdnn --mode=I --rnn --flags=X l1t1mb1sic4slc4dhc4dic4; echo $?
# -> 1
```

The same bogus input was run against the peer drivers to confirm the intended behavior is what they already do: `--bnorm --flags=X mb1ic4ih4iw4` and `--lnorm --flags=X 8x16` both exit 1 on unmodified `main`.

The one real regression risk is an existing input file passing a value that is now rejected. Every `--flags` value in `tests/benchdnn/inputs/rnn/` was enumerated and all of them remain valid:

```
$ grep -rho -- "--flags=[^ ]*" inputs/rnn/ | sort | uniq -c
 207 --flags=
   5 --flags=,O
  12 --flags=O
```

Split on the comma that `parse_vector_option` uses, the only two distinct values in the whole tree are the empty string and `O`. The empty string never enters the loop, since the condition is `while (str && *str)`. No batch file outside `inputs/rnn/` drives `--rnn`, so there is nothing else that can reach this parser.

The RNN correctness batches and the self tests were then run to confirm:

```
$ ./benchdnn --mode=C -v1 --engine=cpu --rnn --batch=inputs/rnn/test_rnn_ci
tests:11784 passed:2632 skipped:9060 mistrusted:92 unimplemented:0 invalid_arguments:0 failed:0 listed:0
$ ./benchdnn --mode=C --engine=cpu --rnn --batch=inputs/rnn/test_lstm_ci
tests:3666 passed:498 skipped:3168 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
$ ./benchdnn --mode=C --self
tests:19 passed:19 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
```

`test_rnn_ci` is the batch that exercises `--flags=,O`. The large skip counts are the expected data-type and ISA skips for a sequential aarch64 CPU build.

No automated regression test is added. `SAFE_V` calls `exit(1)`, so the rejection path cannot be asserted from inside the in-process `--self` driver, and benchdnn registers only positive batch files with ctest. None of the four peer parsers has a rejection-path test either, so there is no existing harness to extend. The verification above is the CLI-level equivalent. Happy to add a self test for the accept path and the `flags2str` round trip if you would like coverage there, since the RNN driver currently has none.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

The RNN benchdnn batches and `--self` pass locally, as shown above. The full `make test` was not run: this is an aarch64 macOS host, so the x64 portions of the suite cannot execute here. I am relying on CI for full coverage.

`tests/benchdnn/rnn/rnn_aux.cpp` is byte-identical to its `clang-format -style=file` output using the repository `.clang-format`. `.github/automation/commit-msg-check.py` and `scripts/fix_header_guards.py` both pass locally on this commit.

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

Reproducer and exit codes are above. The reason no regression test is added is explained in the verification section.

---

This PR was authored with AI assistance (Claude Code). The behavior described above was reproduced and the fix verified by building and running benchdnn locally, not inferred.
