### PR TITLE
cpu: x64: enable sum post op in IR based gemv

### DIFF
--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -82,7 +82,7 @@ namespace {
 //   dt_bias      - element data type of the bias
 //   dt_sz_bias   - element size in bytes of the bias
 //   mblk_bias_off - byte offset to advance the bias pointer between M blocks
-//   with_injector_postops - whether attribute post-ops (eltwise/binary) are
+//   with_injector_postops - whether attribute post-ops (eltwise/binary/sum) are
 //                    requested
 //   with_src_scales - whether a source scale multiplies the output. Always a
 //                    single common scalar for this kernel
@@ -124,7 +124,8 @@ struct brgemv_ir_conf_t {
         , dt_bias(brg.dt_bias)
         , dt_sz_bias(brg.typesize_bias)
         , mblk_bias_off(dt_sz_bias * m_block)
-        , with_injector_postops(brg.with_eltwise || brg.with_binary)
+        , with_injector_postops(
+                  brg.with_eltwise || brg.with_binary || brg.with_sum)
         , with_src_scales(brg.with_src_scales)
         , with_wei_scales(brg.with_wei_scales)
         , single_wei_scale(brg.gemv_single_wei_scale())
@@ -175,8 +176,15 @@ struct brgemv_ir_conf_t {
 
 // Registers that advance each M-block iteration by a fixed byte offset.
 struct advancing_regs_t {
-    // Current output pointer. Advances by `mblk_y_off` per M-block.
+    // Current `y` pointer, the vector `beta` accumulates into. Advances by
+    // `mblk_y_off` per M-block.
     ir::vreg_t y_ptr = ir::vreg_t::none;
+    // Pointer used to store the M-block result. Usually this is `y_ptr`, but
+    // when post-ops run it holds `ptr_D`, which may be a separate output
+    // buffer. The accumulation and output buffers share the same type and
+    // stride (enforced by `brgemv_ir_supported()`), so `store_ptr` advances
+    // together with `y_ptr`.
+    ir::vreg_t store_ptr = ir::vreg_t::none;
     // Byte offset into A for the current M-block. Starts at 0 and advances by
     // `mblk_a_off` each iteration.
     ir::vreg_t a_off = ir::vreg_t::none;
@@ -265,6 +273,16 @@ m_loop_input_regs_t init_m_loop_input_regs(
     if (cfg.has_post_ops()) {
         regs.invariant.do_post_ops = ir.new_gpr();
         ir.load_param(regs.invariant.do_post_ops, GET_OFF(do_post_ops));
+
+        regs.advancing.store_ptr = ir.new_gpr();
+        ir.mov_reg(regs.advancing.store_ptr, regs.advancing.y_ptr);
+
+        const ir::label_t store_ptr_done = ir.new_label();
+        ir.jz(regs.invariant.do_post_ops, store_ptr_done);
+        ir.load_param(regs.advancing.store_ptr, GET_OFF(ptr_D));
+        ir.label(store_ptr_done);
+    } else {
+        regs.advancing.store_ptr = regs.advancing.y_ptr;
     }
 
     return regs;
@@ -369,6 +387,9 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         // The current implementation supports only 0 and 1 for beta so for the
         // case where beta = 1 we load `y` into the accumulator registers and
         // then the microkernel adds the results of the multiplication to them.
+        //
+        // This reads `y_ptr` while a sum post-op reads `store_ptr`, so the two
+        // never count the same value twice.
         if (cfg.beta == 0.0f)
             ir.vzero(acc[r]);
         else
@@ -454,12 +475,14 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         if (cfg.with_injector_postops) {
             // Each accumulator is horizontally reduced to one scalar, so the
             // injector sees a single active element with no mask register. Its
-            // output offset matches the store displacement below.
+            // output offset matches the store displacement below, so a sum
+            // post-op reads each element from the address its result is
+            // written to.
             std::vector<dim_t> out_byte_off(m_block);
             for (int r = 0; r < m_block; r++)
                 out_byte_off[r] = cfg.dt_sz_y * (dim_t)r * cfg.incy;
 
-            ir.inject_postops(acc, regs.advancing.y_ptr, out_byte_off,
+            ir.inject_postops(acc, regs.advancing.store_ptr, out_byte_off,
                     ir::vreg_t::none, /*elems=*/1);
         }
 
@@ -467,12 +490,16 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     }
 
     for (int r = 0; r < m_block; r++)
-        ir.vstore_masked(regs.advancing.y_ptr,
+        ir.vstore_masked(regs.advancing.store_ptr,
                 cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r], ir::vreg_t::none, 1);
 
     // Advance to next M block
     ir.add_imm(regs.advancing.a_off, cfg.mblk_a_off);
     ir.add_imm(regs.advancing.y_ptr, cfg.mblk_y_off);
+    // When `!has_post_ops()`, `store_ptr` is the same IR vreg as `y_ptr` (see
+    // `init_m_loop_input_regs`), so advancing `y_ptr` above covers both.
+    if (cfg.has_post_ops())
+        ir.add_imm(regs.advancing.store_ptr, cfg.mblk_y_off);
 
     if (cfg.with_bias && cfg.treat_y_as_row)
         ir.add_imm(regs.advancing.bias_ptr, cfg.mblk_bias_off);
@@ -554,7 +581,7 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         std::unique_ptr<ir::postops_injector_t> postops_injector;
         ir::inject_postops_fn_t emit_injector;
 
-        if (brg_.with_eltwise || brg_.with_binary) {
+        if (brg_.with_eltwise || brg_.with_binary || brg_.with_sum) {
             // A partial right-hand-side load reads the vector tail, or one
             // element for a scalar accumulator.
             const int postops_tail_elems
@@ -594,7 +621,7 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         ir::emit_data_section(*this, data);
 
         // Emit the injector's constant table (a no-op unless the chain has
-        // eltwise).
+        // eltwise or sum).
         if (postops_injector) postops_injector->maybe_prepare_table();
     }
 
@@ -639,13 +666,26 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     VCONDCHECK_BRGEMV_IR(
             !brg.transA, VERBOSE_UNSUPPORTED_FEATURE, "transposed A");
 
-    // Post-ops go through the JIT injector. Accept only eltwise and binary, and
-    // only binary arguments the injector can handle on this ISA. Sum and other
-    // kinds fall back.
+    // With post-ops the kernel stores to D instead of C. It cannot convert the
+    // accumulator on the way out, so it takes only `dt_d == dt_c`. The check is
+    // unconditional because `dt_c != dt_d` alone already routes the descriptor
+    // through the store-to-D path (see `are_post_ops_applicable()`), which the
+    // `has_post_ops` below does not cover.
+    VCONDCHECK_BRGEMV_IR(brg.dt_d == brg.dt_c, VERBOSE_UNSUPPORTED_DT);
+
+    const bool has_post_ops = brg.with_bias || brg.with_eltwise
+            || brg.with_binary || brg.with_sum || brg.with_src_scales
+            || brg.with_wei_scales;
+    VCONDCHECK_BRGEMV_IR(IMPLICATION(has_post_ops, brg.LDC == brg.LDD),
+            VERBOSE_UNSUPPORTED_FEATURE, "LDC != LDD");
+
+    // Post-ops go through the JIT injector. Accept eltwise, binary and sum, and
+    // only binary arguments the injector can handle on this ISA. Other kinds
+    // fall back.
     if (brg.attr()) {
         const memory_desc_wrapper dst_d(brg.dst_md());
         const std::vector<injector::post_op_type> accepted
-                = {injector::eltwise, injector::binary};
+                = {injector::eltwise, injector::binary, injector::sum};
         VCONDCHECK_BRGEMV_IR(
                 injector::post_ops_ok({brg.isa_impl, accepted,
                         brg.attr()->post_ops_, &dst_d,

--- a/src/cpu/x64/ir/README.md
+++ b/src/cpu/x64/ir/README.md
@@ -82,10 +82,11 @@ step. They are omitted above for clarity.
 * **Post-ops injector.** The existing Xbyak post-ops injector is reused unchanged,
   plugged in as a single `inject_postops` operation. Its variable-length arguments
   live in a side table indexed from the operation's immediate field, so the
-  operation itself carries only that index. For binary post-ops the table also
-  holds each accumulator's output offset and active-element count, which the
-  injector needs to address its right-hand-side argument. The injector saves and
-  restores its own registers and does not participate in IR allocation.
+  operation itself carries only that index. The table also holds each
+  accumulator's output offset and active-element count, which a binary post-op
+  needs to address its right-hand-side argument and a sum post-op needs to read
+  the previous destination value. The injector saves and restores its own
+  registers and does not participate in IR allocation.
 
 ### Control and Data Flow
 

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -38,10 +38,8 @@ template <typename Vmm>
 std::shared_ptr<void> create_injector(jit_generator_t &gen,
         const post_ops_t &post_ops,
         const binary_injector::static_params_t &bsp) {
-    // The IR path rejects a sum post-op during dispatch, so the injector
-    // never has one to apply.
     return std::make_shared<injector_t<Vmm>>(
-            &gen, post_ops, bsp, /* inject_sum = */ false);
+            &gen, post_ops, bsp, /* inject_sum = */ true);
 }
 
 template <typename Vmm>
@@ -65,8 +63,9 @@ postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
 
     const size_t rhs_dt_helper_vmm_idx = 0;
 
-    // Right-hand-side argument config for binary post-ops. Eltwise does not use
-    // it. `rhs_arg_offset` locates the argument pointer array in the parameter
+    // Right-hand-side argument config, used by binary post-ops and, for the
+    // load path only, by sum. Eltwise does not use it.
+    // `rhs_arg_offset` locates the argument pointer array in the parameter
     // struct. `dst_orig_off` locates the destination origin, used to turn an
     // accumulator address into its destination position. `tail_elems` is the
     // element count a partial load reads on avx2. The avx512 opmask path is not
@@ -85,10 +84,12 @@ postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
     assert(injector_ && "ir post-ops injector creation failed");
 
     with_eltwise_ = post_ops.find(primitive_kind::eltwise) != -1;
+    with_sum_ = post_ops.find(primitive_kind::sum) != -1;
     // Prelu is injected through the binary injector and needs the same
-    // right-hand-side arguments, so treat it like a binary post-op.
-    with_binary_ = post_ops.find(primitive_kind::binary) != -1
-            || post_ops.find(primitive_kind::prelu) != -1;
+    // right-hand-side arguments, so treat it like a binary post-op. The sum
+    // reads the previous destination value through those same arguments.
+    needs_rhs_args_ = post_ops.find(primitive_kind::binary) != -1
+            || post_ops.find(primitive_kind::prelu) != -1 || with_sum_;
 }
 
 void postops_injector_t::apply(const std::vector<int> &acc_phys, int base_phys,
@@ -97,8 +98,9 @@ void postops_injector_t::apply(const std::vector<int> &acc_phys, int base_phys,
     for (int idx : acc_phys)
         vmm_idxs.insert((size_t)idx);
 
-    if (!with_binary_) {
-        // Eltwise-only chains have no right-hand-side arguments to address.
+    if (!needs_rhs_args_) {
+        // Chains without a binary, prelu or sum post-op have nothing to address
+        // relative to the destination.
         if (is_zmm_)
             cast2tgt<Xbyak::Zmm>(injector_.get())
                     ->compute_vector_range(vmm_idxs);
@@ -120,8 +122,9 @@ void postops_injector_t::apply(const std::vector<int> &acc_phys, int base_phys,
     JIT_ASSERT((!is_tail || elems == tail_elems_)
             && "inject_postops: tail count does not match the injector");
 
-    // Map each accumulator to its destination address so the injector locates
-    // the matching right-hand-side slice.
+    // Map each accumulator to its destination address. A binary post-op uses it
+    // to locate the corresponding right-hand-side slice, and the sum operation
+    // uses it to access the previous destination value.
     binary_injector::rhs_arg_dynamic_params_t rhs_args;
     const Xbyak::Reg64 out_reg(base_phys);
     for (size_t i = 0; i < acc_phys.size(); i++) {
@@ -140,8 +143,8 @@ void postops_injector_t::apply(const std::vector<int> &acc_phys, int base_phys,
 }
 
 void postops_injector_t::maybe_prepare_table() {
-    // The constant table is only needed for eltwise.
-    if (!with_eltwise_) return;
+    // The constant table is needed for eltwise and sum.
+    if (!with_eltwise_ && !with_sum_) return;
 
     const bool generate = true;
     if (is_zmm_)

--- a/src/cpu/x64/ir/postops_injector.hpp
+++ b/src/cpu/x64/ir/postops_injector.hpp
@@ -74,8 +74,10 @@ struct postops_injector_t {
     postops_injector_t &operator=(const postops_injector_t &) = delete;
 
     // Apply the post-ops to the accumulators in `acc_phys` (physical vec
-    // register indices). For binary post-ops, `base_phys` and `out_byte_off`
-    // give each accumulator's output address. `elems` is the active element
+    // register indices). For binary and sum post-ops, `base_phys` and
+    // `out_byte_off` give each accumulator's output address: binary reaches its
+    // right-hand-side argument through it, sum reads the previous destination
+    // value from it. `elems` is the active element
     // count, `-1` for a full vector, and limits how many right-hand-side
     // elements are read. `mask_phys` is the tail opmask (a K register), used
     // only by the avx512 emitter, which is not enabled yet.
@@ -83,7 +85,7 @@ struct postops_injector_t {
             const std::vector<dim_t> &out_byte_off, int mask_phys, int elems);
 
     // Emit the post-ops constant table. Call once, after the postamble. Only
-    // eltwise post-ops have a table, so this is a no-op without one.
+    // eltwise and sum post-ops have a table, so this is a no-op without one.
     void DNNL_API maybe_prepare_table();
 
 private:
@@ -91,10 +93,14 @@ private:
     // type when used, based on `is_zmm_`.
     std::shared_ptr<void> injector_;
     bool is_zmm_ = false;
-    // Whether the chain has an eltwise post-op (the only kind with a table).
+    // Whether the chain has an eltwise post-op.
     bool with_eltwise_ = false;
-    // Whether the chain has a binary post-op (the only kind needing rhs args).
-    bool with_binary_ = false;
+    // Whether the chain has a sum post-op.
+    bool with_sum_ = false;
+    // Whether any post-op needs the per-accumulator destination address: binary
+    // and prelu to reach their right-hand-side argument, sum to read the
+    // previous destination value.
+    bool needs_rhs_args_ = false;
     // Number of right-hand-side elements a tail load reads.
     int tail_elems_ = 0;
 };


### PR DESCRIPTION
This PR adds the final missing post-op to IR-based GEMV: `sum`.
