### PR TITLE
benchdnn: bnorm, gnorm, lnorm: report the whole --flags value on error

### DIFF
--- a/tests/benchdnn/bnorm/bnorm_aux.cpp
+++ b/tests/benchdnn/bnorm/bnorm_aux.cpp
@@ -41,23 +41,24 @@ const char *check_alg2str(check_alg_t alg) {
 
 flags_t str2flags(const char *str) {
     flags_t flags = NONE;
-    while (str && *str) {
-        if (*str == 'G') {
+    // Iterate with a separate cursor so `str` still points at the whole value and the
+    // error below can report what the user actually passed rather than its tail.
+    for (const char *s = str; s && *s; s++) {
+        if (*s == 'G') {
             flags |= GLOB_STATS;
-        } else if (*str == 'C') {
+        } else if (*s == 'C') {
             flags |= USE_SCALE;
-        } else if (*str == 'H') {
+        } else if (*s == 'H') {
             flags |= USE_SHIFT;
-        } else if (*str == 'R') {
+        } else if (*s == 'R') {
             flags |= FUSE_NORM_RELU;
-        } else if (*str == 'A') {
+        } else if (*s == 'A') {
             flags |= FUSE_NORM_ADD_RELU;
         } else {
-            BENCHDNN_PRINT(0, "%s \'%c\'\n",
-                    "Error: --flags option doesn't support value", *str);
+            BENCHDNN_PRINT(0, "%s \'%s\'\n",
+                    "Error: --flags option doesn't support value", str);
             SAFE_V(FAIL);
         }
-        str++;
     }
     return flags;
 }

--- a/tests/benchdnn/gnorm/gnorm_aux.cpp
+++ b/tests/benchdnn/gnorm/gnorm_aux.cpp
@@ -21,19 +21,20 @@ namespace gnorm {
 
 flags_t str2flags(const char *str) {
     flags_t flags = NONE;
-    while (str && *str) {
-        if (*str == 'G') {
+    // Iterate with a separate cursor so `str` still points at the whole value and the
+    // error below can report what the user actually passed rather than its tail.
+    for (const char *s = str; s && *s; s++) {
+        if (*s == 'G') {
             flags |= GLOB_STATS;
-        } else if (*str == 'C') {
+        } else if (*s == 'C') {
             flags |= USE_SCALE;
-        } else if (*str == 'H') {
+        } else if (*s == 'H') {
             flags |= USE_SHIFT;
         } else {
-            BENCHDNN_PRINT(0, "%s \'%c\'\n",
-                    "Error: --flags option doesn't support value", *str);
+            BENCHDNN_PRINT(0, "%s \'%s\'\n",
+                    "Error: --flags option doesn't support value", str);
             SAFE_V(FAIL);
         }
-        str++;
     }
     return flags;
 }

--- a/tests/benchdnn/lnorm/lnorm_aux.cpp
+++ b/tests/benchdnn/lnorm/lnorm_aux.cpp
@@ -23,21 +23,22 @@ namespace lnorm {
 
 flags_t str2flags(const char *str) {
     flags_t flags = NONE;
-    while (str && *str) {
-        if (*str == 'G') {
+    // Iterate with a separate cursor so `str` still points at the whole value and the
+    // error below can report what the user actually passed rather than its tail.
+    for (const char *s = str; s && *s; s++) {
+        if (*s == 'G') {
             flags |= GLOB_STATS;
-        } else if (*str == 'C') {
+        } else if (*s == 'C') {
             flags |= USE_SCALE;
-        } else if (*str == 'H') {
+        } else if (*s == 'H') {
             flags |= USE_SHIFT;
-        } else if (*str == 'M') {
+        } else if (*s == 'M') {
             flags |= USE_RMS_NORM;
         } else {
-            BENCHDNN_PRINT(0, "%s \'%c\'\n",
-                    "Error: --flags option doesn't support value", *str);
+            BENCHDNN_PRINT(0, "%s \'%s\'\n",
+                    "Error: --flags option doesn't support value", str);
             SAFE_V(FAIL);
         }
-        str++;
     }
     return flags;
 }


### PR DESCRIPTION
Follow-up to #5760, requested by @dzarukin there.

#5760 made the rnn `--flags` parser report the whole value the user passed rather than the first unsupported character. `bnorm`, `gnorm`, and `lnorm` have the same `str2flags` shape and still print a single character, so this brings them in line.

**What changes**

Each parser kept `str` as its own loop cursor, so by the time the error fired the pointer had already advanced past the earlier flags. Keeping `str` pointing at the whole value and walking it with a separate cursor lets the message name what was actually passed:

```
$ benchdnn --bnorm --flags=GXY ...
Error: --flags option doesn't support value 'GXY'    # was 'X'
```

**Scope**

Only the loop cursor and the error message change. The flag letters each parser accepts, the resulting `flags_t`, and the `SAFE_V(FAIL)` behavior are all untouched, so nothing about valid input is affected.

**Verified**

- `clang-format` with the repo config leaves all three files unchanged.
- The branch is exactly three commits ahead of the merge base, touching only the three `*_aux.cpp` files.
