### PR TITLE
[rls-v3.12] xe: gemm: fix compare with qword immediate

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
@@ -577,7 +577,14 @@ bool Generator<hw>::gemmUpdateCDispatch(GEMMProblem &problem, GEMMStrategy &stra
             and_(1 | ze | f1[0], null.ud(), state.inputs.flags, FlagKPartitioned);
 
         if (checkBeta1 && !beta.fixed()) {
-            cmp(1 | eq | f0[1], vbetar.getReg(0), cast(problem.Ts, 1.0));
+            auto immediate = cast(problem.Ts, 1.0);
+            if (problem.Ts.size() > 4) {
+                auto temp = state.ra.alloc_sub(problem.Ts.ngen());
+                mov(1, temp, immediate);
+                cmp(1 | eq | f0[1], vbetar.getReg(0), temp);
+                state.ra.safeRelease(temp);
+            } else
+                cmp(1 | eq | f0[1], vbetar.getReg(0), immediate);
         }
 
         if (checkBeta0 && !beta.fixed()) {


### PR DESCRIPTION
Backport of #5762 to rls-v3.12.