### PR TITLE
xe: gemm: validate microkernel registers against host thread payload

### DIFF
--- a/src/gpu/intel/compute/ukernels.cpp
+++ b/src/gpu/intel/compute/ukernels.cpp
@@ -16,8 +16,13 @@
 
 #include "gpu/intel/compute/ukernels.hpp"
 
+#include <exception>
+#include <string>
+
 #include "common/verbose.hpp"
+#include "gemmstone/microkernel/fuser.hpp"
 #include "gemmstone/microkernel/shim.hpp"
+#include "gpu/intel/utils.hpp"
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include "gpu/intel/ocl/engine.hpp"
@@ -133,6 +138,20 @@ void microkernel_shims_t::finalize() {
         kernel_ctx_.add_option("-cl-intel-512-GRF-per-thread");
     else if (grf_min_ > 128)
         kernel_ctx_.add_option("-cl-intel-256-GRF-per-thread");
+}
+
+status_t fuse_microkernels(
+        xpu::binary_t &binary, const char *code, int grf_size) {
+    try {
+        if (!gemmstone::microkernel::fuse(binary, code, grf_size))
+            VWARN(common, runtime,
+                    "could not check microkernel registers against the host "
+                    "kernel thread payload");
+    } catch (const std::exception &e) {
+        VERROR(common, runtime, "microkernel fusion failed: %s", e.what());
+        return status::runtime_error;
+    } catch (...) { return status::runtime_error; }
+    return status::success;
 }
 
 } // namespace compute

--- a/src/gpu/intel/compute/ukernels.cpp
+++ b/src/gpu/intel/compute/ukernels.cpp
@@ -17,7 +17,7 @@
 #include "gpu/intel/compute/ukernels.hpp"
 
 #include "common/verbose.hpp"
-#include "gemmstone/microkernel/package.hpp"
+#include "gemmstone/microkernel/shim.hpp"
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include "gpu/intel/ocl/engine.hpp"
@@ -112,6 +112,27 @@ status_t validate_microkernel(const gemmstone::microkernel::Package &package,
     VCONDCHECK(primitive, create, check, gpu, reason == nullptr,
             status::unimplemented, "%s microkernel %s", kernel_name, reason);
     return status::runtime_error;
+}
+
+void microkernel_shims_t::add(const char *header_name, const char *decorator,
+        const gemmstone::microkernel::Package &package) {
+    gemmstone::microkernel::ShimOptions options;
+    options.subgroupSize = subgroup_size_;
+    options.useTileOps = true;
+    options.decorator = decorator;
+    options.microkernelID = next_id_++;
+
+    kernel_ctx_.add_custom_header(header_name,
+            generateShim(package,
+                    gemmstone::microkernel::HostLanguage::OpenCL_C, options));
+    require_grfs(package.grfMin);
+}
+
+void microkernel_shims_t::finalize() {
+    if (arch_ >= gpu_arch_t::xe3p && grf_min_ > 256)
+        kernel_ctx_.add_option("-cl-intel-512-GRF-per-thread");
+    else if (grf_min_ > 128)
+        kernel_ctx_.add_option("-cl-intel-256-GRF-per-thread");
 }
 
 } // namespace compute

--- a/src/gpu/intel/compute/ukernels.hpp
+++ b/src/gpu/intel/compute/ukernels.hpp
@@ -23,6 +23,7 @@
 #include "gpu/intel/compute/device_info.hpp"
 #include "gpu/intel/compute/kernel_ctx.hpp"
 #include "gpu/intel/engine.hpp"
+#include "xpu/utils.hpp"
 
 namespace gemmstone {
 namespace microkernel {
@@ -66,6 +67,11 @@ private:
     uint32_t next_id_ = 0;
     int grf_min_ = 0;
 };
+
+// Splices microkernel machine code embedded in `code` into the IGC-compiled
+// binary. Callers check hasMicrokernels() first.
+status_t fuse_microkernels(
+        xpu::binary_t &binary, const char *code, int grf_size);
 
 } // namespace compute
 } // namespace intel

--- a/src/gpu/intel/compute/ukernels.hpp
+++ b/src/gpu/intel/compute/ukernels.hpp
@@ -17,7 +17,11 @@
 #ifndef GPU_INTEL_COMPUTE_UKERNELS_HPP
 #define GPU_INTEL_COMPUTE_UKERNELS_HPP
 
+#include <algorithm>
+
 #include "common/engine.hpp"
+#include "gpu/intel/compute/device_info.hpp"
+#include "gpu/intel/compute/kernel_ctx.hpp"
 #include "gpu/intel/engine.hpp"
 
 namespace gemmstone {
@@ -39,6 +43,29 @@ bool mayiuse_microkernels(const engine_t *engine);
 // returning a non-success status if it cannot be used.
 status_t validate_microkernel(const gemmstone::microkernel::Package &package,
         const char *kernel_name);
+
+// Embeds microkernel shims, assigning IDs and requesting the needed GRF mode.
+class microkernel_shims_t {
+public:
+    microkernel_shims_t(
+            kernel_ctx_t &kernel_ctx, int subgroup_size, gpu_arch_t arch)
+        : kernel_ctx_(kernel_ctx), subgroup_size_(subgroup_size), arch_(arch) {}
+
+    void add(const char *header_name, const char *decorator,
+            const gemmstone::microkernel::Package &package);
+
+    void require_grfs(int grf_min) { grf_min_ = std::max(grf_min_, grf_min); }
+
+    // Applies the GRF mode required by the packages added so far.
+    void finalize();
+
+private:
+    kernel_ctx_t &kernel_ctx_;
+    int subgroup_size_;
+    gpu_arch_t arch_;
+    uint32_t next_id_ = 0;
+    int grf_min_ = 0;
+};
 
 } // namespace compute
 } // namespace intel

--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -419,18 +419,12 @@ status_t micro_horz_t::init(impl::engine_t *engine) {
     if (lda % 4 == 0 && (pd()->OC() % tile_wgu_m) == 0)
         kernel_ctx.define_int("BLOCK_DST", 1);
 
-    gemmstone::microkernel::ShimOptions shimOptions;
-    shimOptions.subgroupSize = sg_size(engine);
-    shimOptions.useTileOps = true;
-    shimOptions.decorator = "wgu";
-
-    auto header = generateShim(pd()->gemm_gate_up_pkg(),
-            gemmstone::microkernel::HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_gateup.h", std::move(header));
-
-    if (pd()->gemm_gate_up_pkg().grfMin > 128) {
-        kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
-    }
+    compute::microkernel_shims_t shims(kernel_ctx, sg_size(engine),
+            utils::downcast<const intel::engine_t *>(engine)
+                    ->device_info()
+                    ->gpu_arch());
+    shims.add("gemm_gateup.h", "wgu", pd()->gemm_gate_up_pkg());
+    shims.finalize();
 
     CHECK(create_kernel(
             engine, &gemm_gate_up_, "micro_gated_mlp_horz", kernel_ctx));

--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -109,6 +109,9 @@ int sg_size(const impl::engine_t *engine) {
     return intel_engine->device_info()->min_subgroup_size();
 }
 
+// micro_gated_mlp_horz cross-thread argument bytes, plus headroom.
+constexpr int host_argument_bytes = 320;
+
 } // anonymous namespace
 
 status_t micro_horz_t::pd_t::init(const impl::engine_t *engine) {
@@ -262,9 +265,12 @@ status_t micro_horz_t::pd_t::init_microkernels(
     opts_wgu.scaleA = with_wts_gate_scales(this) && !wgu_common_scales;
     opts_wgu.offsetA = with_wts_gate_zp(this);
 
+    const gemmstone::microkernel::HostPayload host {
+            sg_size(engine), host_argument_bytes};
+
     try {
-        gemm_gate_up_pkg_
-                = selectGEMM(opts_wgu, hw_info, sizes, problem_wgu, reqs_wgu);
+        gemm_gate_up_pkg_ = selectGEMM(
+                opts_wgu, host, hw_info, sizes, problem_wgu, reqs_wgu);
     } catch (std::exception &e) {
         VDISPATCH_GATED_MLP(false,
                 "gemm_gateup microkernel generation failed with message: %s",

--- a/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
@@ -15,13 +15,16 @@
 *******************************************************************************/
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "generator/microkernel/elf.hpp"
+#include "generator/microkernel/payload.hpp"
 #include "gemmstone/microkernel/fuser.hpp"
 
 GEMMSTONE_NAMESPACE_START
@@ -29,8 +32,19 @@ namespace microkernel {
 
 static void fixupJumpTargets(uint8_t *start, size_t len, ptrdiff_t adjust);
 
-void fuse(std::vector<uint8_t> &binary,
-        const std::vector<uint8_t> &microkernel, long id) {
+/* Host payloads, checked against the microkernel's register placement. */
+struct PayloadCheck {
+    const std::vector<KernelInfo> *kernels;
+    uint32_t argumentBase;
+    int grfBytes;
+    bool *validated;
+};
+
+static void checkPayload(const PayloadCheck &check, const char *kernelName);
+
+static void fuse(std::vector<uint8_t> &binary,
+        const std::vector<uint8_t> &microkernel, long id,
+        const PayloadCheck *check) {
     auto base = binary.data();
     auto bytes = binary.size();
 
@@ -106,6 +120,9 @@ void fuse(std::vector<uint8_t> &binary,
 
         if (!spliceStart || !spliceEnd) continue;
 
+        // Validate the argument placement against the selected base.
+        if (check && snames) checkPayload(*check, snames + text->name + 6);
+
         int relSectionID = -1;
         std::string rname = ".rel";
         rname += (snames + text->name);
@@ -172,7 +189,7 @@ void fuse(std::vector<uint8_t> &binary,
         std::swap(binary, newBinary);
 
         // Tail-recurse to handle any further instances of this microkernel
-        fuse(binary, microkernel, id);
+        fuse(binary, microkernel, id, check);
         return;
     }
 }
@@ -198,7 +215,57 @@ static void stripIntermediateRepresentation(std::vector<uint8_t> &binary) {
             sheaders[s].type = SectionHeader::Null;
 }
 
-void fuse(std::vector<uint8_t> &binary, const char *source) {
+static bool findZeInfo(
+        const std::vector<uint8_t> &binary, const char *&text, size_t &length) {
+    auto base = binary.data();
+    auto bytes = binary.size();
+
+    if (bytes < sizeof(FileHeader)) return false;
+    auto *fheader = reinterpret_cast<const FileHeader *>(base);
+    if (fheader->magic != ELFMagic || fheader->elfClass != ELFClass64)
+        return false;
+    if (fheader->sectionHeaderSize != sizeof(SectionHeader)) return false;
+    if (fheader->sectionTableOff > bytes) return false;
+    if ((bytes - fheader->sectionTableOff) / sizeof(SectionHeader)
+            < fheader->sectionCount)
+        return false;
+
+    auto *sheaders = reinterpret_cast<const SectionHeader *>(
+            base + fheader->sectionTableOff);
+    for (int s = 0; s < fheader->sectionCount; s++) {
+        if (sheaders[s].type != SectionHeader::Type::ZeInfo) continue;
+        if (sheaders[s].offset > bytes
+                || sheaders[s].size > bytes - sheaders[s].offset)
+            return false;
+        text = reinterpret_cast<const char *>(base + sheaders[s].offset);
+        length = size_t(sheaders[s].size);
+        return true;
+    }
+    return false;
+}
+
+// vISA does not reserve registers against IGC's thread payload, so a microkernel
+// placed too low silently corrupts the host kernel's arguments.
+static void checkPayload(const PayloadCheck &check, const char *kernelName) {
+    for (auto &kernel : *check.kernels) {
+        if (kernel.name != kernelName) continue;
+        *check.validated = true;
+
+        auto payloadEnd = payloadEndBytes(kernel, check.grfBytes);
+        if (payloadEnd <= check.argumentBase) return;
+
+        auto argumentBytes = payloadEnd - crossthreadBase(kernel, check.grfBytes);
+        throw std::runtime_error("Microkernel registers (r"
+                + std::to_string(check.argumentBase / check.grfBytes)
+                + " and up) overlap the thread payload of kernel "
+                + kernel.name + ", which ends at r"
+                + std::to_string((payloadEnd - 1) / check.grfBytes)
+                + ". Raise HostPayload::argumentBytes to "
+                + std::to_string(argumentBytes) + " or more");
+    }
+}
+
+bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes) {
     std::vector<uint8_t> microkernel;
     const auto sigilLen = strlen(sigilBinary);
 
@@ -206,20 +273,34 @@ void fuse(std::vector<uint8_t> &binary, const char *source) {
         return ((c >= 'A') ? (c - 'A' + 10) : (c - '0')) & 0xF;
     };
 
+    /* Read the payload layout before fusing moves the .ze_info section. */
+    std::vector<KernelInfo> kernels;
+    const char *zeInfo = nullptr;
+    size_t zeInfoLength = 0;
+    bool haveLayout = grfBytes > 0 && findZeInfo(binary, zeInfo, zeInfoLength)
+            && parseZeInfo(zeInfo, zeInfoLength, kernels);
+    bool validated = false;
+
     for (const char *s = std::strstr(source, sigilBinary); s;
             s = std::strstr(s, sigilBinary)) {
         s += sigilLen;
         char *after;
         long id = strtol(s, &after, 10);
+        uint32_t argumentBase = 0;
+        if (*after == ':')
+            argumentBase = uint32_t(strtoul(after + 1, &after, 10));
         microkernel.clear();
         for (s = after + 1; *s != '\n'; s += 2) {
             if (!s[0] || !s[1]) break;
             microkernel.push_back(static_cast<uint8_t>(
                     (toNybble(s[0]) << 4) | toNybble(s[1])));
         }
-        fuse(binary, microkernel, id);
+        PayloadCheck check {&kernels, argumentBase, grfBytes, &validated};
+        fuse(binary, microkernel, id,
+                (haveLayout && argumentBase > 0) ? &check : nullptr);
     }
     stripIntermediateRepresentation(binary);
+    return validated;
 }
 
 static void fixupJumpTargets(uint8_t *start, size_t len, ptrdiff_t adjust) {

--- a/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
@@ -26,6 +26,7 @@
 #include "generator/microkernel/elf.hpp"
 #include "generator/microkernel/payload.hpp"
 #include "gemmstone/microkernel/fuser.hpp"
+#include "ngen_elf.hpp"
 
 GEMMSTONE_NAMESPACE_START
 namespace microkernel {
@@ -42,9 +43,33 @@ struct PayloadCheck {
 
 static void checkPayload(const PayloadCheck &check, const char *kernelName);
 
+/* Compacted no-op, used to keep microkernel instructions 16-byte aligned.
+   Encodings are per-arch compaction table entries; verify additions with
+   iga64 (sync.nop {Compacted} / mov (1|M0) null:ud r0.0:ud {Compacted}). */
+static const uint8_t *alignmentFiller(ngen::HW hw) {
+    static const uint8_t syncNop[8] = {0x01, 0, 0, 0xE8, 0x01, 0, 0x11, 0};
+    static const uint8_t movNull[8] = {0x61, 0, 0x84, 0xBC, 0, 0, 0, 0};
+    static const uint8_t movNullXe2[8] = {0x61, 0, 0x84, 0xFC, 0, 0, 0x10, 0};
+    static const uint8_t movNullXe3p[8] = {0x61, 0, 0x84, 0xA4, 0, 0, 0, 0};
+    switch (hw) {
+        case ngen::HW::Unknown:
+        case ngen::HW::Gen9:
+        case ngen::HW::Gen10:
+        case ngen::HW::Gen11:
+        case ngen::HW::XeLP:
+        case ngen::HW::XeHP: return nullptr;
+        case ngen::HW::XeHPG: return syncNop;
+        case ngen::HW::XeHPC: return movNull;
+        case ngen::HW::Xe2:
+        case ngen::HW::Xe3: return movNullXe2;
+        case ngen::HW::Xe3p: return movNullXe3p;
+    }
+    return nullptr;
+}
+
 static void fuse(std::vector<uint8_t> &binary,
         const std::vector<uint8_t> &microkernel, long id,
-        const PayloadCheck *check) {
+        const PayloadCheck *check, const uint8_t *filler) {
     auto base = binary.data();
     auto bytes = binary.size();
 
@@ -139,22 +164,30 @@ static void fuse(std::vector<uint8_t> &binary,
 
         size_t before = spliceStart - base;
         auto after = bytes - before - removeBytes;
-        ptrdiff_t sizeAdjust = microkernel.size() - removeBytes;
 
         auto kbefore = before - text->offset;
+
+        /* Keep the microkernel's (uncompacted) instructions 16-byte aligned
+           so they do not straddle instruction cache lines. */
+        std::vector<uint8_t> blob;
+        if (filler && (kbefore & 8)) blob.assign(filler, filler + 8);
+        blob.insert(blob.end(), microkernel.begin(), microkernel.end());
+
+        ptrdiff_t sizeAdjust = blob.size() - removeBytes;
+
         auto kafter = text->size - kbefore - removeBytes;
 
         std::vector<uint8_t> newBinary(bytes + sizeAdjust);
         auto newBase = newBinary.data();
 
         memmove(newBase, base, before);
-        memmove(newBase + before, microkernel.data(), microkernel.size());
-        memmove(newBase + before + microkernel.size(),
+        memmove(newBase + before, blob.data(), blob.size());
+        memmove(newBase + before + blob.size(),
                 spliceStart + removeBytes, after);
 
         fixupJumpTargets(newBase + text->offset, kbefore, +sizeAdjust);
         fixupJumpTargets(
-                newBase + before + microkernel.size(), kafter, -sizeAdjust);
+                newBase + before + blob.size(), kafter, -sizeAdjust);
 
         fheaderPtr = reinterpret_cast<FileHeader *>(newBase);
 
@@ -189,7 +222,7 @@ static void fuse(std::vector<uint8_t> &binary,
         std::swap(binary, newBinary);
 
         // Tail-recurse to handle any further instances of this microkernel
-        fuse(binary, microkernel, id, check);
+        fuse(binary, microkernel, id, check, filler);
         return;
     }
 }
@@ -269,6 +302,9 @@ bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes) {
     std::vector<uint8_t> microkernel;
     const auto sigilLen = strlen(sigilBinary);
 
+    auto filler = alignmentFiller(
+            ngen::ELFCodeGenerator<ngen::HW::Unknown>::getBinaryArch(binary));
+
     auto toNybble = [](char c) {
         return ((c >= 'A') ? (c - 'A' + 10) : (c - '0')) & 0xF;
     };
@@ -297,7 +333,7 @@ bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes) {
         }
         PayloadCheck check {&kernels, argumentBase, grfBytes, &validated};
         fuse(binary, microkernel, id,
-                (haveLayout && argumentBase > 0) ? &check : nullptr);
+                (haveLayout && argumentBase > 0) ? &check : nullptr, filler);
     }
     stripIntermediateRepresentation(binary);
     return validated;

--- a/src/gpu/intel/gemm/jit/generator/microkernel/payload.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/payload.cpp
@@ -1,0 +1,154 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+
+#include "generator/microkernel/payload.hpp"
+
+GEMMSTONE_NAMESPACE_START
+namespace microkernel {
+
+static std::string unquote(const std::string &s) {
+    if (s.size() >= 2 && (s.front() == '\'' || s.front() == '"')
+            && s.back() == s.front())
+        return s.substr(1, s.size() - 2);
+    return s;
+}
+
+bool parseZeInfo(
+        const char *text, size_t length, std::vector<KernelInfo> &kernels) {
+    kernels.clear();
+
+    bool inKernels = false;
+    enum { None, ExecEnv, Payload, PerThread } section = None;
+    PayloadArgument perThread;
+    auto *end = text + length;
+
+    for (auto *l = text; l < end;) {
+        auto *eol = static_cast<const char *>(
+                std::memchr(l, '\n', size_t(end - l)));
+        if (!eol) eol = end;
+        int indent = 0;
+        while (l + indent < eol && l[indent] == ' ')
+            indent++;
+        std::string line(l + indent, size_t(eol - l - indent));
+        l = (eol < end) ? eol + 1 : end;
+        while (!line.empty() && (line.back() == '\r' || line.back() == ' '))
+            line.pop_back();
+        if (line.empty() || line[0] == '#') continue;
+
+        if (indent == 0) {
+            inKernels = (line == "kernels:");
+            section = None;
+            continue;
+        }
+        if (!inKernels) continue;
+
+        bool item = (line.compare(0, 2, "- ") == 0);
+        if (item) line = line.substr(2);
+
+        /* A list item at kernel level starts a kernel; its first key is inline. */
+        if (indent == 2 && item) {
+            kernels.emplace_back();
+            section = None;
+            indent = 4;
+            item = false;
+        }
+        if (kernels.empty()) return false;
+        auto &kernel = kernels.back();
+
+        auto colon = line.find(':');
+        if (colon == std::string::npos) continue;
+        std::string key = line.substr(0, colon), val;
+        auto v = line.find_first_not_of(' ', colon + 1);
+        if (v != std::string::npos) val = unquote(line.substr(v));
+
+        auto number = [&] {
+            return uint32_t(std::strtoul(val.c_str(), nullptr, 10));
+        };
+
+        if (indent == 4 && !item) {
+            if (key == "name") {
+                kernel.name = val;
+                continue;
+            }
+            if (val.empty()) {
+                section = (key == "execution_env")                ? ExecEnv
+                        : (key == "payload_arguments")            ? Payload
+                        : (key == "per_thread_payload_arguments") ? PerThread
+                                                                  : None;
+                perThread = {};
+                continue;
+            }
+        }
+        if (section == None) continue;
+
+        if (section == ExecEnv) {
+            if (key == "inline_data_payload_size")
+                kernel.inlineDataBytes = number();
+            continue;
+        }
+
+        if (section == PerThread) {
+            /* Only the extent matters; local IDs need no padding fixup. */
+            if (item) perThread = {};
+            if (key == "offset") perThread.offset = number();
+            else if (key == "size") perThread.size = number();
+            kernel.perThreadBytes = std::max(
+                    kernel.perThreadBytes, perThread.offset + perThread.size);
+            continue;
+        }
+
+        if (item) kernel.payload.emplace_back();
+        if (kernel.payload.empty()) { kernels.clear(); return false; }
+        auto &arg = kernel.payload.back();
+        if (key == "offset") arg.offset = number();
+        else if (key == "size") arg.size = number();
+    }
+
+    return !kernels.empty();
+}
+
+static uint32_t alignUp(uint32_t x, uint32_t align) {
+    return (x + align - 1) & ~(align - 1);
+}
+
+uint32_t crossthreadBase(const KernelInfo &kernel, int grfBytes) {
+    auto grf = uint32_t(grfBytes);
+    return grf + alignUp(kernel.perThreadBytes, grf);
+}
+
+uint32_t payloadEndBytes(const KernelInfo &kernel, int grfBytes) {
+    // Inline data occupies a whole GRF regardless of inline_data_payload_size,
+    // so offsets at or past it shift by the padding.
+    auto inlineData = kernel.inlineDataBytes;
+    uint32_t pad = inlineData
+            ? alignUp(inlineData, uint32_t(grfBytes)) - inlineData
+            : 0;
+
+    auto base = crossthreadBase(kernel, grfBytes);
+    auto end = base;
+    for (auto &arg : kernel.payload) {
+        auto offset = base + arg.offset + ((arg.offset >= inlineData) ? pad : 0);
+        end = std::max(end, offset + arg.size);
+    }
+    return end;
+}
+
+}
+GEMMSTONE_NAMESPACE_END

--- a/src/gpu/intel/gemm/jit/generator/microkernel/payload.hpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/payload.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GEMMSTONE_GENERATOR_MICROKERNEL_PAYLOAD_HPP
+#define GEMMSTONE_GENERATOR_MICROKERNEL_PAYLOAD_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "gemmstone/config.hpp"
+
+GEMMSTONE_NAMESPACE_START
+namespace microkernel {
+
+// A thread payload argument, at a byte offset within its payload block.
+struct PayloadArgument {
+    uint32_t offset = 0;
+    uint32_t size = 0;
+};
+
+struct KernelInfo {
+    std::string name;
+    uint32_t inlineDataBytes = 0;
+    uint32_t perThreadBytes = 0;
+    // Kept per-argument: inline-data padding shifts each offset individually,
+    // and .ze_info may list the arguments before inline_data_payload_size.
+    std::vector<PayloadArgument> payload;
+};
+
+// Reads kernel thread payload layouts from zebin .ze_info metadata.
+// Unrecognized keys are skipped; returns false if no kernel list was found.
+bool parseZeInfo(const char *text, size_t length, std::vector<KernelInfo> &kernels);
+
+// Thread payload geometry, in GRF bytes relative to r0. `grfBytes` must be
+// supplied: .ze_info records grf_count, not the GRF width.
+uint32_t crossthreadBase(const KernelInfo &kernel, int grfBytes);
+uint32_t payloadEndBytes(const KernelInfo &kernel, int grfBytes);
+
+}
+GEMMSTONE_NAMESPACE_END
+
+#endif

--- a/src/gpu/intel/gemm/jit/generator/microkernel/shim.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/shim.cpp
@@ -750,7 +750,8 @@ std::string generateShim(const Package &package, HostLanguage language,
 
     /* Insert binary code in comment for fuser */
     const char hexChars[] = "0123456789abcdef";
-    shim << "    // " << sigilBinary << options.microkernelID << ' ';
+    shim << "    // " << sigilBinary << options.microkernelID << ':'
+         << package.argumentBase << ' ';
     for (auto b : package.binary)
         shim << hexChars[(b >> 4) & 0xF] << hexChars[b & 0xF];
     shim << '\n';

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -115,17 +115,16 @@ InterfaceHandler GEMMOptions::generateInterface(HW hw, HostPayload host) const {
     /* Set up arguments for microkernel */
     InterfaceHandler interface(hw);
 
-    if (host.simd <= 0 || host.argumentBytes <= 0) {
-        /* Transitional: legacy callers keep the fixed base and r0-r9 claim. */
-        interface.setArgumentBase(ngen::GRF(8));
-    } else {
-        /* Place microkernel arguments above the host kernel's thread payload:
-           r0, the local IDs, then the cross-thread arguments. */
-        interface.requireLocalID(3);
-        interface.requireSIMD(host.simd);
-        interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
-                                      + GRF::bytesToGRFs(hw, host.argumentBytes)));
-    }
+    if (host.simd <= 0 || host.argumentBytes <= 0)
+        stub("Invalid host kernel thread payload");
+
+    /* Place microkernel arguments above the host kernel's thread payload:
+       r0, the local IDs, then the cross-thread arguments. */
+    interface.requireLocalID(3);
+    /* SIMD fixes the local-ID register stride, hence the cross-thread base. */
+    interface.requireSIMD(host.simd);
+    interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
+                                  + GRF::bytesToGRFs(hw, host.argumentBytes)));
     interface.newArgument("A", localA ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
     interface.newArgument("lda", DataType::d);
     interface.newArgument("B", localB ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
@@ -409,14 +408,6 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
         }
     }
     throw std::runtime_error("No matching kernel");
-}
-
-Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
-                   const GEMMProblem &problem, const std::vector<StrategyRequirement> &reqs,
-                   StrategyAdjuster strategyAdjuster, SelectionObserver *observer)
-{
-    return selectGEMM(options, HostPayload(0, 0), hwInfo, sizes, problem, reqs,
-                      strategyAdjuster, observer);
 }
 
 static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool localA, bool localB,

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -111,11 +111,21 @@ Protocol makeProtocol(const GEMMOptions &o) {
     return {"ugemm", arguments(o), settings()};
 }
 
-InterfaceHandler GEMMOptions::generateInterface(HW hw) const {
+InterfaceHandler GEMMOptions::generateInterface(HW hw, HostPayload host) const {
     /* Set up arguments for microkernel */
     InterfaceHandler interface(hw);
 
-    interface.setArgumentBase(ngen::GRF(8));
+    if (host.simd <= 0 || host.argumentBytes <= 0) {
+        /* Transitional: legacy callers keep the fixed base and r0-r9 claim. */
+        interface.setArgumentBase(ngen::GRF(8));
+    } else {
+        /* Place microkernel arguments above the host kernel's thread payload:
+           r0, the local IDs, then the cross-thread arguments. */
+        interface.requireLocalID(3);
+        interface.requireSIMD(host.simd);
+        interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
+                                      + GRF::bytesToGRFs(hw, host.argumentBytes)));
+    }
     interface.newArgument("A", localA ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
     interface.newArgument("lda", DataType::d);
     interface.newArgument("B", localB ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
@@ -160,7 +170,7 @@ std::string strategyToString(HW hw, const GEMMProblem &problem, const GEMMStrate
     return ss.str();
 }
 
-Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation hwInfo, SizeParams sizes,
                    const GEMMProblem &problem_, const std::vector<StrategyRequirement> &reqs_,
                    StrategyAdjuster strategyAdjuster, SelectionObserver *observer)
 {
@@ -241,7 +251,7 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
     evalParams.euCount = hwInfo.euCount;
 
     /* Generate interface */
-    InterfaceHandler interface = effOptions.generateInterface(hw);
+    InterfaceHandler interface = effOptions.generateInterface(hw, host);
 
     kcatalog::Catalog catalog = [&]() {
         if (localA)
@@ -399,6 +409,14 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
         }
     }
     throw std::runtime_error("No matching kernel");
+}
+
+Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+                   const GEMMProblem &problem, const std::vector<StrategyRequirement> &reqs,
+                   StrategyAdjuster strategyAdjuster, SelectionObserver *observer)
+{
+    return selectGEMM(options, HostPayload(0, 0), hwInfo, sizes, problem, reqs,
+                      strategyAdjuster, observer);
 }
 
 static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool localA, bool localB,

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -54,7 +54,12 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
     auto argumentBase = interface.getArgumentBase();
     if (argumentBase.isInvalid() || argumentBase.getBase() < 1)
         stub("Microkernel argument base not set");
-    state.ra.claim(GRFRange(0, argumentBase.getBase()));
+    int claimGRFs = argumentBase.getBase();
+    // XXX: Keep the legacy claim as a workaround for NVL-P to avoid
+    // performance regressions. IGC is sensitive to register range changes.
+    if (getProductFamily() == ngen::ProductFamily::NVLP)
+        claimGRFs = std::max<int>(claimGRFs, 10);
+    state.ra.claim(GRFRange(0, claimGRFs));
 
     moveR0(strategy, state);
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -341,6 +341,7 @@ microkernel::Package Generator<hw>::gemmMicrokernelPackage(const GEMMProblem &pr
     package.settings.push_back({"slm_size", int(slmSize)});
 
     package.barrierCount = interface.getBarrierCount();
+    package.argumentBase = interface.getArgumentBase().getBase() * GRF::bytes(hw);
 
     package.finalize(knownClobbers);
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -50,11 +50,11 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
 
     state.isNested = true;
 
-    /* Leave some space for host kernel arguments */
-    // The host side arguments with 32 byte size registers (DG2)
-    // use 16 registers include padding bytes (aligned with 128 bytes)
-    // r0, r4 are reserved for system threads
-    state.ra.claim((GRF::bytes(hw) >= 64) ? r0-r9 : r0-r15);
+    /* Reserve the host kernel's thread payload, below the microkernel's arguments. */
+    auto argumentBase = interface.getArgumentBase();
+    if (argumentBase.isInvalid() || argumentBase.getBase() < 1)
+        stub("Microkernel argument base not set");
+    state.ra.claim(GRFRange(0, argumentBase.getBase()));
 
     moveR0(strategy, state);
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/fuser.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/fuser.hpp
@@ -30,12 +30,11 @@ static constexpr uint32_t sigilStart = 0xCAFEFADE;
 static constexpr uint32_t sigilEnd = 0xFADECAFE;
 static constexpr const char *sigilBinary = "@_u_@";
 
-// Fuse the microkernel machine code into the program binary of a compiled host kernel.
-void fuse(std::vector<uint8_t> &binary,
-        const std::vector<uint8_t> &microkernel, int id = 0);
-
-// Fusing microkernels that were embedded directly in source code.
-void fuse(std::vector<uint8_t> &binary, const char *source);
+// Fuse source-embedded microkernels into the compiled host kernel's binary.
+// Each is checked against the host thread payload; an overlap throws, leaving
+// `binary` partially fused. Returns false if none could be checked (fused but
+// unvalidated).
+bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes);
 bool hasMicrokernels(const char *source);
 
 }

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
@@ -99,6 +99,7 @@ struct Package {
     /* Register usage */
     std::vector<Argument> arguments; // Input and output arguments for microkernel
     std::vector<RegisterRange> clobbers; // Registers clobbered by microkernel (includes arguments) [*]
+    uint32_t argumentBase = 0; // First GRF byte used by microkernel; host thread payload lies below
 
     /* Requirements */
     uint32_t gmdidCompat; // Compatible GMDID

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -34,6 +34,14 @@ struct HWInformation {
     bool isEfficient64Bit;
 };
 
+/* Host kernel thread payload. Microkernel registers are placed above it. */
+struct HostPayload {
+    HostPayload(int simd, int argumentBytes) : simd(simd), argumentBytes(argumentBytes) {}
+
+    int simd;             /* host kernel SIMD width */
+    int argumentBytes;    /* cross-thread argument bytes, with headroom */
+};
+
 struct GEMMOptions {
     bool localA = false;
     bool localB = false;
@@ -46,13 +54,20 @@ struct GEMMOptions {
     bool kParallelLocal = false;
 
     GEMMOptions() = default;
-    ngen::InterfaceHandler generateInterface(ngen::HW hw) const;
+    ngen::InterfaceHandler generateInterface(ngen::HW hw, HostPayload host) const;
     GEMMOptions transpose() const;
 };
 
 /* Main entrypoint for microkernel auto-selection */
 using StrategyAdjuster = std::function<void(GEMMStrategy&)>;
-Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes, const GEMMProblem &problem,
+Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation hwInfo, SizeParams sizes,
+                                     const GEMMProblem &problem,
+                                     const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
+                                     StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
+
+/* Transitional overload for callers that do not yet pass a HostPayload. */
+Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+                                     const GEMMProblem &problem,
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                      StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -65,12 +65,6 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                      StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
 
-/* Transitional overload for callers that do not yet pass a HostPayload. */
-Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
-                                     const GEMMProblem &problem,
-                                     const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
-                                     StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
-
 /* Helpers */
 static inline int alignmentForLD(int ld)
 {

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cl
@@ -99,11 +99,14 @@ void load_bias(
 
 #if WITH_POST_OP
 #if WITH_BINARY_GROUPED_SCALE
+// One column-block of the [M,N] grouped scale, applied a block at a time.
+DECLARE_2D_TILE(binary_group_chunk_type, float, SUBGROUP_SIZE,
+        ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
+        ugemm_grouped_c_type_nblock0, 1)
 #if !BINARY_SCALE_GROUPED_DT_F32
-// Intermediate tile for loading non-float binary scale data before converting
-DECLARE_2D_TILE(binary_group_in_tile_type, BINARY_SCALE_GROUPED_TILE_DATA_T,
+DECLARE_2D_TILE(binary_group_chunk_in_type, BINARY_SCALE_GROUPED_TILE_DATA_T,
         SUBGROUP_SIZE, ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
-        ugemm_grouped_c_type_nblock0, ugemm_grouped_c_type_nblock1)
+        ugemm_grouped_c_type_nblock0, 1)
 #endif
 #endif
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -281,14 +281,13 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(
     CHECK(compute::validate_microkernel(gemm_, "grouped_gemm"));
 
     /* Generate microkernel shims */
-    ShimOptions shimOptions;
-    shimOptions.subgroupSize = sg_size_;
-    shimOptions.useTileOps = true;
-    shimOptions.decorator = "grouped";
-
     kernel_ctx_.define_int("SUBGROUP_SIZE", sg_size_);
-    kernel_ctx_.add_custom_header("gemm_grouped.h",
-            generateShim(gemm_, HostLanguage::OpenCL_C, shimOptions));
+
+    compute::microkernel_shims_t shims(
+            kernel_ctx_, sg_size_, dev_info->gpu_arch());
+    shims.add("gemm_grouped.h", "grouped", gemm_);
+    shims.require_grfs(strategyGRFs_);
+    shims.finalize();
 
     return status::success;
 }
@@ -479,14 +478,6 @@ status_t grouped_micro_gemm_t::pd_t::init(const impl::engine_t *engine) {
     wei_quant_.define_macros(kernel_ctx_, "WEI");
 
     kernel_ctx_.set_data_type(dst_dt);
-
-    const int grf_min = std::max(strategyGRFs_, gemm_.grfMin);
-    const bool is_xe3p = dev_info->gpu_arch() >= compute::gpu_arch_t::xe3p;
-    if (is_xe3p && grf_min > 256) {
-        kernel_ctx_.add_option("-cl-intel-512-GRF-per-thread");
-    } else if (grf_min > 128) {
-        kernel_ctx_.add_option("-cl-intel-256-GRF-per-thread");
-    }
 
     def_data_type(kernel_ctx_, src_dt, "SRC");
     def_data_type(kernel_ctx_, wei_dt, "WEI");

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -38,6 +38,13 @@ namespace gpu {
 namespace intel {
 namespace matmul {
 
+namespace {
+
+// grouped_micro_gemm cross-thread argument bytes, plus headroom.
+constexpr int host_argument_bytes = 256;
+
+} // namespace
+
 status_t grouped_micro_gemm_t::pd_t::init_microkernels(
         const impl::engine_t *engine) {
     using namespace jit;
@@ -94,6 +101,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(
     opts.offsetB = src_quant_.with_zp();
     opts.slmPtr = true;
     opts.kParallelLocal = is_gemv_;
+    const HostPayload host {sg_size_, host_argument_bytes};
 
     if (opts.scaleA) {
         data_type_t wei_scale_dt = wei_quant_.scale_dt();
@@ -215,7 +223,8 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(
     };
 
     try {
-        gemm_ = selectGEMM(opts, hw_info, sizes, problem, {}, strat_override);
+        gemm_ = selectGEMM(
+                opts, host, hw_info, sizes, problem, {}, strat_override);
     } catch (const std::runtime_error &) {
         std::vector<StrategyRequirement> reqs;
 
@@ -270,7 +279,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(
                         std::min((dim_t)(avg_m / reqs[1].value), max_wg_n))));
         try {
             gemm_ = selectGEMM(
-                    opts, hw_info, sizes, problem, reqs, strat_override);
+                    opts, host, hw_info, sizes, problem, reqs, strat_override);
         } catch (const std::runtime_error &ex) {
             VDISPATCH_MATMUL_IC(false,
                     "gemm microkernel generation failure with message: %s",

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -157,24 +157,35 @@ inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, l
                     to_ocl_float(e.eltwise.alpha).c_str(), i, i);
         } else if (e.is_binary()) {
             if (po_chain[i] == po_kind_t::binary_grouped_scale) {
-                s += utils::format(R"(
-#define CONCAT_I(var) var##_%d
-    const global BINARY_SCALE_GROUPED_TILE_DATA_T *group_scale_ptr = grouped_scale + src_offset * lddst;
-
-    ugemm_grouped_c_type CONCAT_I(binary_group_tile);
+                s += R"(
+    {
+        const global BINARY_SCALE_GROUPED_TILE_DATA_T *group_scale_ptr
+                = grouped_scale + src_offset * lddst;
+#define GRP_BC ugemm_grouped_c_type_block1
+#define GRP_NBR ugemm_grouped_c_type_nblock0
+#define GRP_NBC ugemm_grouped_c_type_nblock1
+#pragma unroll
+        for (int gcb = 0; gcb < GRP_NBC; gcb++) {
+            binary_group_chunk_type binary_group_chunk;
 #if BINARY_SCALE_GROUPED_DT_F32
-    tile_load(&CONCAT_I(binary_group_tile), group_scale_ptr, n, m, lddst, sg_i0, sg_j0);
+            tile_load(&binary_group_chunk, group_scale_ptr, n, m, lddst, sg_i0,
+                    sg_j0 + gcb * GRP_BC);
 #else
-    binary_group_in_tile_type CONCAT_I(binary_group_in_tile);
-    tile_load(&CONCAT_I(binary_group_in_tile), group_scale_ptr, n, m, lddst, sg_i0, sg_j0);
-    tile_convert(CONCAT_I(binary_group_in_tile), CONCAT_I(binary_group_tile), BINARY_SCALE_GROUPED_TO_FLOAT);
+            binary_group_chunk_in_type binary_group_chunk_in;
+            tile_load(&binary_group_chunk_in, group_scale_ptr, n, m, lddst,
+                    sg_i0, sg_j0 + gcb * GRP_BC);
+            tile_convert(binary_group_chunk_in, binary_group_chunk,
+                    BINARY_SCALE_GROUPED_TO_FLOAT);
 #endif
-#define binary_mul_%d(a, b) ((a) * (b))
-    tile_binary((*c_tile), CONCAT_I(binary_group_tile), CONCAT_I(binary_mul));
-#undef binary_mul_%d
-#undef CONCAT_I
-                         )",
-                        i, i, i);
+#pragma unroll
+            for (int gbb = 0; gbb < GRP_NBR; gbb++)
+                (*c_tile).x[GRP_NBR * gcb + gbb] *= binary_group_chunk.x[gbb];
+        }
+#undef GRP_BC
+#undef GRP_NBR
+#undef GRP_NBC
+    }
+                         )";
             } else if (po_chain[i] == po_kind_t::binary_dense_scale) {
                 s += utils::format(
                         R"(

--- a/src/gpu/intel/ocl/engine.cpp
+++ b/src/gpu/intel/ocl/engine.cpp
@@ -27,6 +27,7 @@
 
 #include "gemmstone/dsl/runtime.hpp"
 #include "gemmstone/microkernel/fuser.hpp"
+#include "gpu/intel/compute/ukernels.hpp"
 #include "gpu/intel/jit/generator_base.hpp"
 #include "gpu/intel/logging.hpp"
 #include "gpu/intel/ocl/device_info.hpp"
@@ -236,7 +237,8 @@ cl_int maybe_print_debug_info(
 }
 
 inline status_t fuse_microkernels(cl_context context, cl_device_id device,
-        xpu::ocl::wrapper_t<cl_program> &program, const char *code) {
+        xpu::ocl::wrapper_t<cl_program> &program, const char *code,
+        int grf_size) {
     if (gemmstone::microkernel::hasMicrokernels(code)) {
         cl_int status = CL_SUCCESS;
         size_t binary_size = 0;
@@ -248,9 +250,7 @@ inline status_t fuse_microkernels(cl_context context, cl_device_id device,
         OCL_CHECK(xpu::ocl::clGetProgramInfo(program, CL_PROGRAM_BINARIES,
                 sizeof(binary_data), &binary_data, nullptr));
 
-        try {
-            gemmstone::microkernel::fuse(binary, code);
-        } catch (...) { return status::runtime_error; }
+        CHECK(compute::fuse_microkernels(binary, code, grf_size));
 
         auto nbinary_size = binary.size();
         auto nbinary_data = const_cast<const uint8_t *>(binary.data());
@@ -320,7 +320,8 @@ status_t engine_t::build_program_from_source(
     OCL_CHECK(maybe_print_debug_info(err, program, dev));
 
     if (kernel_ctx.has_custom_headers())
-        CHECK(fuse_microkernels(ctx, dev, program, pp_code_str_ptr));
+        CHECK(fuse_microkernels(
+                ctx, dev, program, pp_code_str_ptr, dev_info->grf_size()));
 
     return status::success;
 }

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -62,12 +62,16 @@ bool with_quantize_common(const quant_entry_t &entry) {
     return !entry.has_default_values() && ((entry.get_mask() & 12) == 0);
 }
 
+// micro_sdpa/micro_sdpa_bwd cross-thread argument bytes, plus headroom.
+constexpr int host_argument_bytes_fwd = 320;
+constexpr int host_argument_bytes_bwd = 256;
+
 compute::gpu_arch_t gpu_arch(const micro::HWInformation &hw_info) {
     return jit::convert_ngen_arch_to_dnnl(
             getCore(ngen::npack::decodeHWIPVersion(hw_info.gmdid).family));
 }
 
-} /* anonymous namespace */
+} // namespace
 
 status_t update_config_from_devenv_values(
         fwd_config_t *config, bool quantized) {
@@ -1181,6 +1185,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
             opts_vs, sizes_kq, sizes_vs, ukernel_config);
 
+    const micro::HostPayload host {subgroup_size, host_argument_bytes_fwd};
     const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs;
@@ -1224,8 +1229,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
         }
     };
     try {
-        gemm_kq = micro::selectGEMM(opts_kq, hw_info, sizes_kq, problem_kq,
-                reqs_kq, kq_strat_override);
+        gemm_kq = micro::selectGEMM(opts_kq, host, hw_info, sizes_kq,
+                problem_kq, reqs_kq, kq_strat_override);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_kq microkernel generation failure with message: %s",
@@ -1259,11 +1264,11 @@ status_t micro_fwd_params_t::get_kernel_ctx(
                 strategy.dpasw |= strategy.fused;
                 vs_strat_override(strategy);
             };
-            gemm_vs = micro::selectGEMM(
-                    opts_vs, hw_info, sizes_vs, problem_vs, reqs_vs, adjust_vs);
+            gemm_vs = micro::selectGEMM(opts_vs, host, hw_info, sizes_vs,
+                    problem_vs, reqs_vs, adjust_vs);
         } else {
-            gemm_vs = micro::selectGEMM(opts_vs, hw_info, sizes_vs, problem_vs,
-                    reqs_vs, vs_strat_override);
+            gemm_vs = micro::selectGEMM(opts_vs, host, hw_info, sizes_vs,
+                    problem_vs, reqs_vs, vs_strat_override);
         }
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
@@ -1349,6 +1354,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
             opts_vtdA, opts_ktq, opts_qdSt, sizes_kq, sizes_vs, sizes_vtdA,
             sizes_ktq, sizes_qdSt, ukernel_config);
 
+    const micro::HostPayload host {subgroup_size, host_argument_bytes_bwd};
     const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs, gemm_vtdA, gemm_ktq, gemm_qdSt;
@@ -1395,7 +1401,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     /* Ask microkernel provider for microkernel */
     try {
         gemm_kq = micro::selectGEMM(
-                opts_kq, hw_info, sizes_kq, problem_kq, reqs_kq);
+                opts_kq, host, hw_info, sizes_kq, problem_kq, reqs_kq);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_kq microkernel generation failure with message: %s",
@@ -1409,11 +1415,11 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 /* Enable dpasw */
                 strategy.dpasw |= strategy.fused;
             };
-            gemm_vs = micro::selectGEMM(
-                    opts_vs, hw_info, sizes_vs, problem_vs, reqs_vs, adjust_vs);
+            gemm_vs = micro::selectGEMM(opts_vs, host, hw_info, sizes_vs,
+                    problem_vs, reqs_vs, adjust_vs);
         } else {
             gemm_vs = micro::selectGEMM(
-                    opts_vs, hw_info, sizes_vs, problem_vs, reqs_vs);
+                    opts_vs, host, hw_info, sizes_vs, problem_vs, reqs_vs);
         }
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
@@ -1435,7 +1441,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
 
     try {
         gemm_vtdA = micro::selectGEMM(
-                opts_vtdA, hw_info, sizes_vtdA, problem_vtdA, reqs_vtdA);
+                opts_vtdA, host, hw_info, sizes_vtdA, problem_vtdA, reqs_vtdA);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_vtdA microkernel generation failure with message: %s",
@@ -1447,7 +1453,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
 
     try {
         gemm_ktq = micro::selectGEMM(
-                opts_ktq, hw_info, sizes_ktq, problem_ktq, reqs_ktq);
+                opts_ktq, host, hw_info, sizes_ktq, problem_ktq, reqs_ktq);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_ktq microkernel generation failure with message: %s",
@@ -1459,7 +1465,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
 
     try {
         gemm_qdSt = micro::selectGEMM(
-                opts_qdSt, hw_info, sizes_qdSt, problem_qdSt, reqs_qdSt);
+                opts_qdSt, host, hw_info, sizes_qdSt, problem_qdSt, reqs_qdSt);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_qdSt microkernel generation failure with message: %s",

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -66,6 +66,16 @@ bool with_quantize_common(const quant_entry_t &entry) {
 constexpr int host_argument_bytes_fwd = 320;
 constexpr int host_argument_bytes_bwd = 256;
 
+// XXX: Use the adjusted argument base as a workaround to avoid performance
+// regressions in some cases.
+int host_argument_bytes_fwd_for(
+        const micro::HWInformation &hw_info, bool systolic) {
+    auto family = ngen::npack::decodeHWIPVersion(hw_info.gmdid).family;
+    if (family == ngen::ProductFamily::NVLP) return 256;
+    if (systolic && ngen::getCore(family) == ngen::HW::XeHPG) return 288;
+    return host_argument_bytes_fwd;
+}
+
 compute::gpu_arch_t gpu_arch(const micro::HWInformation &hw_info) {
     return jit::convert_ngen_arch_to_dnnl(
             getCore(ngen::npack::decodeHWIPVersion(hw_info.gmdid).family));
@@ -1185,7 +1195,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
             opts_vs, sizes_kq, sizes_vs, ukernel_config);
 
-    const micro::HostPayload host {subgroup_size, host_argument_bytes_fwd};
+    const micro::HostPayload host {subgroup_size,
+            host_argument_bytes_fwd_for(hw_info, use_systolic_ukernel)};
     const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs;

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -28,6 +28,7 @@
 #include "gpu/intel/compute/ukernels.hpp"
 #include "gpu/intel/compute/utils.hpp"
 #include "gpu/intel/gemm/jit/gen_kernel.hpp"
+#include "gpu/intel/jit/utils/type_bridge.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 #include "gpu/intel/utils.hpp"
 
@@ -59,6 +60,11 @@ using namespace gemmstone;
 ///   |  8 (0001) | false   |
 bool with_quantize_common(const quant_entry_t &entry) {
     return !entry.has_default_values() && ((entry.get_mask() & 12) == 0);
+}
+
+compute::gpu_arch_t gpu_arch(const micro::HWInformation &hw_info) {
+    return jit::convert_ngen_arch_to_dnnl(
+            getCore(ngen::npack::decodeHWIPVersion(hw_info.gmdid).family));
 }
 
 } /* anonymous namespace */
@@ -1175,6 +1181,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
             opts_vs, sizes_kq, sizes_vs, ukernel_config);
 
+    const auto hw_arch = gpu_arch(hw_info);
+
     micro::Package gemm_kq, gemm_vs;
 
     /* Set up microkernel strategy */
@@ -1268,28 +1276,10 @@ status_t micro_fwd_params_t::get_kernel_ctx(
             problem_kq.toString().c_str(), problem_vs.toString().c_str());
 
     /* Generate microkernel shims */
-    micro::ShimOptions shimOptions;
-    shimOptions.subgroupSize = subgroup_size;
-    shimOptions.useTileOps = true;
-    shimOptions.decorator = "kq";
-
-    kernel_ctx.add_custom_header("gemm_kq.h",
-            micro::generateShim(gemm_kq, HostLanguage::OpenCL_C, shimOptions));
-
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "vs";
-
-    kernel_ctx.add_custom_header("gemm_vs.h",
-            micro::generateShim(gemm_vs, HostLanguage::OpenCL_C, shimOptions));
-
-    const int grf_min = std::max(gemm_kq.grfMin, gemm_vs.grfMin);
-    const auto product = ngen::npack::decodeHWIPVersion(hw_info.gmdid);
-    const bool is_xe3p = getCore(product.family) >= ngen::HW::Xe3p;
-    if (is_xe3p && grf_min > 256) {
-        kernel_ctx.add_option("-cl-intel-512-GRF-per-thread");
-    } else if (grf_min > 128) {
-        kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
-    }
+    compute::microkernel_shims_t shims(kernel_ctx, subgroup_size, hw_arch);
+    shims.add("gemm_kq.h", "kq", gemm_kq);
+    shims.add("gemm_vs.h", "vs", gemm_vs);
+    shims.finalize();
 
     return status::success;
 }
@@ -1358,6 +1348,8 @@ status_t micro_bwd_params_t::get_kernel_ctx(
             problem_vtdA, problem_ktq, problem_qdSt, opts_kq, opts_vs,
             opts_vtdA, opts_ktq, opts_qdSt, sizes_kq, sizes_vs, sizes_vtdA,
             sizes_ktq, sizes_qdSt, ukernel_config);
+
+    const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs, gemm_vtdA, gemm_ktq, gemm_qdSt;
 
@@ -1437,21 +1429,9 @@ status_t micro_bwd_params_t::get_kernel_ctx(
             problem_qdSt.toString().c_str());
 
     /* Generate microkernel shims */
-    micro::ShimOptions shimOptions;
-    shimOptions.subgroupSize = subgroup_size;
-    shimOptions.useTileOps = true;
-    shimOptions.decorator = "kq";
-
-    std::string gemm_kq_header
-            = micro::generateShim(gemm_kq, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_kq.h", std::move(gemm_kq_header));
-
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "vs";
-
-    std::string gemm_vs_header
-            = micro::generateShim(gemm_vs, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_vs.h", std::move(gemm_vs_header));
+    compute::microkernel_shims_t shims(kernel_ctx, subgroup_size, hw_arch);
+    shims.add("gemm_kq.h", "kq", gemm_kq);
+    shims.add("gemm_vs.h", "vs", gemm_vs);
 
     try {
         gemm_vtdA = micro::selectGEMM(
@@ -1463,12 +1443,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     }
     CHECK(compute::validate_microkernel(gemm_vtdA, "gemm_vtdA"));
 
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "vtdA";
-
-    std::string gemm_vtdA_header = micro::generateShim(
-            gemm_vtdA, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_vtdA.h", std::move(gemm_vtdA_header));
+    shims.add("gemm_vtdA.h", "vtdA", gemm_vtdA);
 
     try {
         gemm_ktq = micro::selectGEMM(
@@ -1480,12 +1455,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     }
     CHECK(compute::validate_microkernel(gemm_ktq, "gemm_ktq"));
 
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "ktq";
-
-    std::string gemm_ktq_header = micro::generateShim(
-            gemm_ktq, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_ktq.h", std::move(gemm_ktq_header));
+    shims.add("gemm_ktq.h", "ktq", gemm_ktq);
 
     try {
         gemm_qdSt = micro::selectGEMM(
@@ -1497,22 +1467,9 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     }
     CHECK(compute::validate_microkernel(gemm_qdSt, "gemm_qdSt"));
 
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "qdSt";
+    shims.add("gemm_qdSt.h", "qdSt", gemm_qdSt);
 
-    std::string gemm_qdSt_header = micro::generateShim(
-            gemm_qdSt, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_qdSt.h", std::move(gemm_qdSt_header));
-
-    const int grf_min = std::max({gemm_kq.grfMin, gemm_vs.grfMin,
-            gemm_vtdA.grfMin, gemm_ktq.grfMin, gemm_qdSt.grfMin});
-    const auto product = ngen::npack::decodeHWIPVersion(hw_info.gmdid);
-    const bool is_xe3p = getCore(product.family) >= ngen::HW::Xe3p;
-    if (is_xe3p && grf_min > 256) {
-        kernel_ctx.add_option("-cl-intel-512-GRF-per-thread");
-    } else if (grf_min > 128) {
-        kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
-    }
+    shims.finalize();
 
     return status::success;
 }

--- a/src/gpu/intel/ze/engine.cpp
+++ b/src/gpu/intel/ze/engine.cpp
@@ -149,11 +149,8 @@ status_t engine_t::create_kernels(std::vector<compute::kernel_t> *kernels,
             device(), context(), code, options, binary));
 
     if (kernel_ctx.has_custom_headers()
-            && gemmstone::microkernel::hasMicrokernels(code_c)) {
-        try {
-            gemmstone::microkernel::fuse(binary, code_c);
-        } catch (...) { return status::runtime_error; }
-    }
+            && gemmstone::microkernel::hasMicrokernels(code_c))
+        CHECK(compute::fuse_microkernels(binary, code_c, dev_info->grf_size()));
 
     CHECK(convert_to_ze(*kernels, kernel_names, binary));
 

--- a/third_party/ngen/ngen_interface.hpp
+++ b/third_party/ngen/ngen_interface.hpp
@@ -141,6 +141,7 @@ public:
                           size_t z = 1)                  { wg[0] = x; wg[1] = y; wg[2] = z; }
 
     void setArgumentBase(RegData base)                   { baseOverride = base; }
+    RegData getArgumentBase() const                      { return baseOverride; }
     void setInlineGRFCount(int grfs)                     { requestedInlineBytes = grfs * GRF::bytes(hw); }
     int32_t getSkipCrossThreadOffset() const             { return offsetSkipCrossThread; }
     std::array<int32_t, 2> getCTPatchOffsets() const     { return offsetCTPatches; }


### PR DESCRIPTION
This PR unblocks https://github.com/uxlfoundation/oneDNN/pull/5716.

**Background:** microkernels use `.implicit_PSEUDO_INPUT` vISA declaration to reserve register regions. It works as follows: IGC places its register allocation around these regions (spilling to memory when required). However, there are two practical issues with this mechanism:

1. IGC places arguments without regard for `.implicit_PSEUDO_INPUT`. If there is an overlap, the generated kernel binary may produce incorrect results or cause invalid access. An overlap is harmless if the argument is read before the microkernel clobbers it.
2. IGC does not have any validation to detect the overlap

(1) is to be checked with the IGC team, to see whether they can fix the argument placement to respect `.implicit_PSEUDO_INPUT` declarations
(2) is a usability improvement. Currently this mechanism may silently break without any diagnostics. However, the GPU compiler has all the information to validate and report an error if an overlap is found.

**PR changes**

- Bump the protected regions to match the real payload placements for microkernels
- Add validation via `.ze_info` parsing to catch argument overlap. It fails hard, returning `status::unimplemented`
    - This is a stopgap fix for (2)

Also see comments from Stephen [here](https://jira.devtools.intel.com/browse/MFDNN-14796?focusedId=29477924&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-29477924).