### PR TITLE
[PowerPC] Fix build failure after pd_t::init() refactor to const engine_t

### DIFF
--- a/src/cpu/ppc64/ppc64_gemm_reorder.cpp
+++ b/src/cpu/ppc64/ppc64_gemm_reorder.cpp
@@ -72,7 +72,7 @@ status_t ppc64_matrixA_reorder_t::pd_t::init(const engine_t *engine,
 }
 
 status_t ppc64_matrixA_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
-        engine_t *engine, const primitive_attr_t *attr,
+        const engine_t *engine, const primitive_attr_t *attr,
         const engine_t *src_engine, const memory_desc_t *src_md,
         const engine_t *dst_engine, const memory_desc_t *dst_md) {
     auto _pd = make_unique_pd<pd_t>(

--- a/src/cpu/ppc64/ppc64_gemm_reorder.hpp
+++ b/src/cpu/ppc64/ppc64_gemm_reorder.hpp
@@ -56,10 +56,10 @@ struct ppc64_matrixA_reorder_t : public primitive_t {
                 const engine_t *dst_engine);
 
     private:
-        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
-                const primitive_attr_t *attr, const engine_t *src_engine,
-                const memory_desc_t *src_md, const engine_t *dst_engine,
-                const memory_desc_t *dst_md);
+        static status_t create(reorder_pd_t **reorder_pd,
+                const engine_t *engine, const primitive_attr_t *attr,
+                const engine_t *src_engine, const memory_desc_t *src_md,
+                const engine_t *dst_engine, const memory_desc_t *dst_md);
 
         void init_scratchpad() {}
         friend dnnl::impl::impl_list_item_t;


### PR DESCRIPTION
# Description

The recent refactor of pd_t::init() introduced a build failure for the PowerPC implementation (see #5611).

The create() method in the PowerPC reorder implementation was not updated to match the new function signature. Specifically, the first engine_t * parameter should now be const engine_t *, resulting in a function pointer type mismatch during compilation.


**Failure cases:**
```
oneDNN/src/common/impl_list_item.hpp:116:11: error: invalid conversion from 'dnnl::impl::status_t (*)(dnnl::impl::reorder_pd_t**, dnnl::impl::engine_t*, ...)' to 'dnnl::impl::impl_list_item_t::create_reorder_pd_func_t'
```
----

## Fix

Update the PowerPC create() method signature to accept const engine_t *, matching the refactored pd_t::init() interface.

## Validation

The project builds successfully on PowerPC after this change.

Validation performed using:

make test

Result:
```
100% tests passed out of 233
```
