### PR TITLE
xe: ocl: fix logging issue for missing name

### DIFF
--- a/src/gpu/intel/ocl/engine.cpp
+++ b/src/gpu/intel/ocl/engine.cpp
@@ -57,11 +57,12 @@ status_t engine_create(impl::engine_t **engine, engine_kind_t engine_kind,
 void maybe_print_build_info(const std::vector<const char *> &kernel_names,
         const compute::kernel_ctx_t &kernel_ctx) {
 
-    ostringstream_t names;
-    for (const char *name : kernel_names)
-        names << " " << name;
-
-    gpu_info() << "build kernels:" << names;
+    gpu_info() << "build kernels:" << [&]() {
+        ostringstream_t names;
+        for (const char *name : kernel_names)
+            if (name) names << " " << name;
+        return names.str();
+    }();
     gpu_info() << "build options: " << kernel_ctx.options();
 }
 


### PR DESCRIPTION
The bnorm implementation uses nullptr placeholders for unused slots in a fixed size vector. This triggered a segfault when these names were logged. Additionally, this modifies the implementation to only construct the names string when it is necessary for logging purposes.

Fixes a bug exposed by 5bb5d33bfbb91e594d5fa1b82bd81b6d4569299d and tracked in [MFDNN-15430](https://jira.devtools.intel.com/projects/MFDNN/issues/MFDNN-15430).