### PR TITLE
[GPU] Downstream some gemmstone updates

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
@@ -482,8 +482,11 @@ bool Generator<hw>::gemmFusedPostOpsFinalize(Label &labelLateExit, GEMMProblem &
         globalMemBarrier(temp, r0_info, strategy);
     });
 
-    if (strategy.altFusedBeta)
+    if (strategy.altFusedBeta) {
+        cmp(1 | eq | f0[1], state.wgK, 0);
         gemmFusedBetaNotifyCompletion(problem, strategy, state);
+        jmpi(1 | f0[1], labelLateExit);     /* Zero-length chunks do not participate in post-ops. */
+    }
 
     /* Leader adds our k slice to the total "k done" counter and broadcasts to WG.
         Consider splitting counter and doing this check earlier to absorb latency. */

--- a/src/gpu/intel/gemm/jit/generator/pieces/common.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/common.cxx
@@ -63,7 +63,7 @@ void Generator<hw>::epilogue(const CommonStrategy &strategy, CommonState &state)
 {
     auto r0_info = state.r0_info;
 
-    if (r0_info.getBase() < 112) {
+    if (!getEfficient64Bit() && r0_info.getBase() < 112) {
         mov<uint32_t>(r0DWords(hw), r127, r0_info);
         r0_info = r127;
     }

--- a/src/gpu/intel/gemm/jit/generator/pieces/problem_utils.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/problem_utils.cpp
@@ -72,10 +72,13 @@ std::string GEMMProblem::toString() const
         case BatchMode::Variable:   ss << "batchnv "; break;
     }
 
-    auto appendQString = [&](char matrix, Type T, int ptrDims, int xqGroupR, int xqGroupC) {
+    auto appendQString = [&](char matrix, Type T, int ptrDims, int xqGroupR, int xqGroupC, bool precalc = false) {
         ss << matrix;
-        if (ptrDims < 0 || ptrDims > 2) return;
-        ss << "[" << "pvg"[ptrDims];
+        if (ptrDims < -1 || ptrDims > 2) return;
+        ss << "[";
+        char tchar = "spvg"[ptrDims + 1];
+        if (precalc) tchar = std::toupper(tchar);
+        ss << tchar;
         if (ptrDims == 2)
             ss << std::max(xqGroupR, 1) << 'x' << std::max(xqGroupC, 1);
         ss << ',';
@@ -88,9 +91,9 @@ std::string GEMMProblem::toString() const
     bool offsetc = (cOffset == COffset::Post);
     if (offseta || offsetb || offsetc) {
         ss << "offset";
-        if (offseta) appendQString('a', Tao, aoPtrDims, aqGroupM, aqGroupK);
-        if (offsetb) appendQString('b', Tbo, boPtrDims, bqGroupK, bqGroupN);
-        if (offsetc) appendQString('c', Tco, -1, 0, 0);
+        if (offseta) appendQString('a', Tao, aoPtrDims, aqGroupM, aqGroupK, (aOffset == ABOffset::Load));
+        if (offsetb) appendQString('b', Tbo, boPtrDims, bqGroupK, bqGroupN, (bOffset == ABOffset::Load));
+        if (offsetc) appendQString('c', Tco, coPtrDims, 0, 0);
         ss << ' ';
     }
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/state.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/state.hpp
@@ -145,7 +145,7 @@ struct CommonState {
     std::array<VirtualFlag, 8> activeVFlags;
     VirtualFlagAllocator raVFlag;
     TokenAllocator tokenAllocator;
-    std::vector<std::pair<uint8_t, int8_t>> tokenMap;
+    std::vector<std::pair<uint16_t, int8_t>> tokenMap;
     ngen::Subregister readFailures;
     ngen::Subregister fusedID;
     ngen::Subregister lsDescConstant[4];


### PR DESCRIPTION
PR includes a few updates from gemmstone. The most notable is the `tokenMap` type update from 8-bit to 16-bit. 512-GRF kernels require 16 bits. Otherwise, tokens could be incorrectly determined, causing suboptimal SWSB.

This work is part of oneDNN/gemmstone alignment for CRI.