### PR TITLE
benchdnn: supply --impl=name option for a REPRO line

### DIFF
--- a/tests/benchdnn/binary/binary_aux.cpp
+++ b/tests/benchdnn/binary/binary_aux.cpp
@@ -25,7 +25,6 @@ std::string prb_t::set_repro_line() {
     using ::operator<<;
 
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || sdt != def.sdt[0]) s << "--sdt=" << sdt << " ";

--- a/tests/benchdnn/bnorm/bnorm_aux.cpp
+++ b/tests/benchdnn/bnorm/bnorm_aux.cpp
@@ -195,7 +195,6 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";

--- a/tests/benchdnn/brgemm/brgemm_aux.cpp
+++ b/tests/benchdnn/brgemm/brgemm_aux.cpp
@@ -205,7 +205,6 @@ void prb_t::skip_invalid(res_t *res) const {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_dts = true;

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -29,10 +29,12 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "common.hpp"
+#include "dnn_types.hpp"
 
 #include "utils/fill.hpp"
 #include "utils/parallel.hpp"
 #include "utils/parser.hpp"
+#include "utils/stringstream.hpp"
 
 /* result structure */
 const char *state2str(res_state_t state) {
@@ -151,10 +153,15 @@ void parse_result(res_t &res, const char *pstr) {
     const int64_t tct_ms = static_cast<int64_t>(tct.ms(bt::mode_t::sum));
     std::string tct_str = " (" + std::to_string(tct_ms) + " ms)";
 
+    // Global (driver-agnostic) parameters are dumped here so that each driver's
+    // `set_repro_line` only needs to collect its own settings.
+    stringstream_t ss;
+    dump_global_params(ss);
+
     // This is the common format of the repro line ([] - for optional entries):
     // case_num:status[ (reason)][ (error_stats)] (time) __REPRO: prb_str
     std::string full_repro = std::to_string(bs.tests) + ":" + std::string(state)
-            + reason + error_stat + tct_str + " __REPRO: " + pstr;
+            + reason + error_stat + tct_str + " __REPRO: " + ss.str() + pstr;
     if (is_failed) {
         bs.failed++;
         bs.failed_cases.emplace(bs.tests, full_repro);

--- a/tests/benchdnn/common.cpp
+++ b/tests/benchdnn/common.cpp
@@ -157,9 +157,13 @@ void parse_result(res_t &res, const char *pstr) {
     // `set_repro_line` only needs to collect its own settings.
     stringstream_t ss;
     dump_global_params(ss);
+    // Append an `--impl=name` option for better understanding what library
+    // implementation executed the case.
+    if (!res.impl_name.empty()) ss << "--impl=" + res.impl_name + " ";
 
     // This is the common format of the repro line ([] - for optional entries):
-    // case_num:status[ (reason)][ (error_stats)] (time) __REPRO: prb_str
+    // case_num:status[ (reason)][ (error_stats)] (time) \n
+    // __REPRO:[ --impl=impl_name] prb_str
     std::string full_repro = std::to_string(bs.tests) + ":" + std::string(state)
             + reason + error_stat + tct_str + " __REPRO: " + ss.str() + pstr;
     if (is_failed) {

--- a/tests/benchdnn/concat/concat_aux.cpp
+++ b/tests/benchdnn/concat/concat_aux.cpp
@@ -24,7 +24,6 @@ std::string prb_t::set_repro_line() {
     using ::operator<<;
 
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_tags = true;

--- a/tests/benchdnn/conv/conv_aux.cpp
+++ b/tests/benchdnn/conv/conv_aux.cpp
@@ -402,7 +402,6 @@ void prb_t::count_ops() {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_dts = true;

--- a/tests/benchdnn/deconv/deconv_aux.cpp
+++ b/tests/benchdnn/deconv/deconv_aux.cpp
@@ -400,7 +400,6 @@ void prb_t::count_ops() {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_dts = true;

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -1199,7 +1199,6 @@ std::ostream &dump_global_params(std::ostream &s) {
     if (canonical || execution_mode != default_execution_mode)
         s << "--execution-mode=" << execution_mode << " ";
 
-    s << "--" << driver_name << " ";
     if (canonical) s << "--canonical=" << bool2str(canonical) << " ";
     if (canonical || engine_tgt_kind != dnnl_cpu) {
         s << "--engine=" << engine_tgt_kind;
@@ -1230,6 +1229,8 @@ std::ostream &dump_global_params(std::ostream &s) {
         s << "--cold-cache=" << cold_cache_input << " ";
     if (canonical || !buffer_prefix.empty())
         s << "--buffer-prefix=" << buffer_prefix << " ";
+
+    s << "--" << driver_name << " ";
 
     return s;
 }

--- a/tests/benchdnn/eltwise/eltwise_aux.cpp
+++ b/tests/benchdnn/eltwise/eltwise_aux.cpp
@@ -24,7 +24,6 @@ namespace eltwise {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";

--- a/tests/benchdnn/gnorm/gnorm_aux.cpp
+++ b/tests/benchdnn/gnorm/gnorm_aux.cpp
@@ -163,7 +163,6 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_dts = true;

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -368,7 +368,6 @@ std::string case_to_str(const std::string &json_file,
         const std::map<size_t, std::string> &op_kind_map,
         const std::map<size_t, std::string> &tensor_property) {
     stringstream_t s;
-    dump_global_params(s);
 
     if (mb != 0) { s << "--mb=" << mb << " "; }
 

--- a/tests/benchdnn/ip/ip_aux.cpp
+++ b/tests/benchdnn/ip/ip_aux.cpp
@@ -146,7 +146,6 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_dts = true;

--- a/tests/benchdnn/lnorm/lnorm_aux.cpp
+++ b/tests/benchdnn/lnorm/lnorm_aux.cpp
@@ -44,7 +44,6 @@ flags_t str2flags(const char *str) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_dts = true;

--- a/tests/benchdnn/lrn/lrn_aux.cpp
+++ b/tests/benchdnn/lrn/lrn_aux.cpp
@@ -168,7 +168,6 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";

--- a/tests/benchdnn/matmul/matmul_aux.cpp
+++ b/tests/benchdnn/matmul/matmul_aux.cpp
@@ -68,7 +68,6 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_dts = true;

--- a/tests/benchdnn/pool/pool_aux.cpp
+++ b/tests/benchdnn/pool/pool_aux.cpp
@@ -321,7 +321,6 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_dts = true;

--- a/tests/benchdnn/prelu/prelu_aux.cpp
+++ b/tests/benchdnn/prelu/prelu_aux.cpp
@@ -26,7 +26,6 @@ std::string prb_t::set_repro_line() {
     stringstream_t s;
     using ::operator<<;
 
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";

--- a/tests/benchdnn/reduction/reduction_aux.cpp
+++ b/tests/benchdnn/reduction/reduction_aux.cpp
@@ -76,7 +76,6 @@ dnnl_alg_kind_t alg2alg_kind(alg_t alg) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || sdt != def.sdt[0]) s << "--sdt=" << sdt << " ";

--- a/tests/benchdnn/reorder/reorder_aux.cpp
+++ b/tests/benchdnn/reorder/reorder_aux.cpp
@@ -156,7 +156,6 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     s << "--sdt=" << sdt << " ";

--- a/tests/benchdnn/resampling/resampling_aux.cpp
+++ b/tests/benchdnn/resampling/resampling_aux.cpp
@@ -213,7 +213,6 @@ std::ostream &operator<<(std::ostream &s, const desc_t &d) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";

--- a/tests/benchdnn/rnn/rnn_aux.cpp
+++ b/tests/benchdnn/rnn/rnn_aux.cpp
@@ -273,7 +273,6 @@ std::string prb_t::set_repro_line() {
     using ::operator<<;
 
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || prop != prop2prop_kind(def.prop[0]))

--- a/tests/benchdnn/sdpa/sdpa_aux.cpp
+++ b/tests/benchdnn/sdpa/sdpa_aux.cpp
@@ -109,7 +109,6 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";

--- a/tests/benchdnn/shuffle/shuffle_aux.cpp
+++ b/tests/benchdnn/shuffle/shuffle_aux.cpp
@@ -24,7 +24,6 @@ namespace shuffle {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";

--- a/tests/benchdnn/softmax/softmax_aux.cpp
+++ b/tests/benchdnn/softmax/softmax_aux.cpp
@@ -46,7 +46,6 @@ const char *alg2str(alg_t alg) {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dir != def.dir[0]) s << "--dir=" << dir << " ";

--- a/tests/benchdnn/sum/sum_aux.cpp
+++ b/tests/benchdnn/sum/sum_aux.cpp
@@ -39,7 +39,6 @@ std::string prb_t::set_repro_line() {
     using sum::operator<<;
 
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     bool has_default_tags = true;

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1870,7 +1870,8 @@ static bool parse_execution_mode(
                     parsers::str2execution_mode, str, option_name, help);
 
 #if !defined(DNNL_WITH_SYCL)
-    if (parsed) {
+    // Default execution mode is legit for any build configuration.
+    if (parsed && execution_mode != default_execution_mode) {
         BENCHDNN_PRINT(0,
                 "Error: option `--%s` is supported with DPC++ "
                 "builds only, exiting...\n",

--- a/tests/benchdnn/utils/perf_report.cpp
+++ b/tests/benchdnn/utils/perf_report.cpp
@@ -24,6 +24,12 @@
 void base_perf_report_t::report(res_t *res, const char *prb_str) const {
     dump_perf_header();
 
+    // `prb_str` carries only driver-specific settings. Prepend the global
+    // (driver-agnostic) parameters so that `%prb%` stays a complete reproducer.
+    stringstream_t global_params_ss;
+    dump_global_params(global_params_ss);
+    const std::string full_prb_str = global_params_ss.str() + prb_str;
+
     stringstream_t ss;
 
     const char *pt = pt_;
@@ -33,7 +39,7 @@ void base_perf_report_t::report(res_t *res, const char *prb_str) const {
             ss << c;
             continue;
         }
-        handle_option(ss, pt, res, prb_str);
+        handle_option(ss, pt, res, full_prb_str.c_str());
     }
 
     std::string str = ss.str();

--- a/tests/benchdnn/zeropad/zeropad_aux.cpp
+++ b/tests/benchdnn/zeropad/zeropad_aux.cpp
@@ -23,7 +23,6 @@ namespace zeropad {
 
 std::string prb_t::set_repro_line() {
     stringstream_t s;
-    dump_global_params(s);
     settings_t def;
 
     if (canonical || dt != def.dt[0]) s << "--dt=" << dt << " ";


### PR DESCRIPTION
The change targets better understanding which implementation was called when run in a batch file. It's quite helpful with generated cases.

PR also makes all global benchdnn settings to be dumped before the driver name to have a clear separation between global context, a driver name as a bridge to test case options. It doesn't affect the ability to specify global options past driver name in CLI.

``` diff
./benchdnn --matmul --stag=bac --dtag=bac --attr-fpmath=f16 2x77x543:2x543x164
- 0:PASSED (5 ms) __REPRO: --matmul --stag=bac --dtag=bac --attr-fpmath=f16 --skip-impl=ref 2x77x543:2x543x164
+ 0:PASSED (5 ms) __REPRO: --matmul --impl=brg_matmul:avx512_core --stag=bac --dtag=bac --attr-fpmath=f16 --skip-impl=ref 2x77x543:2x543x164
```