### PR TITLE
Fixes to new CI coverage

### DIFF
--- a/src/common/nstl.hpp
+++ b/src/common/nstl.hpp
@@ -136,8 +136,10 @@ struct numeric_limits<float4_e2m1_t> {
     static constexpr int bias = 0x1;
     static constexpr int digits = 2; // 1+1 implicit bits
 
+    // Can't be computed as a normal value due to short exponent. Uses a
+    // subnormal value in f4_e2m1 data type range.
     static constexpr float4_e2m1_t epsilon() {
-        return float4_e2m1_t(0x2, true);
+        return float4_e2m1_t(0x1, true);
     }
 };
 

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -296,6 +296,35 @@ inline T digits(data_type_t data_type) {
 #undef CASE
 }
 
+template <typename T>
+inline T epsilon_value(data_type_t data_type) {
+    using namespace data_type;
+#define CASE(x) \
+    case x: \
+        return static_cast<T>( \
+                nstl::numeric_limits<prec_traits_t<x>::type>::epsilon())
+    switch (data_type) {
+        CASE(f4_e2m1);
+        CASE(e8m0);
+        CASE(f8_e5m2);
+        CASE(f8_e4m3);
+        CASE(f16);
+        CASE(bf16);
+        CASE(f32);
+        CASE(f64);
+        CASE(s64);
+        CASE(s32);
+        CASE(s8);
+        CASE(u8);
+        CASE(s4);
+        CASE(u4);
+        case data_type::undef:
+        default: assert(!"unknown data_type");
+    }
+    return static_cast<T>(0); /* not supposed to be reachable */
+#undef CASE
+}
+
 inline float round_to_dt(data_type_t data_type, float val) {
     using namespace data_type;
 

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -350,14 +350,18 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                             = types::round_to_dt(dst_scale_dt, dst_group_scale);
                 }
                 if (attr_scales.get(DNNL_ARG_DST).is_dynamic_fp()) {
-                    // In case of a dst group produced a zero `max_dst_group`,
-                    // clamp the scale value to the minimal normal e4m3 value.
-                    dst_group_scale = max_dst_group == 0.f
-                            ? 1.f
-                            : types::round_to_dt(dst_scale_dt,
-                                      max_dst_group
-                                              / types::max_value<float>(
-                                                      dst_d.data_type()));
+                    // Clamp the scale value to epsilon(dst_scale_dt) from the
+                    // down and to max(dst_scale_dt) from the up.
+                    // This is done to deal with zero block and small values
+                    // obtained after dividing a group max value.
+                    dst_group_scale = max_dst_group
+                            / types::max_value<float>(dst_d.data_type());
+                    dst_group_scale = nstl::min(dst_group_scale,
+                            types::max_value<float>(dst_scale_dt));
+                    dst_group_scale = nstl::max(dst_group_scale,
+                            types::epsilon_value<float>(dst_scale_dt));
+                    dst_group_scale
+                            = types::round_to_dt(dst_scale_dt, dst_group_scale);
                 }
 
                 dims_t dst_dims_idx;

--- a/src/gpu/intel/dynamic_scale.cl
+++ b/src/gpu/intel/dynamic_scale.cl
@@ -33,8 +33,9 @@ inline float mx_recipe(float group_max) {
 }
 
 inline float fp_recipe(float group_max) {
-    float clamped = clamp_scale(group_max / DST_DATA_FMAX);
-    return group_max == 0.f ? 1.f : clamped;
+    float unclamped = max(min(group_max / DST_DATA_FMAX, DST_SCALES_DATA_FMAX),
+            DST_SCALES_DATA_FEPS);
+    return clamp_scale(unclamped);
 }
 
 #if DST_SCALES_DT_E8M0

--- a/src/gpu/intel/include/types_specific.h
+++ b/src/gpu/intel/include/types_specific.h
@@ -718,9 +718,13 @@
 #if DST_SCALES_DT_HF8
 #define DST_SCALES_TO_REF(x) into_float(x)
 #define REF_TO_DST_SCALES(x) into_f8_e4m3(x)
+#define DST_SCALES_DATA_FMAX into_float(as_f8_e4m3((uchar)0x7E))
+#define DST_SCALES_DATA_FEPS into_float(as_f8_e4m3((uchar)0x20))
 #elif DST_SCALES_DT_BF8
 #define DST_SCALES_TO_REF(x) into_float(x)
 #define REF_TO_DST_SCALES(x) into_f8_e5m2(x)
+#define DST_SCALES_DATA_FMAX into_float(as_f8_e5m2((uchar)0x7B))
+#define DST_SCALES_DATA_FEPS into_float(as_f8_e5m2((uchar)0x34))
 #elif DST_SCALES_DT_F16
 #define DST_SCALES_TO_REF(x) convert_float(x)
 #define REF_TO_DST_SCALES(x) convert_half(x)
@@ -730,6 +734,8 @@
 #elif DST_SCALES_DT_E8M0
 #define DST_SCALES_TO_REF(x) into_float(x)
 #define REF_TO_DST_SCALES(x) into_e8m0(x)
+#define DST_SCALES_DATA_FMAX into_float(as_e8m0((uchar)0xFE))
+#define DST_SCALES_DATA_FEPS into_float(as_e8m0((uchar)0x80))
 #else
 #define DST_SCALES_TO_REF(x) (x)
 #endif

--- a/tests/benchdnn/inputs/matmul/harness_matmul_generated_ci
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_generated_ci
@@ -1560,7 +1560,7 @@
 --reset --dt=bf16:bf16:bf16 --stag=abx --dtag=abx --attr-scales=wei:common:2:bf16 --attr-post-ops=min:u8:common 148x367:367x2008
 --reset --dt=f4_e2m1:f4_e2m1:f16 --stag=abx --wtag=acb --dtag=abx --attr-scales=src:per_tensor:e8m0:1x32+wei:per_tensor:f8_e4m3:16x1 --attr-post-ops=sum:1.0 5x37x2080:5x2080x1
 --reset --dt=f8_e5m2:f8_e5m2:f4_e2m1 --stag=abx --wtag=ba --dtag=abx --attr-scales=src:per_tensor:e8m0:1x32+wei:per_tensor:f32:64x1+dst:mx:e8m0:1x32 828x192:192x1504
---reset --dt=f8_e4m3:f8_e4m3:f8_e4m3 --stag=abx --wtag=ba --dtag=abx --attr-scales=src:per_tensor:e8m0:1x32+wei:per_tensor:e8m0:32x32+dst:mx:e8m0:1x32 --attr-post-ops=sqrt --bia-dt=f32 --bia_mask=1 112x2720:2720x320
+--reset --dt=f8_e4m3:f8_e4m3:f8_e4m3 --stag=abx --wtag=ba --dtag=abx --attr-scales=src:per_tensor:e8m0:1x32+wei:per_tensor:e8m0:32x32+dst:mx:e8m0:1x32 --bia-dt=f32 --bia_mask=1 112x2720:2720x320
 --reset --dt=u8:u8:f32 --stag=abx --wtag=ba --dtag=abx --attr-scales=src:per_tensor:bf16:1x32+wei:per_oc:bf16 --attr-zero-points=src:host_scalar:2:u8+wei:common:2:u8 --attr-post-ops=elu:0.5 588x640:640x408
 --reset --dt=u8:u8:f32 --stag=abx --dtag=abx --strides=:1x1: --attr-scales=wei:per_tensor:f16:128x1 --attr-zero-points=wei:per_tensor:u8:64x1 --attr-precomputed-reductions=src:per_tensor:s32:1x64 --attr-post-ops=add:u8:common 1116x128:128x1
 --reset --dt=s8:u8:s8 --stag=abx --wtag=abx --dtag=abx --attr-scales=src:common:4:bf16+wei:per_oc:bf16+dst:common:4:f16 --attr-zero-points=src:host_scalar:2:s8+wei:common:2:s32 --attr-post-ops=swish:4.0 5x1x3x8x448:1x2x3x448x1588

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -289,7 +289,15 @@ static void compute_ref_matmul_chunk(const chunk_params_t &p, int64_t M,
         for (int64_t n = nc * p.dst_N_group;
                 n < MIN2((nc + 1) * p.dst_N_group, N); ++n) {
             const auto dst_off = (dst_row_base + m) * N + n;
-            dst_scale = MAX2(fabsf(p.dst_m->get_f32_elem(dst_off)), dst_scale);
+            const float dst = fabsf(p.dst_m->get_f32_elem(dst_off));
+            // The following check and explicit set of scale to NAN is done on
+            // purpose to highlight the test case to adjust it as there's no
+            // practical application of NAN scales.
+            if (std::isnan(dst) || std::isnan(dst_scale)) {
+                dst_scale = NAN;
+                continue;
+            }
+            dst_scale = MAX2(dst, dst_scale);
         }
         if (p.has_dst_mx) {
             dst_scale

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -299,10 +299,17 @@ static void compute_ref_matmul_chunk(const chunk_params_t &p, int64_t M,
             dst_scale
                     = round_to_nearest_representable(p.dst_scale_dt, dst_scale);
         } else if (p.has_dst_dynamic_fp) {
-            dst_scale = dst_scale == 0.f
-                    ? 1.f
-                    : round_to_nearest_representable(
-                              p.dst_scale_dt, dst_scale / max_dt(p.dst_dt));
+            // Clamp the scale value to epsilon(dst_scale_dt) from the down and
+            // to max(dst_scale_dt) from the up.
+            // This is done to deal with zero block and small values obtained
+            // after dividing a group max value.
+            // See the following link for more details:
+            // https://github.com/pytorch/ao/blob/main/torchao/prototype/mx_formats/nvfp4_tensor.py
+            dst_scale = MAX2(
+                    MIN2(dst_scale / max_dt(p.dst_dt), max_dt(p.dst_scale_dt)),
+                    epsilon_dt(p.dst_scale_dt));
+            dst_scale
+                    = round_to_nearest_representable(p.dst_scale_dt, dst_scale);
         }
         const auto dst_off
                 = (dst_row_base + mc * p.dst_M_group) * N + nc * p.dst_N_group;

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -456,26 +456,12 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
                             || args.rel_diff <= binary_comp_po_rdiff_trh);
             if (ok) break;
 
-            // Some drivers (like pooling or resampling) on integer data types
-            // may result in sporadic order of operations. This may cause a
-            // difference around `x.5f` value, and can be rounded either way to
-            // `x` or `x + 1` which can't be fixed by filling.
-            const auto is_int8_round_good = [&]() -> bool {
-                // Check that original value is close to x.5f.
-                static constexpr float small_eps = 9e-6f;
-                const float floor_val = floorf(args.exp_f32);
-                const float ceil_val = ceilf(args.exp_f32);
-                if (fabsf((floor_val + 0.5f) - args.exp_f32) >= small_eps)
-                    return false;
+            // A check for `off-by-1` errors for both integral data types and
+            // low-precision floating-point data types.
+            ok = (is_integral_dt(args.dt) || bits_dt(args.dt) <= 8)
+                    && is_off_by_one(args);
+            if (ok) break;
 
-                // If it is, check exp and got values are on opposite sides.
-                if (args.exp == floor_val) {
-                    return got_val == ceil_val;
-                } else if (args.exp == ceil_val) {
-                    return got_val == floor_val;
-                }
-                return false;
-            };
             // Another class of `off-by-1` issues coming from optimized
             // reference when transcendental operation present in the chain. In
             // such cases, there's no way to test original output as both
@@ -507,8 +493,7 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
                 return true;
             };
             ok = is_integral_dt(args.dt)
-                    && (is_int8_round_good()
-                            || is_int8_prim_ref_and_transcedental()
+                    && (is_int8_prim_ref_and_transcedental()
                             || is_nan_to_int_good());
             if (ok) break;
 
@@ -640,6 +625,35 @@ void compare_t::dump_p2p_errors() const {
     for (size_t i = 0; i < max_dump_size; i++) {
         dump_point_values(get_kind_str(), p2p_dumps_[i]);
     }
+}
+
+bool compare_t::is_off_by_one(const driver_check_func_args_t &args) const {
+    // Preserve testing floor/ceil for integral types and not a stricter
+    // threshold
+    if (is_integral_dt(args.dt)) {
+        static constexpr float small_eps = 9e-6f;
+        const float floor_val = floorf(args.exp_f32);
+        const float ceil_val = ceilf(args.exp_f32);
+        if (fabsf((floor_val + 0.5f) - args.exp_f32) >= small_eps) return false;
+        if (args.exp == floor_val) return args.got == ceil_val;
+        if (args.exp == ceil_val) return args.got == floor_val;
+        return false;
+    }
+
+    // Low-precision floats (fp8/fp4) use half their epsilon as the window
+    const float half_eps = epsilon_dt(args.dt) / 2.f;
+    const float next
+            = round_to_nearest_representable(args.dt, args.exp_f32 + half_eps);
+    const float prev
+            = round_to_nearest_representable(args.dt, args.exp_f32 - half_eps);
+
+    // Important conditions:
+    // * Expected f32 value shoudn't be equal to expected `float` value.
+    // * Expected and got values should be either `next` or `prev`.
+    // * Got value and expected values are different from one another.
+    if (args.exp_f32 == args.exp) return false;
+    return (args.got == next && args.exp == prev)
+            || (args.got == prev && args.exp == next);
 }
 
 int compare_t::compare(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,

--- a/tests/benchdnn/utils/compare.cpp
+++ b/tests/benchdnn/utils/compare.cpp
@@ -256,9 +256,15 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
     }
     const dnn_mem_t &exp_f32 = exp_f32_plain ? exp_f32_plain : exp_mem;
 
+    // Note: the section below has some adjustable settings but they all seem
+    // to target DST kind_.
+    // TODO: add a list of allowed kinds to get into, and adjust settings to
+    // apply only to kinds they aim. So far, play it safe and remove DST_SCALES
+    // when not applicable.
     const auto dt = got_mem.dt();
-    const bool has_eltwise
-            = attr.post_ops.eltwise_index() != -1 || has_eltwise_post_op_;
+    const bool kind_is_dst_scales = kind_ == DST_SCALES;
+    const bool has_eltwise = !kind_is_dst_scales
+            && (attr.post_ops.eltwise_index() != -1 || has_eltwise_post_op_);
     // Output fp8 data types expected to have dynamic dst scaling. When such
     // scaling is enabled, it saturates, doesn't overflow, thus, NaNs are not
     // expected in the output. No dynamic scaling - NaN may happen.
@@ -269,8 +275,8 @@ int compare_t::compare_p2p(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
             || eltwise::eltwise_alg_returns_nan_or_inf(attr)
             || has_binary_po_algs(attr, {attr_t::post_ops_t::kind_t::DIV})
             || dt == dnnl_f16 || non_scaled_fp8_output;
-    const bool has_exp_eltwise
-            = attr.post_ops.find(attr_t::post_ops_t::kind_t::EXP) >= 0;
+    const bool has_exp_eltwise = !kind_is_dst_scales
+            && attr.post_ops.find(attr_t::post_ops_t::kind_t::EXP) >= 0;
     const auto &dst_scale = attr.scales.get(DNNL_ARG_DST);
     const bool has_dst_scale = !dst_scale.is_def();
 

--- a/tests/benchdnn/utils/compare.hpp
+++ b/tests/benchdnn/utils/compare.hpp
@@ -134,7 +134,25 @@ private:
             const attr_t &attr, res_t *res) const;
     int compare_norm(const dnn_mem_t &exp_mem, const dnn_mem_t &got_mem,
             const attr_t &attr, res_t *res) const;
+
     void dump_p2p_errors() const;
+    // There's a class of rounding errors when two representable values of a dst
+    // data type are on some distance in terms of `float` data type (e.g., int8
+    // `0.f` and `1.f`), and the `exp_f32` comes right in the middle between
+    // those values (e.g., `0.5f`).
+    //
+    // In this case it's possible that the library ends up with a `float` value
+    // to the right/left end of it (e.g., `0.500002f`) due to hardware design or
+    // non-transitive floating-point effects (such as order of accumulation).
+    //
+    // Due to the Round Nearest, ties to Even, or RNE mode, final expected and
+    // got values will be on different ends.
+    //
+    // In benchdnn such error are called `off-by-1` for any data types.
+    //
+    // Examples include pooling and resampling problems on integer data
+    // types, or matmul's fp4 dynamic scaling.
+    bool is_off_by_one(const driver_check_func_args_t &args) const;
 
     std::string get_kind_str() const {
         std::string kind_str;

--- a/tests/gtests/internals/test_nibble.cpp
+++ b/tests/gtests/internals/test_nibble.cpp
@@ -42,7 +42,7 @@ TEST(test_limits, uint4) {
 }
 
 TEST(test_limits, f4_e2m1) {
-    test_limits<impl::float4_e2m1_t>(6.0f, -6.0f, 1.0f);
+    test_limits<impl::float4_e2m1_t>(6.0f, -6.0f, 0.5f);
 }
 
 template <typename T>


### PR DESCRIPTION
PR addresses two problems in current tests:
* dynamic_fp scaling (NVFP4 scheme) doesn't saturate the scale around zero. This PR addresses it and aligns the implementation with PyTorch (there's a link in benchdnn reference code).
* benchdnn has off-by-1 for fp8/fp4, since there values are distributed like integers. Internal summation may slightly move left or right when accumulating in f32 resulting in final values rounded different sides.

For off-by-1, it should be validated thoroughly on all drivers as previous threshold to move left/right changed, I can't recall if it can be a problem (whether reference only hit a middle points in which case it should be fine). If it isn't good, need to restore the previous threshold as it worked fine.

Another commit forces a benchdnn ref to save NaN value in dynamic dst_scales if there were any NaNs during the max value collection. It's needed to identify "bad" cases with transcendental post-ops which don't make sense at this point as there's no recipe to follow and the industry standard that any team would ask oneDNN to implement. If you still see such cases, just drop them until it becomes a clear POR, then we start testing it properly.

And one commit makes benchdnn stop masking errors in dst_scales.