### PR TITLE
cpu: aarch64: reorder: make jit_blk reorder async compatible

### DIFF
--- a/src/cpu/aarch64/reorder/jit_blk_reorder.cpp
+++ b/src/cpu/aarch64/reorder/jit_blk_reorder.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2022-2025 Arm Ltd. and affiliates
+* Copyright 2022-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@
 #include <cassert>
 
 #include "common/c_types_map.hpp"
+#include "common/compiler_workarounds.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/memory_desc_wrapper.hpp"
 #include "common/nstl.hpp"
@@ -135,7 +136,7 @@ status_t jit_blk_reorder_t::execute(const exec_ctx_t &ctx) const {
     auto itype_sz_ = data_type_size(pd()->prb_.itype);
     auto otype_sz_ = data_type_size(pd()->prb_.otype);
 
-    parallel_nd(BH, FL, [&](dim_t bh, dim_t fl) {
+    parallel_nd(BH, FL, [= COMPAT_THIS_CAPTURE](dim_t bh, dim_t fl) {
         auto fl_b = fl * block_sz;
         auto bh_b = bh_stride * bh;
         auto *i = in + (bh_b + fl_b * i1) * itype_sz_;

--- a/tests/benchdnn/inputs/reorder/test_reorder_all
+++ b/tests/benchdnn/inputs/reorder/test_reorder_all
@@ -60,6 +60,11 @@
 --stag=aBx4b,aBx8b --dtag=aBx16b 2x71x16x16 2x72x16x16 2x73x16x16
 --stag=aBx16b      --dtag=aBx8b  2x71x16x16 2x72x16x16 2x73x16x16
 
+# Isolated jit:blk coverage with no jit:uni execution
+--reset
+--sdt=f32 --ddt=f32
+--stag=abx --dtag=aBx4b 8x64x15000
+
 # f16
 --batch=test_reorder_float16
 


### PR DESCRIPTION
# Description

This change makes the AArch64 `jit_blk_reorder` implementation safe for asynchronous threadpool execution.   The fix follows the current x64 `jit_blk_reorder` pattern by using capture-by-value with `COMPAT_THIS_CAPTURE`.   This PR also adds an isolated jit:blk benchdnn reorder case to test_reorder_all:


 Validated on AArch64 with THREADPOOL + EIGEN_ASYNC builds. Reference https://github.com/uxlfoundation/oneDNN/pull/5562 

Test case:
```
  --mode=R --mode-modifier=M --reorder \
    --sdt=f32 --ddt=f32 \
    --stag=abx --dtag=aBx4b \
    8x64x15000
```
 Results:
```
 • Original + OMP runtime release build (BASELINE):

  onednn_verbose,v1,info,oneDNN v3.14.0 (commit f586e93cb209e3febb5fbb6e627d8cf52b1e0509)
  onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:64
  onednn_verbose,v1,info,cpu,isa:AArch64 SVE (128 bits)
  onednn_verbose,v1,info,gpu,runtime:none
  onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
  onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.112061
  onednn_verbose,v1,primitive,create:cache_hit,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.000976562
  onednn_verbose,v1,primitive,exec,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,1.57983
  0:EXECUTED (19 ms) __REPRO: --mode=R --mode-modifier=M --reorder --sdt=f32 --ddt=f32 --stag=abx --dtag=aBx4b 8x64x15000
  ============================================================
  = Implementation statistics (--summary=no-impl to disable) =
  ============================================================
  | jit:blk : 1 (100%)                                       |
  ============================================================
  tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
  total: 0.02s; create_pd: 0.00s (0%); create_prim: 0.00s (1%); fill: 0.00s (0%); execute: 0.00s (8%);


  • Original + EIGEN_ASYNC Release

  onednn_verbose,v1,info,oneDNN v3.14.0 (commit f586e93cb209e3febb5fbb6e627d8cf52b1e0509)
  onednn_verbose,v1,info,cpu,runtime:threadpool,nthr:64
  onednn_verbose,v1,info,cpu,isa:AArch64 SVE (128 bits)
  onednn_verbose,v1,info,gpu,runtime:none
  onednn_verbose,v1,info,graph,backend,0:dnnl_backend
  onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
  onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
  onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.111084
  onednn_verbose,v1,primitive,create:cache_hit,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.000976562
  timeout: the monitored command dumped core

  Patched + EIGEN_ASYNC Release

  onednn_verbose,v1,info,oneDNN v3.14.0 (commit 63884fd1da146d882dc3f9096d1e16198aee75e4)
  onednn_verbose,v1,info,cpu,runtime:threadpool,nthr:64
  onednn_verbose,v1,info,cpu,isa:AArch64 SVE (128 bits)
  onednn_verbose,v1,info,gpu,runtime:none
  onednn_verbose,v1,info,graph,backend,0:dnnl_backend
  onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
  onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
  onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.126953
  onednn_verbose,v1,primitive,create:cache_hit,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.000976562
  onednn_verbose,v1,primitive,exec,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.00292969
  0:EXECUTED (17 ms) __REPRO: --mode=R --mode-modifier=M --reorder --sdt=f32 --ddt=f32 --stag=abx --dtag=aBx4b 8x64x15000
  ============================================================
  = Implementation statistics (--summary=no-impl to disable) =
  ============================================================
  | jit:blk : 1 (100%)                                       |
  ============================================================
  tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
  total: 0.02s; create_pd: 0.00s (0%); create_prim: 0.00s (1%); fill: 0.00s (0%); execute: 0.00s (2%);

  Original + ASan + EIGEN_ASYNC

  onednn_verbose,v1,info,oneDNN v3.14.0 (commit f586e93cb209e3febb5fbb6e627d8cf52b1e0509)
  onednn_verbose,v1,info,cpu,runtime:threadpool,nthr:64
  onednn_verbose,v1,info,cpu,isa:AArch64 SVE (128 bits)
  onednn_verbose,v1,info,gpu,runtime:none
  onednn_verbose,v1,info,graph,backend,0:dnnl_backend
  onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
  onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
  onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.399902
  onednn_verbose,v1,primitive,create:cache_hit,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.0270996
  onednn_verbose,v1,primitive,exec,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.0739746
  =================================================================
  ==32162==ERROR: AddressSanitizer: stack-use-after-return on address 0xe5b0c06c5e60 at pc 0xe5b0c6ae3184 bp 0xe5b0764808f0 sp 0xe5b0764808e8
  READ of size 4 at 0xe5b0c06c5e60 thread T63

  Patched + ASan + EIGEN_ASYNC

  onednn_verbose,v1,info,oneDNN v3.14.0 (commit 63884fd1da146d882dc3f9096d1e16198aee75e4)
  onednn_verbose,v1,info,cpu,runtime:threadpool,nthr:64
  onednn_verbose,v1,info,cpu,isa:AArch64 SVE (128 bits)
  onednn_verbose,v1,info,gpu,runtime:none
  onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
  onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.5
  onednn_verbose,v1,primitive,create:cache_hit,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.0319824
  onednn_verbose,v1,primitive,exec,cpu,reorder,jit:blk,undef,src:f32::blocked:abc::f0 dst:f32::blocked:aBc4b::f0,,,8x64x15000,0.0661621
  0:EXECUTED (25 ms) __REPRO: --mode=R --mode-modifier=M --reorder --sdt=f32 --ddt=f32 --stag=abx --dtag=aBx4b 8x64x15000
  ============================================================
  = Implementation statistics (--summary=no-impl to disable) =
  ============================================================
  | jit:blk : 1 (100%)                                       |
  ============================================================
  tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
  total: 0.03s; create_pd: 0.00s (5%); create_prim: 0.00s (2%); fill: 0.00s (0%); execute: 0.00s (7%);
```
# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
    - Partial: targeted AArch64 jit:blk benchdnn validation passed on the patched THREADPOOL + EIGEN_ASYNC build. Full test suites were not run.
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [x] Have you added relevant tests?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
