### PR TITLE
x64: injectors: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brdgmm_kernel.cpp
@@ -57,15 +57,14 @@ jit_brdgmm_kernel_base_t<Wmm>::jit_brdgmm_kernel_base_t(
         static constexpr bool preserve_vmm = false;
         static constexpr bool use_exact_tail_scalar_bcast = false;
         const auto dst_md_wrapper = memory_desc_wrapper(brg.dst_md());
-        const size_t tail = tail_length();
+        const int tail = tail_length();
 
         static const bcast_set_t enabled_bcast_strategy
                 = {broadcasting_strategy_t::scalar,
                         broadcasting_strategy_t::per_oc,
                         broadcasting_strategy_t::no_broadcast};
-        const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(vmm_b().getIdx()), r14, r15, r13,
-                preserve_gpr, preserve_vmm,
+        const binary_injector::rhs_arg_static_params_t rhs_sp {vmm_b().getIdx(),
+                r14, r15, r13, preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
                 dst_md_wrapper, tail, k_mask, use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp {

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -85,11 +85,11 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
             const auto dst_md_wrapper = memory_desc_wrapper(brg.dst_md());
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
-                    static_cast<size_t>(Xbyak::Zmm(1).getIdx()), this->r14,
-                    this->r15, this->r13, preserve_gpr, preserve_vmm,
+                    Xbyak::Zmm(1).getIdx(), this->r14, this->r15, this->r13,
+                    preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<size_t>(brg.ldb_tail),
-                    ld_tail_mask, use_exact_tail_scalar_bcast};
+                    dst_md_wrapper, brg.ldb_tail, ld_tail_mask,
+                    use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp(this->param1,
                     binary_injector::get_all_strategies_supported_by_injector(),

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -108,16 +108,16 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
             // one element can be safely loaded. Therefore, we need to
             // provide information about what the tail size would have
             // been in a non-GEMV case.
-            const dim_t tail_size = !brg.is_gemv
+            const int tail_size = !brg.is_gemv
                     ? brg.ldb_tail
                     : (brg.gemv_acc_is_vector() ? brg.gemv_tail : 1);
             const auto k_mask = !brg.is_gemv ? ld_tail_mask : gemv_partial_mask;
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
-                    static_cast<size_t>(vmm_tmp(0).getIdx()), this->r14,
-                    this->r15, this->r13, preserve_gpr, preserve_vmm,
+                    vmm_tmp(0).getIdx(), this->r14, this->r15, this->r13,
+                    preserve_gpr, preserve_vmm,
                     GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(data_C_ptr_),
-                    dst_md_wrapper, static_cast<size_t>(tail_size), k_mask,
+                    dst_md_wrapper, tail_size, k_mask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {this->param1,

--- a/src/cpu/x64/injectors/injector_utils.cpp
+++ b/src/cpu/x64/injectors/injector_utils.cpp
@@ -24,16 +24,16 @@ namespace cpu {
 namespace x64 {
 namespace injector_utils {
 
-static std::size_t get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
+static int get_vmm_size_bytes(const Xbyak::Xmm &vmm) {
     static constexpr int byte_size_bits = 8;
     return vmm.getBit() / byte_size_bits;
 }
 
-static std::size_t calc_vmm_to_preserve_size_bytes(
+static int calc_vmm_to_preserve_size_bytes(
         const std::initializer_list<Xbyak::Xmm> &vmm_to_preserve) {
 
-    return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(),
-            std::size_t(0u), [](std::size_t accum, const Xbyak::Xmm &vmm) {
+    return std::accumulate(vmm_to_preserve.begin(), vmm_to_preserve.end(), 0,
+            [](int accum, const Xbyak::Xmm &vmm) {
         return accum + get_vmm_size_bytes(vmm);
     });
 }
@@ -228,7 +228,7 @@ void reg64_savable_t::addTo(const Xbyak::Reg64 &reg) const {
         regscratchpad_.jit().add(reg, *this);
 }
 
-void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, int imm) const {
+void reg64_savable_t::imulTo(const Xbyak::Reg64 &reg, dim_t imm) const {
     if (booking_ >= 0)
         regscratchpad_.jit().imul(reg, getStoragePtr(), imm);
     else

--- a/src/cpu/x64/injectors/injector_utils.hpp
+++ b/src/cpu/x64/injectors/injector_utils.hpp
@@ -30,8 +30,8 @@ namespace cpu {
 namespace x64 {
 namespace injector_utils {
 
-using vmm_index_set_t = typename std::set<size_t>;
-using vmm_index_set_iterator_t = typename std::set<size_t>::iterator;
+using vmm_index_set_t = typename std::set<int>;
+using vmm_index_set_iterator_t = typename std::set<int>::iterator;
 
 enum class layout_t { ncsp, c_blocked, nspc, cspn, unsupported };
 
@@ -65,7 +65,7 @@ private:
     jit_generator_t *host_;
     std::stack<Xbyak::Reg64> reg64_stack_;
     std::stack<Xbyak::Xmm> vmm_stack_;
-    size_t vmm_to_preserve_size_bytes_;
+    int vmm_to_preserve_size_bytes_;
 };
 
 class conditional_register_preserve_guard_t : public register_preserve_guard_t {
@@ -149,7 +149,7 @@ public:
     void restoreTo(const Xbyak::Reg64 &reg) const;
     void restoreTo(const Xbyak::Reg32 &reg32) const;
     void addTo(const Xbyak::Reg64 &reg) const;
-    void imulTo(const Xbyak::Reg64 &reg, int imm) const;
+    void imulTo(const Xbyak::Reg64 &reg, dim_t imm) const;
     Xbyak::Address getStoragePtr() const {
         return regscratchpad_.getPtr(booking_);
     }

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -269,7 +269,7 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
         const std::vector<const void *> &orig_post_ops_binary_rhs_arg_vec,
         std::vector<const void *> &post_ops_binary_rhs_arg_vec,
         uint8_t *expanded_rhs, const std::vector<dim_t> &expanded_elems_len) {
-    size_t offset = 0;
+    dim_t offset = 0;
     const int po_len = post_ops.len();
     auto binary_post_op_idx = 0;
 
@@ -287,7 +287,7 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
             auto *dst = expanded_rhs + offset;
 
             for (dim_t j = 0; j < expanded_elems_len[i]; ++j) {
-                const size_t src_idx = j % rhs_len;
+                const dim_t src_idx = j % rhs_len;
                 memcpy(dst + j * dt_size, src + src_idx * dt_size, dt_size);
             }
 
@@ -322,56 +322,50 @@ static_params_t::static_params_t(const Xbyak::Reg64 &param1,
     : static_params_t(param1, get_all_strategies_supported_by_injector(),
               rhs_arg_static_params) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, int abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, int tail_size,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, Xbyak::Opmask(2), use_exact_tail_scalar_bcast,
               rhs_helper_reg, false /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, int abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, int tail_size,
+        const Xbyak::Opmask &tail_opmask, bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, tail_opmask, use_exact_tail_scalar_bcast,
               rhs_helper_reg, true /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        const Xbyak::Reg64 &reg_tail_size, bool use_exact_tail_scalar_bcast)
+        bool preserve_vmm_helper, int abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, int tail_size,
+        const Xbyak::Opmask &tail_opmask, const Xbyak::Reg64 &reg_tail_size,
+        bool use_exact_tail_scalar_bcast)
     : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
               rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
               preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
               tail_size, tail_opmask, use_exact_tail_scalar_bcast,
               reg_tail_size, true /*is_opmask_set*/) {}
 
-rhs_arg_static_params_t::rhs_arg_static_params_t(
-        std::size_t rhs_dt_helper_vmm_idx, const Xbyak::Reg64 &rhs_addr_reg,
-        const Xbyak::Reg64 &rhs_helper_reg,
+rhs_arg_static_params_t::rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
+        const Xbyak::Reg64 &rhs_addr_reg, const Xbyak::Reg64 &rhs_helper_reg,
         const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-        bool preserve_vmm_helper, std::size_t abi_param_offset,
-        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-        std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        bool use_exact_tail_scalar_bcast, const Xbyak::Reg64 &reg_tail_size,
-        bool is_opmask_set)
+        bool preserve_vmm_helper, int abi_param_offset, dim_t dst_orig_offset,
+        const memory_desc_wrapper &dst_d, int tail_size,
+        const Xbyak::Opmask &tail_opmask, bool use_exact_tail_scalar_bcast,
+        const Xbyak::Reg64 &reg_tail_size, bool is_opmask_set)
     : rhs_dt_helper_vmm_idx(rhs_dt_helper_vmm_idx)
     , rhs_addr_reg(rhs_addr_reg)
     , rhs_helper_reg(rhs_helper_reg)
@@ -408,7 +402,7 @@ static bool params_differ(ParamsMap &params,
     return it1->second != it2->second;
 }
 
-static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
+static bool rhs_arg_params_differ(int vmm_idx1, int vmm_idx2,
         const rhs_arg_dynamic_params_t &rhs_arg_params,
         broadcasting_strategy_t rhs_broadcasting_strategy) {
 
@@ -496,20 +490,19 @@ std::pair<bool, int> jit_uni_binary_injector_t<Vmm>::should_preserve_vmm(
 }
 
 template <typename Vmm>
-void jit_uni_binary_injector_t<Vmm>::compute_vector_range(size_t start_idx,
-        size_t end_idx, std::size_t rhs_arg_idx,
-        const dnnl_post_ops::entry_t &post_op,
+void jit_uni_binary_injector_t<Vmm>::compute_vector_range(int start_idx,
+        int end_idx, int rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
     injector_utils::vmm_index_set_t vmm_idxs;
-    for (size_t i = start_idx; i < end_idx; i++)
+    for (int i = start_idx; i < end_idx; i++)
         vmm_idxs.emplace(i);
     compute_vector_range(vmm_idxs, rhs_arg_idx, post_op, rhs_arg_params);
 }
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
-        const injector_utils::vmm_index_set_t &vmm_idxs,
-        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+        const injector_utils::vmm_index_set_t &vmm_idxs, int rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
 
     if (vmm_idxs.empty()) return;
@@ -545,9 +538,9 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
             || rhs_arg_data_type != data_type::f32 || bcast_f32_non_avx512
             || should_preserve_vmm_tail || post_op.is_prelu();
     const auto tail_load_mode = rhs_arg_params.tail_load_mode;
-    const int simd_w
-            = isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int simd_w = static_cast<int>(
+            isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type()));
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
     const bool use_offset_conversions
             = (!rhs_arg_params.vmm_idx_to_out_addr.empty()
                     || !rhs_arg_params.vmm_idx_to_out_reg.empty());
@@ -727,9 +720,8 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
 }
 
 template <typename Vmm>
-Xbyak::Address jit_uni_binary_injector_t<Vmm>::prepare_rhs_arg_addr(
-        std::size_t vmm_idx, std::size_t rhs_arg_idx,
-        const dnnl_post_ops::entry_t &post_op,
+Xbyak::Address jit_uni_binary_injector_t<Vmm>::prepare_rhs_arg_addr(int vmm_idx,
+        int rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params,
         const broadcasting_strategy_t rhs_broadcasting_strategy, bool is_first,
         bool is_ternary_input) const {
@@ -860,9 +852,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_no_broadcast_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first, bool cache_addr) const {
+        dim_t elem_size_bytes, bool is_first, bool cache_addr) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -878,7 +870,7 @@ void jit_uni_binary_injector_t<Vmm>::append_no_broadcast_offset(
         if (is_first || !cache_addr) {
             calculate_no_broadcast_base(out_addr, tmp_reg);
             if (elem_size_bytes > 1) {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->sal(tmp_reg, shift_val);
             }
             host_->add(addr_reg, tmp_reg);
@@ -906,14 +898,14 @@ void jit_uni_binary_injector_t<Vmm>::calculate_no_broadcast_base(
     host_->sub(out_reg,
             host_->ptr[param1_ + rhs_arg_static_params_.dst_orig_offset]);
     host_->shr(out_reg,
-            std::log2(types::data_type_size(
+            math::ilog2q(types::data_type_size(
                     rhs_arg_static_params_.dst_d.data_type())));
 }
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_no_broadcast_partial(
-        const std::size_t offset, const Xbyak::Reg64 &out_reg,
-        std::size_t elem_size_bytes) const {
+        const dim_t offset, const Xbyak::Reg64 &out_reg,
+        dim_t elem_size_bytes) const {
     const auto offset_adj = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     host_->mov(out_reg,
@@ -925,9 +917,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_oc_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -979,7 +971,7 @@ void jit_uni_binary_injector_t<Vmm>::append_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1034,8 +1026,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_ncsp_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_oc_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = (offset % strides[0]) / strides[1]
     const auto offset_adj
             = ((offset >> math::ilog2q(types::data_type_size(
@@ -1053,9 +1045,9 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_blocked_base(
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     // output = rax
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int simd_w
-            = isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int simd_w = static_cast<int>(
+            isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type()));
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
     const auto r8 = host_->r8;
@@ -1080,11 +1072,11 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_blocked_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_oc_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = ((offset % strides[0]) / strides[1]) * strides[ndims - 1] + offset % blk_size
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
     const auto offset_adj = ((offset_shr % strides[0]) / strides[1]) * blk_size
@@ -1112,8 +1104,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_nspc_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_oc_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = offset % C
     const auto C = rhs_arg_static_params_.dst_d.dims()[1];
     const auto offset_adj = (offset >> math::ilog2q(types::data_type_size(
@@ -1140,8 +1132,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_cspn_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_oc_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // c = offset / strides[1]
     const auto offset_adj = (offset >> math::ilog2q(types::data_type_size(
                                      rhs_arg_static_params_.dst_d.data_type())))
@@ -1155,9 +1147,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_oc_d_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -1198,7 +1190,7 @@ void jit_uni_binary_injector_t<Vmm>::append_oc_d_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1258,8 +1250,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_d_ncsp_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_oc_d_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // dst_offset % dstride[0] / dstride[2] = b*C + c
     const auto offset_adj
             = ((offset >> math::ilog2q(types::data_type_size(
@@ -1275,9 +1267,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_mb_sp_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first,
+        dim_t elem_size_bytes, bool is_first,
         const memory_desc_wrapper &rhs_d) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
@@ -1336,7 +1328,7 @@ void jit_uni_binary_injector_t<Vmm>::append_mb_sp_offset(
                 if (elem_size_bytes == 1) {
                     host_->add(addr_reg, rax);
                 } else {
-                    const int shift_val = std::log2(elem_size_bytes);
+                    const int shift_val = math::ilog2q(elem_size_bytes);
                     host_->mov(tmp_reg, rax);
                     host_->sal(tmp_reg, shift_val);
                     host_->add(addr_reg, tmp_reg);
@@ -1382,7 +1374,7 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
         const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
         const dim_t *dst_strides, const Xbyak::Reg64 &addr_reg,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const {
     // offset = n*dst_stride_n + c*dst_stride_c + d*dst_stride_d + h*dst_stride_h + w*dst_stride_w
     // rhs_off = n*rhs_stride_n + d*rhs_stride_d + h*rhs_stride_h + w*rhs_stride_w
     // per_mb_spatial: channel c is broadcast, so rem = (offset % dst_stride_n) % dst_stride_c.
@@ -1456,7 +1448,7 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, r8);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = math::ilog2q(elem_size_bytes);
         host_->mov(tmp_reg, r8);
         host_->sal(tmp_reg, shift_val);
         host_->add(addr_reg, tmp_reg);
@@ -1466,8 +1458,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_base_rhs_strided(
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_partial_rhs_strided(
         const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
-        std::size_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        dim_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
+        const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const {
     const dim_t rhs_offset
             = rhs_offset_per_mb_spatial(dst_d, rhs_d, dst_offset_bytes);
     if (rhs_offset == 0) return;
@@ -1475,7 +1467,7 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_partial_rhs_strided(
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, rhs_offset);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = math::ilog2q(elem_size_bytes);
         const uint64_t rhs_offset_bytes = static_cast<uint64_t>(rhs_offset)
                 << shift_val;
         host_->mov(tmp_reg, rhs_offset_bytes);
@@ -1529,8 +1521,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_sp_off = (n * (stride_n/C)) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW)
@@ -1559,9 +1551,9 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_blocked_base(
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
     // output = rax
     const auto dst_d = rhs_arg_static_params_.dst_d;
-    const int simd_w
-            = isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type());
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int simd_w = static_cast<int>(
+            isa_max_vlen(isa_) / types::data_type_size(dst_d.data_type()));
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
 
     const auto rax = host_->rax;
     const auto rdx = host_->rdx;
@@ -1583,8 +1575,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_blocked_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // mb_sp_off = offset - (c * stride_c) - (n * (C - 1)DHW) - c % blk_size
 
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1593,7 +1585,7 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_blocked_partial(
     const auto D = (ndims >= 5) ? dst_d.dims()[ndims - 3] : 1;
     const auto H = (ndims >= 4) ? dst_d.dims()[ndims - 2] : 1;
     const auto W = (ndims >= 3) ? dst_d.dims()[ndims - 1] : 1;
-    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const int blk_size = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
 
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
                                     rhs_arg_static_params_.dst_d.data_type()));
@@ -1625,8 +1617,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_nspc_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_sp_off = nDHW + dHW + hW + w
     // mb_sp_off = offset / C
@@ -1658,8 +1650,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_cspn_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_sp_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_sp_off = dHWN + hWN + wN + n
     // mb_sp_off = offset % stride_c
@@ -1675,9 +1667,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_mb_w_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -1730,7 +1722,7 @@ void jit_uni_binary_injector_t<Vmm>::append_mb_w_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -1827,8 +1819,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_ncsp_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1858,8 +1850,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_blocked_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_blocked_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // mb_w_off = (n * (stride_n/(C*D*H))) + (w * stride_w)
     calculate_mb_w_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
 }
@@ -1918,8 +1910,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_nspc_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_w_off = nW + w
     const auto dst_d = rhs_arg_static_params_.dst_d;
@@ -1968,8 +1960,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_cspn_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_w_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_w_off = wN + n
     const auto ndims = rhs_arg_static_params_.dst_d.ndims();
@@ -1986,9 +1978,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_hw_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2040,7 +2032,7 @@ void jit_uni_binary_injector_t<Vmm>::append_hw_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2073,8 +2065,8 @@ void jit_uni_binary_injector_t<Vmm>::append_hw_offset(
 }
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_hw_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nCHW + cHW + hW + w (for 4D)
     // per_spatial_off = offset % HW
 
@@ -2120,9 +2112,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_w_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2163,9 +2155,7 @@ void jit_uni_binary_injector_t<Vmm>::append_w_offset(
     if (it_off_val != vmm_idx_to_out_elem_off_val.end()) {
         const auto off_elems = it_off_val->second
                 >> math::ilog2q(types::data_type_size(dst_d.data_type()));
-        assert(off_elems <= (size_t)std::numeric_limits<int>::max()
-                && "destination element offset does not fit a displacement");
-        if (off_elems) host_->add(tmp_reg, (int)off_elems);
+        if (off_elems) host_->add(tmp_reg, off_elems);
     }
 
     const injector_utils::conditional_register_preserve_guard_t register_guard {
@@ -2192,7 +2182,7 @@ void jit_uni_binary_injector_t<Vmm>::append_w_offset(
     if (elem_size_bytes == 1) {
         host_->add(addr_reg, rax);
     } else {
-        const int shift_val = std::log2(elem_size_bytes);
+        const int shift_val = math::ilog2q(elem_size_bytes);
         host_->mov(tmp_reg, rax);
         host_->sal(tmp_reg, shift_val);
         host_->add(addr_reg, tmp_reg);
@@ -2272,9 +2262,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_mb_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2326,7 +2316,7 @@ void jit_uni_binary_injector_t<Vmm>::append_mb_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2379,8 +2369,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_ncsp_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // mb_off = offset / stride_n
     // mb_off = n
@@ -2402,8 +2392,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_nspc_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_off = n;
     calculate_mb_ncsp_partial(strides, offset, tmp_reg, elem_size_bytes);
@@ -2431,8 +2421,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_cspn_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_off = offset % N = offset % strides[ndims-1]
     // mb_off = n
@@ -2449,9 +2439,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_oc_spatial_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2503,7 +2493,7 @@ void jit_uni_binary_injector_t<Vmm>::append_oc_spatial_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2554,8 +2544,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_ncsp_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = (n * stride_n) + (c * stride_c) + (d * stride_d) + (h * stride_h) + (w * stride_w)
     // oc_spatial_off = offset % stride_n
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2576,8 +2566,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_nspc_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // oc_spatial_off = offset % stride_n
     calculate_oc_spatial_ncsp_partial(
@@ -2603,8 +2593,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_cspn_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_oc_spatial_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // oc_spatial_off = offset / strides[ndims - 1]
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2620,9 +2610,9 @@ template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::append_mb_oc_offset(
         const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
         const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
         const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-        std::size_t elem_size_bytes, bool is_first) const {
+        dim_t elem_size_bytes, bool is_first) const {
 
     const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
     const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
@@ -2674,7 +2664,7 @@ void jit_uni_binary_injector_t<Vmm>::append_mb_oc_offset(
             if (elem_size_bytes == 1) {
                 host_->add(addr_reg, rax);
             } else {
-                const int shift_val = std::log2(elem_size_bytes);
+                const int shift_val = math::ilog2q(elem_size_bytes);
                 host_->mov(tmp_reg, rax);
                 host_->sal(tmp_reg, shift_val);
                 host_->add(addr_reg, tmp_reg);
@@ -2725,8 +2715,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_ncsp_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_ncsp_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nCDHW + cDHW + dHW + hW + w
     // mb_oc_off = offset / DHW
     const auto offset_shr = offset >> math::ilog2q(types::data_type_size(
@@ -2768,8 +2758,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_nspc_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_nspc_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = nDHWC + dHWC + hWC + wC + c
     // mb_oc_off = nC + c
     // mb_oc_off = (offset / DHWC) * C + offset % C
@@ -2817,8 +2807,8 @@ void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_cspn_base(
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::calculate_mb_oc_cspn_partial(
-        const dim_t *strides, const std::size_t offset,
-        const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const {
+        const dim_t *strides, const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+        dim_t elem_size_bytes) const {
     // offset = cDHWN + dHWN + hWN + wN + n
     // mb_oc_off = cN + n
     // mb_oc_off = (offset / DHWN) * N + offset % N
@@ -3012,14 +3002,13 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs(const data_type_t &data_type,
 
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::load_acc_as_f32(const Vmm &dst,
-        const Xbyak::Reg64 &base, size_t byte_off, data_type_t data_type,
+        const Xbyak::Reg64 &base, dim_t byte_off, data_type_t data_type,
         bool with_tail, const tail_lode_mode_t tail_load_mode) const {
 
     // The RHS address register, reused here to point at accumulator memory
     // (see the declaration on reusing the RHS load path).
     const auto addr_reg = rhs_arg_static_params_.rhs_addr_reg;
-    const bool byte_off_fits
-            = byte_off <= (size_t)std::numeric_limits<int>::max();
+    const bool byte_off_fits = byte_off <= std::numeric_limits<int>::max();
 
     // The address needs its own register (`addr_reg`) when it cannot be
     // represented as a `[base + disp]` operand. Two cases force that:
@@ -3227,8 +3216,8 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_with_opmask(
 
 static constexpr int xmm_size_elem = 4;
 
-static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
-        std::size_t tail_size, const std::function<void()> &init_op,
+static void load_tail_avx(jit_generator_t *host, int ymm_idx, int tail_size,
+        const std::function<void()> &init_op,
         const std::function<void(int, bool)> &ymm_upper_half_op,
         const std::function<void(int)> &ymm_lower_half_op) {
 
@@ -3256,8 +3245,7 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
     }
 }
 
-static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
-        std::size_t tail_size,
+static void load_tail_avx(jit_generator_t *host, int ymm_idx, int tail_size,
         const std::function<void(int, bool)> &ymm_upper_half_op,
         const std::function<void(int)> &ymm_lower_half_op) {
     load_tail_avx(host, ymm_idx, tail_size, nullptr, ymm_upper_half_op,
@@ -3266,12 +3254,12 @@ static void load_tail_avx(jit_generator_t *host, std::size_t ymm_idx,
 
 static Xbyak::uint8 MM_SHUFFLE(
         Xbyak::uint8 z, Xbyak::uint8 y, Xbyak::uint8 x, Xbyak::uint8 w) {
-    return (((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
+    return static_cast<Xbyak::uint8>(
+            ((z) << 6) | ((y) << 4) | ((x) << 2) | (w));
 }
 
 static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
-        const Xbyak::Ymm &vmm, const Xbyak::Address &rhs_addr,
-        std::size_t tail_size) {
+        const Xbyak::Ymm &vmm, const Xbyak::Address &rhs_addr, int tail_size) {
 
     const auto vmm_idx = vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
@@ -3295,8 +3283,7 @@ static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
 }
 
 static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
-        const Xbyak::Xmm &vmm, const Xbyak::Address &rhs_addr,
-        std::size_t tail_size) {
+        const Xbyak::Xmm &vmm, const Xbyak::Address &rhs_addr, int tail_size) {
 
     const auto vmm_idx = vmm.getIdx();
     const auto tmp_xmm = Xbyak::Xmm(vmm_idx);
@@ -3312,7 +3299,7 @@ static void execute_broadcast_f32_tail_avx(jit_generator_t *host,
 template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_statically(
         const data_type_t &data_type, const Vmm &tmp_vmm,
-        const Xbyak::Address &rhs_addr, const std::size_t tail_size) const {
+        const Xbyak::Address &rhs_addr, const int tail_size) const {
     // An opmask-capable ISA has no static tail path. `execute_broadcast` sends
     // its tails to `execute_broadcast_tail_with_opmask`, so arriving here means
     // the caller asked for a tail mode this ISA does not implement.
@@ -3335,7 +3322,7 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_statically(
         const auto tmp_lower_vmm =
                 typename vreg_traits_t<Vmm>::Vmm_lower_t(vmm_idx);
         host_->load_bytes(tmp_lower_vmm, rhs_addr,
-                tail_size * types::data_type_size(data_type));
+                static_cast<int>(tail_size * types::data_type_size(data_type)));
         if (data_type == data_type::bf16) {
             host_->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
             host_->vpslld(tmp_vmm, tmp_vmm, 16);
@@ -3357,8 +3344,8 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_statically(
             execute_broadcast_f32_tail_avx(host_, tmp_vmm, rhs_addr, tail_size);
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
         if (is_sse41_) {
-            for (std::size_t i = 0; i < tail_size; i++)
-                host_->pinsrb(tmp_xmm, rhs_addr, i);
+            for (int i = 0; i < tail_size; i++)
+                host_->uni_vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, i);
 
             if (data_type == data_type::s8)
                 host_->pmovsxbd(tmp_xmm, tmp_xmm);
@@ -3397,8 +3384,8 @@ void jit_uni_binary_injector_t<Vmm>::execute_broadcast_tail_statically(
             // The destination is at most 128 bits wide, or the ISA extends
             // bytes straight to a wider destination, so the tail is inserted
             // element by element and extended in one step.
-            for (std::size_t i = 0; i < tail_size; i++)
-                host_->vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, i);
+            for (int i = 0; i < tail_size; i++)
+                host_->uni_vpinsrb(tmp_xmm, tmp_xmm, rhs_addr, i);
 
             if (data_type == data_type::s8)
                 host_->vpmovsxbd(tmp_vmm, tmp_xmm);
@@ -3588,8 +3575,8 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_statically(
             && utils::one_of(data_type, data_type::bf16, data_type::f16)) {
         const auto tmp_lower_vmm =
                 typename vreg_traits_t<Vmm>::Vmm_lower_t(tmp_vmm.getIdx());
-        host_->load_bytes(
-                tmp_lower_vmm, rhs_addr_reg, 0, tail_size * sizeof(bfloat16_t));
+        host_->load_bytes(tmp_lower_vmm, rhs_addr_reg, 0,
+                static_cast<int>(tail_size * sizeof(bfloat16_t)));
         if (data_type == data_type::bf16) {
             host_->vpmovzxwd(tmp_vmm, tmp_lower_vmm);
             host_->vpslld(tmp_vmm, tmp_vmm, 16);
@@ -3627,7 +3614,7 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_statically(
                         ? xmm_size_elem * sizeof(float)
                         : 0;
                 for (int i = 0; i < res.rem; i++)
-                    host_->vpinsrd(tmp_xmm, tmp_xmm,
+                    host_->uni_vpinsrd(tmp_xmm, tmp_xmm,
                             host_->ptr[rhs_addr_reg + offset
                                     + i * sizeof(float)],
                             i);
@@ -3640,8 +3627,8 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_statically(
             load_tail_avx(
                     host_, vmm_idx, tail_size, upper_half_op, lower_half_op);
         } else {
-            for (size_t i = 0; i < tail_size; i++)
-                host_->vpinsrd(tmp_xmm, tmp_xmm,
+            for (int i = 0; i < tail_size; i++)
+                host_->uni_vpinsrd(tmp_xmm, tmp_xmm,
                         host_->ptr[rhs_addr_reg + i * sizeof(float)], i);
         }
     } else if (data_type == data_type::u8 || data_type == data_type::s8) {
@@ -3657,7 +3644,7 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_statically(
                                                bool should_load_lower_half) {
                 const int offset = should_load_lower_half ? xmm_size_elem : 0;
                 for (int i = 0; i < upper_half_data_size; i++)
-                    host_->vpinsrb(tmp_xmm, tmp_xmm,
+                    host_->uni_vpinsrb(tmp_xmm, tmp_xmm,
                             host_->ptr[rhs_addr_reg + offset
                                     + i * sizeof(int8_t)],
                             i);
@@ -3670,8 +3657,8 @@ void jit_uni_binary_injector_t<Vmm>::load_rhs_tail_statically(
             load_tail_avx(
                     host_, vmm_idx, tail_size, upper_half_op, lower_half_op);
         } else {
-            for (size_t i = 0; i < tail_size; i++)
-                host_->vpinsrb(tmp_xmm, tmp_xmm,
+            for (int i = 0; i < tail_size; i++)
+                host_->uni_vpinsrb(tmp_xmm, tmp_xmm,
                         host_->ptr[rhs_addr_reg + i * sizeof(int8_t)], i);
             cvt_to_dword(tmp_xmm);
         }
@@ -3703,7 +3690,7 @@ void jit_uni_binary_injector_t<Vmm>::execute_cmp_binary(const Vmm &dst,
         const Xbyak::Reg64 reg_tmp = rhs_arg_static_params_.rhs_helper_reg;
 
         push_opmask(host_, cmp_mask);
-        host_->vcmpps(cmp_mask, lhs, rhs, cmp_predicate);
+        host_->vcmpps(cmp_mask, lhs, rhs, static_cast<uint8_t>(cmp_predicate));
         host_->mov(reg_tmp, float2int(1));
         host_->uni_vmovq(xreg_one, reg_tmp);
         // broadcast 1.0f with mask
@@ -3796,8 +3783,8 @@ void jit_uni_binary_injector_t<Vmm>::execute_prelu(
 }
 
 template <typename Vmm>
-void jit_uni_binary_injector_t<Vmm>::compute_vector(size_t idx,
-        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+void jit_uni_binary_injector_t<Vmm>::compute_vector(int idx, int rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
         const rhs_arg_dynamic_params_t &rhs_arg_params) const {
     compute_vector_range({idx}, rhs_arg_idx, post_op, rhs_arg_params);
 }

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -110,57 +110,56 @@ void extend_binary_args_per_w(const post_ops_t &post_ops,
  * for load with tail in runtime.
  */
 struct rhs_arg_static_params_t {
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size = 0u,
-            bool use_exact_tail_scalar_bcast = false);
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            bool preserve_vmm_helper, int abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            int tail_size = 0, bool use_exact_tail_scalar_bcast = false);
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, int abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            int tail_size, const Xbyak::Opmask &tail_opmask,
             bool use_exact_tail_scalar_bcast);
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, int abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            int tail_size, const Xbyak::Opmask &tail_opmask,
             const Xbyak::Reg64 &reg_tail_size,
             bool use_exact_tail_scalar_bcast);
 
     bool is_opmask_set() const noexcept { return is_opmask_set_; }
 
-    mutable std::size_t rhs_dt_helper_vmm_idx;
+    mutable int rhs_dt_helper_vmm_idx;
     Xbyak::Reg64 rhs_addr_reg;
     Xbyak::Reg64 rhs_helper_reg;
     Xbyak::Reg64 rhs_addr_cache_reg;
     bool preserve_gpr_helpers;
     bool preserve_vmm_helper;
-    std::size_t abi_param_offset;
-    std::size_t dst_orig_offset;
+    int abi_param_offset;
+    dim_t dst_orig_offset;
     memory_desc_wrapper dst_d;
-    std::size_t tail_size;
+    int tail_size;
     Xbyak::Opmask tail_opmask;
     bool use_exact_tail_scalar_bcast;
     Xbyak::Reg64 reg_tail_size;
     bool is_tail;
 
 private:
-    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+    rhs_arg_static_params_t(int rhs_dt_helper_vmm_idx,
             const Xbyak::Reg64 &rhs_addr_reg,
             const Xbyak::Reg64 &rhs_helper_reg,
             const Xbyak::Reg64 &rhs_addr_cache_reg, bool preserve_gpr_helpers,
-            bool preserve_vmm_helper, std::size_t abi_param_offset,
-            std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
-            std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
+            bool preserve_vmm_helper, int abi_param_offset,
+            dim_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+            int tail_size, const Xbyak::Opmask &tail_opmask,
             bool use_exact_tail_scalar_bcast, const Xbyak::Reg64 &reg_tail_size,
             bool is_opmask_set);
 
@@ -237,7 +236,7 @@ enum class tail_lode_mode_t { STATIC, DYNAMIC, DEFAULT };
 struct rhs_arg_dynamic_params_t {
     std::map<int, Xbyak::Address> vmm_idx_to_out_addr;
     std::map<int, Xbyak::Reg64> vmm_idx_to_out_reg;
-    std::map<int, size_t> vmm_idx_to_out_elem_off_val;
+    std::map<int, dim_t> vmm_idx_to_out_elem_off_val;
 
     std::unordered_set<int> vmm_tail_idx_;
     tail_lode_mode_t tail_load_mode = tail_lode_mode_t::DEFAULT;
@@ -285,7 +284,7 @@ public:
      * described inside rhs_arg_params.
      */
     void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            int rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
     /*
@@ -295,8 +294,8 @@ public:
      * determined broadcast strategy and information about stored data in particular
      * vmm described inside rhs_arg_params.
      */
-    void compute_vector_range(size_t start_idx, size_t end_idx,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+    void compute_vector_range(int start_idx, int end_idx, int rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
     /*
@@ -305,7 +304,7 @@ public:
      * for computations based on internally determined broadcast strategy and information
      * about stored data in particular vmm described inside rhs_arg_params.
      */
-    void compute_vector(size_t idx, std::size_t rhs_arg_idx,
+    void compute_vector(int idx, int rhs_arg_idx,
             const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params) const;
 
@@ -318,7 +317,7 @@ public:
      * scratch register.
      */
     void load_acc_as_f32(const Vmm &dst, const Xbyak::Reg64 &base,
-            size_t byte_off, data_type_t data_type, bool with_tail,
+            dim_t byte_off, data_type_t data_type, bool with_tail,
             tail_lode_mode_t tail_load_mode = tail_lode_mode_t::DEFAULT) const;
 
 private:
@@ -335,8 +334,8 @@ private:
      * address of rhs tensor slice needed for binary operation and returns
      * ptr to it.
      */
-    Xbyak::Address prepare_rhs_arg_addr(std::size_t vmm_idx,
-            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+    Xbyak::Address prepare_rhs_arg_addr(int vmm_idx, int rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
             const rhs_arg_dynamic_params_t &rhs_arg_params,
             const broadcasting_strategy_t rhs_broadcasting_strategy,
             bool is_first, bool is_ternary_input) const;
@@ -359,126 +358,115 @@ private:
     void append_no_broadcast_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
-            bool is_first, bool cache_addr) const;
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes, bool is_first,
+            bool cache_addr) const;
     void calculate_no_broadcast_base(
             Xbyak::Address addr, const Xbyak::Reg64 &out_reg) const;
-    void calculate_no_broadcast_partial(const std::size_t offset,
-            const Xbyak::Reg64 &out_reg, std::size_t elem_size_bytes) const;
+    void calculate_no_broadcast_partial(const dim_t offset,
+            const Xbyak::Reg64 &out_reg, dim_t elem_size_bytes) const;
 
     void append_oc_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_blocked_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_oc_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_oc_d_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_d_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_oc_d_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_oc_d_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_sp_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
-            bool is_first, const memory_desc_wrapper &rhs_d) const;
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes, bool is_first,
+            const memory_desc_wrapper &rhs_d) const;
     void calculate_mb_sp_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_ncsp_base_rhs_strided(const memory_desc_wrapper &dst_d,
             const memory_desc_wrapper &rhs_d, const dim_t *dst_strides,
             const Xbyak::Reg64 &addr_reg, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            dim_t elem_size_bytes) const;
     void calculate_mb_sp_ncsp_partial_rhs_strided(
             const memory_desc_wrapper &dst_d, const memory_desc_wrapper &rhs_d,
-            std::size_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes) const;
+            dim_t dst_offset_bytes, const Xbyak::Reg64 &addr_reg,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_mb_sp_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_mb_sp_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_sp_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_sp_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_sp_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_w_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_w_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_w_blocked_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_mb_w_blocked_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_mb_w_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_w_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_w_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_w_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_w_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_w_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
@@ -492,84 +480,77 @@ private:
     void append_mb_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_oc_spatial_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_oc_spatial_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_oc_spatial_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
     void calculate_oc_spatial_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_oc_spatial_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+            const dim_t offset, const Xbyak::Reg64 &tmp_reg,
+            dim_t elem_size_bytes) const;
 
     void append_hw_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_hw_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_hw_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_hw_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     void append_mb_oc_offset(
             const std::map<int, Xbyak::Address> &vmm_idx_to_out_addr,
             const std::map<int, Xbyak::Reg64> &vmm_idx_to_out_reg,
-            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            const std::map<int, dim_t> &vmm_idx_to_out_elem_off_val,
             int vmm_idx, const Xbyak::Reg64 &addr_reg,
-            const Xbyak::Reg64 &tmp_reg, std::size_t elem_size_bytes,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes,
             bool is_first) const;
     void calculate_mb_oc_ncsp_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_ncsp_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_ncsp_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_oc_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_nspc_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_nspc_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
     void calculate_mb_oc_cspn_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
-    void calculate_mb_oc_cspn_partial(const dim_t *strides,
-            const std::size_t offset, const Xbyak::Reg64 &tmp_reg,
-            std::size_t elem_size_bytes) const;
+    void calculate_mb_oc_cspn_partial(const dim_t *strides, const dim_t offset,
+            const Xbyak::Reg64 &tmp_reg, dim_t elem_size_bytes) const;
 
     template <typename T>
     void execute_cmp_binary(const Vmm &dst, const Vmm &lhs, const T &rhs,
@@ -595,7 +576,7 @@ private:
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr) const;
     void execute_broadcast_tail_statically(const data_type_t &data_type,
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr,
-            const std::size_t tail_size) const;
+            const int tail_size) const;
     void execute_broadcast_tail_with_gpr(const data_type_t &data_type,
             const Vmm &tmp_reg, const Xbyak::Address &rhs_addr) const;
     void load_rhs_tail_dynamically_with_opmask(const data_type_t &data_type,

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -64,7 +64,7 @@ bool is_supported(cpu_isa_t isa, alg_kind_t alg, data_type_t dt) {
 using namespace Xbyak;
 
 template <typename Wmm>
-size_t jit_uni_eltwise_injector_t<Wmm>::get_stack_vmm_space() {
+int jit_uni_eltwise_injector_t<Wmm>::get_stack_vmm_space() {
     return (save_state_ * preserve_vmm_ * n_vregs_to_preserve_
                    + op_vecs_count(isa_, alg_, is_fwd_))
             * vlen_;
@@ -83,7 +83,8 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble(
 
     n_vregs_preserved_ = 0;
     assert(IMPLICATION(!vmm_aux_indices.empty(),
-            vmm_aux_indices.size() == n_vregs_to_preserve_));
+            vmm_aux_indices.size()
+                    == static_cast<size_t>(n_vregs_to_preserve_)));
 
     const auto start_idx = *(vmm_compute_idxs.begin());
     const auto end_idx = *(vmm_compute_idxs.rbegin()) + 1;
@@ -99,21 +100,21 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble(
 
     // `n_vregs_preserved_` is 0 for isa higher than `sse41`.
     // Note that by happy coincidence, idx=0 is skipped for `sse41`.
-    for (size_t idx = n_vregs_preserved_; idx < n_vregs_; idx++) {
+    for (int idx = n_vregs_preserved_; idx < n_vregs_; idx++) {
         // Once reserved enough vmm registers, break the loop.
         if (n_vregs_preserved_ >= n_vregs_to_preserve_) break;
 
         // Thanks to `std::set` LegacyBidirectionalIterator `iterator` member
         // that doesn't have operator+ defined.
-        size_t external_idx = 0;
+        int external_idx = 0;
         if (!vmm_aux_indices.empty()) {
             auto it = vmm_aux_indices.begin();
-            for (size_t i = 0; i < idx; i++)
+            for (int i = 0; i < idx; i++)
                 it++;
             external_idx = *it;
             assert(it != vmm_aux_indices.end());
         }
-        size_t preserve_idx = vmm_aux_indices.empty() ? idx : external_idx;
+        int preserve_idx = vmm_aux_indices.empty() ? idx : external_idx;
 
         // `start_idx` and `end_idx` is the range of indices passed to the
         // injector to apply `alg_` on top of them. Thus, they don't need to
@@ -145,8 +146,8 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble(
     // injector will take first `n_vregs_not_preserved` from `vmm_compute_idxs`
     // to have legit generated code. This fact is saved through
     // `start_idx_tail_it` iterator and a second round of compute will happen.
-    size_t n_vregs_not_preserved = n_vregs_to_preserve_ - n_vregs_preserved_;
-    for (size_t i = 0; i < n_vregs_not_preserved; i++) {
+    int n_vregs_not_preserved = n_vregs_to_preserve_ - n_vregs_preserved_;
+    for (int i = 0; i < n_vregs_not_preserved; i++) {
         preserved_vmm_indices_[n_vregs_preserved_ - need_vmm_mask_register_]
                 = *start_idx_tail_it;
         n_vregs_preserved_++;
@@ -155,8 +156,8 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble(
     assert(n_vregs_preserved_ == n_vregs_to_preserve_);
 
     // Preserve GPRs.
-    size_t preserved_gprs_count = 0;
-    size_t n_gprs_to_preserve = aux_gprs_count(isa_, alg_, is_fwd_, alpha_);
+    int preserved_gprs_count = 0;
+    int n_gprs_to_preserve = aux_gprs_count(isa_, alg_, is_fwd_, alpha_);
     if (n_gprs_to_preserve > 0) {
         // Allocate GPRs from the end not to mess with ABI compatibility.
         for (int gpr_idx = Operand::R15; gpr_idx >= 0; gpr_idx--) {
@@ -175,7 +176,7 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble(
     if (save_state_) {
         if (preserve_p_table_) h->push(p_table_);
 
-        for (size_t i = 0; i < preserved_gprs_count; ++i)
+        for (int i = 0; i < preserved_gprs_count; ++i)
             h->push(Reg64(preserved_gpr_indices_[i]));
     }
 
@@ -202,13 +203,12 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble(
             assert(vmm_aux_indices.empty());
 
             if (need_vmm_mask_register_) {
-                size_t i = 0;
+                int i = 0;
                 h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
                         Vmm(preserved_vmm_tail_indices_[i]));
             }
 
-            for (size_t i = need_vmm_mask_register_; i < n_vregs_preserved_;
-                    ++i)
+            for (int i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
                 h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_],
                         Vmm(preserved_vmm_indices_[i
                                 - need_vmm_mask_register_]));
@@ -224,11 +224,11 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble(
 
 template <typename Wmm>
 void jit_uni_eltwise_injector_t<Wmm>::injector_preamble_tail(
-        size_t n_vregs_not_preserved) {
+        int n_vregs_not_preserved) {
     // There was enough vmm registers to compute everything in one round.
     if (n_vregs_not_preserved == 0) return;
 
-    const size_t idx_off = n_vregs_to_preserve_ - n_vregs_not_preserved;
+    const int idx_off = n_vregs_to_preserve_ - n_vregs_not_preserved;
     assert(idx_off < n_vregs_to_preserve_); // Overflow is undesired.
 
     if (save_state_) {
@@ -236,7 +236,7 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble_tail(
         // an issue and `!preserve_vmm_` case never reaches this piece.
         assert(preserve_vmm_);
 
-        for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+        for (int i = 0; i < n_vregs_not_preserved; ++i)
             h->uni_vmovups(Vmm(preserved_vmm_indices_[idx_off + i
                                    - need_vmm_mask_register_]),
                     h->ptr[reg_vmm_stack_ptr_
@@ -246,12 +246,12 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_preamble_tail(
     // Update the rightmost indices. The injector uses vmms with indices coming
     // after compute vmm indices.
     // TODO: is it always a valid index?
-    for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+    for (int i = 0; i < n_vregs_not_preserved; ++i)
         preserved_vmm_indices_[idx_off + i - need_vmm_mask_register_]
                 += n_vregs_not_preserved;
 
     if (save_state_ && preserve_vmm_) {
-        for (size_t i = 0; i < n_vregs_not_preserved; ++i)
+        for (int i = 0; i < n_vregs_not_preserved; ++i)
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_
                                    + (i - n_vregs_not_preserved) * vlen_],
                     Vmm(preserved_vmm_indices_[idx_off + i
@@ -267,14 +267,14 @@ void jit_uni_eltwise_injector_t<Wmm>::injector_postamble() {
     const int stack_vmm_space = get_stack_vmm_space();
 
     if (save_state_ && preserve_vmm_) {
-        for (size_t i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
+        for (int i = need_vmm_mask_register_; i < n_vregs_preserved_; ++i)
             h->uni_vmovups(
                     Vmm(preserved_vmm_indices_[i - need_vmm_mask_register_]),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_preserved_) * vlen_]);
 
         if (need_vmm_mask_register_) {
-            size_t i = 0;
+            int i = 0;
             h->uni_vmovups(Vmm(preserved_vmm_tail_indices_[i]),
                     h->ptr[reg_vmm_stack_ptr_
                             + (i - n_vregs_preserved_) * vlen_]);
@@ -324,7 +324,7 @@ void jit_uni_eltwise_injector_t<Wmm>::assign_regs() {
 // initialized with stock values from the injector, or with external values
 // provided by the user.
 template <typename Wmm>
-Wmm jit_uni_eltwise_injector_t<Wmm>::vmm_aux(size_t idx) {
+Wmm jit_uni_eltwise_injector_t<Wmm>::vmm_aux(int idx) {
     assert(idx < (n_vregs_preserved_ - need_vmm_mask_register_));
     return Vmm(preserved_vmm_indices_[idx]);
 }
@@ -345,11 +345,11 @@ void jit_uni_eltwise_injector_t<Wmm>::vec_shift(const Vmm &vmm_dst,
         if (vmm_dst.getIdx() != vmm_src.getIdx()) h->vmovups(ymm_dst, ymm_src);
         h->vextractf128(xmm_tmp_, ymm_dst, 1);
         if (shift_left) {
-            h->vpslld(xmm_dst, xmm_dst, imm);
-            h->vpslld(xmm_tmp_, xmm_tmp_, imm);
+            h->vpslld(xmm_dst, xmm_dst, static_cast<uint8_t>(imm));
+            h->vpslld(xmm_tmp_, xmm_tmp_, static_cast<uint8_t>(imm));
         } else {
-            h->vpsrld(xmm_dst, xmm_dst, imm);
-            h->vpsrld(xmm_tmp_, xmm_tmp_, imm);
+            h->vpsrld(xmm_dst, xmm_dst, static_cast<uint8_t>(imm));
+            h->vpsrld(xmm_tmp_, xmm_tmp_, static_cast<uint8_t>(imm));
         }
         h->vinsertf128(ymm_dst, ymm_dst, xmm_tmp_, 1);
     }
@@ -361,7 +361,8 @@ template <typename Wmm>
 void jit_uni_eltwise_injector_t<Wmm>::compute_cmp_mask(const Vmm &vmm_src,
         const Xbyak::Operand &compare_operand, int cmp_predicate) {
     if (has_avx512_core_) {
-        h->vcmpps(k_mask_, vmm_src, compare_operand, cmp_predicate);
+        h->vcmpps(k_mask_, vmm_src, compare_operand,
+                static_cast<uint8_t>(cmp_predicate));
     } else {
         h->uni_vcmpps(vmm_mask_, vmm_src, compare_operand, cmp_predicate);
     }
@@ -553,11 +554,13 @@ void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_fwd(
     auto gather_coefficient_init = [&](Vmm vmm_pol_idx, int nelems) {
         if (is_sse41_) {
             for (int i = 0; i < XMM_float_elems_count; ++i)
-                h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx, i);
+                h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx,
+                        static_cast<uint8_t>(i));
         } else if (is_avx_) {
             Xmm xmm_pol_idx = Xmm(vmm_pol_idx.getIdx());
             for (int i = 0; i < XMM_float_elems_count; ++i)
-                h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx, i);
+                h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx,
+                        static_cast<uint8_t>(i));
         } else if (has_avx2_ && !has_avx512_core_) {
             // Zero the mask so that the `_cmp_eq_oq` compare in
             // `gather_coefficient` yields all ones. A NaN left over in the
@@ -572,14 +575,15 @@ void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_fwd(
             for (int idx = 0; idx < 4; ++idx) {
                 Xbyak::Address coeff_addr = ptr[p_table_ + coeffs_off(coeff_idx)
                         + gpr_idx[idx] * sizeof(float)];
-                h->pinsrd(vmm_coeff, coeff_addr, idx);
+                h->pinsrd(vmm_coeff, coeff_addr, static_cast<uint8_t>(idx));
             }
         } else if (is_avx_) {
             Xmm xmm_coeff = Xmm(vmm_coeff.getIdx());
             for (int idx = 0; idx < 4; ++idx) {
                 Xbyak::Address coeff_addr = ptr[p_table_ + coeffs_off(coeff_idx)
                         + gpr_idx[idx] * sizeof(float)];
-                h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr, idx);
+                h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr,
+                        static_cast<uint8_t>(idx));
             }
         } else if (has_avx2_ && !has_avx512_core_) {
             Xbyak::Address idx_addr = ptr[p_table_ + coeffs_off(coeff_idx)
@@ -1030,7 +1034,7 @@ void jit_uni_eltwise_injector_t<Wmm>::log_compute_vector_fwd(
     const auto table_start_idx = (*it).second.off;
 
     auto gather_table_values
-            = [&](const Vmm &vmm_dst, const Vmm &vmm_idxs, size_t offt = 0) {
+            = [&](const Vmm &vmm_dst, const Vmm &vmm_idxs, dim_t offt = 0) {
         Xbyak::Address table_idx = h->ptr[p_table_ + table_start_idx + offt
                 + vmm_idxs * sizeof(float)];
         if (has_avx512_core_) {
@@ -1053,7 +1057,7 @@ void jit_uni_eltwise_injector_t<Wmm>::log_compute_vector_fwd(
             // fetched values into vector register.
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + vlen_], vmm_idxs);
 
-            for (size_t i = 0; i < vlen_ / sizeof(float); ++i) {
+            for (int i = 0; i < vlen_ / static_cast<int>(sizeof(float)); ++i) {
                 h->mov(reg_tmp.cvt32(),
                         h->ptr[reg_vmm_stack_ptr_ + vlen_ + i * sizeof(float)]);
                 h->shl(reg_tmp.cvt32(), 2); // multiply by simd_w
@@ -1169,21 +1173,21 @@ void jit_uni_eltwise_injector_t<Wmm>::pow_compute_vector_fwd(
         h->uni_vmulps(vmm_src, vmm_src, table_val(alpha));
     } else { // general path
         // caller obligation to save gprs as callee may use them
-        size_t gpr_size = 8;
+        int gpr_size = 8;
         Xbyak::Operand gprs_to_save[] = {h->r8, h->r9, h->r10, h->r11, h->r12,
                 h->rax, h->rcx, h->rdx, h->rdi, h->rsi, h->rbx};
-        size_t n_gprs_to_save = sizeof(gprs_to_save) / sizeof(gprs_to_save[0]);
+        int n_gprs_to_save = sizeof(gprs_to_save) / sizeof(gprs_to_save[0]);
 
         h->sub(h->rsp, n_gprs_to_save * gpr_size);
-        for (size_t i = 0; i < n_gprs_to_save; ++i)
+        for (int i = 0; i < n_gprs_to_save; ++i)
             h->mov(h->ptr[h->rsp + i * gpr_size], gprs_to_save[i]);
 
         // caller obligation to save k-regs as callee may use them
         static constexpr int k_mask_size = 8;
-        size_t n_k_regs_to_save = 8;
+        int n_k_regs_to_save = 8;
         if (has_avx512_core_) {
             h->sub(h->rsp, n_k_regs_to_save * k_mask_size);
-            for (size_t i = 0; i < n_k_regs_to_save; ++i) {
+            for (int i = 0; i < n_k_regs_to_save; ++i) {
                 if (mayiuse(avx512_core))
                     h->kmovq(h->ptr[h->rsp + i * k_mask_size], Opmask(i));
                 else
@@ -1196,7 +1200,7 @@ void jit_uni_eltwise_injector_t<Wmm>::pow_compute_vector_fwd(
         // this space and space for beta.
         // 3. The injector takes its `isa` from the host code, thus, `n_vregs_`
         // and `vlen_` always match the host.
-        for (size_t i = 2; i < n_vregs_ + 2; ++i)
+        for (int i = 2; i < n_vregs_ + 2; ++i)
             h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + i * vlen_], Vmm(i - 2));
         h->uni_vmovups(h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_], vmm_src); // src
         h->uni_vmovups(vmm_src, table_val(beta));
@@ -1222,7 +1226,7 @@ void jit_uni_eltwise_injector_t<Wmm>::pow_compute_vector_fwd(
 
         // Take src, apply powf on it and replace value on a stack with dst.
         Xmm xmm0 = Xmm(0), xmm1 = Xmm(1);
-        for (size_t i = 0; i < vlen_ / sizeof(float); ++i) {
+        for (int i = 0; i < vlen_ / static_cast<int>(sizeof(float)); ++i) {
             const Address &source
                     = h->ptr[reg_vmm_stack_ptr_ + i * sizeof(float)];
             h->uni_vmovss(xmm0, source);
@@ -1237,7 +1241,7 @@ void jit_uni_eltwise_injector_t<Wmm>::pow_compute_vector_fwd(
         h->add(h->rsp, h->rbx);
 
         // restore vector registers
-        for (size_t i = n_vregs_ + 1; i >= 2; --i)
+        for (int i = n_vregs_ + 1; i >= 2; --i)
             h->uni_vmovups(Vmm(i - 2), h->ptr[reg_vmm_stack_ptr_ + i * vlen_]);
         h->uni_vmovups(vmm_src, h->ptr[reg_vmm_stack_ptr_ + 0 * vlen_]);
 
@@ -1777,7 +1781,7 @@ void jit_uni_eltwise_injector_t<Wmm>::round_compute_vector_fwd(
 }
 
 template <typename Wmm>
-size_t jit_uni_eltwise_injector_t<Wmm>::aux_gprs_count(
+int jit_uni_eltwise_injector_t<Wmm>::aux_gprs_count(
         cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha) {
     using namespace alg_kind;
     int ret = 0;
@@ -1798,7 +1802,7 @@ bool jit_uni_eltwise_injector_t<Wmm>::need_vmm_stack_ptr(
 }
 
 template <typename Wmm>
-size_t jit_uni_eltwise_injector_t<Wmm>::op_vecs_count(
+int jit_uni_eltwise_injector_t<Wmm>::op_vecs_count(
         cpu_isa_t isa, alg_kind_t alg, bool is_fwd) {
     using namespace alg_kind;
     int ret = 0;
@@ -1822,11 +1826,11 @@ size_t jit_uni_eltwise_injector_t<Wmm>::op_vecs_count(
 }
 
 template <typename Wmm>
-size_t jit_uni_eltwise_injector_t<Wmm>::aux_vecs_count(
+int jit_uni_eltwise_injector_t<Wmm>::aux_vecs_count(
         cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha) {
     // For avx we need a register to save the upper part of Ymm
     const bool extra_avx_vmm = is_superset(isa, avx) && !is_superset(isa, avx2);
-    size_t n_vmms = 0;
+    int n_vmms = 0;
 
     using namespace alg_kind;
     if (is_fwd) {
@@ -1982,7 +1986,7 @@ void jit_uni_eltwise_injector_t<Wmm>::compute_body(
         const injector_utils::vmm_index_set_iterator_t &start_idx_it,
         const injector_utils::vmm_index_set_iterator_t &end_idx_it) {
     using namespace alg_kind;
-    std::for_each(start_idx_it, end_idx_it, [&](size_t idx) {
+    std::for_each(start_idx_it, end_idx_it, [&](int idx) {
         if (is_fwd_) {
             switch (alg_) {
                 case eltwise_relu_use_dst_for_bwd:
@@ -2084,10 +2088,10 @@ void jit_uni_eltwise_injector_t<Wmm>::compute_body(
 
 template <typename Wmm>
 void jit_uni_eltwise_injector_t<Wmm>::compute_vector_range(
-        size_t start_compute_idx, size_t end_compute_idx,
+        int start_compute_idx, int end_compute_idx,
         const injector_utils::vmm_index_set_t &vmm_aux_indices) {
     injector_utils::vmm_index_set_t vmm_compute_idxs;
-    for (size_t i = start_compute_idx; i < end_compute_idx; i++)
+    for (int i = start_compute_idx; i < end_compute_idx; i++)
         vmm_compute_idxs.emplace(i);
     compute_vector_range(vmm_compute_idxs, vmm_aux_indices);
 }
@@ -2108,8 +2112,12 @@ void jit_uni_eltwise_injector_t<Wmm>::compute_vector_range(
     injector_preamble(vmm_compute_idxs, start_idx_tail_it, vmm_aux_indices);
     compute_body(start_idx_tail_it, end_idx_it);
 
-    size_t n_vregs_not_preserved
-            = std::distance(start_idx_it, start_idx_tail_it);
+    // `std::distance` on a `std::set<int>` iterator returns a
+    // `ptrdiff_t`; this is the one genuine, documented boundary where we
+    // narrow it down to the bounded vmm-register count expected by
+    // `injector_preamble_tail`.
+    const int n_vregs_not_preserved
+            = static_cast<int>(std::distance(start_idx_it, start_idx_tail_it));
     injector_preamble_tail(n_vregs_not_preserved);
     compute_body(start_idx_it, start_idx_tail_it);
     injector_postamble();
@@ -2129,7 +2137,7 @@ void jit_uni_eltwise_injector_t<Wmm>::prepare_table(bool gen_table) {
     // when we set the offsets. We verify that in asserts.
     // table_entry_val_t is assumed to be 32 bits
 #ifndef NDEBUG
-    size_t off = 0;
+    dim_t off = 0;
     key_t curr_key = undef_key;
     int key_occurences = 0;
 #endif
@@ -2897,7 +2905,7 @@ void jit_uni_eltwise_injector_t<Wmm>::register_table_entries() {
     // entries should be registered after this point.  This allows to
     // expect the same order when injecting the table entries in
     // prepare_table.
-    size_t off = 0;
+    dim_t off = 0;
     for (auto it = entry_map_.begin(); it != entry_map_.end(); it++) {
         auto &te = (*it).second;
         te.off = off;

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.cpp
@@ -338,18 +338,18 @@ void jit_uni_eltwise_injector_t<Wmm>::vec_shift(const Vmm &vmm_dst,
         else
             h->uni_vpsrld(vmm_dst, vmm_src, imm);
     } else {
-        // Declare appropriate vectors to use non-uni instructions
+        // AVX lacks 256-bit integer shifts, so shift each 128-bit half apart.
         Xmm xmm_dst = Xmm(vmm_dst.getIdx());
         Ymm ymm_dst = Ymm(vmm_dst.getIdx());
         Ymm ymm_src = Ymm(vmm_src.getIdx());
         if (vmm_dst.getIdx() != vmm_src.getIdx()) h->vmovups(ymm_dst, ymm_src);
         h->vextractf128(xmm_tmp_, ymm_dst, 1);
         if (shift_left) {
-            h->vpslld(xmm_dst, xmm_dst, static_cast<uint8_t>(imm));
-            h->vpslld(xmm_tmp_, xmm_tmp_, static_cast<uint8_t>(imm));
+            h->uni_vpslld(xmm_dst, xmm_dst, imm);
+            h->uni_vpslld(xmm_tmp_, xmm_tmp_, imm);
         } else {
-            h->vpsrld(xmm_dst, xmm_dst, static_cast<uint8_t>(imm));
-            h->vpsrld(xmm_tmp_, xmm_tmp_, static_cast<uint8_t>(imm));
+            h->uni_vpsrld(xmm_dst, xmm_dst, imm);
+            h->uni_vpsrld(xmm_tmp_, xmm_tmp_, imm);
         }
         h->vinsertf128(ymm_dst, ymm_dst, xmm_tmp_, 1);
     }
@@ -554,13 +554,11 @@ void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_fwd(
     auto gather_coefficient_init = [&](Vmm vmm_pol_idx, int nelems) {
         if (is_sse41_) {
             for (int i = 0; i < XMM_float_elems_count; ++i)
-                h->pextrd(gpr_idx[i].cvt32(), vmm_pol_idx,
-                        static_cast<uint8_t>(i));
+                h->uni_vpextrd(gpr_idx[i].cvt32(), vmm_pol_idx, i);
         } else if (is_avx_) {
             Xmm xmm_pol_idx = Xmm(vmm_pol_idx.getIdx());
             for (int i = 0; i < XMM_float_elems_count; ++i)
-                h->vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx,
-                        static_cast<uint8_t>(i));
+                h->uni_vpextrd(gpr_idx[i].cvt32(), xmm_pol_idx, i);
         } else if (has_avx2_ && !has_avx512_core_) {
             // Zero the mask so that the `_cmp_eq_oq` compare in
             // `gather_coefficient` yields all ones. A NaN left over in the
@@ -575,15 +573,14 @@ void jit_uni_eltwise_injector_t<Wmm>::tanh_compute_vector_fwd(
             for (int idx = 0; idx < 4; ++idx) {
                 Xbyak::Address coeff_addr = ptr[p_table_ + coeffs_off(coeff_idx)
                         + gpr_idx[idx] * sizeof(float)];
-                h->pinsrd(vmm_coeff, coeff_addr, static_cast<uint8_t>(idx));
+                h->uni_vpinsrd(vmm_coeff, vmm_coeff, coeff_addr, idx);
             }
         } else if (is_avx_) {
             Xmm xmm_coeff = Xmm(vmm_coeff.getIdx());
             for (int idx = 0; idx < 4; ++idx) {
                 Xbyak::Address coeff_addr = ptr[p_table_ + coeffs_off(coeff_idx)
                         + gpr_idx[idx] * sizeof(float)];
-                h->vpinsrd(xmm_coeff, xmm_coeff, coeff_addr,
-                        static_cast<uint8_t>(idx));
+                h->uni_vpinsrd(xmm_coeff, xmm_coeff, coeff_addr, idx);
             }
         } else if (has_avx2_ && !has_avx512_core_) {
             Xbyak::Address idx_addr = ptr[p_table_ + coeffs_off(coeff_idx)

--- a/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_eltwise_injector.hpp
@@ -135,12 +135,12 @@ struct jit_uni_eltwise_injector_t {
                   eltwise.beta, eltwise.scale, dt, save_state, p_table, k_mask,
                   is_fwd, use_dst, preserve_vmm, preserve_p_table) {}
 
-    void compute_vector_range(size_t start_compute_idx, size_t end_compute_idx,
+    void compute_vector_range(int start_compute_idx, int end_compute_idx,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {});
     void compute_vector_range(
             const injector_utils::vmm_index_set_t &vmm_compute_idxs,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {});
-    void compute_vector(size_t compute_idx,
+    void compute_vector(int compute_idx,
             const injector_utils::vmm_index_set_t &vmm_aux_indices = {}) {
         compute_vector_range({compute_idx}, vmm_aux_indices);
     }
@@ -151,7 +151,7 @@ struct jit_uni_eltwise_injector_t {
     // saving state if the caller can supply the necessary number of vmms. The
     // decision must be made BEFORE constructing the injector, thus, `static`,
     // and `isa` comes as an argument since there's no host to query yet.
-    static size_t aux_vecs_count(
+    static int aux_vecs_count(
             cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha);
 
 private:
@@ -192,21 +192,21 @@ private:
     const bool is_avx_ = is_superset(isa_, avx) && !has_avx2_;
     const bool is_sse41_ = !is_superset(isa_, avx);
 
-    static constexpr size_t vlen_ = vreg_traits_t<Vmm>::vlen;
-    static constexpr size_t preserved_vecs_max_ = 6;
-    static constexpr size_t preserved_gprs_max_ = 5;
-    const size_t n_vregs_ = isa_num_vregs(isa_);
+    static constexpr int vlen_ = vreg_traits_t<Vmm>::vlen;
+    static constexpr int preserved_vecs_max_ = 6;
+    static constexpr int preserved_gprs_max_ = 5;
+    const int n_vregs_ = isa_num_vregs(isa_);
     static constexpr int n_mantissa_bits_ = 23;
 
-    const size_t n_vregs_to_preserve_;
-    size_t n_vregs_preserved_ = 0;
+    const int n_vregs_to_preserve_;
+    int n_vregs_preserved_ = 0;
     bool need_vmm_mask_register_ = false;
     // Default initialization will put zeros. Putting any value to trigger a
     // potential error to Xbyak is not working as Xbyak cycles vmm indices
     // over 32 value.
-    size_t preserved_vmm_indices_[preserved_vecs_max_] = {};
-    size_t preserved_vmm_tail_indices_[preserved_vecs_max_] = {};
-    size_t preserved_gpr_indices_[preserved_gprs_max_] = {};
+    int preserved_vmm_indices_[preserved_vecs_max_] = {};
+    int preserved_vmm_tail_indices_[preserved_vecs_max_] = {};
+    int preserved_gpr_indices_[preserved_gprs_max_] = {};
 
     Vmm vmm_mask_;
     Vmm vmm_tmp_;
@@ -215,12 +215,12 @@ private:
 
     static bool need_mask_register(
             cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha);
-    static size_t aux_gprs_count(
+    static int aux_gprs_count(
             cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha);
     static bool need_vmm_stack_ptr(
             cpu_isa_t isa, alg_kind_t alg, bool is_fwd, float alpha);
-    static size_t op_vecs_count(cpu_isa_t isa, alg_kind_t alg, bool is_fwd);
-    size_t get_stack_vmm_space();
+    static int op_vecs_count(cpu_isa_t isa, alg_kind_t alg, bool is_fwd);
+    int get_stack_vmm_space();
 
     void compute_body(
             const injector_utils::vmm_index_set_iterator_t &start_idx_it,
@@ -228,10 +228,10 @@ private:
     void injector_preamble(const injector_utils::vmm_index_set_t &vmm_idxs,
             injector_utils::vmm_index_set_iterator_t &start_idx_tail_it,
             const injector_utils::vmm_index_set_t &vmm_aux_indices);
-    void injector_preamble_tail(size_t n_vregs_not_preserved);
+    void injector_preamble_tail(int n_vregs_not_preserved);
     void injector_postamble();
     void assign_regs();
-    Wmm vmm_aux(size_t idx);
+    Wmm vmm_aux(int idx);
     void vec_shift(const Vmm &vmm_dst, const Vmm &vmm_src, bool shift_left,
             const int imm);
     void compute_cmp_mask(const Vmm &vmm_src,
@@ -343,7 +343,7 @@ private:
         undef_key,
     };
 
-    size_t table_off(key_t key, size_t key_off_val_shift = 0) {
+    dim_t table_off(key_t key, dim_t key_off_val_shift = 0) {
         // assumption: all table entries sharing the same key also
         // share their broadcast property
         // TODO: enforce through data structure
@@ -356,7 +356,7 @@ private:
         const auto scale = te.bcast ? vlen_ : sizeof(table_entry_val_t);
         return te.off + key_off_val_shift * scale;
     }
-    Xbyak::Address table_val(key_t key, size_t key_off_val_shift = 0) {
+    Xbyak::Address table_val(key_t key, dim_t key_off_val_shift = 0) {
         auto off = table_off(key, key_off_val_shift);
         return h->ptr[p_table_ + off];
     }

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.cpp
@@ -27,8 +27,8 @@ namespace injector {
 #define VCHECK_PO_INJ_BOOL(cond, msg) \
     VCONDCHECK(primitive, create, check, postops_injector, cond, false, msg);
 
-size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd) {
-    size_t res = 0;
+int aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd) {
+    int res = 0;
     for (int i = 0; i < post_ops.len(); i++) {
         const auto &post_op = post_ops.entry_[i];
         if (post_op.is_eltwise()) {
@@ -122,19 +122,19 @@ jit_uni_postops_injector_t<Vmm>::jit_uni_postops_injector_t(
               eltwise_injector::static_params_t(), inject_sum) {}
 
 template <typename Vmm>
-void jit_uni_postops_injector_t<Vmm>::compute_vector_range(size_t start_idx,
-        size_t end_idx,
+void jit_uni_postops_injector_t<Vmm>::compute_vector_range(int start_idx,
+        int end_idx,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
     injector_utils::vmm_index_set_t vmm_idxs;
-    for (size_t i = start_idx; i < end_idx; i++)
+    for (int i = start_idx; i < end_idx; i++)
         vmm_idxs.emplace(i);
     compute_vector_range(vmm_idxs, rhs_arg_params);
 }
 
 template <typename Vmm>
 void jit_uni_postops_injector_t<Vmm>::compute_vector_range(
-        size_t start_idx, size_t end_idx) {
+        int start_idx, int end_idx) {
     compute_vector_range(
             start_idx, end_idx, binary_injector::rhs_arg_dynamic_params_t());
 }
@@ -144,7 +144,7 @@ void jit_uni_postops_injector_t<Vmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
 
-    std::size_t rhs_arg_idx = 0;
+    int rhs_arg_idx = 0;
     for (int i = 0; i < post_ops_.len(); i++) {
         const auto &post_op = post_ops_.entry_[i];
         if (post_op.is_eltwise()) {
@@ -183,13 +183,13 @@ void jit_uni_postops_injector_t<Vmm>::prepare_table(bool gen_table) {
 }
 
 template <typename Vmm>
-void jit_uni_postops_injector_t<Vmm>::compute_vector(size_t idx,
+void jit_uni_postops_injector_t<Vmm>::compute_vector(int idx,
         const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
     compute_vector_range({idx}, rhs_arg_params);
 }
 
 template <typename Vmm>
-void jit_uni_postops_injector_t<Vmm>::compute_vector(size_t idx) {
+void jit_uni_postops_injector_t<Vmm>::compute_vector(int idx) {
     compute_vector_range({idx});
 }
 

--- a/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_postops_injector.hpp
@@ -36,7 +36,7 @@ namespace cpu {
 namespace x64 {
 namespace injector {
 
-size_t aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd);
+int aux_vec_count(const post_ops_t &post_ops, cpu_isa_t isa, bool is_fwd);
 
 // The main mechanism of handling various post-ops types. It utilizes internally
 // specialized injectors to generate post-ops code to host primitive. Random
@@ -88,16 +88,16 @@ public:
     // Generates code of post_ops chain injected to host primitive. Applied to
     // range <start_idx, end_idx) of vector registers' indexes.
     // @rhs_arg_params: see jit_uni_binary_injector description
-    void compute_vector_range(size_t start_idx, size_t end_idx,
+    void compute_vector_range(int start_idx, int end_idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
-    void compute_vector_range(size_t start_idx, size_t end_idx);
+    void compute_vector_range(int start_idx, int end_idx);
 
     // Generates code of post_ops chain injected to host primitive. Applied to
     // a single vector register index.
     // @rhs_arg_params: see jit_uni_binary_injector description
-    void compute_vector(size_t idx,
+    void compute_vector(int idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
-    void compute_vector(size_t idx);
+    void compute_vector(int idx);
 
     // Thin wrapper for eltwise injector specific function
     void prepare_table(bool gen_table);

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -51,8 +51,8 @@ injector_t<Vmm> *cast2tgt(void *injector) {
 
 postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
         const post_ops_t &post_ops, const memory_desc_t &dst_md,
-        const Xbyak::Reg64 &param_reg, size_t rhs_arg_offset,
-        size_t dst_orig_off, int tail_elems)
+        const Xbyak::Reg64 &param_reg, int rhs_arg_offset, dim_t dst_orig_off,
+        int tail_elems)
     : is_zmm_(is_superset(isa, avx512_core)), tail_elems_(tail_elems) {
     const memory_desc_wrapper dst_d(dst_md);
 
@@ -72,8 +72,8 @@ postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
     // enabled yet.
     const binary_injector::rhs_arg_static_params_t rhs_sp {
             rhs_dt_helper_vmm_idx, gen.r14, gen.r15, gen.r13, preserve_gpr,
-            preserve_vmm, rhs_arg_offset, dst_orig_off, dst_d,
-            (size_t)tail_elems, use_exact_tail_scalar_bcast};
+            preserve_vmm, rhs_arg_offset, dst_orig_off, dst_d, tail_elems,
+            use_exact_tail_scalar_bcast};
 
     const binary_injector::static_params_t bsp {param_reg,
             binary_injector::get_all_strategies_supported_by_injector(),

--- a/src/cpu/x64/ir/postops_injector.hpp
+++ b/src/cpu/x64/ir/postops_injector.hpp
@@ -67,8 +67,8 @@ struct postops_injector_t {
     // tail_elems     - right-hand-side elements a partial (tail) load reads
     DNNL_API postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
             const post_ops_t &post_ops, const memory_desc_t &dst_md,
-            const Xbyak::Reg64 &param_reg, size_t rhs_arg_offset,
-            size_t dst_orig_off, int tail_elems);
+            const Xbyak::Reg64 &param_reg, int rhs_arg_offset,
+            dim_t dst_orig_off, int tail_elems);
 
     postops_injector_t(const postops_injector_t &) = delete;
     postops_injector_t &operator=(const postops_injector_t &) = delete;

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -55,7 +55,7 @@ jit_avx2_1x1_conv_kernel_f32_t::jit_avx2_1x1_conv_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const int tail_size = jcp.oc_without_padding % isa_simd_width_;
 
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r13, r14,
                 r15, preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -60,7 +60,7 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const int tail_size = jcp.oc_without_padding % isa_simd_width_;
 
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r13, r14,
                 r15, preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -56,7 +56,7 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const int tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -102,7 +102,7 @@ jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const int tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_args_static_params {

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -50,7 +50,7 @@ jit_avx512_core_amx_1x1_fwd_kernel_t::jit_avx512_core_amx_1x1_fwd_kernel_t(
         const auto &rhs_addr_cache_reg = bin_injector_helper_reg_3;
         static constexpr bool preserve_gpr = false;
         static constexpr bool preserve_vmm = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const int tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {31, rhs_addr_reg,

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -1082,7 +1082,7 @@ jit_avx512_core_amx_fwd_kernel_t::jit_avx512_core_amx_fwd_kernel_t(
         const auto &rhs_addr_cache_reg = bin_injector_helper_reg_3;
         static constexpr bool preserve_gpr = false;
         static constexpr bool preserve_vmm = false;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const int tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -51,7 +51,7 @@ jit_avx512_core_bf16_1x1_conv_kernel_t::jit_avx512_core_bf16_1x1_conv_kernel_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t tail_size = jcp.oc_without_padding % isa_simd_width_;
+        const int tail_size = jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -106,8 +106,8 @@ jit_avx512_core_bf16_fwd_kernel_vmm_t<
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t oc_block_tail = jcp.oc_block % isa_simd_width_;
-        const size_t tail_size = oc_block_tail
+        const int oc_block_tail = jcp.oc_block % isa_simd_width_;
+        const int tail_size = oc_block_tail
                 ? oc_block_tail
                 : jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -42,7 +42,7 @@ jit_avx512_dw_conv_fwd_kernel_bf16_t::jit_avx512_dw_conv_fwd_kernel_bf16_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         static constexpr bool use_exact_tail_scalar_bcast = true;
-        const size_t tail_size = jcp.oc_without_padding
+        const int tail_size = jcp.oc_without_padding
                 % (cpu_isa_traits_t<avx512_core>::vlen / sizeof(float));
 
         const rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx,

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -63,8 +63,7 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
             jcp.src_dt, jcp.dst_dt};
     io_ = utils::make_unique<io::jit_io_multi_dt_helper_t<Xbyak::Zmm>>(this,
             jcp.isa, data_types, io::io_conf_t {},
-            io::io_tail_conf_t {simd_w, static_cast<std::size_t>(tail_size),
-                    k_oc_tail_mask, 0, reg_tmp});
+            io::io_tail_conf_t {simd_w, tail_size, k_oc_tail_mask, 0, reg_tmp});
 }
 
 static bool check_if_tail(const bool is_ch_tail, const dim_t c_tail,

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -39,7 +39,7 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
         const jit_conv_conf_t &ajcp, const memory_desc_t &dst_md)
     : jit_generator_t(jit_name(), ajcp.isa), jcp(ajcp) {
     const auto simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const auto tail_size = jcp.oc_without_padding % simd_w;
+    const int tail_size = jcp.oc_without_padding % simd_w;
     if (jcp.with_eltwise || jcp.with_binary) {
         using namespace binary_injector;
         static constexpr auto preserve_gpr = true;
@@ -63,11 +63,12 @@ jit_avx512_dw_conv_fwd_kernel_f16_t::jit_avx512_dw_conv_fwd_kernel_f16_t(
             jcp.src_dt, jcp.dst_dt};
     io_ = utils::make_unique<io::jit_io_multi_dt_helper_t<Xbyak::Zmm>>(this,
             jcp.isa, data_types, io::io_conf_t {},
-            io::io_tail_conf_t {simd_w, tail_size, k_oc_tail_mask, 0, reg_tmp});
+            io::io_tail_conf_t {simd_w, static_cast<std::size_t>(tail_size),
+                    k_oc_tail_mask, 0, reg_tmp});
 }
 
-static bool check_if_tail(const bool is_ch_tail, const int c_tail, const int ch,
-        const int ur_ch_blocks, const int simd_w) {
+static bool check_if_tail(const bool is_ch_tail, const dim_t c_tail,
+        const int ch, const int ur_ch_blocks, const int simd_w) {
     return is_ch_tail && (ch + 1 == ur_ch_blocks) && simd_w > c_tail;
 }
 

--- a/src/cpu/x64/jit_avx512_core_resampling.cpp
+++ b/src/cpu/x64/jit_avx512_core_resampling.cpp
@@ -751,7 +751,7 @@ private:
         if (tail_size_ != 0) resample_nearest(true);
     }
 
-    static constexpr std::size_t simd_w() {
+    static constexpr int simd_w() {
         return cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
     }
 
@@ -791,7 +791,7 @@ private:
     dim_t stride_w_ = 0;
     dim_t inner_stride_ = 0;
     unsigned number_of_loops_ = 0;
-    size_t tail_size_ = 0;
+    int tail_size_ = 0;
     bool is_saturation_needed_ = false;
     unsigned stack_size_needed_ = 0;
 };

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -58,8 +58,8 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr unsigned helper_vmm_idx = 31;
-        const size_t oc_block_tail = jcp.oc_block % isa_simd_width_;
-        const size_t tail_size = oc_block_tail
+        const int oc_block_tail = jcp.oc_block % isa_simd_width_;
+        const int tail_size = oc_block_tail
                 ? oc_block_tail
                 : jcp.oc_without_padding % isa_simd_width_;
         static constexpr bool use_exact_tail_scalar_bcast = true;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -66,10 +66,9 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
-        const size_t block_tail
-                = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
+        const int block_tail = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
                 % isa_simd_width_;
-        const size_t tail_size = block_tail
+        const int tail_size = block_tail
                 ? block_tail
                 : (jcp.is_depthwise ? jcp.ngroups : jcp.oc_without_padding)
                         % isa_simd_width_;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -50,7 +50,7 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
     , postops_injector_(nullptr) {
 
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
-        const std::size_t tail_size = jcp.is_depthwise
+        const int tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
 
@@ -59,8 +59,8 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(Xbyak::Xmm(31).getIdx()), this->r14,
-                this->r15, this->r13, preserve_gpr, preserve_vmm,
+                Xbyak::Xmm(31).getIdx(), this->r14, this->r15, this->r13,
+                preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
                 memory_desc_wrapper(dst_md), tail_size, ktail_mask,
                 use_exact_tail_scalar_bcast};

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -82,11 +82,10 @@ dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(vmm_tmp(4).getIdx()), this->r14, this->r15,
-                this->r13, preserve_gpr, preserve_vmm,
-                GET_OFF(ptr_binary_post_ops_rhs), GET_OFF(dst_orig),
-                memory_desc_wrapper(brg_.dst_md()),
-                static_cast<size_t>(brg_.load_dim % brg_.ld_block), k_tail_mask,
+                vmm_tmp(4).getIdx(), this->r14, this->r15, this->r13,
+                preserve_gpr, preserve_vmm, GET_OFF(ptr_binary_post_ops_rhs),
+                GET_OFF(dst_orig), memory_desc_wrapper(brg_.dst_md()),
+                static_cast<int>(brg_.load_dim % brg_.ld_block), k_tail_mask,
                 use_exact_tail_scalar_bcast};
         const binary_injector::static_params_t bsp(this->param1,
                 binary_injector::get_all_strategies_supported_by_injector(),

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -313,7 +313,7 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
 #define PARAM_OFF(field) offsetof(ker_args_t, field)
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
-        static const size_t helper_vmm_idx = is_avx512_ ? 31 : 15;
+        static const int helper_vmm_idx = is_avx512_ ? 31 : 15;
         static constexpr bool use_exact_tail_scalar_bcast = false;
         const auto dst_md_wrapper = memory_desc_wrapper(*dst_md);
 
@@ -326,7 +326,7 @@ jit_pp_kernel_t<isa>::jit_pp_kernel_t(size_t OC, size_t MB, dim_t dst_mb_stride,
             OC_loop = vlen * max_OC_loop_unroll_;
             OC_tail = OC % OC_loop;
         }
-        size_t tail_size = OC_tail % vlen;
+        int tail_size = static_cast<int>(OC_tail % vlen);
         // enable tail processing for runtime load even if there is no tail
         // for the OC
         tail_size = !!tail_size ? tail_size : 1;

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -47,7 +47,7 @@ jit_sse41_1x1_conv_kernel_f32_t::jit_sse41_1x1_conv_kernel_f32_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t tail_size = jcp.oc_without_padding % simd_w_;
+        const int tail_size = jcp.oc_without_padding % simd_w_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -46,7 +46,7 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t tail_size = jcp.oc_without_padding % simd_w_;
+        const int tail_size = jcp.oc_without_padding % simd_w_;
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_arg_static_params {

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -796,7 +796,7 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
         std::vector<unsigned> indices(simd_w);
 
         const dim_t src1_different_layout_stride = conf.src1_stride;
-        for (size_t i = 0; i < simd_w; i++)
+        for (int i = 0; i < simd_w; i++)
             indices[i] = i * src1_different_layout_stride * src1_type_size;
 
         const dim_t batch = src0_d.dims()[0];

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -54,7 +54,7 @@ binary_kernel_t::binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
     , padding_tail_size_(
               pd->src_md(0)->padded_dims[1] - pd->src_md(0)->dims[1]) {}
 
-size_t binary_kernel_t::get_tail_size() const {
+int binary_kernel_t::get_tail_size() const {
     memory_desc_wrapper src0_d(pd_->src_md(0));
     const auto &dims = src0_d.dims();
     const auto &ndims = src0_d.ndims();
@@ -143,8 +143,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::init_post_ops_injector() {
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {10, reg_tmp_,
             reg_elt_inj_table_, r13, true /*preserve gpr*/,
             true /*preserve vmm*/, PARAM_OFF(post_ops_binary_rhs_arg_vec),
-            PARAM_OFF(dst_orig), dst_d, static_cast<int>(tail_size_),
-            tail_opmask_, false /*use_exact_tail_scalar_bcast*/};
+            PARAM_OFF(dst_orig), dst_d, tail_size_, tail_opmask_,
+            false /*use_exact_tail_scalar_bcast*/};
     const binary_injector::static_params_t bsp(this->param1,
             get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -143,8 +143,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::init_post_ops_injector() {
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {10, reg_tmp_,
             reg_elt_inj_table_, r13, true /*preserve gpr*/,
             true /*preserve vmm*/, PARAM_OFF(post_ops_binary_rhs_arg_vec),
-            PARAM_OFF(dst_orig), dst_d, tail_size_, tail_opmask_,
-            false /*use_exact_tail_scalar_bcast*/};
+            PARAM_OFF(dst_orig), dst_d, static_cast<int>(tail_size_),
+            tail_opmask_, false /*use_exact_tail_scalar_bcast*/};
     const binary_injector::static_params_t bsp(this->param1,
             get_supported_postops_bcast_strategies(), rhs_arg_bsp);
 

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -51,21 +51,21 @@ struct binary_kernel_t : public jit_generator_t {
         jit_generator_t::operator()(p);
     }
 
-    size_t simd_w() const noexcept { return simd_w_; }
+    int simd_w() const noexcept { return simd_w_; }
     size_t vlen() const noexcept { return vlen_; }
 
 protected:
-    size_t get_tail_size() const;
+    int get_tail_size() const;
 
     const size_t vlen_;
-    const size_t simd_w_;
+    const int simd_w_;
     constexpr static int vmm_start_idx_ = 1;
     const binary_pd_t *pd_;
     const jit_binary_conf_t conf_;
     const bool is_tail_kernel_;
     const bool is_src1_outer_dims_tail_;
-    const size_t tail_size_;
-    const size_t padding_tail_size_;
+    const int tail_size_;
+    const int padding_tail_size_;
 };
 
 template <cpu_isa_t isa, typename Vmm>

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -45,7 +45,7 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 31;
         static constexpr bool use_exact_tail_scalar_bcast = true;
-        const size_t tail_size = jcp.oc_without_padding
+        const int tail_size = jcp.oc_without_padding
                 % (cpu_isa_traits_t<isa>::vlen / sizeof(float));
         rhs_arg_static_params_t rhs_arg_static_params {helper_vmm_idx, r14, r15,
                 r12, preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -64,7 +64,9 @@ protected:
         return utils::one_of(
                 data_type(), data_type::f8_e5m2, data_type::f8_e4m3);
     }
-    int dtype_size() const { return types::data_type_size(data_type()); }
+    int dtype_size() const {
+        return static_cast<int>(types::data_type_size(data_type()));
+    }
     cpu_isa_t get_io_isa(cpu_isa_t isa) const {
         // reusing avx512_core instantiation for bf16
         return is_bf16() && is_superset(isa, avx512_core)

--- a/src/cpu/x64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/x64/jit_uni_eltwise_int.cpp
@@ -36,7 +36,7 @@ struct jit_args_int8_t {
     const void *from;
     const void *for_comparison;
     const void *to;
-    size_t work_amount;
+    dim_t work_amount;
 };
 
 struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
@@ -50,7 +50,9 @@ struct jit_uni_eltwise_int_kernel_t : public jit_generator_t {
 
 protected:
     data_type_t data_type() const { return pd_->src_md()->data_type; }
-    int dtype_size() const { return types::data_type_size(data_type()); }
+    int dtype_size() const {
+        return static_cast<int>(types::data_type_size(data_type()));
+    }
 
     const eltwise_desc_t &desc() const { return *pd_->desc(); }
 
@@ -80,11 +82,11 @@ struct jit_uni_subkernel_int_t : public jit_uni_eltwise_int_kernel_t {
     void generate() override {
         Reg64 param = abi_param1;
 
-        const size_t vlen = cpu_isa_traits_t<isa>::vlen;
-        const size_t simd_w = vlen / sizeof(float);
-        const size_t loop_dec[] = {simd_w, 1};
-        const size_t uf[] = {1, 1};
-        const size_t shift[] = {dtype_size() * simd_w, (size_t)dtype_size()};
+        const int vlen = cpu_isa_traits_t<isa>::vlen;
+        const int simd_w = vlen / static_cast<int>(sizeof(float));
+        const int loop_dec[] = {simd_w, 1};
+        const int uf[] = {1, 1};
+        const int shift[] = {dtype_size() * simd_w, dtype_size()};
         const bool loop_vectorize[] = {true, false};
 
         preamble();
@@ -232,35 +234,35 @@ private:
             store_8bit(vectorize, mem_to, vr_to, data_type() == data_type::s8);
     }
 
-    void compute_step(bool vectorize, const size_t uf, const size_t shift,
+    void compute_step(bool vectorize, const int uf, const int shift,
             const alg_kind_t alg) {
 
-        auto vreg_from = [&](const size_t i) -> Vmm { return Vmm(i + 1); };
-        auto vreg_to = [&](const size_t i) -> Vmm { return Vmm(uf + i + 1); };
+        auto vreg_from = [&](const int i) -> Vmm { return Vmm(i + 1); };
+        auto vreg_to = [&](const int i) -> Vmm { return Vmm(uf + i + 1); };
 
         // 1. Load (vregs <- mem)
-        for (size_t i = 0; i < uf; i++)
+        for (int i = 0; i < uf; i++)
             load(vectorize, vreg_from(i), ptr[reg_from + i * shift]);
 
         // 2. Process (vregs <- vergs)
         switch (alg) {
             case alg_kind::eltwise_linear:
-                for (size_t i = 0; i < uf; i++)
+                for (int i = 0; i < uf; i++)
                     process_linear(vreg_to(i), vreg_from(i));
                 break;
             case alg_kind::eltwise_relu:
-                for (size_t i = 0; i < uf; i++)
+                for (int i = 0; i < uf; i++)
                     process_relu(vreg_to(i), vreg_from(i));
                 break;
             case alg_kind::eltwise_clip:
-                for (size_t i = 0; i < uf; i++)
+                for (int i = 0; i < uf; i++)
                     process_clip(vreg_to(i), vreg_from(i));
                 break;
             default: assert(!"unsupported alg");
         }
 
         // 3. Store (mem <- vregs)
-        for (size_t i = 0; i < uf; i++)
+        for (int i = 0; i < uf; i++)
             store(vectorize, ptr[reg_to + i * shift], vreg_to(i));
     }
 };
@@ -493,14 +495,15 @@ status_t jit_uni_eltwise_int_fwd_t<isa>::execute_forward(
 
     const memory_desc_wrapper src_d(pd()->src_md());
 
-    const size_t nelems = src_d.nelems(true);
+    const dim_t nelems = src_d.nelems(true);
 
-    src += src_d.data_type_size() * src_d.offset0();
-    dst += src_d.data_type_size() * src_d.offset0();
+    const dim_t data_type_size = src_d.data_type_size();
+    src += data_type_size * src_d.offset0();
+    dst += data_type_size * src_d.offset0();
 
-    const int cache_line = 64 / src_d.data_type_size();
+    const int cache_line = static_cast<int>(64 / data_type_size);
     parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
 
         balance211(utils::div_up(nelems, cache_line), nthr, ithr, start, end);
         start = nstl::min(nelems, start * cache_line);
@@ -508,9 +511,9 @@ status_t jit_uni_eltwise_int_fwd_t<isa>::execute_forward(
         if (start == end) return;
 
         jit_args_int8_t arg;
-        arg.from = src + src_d.data_type_size() * start;
-        arg.for_comparison = src + src_d.data_type_size() * start;
-        arg.to = dst + src_d.data_type_size() * start;
+        arg.from = src + data_type_size * start;
+        arg.for_comparison = src + data_type_size * start;
+        arg.to = dst + data_type_size * start;
         arg.work_amount = end - start;
         (*kernel_)(&arg);
     });

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -127,7 +127,7 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
             static constexpr bool preserve_gpr = true;
             static constexpr bool preserve_vmm = true;
             static constexpr bool use_exact_tail_scalar_bcast = true;
-            static const std::size_t tmp_vmm_injector = this->vmm_tmp.getIdx();
+            static const int tmp_vmm_injector = this->vmm_tmp.getIdx();
 
             const eltwise_injector::static_params_t esp(true /*save_state*/,
                     reg_po_injector_helper_, elt_inj_opmask, true /*is_fwd*/,
@@ -137,7 +137,7 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<size_t>(axis_simd_tail_), tail_opmask,
+                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {

--- a/src/cpu/x64/jit_uni_group_normalization.cpp
+++ b/src/cpu/x64/jit_uni_group_normalization.cpp
@@ -106,8 +106,8 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
 
         VDEBUGINFO(1, primitive, group_normalization,
                 "%s:\n    C_=%" PRId64 "\n    C_PER_G_=%" PRId64
-                "\n    simd_w_=%zu\n    axis_simd_full_=%" PRId64
-                "\n    axis_simd_tail_=%" PRId64
+                "\n    simd_w_=%d\n    axis_simd_full_=%" PRId64
+                "\n    axis_simd_tail_=%d"
                 "\n    use_scale_=%d\n    use_shift_=%d",
                 jit_name(), C_, C_PER_G_, simd_w_, axis_simd_full_,
                 axis_simd_tail_, use_scale_, use_shift_);
@@ -137,7 +137,7 @@ struct kernel_t : public jit_uni_group_normalization_fwd_t::kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
+                    dst_d_, axis_simd_tail_, tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {
@@ -248,9 +248,9 @@ protected:
     const memory_desc_wrapper src_d_, dst_d_;
     const dim_t C_;
     const dim_t C_PER_G_;
-    const size_t simd_w_;
+    const int simd_w_;
     const dim_t axis_simd_full_;
-    const dim_t axis_simd_tail_;
+    const int axis_simd_tail_;
     const bool use_scale_ = false;
     const bool use_shift_ = false;
     const float eps_;
@@ -428,7 +428,7 @@ struct kernel_stat_t
         VDEBUGINFO(1, primitive, group_normalization,
                 "%s:\n    compute_var_=%d\n    C_=%" PRId64
                 "\n    C_PER_G_=%" PRId64
-                "\n    simd_w_=%zu\n    axis_simd_tail_=%" PRId64
+                "\n    simd_w_=%d\n    axis_simd_tail_=%d"
                 "\n    unroll_c_=%" PRId64 "\n    c_block_=%" PRId64
                 "\n    nc_blocks_=%" PRId64 "\n    c_block_tail_=%" PRId64
                 "\n    unroll_c_tail_=%" PRId64,
@@ -592,8 +592,8 @@ protected:
     const dim_t C_;
     const dim_t C_PER_G_;
     const dim_t SP_;
-    const size_t simd_w_;
-    const dim_t axis_simd_tail_;
+    const int simd_w_;
+    const int axis_simd_tail_;
     static constexpr dim_t unroll_c_ = 4;
     const dim_t c_block_;
     const dim_t nc_blocks_;

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -239,7 +239,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
         if (jpp.with_postops) {
 
             const int simd_w = cpu_isa_traits_t<isa>::vlen / sizeof(float);
-            const std::size_t c_tail_elems = jpp.c % simd_w;
+            const int c_tail_elems = jpp.c % simd_w;
             post_op_tail_opmask_idx_ = 0;
             if (c_tail_elems) {
                 for (int ll = max_num_ll - 1; ll >= 0; ll--) {
@@ -253,7 +253,7 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
             static constexpr bool preserve_gpr = true;
             static constexpr bool preserve_vmm = true;
             static constexpr bool use_exact_tail_scalar_bcast = false;
-            static constexpr std::size_t tmp_vmm_injector = 0u;
+            static constexpr int tmp_vmm_injector = 0;
 
             const binary_injector::rhs_arg_static_params_t rhs_sp {
                     tmp_vmm_injector, r14, r15, r13, preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -127,7 +127,7 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
+                    dst_d_, axis_simd_tail_, tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {
@@ -237,9 +237,9 @@ protected:
     io::jit_io_multi_dt_helper_t<Vmm> io_;
     const memory_desc_wrapper src_d_, dst_d_;
     const dim_t C_;
-    const size_t simd_w_;
+    const int simd_w_;
     const dim_t axis_simd_full_;
-    const dim_t axis_simd_tail_;
+    const int axis_simd_tail_;
     const bool use_scale_ = false;
     const bool use_shift_ = false;
     const float eps_;
@@ -500,8 +500,8 @@ protected:
     const memory_desc_wrapper src_d_;
     bool compute_var_;
     const dim_t C_;
-    const size_t simd_w_;
-    const dim_t axis_simd_tail_;
+    const int simd_w_;
+    const int axis_simd_tail_;
     const dim_t unroll_c_;
     const dim_t c_block_;
     const dim_t nc_blocks_;

--- a/src/cpu/x64/jit_uni_instance_normalization.cpp
+++ b/src/cpu/x64/jit_uni_instance_normalization.cpp
@@ -117,7 +117,7 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
             static constexpr bool preserve_gpr = true;
             static constexpr bool preserve_vmm = true;
             static constexpr bool use_exact_tail_scalar_bcast = true;
-            static const std::size_t tmp_vmm_injector = this->vmm_tmp.getIdx();
+            static const int tmp_vmm_injector = this->vmm_tmp.getIdx();
 
             const eltwise_injector::static_params_t esp(true /*save_state*/,
                     reg_po_injector_helper_, elt_inj_opmask, true /*is_fwd*/,
@@ -127,7 +127,7 @@ struct kernel_t : public jit_uni_instance_normalization_fwd_t::kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<size_t>(axis_simd_tail_), tail_opmask,
+                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -549,7 +549,7 @@ protected:
             static constexpr bool preserve_gpr = true;
             static constexpr bool preserve_vmm = true;
             static constexpr bool use_exact_tail_scalar_bcast = true;
-            static const std::size_t tmp_vmm_injector = this->vmm_tmp.getIdx();
+            static const int tmp_vmm_injector = this->vmm_tmp.getIdx();
 
             const eltwise_injector::static_params_t esp(true /*save_state*/,
                     reg_po_injector_helper_, elt_inj_opmask, true /*is_fwd*/,
@@ -559,7 +559,7 @@ protected:
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<size_t>(axis_simd_tail_), tail_opmask,
+                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {reg_param,

--- a/src/cpu/x64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/x64/jit_uni_layer_normalization.cpp
@@ -175,10 +175,10 @@ protected:
 
     io::jit_io_multi_dt_helper_t<Vmm> io_;
     const memory_desc_wrapper src_d_, dst_d_;
-    const size_t simd_w_;
+    const int simd_w_;
     const dim_t C_;
     const dim_t axis_simd_full_;
-    const dim_t axis_simd_tail_;
+    const int axis_simd_tail_;
     const bool use_scale_;
     const bool use_shift_;
     const bool save_stats_;
@@ -559,7 +559,7 @@ protected:
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst),
-                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
+                    dst_d_, axis_simd_tail_, tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {reg_param,
@@ -793,10 +793,10 @@ protected:
 
     io::jit_io_multi_dt_helper_t<Vmm> io_;
     const memory_desc_wrapper src_d_, d_dst_d_;
-    const size_t simd_w_;
+    const int simd_w_;
     const dim_t C_;
     const dim_t axis_simd_full_;
-    const dim_t axis_simd_tail_;
+    const int axis_simd_tail_;
     const float eps_;
     const bool skip_mean_;
 
@@ -998,10 +998,10 @@ protected:
 
     io::jit_io_multi_dt_helper_t<Vmm> io_;
     const memory_desc_wrapper src_d_, d_dst_d_, d_src_d_;
-    const size_t simd_w_;
+    const int simd_w_;
     const dim_t C_;
     const dim_t axis_simd_full_;
-    const dim_t axis_simd_tail_;
+    const int axis_simd_tail_;
     const bool use_scale_;
     const bool use_shift_;
     const bool calculate_diff_stats_;

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -89,14 +89,13 @@ jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
         static constexpr bool use_exact_tail_scalar_bcast = false;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<std::size_t>(this->xmm4.getIdx()), this->r14,
-                this->r15, this->r13, preserve_gpr, preserve_vmm,
+                this->xmm4.getIdx(), this->r14, this->r15, this->r13,
+                preserve_gpr, preserve_vmm,
                 GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig),
                 memory_desc_wrapper(jpp.tag_kind == jit_memory_tag_kind_t::ncsp
                                 ? jpp.tmp_md
                                 : *dst_md),
-                static_cast<size_t>(tail_size), k_c_tail_mask,
-                use_exact_tail_scalar_bcast};
+                tail_size, k_c_tail_mask, use_exact_tail_scalar_bcast};
 
         const binary_injector::static_params_t bsp {reg_param,
                 get_supported_bcast_strategies(), rhs_sp, f8_e5m2_cvt_.get(),

--- a/src/cpu/x64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.cpp
@@ -154,11 +154,11 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::init_post_ops_injector(
             reg_po_injector_helper_1_, elt_inj_opmask_, true /*is_fwd*/,
             false /*use_dst*/);
     const binary_injector::rhs_arg_static_params_t rhs_arg_bsp {
-            static_cast<size_t>(rhs_dt_helper_vmm_.getIdx()),
-            reg_po_injector_helper_1_, reg_po_injector_helper_2_,
-            reg_po_injector_helper_3_, true /*preserve gpr*/,
-            true /*preserve vmm*/, GET_OFF(post_ops_binary_rhs_arg_vec),
-            GET_OFF(dst_orig), dst_d, store_tail_size_, k_tail_store_mask_,
+            rhs_dt_helper_vmm_.getIdx(), reg_po_injector_helper_1_,
+            reg_po_injector_helper_2_, reg_po_injector_helper_3_,
+            true /*preserve gpr*/, true /*preserve vmm*/,
+            GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig), dst_d,
+            store_tail_size_, k_tail_store_mask_,
             false /*use_exact_tail_scalar_bcast*/};
     const binary_injector::static_params_t bsp(
             reg_param_, get_supported_postops_bcast_strategies(), rhs_arg_bsp);

--- a/src/cpu/x64/jit_uni_reduction_kernel.cpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.cpp
@@ -361,7 +361,7 @@ void jit_uni_reduction_kernel_t<isa, Vmm>::apply_postops(const int data_idx) {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_reduction_kernel_t<isa, Vmm>::finalize() {
-    if (static_cast<std::size_t>(conf_.reduce_size) > load_tail_size_) {
+    if (conf_.reduce_size > load_tail_size_) {
         reduce_vmm_to_scalar(
                 vmm_acc_, vmm_tmp1_, vmm_tmp2_, vmm_tmp3_, simd_w_);
     }

--- a/src/cpu/x64/jit_uni_reduction_kernel.hpp
+++ b/src/cpu/x64/jit_uni_reduction_kernel.hpp
@@ -114,12 +114,12 @@ private:
     static constexpr bool is_zmm_ = std::is_same<Vmm, Xbyak::Zmm>::value;
     static constexpr bool is_ymm_ = std::is_same<Vmm, Xbyak::Ymm>::value;
     static constexpr std::size_t vlen_ = is_zmm_ ? 64 : is_ymm_ ? 32 : 16;
-    static constexpr std::size_t simd_w_ = vlen_ / sizeof(float);
+    static constexpr int simd_w_ = vlen_ / sizeof(float);
     static constexpr std::size_t number_of_f32_in_xmm_ = 4;
     static constexpr std::size_t number_of_f32_in_ymm_ = 8;
     static constexpr std::size_t number_of_f32_in_zmm_ = 16;
-    const std::size_t load_tail_size_;
-    static constexpr std::size_t store_tail_size_ = 1;
+    const int load_tail_size_;
+    static constexpr int store_tail_size_ = 1;
 
     io::jit_io_helper_t<Vmm> io_load_;
     io::jit_io_helper_t<Vmm> io_store_;

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
@@ -44,7 +44,7 @@ struct direct_copy_kernel_t
 
         const memory_desc_wrapper src_d(pd_->src_md());
 
-        tail_size_ = src_d.nelems() % simd_w_;
+        tail_size_ = static_cast<int>(src_d.nelems() % simd_w_);
 
         io::io_conf_t io_conf;
         io::io_tail_conf_t io_tail_conf(
@@ -220,7 +220,7 @@ private:
     cpu_isa_t isa_;
     data_type_t src_dt_, dst_dt_;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
-    size_t tail_size_;
+    int tail_size_;
 
     const Reg64 reg_tmp_ = rax;
     const Reg64 reg_src = r8;

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -58,8 +58,8 @@ jit_uni_resampling_kernel_t<isa, Vmm>::jit_uni_resampling_kernel_t(
         const binary_injector::rhs_arg_static_params_t rhs_sp {
                 vmm_post_op_helper_.getIdx(), r14, r15, r13, preserve_gpr,
                 preserve_vmm, GET_OFF(post_ops_binary_rhs_arg_vec),
-                GET_OFF(dst_orig), dst_d, static_cast<int>(tail_size_),
-                k_tail_mask_, use_exact_tail_scalar_bcast};
+                GET_OFF(dst_orig), dst_d, tail_size_, k_tail_mask_,
+                use_exact_tail_scalar_bcast};
 
         const bcast_set_t accepted_broadcasts
                 = {broadcasting_strategy_t::scalar,

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -56,10 +56,10 @@ jit_uni_resampling_kernel_t<isa, Vmm>::jit_uni_resampling_kernel_t(
         static constexpr bool use_exact_tail_scalar_bcast = true;
 
         const binary_injector::rhs_arg_static_params_t rhs_sp {
-                static_cast<size_t>(vmm_post_op_helper_.getIdx()), r14, r15,
-                r13, preserve_gpr, preserve_vmm,
-                GET_OFF(post_ops_binary_rhs_arg_vec), GET_OFF(dst_orig), dst_d,
-                tail_size_, k_tail_mask_, use_exact_tail_scalar_bcast};
+                vmm_post_op_helper_.getIdx(), r14, r15, r13, preserve_gpr,
+                preserve_vmm, GET_OFF(post_ops_binary_rhs_arg_vec),
+                GET_OFF(dst_orig), dst_d, static_cast<int>(tail_size_),
+                k_tail_mask_, use_exact_tail_scalar_bcast};
 
         const bcast_set_t accepted_broadcasts
                 = {broadcasting_strategy_t::scalar,

--- a/src/cpu/x64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.hpp
@@ -194,8 +194,8 @@ private:
     static constexpr bool is_ymm_ = std::is_same<Vmm, Xbyak::Ymm>::value;
     static constexpr bool is_xmm_ = std::is_same<Vmm, Xbyak::Xmm>::value;
     static constexpr std::size_t vlen_ = is_zmm_ ? 64 : is_ymm_ ? 32 : 16;
-    static constexpr std::size_t simd_w_ = vlen_ / sizeof(float);
-    const std::size_t tail_size_;
+    static constexpr int simd_w_ = vlen_ / sizeof(float);
+    const int tail_size_;
 
     bool any_binary_postop_is_per_oc_bcast_type_ = false;
     bool any_binary_postop_is_per_oc_sp_bcast_type_ = false;

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -638,7 +638,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                             = jit_uni_eltwise_injector_t<Vmm>::aux_vecs_count(
                                     isa, alg_kind::eltwise_exp, pd_->is_fwd(),
                                     0.f);
-                    for (size_t j = 0; j < exp_vmm_aux_count; j++) {
+                    for (int j = 0; j < exp_vmm_aux_count; j++) {
                         // Insert the next idx starting after `vreg_tmp_sum`.
                         exp_aux_indices.insert(static_cast<size_t>(
                                 get_aux_vmm(vreg_tmp_sum, (j + 1) * max_unroll)
@@ -959,7 +959,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig),
-                    dst_d_, axis_simd_tail_, tail_opmask,
+                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {
@@ -1544,7 +1544,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig),
-                    dst_d_, axis_simd_tail_, tail_opmask,
+                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -122,7 +122,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     size_t unroll_regs_ = 4;
 
     size_t axis_simd_full_;
-    size_t axis_simd_tail_;
+    int axis_simd_tail_;
     size_t n_loops_;
     size_t loop_tail_;
     size_t process_n_elems_;
@@ -959,7 +959,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig),
-                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
+                    dst_d_, axis_simd_tail_, tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {
@@ -1010,7 +1010,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                                   accumulation_mode::any)))
         , use_ext_aux_vmms_(!is_logsoftmax_ && n_vregs > 16)
         , axis_simd_full_(pd_->axis_size() / simd_w_)
-        , axis_simd_tail_(pd_->axis_size() % simd_w_) {
+        , axis_simd_tail_(static_cast<int>(pd_->axis_size() % simd_w_)) {
 
         const auto &post_ops = pd_->attr()->post_ops_;
         with_postops_ = post_ops.len() != 0;
@@ -1108,7 +1108,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     size_t axis_size_unroll_tail_;
     size_t axis_stride_;
     size_t axis_simd_full_;
-    size_t axis_simd_tail_;
+    int axis_simd_tail_;
     size_t n_loops_;
     size_t loop_tail_;
     size_t src_next_vreg_stride_;
@@ -1544,7 +1544,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
                     tmp_vmm_injector, this->r14, this->r15, this->r13,
                     preserve_gpr, preserve_vmm,
                     PARAM_OFF(post_ops_binary_rhs_arg_vec), PARAM_OFF(dst_orig),
-                    dst_d_, static_cast<int>(axis_simd_tail_), tail_opmask,
+                    dst_d_, axis_simd_tail_, tail_opmask,
                     use_exact_tail_scalar_bcast};
 
             const binary_injector::static_params_t bsp {
@@ -1594,7 +1594,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         // different pieces from the dense version.
         , axis_stride_(pd_->axis_stride())
         , axis_simd_full_(axis_stride_ / simd_w_)
-        , axis_simd_tail_(axis_stride_ % simd_w_) {
+        , axis_simd_tail_(static_cast<int>(axis_stride_ % simd_w_)) {
 
         // Scratchpad size is limited to a single simd_w, thus, no unrolling
         // for such cases.

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -54,7 +54,7 @@ jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa,
         using namespace binary_injector;
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;
-        const size_t tail_size = get_tail_size();
+        const int tail_size = get_tail_size();
         static constexpr bool use_exact_tail_scalar_bcast = false;
         rhs_arg_static_params_t rhs_arg_static_params {15, r13, r14, r15,
                 preserve_gpr, preserve_vmm,

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -63,10 +63,9 @@ jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::jit_uni_x8s8s32x_fwd_kernel_vmm_t(
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = false;
         static constexpr size_t helper_vmm_idx = 15;
-        const size_t block_tail
-                = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
+        const int block_tail = (jcp.is_depthwise ? jcp.ch_block : jcp.oc_block)
                 % isa_simd_width_;
-        const size_t tail_size = block_tail
+        const int tail_size = block_tail
                 ? block_tail
                 : (jcp.is_depthwise ? jcp.ngroups : jcp.oc_without_padding)
                         % isa_simd_width_;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -429,7 +429,7 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
     , ker_max_regs_(jcp_.has_vnni ? 14 : 12) {
 
     if (jcp_.with_eltwise || jcp_.with_binary || jcp_.with_sum) {
-        const std::size_t tail_size = get_tail_size();
+        const int tail_size = get_tail_size();
 
         static constexpr bool preserve_gpr = true;
         static constexpr bool preserve_vmm = true;

--- a/src/cpu/x64/prelu/jit_prelu_backward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_backward.cpp
@@ -164,7 +164,7 @@ status_t jit_prelu_bwd_t::execute(const exec_ctx_t &ctx) const {
 
     const auto kernel = kernel_.get();
     const auto &bcast = kernel->get_bcast();
-    const auto &simd_w = kernel->simd_w();
+    const dim_t simd_w = kernel->simd_w();
     int nthr = pd()->nthr_;
 
     if (bcast == prelu::bcast::full) {

--- a/src/cpu/x64/prelu/jit_prelu_base_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_base_kernel.cpp
@@ -33,7 +33,7 @@ jit_prelu_base_kernel_t::jit_prelu_base_kernel_t(const cpu_isa_t &isa, int vlen,
     , tensor_md_(tensor_md)
     , number_vmm_single_compute_(number_vmm_single_compute) {}
 
-size_t jit_prelu_base_kernel_t::simd_w() const noexcept {
+int jit_prelu_base_kernel_t::simd_w() const noexcept {
     return simd_w_;
 }
 

--- a/src/cpu/x64/prelu/jit_prelu_base_kernel.hpp
+++ b/src/cpu/x64/prelu/jit_prelu_base_kernel.hpp
@@ -31,7 +31,7 @@ public:
             const prelu::bcast &bcast, const memory_desc_wrapper &tensor_md,
             const size_t number_vmm_single_compute, const char *name);
 
-    size_t simd_w() const noexcept;
+    int simd_w() const noexcept;
     prelu::bcast get_bcast() const noexcept;
 
 protected:
@@ -41,9 +41,9 @@ protected:
     size_t get_number_reserved_vmms() const noexcept;
 
     const cpu_isa_t isa_;
-    const size_t simd_w_ = 0;
+    const int simd_w_ = 0;
     const prelu::bcast bcast_ = prelu::bcast::unsupported;
-    const size_t tail_size_ = 0u;
+    const int tail_size_ = 0;
     const Xbyak::Reg64 &reg_data_size_ = r8;
     const Xbyak::Reg64 &reg_offset_ = r9;
 

--- a/src/cpu/x64/prelu/jit_prelu_forward.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_forward.cpp
@@ -128,7 +128,7 @@ status_t jit_prelu_fwd_t::execute(const exec_ctx_t &ctx) const {
 
     if (bcast == prelu::bcast::full) {
         const auto nelems = src_d.nelems(true);
-        const auto simd_w = kernel->simd_w();
+        const dim_t simd_w = kernel->simd_w();
         const auto res = std::div(nelems, simd_w);
         const auto &nelems_simd = res.quot;
         const auto &nelems_tail = res.rem;

--- a/src/cpu/x64/prelu/jit_prelu_reduction_kernel.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_reduction_kernel.cpp
@@ -44,7 +44,7 @@ jit_prelu_reduction_kernel_t::jit_prelu_reduction_kernel_t(
 
 #define PARAM_OFF(x) offsetof(call_params_t, x)
 
-size_t jit_prelu_reduction_kernel_t::simd_w() const {
+int jit_prelu_reduction_kernel_t::simd_w() const {
     return simd_w_;
 }
 

--- a/src/cpu/x64/prelu/jit_prelu_reduction_kernel.hpp
+++ b/src/cpu/x64/prelu/jit_prelu_reduction_kernel.hpp
@@ -42,7 +42,7 @@ public:
     };
 
     void generate() override;
-    size_t simd_w() const;
+    int simd_w() const;
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_prelu_reduction_kernel_t)
 
     void operator()(const jit_prelu_reduction_kernel_t::call_params_t *params) {
@@ -68,9 +68,9 @@ protected:
     Xbyak::Address diff_scratch_ptr(int unrolling_group) const;
     int reserve_vmm();
 
-    const size_t simd_w_ = 0;
+    const int simd_w_ = 0;
     const data_type_t data_type_;
-    const size_t tail_size_ = 0;
+    const int tail_size_ = 0;
     const Xbyak::Reg64 &reg_offset_ = r9;
     const Xbyak::Reg64 &reg_weights_diff_ = r11;
     const Xbyak::Reg8 &reg_last_c_blk_byte_ = r13b;

--- a/src/cpu/x64/rnn/jit_diff_weights_peephole.cpp
+++ b/src/cpu/x64/rnn/jit_diff_weights_peephole.cpp
@@ -37,9 +37,8 @@ jit_diff_weights_peephole_t::jit_diff_weights_peephole_t(
                       : mayiuse(avx512_core_bf16) ? avx512_core_bf16
                                                   : avx512_core,
               {c_states_dt_, scratch_dt_, dst_dt_}, {},
-              io::io_tail_conf_t {static_cast<std::size_t>(simd_w_),
-                      static_cast<std::size_t>(tail_size_), tail_opmask_, 0,
-                      reg_tmp_}) {}
+              io::io_tail_conf_t {
+                      simd_w_, tail_size_, tail_opmask_, 0, reg_tmp_}) {}
 
 void jit_diff_weights_peephole_t::generate() {
     preamble();

--- a/src/cpu/x64/rnn/jit_diff_weights_peephole.hpp
+++ b/src/cpu/x64/rnn/jit_diff_weights_peephole.hpp
@@ -54,7 +54,7 @@ private:
     void compute_loop();
     void compute_dst(size_t unrolling, bool tail);
 
-    static constexpr dim_t simd_w_ = 16;
+    static constexpr int simd_w_ = 16;
     static constexpr dim_t max_unrolling = 10;
 
     const data_type_t c_states_dt_;
@@ -71,7 +71,7 @@ private:
     const Xbyak::Opmask &tail_opmask_ = k3;
 
     const dim_t compute_block_size_;
-    const dim_t tail_size_;
+    const int tail_size_;
 
     io::jit_io_multi_dt_helper_t<Xbyak::Zmm> io_;
 };

--- a/src/cpu/x64/utils/jit_io_helper.cpp
+++ b/src/cpu/x64/utils/jit_io_helper.cpp
@@ -30,18 +30,18 @@ namespace io {
 io_conf_t::io_conf_t(const bool nt_stores_enabled)
     : nt_stores_enabled_(nt_stores_enabled) {}
 
-io_tail_conf_t::io_tail_conf_t(const std::size_t simd_w,
-        const std::size_t tail_size, const Xbyak::Opmask &tail_opmask,
-        const int tail_vmm_mask_idx, const Xbyak::Reg64 &reg_tmp)
+io_tail_conf_t::io_tail_conf_t(const int simd_w, const int tail_size,
+        const Xbyak::Opmask &tail_opmask, const int tail_vmm_mask_idx,
+        const Xbyak::Reg64 &reg_tmp)
     : simd_w_(simd_w)
     , tail_size_(tail_size)
     , tail_opmask_(tail_opmask)
     , tail_vmm_mask_idx_(tail_vmm_mask_idx)
     , reg_tmp_(reg_tmp) {}
 
-io_tail_conf_t::io_tail_conf_t(const std::size_t simd_w,
-        const std::size_t tail_size, int tail_opmask_idx,
-        const int tail_vmm_mask_idx, const Xbyak::Reg64 &reg_tmp)
+io_tail_conf_t::io_tail_conf_t(const int simd_w, const int tail_size,
+        int tail_opmask_idx, const int tail_vmm_mask_idx,
+        const Xbyak::Reg64 &reg_tmp)
     : simd_w_(simd_w)
     , tail_size_(tail_size)
     , tail_opmask_(Xbyak::Opmask(tail_opmask_idx))
@@ -97,7 +97,7 @@ io_saturation_conf_t::io_saturation_conf_t(const int vreg_zero_saturation_idx,
     , vreg_saturation_ubound_idx_(vreg_saturation_ubound_idx)
     , reg_tmp_(reg_tmp) {}
 
-io_gather_conf_t::io_gather_conf_t(const std::size_t simd_w,
+io_gather_conf_t::io_gather_conf_t(const int simd_w,
         const Xbyak::Opmask &full_opmask, const int full_vmm_mask_idx,
         const Xbyak::Reg64 &reg_tmp, const Xbyak::Reg64 &reg_tmp1,
         const utils::optional_t<int> &vmm_tmp_idx)
@@ -223,9 +223,8 @@ void jit_io_helper_t<Vmm>::init_bf16() {
 }
 
 template <typename Vmm>
-void jit_io_helper_t<Vmm>::prepare_opmask(
-        const std::size_t how_many_bits_to_set, const Xbyak::Reg64 &reg_tmp,
-        const Xbyak::Opmask &mask) {
+void jit_io_helper_t<Vmm>::prepare_opmask(const int how_many_bits_to_set,
+        const Xbyak::Reg64 &reg_tmp, const Xbyak::Opmask &mask) {
     const int mask_f32 = (1 << how_many_bits_to_set) - 1;
     const Xbyak::Reg32 regw_tmp = reg_tmp.cvt32();
     host_->mov(regw_tmp, mask_f32);
@@ -233,9 +232,8 @@ void jit_io_helper_t<Vmm>::prepare_opmask(
 }
 
 template <typename Vmm>
-void jit_io_helper_t<Vmm>::prepare_vmm_mask(
-        const std::size_t how_many_bits_to_set, const std::size_t simd_w,
-        const Xbyak::Reg64 &reg_tmp, const Vmm &mask) {
+void jit_io_helper_t<Vmm>::prepare_vmm_mask(const int how_many_bits_to_set,
+        const int simd_w, const Xbyak::Reg64 &reg_tmp, const Vmm &mask) {
     static const uint32_t mask_f32[14]
             = {0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff,
                     0xffffffff, 0xffffffff, 0, 0, 0, 0, 0, 0, 0};
@@ -322,17 +320,19 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
         for (int j = 0; j < number_of_values_to_load; j++) {
 
             if (j % num_indices_in_xmm == 0)
-                host_->vextractf32x4(xmm_tmp, indices_vmm, idx++);
-            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
+                host_->vextractf32x4(
+                        xmm_tmp, indices_vmm, static_cast<uint8_t>(idx++));
+            host_->uni_vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
             host_->add(src_reg, gather_conf_->reg_tmp_);
             switch (data_type_) {
                 case data_type::f16:
                     assert(f16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg], j);
+                    host_->uni_vpinsrw(
+                            xmm_dst, xmm_dst, host_->ptr[src_reg], j);
                     break;
                 case data_type::bf16:
                     assert(bf16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(
+                    host_->uni_vpinsrw(
                             xmm_dst, xmm_dst, host_->ptr[src_reg], j * 2);
                     break;
                 case data_type::s8:
@@ -344,7 +344,7 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                            data_type::f8_e5m2),
                                    fp8_supported_)
                             && "Unsupported data type.");
-                    host_->vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                    host_->uni_vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
                             i * xmm_size_elem + j);
                     break;
                 }
@@ -353,10 +353,12 @@ void jit_io_helper_t<Xbyak::Zmm>::emu_gather(const Xbyak::Reg64 &src_reg,
             host_->mov(src_reg, gather_conf_->reg_tmp1_);
         }
         if (data_type_ == data_type::bf16) {
-            host_->vinsertf32x4(dst_vmm, dst_vmm, xmm_dst, i);
+            host_->vinsertf32x4(
+                    dst_vmm, dst_vmm, xmm_dst, static_cast<uint8_t>(i));
             host_->vpxord(xmm_dst, xmm_dst, xmm_dst);
         } else if (data_type_ == data_type::f16) {
-            host_->vinsertf32x4(dst_ymm, dst_ymm, xmm_dst, i);
+            host_->vinsertf32x4(
+                    dst_ymm, dst_ymm, xmm_dst, static_cast<uint8_t>(i));
             host_->vpxord(xmm_dst, xmm_dst, xmm_dst);
         }
     }
@@ -395,29 +397,30 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
             ? utils::div_up(tail_conf_->tail_size_, xmm_size_elem)
             : utils::div_up(gather_conf_->simd_w_, xmm_size_elem);
     for (int i = 0; i < number_of_xmms; i++) {
-        host_->vextractf128(xmm_tmp, indices_vmm, i);
+        host_->vextractf128(xmm_tmp, indices_vmm, static_cast<uint8_t>(i));
 
         const int number_of_values_to_load = i == number_of_xmms - 1 && tail
                         && tail_conf_->tail_size_ % xmm_size_elem != 0
                 ? tail_conf_->tail_size_ % xmm_size_elem
                 : xmm_size_elem;
         for (int j = 0; j < number_of_values_to_load; j++) {
-            host_->vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
+            host_->uni_vpextrd(gather_conf_->reg_tmp_.cvt32(), xmm_tmp, j);
             host_->add(src_reg, gather_conf_->reg_tmp_);
             switch (data_type_) {
                 case data_type::f32:
                 case data_type::s32: {
-                    host_->vpinsrd(xmm_dst, xmm_dst, host_->ptr[src_reg], j);
+                    host_->uni_vpinsrd(
+                            xmm_dst, xmm_dst, host_->ptr[src_reg], j);
                     break;
                 }
                 case data_type::f16:
                     assert(f16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                    host_->uni_vpinsrw(xmm_dst, xmm_dst, host_->ptr[src_reg],
                             i * xmm_size_elem + j);
                     break;
                 case data_type::bf16:
                     assert(bf16_supported_ && "Unsupported data type.");
-                    host_->vpinsrw(
+                    host_->uni_vpinsrw(
                             xmm_dst, xmm_dst, host_->ptr[src_reg], j * 2);
                     break;
                 case data_type::s8:
@@ -429,7 +432,7 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                            data_type::f8_e5m2),
                                    fp8_supported_)
                             && "Unsupported data type.");
-                    host_->vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
+                    host_->uni_vpinsrb(xmm_dst, xmm_dst, host_->ptr[src_reg],
                             i * xmm_size_elem + j);
                     break;
                 }
@@ -440,7 +443,8 @@ void jit_io_helper_t<Xbyak::Ymm>::emu_gather(const Xbyak::Reg64 &src_reg,
 
         if (utils::one_of(data_type_, data_type::f32, data_type::s32,
                     data_type::bf16))
-            host_->vinsertf128(dst_vmm, dst_vmm, xmm_dst, i);
+            host_->vinsertf128(
+                    dst_vmm, dst_vmm, xmm_dst, static_cast<uint8_t>(i));
     }
 
     if (data_type_ == data_type::s32 || data_type_ == data_type::bf16)
@@ -461,25 +465,26 @@ void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
     host_->mov(gather_conf_->reg_tmp_, 0);
     host_->mov(gather_conf_->reg_tmp1_, src_reg);
 
-    const unsigned xmm_size_elem = 4;
-    const unsigned number_of_values_to_load
+    const int xmm_size_elem = 4;
+    const int number_of_values_to_load
             = tail ? tail_conf_->tail_size_ : xmm_size_elem;
-    for (unsigned j = 0; j < number_of_values_to_load; j++) {
-        host_->pextrd(gather_conf_->reg_tmp_.cvt32(), indices_vmm, j);
+    for (int j = 0; j < number_of_values_to_load; j++) {
+        host_->uni_vpextrd(gather_conf_->reg_tmp_.cvt32(), indices_vmm, j);
         host_->add(src_reg, gather_conf_->reg_tmp_);
         switch (data_type_) {
             case data_type::f32:
             case data_type::s32: {
-                host_->pinsrd(dst_vmm, host_->ptr[src_reg], j);
+                host_->uni_vpinsrd(dst_vmm, dst_vmm, host_->ptr[src_reg], j);
                 break;
             }
             case data_type::f16:
                 assert(f16_supported_ && "Unsupported data type.");
-                host_->pinsrw(dst_vmm, host_->ptr[src_reg], j);
+                host_->uni_vpinsrw(dst_vmm, dst_vmm, host_->ptr[src_reg], j);
                 break;
             case data_type::bf16:
                 assert(bf16_supported_ && "Unsupported data type.");
-                host_->pinsrw(dst_vmm, host_->ptr[src_reg], j * 2);
+                host_->uni_vpinsrw(
+                        dst_vmm, dst_vmm, host_->ptr[src_reg], j * 2);
                 break;
             case data_type::s8:
             case data_type::u8:
@@ -489,7 +494,7 @@ void jit_io_helper_t<Xbyak::Xmm>::emu_gather(const Xbyak::Reg64 &src_reg,
                                            data_type::f8_e5m2),
                                fp8_supported_)
                         && "Unsupported data type.");
-                host_->pinsrb(dst_vmm, host_->ptr[src_reg], j);
+                host_->uni_vpinsrb(dst_vmm, dst_vmm, host_->ptr[src_reg], j);
                 break;
             }
             default: assert(!"Unsupported data type.");
@@ -785,7 +790,7 @@ void jit_io_helper_t<Vmm>::store(const Vmm &src_raw_vmm,
                 = vreg_traits_t<Xbyak::Xmm>::vlen / sizeof(int32_t);
         const size_t store_size = (tail ? tail_conf_->tail_size_ : xmm_length)
                 * types::data_type_size(data_type_);
-        store_byte_by_byte(src_vmm, dst_addr, store_size);
+        store_byte_by_byte(src_vmm, dst_addr, static_cast<int>(store_size));
     } else {
         switch (data_type_) {
             case data_type::f32:

--- a/src/cpu/x64/utils/jit_io_helper.hpp
+++ b/src/cpu/x64/utils/jit_io_helper.hpp
@@ -49,18 +49,17 @@ public:
 
 class io_tail_conf_t {
 public:
-    io_tail_conf_t(const std::size_t simd_w, const std::size_t tail_size,
+    io_tail_conf_t(const int simd_w, const int tail_size,
             const Xbyak::Opmask &tail_opmask, const int tail_vmm_mask_idx,
             const Xbyak::Reg64 &reg_tmp);
-    io_tail_conf_t(const std::size_t simd_w, const std::size_t tail_size,
-            int tail_opmask_idx, const int tail_vmm_mask_idx,
-            const Xbyak::Reg64 &reg_tmp);
+    io_tail_conf_t(const int simd_w, const int tail_size, int tail_opmask_idx,
+            const int tail_vmm_mask_idx, const Xbyak::Reg64 &reg_tmp);
     io_tail_conf_t(const io_tail_conf_t &other) = default;
 
     io_tail_conf_t &operator=(const io_tail_conf_t &other) = default;
 
-    std::size_t simd_w_ = 0;
-    std::size_t tail_size_ = 0;
+    int simd_w_ = 0;
+    int tail_size_ = 0;
     Xbyak::Opmask tail_opmask_;
     int tail_vmm_mask_idx_ = 0;
     Xbyak::Reg64 reg_tmp_;
@@ -130,7 +129,7 @@ public:
 
 class io_gather_conf_t {
 public:
-    io_gather_conf_t(const std::size_t simd_w, const Xbyak::Opmask &full_opmask,
+    io_gather_conf_t(const int simd_w, const Xbyak::Opmask &full_opmask,
             const int full_vmm_mask_idx, const Xbyak::Reg64 &reg_tmp,
             const Xbyak::Reg64 &reg_tmp1,
             const utils::optional_t<int> &vmm_tmp_idx = utils::nullopt);
@@ -138,7 +137,7 @@ public:
 
     io_gather_conf_t &operator=(const io_gather_conf_t &other) = default;
 
-    std::size_t simd_w_ = 0;
+    int simd_w_ = 0;
     Xbyak::Opmask full_opmask_;
     int full_vmm_mask_idx_ = 0;
     Xbyak::Reg64 reg_tmp_;
@@ -203,11 +202,10 @@ public:
 
 private:
     bool is_data_type_supported(const data_type_t dt);
-    void prepare_opmask(const std::size_t how_many_bits_to_set,
+    void prepare_opmask(const int how_many_bits_to_set,
             const Xbyak::Reg64 &reg_tmp, const Xbyak::Opmask &mask);
-    void prepare_vmm_mask(const std::size_t how_many_bits_to_set,
-            const std::size_t simd_w, const Xbyak::Reg64 &reg_tmp,
-            const Vmm &mask);
+    void prepare_vmm_mask(const int how_many_bits_to_set, const int simd_w,
+            const Xbyak::Reg64 &reg_tmp, const Vmm &mask);
     void prepare_i8_data_to_store(const Vmm &i8_vmm);
     void prepare_xf16_data_to_store(const Vmm &vmm);
     // Emulates the behavior of vgatherdps for architectures


### PR DESCRIPTION
It's a second part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
Elimnates implicit narrowing in injectors.
Total number of warnings after this PR: 3224 => 3045.
Used `math::ilog2q` instead of `std::log2()`, `uni_*` methods and casts for remaining implicit conversions. 
