### PR TITLE
cpu: aarch64: accelerate Swish with signed LUT

### DIFF
--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.cpp
@@ -912,16 +912,109 @@ void jit_uni_eltwise_injector_t<isa>::logistic_compute_vector_fwd(
 }
 
 template <cpu_isa_t isa>
-void jit_uni_eltwise_injector_t<isa>::swish_compute_vector_fwd(
+void jit_uni_eltwise_injector_t<isa>::swish_compute_vector_fwd_signed_lut(
         const TRegS &vmm_src) {
-    // IMPORTANT: we use vmm_aux2 to save src as logistic does not use it.
+    h->mov(ZRegD(vmm_aux0.getIdx()), ZRegD(IDX(vmm_src)));
+    h->fmaxnm(vmm_src, p_all / T_m, table_val(swish_lut_min, vmm_aux1));
+    h->fminnm(vmm_src, p_all / T_m, table_val(swish_lut_max, vmm_aux1));
+
+    // Quantize x to the nearest 1/32 grid point. The floating-point
+    // subtraction recovers that point; the integer subtraction yields the
+    // signed table index. The residual is used for a first-order correction.
+    table_val(swish_lut_signed_bias, vmm_aux1);
+    h->fadd(vmm_aux2, vmm_src, vmm_aux1);
+    h->fsub(z_tmp, vmm_aux2, vmm_aux1);
+    h->fsub(vmm_src, p_all / T_m, z_tmp);
+    h->sub(vmm_aux2, vmm_aux2, vmm_aux1);
+
+    h->add_imm(h->X_TMP_1, x_table, swish_lut_base_offset(), h->X_TMP_0);
+    h->ld1w(vmm_aux1, p_all / T_z, ptr(h->X_TMP_1, vmm_aux2, SXTW, 2));
+
+    // sigmoid(x) ~= q + q * (1 - q) * (x - grid(x)).
+    h->mov(ZRegD(z_tmp.getIdx()), ZRegD(vmm_aux1.getIdx()));
+    h->fmls(z_tmp, p_all / T_m, vmm_aux1, vmm_aux1);
+    h->fmla(vmm_aux1, p_all / T_m, z_tmp, vmm_src);
+    h->fmul(vmm_src, vmm_aux0, vmm_aux1);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_eltwise_injector_t<isa>::swish_compute_vector_pair_fwd_signed_lut(
+        const TRegS &vmm_src0, const TRegS &vmm_src1) {
+    h->mov(ZRegD(vmm_aux0.getIdx()), ZRegD(IDX(vmm_src0)));
+    h->mov(ZRegD(vmm_aux1.getIdx()), ZRegD(IDX(vmm_src1)));
+
+    table_val(swish_lut_min, z_tmp);
+    h->fmaxnm(vmm_src0, p_all / T_m, z_tmp);
+    h->fmaxnm(vmm_src1, p_all / T_m, z_tmp);
+    table_val(swish_lut_max, z_tmp);
+    h->fminnm(vmm_src0, p_all / T_m, z_tmp);
+    h->fminnm(vmm_src1, p_all / T_m, z_tmp);
+
+    table_val(swish_lut_signed_bias, z_tmp);
+    h->fadd(vmm_aux2, vmm_src0, z_tmp);
+    h->fadd(vmm_aux3, vmm_src1, z_tmp);
+    h->fsub(vmm_aux4, vmm_aux2, z_tmp);
+    h->fsub(vmm_src0, p_all / T_m, vmm_aux4);
+    h->fsub(vmm_aux4, vmm_aux3, z_tmp);
+    h->fsub(vmm_src1, p_all / T_m, vmm_aux4);
+    h->sub(vmm_aux2, vmm_aux2, z_tmp);
+    h->sub(vmm_aux3, vmm_aux3, z_tmp);
+
+    h->add_imm(h->X_TMP_1, x_table, swish_lut_base_offset(), h->X_TMP_0);
+    h->ld1w(vmm_aux4, p_all / T_z, ptr(h->X_TMP_1, vmm_aux2, SXTW, 2));
+    h->ld1w(z_tmp, p_all / T_z, ptr(h->X_TMP_1, vmm_aux3, SXTW, 2));
+
+    h->mov(ZRegD(vmm_aux2.getIdx()), ZRegD(vmm_aux4.getIdx()));
+    h->mov(ZRegD(vmm_aux3.getIdx()), ZRegD(z_tmp.getIdx()));
+    h->fmls(vmm_aux2, p_all / T_m, vmm_aux4, vmm_aux4);
+    h->fmls(vmm_aux3, p_all / T_m, z_tmp, z_tmp);
+    h->fmla(vmm_aux4, p_all / T_m, vmm_aux2, vmm_src0);
+    h->fmla(z_tmp, p_all / T_m, vmm_aux3, vmm_src1);
+    h->fmul(vmm_src0, vmm_aux0, vmm_aux4);
+    h->fmul(vmm_src1, vmm_aux1, z_tmp);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_eltwise_injector_t<isa>::swish_compute_vector_fwd(
+        const TRegS &vmm_src,
+        injector_utils::vmm_index_set_iterator_t &next_idx_it,
+        const injector_utils::vmm_index_set_iterator_t &end_idx_it) {
+    if (is_swish_lut_enabled()) {
+        if (next_idx_it != end_idx_it) {
+            const TRegS vmm_src1(*next_idx_it++);
+            swish_compute_vector_pair_fwd_signed_lut(vmm_src, vmm_src1);
+            if (scale_ != 1.f)
+                h->fmul(vmm_src1, vmm_src1, table_val(scale, vmm_mask));
+            return;
+        }
+
+        swish_compute_vector_fwd_signed_lut(vmm_src);
+    } else {
+        swish_compute_vector_fwd_fallback(vmm_src);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_eltwise_injector_t<isa>::swish_compute_vector_fwd_fallback(
+        const TRegS &vmm_src) {
+    // Preserve x for the branch-dependent numerator.
     h->mov(ZRegD(vmm_aux2.getIdx()), ZRegD(IDX(vmm_src)));
-    // x*alpha
+
+    // t = alpha * x
     if (alpha_ != 1.f) { h->fmul(vmm_src, vmm_src, table_val(alpha, z_tmp)); }
-    // sigmoid(x*alpha)
-    logistic_compute_vector_fwd(vmm_src);
-    // x*sigmoid(alpha*x)
-    h->fmul(vmm_src, vmm_src, vmm_aux2);
+
+    constexpr unsigned sign_mask = 0x80000000;
+    h->fcmlt(p_mask.s, p_all / T_z, vmm_src, 0.);
+    h->orr(vmm_src, sign_mask);
+    exp_compute_vector_fwd(vmm_src, min_input_, 0.f);
+
+    // With e = exp(-abs(t)), evaluate x * sigmoid(t) as
+    //   x / (1 + e)       for t >= 0,
+    //   x * e / (1 + e)   for t < 0.
+    h->fmul(vmm_aux2, p_mask / T_m, vmm_src);
+    h->fadd(vmm_aux0, vmm_src, table_val(one, z_tmp));
+    h->fdiv(z_tmp, p_all, vmm_aux0);
+    h->fmul(vmm_src, vmm_aux2, z_tmp);
 }
 
 template <cpu_isa_t isa>
@@ -1543,6 +1636,9 @@ size_t jit_uni_eltwise_injector_t<isa>::aux_gprs_count() {
         case eltwise_tanh:
         case eltwise_gelu_tanh:
         case eltwise_gelu_erf: num_gprs_needed = 2; break;
+        case eltwise_swish:
+            num_gprs_needed = is_swish_lut_enabled() ? 2 : 0;
+            break;
         default: return 0;
     }
 
@@ -1586,7 +1682,8 @@ size_t jit_uni_eltwise_injector_t<isa>::aux_vecs_count() {
             case eltwise_gelu_tanh:
                 return (isa == asimd) ? 8 : 6; /* = tanh + 1 */
             case eltwise_swish:
-                return (isa == asimd) ? 7 : 4; /* = logistic + 1 */
+                if (is_swish_lut_enabled()) return isa == asimd ? 7 : 6;
+                return isa == asimd ? 7 : 4;
             case eltwise_log: return 7;
             case eltwise_clip:
             case eltwise_clip_v2_use_dst_for_bwd:
@@ -1637,7 +1734,10 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(
         const injector_utils::vmm_index_set_iterator_t &start_idx_it,
         const injector_utils::vmm_index_set_iterator_t &end_idx_it) {
     using namespace alg_kind;
-    std::for_each(start_idx_it, end_idx_it, [&](size_t idx) {
+
+    auto it = start_idx_it;
+    while (it != end_idx_it) {
+        const size_t idx = *it++;
         if (is_fwd_) {
             switch (alg_) {
                 case eltwise_relu_use_dst_for_bwd:
@@ -1657,7 +1757,10 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(
                 case eltwise_abs: abs_compute_vector_fwd(TReg(idx)); break;
                 case eltwise_sqrt_use_dst_for_bwd:
                 case eltwise_sqrt: sqrt_compute_vector_fwd(TReg(idx)); break;
-                case eltwise_swish: swish_compute_vector_fwd(TRegS(idx)); break;
+                case eltwise_swish:
+                    // The LUT path may consume and scale the next VMM too.
+                    swish_compute_vector_fwd(TRegS(idx), it, end_idx_it);
+                    break;
                 case eltwise_linear:
                     linear_compute_vector_fwd(TRegS(idx));
                     break;
@@ -1742,7 +1845,7 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(
         if (scale_ != 1.f) {
             h->fmul(TRegS(idx), TRegS(idx), table_val(scale, vmm_mask));
         }
-    });
+    }
 }
 
 template <cpu_isa_t isa>
@@ -2158,6 +2261,11 @@ void jit_uni_eltwise_injector_t<isa>::register_table_entries() {
             {gelu_erf_lut_bias, {0x47800000, true}}, // 65536.f
             {gelu_erf_lut_max_index, {0x00000200, true}}, // 512
     };
+    static const table_t swish_lut_consts {
+            {swish_lut_max, {0x41800000, true}}, // 16.f
+            {swish_lut_min, {0xc1800000, true}}, // -16.f
+            {swish_lut_signed_bias, {0x48800200, true}}, // 2^18 + 16
+    };
 
     // gelu_erf(x) polynomial approximation
     static const table_t gelu_erf_polynomial {
@@ -2445,6 +2553,8 @@ void jit_uni_eltwise_injector_t<isa>::register_table_entries() {
     };
 
     need_t need(alg_);
+    const bool use_swish_lut = is_swish_lut_enabled();
+    if (use_swish_lut) need.exp_ = false;
 
     auto push_arg_entry_of = [&](const key_t key, const table_entry_val_t val,
                                      const bool broadcast) {
@@ -2505,6 +2615,23 @@ void jit_uni_eltwise_injector_t<isa>::register_table_entries() {
                 push_arg_entry_of(
                         gelu_erf_lut_scale, float2int(scale_val), false);
             }
+        }
+    }
+    if (use_swish_lut) {
+        push_entries_of(swish_lut_consts);
+        constexpr float lut_step = 1.f / 32.f;
+        constexpr int lut_entries = 1025;
+        for (int i = 0; i < lut_entries; ++i) {
+            const float x = (i - 512) * lut_step;
+            float q;
+            if (i == 0) {
+                q = 0.f;
+            } else if (i == lut_entries - 1) {
+                q = 1.f;
+            } else {
+                q = 1.f / (1.f + std::exp(-x));
+            }
+            push_arg_entry_of(swish_lut_signed, float2int(q), false);
         }
     }
     // Now that we registered the entries, we set the offsets.  No
@@ -3038,16 +3165,114 @@ void jit_uni_eltwise_injector_t<asimd>::logistic_compute_vector_fwd(
 }
 
 template <>
-void jit_uni_eltwise_injector_t<asimd>::swish_compute_vector_fwd(
+void jit_uni_eltwise_injector_t<asimd>::swish_compute_vector_fwd_signed_lut(
         const TRegS &vmm_src) {
-    // IMPORTANT: we use vmm_aux5 to save src as logistic does not use it.
     h->mov(VReg16B(vmm_aux5.getIdx()), VReg16B(vmm_src.getIdx()));
-    // x*alpha
+    h->fmaxnm(vmm_src, vmm_src, table_val(swish_lut_min, z_tmp));
+    h->fminnm(vmm_src, vmm_src, table_val(swish_lut_max, z_tmp));
+
+    table_val(swish_lut_signed_bias, z_tmp);
+    h->fadd(vmm_aux2, vmm_src, z_tmp);
+    h->fsub(vmm_aux3, vmm_aux2, z_tmp);
+    h->fsub(vmm_src, vmm_src, vmm_aux3);
+    h->sub(vmm_aux2, vmm_aux2, z_tmp);
+
+    const XReg x_lut_base = h->X_TMP_0;
+    const XReg x_idx = h->X_TMP_1;
+    h->add_imm(x_lut_base, x_table, swish_lut_base_offset(), x_idx);
+    auto load_value = [&](const int lane, const SReg &dst) {
+        h->umov(WReg(IDX(x_idx)), vmm_aux2[lane]);
+        h->ldr(dst, ptr(x_lut_base, WReg(IDX(x_idx)), SXTW, 2));
+    };
+    load_value(0, SReg(IDX(vmm_aux0)));
+    load_value(1, SReg(IDX(vmm_aux1)));
+    load_value(2, SReg(IDX(vmm_aux3)));
+    load_value(3, SReg(IDX(vmm_aux4)));
+    h->ins(vmm_aux0[1], vmm_aux1[0]);
+    h->ins(vmm_aux0[2], vmm_aux3[0]);
+    h->ins(vmm_aux0[3], vmm_aux4[0]);
+
+    h->mov(VReg16B(vmm_aux1.getIdx()), VReg16B(vmm_aux0.getIdx()));
+    h->fmls(vmm_aux1, vmm_aux0, vmm_aux0);
+    h->fmla(vmm_aux0, vmm_aux1, vmm_src);
+    h->fmul(vmm_src, vmm_aux5, vmm_aux0);
+}
+
+template <>
+void jit_uni_eltwise_injector_t<
+        asimd>::swish_compute_vector_pair_fwd_signed_lut(const TRegS &vmm_src0,
+        const TRegS &vmm_src1) {
+    h->mov(VReg16B(vmm_aux0.getIdx()), VReg16B(vmm_src0.getIdx()));
+    h->mov(VReg16B(vmm_aux1.getIdx()), VReg16B(vmm_src1.getIdx()));
+
+    table_val(swish_lut_min, z_tmp);
+    h->fmaxnm(vmm_src0, vmm_src0, z_tmp);
+    h->fmaxnm(vmm_src1, vmm_src1, z_tmp);
+    table_val(swish_lut_max, z_tmp);
+    h->fminnm(vmm_src0, vmm_src0, z_tmp);
+    h->fminnm(vmm_src1, vmm_src1, z_tmp);
+
+    table_val(swish_lut_signed_bias, z_tmp);
+    h->fadd(vmm_aux2, vmm_src0, z_tmp);
+    h->fadd(vmm_aux3, vmm_src1, z_tmp);
+    h->fsub(vmm_aux4, vmm_aux2, z_tmp);
+    h->fsub(vmm_src0, vmm_src0, vmm_aux4);
+    h->fsub(vmm_aux4, vmm_aux3, z_tmp);
+    h->fsub(vmm_src1, vmm_src1, vmm_aux4);
+    h->sub(vmm_aux2, vmm_aux2, z_tmp);
+    h->sub(vmm_aux3, vmm_aux3, z_tmp);
+
+    const XReg x_lut_base = h->X_TMP_0;
+    const XReg x_idx = h->X_TMP_1;
+    h->add_imm(x_lut_base, x_table, swish_lut_base_offset(), x_idx);
+    auto load_lane
+            = [&](const TRegS &indices, const int lane, const TRegS &values) {
+        h->umov(WReg(IDX(x_idx)), indices[lane]);
+        if (lane == 0) {
+            h->ldr(SReg(IDX(values)),
+                    ptr(x_lut_base, WReg(IDX(x_idx)), SXTW, 2));
+        } else {
+            h->ldr(SReg(IDX(z_tmp)),
+                    ptr(x_lut_base, WReg(IDX(x_idx)), SXTW, 2));
+            h->ins(values[lane], z_tmp[0]);
+        }
+    };
+    for (int lane = 0; lane < 4; ++lane) {
+        load_lane(vmm_aux2, lane, vmm_aux4);
+        load_lane(vmm_aux3, lane, vmm_aux5);
+    }
+
+    h->mov(VReg16B(vmm_aux2.getIdx()), VReg16B(vmm_aux4.getIdx()));
+    h->mov(VReg16B(vmm_aux3.getIdx()), VReg16B(vmm_aux5.getIdx()));
+    h->fmls(vmm_aux2, vmm_aux4, vmm_aux4);
+    h->fmls(vmm_aux3, vmm_aux5, vmm_aux5);
+    h->fmla(vmm_aux4, vmm_aux2, vmm_src0);
+    h->fmla(vmm_aux5, vmm_aux3, vmm_src1);
+    h->fmul(vmm_src0, vmm_aux0, vmm_aux4);
+    h->fmul(vmm_src1, vmm_aux1, vmm_aux5);
+}
+
+template <>
+void jit_uni_eltwise_injector_t<asimd>::swish_compute_vector_fwd_fallback(
+        const TRegS &vmm_src) {
+    // Preserve x for the branch-dependent numerator.
+    h->mov(VReg16B(vmm_aux5.getIdx()), VReg16B(vmm_src.getIdx()));
+
+    // t = alpha * x
     if (alpha_ != 1.f) { h->fmul(vmm_src, vmm_src, table_val(alpha, z_tmp)); }
-    // sigmoid(x*alpha)
-    logistic_compute_vector_fwd(vmm_src);
-    // x*sigmoid(alpha*x)
-    h->fmul(vmm_src, vmm_src, vmm_aux5);
+
+    h->fcmlt(vmm_aux4, vmm_src, 0.);
+    h->orr(VReg16B(IDX(vmm_src)), VReg16B(IDX(vmm_src)),
+            VReg16B(IDX(table_val(sign_mask, z_tmp))));
+    exp_compute_vector_fwd(vmm_src, min_input_, 0.f);
+
+    // Select x * e for negative t and x otherwise.
+    h->fmul(vmm_aux1, vmm_aux5, vmm_src);
+    h->bit(VReg16B(IDX(vmm_aux5)), VReg16B(IDX(vmm_aux1)),
+            VReg16B(IDX(vmm_aux4)));
+    h->fadd(vmm_aux0, vmm_src, table_val(one, z_tmp));
+    h->fdiv(z_tmp, z_tmp, vmm_aux0);
+    h->fmul(vmm_src, vmm_aux5, z_tmp);
 }
 
 template <>
@@ -3272,6 +3497,11 @@ void jit_uni_eltwise_injector_t<asimd>::gelu_erf_compute_vector_fwd(
     // GELU = 0.5 * s * (1 + erf)
     h->fmul(vmm_src, vmm_src, table_val(half, z_tmp));
     h->fmla(vmm_src, vmm_aux0, vmm_src);
+}
+
+template <cpu_isa_t isa>
+size_t jit_uni_eltwise_injector_t<isa>::swish_lut_base_offset() {
+    return table_off(swish_lut_signed) + 512 * sizeof(float);
 }
 
 template <>

--- a/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/aarch64/injectors/jit_uni_eltwise_injector.hpp
@@ -171,6 +171,10 @@ private:
 
     const data_type_t d_type_;
 
+    bool is_swish_lut_enabled() const {
+        return is_fwd_ && alg_ == alg_kind::eltwise_swish && alpha_ == 1.f;
+    }
+
     // if only the injector was inherited from jit_generator...
     enum {
         _cmp_eq_oq = jit_generator_t::_cmp_eq_oq,
@@ -240,7 +244,14 @@ private:
     void mish_compute_vector_fwd(const TRegS &vmm_src);
     void logistic_compute_vector_fwd(const TRegS &vmm_src);
     void gelu_tanh_compute_vector_fwd(const TRegS &vmm_src);
-    void swish_compute_vector_fwd(const TRegS &vmm_src);
+    void swish_compute_vector_fwd_signed_lut(const TRegS &vmm_src);
+    void swish_compute_vector_pair_fwd_signed_lut(
+            const TRegS &vmm_src0, const TRegS &vmm_src1);
+    size_t swish_lut_base_offset();
+    void swish_compute_vector_fwd(const TRegS &vmm_src,
+            injector_utils::vmm_index_set_iterator_t &next_idx_it,
+            const injector_utils::vmm_index_set_iterator_t &end_idx_it);
+    void swish_compute_vector_fwd_fallback(const TRegS &vmm_src);
     void log_compute_vector_fwd(const TRegS &vmm_src);
     void clip_compute_vector_fwd(const TReg &vmm_src);
     void gelu_erf_compute_vector_fwd(const TRegS &vmm_src);
@@ -332,6 +343,10 @@ private:
         gelu_erf_lut, // ERF LUT: [erf(r), scale(r)], 513 pairs
         gelu_erf_lut_erf, // ERF LUT: erf(r), 513 entries
         gelu_erf_lut_scale, // ERF LUT: scale(r), 513 entries
+        swish_lut_max,
+        swish_lut_min,
+        swish_lut_signed_bias, // 2^18 + 16: FP32 rounding bias for 1/32 grid
+        swish_lut_signed, // sigmoid(x), 1025 entries at a 1/32 step
         log_const_127, // 127
         log_ln2, // ln(2) = 0.6931471805599453
         log_inf, // +inf

--- a/tests/benchdnn/inputs/eltwise/option_set_all_algs
+++ b/tests/benchdnn/inputs/eltwise/option_set_all_algs
@@ -9,9 +9,9 @@
 --alg=elu,elu_dst,relu,relu_dst,swish
 --batch=shapes_eltwise
 
-### logsigmoid and soft_relu
+### logsigmoid, soft_relu and swish
 --alpha=-1,1,0.5 --beta=0
---alg=soft_relu
+--alg=soft_relu,swish
 --batch=shapes_eltwise
 
 --alpha=0,0.25,-0.25 --beta=0,0.25,-0.25


### PR DESCRIPTION
## Description

This patch optimizes the AArch64 FP32 Swish injector for the common
`alpha == 1` case by replacing the exponential/division-based sigmoid
evaluation with a signed sigmoid lookup table and first-order correction.

The optimized path is enabled for forward Swish with `alpha == 1` on both SVE
and ASIMD. Other Swish parameters retain an exact numerator-form fallback.

The signed LUT stores 1,025 FP32 sigmoid values over `[-16, 16]` with a grid
step of `1/32`. For a clamped input `c`, nearest grid point `r`, and loaded
value `q = sigmoid(r)`, the injector evaluates the fuction with a 1st taylor aproximation:

```text
Swish(x) ~= x * [q + q * (1 - q) * (c - r)]
```

The identity

```text
sigmoid'(r) = sigmoid(r) * (1 - sigmoid(r)) = q * (1 - q)
```

derives the local slope from the gathered table value, avoiding a second slope
table and gather.

The implementation also pairs independent accumulator vectors in the main
compute loop. This allows the two table accesses in SVE to be issued before either
value is consumed, hiding part of the gather/load latency without changing the
approximation.

The patch includes:

- a 1,025-entry signed sigmoid table emitted in the JIT constant area;
- first-order nearest-grid correction for the LUT value;
- paired-vector schedules;
- an exact numerator-form Swish fallback for `alpha != 1`.

## Motivation

Swish/SiLU is common in modern convolutional models and can be used as a
fused post-op. The existing implementation evaluates sigmoid through an
exponential and division.

The approximation is restricted to the alpha-one case. General Swish keeps the
exact implementation:

```text
e = exp(-abs(alpha * x))

x * sigmoid(alpha * x) = x * e / (1 + e),  when alpha * x < 0
x * sigmoid(alpha * x) = x     / (1 + e),  when alpha * x >= 0
```

## Correctness

For FP32 Swish over a dense 16,777,217-point input sweep across `[-16, 16]`,
the following maximum absolute output errors were measured against the
mathematical FP32 reference:

| Implementation | Alpha | Maximum absolute error | FP32 Swish tolerance |
| --- | ---: | ---: | ---: |
| Signed-pair LUT | 1.0 | `1.97887e-5` | `4e-5` |
| DIV_ONE fallback | 0.5 | `1.90735e-6` | `4e-5` |
| DIV_ONE fallback | 2.0 | `9.53674e-7` | `4e-5` |

The maximum is below the existing benchdnn tolerance. The original input is
preserved for the final multiply, while the clamp is used only for lookup and
interpolation.

## Performance

Benchdnn FP32 forward Swish, contiguous tensor with 1,048,576 elements:

```text
--eltwise --mode=P --dir=FWD_I --dt=f32 --tag=a \
--alg=swish --alpha=1 1048576
```

| Implementation | Alpha | Latency reduction vs matching reference |
| --- | ---: | ---: |
| Signed-pair LUT | 1.0 | 54.55% / 2.20x |
| DIV_ONE fallback | 0.5 | 8.01% / 1.09x |
| DIV_ONE fallback | 2.0 | 8.07% / 1.09x |

The following represents the error at 1,000,001 point equally spaced in the interval [-20,20] relative to the reference implementation:

<img width="2420" height="1430" alt="image" src="https://github.com/user-attachments/assets/694670b1-6abe-40ae-9863-93ab173f0700" />


The same path was measured in an INT8 YOLOv11-L model with fused qconv+SiLU
post-ops:

| Implementation | Improvement vs matching reference |
| --- | ---: |
| Signed-pair LUT | 6.41% |

### Full-model accuracy

The same INT8 YOLOv11-L inference configuration was evaluated on the
1,525-image licensed COCO `val2017_safe` subset. The signed-LUT output stays
within 0.05 percentage points of the exact-path result. The alpha `0.5` and
`2.0` rows deliberately modify the model activation to exercise the
non-unit-alpha fallback. Each is compared only with its matching exact run.
This was done to showcase the that the compounding precision loss of swish
is not problematic.

| Implementation | Alpha | Change in AP@[.50:.95] |
| --- | ---: | ---: |
| Signed-pair LUT | 1.0 | -0.0204 pp |
| DIV_ONE fallback | 0.5 | +0.0297 pp |
| DIV_ONE fallback | 2.0 | -0.0004 pp |

## Checklist

### General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
    All CTest tests pass: 340/341 passed. The reproducible failure is
  `test_benchdnn_modeC_graph_fusions_cpu`, in Graph SDPA/MHA fusion cases.
  It is not related to this patch.
- [x] Have you formatted the code using clang-format?

### Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?
