### PR TITLE
[GPU] mxfp8 fixes

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
@@ -395,6 +395,8 @@ void Generator<hw>::gemmRedirectToTempC(GEMMProblem &problem, GEMMStrategy &stra
     problem.Tc_ext = problem.Tc;
     problem.C = state.tempC;
 
+    if (problem.cMXScale) stub("MX Scale unsupported with Temp C.");
+
     strategy.C = state.tempCStrategy;
     strategy.remHandling[LoopM] = RemainderHandling::Ignore;
     strategy.remHandling[LoopN] = RemainderHandling::Ignore;

--- a/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
@@ -188,7 +188,8 @@ bool Generator<hw>::gemmAccessC(COperation op, const GEMMProblem &problem, const
                        :  ejmpi(1  | mod, labelSkip);
     }
 
-    bool splitUpdateStore = (problem.cOffset == COffset::Post);
+    // MX dst scaling must be applied after all other post-ops before store.
+    bool splitUpdateStore = (problem.cOffset == COffset::Post) || problem.hasCMXScale();
 
     // New post-op path: do all post-ops up to sum, if any.
     size_t poSum = 0;
@@ -219,6 +220,8 @@ bool Generator<hw>::gemmAccessC(COperation op, const GEMMProblem &problem, const
         if (newPostOps)
             gemmApplyPostOps(poSum + 1, problem.postOps.len(), problem, strategy, state);
         storeProblem.postOps = PostOps{};
+        gemmApplyMXScale(problem, strategy, state);
+        storeProblem.cMXScale = false;
 
         if (problem.cOffset == COffset::Post)
             ok = ok && gemmApplyCOffsetDispatch(problem, strategy, state);

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -1891,7 +1891,7 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
 
     auto i0qLate = i0q, j0qLate = j0q;
     auto A_h0qLate = A_h0q, B_h0qLate = B_h0q;
-    auto cMX_j0q = j0q;
+    auto cMX_i0q = i0q, cMX_j0q = j0q;
 
     if (slmA && (((ao2D || aoTo2D) && !lateOffsetA) || (as2D && !state.lateScale2DA))) {
         if (state.ma_slm < unrollM) {
@@ -1995,7 +1995,7 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
 
     if (problem.hasCMXScale()) {
         auto i0qs = state.ra.alloc_sub(cMX_j0q.getType(), getHint(HintType::LongTerm, strategy));
-        divDown(i0qs, i0q, problem.cqGroupM, strategy, state);
+        divDown(i0qs, cMX_i0q, problem.cqGroupM, strategy, state);
         setupQAddr(Type::u8, state.C_scaleAddrs, state.C_scaleLayout, state.inputs.cScalePtr,
                i0qs, cMX_j0q, state.inputs.ldcScale, state.offsetCs);
     }

--- a/src/gpu/intel/gemm/jit/generator/pieces/post_ops.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/post_ops.cxx
@@ -645,22 +645,38 @@ void Generator<hw>::gemmApplyPostOps(size_t poMin, size_t poMax, const GEMMProbl
     if(problem.postOps.cStochasticRound) {
         problem.postOps.injectStochasticRound(this, state.ra, C_grfs, C_ngrf, state.inputs.sroundSeed, problem.Tc_ext.ngen());
     }
-    if(problem.hasCMXScale()) {
-        auto unrollM = strategy.unroll[LoopM];
-        auto unrollN = strategy.unroll[LoopN];
-        int n_elems = (unrollN / problem.cqGroupN) * (unrollM / problem.cqGroupM);
-        int m_stride = state.C_scaleLayout[0].ld / 4;
-        int n_regs = std::max(1, (n_elems * m_stride) / GRF::bytes(hw));
-        auto tmpCScales = state.ra.alloc_range(n_regs);
-        vector<MaskAssignment> masks;
-        assignMasks(state.C_scaleLayout,  LoopNone, LoopN,       masks, strategy, state);
-        loadMasks(masks,        state.remainders,        strategy, state);
 
-        problem.postOps.injectMXScale(this, state.ra, C_grfs, C_ngrf, tmpCScales.sub(hw, 0, ngen::DataType::ub), problem.Tc_ext.ngen(), unrollN);
-        storeMatrix(tmpCScales, state.C_scaleLayout, state.C_scaleAddrs, strategy, state);
-        state.ra.safeRelease(tmpCScales);
-        safeReleaseMaskAssignments(masks, state);
-    }
+    mark(lSkip);
+}
+
+template <HW hw>
+void Generator<hw>::gemmApplyMXScale(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state)
+{
+    if (!problem.hasCMXScale()) return;
+    Label lSkip;
+    and_(1 | nz | state.flagAP, null.ud(), state.inputs.flags, FlagNonfinalKBlock);
+
+    jmpi(1 | state.flagAP, lSkip);
+
+    int C_grfs[GRF::maxRegs()];
+    int C_ngrf = state.C_regs[0].getLen();
+    for (int r = 0; r < C_ngrf; r++)
+        C_grfs[r] = state.C_regs[0][r].getBase();
+
+    auto unrollM = strategy.unroll[LoopM];
+    auto unrollN = strategy.unroll[LoopN];
+    int n_elems = (unrollN / problem.cqGroupN) * (unrollM / problem.cqGroupM);
+    int m_stride = state.C_scaleLayout[0].ld / 4;
+    int n_regs = std::max(1, (n_elems * m_stride) / GRF::bytes(hw));
+    auto tmpCScales = state.ra.alloc_range(n_regs);
+    vector<MaskAssignment> masks;
+    assignMasks(state.C_scaleLayout, LoopNone, LoopN, masks, strategy, state);
+    loadMasks(masks, state.remainders, strategy, state);
+
+    problem.postOps.injectMXScale(this, state.ra, C_grfs, C_ngrf, tmpCScales.sub(hw, 0, ngen::DataType::ub), problem.Tc_ext.ngen(), unrollN);
+    storeMatrix(tmpCScales, state.C_scaleLayout, state.C_scaleAddrs, strategy, state);
+    state.ra.safeRelease(tmpCScales);
+    safeReleaseMaskAssignments(masks, state);
 
     mark(lSkip);
 }

--- a/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/generator.hpp
@@ -511,6 +511,7 @@ protected:
     bool gemmApplyCOffsetDispatch(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
 
     void gemmApplyPostOps(size_t poMin, size_t poMax, const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
+    void gemmApplyMXScale(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
     void gemmLoadBinaryOpArgs(const GEMMProblem &problem, const GEMMStrategy &strategy, GEMMState &state);
 
     // quantization.cxx

--- a/src/gpu/intel/jit/eltwise_injector.cpp
+++ b/src/gpu/intel/jit/eltwise_injector.cpp
@@ -324,7 +324,7 @@ void eltwise_injector_f32_t<ngen_generator_t>::mx_scale_compute_fwd(int simd,
         const ngen::DataType dst_dt, int phase) {
     assert(simd == 32);
     assert(utils::one_of(dst_dt, ngen::DataType::bf8, ngen::DataType::hf8,
-            static_cast<ngen::DataType>(0x5A)));
+            ngen::DataType::e2m1));
 
     int scale_off = (phase / nreg * 4);
     int grf_bytes = GRF::bytes(hw());


### PR DESCRIPTION
# Description

Fix a couple bugs in MX dst scale generation:

- Prevent weights scales with non-trivial 2d groups from corrupting mx dst address computation.
- Require mx dst scales to be computed last rather than during general post-ops handling.

Fixes # [MFDNN-15214](https://jira.devtools.intel.com/browse/MFDNN-15214)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?
