### PR TITLE
cpu: x64: ir: reduce liveness allocations

### DIFF
--- a/src/cpu/x64/ir/reg_alloc.cpp
+++ b/src/cpu/x64/ir/reg_alloc.cpp
@@ -153,22 +153,25 @@ namespace {
 // read at 1 on the next turn. One backward pass finds most of it. The entry to
 // loop_end needs the back-edge, so it appears only on the second pass. A third
 // pass changes nothing, which is the fixed point.
-void compute_liveness(
-        const ir_t &ir, std::vector<std::vector<int8_t>> &live_in) {
+// Time: O(p * n_ops * n_vregs), where p is the number of fixed-point passes.
+// Space: O(n_ops * n_vregs).
+void compute_liveness(const ir_t &ir, std::vector<int8_t> &live_in) {
     const int n_ops = ir.n_ops();
     const int n_vregs = ir.n_vregs();
+    const size_t n_live_entries
+            = static_cast<size_t>(n_ops) * static_cast<size_t>(n_vregs);
 
     // Phase 1: build per-operation def/use sets and the control-flow graph.
     //
     // def_at[i][v] is 1 if operation `i` defines (writes) vreg `v`.
     // use_at[i][v] is 1 if operation `i` uses (reads) vreg `v`.
     // successors[i] lists all operations that may execute immediately after i.
-    std::vector<std::vector<int8_t>> def_at(
-            n_ops, std::vector<int8_t>(n_vregs, 0));
-    std::vector<std::vector<int8_t>> use_at(
-            n_ops, std::vector<int8_t>(n_vregs, 0));
+    std::vector<int8_t> def_at(n_live_entries, 0);
+    std::vector<int8_t> use_at(n_live_entries, 0);
 
-    std::vector<std::vector<int>> successors(n_ops);
+    constexpr int max_successors = 2;
+    std::vector<int> successors(
+            static_cast<size_t>(n_ops) * max_successors, -1);
     std::vector<int> def_vregs, use_vregs;
 
     // Map label IDs to operation indices so jmp/jz can resolve their target
@@ -181,54 +184,55 @@ void compute_liveness(
     for (int i = 0; i < n_ops; i++) {
         const op_t &op = ir.ops()[i];
         ir.def_use(op, def_vregs, use_vregs);
+        const size_t row = static_cast<size_t>(i) * n_vregs;
+        const size_t successor_row = static_cast<size_t>(i) * max_successors;
 
         for (int v : def_vregs)
-            def_at[i][v] = 1;
+            def_at[row + v] = 1;
         for (int v : use_vregs)
-            use_at[i][v] = 1;
+            use_at[row + v] = 1;
 
         // Successor edges include fall-through to `i+1` and any explicit
         // control-flow transfers (branches and loop back-edges).
         if (op.kind == op_kind_t::loop_end) {
-            if (i + 1 < n_ops) successors[i].push_back(i + 1);
-            successors[i].push_back(op.match + 1);
+            if (i + 1 < n_ops) successors[successor_row] = i + 1;
+            successors[successor_row + 1] = op.match + 1;
         } else if (op.kind == op_kind_t::jmp) {
-            successors[i].push_back(label_to_op[(int)op.label_id]);
+            successors[successor_row] = label_to_op[(int)op.label_id];
         } else if (op.kind == op_kind_t::jz) {
-            if (i + 1 < n_ops) successors[i].push_back(i + 1);
-            successors[i].push_back(label_to_op[(int)op.label_id]);
+            if (i + 1 < n_ops) successors[successor_row] = i + 1;
+            successors[successor_row + 1] = label_to_op[(int)op.label_id];
         } else if (i + 1 < n_ops) {
-            successors[i].push_back(i + 1);
+            successors[successor_row] = i + 1;
         }
     }
 
     // Phase 2: compute `live_in` and `live_out` using backward dataflow
     // analysis. Iterate until reaching a fixed point (no changes in a full
     // pass).
-    live_in.assign(n_ops, std::vector<int8_t>(n_vregs, 0));
-    std::vector<std::vector<int8_t>> live_out(
-            n_ops, std::vector<int8_t>(n_vregs, 0));
+    live_in.assign(n_live_entries, 0);
 
     bool changed = true;
     while (changed) {
         changed = false;
         for (int i = n_ops - 1; i >= 0; i--) {
+            const size_t row = static_cast<size_t>(i) * n_vregs;
+            const size_t successor_row
+                    = static_cast<size_t>(i) * max_successors;
             // live_out[i] = OR over successors `s` of live_in[s]
             for (int v = 0; v < n_vregs; v++) {
                 int8_t live_out_v = 0;
-                for (int s : successors[i])
-                    live_out_v |= live_in[s][v];
-                if (live_out_v != live_out[i][v]) {
-                    live_out[i][v] = live_out_v;
-                    changed = true;
+                for (int j = 0; j < max_successors; j++) {
+                    const int successor = successors[successor_row + j];
+                    if (successor >= 0)
+                        live_out_v |= live_in[static_cast<size_t>(successor)
+                                        * n_vregs
+                                + v];
                 }
-            }
-            // live_in[i] = use[i] OR (live_out[i] AND NOT def[i])
-            for (int v = 0; v < n_vregs; v++) {
-                const char live_in_v
-                        = use_at[i][v] || (live_out[i][v] && !def_at[i][v]);
-                if (live_in_v != live_in[i][v]) {
-                    live_in[i][v] = live_in_v;
+                const int8_t live_in_v
+                        = use_at[row + v] || (live_out_v && !def_at[row + v]);
+                if (live_in_v != live_in[row + v]) {
+                    live_in[row + v] = live_in_v;
                     changed = true;
                 }
             }
@@ -400,7 +404,7 @@ reg_alloc_result_t allocate_registers(
     // Step 1: compute operation-level liveness.
     // live_in[i][v] is 1 when virtual register `v` is needed on entry to
     // operation `i`.
-    std::vector<std::vector<int8_t>> live_in;
+    std::vector<int8_t> live_in;
     compute_liveness(ir, live_in);
 
     // Step 2: build a single live interval per virtual register.
@@ -425,7 +429,8 @@ reg_alloc_result_t allocate_registers(
         for (int v : use_vregs)
             extend_interval(v);
         for (int v = 0; v < n_vregs; v++)
-            if (live_in[i][v]) extend_interval(v);
+            if (live_in[static_cast<size_t>(i) * n_vregs + v])
+                extend_interval(v);
     }
 
     // Step 3: run linear-scan register allocation per physical register file,


### PR DESCRIPTION
# Description

Flatten the x64 IR register allocator's per-operation definition, use, and live-in tables into contiguous storage. Store the control-flow graph as at most two successors per operation, and derive live-out values from successor live-in rows instead of retaining a separate live-out matrix.

The current representation creates one heap allocation per row for each nested table and for most control-flow rows during JIT construction. The change preserves the fixed-point liveness equations and the existing asymptotic complexity, while reducing allocation count, metadata, memory traffic, and peak live storage. It changes no API or generated kernel code.

This affects the current default-built x64 IR allocator used by the AVX2 `brg_matmul:avx2` BRGEMV path. There is no linked issue.

## Validation

- Release and Debug `test_internals_cpu_ir`: 14/14 passed in each build.
- Release benchdnn: 16/16 representative cases passed across one and four threads.
- Debug benchdnn: tail and sum cases passed with `brg_matmul:avx2`.
- Clang 19 AddressSanitizer and UndefinedBehaviorSanitizer (UBSan): 14/14 passed under each sanitiser without reports.
- Baseline and patched JIT dumps were byte-identical.
- The generated CPU matmul CI batch was started locally but did not complete within a 30-minute local bound; upstream CI remains required.

## Performance

Configuration:

- CPU: Intel Core i9-13905H
- OS: Debian 13 under WSL2, Linux 5.15.167.4
- Compiler: GCC 14.2.0
- Build: Release
- Baseline: `43b3a68807493401795cfed27f61c8576f0460f1`
- ISA: AVX2
- Threads and affinity: one thread, pinned to CPU 0
- Implementation: `brg_matmul:avx2`
- Data type and formats: f32, default contiguous formats
- Method: four warm-ups followed by 50 process-isolated repetitions per variant and case, with alternating variant order
- Statistic: median cache-miss primitive creation time from `%+cptime%`

| Case | Baseline (ms) | Patched (ms) | Change |
| --- | ---: | ---: | ---: |
| Plain `32x1024:1024x1` | 0.209350 | 0.198974 | -4.96% |
| K-tail `127x4097:4097x1` | 0.249756 | 0.220581 | -11.68% |
| Bias `128x4096:4096x1` | 0.227173 | 0.204590 | -9.94% |
| Sum `128x4096:4096x1` | 0.258179 | 0.239746 | -7.14% |

No median regression was observed. The generated kernel was byte-identical before and after the change.

Representative command:

```bash
ONEDNN_MAX_CPU_ISA=AVX2 OMP_NUM_THREADS=1 taskset -c 0 \
./tests/benchdnn/benchdnn \
--matmul --mode=P --fix-times-per-prb=1 --summary=no-impl --verbose=0 \
'--perf-template=%+cptime%' --dt=f32 32x1024:1024x1
```

# Checklist

## General

- [ ] Do all unit and benchdnn tests (make test and make test_benchdnn_*) pass locally for each commit?
  Targeted unit and benchdnn validation passes; the complete local test matrix is not claimed.
- [x] Targeted unit and benchdnn validation passes; the complete local test matrix is not claimed.
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

### New features

Not applicable.

### Bug fixes

Not applicable.

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

Not applicable.