### PR TITLE
graph: extend quantization ops to support mask attribute

### DIFF
--- a/doc/graph_api/operations/DynamicDequantize.md
+++ b/doc/graph_api/operations/DynamicDequantize.md
@@ -32,7 +32,12 @@ On other dimensions:
 |:-------------------------------------------|:---------------------------------------------------------------------|:-----------|:------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------|
 | [qtype](@ref dnnl::graph::op::attr::qtype) | Specifies which de-quantization type is used.                        | string     | `per_tensor` (default), `per_channel`                                                                                                           | Optional             |
 | [axis](@ref dnnl::graph::op::attr::axis)   | Specifies dimension on which per-channel de-quantization is applied. | s64        | An s64 value in the range of [-r, r-1] where r = rank(src), `1` by default. Negative values mean counting the dimension backwards from the end.  | Optional             |
+| [mask](@ref dnnl::graph::op::attr::mask)   | Specifies which dimensions the scales/zps vary over. Bit `i` set means scales vary on dimension `i`. When set, `qtype` must be not set or set to default. | s64 | A non-negative integer where set bits index source dimensions. | Optional |
 | [group_shape](@ref dnnl::graph::op::attr::group_shape)   | Specifies the group shape of an operation. | s64        | An s64 list indicates the group size on the dimensions where grouped quantization is adopted.  | Optional             |
+
+@note The `mask` attribute is the recommended way to specify quantization
+granularity. The `qtype` and `axis` attributes are retained for backward
+compatibility and will be deprecated in the future.
 
 ## Execution arguments
 
@@ -55,6 +60,11 @@ to the element number of the src tensor along the dimension axis. For
 dimension as the `src` tensor. On the dimensions where grouped quantization is
 applied, the dimension should be the number of groups, which equals to
 `src_dim` / `group_size`, while other dimensions should match the `src` tensor.
+When `mask` is specified, the `scales` tensor is a packed tensor whose dimensions
+correspond to the source dimensions selected by the mask bits. For each bit `i`
+set in `mask`, there is one dimension in `scales` with size equal to
+`src_dims[i]` (or `src_dims[i] / group_shape[i]` when `group_shape` is also
+specified).
 
 @note `zps` is a tensor with offset values that map to zero. For `qtype` =
 `per-tensor`, there should be only one element in the `zps` tensor. For `qtype` =
@@ -63,7 +73,8 @@ tensor along the dimension axis. For `qtype` = `per-group`, the `zps` tensor
 should have the same number of dimensions as the `src` tensor. On the dimensions
 where grouped quantization is applied, the dimension should be the number of
 groups, which equals to `src_dim` / `group_size`, while other dimensions should
-match the `src` tensor. If omitted, the `zps` values are assumed to be zero.
+match the `src` tensor. When `mask` is specified, `zps` must have the same shape
+as `scales`. If omitted, the `zps` values are assumed to be zero.
 
 ### Outputs
 

--- a/doc/graph_api/operations/DynamicQuantize.md
+++ b/doc/graph_api/operations/DynamicQuantize.md
@@ -22,6 +22,11 @@ For per-channel quantization, taking channel axis = 1 as an example:
 |:-------------------------------------------|:---------------------------------------------------------------------|:-----------|:------------------------------------------------------------------------------------------------------------------------------------------------|:---------------------|
 | [qtype](@ref dnnl::graph::op::attr::qtype) | Specifies which de-quantization type is used.                        | string     | `per_tensor` (default), `per_channel`                                                                                                           | Optional             |
 | [axis](@ref dnnl::graph::op::attr::axis)   | Specifies dimension on which per-channel de-quantization is applied. | s64        | A s64 value in the range of [-r, r-1] where r = rank(src), `1` by default. Negative value means counting the dimension backwards from the end.  | Optional             |
+| [mask](@ref dnnl::graph::op::attr::mask)   | Specifies which dimensions the scales/zps vary over. Bit `i` set means scales vary on dimension `i`. When set, `qtype` must be not set or set to the default. | s64 | A non-negative integer where set bits index source dimensions. | Optional |
+
+@note The `mask` attribute is the recommended way to specify quantization
+granularity. The `qtype` and `axis` attributes are retained for backward
+compatibility and will be deprecated in the future.
 
 ## Execution arguments
 
@@ -39,12 +44,15 @@ constructing an operation.
 @note `scales` is an `f32` 1D tensor to be applied to the quantization formula. For
 `qtype` = `per-tensor`, there should be only one element in the scales tensor.
 For `qtype` = `per-channel`, the element number should be equal to the element
-number of src tensor along the dimension axis.
+number of src tensor along the dimension axis. When `mask` is specified, the
+`scales` tensor is a packed tensor whose dimensions correspond to the source
+dimensions selected by the mask bits.
 
 @note `zps` is a 1D tensor with offset values that map to zero. For `qtype` =
 `per-tensor`, there should be only one element in the zps tensor. For `qtype` =
 `per-channel`, the element number should be equal to the element number of input
-tensor along the dimension axis. If omitted, zps values are assumed to be zero.
+tensor along the dimension axis. When `mask` is specified, `zps` must have the
+same shape as `scales`. If omitted, zps values are assumed to be zero.
 
 ### Outputs
 

--- a/include/oneapi/dnnl/dnnl_graph.hpp
+++ b/include/oneapi/dnnl/dnnl_graph.hpp
@@ -937,6 +937,8 @@ public:
         begin_norm_axis = dnnl_graph_op_attr_begin_norm_axis,
         /// Specifies a groups attribute to an op.
         groups = dnnl_graph_op_attr_groups,
+        /// Specifies a quantization scale mask attribute to an op.
+        mask = dnnl_graph_op_attr_mask,
 
         // int64_t vector attributes. The value of these attributes can be a
         // vector of int64 numbers.

--- a/include/oneapi/dnnl/dnnl_graph_types.h
+++ b/include/oneapi/dnnl/dnnl_graph_types.h
@@ -319,6 +319,8 @@ typedef enum {
     dnnl_graph_op_attr_begin_norm_axis,
     /// Specifies a groups attribute to an op.
     dnnl_graph_op_attr_groups,
+    /// Specifies a quantization scale mask attribute to an op.
+    dnnl_graph_op_attr_mask,
 
     // int64_t vector attributes. The value of these attributes can be a vector
     // of int64 numbers.

--- a/src/graph/backend/dnnl/executables/reorder.cpp
+++ b/src/graph/backend/dnnl/executables/reorder.cpp
@@ -120,72 +120,43 @@ reorder_executable_t::desc_t reorder_executable_t::create_desc(
         prm_attr = make_dnnl_primitive_attr(op, fusion_info);
     }
 
-    // generate mask
-    const auto set_reorder_mask = [&op, &prm_attr](int mask) {
+    if (op->has_attr(op_attr::mask)) {
+        const int mask = get_quant_mask(op.get());
+        const bool is_per_group = utils::has_group_shape(op.get());
+        std::vector<int64_t> groups;
+        if (is_per_group) {
+            const auto &group_shape
+                    = op->get_attr<std::vector<int64_t>>(op_attr::group_shape);
+            const auto ndims = group_shape.size();
+            groups = {group_shape[ndims - 2], group_shape[ndims - 1]};
+        }
+
+        bool with_runtime_scales = false;
         if (op->has_attr(op_attr::with_runtime_scales)
                 && op->get_attr<bool>(op_attr::with_runtime_scales)) {
-            auto scale_dt = op->get_input_logical_tensor(1).data_type;
-            // For runtime arg scales, need to get data type information from
-            // the op
-            prm_attr.set_scales(DNNL_ARG_SRC, mask, {},
-                    static_cast<dnnl::memory::data_type>(scale_dt));
+            const auto scale_dt = static_cast<dnnl::memory::data_type>(
+                    op->get_input_logical_tensor(1).data_type);
+            prm_attr.set_scales(DNNL_ARG_FROM, mask, groups, scale_dt);
+            with_runtime_scales = true;
         } else if (op->has_attr(op_attr::scales)) {
             assertm(false, "only support runtime arg scales.\n");
         }
 
         if (op->has_attr(op_attr::with_runtime_src_zps)
                 && op->get_attr<bool>(op_attr::with_runtime_src_zps)) {
-            // For runtime src zps, as graph compilation will add extra
-            // typecast to convert int8 zero points to s32, we may still use
-            // the set_zero_points_mask API which specifies s32 zero point by
-            // default.
-            prm_attr.set_zero_points_mask(DNNL_ARG_FROM, mask);
+            const auto zps_dt = static_cast<dnnl::memory::data_type>(
+                    op->get_input_logical_tensor(with_runtime_scales ? 2 : 1)
+                            .data_type);
+            prm_attr.set_zero_points(DNNL_ARG_FROM, mask, groups, zps_dt);
         } else if (op->has_attr(op_attr::src_zps)) {
             assertm(false, "only support runtime src zero points.\n");
         }
 
         if (op->has_attr(op_attr::with_runtime_dst_zps)
                 && op->get_attr<bool>(op_attr::with_runtime_dst_zps)) {
-            // runtime dst zps
             prm_attr.set_zero_points_mask(DNNL_ARG_TO, mask);
         } else if (op->has_attr(op_attr::dst_zps)) {
             assertm(false, "only support runtime dst zero points.\n");
-        }
-    };
-
-    if (op->has_attr(op_attr::qtype)) {
-        std::string qtype = op->get_attr<std::string>(op_attr::qtype);
-        int64_t axis = op->has_attr(op_attr::axis)
-                ? op->get_attr<int64_t>(op_attr::axis)
-                : 1;
-
-        // For per group quantization, extra handling is needed for setting
-        // group shape and size.
-        if (qtype == "per_group") {
-            const auto &scale_lt = op->get_input_logical_tensor(1);
-            const auto scales_data_type = scale_lt.data_type;
-            const auto &group_shape
-                    = op->get_attr<std::vector<int64_t>>(op_attr::group_shape);
-            const auto ndims = group_shape.size();
-            const int mask = (1 << ndims) - 1;
-
-            const std::vector<int64_t> groups
-                    = {group_shape[ndims - 2], group_shape[ndims - 1]};
-
-            prm_attr.set_scales(DNNL_ARG_FROM, mask, groups,
-                    static_cast<dnnl::memory::data_type>(scales_data_type));
-            if (op->has_attr(op_attr::with_runtime_src_zps)
-                    && op->get_attr<bool>(op_attr::with_runtime_src_zps)) {
-                const auto &zps_lt = op->get_input_logical_tensor(2);
-                const auto zps_data_type = zps_lt.data_type;
-                prm_attr.set_zero_points(DNNL_ARG_FROM, mask, groups,
-                        static_cast<dnnl::memory::data_type>(zps_data_type));
-            }
-
-        } else { // per channel and per tensor quantization
-            int mask = 0;
-            if (qtype == "per_channel") { mask = 1 << axis; }
-            set_reorder_mask(mask);
         }
     }
 

--- a/src/graph/backend/dnnl/fusion_info.cpp
+++ b/src/graph/backend/dnnl/fusion_info.cpp
@@ -54,20 +54,14 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                 "runtime dst scales",
                 op->get_name().c_str());
         int mask = 0;
-        int64_t dt = 0;
+        dnnl::memory::data_type dt = dnnl::memory::data_type::undef;
 
-        if (dst_scales_op->has_attr(op_attr::axis)
-                && dst_scales_op->has_attr(op_attr::qtype)) {
-            int64_t axis = dst_scales_op->get_attr<int64_t>(op_attr::axis);
-            std::string qtype
-                    = dst_scales_op->get_attr<std::string>(op_attr::qtype);
-            mask = qtype == "per_tensor" ? 0 : 1 << axis;
-            dt = dst_scales_op->has_attr(op_attr::data_type)
-                    ? dst_scales_op->get_attr<int64_t>(op_attr::data_type)
-                    : dnnl_f32;
-        }
-        attr.set_scales(DNNL_ARG_DST, mask, default_groups,
-                static_cast<dnnl::memory::data_type>(dt));
+        mask = get_quant_mask(dst_scales_op);
+        dt = dst_scales_op->has_attr(op_attr::data_type)
+                ? static_cast<dnnl::memory::data_type>(
+                          dst_scales_op->get_attr<int64_t>(op_attr::data_type))
+                : dnnl::memory::data_type::f32;
+        attr.set_scales(DNNL_ARG_DST, mask, default_groups, dt);
     }
 
     // convert input scales
@@ -82,24 +76,33 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                     "runtime src scales",
                     op->get_name().c_str());
             int mask = 0;
-            if (in_scales_op->has_attr(op_attr::qtype)) {
-                std::string qtype
-                        = in_scales_op->get_attr<std::string>(op_attr::qtype);
+            if (in_scales_op->has_attr(op_attr::mask)) {
                 const auto scales_data_type
                         = in_scales_op->has_attr(op_attr::data_type)
                         ? in_scales_op->get_attr<int64_t>(op_attr::data_type)
                         : dnnl_f32;
-                if (qtype == "per_tensor") {
-                    mask = 0;
-                    attr.set_scales(in_scales_indices == 0 ? DNNL_ARG_SRC
-                                                           : DNNL_ARG_WEIGHTS,
-                            mask, default_groups,
+                const bool is_per_group = utils::has_group_shape(in_scales_op);
+                if (is_per_group) {
+                    // oneDNN only supports weights-decompressed matmul
+                    if (in_scales_indices != 1
+                            || op->get_kind() != op_kind::_matmul)
+                        continue;
+                    const auto &group_shape
+                            = in_scales_op->get_attr<std::vector<int64_t>>(
+                                    op_attr::group_shape);
+
+                    // Currently oneDNN only supports grouped scales and zps on
+                    // last two dimensions.
+                    std::vector<int64_t> groups(
+                            group_shape.end() - 2, group_shape.end());
+                    mask = get_quant_mask(in_scales_op);
+                    attr.set_scales(DNNL_ARG_WEIGHTS, mask, groups,
                             static_cast<dnnl::memory::data_type>(
                                     scales_data_type));
-                } else if (qtype == "per_channel") { // per-channel quantization
-                    int64_t axis = in_scales_op->has_attr(op_attr::axis)
-                            ? in_scales_op->get_attr<int64_t>(op_attr::axis)
-                            : 1;
+                } else {
+                    mask = get_quant_mask(in_scales_op);
+                    // Conv weights: remap per-OC mask to the expected
+                    // primitive mask (1 without groups, 3 with groups).
                     if (impl::utils::one_of(op->get_kind(),
                                 op_kind::_convolution, op_kind::_convtranspose)
                             && in_scales_indices == 1) {
@@ -113,30 +116,13 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                                 with_groups = true;
                             }
                         }
-                        mask = with_groups ? 3 : 1;
-                    } else {
-                        mask = 1 << axis;
+                        const int expected_oc_mask = with_groups ? 3 : 1;
+                        if (mask != 0 && mask != expected_oc_mask)
+                            mask = expected_oc_mask;
                     }
                     attr.set_scales(in_scales_indices == 0 ? DNNL_ARG_SRC
                                                            : DNNL_ARG_WEIGHTS,
                             mask, default_groups,
-                            static_cast<dnnl::memory::data_type>(
-                                    scales_data_type));
-                } else { // per-group quantization
-                    // oneDNN only supports weights-decompressed matmul
-                    if (in_scales_indices != 1
-                            || op->get_kind() != op_kind::_matmul)
-                        continue;
-                    const auto &group_shape
-                            = in_scales_op->get_attr<std::vector<int64_t>>(
-                                    op_attr::group_shape);
-
-                    // Currently oneDNN only supports grouped scales and zps on
-                    // last two dimensions.
-                    std::vector<int64_t> groups(
-                            group_shape.end() - 2, group_shape.end());
-                    mask = (1 << group_shape.size()) - 1;
-                    attr.set_scales(DNNL_ARG_WEIGHTS, mask, groups,
                             static_cast<dnnl::memory::data_type>(
                                     scales_data_type));
                 }
@@ -156,14 +142,13 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                     "supports runtime src zero points",
                     op->get_name().c_str());
 
-            if (in_zps_op->has_attr(op_attr::qtype)) {
-                std::string qtype
-                        = in_zps_op->get_attr<std::string>(op_attr::qtype);
+            if (in_zps_op->has_attr(op_attr::mask)) {
                 const auto zps_data_type
                         = in_zps_op->has_attr(op_attr::data_type)
                         ? in_zps_op->get_attr<int64_t>(op_attr::data_type)
                         : dnnl_s32;
-                if (qtype == "per_group") {
+                const bool is_per_group = utils::has_group_shape(in_zps_op);
+                if (is_per_group) {
                     // oneDNN only supports weights-decompressed matmul
                     if (in_zps_indices != 1
                             || op->get_kind() != op_kind::_matmul)
@@ -176,15 +161,14 @@ dnnl::primitive_attr make_dnnl_primitive_attr(
                     // last two dimensions.
                     std::vector<int64_t> groups(
                             group_shape.end() - 2, group_shape.end());
-                    int mask = (1 << group_shape.size()) - 1;
+                    int mask = get_quant_mask(in_zps_op);
 
-                    // Currently oneDNN only supports grouped zps on last two dimensions.
                     attr.set_zero_points(DNNL_ARG_WEIGHTS, mask, groups,
                             static_cast<dnnl::memory::data_type>(
                                     zps_data_type));
 
                 } else {
-                    int mask = 0;
+                    int mask = get_quant_mask(in_zps_op);
                     attr.set_zero_points(in_zps_indices == 0 ? DNNL_ARG_SRC
                                                              : DNNL_ARG_WEIGHTS,
                             mask, default_groups,
@@ -404,32 +388,13 @@ dnnl::primitive_attr make_dnnl_sdpa_primitive_attr(
                     "runtime src scales",
                     op->get_name().c_str());
             int mask = 0;
-            if (in_scales_op->has_attr(op_attr::qtype)) {
-                std::string qtype
-                        = in_scales_op->get_attr<std::string>(op_attr::qtype);
+            if (in_scales_op->has_attr(op_attr::mask)) {
                 const auto scales_data_type
                         = in_scales_op->has_attr(op_attr::data_type)
                         ? in_scales_op->get_attr<int64_t>(op_attr::data_type)
                         : dnnl_f32;
-                if (qtype == "per_tensor") {
-                    mask = 0;
-                    attr.set_scales(
-                            static_cast<int>(arg_map.at(in_scales_indices)),
-                            mask, default_groups,
-                            static_cast<dnnl::memory::data_type>(
-                                    scales_data_type));
-                } else if (qtype == "per_channel") { // per-channel quantization
-                    int64_t axis = in_scales_op->has_attr(op_attr::axis)
-                            ? in_scales_op->get_attr<int64_t>(op_attr::axis)
-                            : 1;
-                    mask = 1 << axis;
-                    attr.set_scales(
-                            static_cast<int>(arg_map.at(in_scales_indices)),
-                            mask, default_groups,
-                            static_cast<dnnl::memory::data_type>(
-                                    scales_data_type));
-                } else {
-                    // per-group quantization
+                const bool is_per_group = utils::has_group_shape(in_scales_op);
+                if (is_per_group) {
                     // oneDNN only supports weights-decompressed matmul or sdpa
                     if (arg_map.at(in_scales_indices) != DNNL_ARG_WEIGHTS)
                         continue;
@@ -441,8 +406,15 @@ dnnl::primitive_attr make_dnnl_sdpa_primitive_attr(
                     // last two dimensions.
                     std::vector<int64_t> groups(
                             group_shape.end() - 2, group_shape.end());
-                    mask = (1 << group_shape.size()) - 1;
+                    mask = get_quant_mask(in_scales_op);
                     attr.set_scales(DNNL_ARG_WEIGHTS, mask, groups,
+                            static_cast<dnnl::memory::data_type>(
+                                    scales_data_type));
+                } else {
+                    mask = get_quant_mask(in_scales_op);
+                    attr.set_scales(
+                            static_cast<int>(arg_map.at(in_scales_indices)),
+                            mask, default_groups,
                             static_cast<dnnl::memory::data_type>(
                                     scales_data_type));
                 }
@@ -470,14 +442,13 @@ dnnl::primitive_attr make_dnnl_sdpa_primitive_attr(
                     "supports runtime src zero points",
                     op->get_name().c_str());
 
-            if (in_zps_op->has_attr(op_attr::qtype)) {
-                std::string qtype
-                        = in_zps_op->get_attr<std::string>(op_attr::qtype);
+            if (in_zps_op->has_attr(op_attr::mask)) {
                 const auto zps_data_type
                         = in_zps_op->has_attr(op_attr::data_type)
                         ? in_zps_op->get_attr<int64_t>(op_attr::data_type)
                         : dnnl_s32;
-                if (qtype == "per_group") {
+                const bool is_per_group = utils::has_group_shape(in_zps_op);
+                if (is_per_group) {
                     // oneDNN only supports weights-decompressed matmul
                     if (arg_map.at(in_zps_indices) != DNNL_ARG_WEIGHTS) break;
                     const auto &group_shape
@@ -488,17 +459,14 @@ dnnl::primitive_attr make_dnnl_sdpa_primitive_attr(
                     // last two dimensions.
                     std::vector<int64_t> groups(
                             group_shape.end() - 2, group_shape.end());
-                    int mask = (1 << group_shape.size()) - 1;
+                    int mask = get_quant_mask(in_zps_op);
 
-                    // Currently oneDNN only supports grouped zps on last two
-                    // dimensions.
                     attr.set_zero_points(DNNL_ARG_WEIGHTS, mask, groups,
                             static_cast<dnnl::memory::data_type>(
                                     zps_data_type));
 
                 } else {
-                    // Currently oneDNN doesn't support per_channel zps.
-                    int mask = 0;
+                    int mask = get_quant_mask(in_zps_op);
                     attr.set_zero_points(
                             static_cast<int>(arg_map.at(in_zps_indices)), mask,
                             default_groups,

--- a/src/graph/backend/dnnl/fusion_info.hpp
+++ b/src/graph/backend/dnnl/fusion_info.hpp
@@ -338,6 +338,64 @@ private:
     std::vector<std::shared_ptr<meta_op_t>> post_ops_;
 };
 
+// Compute the quantization mask from any quantization-related op. Handles both
+// op_attr::mask and legacy op_attr::qtype/axis for backward compatibility.
+inline int get_quant_mask(const op_t *quant_op) {
+    // Primary path: mask attribute is set.
+    if (quant_op->has_attr(op_attr::mask))
+        return static_cast<int>(quant_op->get_attr<int64_t>(op_attr::mask));
+
+    // Fallback: derive mask from qtype/axis for backward compatibility.
+    // If qtype is not set, it's per-tensor by default.
+    if (!quant_op->has_attr(op_attr::qtype)) return 0;
+
+    const auto &qtype = quant_op->get_attr<std::string>(op_attr::qtype);
+    if (qtype == "per_tensor") return 0;
+
+    if (qtype == "per_channel") {
+        int64_t axis = quant_op->has_attr(op_attr::axis)
+                ? quant_op->get_attr<int64_t>(op_attr::axis)
+                : 1;
+        if (axis < 0) axis += quant_op->get_input_logical_tensor(0).ndims;
+        return 1LL << axis;
+    }
+
+    if (qtype == "per_group") {
+        // For per_group, mask bit i is set when scale_dims[i] > 1.
+        // Dynamic ops have the scale tensor as input 1.
+        if (quant_op->num_inputs() >= 2) {
+            const auto &scale_lt = quant_op->get_input_logical_tensor(1);
+            const int ndims = scale_lt.ndims;
+            if (ndims > 0) {
+                int mask = 0;
+                for (int i = 0; i < ndims; ++i) {
+                    if (scale_lt.dims[i] > 1) mask |= (1 << i);
+                }
+                // Primitive API requires mask to cover last two dims
+                // when groups are specified.
+                if (ndims >= 2) {
+                    mask |= (1 << (ndims - 1)) | (1 << (ndims - 2));
+                }
+                return mask;
+            }
+        }
+        if (utils::has_group_shape(quant_op)) {
+            const auto &group_shape = quant_op->get_attr<std::vector<int64_t>>(
+                    op_attr::group_shape);
+            int mask = 0;
+            const int ndims = static_cast<int>(group_shape.size());
+            for (int i = 0; i < ndims; ++i) {
+                if (group_shape[i] > 1) mask |= (1 << i);
+            }
+            if (ndims >= 2) { mask |= (1 << (ndims - 1)) | (1 << (ndims - 2)); }
+            return mask;
+        }
+        return 1;
+    }
+
+    return 0;
+}
+
 // This function is used to make a dnnl::primitive_attr from the fusion info.
 // Note that the op and fusion_info arguments must be matched since a fusion
 // info make sense only when it belongs to a specific op.

--- a/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/mqa_decomp_config.cpp
@@ -456,12 +456,9 @@ dnnl::primitive_attr mqa_decomp_config_t::make_primitive_attr(
         attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     if (op && op->get_kind() == op_kind::_reorder) {
-        // generate mask
         int mask = 0;
-        if (op->has_attr(op_attr::axis) && op->has_attr(op_attr::qtype)) {
-            int64_t axis = op->get_attr<int64_t>(op_attr::axis);
-            std::string qtype = op->get_attr<std::string>(op_attr::qtype);
-            mask = qtype == "per_tensor" ? 0 : 1 << axis;
+        if (op->has_attr(op_attr::mask)) {
+            mask = static_cast<int>(op->get_attr<int64_t>(op_attr::mask));
         }
 
         if (op->has_attr(op_attr::with_runtime_dst_zps)

--- a/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
+++ b/src/graph/backend/dnnl/kernels/sdp_decomp_config.cpp
@@ -881,12 +881,9 @@ dnnl::primitive_attr sdp_decomp_config_t::make_primitive_attr(
         attr = make_dnnl_primitive_attr(op, fusion_info);
     }
     if (op && op->get_kind() == op_kind::_reorder) {
-        // generate mask
         int mask = 0;
-        if (op->has_attr(op_attr::axis) && op->has_attr(op_attr::qtype)) {
-            int64_t axis = op->get_attr<int64_t>(op_attr::axis);
-            std::string qtype = op->get_attr<std::string>(op_attr::qtype);
-            mask = qtype == "per_tensor" ? 0 : 1 << axis;
+        if (op->has_attr(op_attr::mask)) {
+            mask = static_cast<int>(op->get_attr<int64_t>(op_attr::mask));
         }
 
         if (op->has_attr(op_attr::with_runtime_dst_zps)

--- a/src/graph/backend/dnnl/passes/insert_ops.cpp
+++ b/src/graph/backend/dnnl/passes/insert_ops.cpp
@@ -366,7 +366,8 @@ status_t insert_permute_for_dynamic_mul_scale_sub_zp(
                 && cur_op->get_kind() != op_kind::_mul_scales)
             continue;
 
-        if (cur_op->get_attr<std::string>(op_attr::qtype) == "per_tensor")
+        if (!cur_op->has_attr(op_attr::mask)
+                || cur_op->get_attr<int64_t>(op_attr::mask) == 0)
             continue;
 
         // This pass only handle dynamic quantization
@@ -419,7 +420,7 @@ status_t insert_permute_for_dynamic_mul_scale_sub_zp(
 
     for (auto &cur_op : permute_op_group) {
         auto ndims = cur_op->get_input_logical_tensor(0).ndims;
-        if (cur_op->get_attr<std::string>(op_attr::qtype) == "per_group") {
+        if (utils::has_group_shape(cur_op.get())) {
             op_ptr permute_op = std::make_shared<op_t>(op_kind::_permute);
             auto perm = get_last_two_dims_permutation(ndims);
             permute_op->set_attr<std::vector<int64_t>>(
@@ -464,10 +465,13 @@ status_t insert_permute_for_matmul(std::shared_ptr<subgraph_t> &sg) {
                 fusion_info_t fusion_info
                         = cur_op->get_attr<fusion_info_t>(op_attr::fusion_info);
                 op_t *scales_op = fusion_info.get_mutable_scales(true, i);
-                if (scales_op
-                        && scales_op->get_attr<std::string>(op_attr::qtype)
-                                == "per_channel") {
-                    scales_op->set_attr<int64_t>(op_attr::axis, ndims - 1);
+                const bool is_per_group
+                        = scales_op && utils::has_group_shape(scales_op);
+                if (scales_op && scales_op->has_attr(op_attr::mask)
+                        && scales_op->get_attr<int64_t>(op_attr::mask) != 0
+                        && !is_per_group) {
+                    scales_op->set_attr<int64_t>(
+                            op_attr::mask, 1LL << (ndims - 1));
                 }
                 cur_op->set_attr<fusion_info_t>(
                         op_attr::fusion_info, fusion_info);
@@ -563,12 +567,11 @@ status_t insert_reshape_for_ndx2d_matmul(std::shared_ptr<subgraph_t> &sg) {
                         op_attr::shape, expected_dims3);
                 rewriter.insert_op_before(reshape_op3, cur_op, offset);
             }
-            // update weight axis
+            // update weight mask
             op_t *scales_op = fusion_info.get_mutable_scales(true, 1);
-            if (scales_op
-                    && scales_op->get_attr<std::string>(op_attr::qtype)
-                            == "per_channel") {
-                scales_op->set_attr<int64_t>(op_attr::axis, 1);
+            if (scales_op && scales_op->has_attr(op_attr::mask)
+                    && scales_op->get_attr<int64_t>(op_attr::mask) != 0) {
+                scales_op->set_attr<int64_t>(op_attr::mask, 1LL << 1);
             }
             // update fusion info
             cur_op->set_attr<fusion_info_t>(op_attr::fusion_info, fusion_info);
@@ -852,16 +855,18 @@ status_t insert_unsqueeze_and_squeeze_for_matmul(
                 rewriter.insert_op_before(unsqueeze_op, op, i);
             }
 
-            // update the axis
+            // update the mask for per-channel scales only
             if (i == 1 && op->has_attr(op_attr::fusion_info)) {
                 fusion_info_t fusion_info
                         = op->get_attr<fusion_info_t>(op_attr::fusion_info);
                 op_t *scales_op = fusion_info.get_mutable_scales(true, 1);
-                if (scales_op
-                        && scales_op->get_attr<std::string>(op_attr::qtype)
-                                == "per_channel") {
-                    scales_op->set_attr<int64_t>(op_attr::axis,
-                            unsqueezed_dst_ndims - 1); // the 2nd dim;
+                const bool is_per_group
+                        = scales_op && utils::has_group_shape(scales_op);
+                if (scales_op && scales_op->has_attr(op_attr::mask)
+                        && scales_op->get_attr<int64_t>(op_attr::mask) != 0
+                        && !is_per_group) {
+                    scales_op->set_attr<int64_t>(
+                            op_attr::mask, 1LL << (unsqueezed_dst_ndims - 1));
                 }
                 op->set_attr<fusion_info_t>(op_attr::fusion_info, fusion_info);
             }
@@ -932,8 +937,7 @@ impl::status_t insert_runtime_u8_to_s8_for_matmul(
                     "only support insert input for wei at the end of inputs");
             std::vector<int64_t> zp {-128};
             auto zps_op = std::make_shared<op_t>(op_kind::_add_zps);
-            zps_op->set_attr<std::string>(op_attr::qtype, "per_tensor");
-            zps_op->set_attr<int64_t>(op_attr::axis, 0);
+            zps_op->set_attr<int64_t>(op_attr::mask, int64_t(0));
             zps_op->set_attr(op_attr::with_runtime_zps, true);
             op_ptr const_data_op;
             const_data_op = std::make_shared<op_t>(op_kind::_constant_zps);
@@ -985,7 +989,7 @@ impl::status_t insert_runtime_u8_to_s8_for_matmul(
         const_zps_dst_value->set_layout_type(layout_type::strided);
         const_zps_dst_value->set_strides({1});
         const_zps_op->add_output(const_zps_dst_value);
-        u8_to_s8_op->set_attr<std::string>(op_attr::qtype, "per_tensor");
+        u8_to_s8_op->set_attr<int64_t>(op_attr::mask, int64_t(0));
         u8_to_s8_op->set_attr(op_attr::with_runtime_dst_zps, true);
         rewriter.insert_op_before(u8_to_s8_op, cur_op, 1);
         u8_to_s8_op->connect_input(1, const_zps_dst_value);
@@ -1036,8 +1040,7 @@ status_t insert_u8_to_s8_for_matmul(std::shared_ptr<subgraph_t> &sg) {
         } else { // fuse a 128 zps
             std::vector<int64_t> zp {-128};
             auto zps_op = std::make_shared<op_t>(op_kind::_add_zps);
-            zps_op->set_attr<std::string>(op_attr::qtype, "per_tensor");
-            zps_op->set_attr<int64_t>(op_attr::axis, 0);
+            zps_op->set_attr<int64_t>(op_attr::mask, int64_t(0));
             zps_op->set_attr<std::vector<int64_t>>(op_attr::zps, zp);
             fusion_info.set_zero_points(zps_op, true, /*the wei index*/ 1);
         }

--- a/src/graph/backend/dnnl/passes/lower.cpp
+++ b/src/graph/backend/dnnl/passes/lower.cpp
@@ -428,9 +428,6 @@ static status_t squared_difference_handler(
 static status_t static_quant_handler(
         const std::shared_ptr<op_t> &op, subgraph_rewriter_t &rewriter) {
     const auto &scales = op->get_attr<std::vector<float>>(op_attr::scales);
-    const auto &qtype = op->get_attr<std::string>(op_attr::qtype);
-    const auto &axis = op->get_attr<int64_t>(op_attr::axis);
-
     std::vector<int64_t> zps(scales.size(), 0);
     if (op->has_attr(op_attr::zps)) {
         zps = op->get_attr<std::vector<int64_t>>(op_attr::zps);
@@ -454,10 +451,9 @@ static status_t static_quant_handler(
     mul_scales_op->set_attr<std::vector<float>>(op_attr::scales, inv_scales);
     add_zps_op->set_attr<std::vector<int64_t>>(op_attr::zps, zps);
 
-    mul_scales_op->set_attr<int64_t>(op_attr::axis, axis);
-    mul_scales_op->set_attr<std::string>(op_attr::qtype, qtype);
-    add_zps_op->set_attr<int64_t>(op_attr::axis, axis);
-    add_zps_op->set_attr<std::string>(op_attr::qtype, qtype);
+    const int64_t mask = get_quant_mask(op.get());
+    mul_scales_op->set_attr<int64_t>(op_attr::mask, mask);
+    add_zps_op->set_attr<int64_t>(op_attr::mask, mask);
 
     // reconnect
     in_vals[0]->remove_consumer(*op, 0);
@@ -485,9 +481,6 @@ static status_t static_quant_handler(
 static status_t static_dequant_handler(
         const std::shared_ptr<op_t> &cur_op, subgraph_rewriter_t &rewriter) {
     const auto &scales = cur_op->get_attr<std::vector<float>>(op_attr::scales);
-    const auto &qtype = cur_op->get_attr<std::string>(op_attr::qtype);
-    const auto &axis = cur_op->get_attr<int64_t>(op_attr::axis);
-
     std::vector<int64_t> zps(scales.size(), 0);
     if (cur_op->has_attr(op_attr::zps)) {
         zps = cur_op->get_attr<std::vector<int64_t>>(op_attr::zps);
@@ -507,10 +500,9 @@ static status_t static_dequant_handler(
     sub_zps_op->set_attr<std::vector<int64_t>>(op_attr::zps, zps);
     mul_scales_op->set_attr<std::vector<float>>(op_attr::scales, scales);
 
-    sub_zps_op->set_attr<int64_t>(op_attr::axis, axis);
-    sub_zps_op->set_attr<std::string>(op_attr::qtype, qtype);
-    mul_scales_op->set_attr<int64_t>(op_attr::axis, axis);
-    mul_scales_op->set_attr<std::string>(op_attr::qtype, qtype);
+    const int64_t mask = get_quant_mask(cur_op.get());
+    sub_zps_op->set_attr<int64_t>(op_attr::mask, mask);
+    mul_scales_op->set_attr<int64_t>(op_attr::mask, mask);
 
     // reconnect
     in_vals[0]->remove_consumer(*cur_op, 0);
@@ -537,9 +529,6 @@ static status_t static_dequant_handler(
 
 static status_t dynamic_quant_handler(
         const std::shared_ptr<op_t> &cur_op, subgraph_rewriter_t &rewriter) {
-    const auto &qtype = cur_op->get_attr<std::string>(op_attr::qtype);
-    const auto &axis = cur_op->get_attr<int64_t>(op_attr::axis);
-
     auto &in_vals = cur_op->get_input_values();
     auto &out_vals = cur_op->get_output_values();
     VCHECK_INVALID_ARGUMENT((in_vals.size() == 3 || in_vals.size() == 2)
@@ -554,13 +543,14 @@ static status_t dynamic_quant_handler(
     value_ptr src = in_vals[0], scales = in_vals[1], dst = out_vals[0], zps;
     if (has_zps) zps = in_vals[2];
 
+    int64_t mask = get_quant_mask(cur_op.get());
+
     // int8 = f32 / scales + zps
     op_ptr mul_scales = std::make_shared<op_t>(op_kind::_mul_scales);
 
     mul_scales->connect_input(1, scales);
     scales->remove_consumer(*cur_op, 1);
-    mul_scales->set_attr<int64_t>(op_attr::axis, axis);
-    mul_scales->set_attr<std::string>(op_attr::qtype, qtype);
+    mul_scales->set_attr<int64_t>(op_attr::mask, mask);
     mul_scales->set_attr<bool>(op_attr::with_runtime_scales, true);
 
     // connect mul_scales to subgraph
@@ -583,8 +573,9 @@ static status_t dynamic_quant_handler(
         op_ptr add_zps = std::make_shared<op_t>(op_kind::_add_zps);
         add_zps->connect_input(1, zps);
         zps->remove_consumer(*cur_op, 2);
-        add_zps->set_attr<int64_t>(op_attr::axis, axis);
-        add_zps->set_attr<std::string>(op_attr::qtype, qtype);
+        const int64_t zps_mask
+                = ltw(zps->get_logical_tensor()).nelems() == 1 ? 0 : mask;
+        add_zps->set_attr<int64_t>(op_attr::mask, zps_mask);
         add_zps->set_attr<bool>(op_attr::with_runtime_zps, true);
 
         // connect add_zps to subgraph
@@ -598,45 +589,38 @@ static status_t dynamic_quant_handler(
 
 static status_t dynamic_dequant_handler(
         const std::shared_ptr<op_t> &cur_op, subgraph_rewriter_t &rewriter) {
-    const auto &qtype = cur_op->get_attr<std::string>(op_attr::qtype);
-    const auto &axis = cur_op->get_attr<int64_t>(op_attr::axis);
-
     auto &in_vals = cur_op->get_input_values();
     auto &out_vals = cur_op->get_output_values();
     VCHECK_INVALID_ARGUMENT((in_vals.size() == 3 || in_vals.size() == 2)
                     && out_vals.size() == 1,
-            "dynamic dequantize must have 2 or 3 inputs and 1 output, but "
-            "got %zu input and %zu output",
+            "DynamicDequantize must have 2 or 3 inputs and 1 output, but got "
+            "%zu input and %zu output",
             in_vals.size(), out_vals.size());
 
-    // DynamicDequantize has optional zps
-    bool has_zps = in_vals.size() == 3;
-    bool is_group_quantization = (qtype == "per_group");
+    const bool has_zps = in_vals.size() == 3;
+    const bool has_valid_groups = utils::has_group_shape(cur_op.get());
 
-    value_ptr src = in_vals[0], scales = in_vals[1], dst = out_vals[0], zps;
-    if (has_zps) zps = in_vals[2];
+    value_ptr src = in_vals[0];
+    value_ptr scl = in_vals[1];
+    value_ptr zps = has_zps ? in_vals[2] : nullptr;
+    value_ptr dst = out_vals[0];
 
-    int64_t group_mask = 0;
-    if (is_group_quantization) {
+    const int64_t mask = get_quant_mask(cur_op.get());
 
-        const auto &group_shape
+    std::vector<int64_t> group_shape;
+    if (has_valid_groups) {
+        group_shape
                 = cur_op->get_attr<std::vector<int64_t>>(op_attr::group_shape);
         const auto src_lt = src->get_logical_tensor();
-        const auto scale_lt = scales->get_logical_tensor();
-
+        const auto scale_lt = scl->get_logical_tensor();
         const auto ndims = ltw(src_lt).ndims();
+        const auto &src_dims = ltw(src_lt).vdims();
+        const auto &scale_dims = ltw(scale_lt).vdims();
+
         VCHECK_INVALID_ARGUMENT(
                 (static_cast<size_t>(ndims) == group_shape.size()),
                 "group shape size should match the number of dimensions of "
                 "src");
-        const auto &src_dims = ltw(src_lt).vdims();
-        const auto &scale_dims = ltw(scale_lt).vdims();
-
-        for (int idx = 0; idx < ndims - 2; ++idx) {
-            VCHECK_INVALID_ARGUMENT((src_dims[idx] == scale_dims[idx]),
-                    "the scale shape should match the input shape on the "
-                    "dimensions where no quantization is applied");
-        }
 
         for (int idx = 0; idx < ndims; ++idx) {
             VCHECK_INVALID_ARGUMENT(
@@ -646,33 +630,23 @@ static status_t dynamic_dequant_handler(
                     idx, static_cast<int>(src_dims[idx]),
                     static_cast<int>(scale_dims[idx]),
                     static_cast<int>(group_shape[idx]));
-
-            if (group_shape[idx] != 1) {
-                group_mask += 1ULL << idx;
-                //Currently group quantization only happens on one dimension
-            }
         }
     }
 
-    const int64_t scales_data_type = scales->get_logical_tensor().data_type;
+    const int64_t scales_data_type = scl->get_logical_tensor().data_type;
+
     // f32 = scales * (int8 - zps)
-    // connect scales to mul_scales op
     op_ptr mul_scales = std::make_shared<op_t>(op_kind::_mul_scales);
-    mul_scales->connect_input(1, scales);
-    scales->remove_consumer(*cur_op, 1);
-    mul_scales->set_attr<int64_t>(op_attr::axis, axis);
-    mul_scales->set_attr<std::string>(op_attr::qtype, qtype);
-    if (is_group_quantization) {
-        const auto &group_shape
-                = cur_op->get_attr<std::vector<int64_t>>(op_attr::group_shape);
+    mul_scales->connect_input(1, scl);
+    scl->remove_consumer(*cur_op, 1);
+    mul_scales->set_attr<int64_t>(op_attr::mask, mask);
+    if (has_valid_groups) {
         mul_scales->set_attr<std::vector<int64_t>>(
                 op_attr::group_shape, group_shape);
-        mul_scales->set_attr<int64_t>(op_attr::group_mask, group_mask);
     }
     mul_scales->set_attr<int64_t>(op_attr::data_type, scales_data_type);
     mul_scales->set_attr<bool>(op_attr::with_runtime_scales, true);
 
-    // connect mul_scales op to subgraph
     mul_scales->connect_input(0, src);
     src->remove_consumer(*cur_op, 0);
     mul_scales->add_output(dst);
@@ -683,22 +657,22 @@ static status_t dynamic_dequant_handler(
         op_ptr sub_zps = std::make_shared<op_t>(op_kind::_sub_zps);
         sub_zps->connect_input(1, zps);
         zps->remove_consumer(*cur_op, 2);
-        sub_zps->set_attr<int64_t>(op_attr::axis, axis);
-        sub_zps->set_attr<std::string>(op_attr::qtype, qtype);
+        const int64_t zps_mask = !has_valid_groups
+                        && ltw(zps->get_logical_tensor()).nelems() == 1
+                ? 0
+                : mask;
+        sub_zps->set_attr<int64_t>(op_attr::mask, zps_mask);
         sub_zps->set_attr<int64_t>(op_attr::data_type, zps_data_type);
-        if (is_group_quantization) {
-            const auto &scale_dims = ltw(scales->get_logical_tensor()).vdims();
+        if (has_valid_groups) {
+            const auto &scale_dims = ltw(scl->get_logical_tensor()).vdims();
             const auto &zp_dims = ltw(zps->get_logical_tensor()).vdims();
             for (size_t idx = 0; idx < scale_dims.size(); ++idx) {
                 VCHECK_INVALID_ARGUMENT((scale_dims[idx] == zp_dims[idx]),
                         "scale and zero point tensors should have the same "
                         "shape");
             }
-            const auto &group_shape = cur_op->get_attr<std::vector<int64_t>>(
-                    op_attr::group_shape);
             sub_zps->set_attr<std::vector<int64_t>>(
                     op_attr::group_shape, group_shape);
-            sub_zps->set_attr<int64_t>(op_attr::group_mask, group_mask);
         }
         sub_zps->set_attr<bool>(op_attr::with_runtime_zps, true);
         // connect sub_zps op to subgraph

--- a/src/graph/backend/dnnl/passes/transform.cpp
+++ b/src/graph/backend/dnnl/passes/transform.cpp
@@ -193,18 +193,14 @@ status_t replace_quant_data_with_binary_post_op(
             insert_empty_scratchpad(bin_op);
 
             // add quant data as a constant input
-            const auto qtype
-                    = quant_data_op->get_attr<std::string>(op_attr::qtype);
+            const int64_t mask
+                    = quant_data_op->get_attr<int64_t>(op_attr::mask);
             const std::vector<int64_t> out_shape
                     = ltw(out_val->get_logical_tensor()).vdims();
             std::vector<int64_t> new_shape(out_shape.size(), 1);
 
-            // axis in  [-r, r-1], it may less 0
-            const auto axis = (quant_data_op->get_attr<int64_t>(op_attr::axis)
-                                      + out_shape.size())
-                    % out_shape.size();
-
-            if (qtype != "per_tensor") new_shape[axis] = out_shape[axis];
+            for (size_t d = 0; d < out_shape.size(); ++d)
+                if (mask & (1LL << d)) new_shape[d] = out_shape[d];
             op_ptr const_data_op;
             if (quant_data_op->get_kind() == op_kind::_mul_scales) {
                 const auto scales = quant_data_op->get_attr<std::vector<float>>(
@@ -474,10 +470,9 @@ status_t fold_mul_scales(std::shared_ptr<subgraph_t> &sg) {
                 for (size_t i = 0; i < new_scales.size(); ++i)
                     new_scales[i] = scales_base[0] * scales_next[i];
                 // set attrs
-                base_op->set_attr<int64_t>(op_attr::axis,
-                        next_op->get_attr<int64_t>(op_attr::axis));
-                base_op->set_attr<std::string>(op_attr::qtype,
-                        next_op->get_attr<std::string>(op_attr::qtype));
+                if (next_op->has_attr(op_attr::mask))
+                    base_op->set_attr<int64_t>(op_attr::mask,
+                            next_op->get_attr<int64_t>(op_attr::mask));
             }
             base_op->set_attr<std::vector<float>>(op_attr::scales, new_scales);
 
@@ -542,10 +537,9 @@ impl::status_t fold_sub_zps_add_zps(std::shared_ptr<subgraph_t> &sg) {
                 for (size_t i = 0; i < new_zps.size(); ++i)
                     new_zps[i] = zps_base[0] - zps_previous[i];
                 // set attrs
-                base_op->set_attr<int64_t>(op_attr::axis,
-                        previous_op->get_attr<int64_t>(op_attr::axis));
-                base_op->set_attr<std::string>(op_attr::qtype,
-                        previous_op->get_attr<std::string>(op_attr::qtype));
+                if (previous_op->has_attr(op_attr::mask))
+                    base_op->set_attr<int64_t>(op_attr::mask,
+                            previous_op->get_attr<int64_t>(op_attr::mask));
             }
             base_op->set_attr<std::vector<int64_t>>(op_attr::zps, new_zps);
 
@@ -1331,27 +1325,26 @@ status_t fuse_src_scales(std::shared_ptr<subgraph_t> &sg) {
         if (offset == 0 || offset == 1) {
             // Matmul only support applying scale per channel along the last
             // dimension for DNNL_ARG_WEIGHTS.
+            const bool is_per_channel = scale_op->has_attr(op_attr::mask)
+                    && scale_op->get_attr<int64_t>(op_attr::mask) != 0;
+            const bool is_per_group = utils::has_group_shape(scale_op);
             if (offset == 1 && next_op.get_kind() == op_kind::_matmul
-                    && scale_op->has_attr(op_attr::qtype)
-                    && scale_op->get_attr<std::string>(op_attr::qtype)
-                            == "per_channel"
-                    && scale_op->has_attr(op_attr::axis)) {
-                int64_t axis = scale_op->get_attr<int64_t>(op_attr::axis);
+                    && is_per_channel && !is_per_group) {
+                int64_t mask = scale_op->get_attr<int64_t>(op_attr::mask);
                 bool trans_flag = next_op.has_attr(op_attr::transpose_b)
                         ? next_op.get_attr<bool>(op_attr::transpose_b)
                         : false;
                 int ndims = scale_op->get_input_value(0)
                                     ->get_logical_tensor()
                                     .ndims;
-                VCHECK_TRANSFORM(
-                        (!trans_flag && (axis == ndims - 1 || axis == -1))
-                                || (trans_flag
-                                        && (axis == ndims - 2 || axis == -2)),
-                        status::unimplemented,
+                const int64_t expected_mask = trans_flag ? (1LL << (ndims - 2))
+                                                         : (1LL << (ndims - 1));
+                VCHECK_TRANSFORM(mask == expected_mask, status::unimplemented,
                         "Matmul only support applying per channel scale "
                         "along the last dimension for DNNL_ARG_WEIGHTS. "
-                        "trans_flag: %d, axis: %ld, ndims: %d",
-                        trans_flag, static_cast<long int>(axis), ndims);
+                        "mask: %ld, expected: %ld, ndims: %d",
+                        static_cast<long int>(mask),
+                        static_cast<long int>(expected_mask), ndims);
             }
             if (!next_op.has_attr(op_attr::fusion_info)) {
                 fusion_info_t fusion_info;
@@ -1773,9 +1766,8 @@ status_t expand_convtranspose_scales(std::shared_ptr<subgraph_t> &sg) {
                     || in1.get_kind() != op_kind::_mul_scales)
                 continue;
 
-            if (in1.has_attr(op_attr::qtype)
-                    && in1.get_attr<std::string>(op_attr::qtype)
-                            == "per_tensor")
+            if (in1.has_attr(op_attr::mask)
+                    && in1.get_attr<int64_t>(op_attr::mask) == 0)
                 continue;
             auto dq_wei_scales
                     = in1.get_attr<std::vector<float>>(op_attr::scales);
@@ -2695,15 +2687,15 @@ status_t fuse_adjacent_reorders(std::shared_ptr<subgraph_t> &sg) {
                 return status::success;
             }
 
-            // if reorder do per channel scaling, their axis should be
-            // same
-            int64_t cur_axis = op->has_attr(op_attr::axis)
-                    ? op->get_attr<int64_t>(op_attr::axis)
-                    : -1;
-            int64_t next_axis = next_op.has_attr(op_attr::axis)
-                    ? next_op.get_attr<int64_t>(op_attr::axis)
-                    : -1;
-            if (cur_axis != -1 && next_axis != -1 && cur_axis != next_axis) {
+            // if reorder do per channel scaling, their mask should be
+            // compatible
+            int64_t cur_mask = op->has_attr(op_attr::mask)
+                    ? op->get_attr<int64_t>(op_attr::mask)
+                    : 0;
+            int64_t next_mask = next_op.has_attr(op_attr::mask)
+                    ? next_op.get_attr<int64_t>(op_attr::mask)
+                    : 0;
+            if (cur_mask != 0 && next_mask != 0 && cur_mask != next_mask) {
                 return status::success;
             }
 
@@ -2810,13 +2802,11 @@ status_t fuse_adjacent_reorders(std::shared_ptr<subgraph_t> &sg) {
                         + dst_zps2[i]));
             }
 
-            int64_t axis = -1;
-            if (op1->has_attr(op_attr::axis)) {
-                axis = op1->get_attr<int64_t>(op_attr::axis);
-            }
-            if (op2->has_attr(op_attr::axis)) {
-                axis = op2->get_attr<int64_t>(op_attr::axis);
-            }
+            int64_t mask = op1->has_attr(op_attr::mask)
+                    ? op1->get_attr<int64_t>(op_attr::mask)
+                    : 0;
+            if (mask == 0 && op2->has_attr(op_attr::mask))
+                mask = op2->get_attr<int64_t>(op_attr::mask);
 
             bool change_layout
                     = (op1->has_attr(op_attr::change_layout)
@@ -2827,7 +2817,7 @@ status_t fuse_adjacent_reorders(std::shared_ptr<subgraph_t> &sg) {
             // create fused op
             op_ptr fused_op = std::make_shared<op_t>(op_kind::_reorder);
             fused_op->set_attr<bool>(op_attr::change_layout, change_layout);
-            if (axis != -1) fused_op->set_attr<int64_t>(op_attr::axis, axis);
+            if (mask != 0) fused_op->set_attr<int64_t>(op_attr::mask, mask);
 
             if (!std::all_of(fused_scales.begin(), fused_scales.end(),
                         [](const float &s) { return s == 1.f; })) {
@@ -3044,14 +3034,10 @@ status_t fuse_dynamic_mul_scales_add_zps(std::shared_ptr<subgraph_t> &sg) {
         op_ptr &mul_scales = fuse_ops.first; // mul_scales
         op_ptr &add_zps = fuse_ops.second; // add_zps
 
-        const int64_t axis = mul_scales->get_attr<int64_t>(op_attr::axis);
-        const std::string &qtype
-                = mul_scales->get_attr<std::string>(op_attr::qtype);
-
         op_ptr fused_op = std::make_shared<op_t>(op_kind::_reorder);
         fused_op->set_attr<bool>(op_attr::change_layout, false);
-        fused_op->set_attr<int64_t>(op_attr::axis, axis);
-        fused_op->set_attr<std::string>(op_attr::qtype, qtype);
+        fused_op->set_attr<int64_t>(
+                op_attr::mask, mul_scales->get_attr<int64_t>(op_attr::mask));
 
         // src must be the 0-th input
         auto src = mul_scales->get_input_value(0);
@@ -3120,20 +3106,14 @@ status_t fuse_dynamic_sub_zps_mul_scales(std::shared_ptr<subgraph_t> &sg) {
         op_ptr &op1 = fuse_ops.first; // sub_zps
         op_ptr &op2 = fuse_ops.second; // mul_scales
 
-        const int64_t axis = op1->get_attr<int64_t>(op_attr::axis);
-        const std::string &qtype = op1->get_attr<std::string>(op_attr::qtype);
-
         op_ptr fused_op = std::make_shared<op_t>(op_kind::_reorder);
         fused_op->set_attr<bool>(op_attr::change_layout, false);
-        fused_op->set_attr<int64_t>(op_attr::axis, axis);
-        fused_op->set_attr<std::string>(op_attr::qtype, qtype);
-        if (qtype == "per_group") {
+        fused_op->set_attr<int64_t>(
+                op_attr::mask, op2->get_attr<int64_t>(op_attr::mask));
+        if (utils::has_group_shape(op2.get())) {
             const auto &group_shape
                     = op2->get_attr<std::vector<int64_t>>(op_attr::group_shape);
-            const int64_t group_mask
-                    = op2->get_attr<int64_t>(op_attr::group_mask);
 
-            fused_op->set_attr<int64_t>(op_attr::group_mask, group_mask);
             fused_op->set_attr<std::vector<int64_t>>(
                     op_attr::group_shape, group_shape);
         }
@@ -3199,21 +3179,14 @@ impl::status_t convert_dynamic_quantize_ops(std::shared_ptr<subgraph_t> &sg) {
 
     subgraph_rewriter_t rewriter(sg);
     for (auto &cur_op : convert_ops) {
-        const int64_t axis = cur_op->get_attr<int64_t>(op_attr::axis);
-        const std::string &qtype
-                = cur_op->get_attr<std::string>(op_attr::qtype);
-
         op_ptr fused_op = std::make_shared<op_t>(op_kind::_reorder);
         fused_op->set_attr<bool>(op_attr::change_layout, false);
-        fused_op->set_attr<int64_t>(op_attr::axis, axis);
-        fused_op->set_attr<std::string>(op_attr::qtype, qtype);
-        if (qtype == "per_group") {
+        fused_op->set_attr<int64_t>(
+                op_attr::mask, cur_op->get_attr<int64_t>(op_attr::mask));
+        if (utils::has_group_shape(cur_op.get())) {
             const auto &group_shape = cur_op->get_attr<std::vector<int64_t>>(
                     op_attr::group_shape);
-            const int64_t group_mask
-                    = cur_op->get_attr<int64_t>(op_attr::group_mask);
 
-            fused_op->set_attr<int64_t>(op_attr::group_mask, group_mask);
             fused_op->set_attr<std::vector<int64_t>>(
                     op_attr::group_shape, group_shape);
         }
@@ -3449,9 +3422,8 @@ status_t reorder_canonicalization(std::shared_ptr<subgraph_t> &sg) {
 
     for (auto &cur_op : sg->get_ops()) {
         if (cur_op->get_kind() != op_kind::_reorder) continue;
-        const std::string &qtype = cur_op->has_attr(op_attr::qtype)
-                ? cur_op->get_attr<std::string>(op_attr::qtype)
-                : "";
+        const int64_t mask = get_quant_mask(cur_op.get());
+        const bool is_per_channel = (mask != 0);
 
         size_t index = 1; // the start index of optional runtime scales and zps
         // optionally skip the runtime scales
@@ -3464,7 +3436,9 @@ status_t reorder_canonicalization(std::shared_ptr<subgraph_t> &sg) {
             return dt == graph::data_type::s4 || dt == graph::data_type::u4;
         };
 
-        if (qtype == "per_channel") {
+        const bool is_per_group = utils::has_group_shape(cur_op.get());
+
+        if (is_per_channel && !is_per_group) {
             VCHECK_TRANSFORM((!(cur_op->has_attr(op_attr::with_runtime_src_zps)
                                      || cur_op->has_attr(
                                              op_attr::with_runtime_dst_zps))),
@@ -3654,19 +3628,15 @@ status_t combine_binary_post_op_scales(std::shared_ptr<subgraph_t> &sg) {
         }
         return fused_scales;
     };
-    const auto fuse_scales_attributes = [](const std::vector<op_t *> &scale_ops)
-            -> std::pair<std::string, int64_t> {
+    const auto fuse_scales_mask
+            = [](const std::vector<op_t *> &scale_ops) -> int64_t {
         for (size_t i = 0; i < scale_ops.size(); ++i) {
-            if (scale_ops[i]->get_attr<std::string>(op_attr::qtype)
-                    == "per_channel") {
-                // assumption: at least one scales per channel will make
-                // combined scales per channel
-                return std::make_pair("per_channel",
-                        scale_ops[i]->get_attr<int64_t>(op_attr::axis));
+            if (scale_ops[i]->has_attr(op_attr::mask)
+                    && scale_ops[i]->get_attr<int64_t>(op_attr::mask) != 0) {
+                return scale_ops[i]->get_attr<int64_t>(op_attr::mask);
             }
         }
-        // scales per tensor, defaulting axis
-        return std::make_pair("per_tensor", static_cast<int64_t>(1));
+        return 0;
     };
 
     std::vector<op_ptr> bin_ops;
@@ -3758,10 +3728,8 @@ status_t combine_binary_post_op_scales(std::shared_ptr<subgraph_t> &sg) {
                 bin_op->get_attr<int64_t>(op_attr::alg_kind));
 
         std::vector<float> new_scales_in1, new_scales_in0;
-        std::string new_qtype_in1;
-        std::string new_qtype_in0;
-        int64_t new_axis_in1 = 0;
-        int64_t new_axis_in0 = 0;
+        int64_t new_mask_in1 = 0;
+        int64_t new_mask_in0 = 0;
         bool drop_other_scales = false;
         const auto multiplier = std::multiplies<float>();
         switch (bin_kind) {
@@ -3774,10 +3742,10 @@ status_t combine_binary_post_op_scales(std::shared_ptr<subgraph_t> &sg) {
                         = fuse_scales(in0_scales, inv_out_scales, multiplier);
                 new_scales_in1
                         = fuse_scales(in1_scales, inv_out_scales, multiplier);
-                std::tie(new_qtype_in1, new_axis_in1) = fuse_scales_attributes(
-                        {&scales_in1_op, &scales_out_op});
-                std::tie(new_qtype_in0, new_axis_in0) = fuse_scales_attributes(
-                        {&scales_in0_op, &scales_out_op});
+                new_mask_in1
+                        = fuse_scales_mask({&scales_in1_op, &scales_out_op});
+                new_mask_in0
+                        = fuse_scales_mask({&scales_in0_op, &scales_out_op});
                 break;
             case dnnl::algorithm::binary_mul:
                 drop_other_scales = true;
@@ -3785,7 +3753,7 @@ status_t combine_binary_post_op_scales(std::shared_ptr<subgraph_t> &sg) {
                         = fuse_scales(in0_scales, in1_scales, multiplier);
                 new_scales_in0 = fuse_scales(
                         new_scales_in0, inv_out_scales, multiplier);
-                std::tie(new_qtype_in0, new_axis_in0) = fuse_scales_attributes(
+                new_mask_in0 = fuse_scales_mask(
                         {&scales_in0_op, &scales_in1_op, &scales_out_op});
                 break;
             default:
@@ -3803,14 +3771,12 @@ status_t combine_binary_post_op_scales(std::shared_ptr<subgraph_t> &sg) {
             rewriter.fuse_op_to_successor(other_scales_op.shared_from_this());
         } else {
             other_scales_op.set_attr(op_attr::scales, new_scales_in1)
-                    .set_attr(op_attr::qtype, new_qtype_in1)
-                    .set_attr(op_attr::axis, new_axis_in1);
+                    .set_attr(op_attr::mask, new_mask_in1);
         }
 
         // update output scales data
         base_scales_op.set_attr(op_attr::scales, new_scales_in0)
-                .set_attr(op_attr::qtype, new_qtype_in0)
-                .set_attr(op_attr::axis, new_axis_in0);
+                .set_attr(op_attr::mask, new_mask_in0);
     }
 
     rewriter.run();
@@ -3944,9 +3910,8 @@ impl::status_t lift_up_quantize(std::shared_ptr<subgraph_t> &sg) {
                     && op->get_input_value(0)->has_producer();
             if (!ok) continue;
 
-            ok = op->has_attr(op_attr::qtype)
-                    && op->get_attr<std::string>(op_attr::qtype)
-                            == "per_tensor";
+            ok = op->has_attr(op_attr::mask)
+                    && op->get_attr<int64_t>(op_attr::mask) == 0;
             if (!ok) continue;
 
             op_t *producer = op->get_input_op(0);
@@ -4076,7 +4041,7 @@ impl::status_t lift_up_weight_reshape_for_depthwiseconv(
                         op_kind::_sub_zps, op_kind::_mul_scales))
                 break;
             if (wei_format == "XIO") {
-                producer->set_attr<int64_t>(op_attr::axis, ndims - 1);
+                producer->set_attr<int64_t>(op_attr::mask, 1LL << (ndims - 1));
             }
             if (to_be_swapped.count(reshape_op))
                 to_be_swapped[reshape_op].emplace_back(producer);

--- a/src/graph/backend/dnnl/passes/utils.cpp
+++ b/src/graph/backend/dnnl/passes/utils.cpp
@@ -604,11 +604,8 @@ bool prelu_doable(const std::vector<dim_t> &src_dims,
 bool is_typecast(const op_t *op) {
     bool is_typecast = op->get_kind() == op_kind::_reorder
             && !op->get_attr<bool>(op_attr::change_layout)
-            && (!op->has_attr(op_attr::qtype)
-                    || op->get_attr<std::string>(op_attr::qtype)
-                            == "per_tensor")
-            && (!op->has_attr(op_attr::axis)
-                    || op->get_attr<int64_t>(op_attr::axis) == -1)
+            && (!op->has_attr(op_attr::mask)
+                    || op->get_attr<int64_t>(op_attr::mask) == 0)
             && !op->has_attr(op_attr::scales) && !op->has_attr(op_attr::src_zps)
             && !op->has_attr(op_attr::dst_zps)
             && (!op->has_attr(op_attr::with_runtime_scales)
@@ -645,11 +642,8 @@ bool with_runtime_scales(const op_ptr &op, bool is_input, size_t index) {
 bool is_layout_reorder(const op_t *op) {
     bool is_layout_reorder = op->get_kind() == op_kind::_reorder
             && op->get_attr<bool>(op_attr::change_layout)
-            && (!op->has_attr(op_attr::qtype)
-                    || op->get_attr<std::string>(op_attr::qtype)
-                            == "per_tensor")
-            && (!op->has_attr(op_attr::axis)
-                    || op->get_attr<int64_t>(op_attr::axis) == -1)
+            && (!op->has_attr(op_attr::mask)
+                    || op->get_attr<int64_t>(op_attr::mask) == 0)
             && !op->has_attr(op_attr::scales) && !op->has_attr(op_attr::src_zps)
             && !op->has_attr(op_attr::dst_zps)
             && (!op->has_attr(op_attr::with_runtime_scales)
@@ -672,9 +666,7 @@ std::shared_ptr<op_t> clone_mul_scales(const std::shared_ptr<op_t> &scale_op) {
     new_op->set_attr<std::vector<float>>(op_attr::scales,
             scale_op->get_attr<std::vector<float>>(op_attr::scales));
     new_op->set_attr<int64_t>(
-            op_attr::axis, scale_op->get_attr<int64_t>(op_attr::axis));
-    new_op->set_attr<std::string>(
-            op_attr::qtype, scale_op->get_attr<std::string>(op_attr::qtype));
+            op_attr::mask, scale_op->get_attr<int64_t>(op_attr::mask));
     return new_op;
 }
 

--- a/src/graph/backend/dnnl/utils.hpp
+++ b/src/graph/backend/dnnl/utils.hpp
@@ -28,6 +28,8 @@
 
 #include "graph/utils/utils.hpp"
 
+#include "graph/interface/op.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace graph {
@@ -67,6 +69,11 @@ inline dim_t offset_compute(
         off += idx[i] * strides[i];
     }
     return off;
+}
+
+inline bool has_group_shape(const op_t *op) {
+    return op->has_attr(op_attr::group_shape)
+            && !op->get_attr<dims>(op_attr::group_shape).empty();
 }
 
 } // namespace utils

--- a/src/graph/interface/c_types_map.hpp
+++ b/src/graph/interface/c_types_map.hpp
@@ -289,6 +289,7 @@ const op_attr_t scales = dnnl_graph_op_attr_scales;
 const op_attr_t axis = dnnl_graph_op_attr_axis;
 const op_attr_t begin_norm_axis = dnnl_graph_op_attr_begin_norm_axis;
 const op_attr_t groups = dnnl_graph_op_attr_groups;
+const op_attr_t mask = dnnl_graph_op_attr_mask;
 
 const op_attr_t axes = dnnl_graph_op_attr_axes;
 const op_attr_t dilations = dnnl_graph_op_attr_dilations;

--- a/src/graph/interface/op.hpp
+++ b/src/graph/interface/op.hpp
@@ -328,6 +328,7 @@ public:
             CASE(axis);
             CASE(begin_norm_axis);
             CASE(groups);
+            CASE(mask);
             CASE(axes);
             CASE(dilations);
             CASE(weights_shape);

--- a/src/graph/interface/op_def.hpp
+++ b/src/graph/interface/op_def.hpp
@@ -1406,13 +1406,9 @@ DNNL_GRAPH_OP_SCHEMA(_mul_scales, 1,
                 .set_input(1, "scales")
                 .set_output(0, "y")
                 .set_output(1, "scratchpad")
-                .set_attr(
-                        op_attr::qtype, false, attribute_kind::s, "per_tensor")
-                .set_attr(op_attr::axis, false, attribute_kind::i, int64_t(1))
+                .set_attr(op_attr::mask, false, attribute_kind::i, int64_t(0))
                 .set_attr(op_attr::group_shape, false, attribute_kind::is,
                         std::vector<int64_t>())
-                .set_attr(op_attr::group_mask, false, attribute_kind::i,
-                        int64_t(0))
                 .set_attr(op_attr::data_type, false, attribute_kind::i,
                         int64_t(0))
                 .set_attr(op_attr::scales, false, attribute_kind::fs,
@@ -1453,17 +1449,13 @@ DNNL_GRAPH_OP_SCHEMA(_add_zps, 1,
                 .set_input(0, "x")
                 .set_input(1, "zps")
                 .set_output(0, "y")
-                .set_attr(
-                        op_attr::qtype, false, attribute_kind::s, "per_tensor")
-                .set_attr(op_attr::axis, false, attribute_kind::i, int64_t(1))
+                .set_attr(op_attr::mask, false, attribute_kind::i, int64_t(0))
                 .set_attr(op_attr::zps, false, attribute_kind::is,
                         std::vector<int64_t>())
                 .set_attr(op_attr::with_runtime_zps, false, attribute_kind::b,
                         false)
                 .set_attr(op_attr::group_shape, false, attribute_kind::is,
                         std::vector<int64_t>())
-                .set_attr(op_attr::group_mask, false, attribute_kind::i,
-                        int64_t(0))
                 .set_attr(op_attr::data_type, false, attribute_kind::i,
                         int64_t(0))
                 .set_shape_inference_function(infer_identity_output_shape))
@@ -1476,17 +1468,13 @@ DNNL_GRAPH_OP_SCHEMA(_sub_zps, 1,
                 .set_input(0, "x")
                 .set_input(1, "zps")
                 .set_output(0, "y")
-                .set_attr(
-                        op_attr::qtype, false, attribute_kind::s, "per_tensor")
-                .set_attr(op_attr::axis, false, attribute_kind::i, int64_t(1))
+                .set_attr(op_attr::mask, false, attribute_kind::i, int64_t(0))
                 .set_attr(op_attr::zps, false, attribute_kind::is,
                         std::vector<int64_t>())
                 .set_attr(op_attr::with_runtime_zps, false, attribute_kind::b,
                         false)
                 .set_attr(op_attr::group_shape, false, attribute_kind::is,
                         std::vector<int64_t>())
-                .set_attr(op_attr::group_mask, false, attribute_kind::i,
-                        int64_t(0))
                 .set_attr(op_attr::data_type, false, attribute_kind::i,
                         int64_t(0))
                 .set_shape_inference_function(infer_identity_output_shape))
@@ -2278,11 +2266,7 @@ DNNL_GRAPH_OP_SCHEMA(_reorder, 1,
                 .set_input(0, "input")
                 .set_output(0, "output")
                 .set_output(1, "scratchpad")
-                // TODO(xxx) Multiple ops will be mapped to dnnl_reorder
-                // finally, how to deal with the attrs?
-                .set_attr(
-                        op_attr::qtype, false, attribute_kind::s, "per_tensor")
-                // Attributes
+                .set_attr(op_attr::mask, false, attribute_kind::i, int64_t(0))
                 .set_attr(op_attr::fusion_info, false,
                         attribute_kind::fusion_info)
                 .set_attr(
@@ -2291,15 +2275,12 @@ DNNL_GRAPH_OP_SCHEMA(_reorder, 1,
                 .set_attr(op_attr::src_zps, false, attribute_kind::is)
                 .set_attr(op_attr::dst_zps, false, attribute_kind::is)
                 .set_attr(op_attr::group_shape, false, attribute_kind::is)
-                .set_attr(op_attr::group_mask, false, attribute_kind::i,
-                        int64_t(0))
                 .set_attr(op_attr::with_runtime_scales, false,
                         attribute_kind::b, false)
                 .set_attr(op_attr::with_runtime_src_zps, false,
                         attribute_kind::b, false)
                 .set_attr(op_attr::with_runtime_dst_zps, false,
                         attribute_kind::b, false)
-                .set_attr(op_attr::axis, false, attribute_kind::i, int64_t(-1))
                 .SET_ATTR_IS_CONSTANT // used for constant prop and cache
                 // Analysis rules
                 .set_shape_inference_function(infer_identity_output_shape))

--- a/src/graph/interface/op_def.hpp
+++ b/src/graph/interface/op_def.hpp
@@ -1313,6 +1313,7 @@ DNNL_GRAPH_OP_SCHEMA(DynamicQuantize, 1,
                 .set_attr(
                         op_attr::qtype, false, attribute_kind::s, "per_tensor")
                 .set_attr(op_attr::axis, false, attribute_kind::i, int64_t(1))
+                .set_attr(op_attr::mask, false, attribute_kind::i)
                 .set_type_constraints("T1", {data_type::f32})
                 .set_type_constraints(
                         "T2", {data_type::u8, data_type::s8, data_type::s32})
@@ -1333,6 +1334,7 @@ DNNL_GRAPH_OP_SCHEMA(DynamicDequantize, 1,
                 .set_attr(
                         op_attr::qtype, false, attribute_kind::s, "per_tensor")
                 .set_attr(op_attr::axis, false, attribute_kind::i, int64_t(1))
+                .set_attr(op_attr::mask, false, attribute_kind::i)
                 .set_attr(op_attr::group_shape, false, attribute_kind::is)
                 .set_type_constraints("T1",
                         {data_type::u8, data_type::s8, data_type::s4,

--- a/src/graph/interface/op_def_constraint.cpp
+++ b/src/graph/interface/op_def_constraint.cpp
@@ -359,14 +359,71 @@ bool check_quant_dequant_scales_zps(const op_t *n) {
 // unlike Quantize/Dequantize, scales and zps are inputs here.
 bool check_dyn_quant_dequant_scales_zps(const op_t *n) {
     const int64_t inputs_num = n->num_inputs();
-    const int64_t sz_scales = n->get_input_logical_tensor(1).dims[0];
+    const auto &src_lt = n->get_input_logical_tensor(0);
+    const auto &scales_lt = n->get_input_logical_tensor(1);
+    const int64_t sz_scales = scales_lt.ndims == 0 ? 1 : scales_lt.dims[0];
     // in case of not setting value for scales
     if (sz_scales == DNNL_GRAPH_UNKNOWN_DIM) { return true; }
+
+    // FP8 quantization does not support zps regardless of mask or qtype.
+    if (inputs_num == 3) {
+        const auto &dst_lt = n->get_output_logical_tensor(0);
+        const bool f8_src = utils::one_of(
+                src_lt.data_type, data_type::f8_e5m2, data_type::f8_e4m3);
+        const bool f8_dst = utils::one_of(
+                dst_lt.data_type, data_type::f8_e5m2, data_type::f8_e4m3);
+        VCHECK_SHAPE_INFER(!(f8_src || f8_dst),
+                "%s, f8 quantization or dequantization does not support zps.",
+                op_t::kind2str(n->get_kind()).c_str());
+    }
 
     // qtype is not a required attribute.
     const auto qtype = n->has_attr(op_attr::qtype)
             ? n->get_attr<std::string>(op_attr::qtype)
             : "per_tensor";
+    if (n->has_attr(op_attr::mask)) {
+        const int64_t mask = n->get_attr<int64_t>(op_attr::mask);
+        VCHECK_SHAPE_INFER(mask >= 0,
+                "%s, mask must be non-negative, given mask: %d.",
+                op_t::kind2str(n->get_kind()).c_str(), static_cast<int>(mask));
+        VCHECK_SHAPE_INFER((mask >> src_lt.ndims) == 0,
+                "%s, mask must not select dimensions outside the source rank. "
+                "given mask: %d, source rank: %d.",
+                op_t::kind2str(n->get_kind()).c_str(), static_cast<int>(mask),
+                src_lt.ndims);
+        VCHECK_SHAPE_INFER(qtype == "per_tensor",
+                "%s, qtype must be per_tensor when mask is specified.",
+                op_t::kind2str(n->get_kind()).c_str());
+
+        int64_t scale_dim = 0;
+        for (int64_t dim = 0; dim < src_lt.ndims; ++dim) {
+            if ((mask & (1LL << dim)) == 0) continue;
+            VCHECK_SHAPE_INFER(scale_dim < scales_lt.ndims,
+                    "%s, scales rank does not match mask.",
+                    op_t::kind2str(n->get_kind()).c_str());
+            VCHECK_SHAPE_INFER(scales_lt.dims[scale_dim] == src_lt.dims[dim],
+                    "%s, scales shape does not match masked source dimensions.",
+                    op_t::kind2str(n->get_kind()).c_str());
+            ++scale_dim;
+        }
+        VCHECK_SHAPE_INFER(scale_dim == scales_lt.ndims,
+                "%s, scales rank does not match mask.",
+                op_t::kind2str(n->get_kind()).c_str());
+
+        if (inputs_num == 3) {
+            const auto &zps_lt = n->get_input_logical_tensor(2);
+            VCHECK_SHAPE_INFER(zps_lt.ndims == scales_lt.ndims,
+                    "%s, zps rank does not match scales rank.",
+                    op_t::kind2str(n->get_kind()).c_str());
+            VCHECK_SHAPE_INFER(
+                    std::equal(scales_lt.dims, scales_lt.dims + scales_lt.ndims,
+                            zps_lt.dims),
+                    "%s, zps shape does not match scales shape.",
+                    op_t::kind2str(n->get_kind()).c_str());
+        }
+
+        return true;
+    }
     // zps is not a required input.
     if (inputs_num == 2) {
         if (qtype == "per_tensor") {

--- a/tests/benchdnn/graph/flex_rewrite.cpp
+++ b/tests/benchdnn/graph/flex_rewrite.cpp
@@ -262,17 +262,22 @@ int flex_rewrite_t::linked_shape_and_attr_rewrite(
     for (auto &aop : dgraph.ops_) {
         if (aop.kind_ == "DynamicDequantize") {
             auto &attr = aop.attrs_;
-            if (attr.find("qtype") == attr.end()
-                    || attr["qtype"].str_value_ != "per_group")
-                continue;
-            if (attr.find("group_shape") == attr.end()) {
+            // Keep the check for legacy attributes: if qtype is per_group, the
+            // group_shape must be specified. But now, the user can also specify
+            // mask + group_shape. So once group_shape is provided, we think
+            // it's per-group quantization and proceed the rewrite.
+            const bool legacy_per_group = attr.find("qtype") != attr.end()
+                    && attr["qtype"].str_value_ == "per_group";
+            const bool has_group_shape = attr.find("group_shape") != attr.end()
+                    && !attr["group_shape"].s64_vector_.empty();
+            if (legacy_per_group && !has_group_shape) {
                 BENCHDNN_PRINT(0,
                         "Error: missed `group-shape` attribute for "
                         "per-group quantization for op with id=\'%zu\'\n",
                         aop.id_);
                 SAFE(FAIL, WARN);
             }
-
+            if (!has_group_shape) continue;
             bool input_shape_rewrite = std::any_of(aop.in_lts_.begin(),
                     aop.in_lts_.end(), [&](const deserialized_lt_t &in_lt) {
                 return in_shapes_.count(in_lt.id_)

--- a/tests/benchdnn/graph/flex_rewrite.cpp
+++ b/tests/benchdnn/graph/flex_rewrite.cpp
@@ -1404,6 +1404,11 @@ int flex_rewrite_t::op_attrs_rewrite(deserialized_graph_t &dgraph) {
         for (const auto &new_attr : attrs) {
             const auto &attr_name = new_attr.first;
             const auto &new_val = new_attr.second;
+            // clear an attribute if the new value is "-".
+            if (new_val == "-") {
+                temp_op.attrs_.erase(attr_name);
+                continue;
+            }
             std::string attr_type = "undef";
             // If the `new_attr` is missing from the original JSON (hence not in
             // `temp_op.attrs_`), deduce the attribute value type using

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -1999,8 +1999,6 @@ bool get_reorder_attrs(const deserialized_op_t &base_op_ref,
         attr_t::arg_scales_t &arg_scales, attr_t::zero_points_t &zp) {
 
     const auto &op_kind = base_op_ref.kind_;
-    std::string qtype {};
-    base_op_ref.get_attr_string(qtype, "qtype");
     int arg = 0;
     if (op_kind == "Dequantize" || op_kind == "DynamicDequantize")
         arg = DNNL_ARG_SRC;
@@ -2009,71 +2007,117 @@ bool get_reorder_attrs(const deserialized_op_t &base_op_ref,
     else
         return false;
 
-    // scale
-    attr_t::policy_t scale_policy = attr_t::policy_t::COMMON;
-    int64_t axis = 1;
-    std::vector<dnnl_dim_t> groups;
-    dnnl_data_type_t scale_dt, zp_dt;
+    if (op_kind == "Dequantize" || op_kind == "Quantize") {
+        // Static quantization: scales and zps are op attributes. And there is
+        // no mask attribute.
+        std::string qtype {};
+        base_op_ref.get_attr_string(qtype, "qtype");
 
-    const int ndims
-            = static_cast<int>(base_op_ref.in_lts_.front().shape_.size());
-    base_op_ref.get_attr_s64(axis, "axis");
-    if (axis < 0) axis += ndims;
-
-    // per dimension
-    if (qtype == "per_channel") {
-        if (axis < 0) axis += ndims;
-        if (axis == 0) {
-            scale_policy = attr_t::PER_DIM_0;
-        } else if (axis == 1) {
-            scale_policy = attr_t::PER_DIM_1;
-        } else if (axis == 2) {
-            scale_policy = attr_t::PER_DIM_2;
-        } else if (axis == 3) {
-            scale_policy = attr_t::PER_DIM_3;
-        } else {
-            assert(!"unsupported axis");
+        attr_t::policy_t scale_policy = attr_t::policy_t::COMMON;
+        if (qtype == "per_channel") {
+            int64_t axis = 1;
+            base_op_ref.get_attr_s64(axis, "axis");
+            const int ndims = static_cast<int>(
+                    base_op_ref.in_lts_.front().shape_.size());
+            if (axis < 0) axis += ndims;
+            if (axis == 0)
+                scale_policy = attr_t::PER_DIM_0;
+            else if (axis == 1)
+                scale_policy = attr_t::PER_DIM_1;
+            else if (axis == 2)
+                scale_policy = attr_t::PER_DIM_2;
+            else if (axis == 3)
+                scale_policy = attr_t::PER_DIM_3;
+            else
+                assert(!"unsupported axis");
         }
-    } else if (qtype == "per_group") {
-        scale_policy = attr_t::PER_TENSOR;
+
+        std::vector<float> scales {};
+        if (base_op_ref.get_attr_f32_vector(scales, "scales"))
+            arg_scales.set(arg, {scale_policy, scales.front()});
+
+        std::vector<int64_t> zps;
+        if (base_op_ref.get_attr_s64_vector(zps, "zps") && !zps.empty())
+            zp.set(arg, attr_t::policy_t::COMMON, zps.front());
+
+    } else if (op_kind == "DynamicDequantize" || op_kind == "DynamicQuantize") {
+        // Dynamic quantization: scales and zps are runtime inputs.
+        // Use explicit mask to avoid lossy policy round-trips.
+        const int ndims
+                = static_cast<int>(base_op_ref.in_lts_.front().shape_.size());
+
+        // Determine mask from explicit attribute or legacy qtype/axis.
+        int64_t mask = 0;
+        bool has_explicit_mask = false;
+        if (base_op_ref.get_attr_s64(mask, "mask")) has_explicit_mask = true;
 
         std::vector<int64_t> group_shape;
         base_op_ref.get_attr_s64_vector(group_shape, "group_shape");
-        groups = {group_shape[ndims - 2], group_shape[ndims - 1]};
-    }
+        std::string qtype {};
+        base_op_ref.get_attr_string(qtype, "qtype");
+        const bool is_per_group = !group_shape.empty() || qtype == "per_group";
 
-    if (op_kind == "Dequantize" || op_kind == "Quantize") {
-        std::vector<float> scales {};
-        const auto has_scales
-                = base_op_ref.get_attr_f32_vector(scales, "scales");
-        if (has_scales) arg_scales.set(arg, {scale_policy, scales.front()});
-
-        std::vector<int64_t> zps;
-        const auto has_zps = base_op_ref.get_attr_s64_vector(zps, "zps");
-        // currently, zps only support per_tensor quantization in primitive
-        if (has_zps && !zps.empty())
-            zp.set(arg, attr_t::policy_t::COMMON, zps.front());
-    } else if (op_kind == "DynamicDequantize" || op_kind == "DynamicQuantize") {
-        // For reference path, it always use f32 for computation.
-        scale_dt = dnnl_f32;
-
-        //  TODO: benchdnn needs to alloc memory based on is_def() function.
-        //  so add tmp value for per_tensor scales && zps to make is_def()
-        //  return false to alloc memory.
-        if (qtype == "per_tensor") {
-            arg_scales.set(arg, {scale_policy, 2});
-        } else if (qtype == "per_group") {
-            arg_scales.set(arg, {scale_policy, 1.f, scale_dt, groups});
-        } else {
-            arg_scales.set(arg, {scale_policy});
+        // Validate the explicit mask which should cover the last two dimensions
+        // as required by the primitive API.
+        if (has_explicit_mask && !group_shape.empty()) {
+            if (ndims < 2) return false;
+            const int64_t grouped_mask
+                    = (1LL << (ndims - 2)) | (1LL << (ndims - 1));
+            if ((mask & grouped_mask) != grouped_mask) return false;
         }
+
+        if (!has_explicit_mask) {
+            int64_t axis = 1;
+            base_op_ref.get_attr_s64(axis, "axis");
+            if (axis < 0) axis += ndims;
+
+            if (qtype == "per_channel") {
+                mask = 1LL << axis;
+            } else if (is_per_group && base_op_ref.in_lts_.size() >= 2) {
+                const auto &scale_shape = base_op_ref.in_lts_[1].shape_;
+                for (int i = 0; i < ndims; ++i) {
+                    if (static_cast<size_t>(i) < scale_shape.size()
+                            && scale_shape[i] > 1)
+                        mask |= (1LL << i);
+                }
+                // Primitive API requires mask to cover last two dims
+                // when groups are specified.
+                if (ndims >= 2)
+                    mask |= (1LL << (ndims - 1)) | (1LL << (ndims - 2));
+            }
+        }
+
+        std::vector<dnnl_dim_t> groups;
+        if (is_per_group && !group_shape.empty())
+            groups = {group_shape[ndims - 2], group_shape[ndims - 1]};
+
+        // Build scale entry with explicit mask.
+        attr_t::arg_scales_t::entry_t scale_entry;
+        if (is_per_group) {
+            scale_entry = {attr_t::COMMON, 1.f, dnnl_f32, groups};
+        } else {
+            // Dummy value (2) ensures is_def() returns false for memory alloc.
+            scale_entry = {attr_t::COMMON, mask == 0 ? 2.f : 1.f};
+        }
+        if (mask != 0) {
+            scale_entry.mask = mask;
+            scale_entry.mask_input = attr_t::mask_input_t::mask;
+        }
+        arg_scales.set(arg, scale_entry);
+
         // zps is optional for DynamicDequantize/DynamicQuantize, default is
         // symmetric quantization
         if (base_op_ref.in_lts_.size() == 3) {
-            if (qtype == "per_group") {
-                zp_dt = static_cast<dnnl_data_type_t>(
+            if (is_per_group) {
+                auto zp_dt = static_cast<dnnl_data_type_t>(
                         base_op_ref.in_lts_[2].get_data_type());
-                zp.set(arg, {scale_policy, 0, zp_dt, groups});
+                attr_t::zero_points_t::entry_t zp_entry(
+                        attr_t::COMMON, 0, zp_dt, groups);
+                if (mask != 0) {
+                    zp_entry.mask = mask;
+                    zp_entry.mask_input = attr_t::mask_input_t::mask;
+                }
+                zp.set(arg, zp_entry);
             } else {
                 zp.set(arg, attr_t::policy_t::COMMON, 1);
             }

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -428,6 +428,7 @@ dnnl::graph::op::attr attrstr2kind(const std::string &attr_name) {
             {"begin_norm_axis", dnnl::graph::op::attr::begin_norm_axis},
             {"groups", dnnl::graph::op::attr::groups},
             {"group_shape", dnnl::graph::op::attr::group_shape},
+            {"mask", dnnl::graph::op::attr::mask},
             // int64_t vector attributes. The value of these attributes can be a
             // vector of int64 numbers.
             {"axes", dnnl::graph::op::attr::axes},
@@ -500,6 +501,7 @@ const std::string &attrstr2type(const std::string &attr_name) {
             {"begin_norm_axis", "s64"},
             {"groups", "s64"},
             {"group_shape", "s64"},
+            {"mask", "s64"},
             // int64_t vector attributes. The value of these attributes can be a
             // vector of int64 numbers.
             {"axes", "s64[]"},

--- a/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
+++ b/tests/benchdnn/inputs/graph/complex_fusion/harness_mha_all
@@ -151,7 +151,7 @@
 --reset --dt=15:f32+4:f32+16:f32+18:f32 --case=complex_fusion/mha/sdpa-compressed-v-int8-gs32.json
 
 # per-tensor quantization
---reset --dt=15:f32+4:f32+18:f32+16:f32 --op-attrs=34107656704:qtype:per_tensor --in-shapes=1:1+2:1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
+--reset --dt=15:f32+4:f32+18:f32+16:f32 --op-attrs=34107656704:qtype:per_tensor*group_shape:- --in-shapes=1:1+2:1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
 
 # phi3-mini-4k-instruct, group size=96
 --reset
@@ -207,7 +207,7 @@
 
 # reference implementation test
 --reset --op-attrs=34107656704:group_shape:1x1x1x32+34107654464:transpose_b:1 --in-shapes=0:1x32x32x128+1:1x32x32x4+2:1x32x32x4 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
---reset --op-attrs=34107656704:qtype:per_channel*axis:3 --in-shapes=1:32+2:1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
+--reset --op-attrs=34107656704:qtype:per_channel*axis:3*group_shape:- --in-shapes=1:32+2:1 --case=complex_fusion/mha/sdpa-compressed-k-int8-gs32.json
 
 # d_qk != d_v
 --reset --in-shapes=8:1x16x384x32,8:1x16x384x64,8:1x16x384x128 --tensor-property=3:undef,3:host_scalar --case=complex_fusion/mha/sdpa-plain-simplified-f32.json

--- a/tests/benchdnn/inputs/graph/op/harness_f32_all
+++ b/tests/benchdnn/inputs/graph/op/harness_f32_all
@@ -74,12 +74,6 @@
 --reset --in-shapes=1:1x128x56x56 --op-attrs=0:auto_pad:SAME_LOWER --case=op/f32/deconv_bwd_w.json
 --reset --in-shapes=1:1x128x57x57 --op-attrs=0:auto_pad:VALID --case=op/f32/deconv_bwd_w.json
 --reset --in-shapes=0:1x28x28x32+1:1x16x16x128 --op-attrs=0:data_format:NXC --case=op/f32/deconv_bwd_w.json
---reset --case=op/f32/dequantize_s8.json
---reset --case=op/f32/dequantize_u8.json
---reset --case=op/f32/dequantize_f8_e4m3.json
---reset --case=op/f32/dequantize_f8_e5m2.json
---reset --case=op/f32/dynamicdq_s4.json
---reset --case=op/f32/dynamicdq_u4.json
 --reset --in-shapes=,0:64x16x28x28 --op-kind=0:Elu,0:LeakyReLU --case=op/f32/elu.json
 --reset --case=op/f32/elu_bwd.json
 --reset --case=op/f32/hardsigmoid.json
@@ -140,9 +134,6 @@
 --reset --op-attrs=0:data_format:NXC --case=op/f32/prelu.json
 --reset --case=op/f32/prelu_bwd.json
 --reset --op-attrs=0:data_format:NXC --case=op/f32/prelu_bwd.json
---reset --case=op/f32/quantize.json
---reset --case=op/f32/quantize_f8_e4m3.json
---reset --case=op/f32/quantize_f8_e5m2.json
 --reset --case=op/f32/reducel1.json
 --reset --case=op/f32/reducel2.json
 --reset --case=op/f32/reducemax.json
@@ -313,8 +304,7 @@
 --reset --in-shapes=0:2x17x5x5x5+1:17x1x3x3x3 --op-attrs=0:strides:1x1x1*dilations:1x1x1*pads_begin:1x1x1*pads_end:1x1x1*groups:17 --case=op/f32/deconv_bwd_d.json
 --reset --in-shapes=0:2x16x5x5x5+1:16x4x3x3x3 --op-attrs=0:strides:1x1x1*dilations:1x1x1*pads_begin:1x1x1*pads_end:1x1x1*groups:4 --case=op/f32/deconv_bwd_d.json
 --reset --in-shapes=0:2x20x5x5x5+1:16x5x3x3x3 --op-attrs=0:strides:1x1x1*dilations:1x1x1*pads_begin:1x1x1*pads_end:1x1x1*groups:4 --case=op/f32/deconv_bwd_d.json
---reset --case=op/f32/dynamicq.json
---reset --case=op/f32/dynamicdq.json
+
 # case from large scope
 --reset --in-shapes=0:*abcd --case=op/f32/reorder.json
 --reset --in-shapes=0:*cdba --case=op/f32/reorder.json
@@ -874,3 +864,22 @@
 --reset --op-attrs=0:mode:gelu_erf,0:mode:gelu_tanh --case=op/f32/gelu.json
 --reset --case=op/f32/rmsnorm.json
 --reset --op-attrs=0:epsilon:0.00001 --case=op/f32/rmsnorm.json
+
+# quantization
+--reset --case=op/f32/quantize.json
+--reset --case=op/f32/quantize_f8_e4m3.json
+--reset --case=op/f32/quantize_f8_e5m2.json
+--reset --case=op/f32/dequantize_s8.json
+--reset --case=op/f32/dequantize_u8.json
+--reset --case=op/f32/dequantize_f8_e4m3.json
+--reset --case=op/f32/dequantize_f8_e5m2.json
+--reset --case=op/f32/dynamicdq_s4.json
+--reset --case=op/f32/dynamicdq_u4.json
+--reset --case=op/f32/dynamicq.json
+--reset --case=op/f32/dynamicdq.json
+--reset --op-attrs=0:qtype:per_tensor*mask:2 --case=op/f32/dynamicq.json
+--reset --op-attrs=0:qtype:per_tensor*mask:2 --case=op/f32/dynamicdq.json
+--reset --op-attrs=0:qtype:per_tensor*mask:3 --in-shapes=1:2x64 --case=op/f32/dynamicq.json
+--reset --op-attrs=0:qtype:per_tensor*mask:3 --in-shapes=1:2x64 --case=op/f32/dynamicdq.json
+--reset --op-attrs=0:qtype:per_tensor*mask:0 --in-shapes=1:- --case=op/f32/dynamicq.json
+--reset --op-attrs=0:qtype:per_tensor*mask:0 --in-shapes=1:- --case=op/f32/dynamicdq.json


### PR DESCRIPTION
- The draft implementation for #5743 
- Added `op::attr::mask` attribute to API. The attribute accepts int64_t value.
- Refactored the backend code to:
   - Handle the new `mask` attribute if it's specified.
   - Unify to `mask` internally by mapping legacy `qtype` and `axis` to the corresponding mask value.
   - Pass the `mask` and `group_shape` parameters to primitive API.
- Benchdnn graph driver to support and validate the `mask` attribute (via rewriting the case by `--op-attrs`).
- Updated the operation documents.