### PR TITLE
Add ACE v1 encoders and ISA detection

### DIFF
--- a/doc/performance_considerations/dispatcher_control.md
+++ b/doc/performance_considerations/dispatcher_control.md
@@ -43,6 +43,11 @@ still take effect.
 | \                    | AVX10_2 or AVX10_2_512                       | Intel AVX10.2                                                                                                    |
 | \                    | AVX10_2_AMX_2 or AVX10_2_512_AMX_2           | Intel AVX10.2 and Intel AMX with 8-bit integer, bfloat16, float16, float8 support                                |
 | \                    | **DEFAULT**                                  | **No restrictions on the above ISAs, but excludes the below ISAs with preview support in the library (default)** |
+| \                    | AVX10_2_ACE                                  | Intel AVX10.2 with AI Compute Extensions (ACE)                                                                   |
+
+@note AVX10_2_ACE requires AI Compute Extensions (ACE) version 1. Refer to the
+[ACE v1 specification](https://x86ecosystem.org/wp-content/uploads/2026/06/ACE_v1_Specification_public_1_15.pdf)
+for the instruction set details.
 
 @note The ISAs are partially ordered:
 * SSE41 < AVX < AVX2 < AVX2_VNNI < AVX2_VNNI_2,
@@ -51,7 +56,8 @@ still take effect.
 * AVX10_1_512 < AVX10_1_512_AMX < AVX10_1_512_AMX_FP16
   < AVX10_2_AMX_2,
 * AVX2_VNNI < AVX10_1_512,
-* AVX10_2 < AVX10_2_AMX_2.
+* AVX10_2 < AVX10_2_AMX_2,
+* AVX10_2 < AVX10_2_ACE.
 
 The below values are aliased for backward compatibility with the introduction of
 AVX10.1:

--- a/include/oneapi/dnnl/dnnl.h
+++ b/include/oneapi/dnnl/dnnl.h
@@ -3980,7 +3980,8 @@ dnnl_status_t DNNL_API dnnl_set_jit_profiling_jitdumpdir(const char *dir);
 ///         - AVX10_1_512 < AVX10_1_512_AMX < AVX10_1_512_AMX_FP16
 ///           < AVX10_2_AMX_2,
 ///         - AVX2_VNNI < AVX10_1_512,
-///         - AVX10_2 < AVX10_2_AMX_2
+///         - AVX10_2 < AVX10_2_AMX_2,
+///         - AVX10_2 < AVX10_2_ACE
 ///
 ///     Aliases:
 ///         - AVX512_CORE_FP16 = AVX10_1_512

--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -14175,6 +14175,8 @@ enum class cpu_isa {
     avx10_2_amx_2 = dnnl_cpu_isa_avx10_2_amx_2,
     /// @copydoc dnnl_cpu_isa_avx10_2_512_amx_2
     avx10_2_512_amx_2 = dnnl_cpu_isa_avx10_2_512_amx_2,
+    /// @copydoc dnnl_cpu_isa_avx10_2_ace
+    avx10_2_ace = dnnl_cpu_isa_avx10_2_ace,
 };
 
 /// @copydoc dnnl_set_max_cpu_isa()

--- a/include/oneapi/dnnl/dnnl_types.h
+++ b/include/oneapi/dnnl/dnnl_types.h
@@ -3019,6 +3019,10 @@ typedef enum {
     dnnl_cpu_isa_avx10_2_amx_2 = 0x22fff,
     /// @copydoc dnnl_cpu_isa_avx10_2_amx_2
     dnnl_cpu_isa_avx10_2_512_amx_2 = dnnl_cpu_isa_avx10_2_amx_2,
+
+    /// Intel AVX10.2 with AI Compute Extensions (ACE).
+    /// This ISA has preview support in the library and is disabled by default.
+    dnnl_cpu_isa_avx10_2_ace = 0xa03ff,
 } dnnl_cpu_isa_t;
 
 /// CPU ISA hints flags

--- a/src/common/dnnl_debug_autogenerated.cpp
+++ b/src/common/dnnl_debug_autogenerated.cpp
@@ -1967,6 +1967,7 @@ const char *dnnl_cpu_isa2str(dnnl_cpu_isa_t v) {
     if (v == dnnl_cpu_isa_avx10_2_512) return "cpu_isa_avx10_2_512";
     if (v == dnnl_cpu_isa_avx10_2_amx_2) return "cpu_isa_avx10_2_amx_2";
     if (v == dnnl_cpu_isa_avx10_2_512_amx_2) return "cpu_isa_avx10_2_512_amx_2";
+    if (v == dnnl_cpu_isa_avx10_2_ace) return "cpu_isa_avx10_2_ace";
     assert(!"unknown cpu_isa");
     return "unknown cpu_isa";
 }

--- a/src/cpu/x64/cpu_isa_traits.cpp
+++ b/src/cpu/x64/cpu_isa_traits.cpp
@@ -68,6 +68,7 @@ cpu_isa_t init_max_cpu_isa() {
         ELSEIF_HANDLE_CASE(avx512_core_amx_fp16);
         ELSEIF_HANDLE_CASE(avx10_2);
         ELSEIF_HANDLE_CASE(avx10_2_amx_2);
+        ELSEIF_HANDLE_CASE(avx10_2_ace);
 
 #undef IF_HANDLE_CASE
 #undef ELSEIF_HANDLE_CASE
@@ -104,13 +105,14 @@ set_once_before_first_get_setting_t<dnnl_cpu_isa_hints_t> &cpu_isa_hints() {
 } // namespace
 
 struct isa_info_t {
-    isa_info_t(cpu_isa_t aisa) : isa(aisa) {};
+    isa_info_t(cpu_isa_t aisa) : isa(aisa) {}
 
     // this converter is needed as code base defines certain ISAs
     // that the library does not expose (e.g. avx512_core_bf16_ymm),
     // so the internal and external enum types do not coincide.
     dnnl_cpu_isa_t convert_to_public_enum(void) const {
         switch (isa) {
+            case avx10_2_ace: return dnnl_cpu_isa_avx10_2_ace;
             case avx10_2_amx_2: return dnnl_cpu_isa_avx10_2_amx_2;
             case avx10_2: return dnnl_cpu_isa_avx10_2;
             case avx512_core_amx_fp16: return dnnl_cpu_isa_avx512_core_amx_fp16;
@@ -131,6 +133,7 @@ struct isa_info_t {
 
     const char *get_name() const {
         switch (isa) {
+            case avx10_2_ace: return "Intel AVX10.2 and ACE support (preview)";
             case avx10_2_amx_2:
                 return "Intel AVX10.2 and Intel AMX with float8, float16, "
                        "bfloat16 and 8-bit integer support";
@@ -174,7 +177,10 @@ static isa_info_t get_isa_info_t(void) {
     // descending order due to mayiuse check
 #define HANDLE_CASE(cpu_isa) \
     if (mayiuse(cpu_isa)) return isa_info_t(cpu_isa);
+    // Note: avx10_2_amx_2 and avx10_2_ace are not ordered with respect to each
+    // other. Probe TMUL first as it carries the compute-heavy AMX features.
     HANDLE_CASE(avx10_2_amx_2);
+    HANDLE_CASE(avx10_2_ace);
     HANDLE_CASE(avx10_2);
     HANDLE_CASE(avx512_core_amx_fp16);
     HANDLE_CASE(avx512_core_amx);
@@ -234,6 +240,7 @@ status_t set_max_cpu_isa(dnnl_cpu_isa_t isa) {
         HANDLE_CASE(avx512_core_amx_fp16);
         HANDLE_CASE(avx10_2);
         HANDLE_CASE(avx10_2_amx_2);
+        HANDLE_CASE(avx10_2_ace);
         default: return invalid_arguments;
     }
     assert(isa_to_set != isa_undef);
@@ -275,7 +282,9 @@ int get_max_palette() {
     }
 }
 int get_target_palette() {
-    constexpr int max_supported_palette = 1;
+    // Only the TMUL palette is returned here; ACE code paths select
+    // amx_palette_ace explicitly instead.
+    constexpr int max_supported_palette = amx_palette_tmul;
     return nstl::min(max_supported_palette, get_max_palette());
 }
 
@@ -399,6 +408,61 @@ bool is_available() {
     return amx_setting().get();
 }
 } // namespace amx
+
+namespace ace {
+
+namespace {
+#if defined(__linux__) || defined(_WIN32)
+// SCALEDATA (Block Scale Register) XSAVE state component.
+constexpr int xfeature_scaledata = 20;
+#endif
+
+#ifdef __linux__
+bool init() {
+    // ACE requires XCR0[20,18:17] == 0b111: the AMX TILECFG/TILEDATA state
+    // must be enabled in addition to SCALEDATA.
+    if (!amx::is_available()) return false;
+
+    unsigned long bitmask = 0;
+    long status = syscall(SYS_arch_prctl, ARCH_GET_XCOMP_PERM, &bitmask);
+    if (0 != status) return false;
+    if (bitmask & (1UL << xfeature_scaledata)) return true;
+
+    status = syscall(SYS_arch_prctl, ARCH_REQ_XCOMP_PERM, xfeature_scaledata);
+    if (0 != status) return false; // SCALEDATA setup failed, ACE is not allowed
+
+    status = syscall(SYS_arch_prctl, ARCH_GET_XCOMP_PERM, &bitmask);
+    if (0 != status || !(bitmask & (1UL << xfeature_scaledata))) return false;
+
+    return true;
+}
+#elif defined(_WIN32)
+bool init() {
+    if (!amx::is_available()) return false;
+
+    const bool xsave_supported = cpu().has(Xbyak::util::Cpu::tOSXSAVE);
+    if (!xsave_supported) return false;
+
+    const uint64_t xcr0_features = Xbyak::util::Cpu::getXfeature();
+    return ((xcr0_features >> xfeature_scaledata) & 1) == 1;
+}
+#else
+bool init() {
+    // Disable ACE by default to avoid potential crashes.
+    return false;
+}
+#endif
+
+set_once_before_first_get_setting_t<bool> &ace_setting() {
+    static set_once_before_first_get_setting_t<bool> setting(init());
+    return setting;
+}
+} // namespace
+
+bool is_available() {
+    return ace_setting().get();
+}
+} // namespace ace
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -96,6 +96,7 @@ enum cpu_isa_bit_t : unsigned {
     amx_bf16_bit = 1u << 16,
     amx_fp16_bit = 1u << 17,
     amx_2_bit = 1u << 18,
+    ace_bit = 1u << 19,
 
     // Fill in hints from most significant bit to least significant bit
     prefer_ymm_bit = 1u << (cpu_isa_total_bits - 1),
@@ -159,8 +160,16 @@ enum cpu_isa_t : unsigned {
     avx10_2_amx_2
     = avx10_2 | amx_tile | amx_int8 | amx_bf16 | amx_fp16 | amx_2_bit,
     avx10_2_512_amx_2 = avx10_2_amx_2,
+    // ACE includes amx_tile because it shares the tile register file and the
+    // tile management instructions with AMX. It is not derived from
+    // avx10_2_amx_2: the TMUL and ACE palettes are independent, so that would
+    // claim TMUL compute support an ACE-only part does not have.
+    avx10_2_ace = avx10_2 | amx_tile | ace_bit,
     // NOTES: 1. isa_all by default has no isa specific hints
-    isa_all = ~0u & ~cpu_isa_hints_utils::hints_mask,
+    //        2. avx10_2_ace is under preview support and turned off by
+    //           default. It is enabled only when the max CPU ISA is explicitly
+    //           set to avx10_2_ace.
+    isa_all = ~0u & ~ace_bit & ~cpu_isa_hints_utils::hints_mask,
 };
 
 std::string isa2str(cpu_isa_t isa);
@@ -266,6 +275,15 @@ struct palette_config_t {
     uint8_t rows[max_size];
 };
 #pragma pack(pop)
+
+// AMX/ACE tile palette identifiers.
+// Palette 0 selects the INIT state, palette 1 the AMX TMUL tile configuration
+// and palette 2 the ACE configuration with fixed 16x64B tiles.
+enum : uint8_t {
+    amx_palette_init = 0,
+    amx_palette_tmul = 1,
+    amx_palette_ace = 2,
+};
 
 template <>
 struct cpu_isa_traits_t<isa_all> {
@@ -373,6 +391,12 @@ struct cpu_isa_traits_t<avx10_2_amx_2> : public cpu_isa_traits_t<avx10_2> {
     static constexpr const char *user_option_env = "avx10_2_amx_2";
 };
 
+template <>
+struct cpu_isa_traits_t<avx10_2_ace> : public cpu_isa_traits_t<avx10_2> {
+    static constexpr dnnl_cpu_isa_t user_option_val = dnnl_cpu_isa_avx10_2_ace;
+    static constexpr const char *user_option_env = "avx10_2_ace";
+};
+
 inline const Xbyak::util::Cpu &cpu() {
     const static Xbyak::util::Cpu cpu_;
     return cpu_;
@@ -409,6 +433,15 @@ inline int get_max_palette_size() {
 }
 
 } // namespace amx
+
+namespace ace {
+
+// ACE adds the SCALEDATA (Block Scale Register) XSAVE state component on top
+// of the AMX TILECFG/TILEDATA components. ACE instructions require
+// XCR0[20,18:17] == 0b111, so AMX state alone is not sufficient.
+bool DNNL_API is_available();
+
+} // namespace ace
 
 namespace {
 
@@ -486,6 +519,20 @@ inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
             REG_AMX_ISA(return mayiuse(avx10_2, soft) && mayiuse(amx_tile, soft)
                     && cpu().has(Cpu::tAMX_TF32) && cpu().has(Cpu::tAMX_AVX512)
                     && cpu().has(Cpu::tAMX_MOVRS) && cpu().has(Cpu::tAMX_FP8));
+        case avx10_2_ace:
+            // ACE v1 detection:
+            //   1. AVX10.2
+            //   2. AVX10_V2_AUX
+            //   3. ACE
+            //   4. ACE_VSN >= 1 (and MAX_PALETTE >= 2)
+            //   5. XCR0[20,18:17] = 0b111  (ace::is_available)
+            //   6. XCR0[7:5] = 0b111       (implied by the AVX10 checks)
+            //   7. CR4.OSXSAVE = 1         (implied by the XCR0 queries)
+            REG_AMX_ISA(return mayiuse(avx10_2, soft) && mayiuse(amx_tile, soft)
+                    && cpu().has(Cpu::tACE) && cpu().getACEversion() >= 1
+                    && cpu().getMaxPalette() >= amx_palette_ace
+                    && cpu().has(Cpu::tAVX10_V2_AUX)
+                    && x64::ace::is_available());
         case isa_all: return false;
         case isa_undef: return true;
     }
@@ -512,6 +559,13 @@ inline bool isa_has_f16(cpu_isa_t isa) {
 
 inline bool isa_has_masks(cpu_isa_t isa) {
     return is_superset(isa, avx512_core);
+}
+
+// True when matrix multiplication accumulates into tile registers, through
+// TMUL, through the ACE outer products, or through both. This is "has tiles",
+// not "can emit TMUL": the latter is false on an ACE-only part.
+inline bool isa_has_tile_accumulators(cpu_isa_t isa) {
+    return is_superset(isa, avx512_core_amx) || is_superset(isa, avx10_2_ace);
 }
 
 // Check if the ISA has saturating conversion support
@@ -572,6 +626,7 @@ inline int isa_num_vregs(cpu_isa_t isa) {
     (isa) == avx10_1_512_amx_fp16 ? prefix STRINGIFY(avx10_1_512_amx_fp16) : \
     (isa) == avx10_2 ? prefix STRINGIFY(avx10_2) : \
     (isa) == avx10_2_amx_2 ? prefix STRINGIFY(avx10_2_amx_2) : \
+    (isa) == avx10_2_ace ? prefix STRINGIFY(avx10_2_ace) : \
     prefix suffix_if_any)
 /* clang-format on */
 

--- a/tests/test_isa_common.hpp
+++ b/tests/test_isa_common.hpp
@@ -58,6 +58,7 @@ inline impl::cpu::x64::cpu_isa_t cvt_to_internal_cpu_isa(cpu_isa input_isa) {
         HANDLE_ISA(avx512_core_amx_fp16);
         HANDLE_ISA(avx10_2);
         HANDLE_ISA(avx10_2_amx_2);
+        HANDLE_ISA(avx10_2_ace);
         default:
             assert(input_isa == cpu_isa::isa_default);
             return impl::cpu::x64::cpu_isa_t::isa_all;
@@ -114,7 +115,8 @@ inline const std::set<cpu_isa> &cpu_isa_list() {
             cpu_isa::avx512_core, cpu_isa::avx512_core_vnni,
             cpu_isa::avx512_core_bf16, cpu_isa::avx512_core_fp16,
             cpu_isa::avx512_core_amx, cpu_isa::avx512_core_amx_fp16,
-            cpu_isa::avx10_2, cpu_isa::avx10_2_amx_2, cpu_isa::isa_default};
+            cpu_isa::avx10_2, cpu_isa::avx10_2_amx_2, cpu_isa::avx10_2_ace,
+            cpu_isa::isa_default};
 
     return isa_list;
 }
@@ -183,6 +185,13 @@ inline const std::set<cpu_isa> &compatible_cpu_isa(cpu_isa input_isa) {
             {cpu_isa::avx10_2,
                     {cpu_isa::avx10_2, cpu_isa::avx10_1_512,
                             cpu_isa::avx512_core_fp16,
+                            cpu_isa::avx512_core_bf16,
+                            cpu_isa::avx512_core_vnni, cpu_isa::avx512_core,
+                            cpu_isa::avx2_vnni_2, cpu_isa::avx2_vnni,
+                            cpu_isa::avx2, cpu_isa::avx, cpu_isa::sse41}},
+            {cpu_isa::avx10_2_ace,
+                    {cpu_isa::avx10_2_ace, cpu_isa::avx10_2,
+                            cpu_isa::avx10_1_512, cpu_isa::avx512_core_fp16,
                             cpu_isa::avx512_core_bf16,
                             cpu_isa::avx512_core_vnni, cpu_isa::avx512_core,
                             cpu_isa::avx2_vnni_2, cpu_isa::avx2_vnni,

--- a/third_party/xbyak/xbyak/xbyak.h
+++ b/third_party/xbyak/xbyak/xbyak.h
@@ -2769,6 +2769,12 @@ private:
 		}
 		XBYAK_THROW(ERR_BAD_COMBINATION);
 	}
+	// (x, x, x/m), (x, y, y/m), (x, z, z/m) ; 4:1 narrowing with a bias operand
+	void opCvt7(const Xmm& x1, const Xmm& x2, const Operand& op, uint64_t type, int code)
+	{
+		if (!(x1.isXMM() && (x2.getBit() == op.getBit() || op.isMEM()))) XBYAK_THROW(ERR_BAD_COMBINATION)
+		opVex(x1, &x2, op, type, code);
+	}
 	const Xmm& cvtIdx0(const Operand& x) const
 	{
 		return x.isZMM() ? zm0 : x.isYMM() ? ym0 : xm0;

--- a/third_party/xbyak/xbyak/xbyak_mnemonic.h
+++ b/third_party/xbyak/xbyak/xbyak_mnemonic.h
@@ -1617,6 +1617,8 @@ void vtestps(const Xmm& xm, const Operand& op) { opAVX_X_XM_IMM(xm, op, T_66|T_0
 void vucomisd(const Xmm& xm, const Operand& op) { opAVX_X_XM_IMM(xm, op, T_N8|T_66|T_0F|T_EW1|T_EVEX|T_SAE_X, 0x2E); }
 void vucomiss(const Xmm& xm, const Operand& op) { opAVX_X_XM_IMM(xm, op, T_N4|T_0F|T_W0|T_EVEX|T_SAE_X, 0x2E); }
 void vunpckhpd(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_66|T_0F|T_EW1|T_YMM|T_EVEX|T_B64, 0x15); }
+// ACE v1: sub-byte element extraction to byte lanes.
+void vunpackb(const Xmm& x, const Operand& op, uint8_t imm) { opAVX_X_XM_IMM(x, op, T_0F3A|T_W0|T_YMM|T_MUST_EVEX, 0x3D, imm); }
 void vunpckhps(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_0F|T_W0|T_YMM|T_EVEX|T_B32, 0x15); }
 void vunpcklpd(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_66|T_0F|T_EW1|T_YMM|T_EVEX|T_B64, 0x14); }
 void vunpcklps(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_0F|T_W0|T_YMM|T_EVEX|T_B32, 0x14); }
@@ -2007,6 +2009,28 @@ void tilerelease() { db(0xc4); db(0xe2); db(0x78); db(0x49); db(0xc0); }
 void tilezero(const Tmm& t) { opVex(t, &tmm0, tmm0, T_F2|T_0F38|T_W0, 0x49); }
 void tconjtfp16(const Tmm& t1, const Tmm& t2) { opVex(t1, 0, t2, T_66|T_0F38|T_W0, 0x6B); }
 void ttransposed(const Tmm& t1, const Tmm& t2) { opVex(t1, 0, t2, T_F3|T_0F38|T_W0, 0x5F); }
+// ACE v1 tile outer products.
+void top2bf16ps(const Tmm& x1, const Zmm& x2, const Zmm& x3) { opVex(x1, &x3, x2, T_F3 | T_0F38 | T_W0 | T_EVEX, 0x5c); }
+void top4buud(const Tmm& x1, const Zmm& x2, const Zmm& x3) { opVex(x1, &x3, x2, T_0F38 | T_W0 | T_EVEX, 0x5e); }
+void top4busd(const Tmm& x1, const Zmm& x2, const Zmm& x3) { opVex(x1, &x3, x2, T_66 | T_0F38 | T_W0 | T_EVEX, 0x5e); }
+void top4bsud(const Tmm& x1, const Zmm& x2, const Zmm& x3) { opVex(x1, &x3, x2, T_F3 | T_0F38 | T_W0 | T_EVEX, 0x5e); }
+void top4bssd(const Tmm& x1, const Zmm& x2, const Zmm& x3) { opVex(x1, &x3, x2, T_F2 | T_0F38 | T_W0 | T_EVEX, 0x5e); }
+// BSRINIT bsr0: VEX.128.F2.0F38.W1 49 C0 -- initializes BSR0 to all 0x7F (scale=1.0)
+void bsrinit() { db(0xc4); db(0xe2); db(0xfb); db(0x49); db(0xc0); }
+// ACE v1 Block Scale Register moves. Only one BSR is architected (bsr0), so
+// it is implicit and encoded as reg field 000.
+void bsrmovf(const Zmm& x1, const Operand& op) { opVex(zmm0, &x1, op, T_MAP6 | T_EW1 | T_MUST_EVEX, 0x95); }
+void bsrmovh(const Operand& op) { opVex(zmm0, 0, op, T_F2 | T_MAP6 | T_EW1 | T_MUST_EVEX, 0x95); }
+void bsrmovh_store(const Operand& op) { opVex(zmm0, 0, op, T_F2 | T_MAP6 | T_W0 | T_MUST_EVEX, 0x95); }
+void bsrmovl(const Operand& op) { opVex(zmm0, 0, op, T_F3 | T_MAP6 | T_EW1 | T_MUST_EVEX, 0x95); }
+void bsrmovl_store(const Operand& op) { opVex(zmm0, 0, op, T_F3 | T_MAP6 | T_W0 | T_MUST_EVEX, 0x95); }
+// ACE v1 MX FP8 rank-4 outer products.
+void top4mxbf8ps(const Tmm& x1, const Zmm& x2, const Zmm& x3, uint8_t imm) { opVex(x1, &x3, x2, T_0F3A | T_W0 | T_EVEX, 0x8d, imm); }
+void top4mxhf8ps(const Tmm& x1, const Zmm& x2, const Zmm& x3, uint8_t imm) { opVex(x1, &x3, x2, T_66 | T_0F3A | T_W0 | T_EVEX, 0x8d, imm); }
+void top4mxbhf8ps(const Tmm& x1, const Zmm& x2, const Zmm& x3, uint8_t imm) { opVex(x1, &x3, x2, T_F2 | T_0F3A | T_W0 | T_EVEX, 0x8d, imm); }
+void top4mxhbf8ps(const Tmm& x1, const Zmm& x2, const Zmm& x3, uint8_t imm) { opVex(x1, &x3, x2, T_F3 | T_0F3A | T_W0 | T_EVEX, 0x8d, imm); }
+// ACE v1 MX INT8 rank-4 outer product.
+void top4mxbssps(const Tmm& x1, const Zmm& x2, const Zmm& x3, uint8_t imm) { opVex(x1, &x3, x2, T_F2 | T_0F3A | T_W0 | T_EVEX, 0x8f, imm); }
 #else
 void jcxz(std::string label) { db(0x67); opJmp(label, T_SHORT, 0xe3, 0, 0); }
 void jcxz(const Label& label) { db(0x67); opJmp(label, T_SHORT, 0xe3, 0, 0); }
@@ -2262,12 +2286,28 @@ void vcvt2ph2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_X
 void vcvt2ps2phx(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_66|T_0F38|T_W0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x67); }
 void vcvtbf162ibs(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_F2|T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x69); }
 void vcvtbf162iubs(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_F2|T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x6B); }
+// ACE v1 sub-byte converts: bf4/bf6 are the FP4/FP6 formats, bf8/hf8 the two
+// FP8 formats, a "rop" infix selects RTO rounding and a trailing "s"
+// saturates. FP32 forms change width 4:1, so the narrow side is always xmm.
+void vcvtbf42hf8(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_N8|T_N_VL|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x37); }
+void vcvtbf62hf8(const Xmm& x1, const Xmm& x2) { opAVX_X_XM_IMM(x1, x2, T_66|T_MAP5|T_EW1|T_YMM|T_MUST_EVEX, 0x37); }
+void vcvtbf82bf4s(const Operand& op, const Xmm& x) { opVmov(op, x, T_N8|T_N_VL|T_F3|T_MAP5|T_EW1|T_YMM|T_MUST_EVEX, 0x3D, true); }
+void vcvtbf82bf6s(const Xmm& x1, const Xmm& x2) { opAVX_X_XM_IMM(x1, x2, T_F3|T_MAP5|T_EW1|T_YMM|T_MUST_EVEX, 0x3E); }
+void vcvtbf82ps(const Xmm& x, const Operand& op) { if (!op.isXMM() && !op.isMEM()) XBYAK_THROW(ERR_BAD_COMBINATION) opVex(x, 0, op, T_N4|T_N_VL|T_MAP5|T_EW1|T_YMM|T_MUST_EVEX, 0x36); }
 void vcvtbiasph2bf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_0F38|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
 void vcvtbiasph2bf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x74); }
 void vcvtbiasph2hf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x18); }
 void vcvtbiasph2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt6(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B16, 0x1B); }
+void vcvtbiasps2bf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt7(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x39); }
+void vcvtbiasps2bf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt7(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x3B); }
+void vcvtbiasps2hf8(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt7(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x38); }
+void vcvtbiasps2hf8s(const Xmm& x1, const Xmm& x2, const Operand& op) { opCvt7(x1, x2, op, T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x3A); }
 void vcvtdq2ph(const Xmm& x, const Operand& op) { checkCvt4(x, op); opCvt(x, op, T_N16|T_N_VL|T_MAP5|T_W0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x5B); }
+void vcvthf62hf8(const Xmm& x1, const Xmm& x2) { opAVX_X_XM_IMM(x1, x2, T_66|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x37); }
+void vcvthf82bf4s(const Operand& op, const Xmm& x) { opVmov(op, x, T_N8|T_N_VL|T_F3|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x3D, true); }
+void vcvthf82hf6s(const Xmm& x1, const Xmm& x2) { opAVX_X_XM_IMM(x1, x2, T_F3|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x3C); }
 void vcvthf82ph(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_N8|T_N_VL|T_F2|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x1E); }
+void vcvthf82ps(const Xmm& x, const Operand& op) { if (!op.isXMM() && !op.isMEM()) XBYAK_THROW(ERR_BAD_COMBINATION) opVex(x, 0, op, T_N4|T_N_VL|T_MAP5|T_W0|T_YMM|T_MUST_EVEX, 0x36); }
 void vcvtne2ps2bf16(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_F2|T_0F38|T_W0|T_YMM|T_SAE_Z|T_MUST_EVEX|T_B32, 0x72); }
 void vcvtpd2ph(const Xmm& x, const Operand& op) { opCvt5(x, op, T_N16|T_N_VL|T_66|T_MAP5|T_EW1|T_ER_Z|T_MUST_EVEX|T_B64, 0x5A); }
 void vcvtpd2qq(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_66|T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0x7B); }
@@ -2290,12 +2330,20 @@ void vcvtph2w(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_66|T_MA
 void vcvtps2ibs(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_66|T_MAP5|T_W0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x69); }
 void vcvtps2iubs(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_66|T_MAP5|T_W0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x6B); }
 void vcvtps2phx(const Xmm& x, const Operand& op) { checkCvt4(x, op); opCvt(x, op, T_N16|T_N_VL|T_66|T_MAP5|T_W0|T_ER_Z|T_MUST_EVEX|T_B32, 0x1D); }
+// ACE v1 FP32 to FP8 converts.
+void vcvtps2bf8(const Xmm& x, const Operand& op) { opCvt5(x, op, T_F3|T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x39); }
+void vcvtps2bf8s(const Xmm& x, const Operand& op) { opCvt5(x, op, T_F3|T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x3B); }
+void vcvtps2hf8(const Xmm& x, const Operand& op) { opCvt5(x, op, T_F3|T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x38); }
+void vcvtps2hf8s(const Xmm& x, const Operand& op) { opCvt5(x, op, T_F3|T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x3A); }
 void vcvtps2qq(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_N8|T_N_VL|T_66|T_0F|T_W0|T_YMM|T_ER_Y|T_MUST_EVEX|T_B32, 0x7B); }
 void vcvtps2udq(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_0F|T_W0|T_YMM|T_ER_Z|T_MUST_EVEX|T_B32, 0x79); }
 void vcvtps2uqq(const Xmm& x, const Operand& op) { checkCvt1(x, op); opVex(x, 0, op, T_N8|T_N_VL|T_66|T_0F|T_W0|T_YMM|T_ER_Y|T_MUST_EVEX|T_B32, 0x79); }
 void vcvtqq2pd(const Xmm& x, const Operand& op) { opAVX_X_XM_IMM(x, op, T_F3|T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0xE6); }
 void vcvtqq2ph(const Xmm& x, const Operand& op) { opCvt5(x, op, T_N16|T_N_VL|T_MAP5|T_EW1|T_ER_Z|T_MUST_EVEX|T_B64, 0x5B); }
 void vcvtqq2ps(const Xmm& x, const Operand& op) { opCvt2(x, op, T_0F|T_EW1|T_YMM|T_ER_Z|T_MUST_EVEX|T_B64, 0x5B); }
+// ACE v1 FP32 to FP8 converts, RTO rounding.
+void vcvtrops2hf8(const Xmm& x, const Operand& op) { opCvt5(x, op, T_66|T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x38); }
+void vcvtrops2hf8s(const Xmm& x, const Operand& op) { opCvt5(x, op, T_66|T_MAP5|T_W0|T_YMM|T_MUST_EVEX|T_B32, 0x3A); }
 void vcvtsd2sh(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N8|T_F2|T_MAP5|T_EW1|T_ER_X|T_MUST_EVEX, 0x5A); }
 void vcvtsd2usi(const Reg32e& r, const Operand& op) { uint64_t type = (T_N8|T_F2|T_0F|T_ER_X|T_MUST_EVEX) | (r.isREG(64) ? T_EW1 : T_W0); opVex(r, &xm0, op, type, 0x79); }
 void vcvtsh2sd(const Xmm& x1, const Xmm& x2, const Operand& op) { opAVX_X_X_XM(x1, x2, op, T_N2|T_F3|T_MAP5|T_W0|T_SAE_X|T_MUST_EVEX, 0x5A); }
@@ -2584,6 +2632,9 @@ void vpmovqb(const Operand& op, const Xmm& x) { opVmov(op, x, T_N2|T_N_VL|T_F3|T
 void vpmovqd(const Operand& op, const Xmm& x) { opVmov(op, x, T_N8|T_N_VL|T_F3|T_0F38|T_W0|T_YMM|T_MUST_EVEX|T_M_K, 0x35, true); }
 void vpmovqw(const Operand& op, const Xmm& x) { opVmov(op, x, T_N4|T_N_VL|T_F3|T_0F38|T_W0|T_YMM|T_MUST_EVEX|T_M_K, 0x34, false); }
 void vpmovsdb(const Operand& op, const Xmm& x) { opVmov(op, x, T_N4|T_N_VL|T_F3|T_0F38|T_W0|T_YMM|T_MUST_EVEX|T_M_K, 0x21, false); }
+// ACE v1: symmetric signed saturation narrow. Unlike VPMOVSDB
+// this clamps to [-127, +127] so the result stays negatable.
+void vpmovssdb(const Operand& op, const Xmm& x) { opVmov(op, x, T_N4|T_N_VL|T_F3|T_0F38|T_W0|T_YMM|T_MUST_EVEX|T_M_K, 0x41, false); }
 void vpmovsdw(const Operand& op, const Xmm& x) { opVmov(op, x, T_N8|T_N_VL|T_F3|T_0F38|T_W0|T_YMM|T_MUST_EVEX|T_M_K, 0x23, true); }
 void vpmovsqb(const Operand& op, const Xmm& x) { opVmov(op, x, T_N2|T_N_VL|T_F3|T_0F38|T_W0|T_YMM|T_MUST_EVEX|T_M_K, 0x22, false); }
 void vpmovsqd(const Operand& op, const Xmm& x) { opVmov(op, x, T_N8|T_N_VL|T_F3|T_0F38|T_W0|T_YMM|T_MUST_EVEX|T_M_K, 0x25, true); }
@@ -2734,8 +2785,15 @@ void tcvtrowps2phh(const Zmm& z, const Tmm& t, const Reg32& r) { opVex(z, &r, t,
 void tcvtrowps2phh(const Zmm& z, const Tmm& t, uint8_t imm) { opVex(z, 0, t, T_0F3A|T_W0|T_MUST_EVEX, 0x07, imm); }
 void tcvtrowps2phl(const Zmm& z, const Tmm& t, const Reg32& r) { opVex(z, &r, t, T_66|T_0F38|T_W0|T_MUST_EVEX, 0x6D); }
 void tcvtrowps2phl(const Zmm& z, const Tmm& t, uint8_t imm) { opVex(z, 0, t, T_F2|T_0F3A|T_W0|T_MUST_EVEX, 0x77, imm); }
+// ACE v1: write a column of a tile register.
+void tilemovcol(const Tmm& t, const Zmm& z, const Reg32& r) { opVex(t, &r, z, T_66|T_0F38|T_EW1|T_MUST_EVEX, 0x4B); }
+void tilemovcol(const Tmm& t, const Zmm& z, uint8_t imm) { opVex(t, 0, z, T_66|T_0F3A|T_EW1|T_MUST_EVEX, 0x2F, imm); }
 void tilemovrow(const Zmm& z, const Tmm& t, const Reg32& r) { opVex(z, &r, t, T_66|T_0F38|T_W0|T_MUST_EVEX, 0x4A); }
 void tilemovrow(const Zmm& z, const Tmm& t, uint8_t imm) { opVex(z, 0, t, T_66|T_0F3A|T_W0|T_MUST_EVEX, 0x07, imm); }
+// ACE v1 extends TILEMOVROW to also write a tile register row.
+// Same opcodes as the read forms above; the direction is selected by W.
+void tilemovrow(const Tmm& t, const Zmm& z, const Reg32& r) { opVex(t, &r, z, T_66|T_0F38|T_EW1|T_MUST_EVEX, 0x4A); }
+void tilemovrow(const Tmm& t, const Zmm& z, uint8_t imm) { opVex(t, 0, z, T_66|T_0F3A|T_EW1|T_MUST_EVEX, 0x07, imm); }
 void vmovrsb(const Xmm& x, const Address& addr) { opVex(x, 0, addr, T_F2|T_MAP5|T_W0|T_MUST_EVEX, 0x6F); }
 void vmovrsd(const Xmm& x, const Address& addr) { opVex(x, 0, addr, T_F3|T_MAP5|T_W0|T_MUST_EVEX, 0x6F); }
 void vmovrsq(const Xmm& x, const Address& addr) { opVex(x, 0, addr, T_F3|T_MAP5|T_EW1|T_MUST_EVEX, 0x6F); }

--- a/third_party/xbyak/xbyak/xbyak_util.h
+++ b/third_party/xbyak/xbyak/xbyak_util.h
@@ -224,6 +224,8 @@ private:
 	uint32_t coresSharingDataCache_[maxNumberCacheLevels];
 	uint32_t dataCacheLevels_;
 	uint32_t avx10version_;
+	uint32_t aceVersion_;
+	uint32_t maxPalette_;
 
 	uint32_t get32bitAsBE(const char *x) const
 	{
@@ -635,6 +637,9 @@ public:
 	XBYAK_DEFINE_TYPE(96, tMOVRS);
 	XBYAK_DEFINE_TYPE(97, tHYBRID);
 	XBYAK_DEFINE_TYPE(98, tAMX_COMPLEX);
+	XBYAK_DEFINE_TYPE(99, tACE); // AI Compute Extensions (ACE)
+	XBYAK_DEFINE_TYPE(100, tAVX10_V1_AUX);
+	XBYAK_DEFINE_TYPE(101, tAVX10_V2_AUX);
 
 #undef XBYAK_SPLIT_ID
 #undef XBYAK_DEFINE_TYPE
@@ -646,6 +651,8 @@ public:
 		, coresSharingDataCache_()
 		, dataCacheLevels_(0)
 		, avx10version_(0)
+		, aceVersion_(0)
+		, maxPalette_(0)
 	{
 		uint32_t data[4] = {};
 		const uint32_t& eax = data[0];
@@ -793,6 +800,8 @@ public:
 				if (edx & (1U << 14)) type_ |= tPREFETCHITI;
 				if (edx & (1U << 19)) type_ |= tAVX10;
 				if (edx & (1U << 21)) type_ |= tAPX_F;
+				// ACE: CPUID.(EAX=07H, ECX=1):ECX[11]
+				if (ecx & (1U << 11)) type_ |= tACE;
 
 				getCpuidEx(0x1e, 1, data);
 				if (eax & (1U << 4)) type_ |= tAMX_FP8;
@@ -811,6 +820,21 @@ public:
 		if (has(tAVX10) && maxNum >= 0x24) {
 			getCpuidEx(0x24, 0, data);
 			avx10version_ = ebx & mask(7);
+			// Converged Vector ISA Sub-Leaf 1
+			if (eax >= 1) {
+				getCpuidEx(0x24, 1, data);
+				if (ecx & (1U << 2)) type_ |= tAVX10_V1_AUX;
+				if (ecx & (1U << 3)) type_ |= tAVX10_V2_AUX;
+			}
+		}
+		// Tile Information: MAX_PALETTE and, for palette 2, the ACE version.
+		if (has(tAMX_TILE) && maxNum >= 0x1d) {
+			getCpuidEx(0x1d, 0, data);
+			maxPalette_ = eax;
+			if (maxPalette_ >= 2) {
+				getCpuidEx(0x1d, 2, data);
+				aceVersion_ = eax & mask(8);
+			}
 		}
 		setFamily();
 		setNumCores();
@@ -829,6 +853,10 @@ public:
 		return (type & type_) == type;
 	}
 	int getAVX10version() const { return avx10version_; }
+	// ACE ISA major version (CPUID.(EAX=1DH, ECX=2):EAX[7:0]); 0 if no ACE.
+	int getACEversion() const { return aceVersion_; }
+	// MAX_PALETTE (CPUID.(EAX=1DH, ECX=0):EAX); 0 if AMX tile is unsupported.
+	int getMaxPalette() const { return maxPalette_; }
 };
 #ifdef _MSC_VER
 	#pragma warning(pop)


### PR DESCRIPTION
This PR adds support for Intel AVX10 with AI Compute Extensions (ACE). 
The changes introduce new ISA (Instruction Set Architecture) identifiers, detection logic, and instruction definitions for ACE, enabling the library to detect, expose, and utilize Intel AVX10 ACE features, including new tile and palette management and ACE-specific instructions.
The updates span the main DNNL headers, CPU ISA traits, and the Xbyak JIT assembler.

**Key changes include:**

### 1. AVX10 ACE ISA Integration

- Added the `avx10_512_ace` ISA to both public (`dnnl_cpu_isa_t` in `dnnl_types.h`) and internal (`cpu_isa_t` in `cpu_isa_traits.hpp`) enumerations, with associated documentation and string conversion support. 
- Implemented detection logic for ACE support, including OS-specific checks for the required XSAVE state (SCALEDATA) and palette support. 
- Added trait specializations and user option environment variables for the new ISA.

### 2. Tile and Palette Support Extensions

- Defined ACE-specific palette identifiers and updated palette selection logic to distinguish between AMX and ACE. 
- Updated helper functions to recognize ACE as having tile accumulator support.

### 3. Xbyak JIT Assembler: ACE Instruction Support

- Added new Xbyak assembler methods for ACE v1 instructions, including tile outer products, block scale register moves, and sub-byte element extraction.

### 4. Miscellaneous

- Updated name and stringification utilities to handle the new ISA and provide descriptive names. 
- Added a new ISA bitmask for ACE.

