### PR TITLE
third_party: ngen: sync with upstream

### DIFF
--- a/third_party/ngen/ngen.hpp
+++ b/third_party/ngen/ngen.hpp
@@ -372,6 +372,13 @@ protected:
 
     void setEfficient64Bit(bool def = true)         { useEfficient64Bit = def; }
     bool getEfficient64Bit() const                  { return useEfficient64Bit; }
+    AddressBase getScratchSurface() const {
+        if (getEfficient64Bit()) {
+            return AddressBase::createSS(0);    // scratch surface state at IND0
+        } else {
+            return AddressBase::createBSS(0);
+        }
+    }
 
     // Stream handling.
     void pushStream()                               { pushStream(new InstructionStream()); }
@@ -1278,14 +1285,16 @@ public:
         auto udst = dst, usrc0 = src0;
         udst.setType(unsignedType(dst.getType()));
         usrc0.setType(unsignedType(src0.getType()));
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, unsignedType(getDataType<DT>()), mod, udst, usrc0, src1, loc);
+        auto utype = unsignedType(getDataType<DT>());
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, utype, mod, udst, usrc0, src1, loc);
     }
     template <typename DT = void>
     void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
         auto udst = dst, usrc0 = src0;
         udst.setType(unsignedType(dst.getType()));
         usrc0.setType(unsignedType(src0.getType()));
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, unsignedType(getDataType<DT>()), mod, udst, usrc0, src1, loc);
+        auto utype = unsignedType(getDataType<DT>());
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, utype, mod, udst, usrc0, src1, loc);
     }
     template <typename DT = void>
     void smov(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
@@ -1516,7 +1525,7 @@ public:
         wrdep(r-r, loc);
     }
     void fencedep(Label &fenceLocation, SourceLocation loc = {}) {
-        addFixup(LabelFixup(fenceLocation.getID(labelManager), LabelFixup::JIPOffset));
+            addFixup(LabelFixup(fenceLocation.getID(labelManager), LabelFixup::JIPOffset));
         opDirective(Directive::fencedep, null, Immediate::ud(0), loc);
     }
     void disablePVCWARWA(SourceLocation loc = {}) {
@@ -1543,6 +1552,8 @@ void requireGRF(int grfs) { scope::requireGRF(grfs); }
 #define NGEN_PENTARY_OP(op, scope) template <typename A0, typename A1, typename A2, typename A3, typename A4> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), loc);}
 #define NGEN_HEXARY_OP(op, scope) template <typename A0, typename A1, typename A2, typename A3, typename A4, typename A5> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), loc);}
 #define NGEN_SEPTARY_OP(op, scope) template <typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, A6 &&a6, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), std::forward<A6>(a6), loc);}
+#define NGEN_DODECARY_OP(op, scope) template <typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6,typename A7, typename A8, typename A9, typename A10, typename A11> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, A6 &&a6, A7 &&a7, A8 &&a8, A9 &&a9, A10 &&a10, A11 &&a11,      NGEN_NAMESPACE::SourceLocation loc = {}) {scope::op(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), std::forward<A6>(a6), std::forward<A7>(a7), std::forward<A8>(a8), std::forward<A9>(a9), std::forward<A10>(a10), std::forward<A11>(a11), loc);}
+
 
 #define NGEN_FORWARD_SCOPE_OP(op, scope) \
     NGEN_UNARY_OP(op, scope)       \
@@ -1552,6 +1563,7 @@ void requireGRF(int grfs) { scope::requireGRF(grfs); }
     NGEN_PENTARY_OP(op, scope)     \
     NGEN_HEXARY_OP(op, scope)      \
     NGEN_SEPTARY_OP(op, scope)     \
+    NGEN_DODECARY_OP(op, scope)     \
 
 #define NGEN_BINARY_DT_OP(op, scope) template <typename DT = void, typename A0, typename A1> void op(A0 &&a0, A1 &&a1, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::template op<DT>(std::forward<A0>(a0), std::forward<A1>(a1), loc);}
 #define NGEN_TERNARY_DT_OP(op, scope) template <typename DT = void, typename A0, typename A1, typename A2> void op(A0 &&a0, A1 &&a1, A2 &&a2, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::template op<DT>(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), loc);}
@@ -1559,7 +1571,9 @@ void requireGRF(int grfs) { scope::requireGRF(grfs); }
 #define NGEN_PENTARY_DT_OP(op, scope) template <typename DT = void, typename A0, typename A1, typename A2, typename A3, typename A4> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::template op<DT>(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), loc);}
 #define NGEN_HEXARY_DT_OP(op, scope) template <typename DT = void, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::template op<DT>(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), loc);}
 #define NGEN_HEPTARY_DT_OP(op, scope) template <typename DT = void, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, A6 &&a6, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::template op<DT>(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), std::forward<A6>(a6), loc);}
+#define NGEN_OCTARY_DT_OP(op, scope) template <typename DT = void, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, A6 &&a6, A7 &&a7, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::template op<DT>(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3),std::forward<A4>(a4), std::forward<A5>(a5), std::forward<A6>(a6), std::forward<A7>(a7), loc);}
 #define NGEN_NONARY_DT_OP(op, scope) template <typename DT = void, typename A0, typename A1, typename A2, typename A3, typename A4, typename A5, typename A6, typename A7, typename A8> void op(A0 &&a0, A1 &&a1, A2 &&a2, A3 &&a3, A4 &&a4, A5 &&a5, A6 &&a6, A7 &&a7, A8 &&a8, NGEN_NAMESPACE::SourceLocation loc = {}) {scope::template op<DT>(std::forward<A0>(a0), std::forward<A1>(a1), std::forward<A2>(a2), std::forward<A3>(a3), std::forward<A4>(a4), std::forward<A5>(a5), std::forward<A6>(a6), std::forward<A7>(a7), std::forward<A8>(a8), loc);}
+
 
 #define NGEN_FORWARD_SCOPE_DT_OP(op, scope) \
     NGEN_BINARY_DT_OP(op, scope)      \
@@ -1568,6 +1582,7 @@ void requireGRF(int grfs) { scope::requireGRF(grfs); }
     NGEN_PENTARY_DT_OP(op, scope)     \
     NGEN_HEXARY_DT_OP(op, scope)      \
     NGEN_HEPTARY_DT_OP(op, scope)     \
+    NGEN_OCTARY_DT_OP(op, scope)      \
     NGEN_NONARY_DT_OP(op, scope)      \
 
 #define NGEN_FORWARD_SCOPE_NO_ELF_OVERRIDES(scope) \
@@ -1688,6 +1703,7 @@ using scope::store; \
 using scope::atomic; \
 NGEN_FORWARD_SCOPE_OP(memfence, scope) \
 NGEN_FORWARD_SCOPE_OP(slmfence, scope) \
+NGEN_NILARY_OP(slmfence, scope) \
 NGEN_NILARY_OP(fencewait, scope) \
 NGEN_FORWARD_SCOPE_OP(loadlid, scope) \
 NGEN_FORWARD_SCOPE_OP(loadargs, scope) \
@@ -1975,6 +1991,7 @@ inline void BinaryCodeGenerator<hw>::unsupported()
 #endif
 }
 
+
 template <HW hw>
 typename BinaryCodeGenerator<hw>::InstructionStream *BinaryCodeGenerator<hw>::popStream()
 {
@@ -2068,12 +2085,12 @@ std::vector<uint8_t> BinaryCodeGenerator<hw>::getCode()
         auto nextMov = movs.begin();
 
         for (uint32_t isrc = 0; isrc < program.size(); isrc++, psrc++) {
-            if (psrc->opcode() == Opcode::directive)
-                continue;
             while ((nextSync != syncs.end()) && (nextSync->second->inum == isrc))
                 *pdst++ = encodeSyncInsertion<hw>(*(nextSync++)->second);
             while ((nextMov != movs.end()) && (nextMov->second->inum == isrc))
                 *pdst++ = encodeDummyMovInsertion<hw>(*(nextMov++)->second);
+            if (psrc->opcode() == Opcode::directive)
+                continue;
 
             if(!srcLines.empty())
                 srcLines[psrc - psrc_start].address = sizeof(*pdst) * (pdst - pdst_start);
@@ -2188,7 +2205,7 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
     if (getBytes(src0.getType()) == 8)
         i.imm64.value = static_cast<uint64_t>(src0);
     else
-        i.imm32.value = (uint32_t)static_cast<uint64_t>(src0);
+        i.imm32.value = (int32_t)static_cast<uint64_t>(src0);
 
     db(i, loc);
 }
@@ -2358,7 +2375,7 @@ BinaryCodeGenerator<hw>::opX(Opcode op, DataType defaultType, const InstructionM
     i.binary.src0RegFile = src0.getRegFile();
     i.binary.src1RegFile = src1.getRegFile();
 
-    i.imm32.value = (uint32_t)static_cast<uint64_t>(src1);
+    i.imm32.value = (int32_t)static_cast<uint64_t>(src1);
 
     db(i, loc);
 }

--- a/third_party/ngen/ngen_asm.hpp
+++ b/third_party/ngen/ngen_asm.hpp
@@ -145,7 +145,11 @@ inline void Align16Operand::outputText(std::ostream &str, PrintDetail detail, La
 
 inline void GRFRange::outputText(std::ostream &str, PrintDetail detail, LabelManager &man) const
 {
-    str << 'r' << int(base) << ':' << int(len);
+    {
+        str << 'r' << int(base);
+        if (int(len) > 1)
+            str << "-r" << (int(base) + int(len) - 1);
+    }
 }
 
 inline void Label::outputText(std::ostream &str, PrintDetail detail, LabelManager &man) {
@@ -496,6 +500,7 @@ public:
     }
 
     explicit AsmCodeGenerator(HW hardware_, int stepping_ = 0) : AsmCodeGenerator({genericProductFamily(hardware_), 0, PlatformType::Unknown}) {}
+    AsmCodeGenerator(AsmCodeGenerator &&) = default;
 
     AsmCodeGenerator(HW hardware_, std::ostream &defaultOutput_, int stepping_ = 0) : AsmCodeGenerator(hardware_, stepping_) {
         defaultOutput = &defaultOutput_;
@@ -1010,10 +1015,13 @@ public:
     template <typename DT = void> void frc(const RegData &dst, const RegData &src0, SourceLocation loc = {}) {
         frc<DT>(defaultMods(), dst, src0);
     }
-    void goto_(const InstructionModifier &mod, Label &jip, Label &uip, bool branchCtrl = false, SourceLocation loc = {}) {
+    void goto_(const InstructionModifier &mod, Label &jip, Label &uip, bool branchCtrl, SourceLocation loc = {}) {
         (void) jip.getID(labelManager);
         (void) uip.getID(labelManager);
         opX(Opcode::goto_, DataType::invalid, mod, NoOperand(), jip, uip, NoOperand(), branchCtrl);
+    }
+    void goto_(const InstructionModifier &mod, Label &jip, Label &uip, SourceLocation loc = {}) {
+        goto_(mod, jip, uip, false);
     }
     void goto_(const InstructionModifier &mod, Label &jip, SourceLocation loc = {}) {
         goto_(mod, jip, jip);
@@ -1585,14 +1593,16 @@ public:
         auto udst = dst, usrc0 = src0;
         udst.setType(unsignedType(dst.getType()));
         usrc0.setType(unsignedType(src0.getType()));
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, unsignedType(getDataType<DT>()), mod, udst, usrc0, src1);
+        auto utype = unsignedType(getDataType<DT>());
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, utype, mod, udst, usrc0, src1);
     }
     template <typename DT = void>
     void shr(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
         auto udst = dst, usrc0 = src0;
         udst.setType(unsignedType(dst.getType()));
         usrc0.setType(unsignedType(src0.getType()));
-        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, unsignedType(getDataType<DT>()), mod, udst, usrc0, src1);
+        auto utype = unsignedType(getDataType<DT>());
+        opX(isGen12 ? Opcode::shr_gen12 : Opcode::shr, utype, mod, udst, usrc0, src1);
     }
     template <typename DT = void>
     void smov(const InstructionModifier &mod, const RegData &dst, const RegData &src0, const Immediate &src1, SourceLocation loc = {}) {
@@ -1701,7 +1711,6 @@ private:
     };
 public:
     Shfl shfl;
-
 
 private:
     struct Sync {
@@ -1981,7 +1990,6 @@ static const char *getMnemonic(Opcode op, HW hw)
         "cmp", "cmpn", "csel", "", "", "", "", "bfrev",
         "bfe", "bfi1", "bfi2", "", "", "", "nop", ""
     };
-
 
     const char *mnemonic = names[static_cast<int>(op) & 0x7F];
 

--- a/third_party/ngen/ngen_auto_swsb.hpp
+++ b/third_party/ngen/ngen_auto_swsb.hpp
@@ -181,7 +181,7 @@ struct Dependency {
     uint32_t tokenMaskSrc, tokenMaskDst;                // Bitmasks of token src/dst dependencies
     DependencyRegion region;                            // GRF region covered
 
-    Dependency() : label{0}, pipe{}, tokenTime{0},
+    Dependency() : label{0}, pipe{}, tokenTime{0}, inum{0xffffffff},
         rw{false}, swsb{false}, active{true}, tokenTBD{false},
         tokenMaskSrc{0u}, tokenMaskDst{0u}, region{} { counters.fill(0); dists.fill(0); }
 
@@ -346,7 +346,6 @@ template <typename Instruction>
 inline GeneralizedPipe getPipe(HW hw, const Instruction &insn, bool checkOOO = true)
 {
     auto op = insn.opcode();
-
 
     // Check jumps and no-ops
     if (isBranch(op) || op == Opcode::nop_gen12 || op == Opcode::sync || op == Opcode::illegal || op == Opcode::directive)
@@ -1595,8 +1594,10 @@ inline SWSBInfo encodeSWSB(HW hw, const Instruction *insn, const Producer &produ
             defaultPipeMask = consume.pipe.inOrderPipe();
     }
 
-    consume.tokenMaskSrc &= ~produce.tokenMaskSrc;
-    consume.tokenMaskDst &= ~produce.tokenMaskDst;
+    {
+        consume.tokenMaskSrc &= ~produce.tokenMaskSrc;
+        consume.tokenMaskDst &= ~produce.tokenMaskDst;
+    }
 
     auto swsb = encodeSWSBItems<2>(consume, defaultPipeMask);
     if (produce.hasToken())
@@ -1673,7 +1674,7 @@ inline uint8_t chooseSBID(HW hw, int tokens, Program &program, const BasicBlock 
         }
     }
 
-    // Priority 2: assign SBID based on base register of dst, src1, src0 (in that order),
+    // Priority 2: assign SBID based on base register of dst, src1, src0, src2, src3 (in that order),
     //  if it's unclaimed or expired.
     for (int opNum : {-1, 1, 0, 2, 3}) {
         auto &region = bb.getOperandRegion(inum, opNum);
@@ -2193,8 +2194,10 @@ inline void analyze(HW hw, int tokens, Program &program, BasicBlock &bb, int pha
                 insn.setSWSB({SBID(newToken).set});
                 preconsumeTokenSrc |= generated.tokenMaskSrc;
                 preconsumeTokenDst |= generated.tokenMaskDst;
-                tokenMaskSrc &= ~generated.tokenMaskSrc;
-                tokenMaskDst &= ~generated.tokenMaskDst;
+                {
+                    tokenMaskSrc &= ~generated.tokenMaskSrc;
+                    tokenMaskDst &= ~generated.tokenMaskDst;
+                }
             }
 
             // Finalize SWSB computation.
@@ -2244,9 +2247,12 @@ inline void analyze(HW hw, int tokens, Program &program, BasicBlock &bb, int pha
                 // For {Atomic} chains, do the same, but for a different reason -- it's possible
                 //   our token may be in use and we must clear it prior to entering the chain.
                 // In all other cases, remove dependencies on our own token.
-                if (tokenAssigned && inumChain < 0)
+                if (tokenAssigned && inumChain < 0
+                )
                     tokenMaskDst &= ~(1 << tokenInfo.getToken());
-                if (tokenAssigned && (insn.predicated() || inumChain >= 0) && tokenMayBeActive)
+                if (tokenAssigned && tokenMayBeActive
+                    && (insn.predicated() || inumChain >= 0
+                       ))
                     tokenMaskDst |=  (1 << tokenInfo.getToken());
 
                 tokenMaskSrc &= ~tokenMaskDst;

--- a/third_party/ngen/ngen_config_internal.hpp
+++ b/third_party/ngen/ngen_config_internal.hpp
@@ -36,6 +36,10 @@
 #define NGEN_ASM
 #endif
 
+#ifndef NGEN_DUMP
+#define NGEN_DUMP
+#endif
+
 #if (__cplusplus >= 202002L || _MSVC_LANG >= 202002L)
 #if __has_include(<version>)
 #include <version>
@@ -50,5 +54,6 @@
 #endif
 
 #endif
+
 
 #endif /* header guard */

--- a/third_party/ngen/ngen_core.hpp
+++ b/third_party/ngen/ngen_core.hpp
@@ -107,6 +107,9 @@ class InstructionModifier;
 struct Instruction12;
 enum class Opcode;
 
+inline void unimplemented();
+inline void unsupported();
+
 struct EncodingTag12;
 static inline void encodeCommon12(Instruction12 &i, Opcode opcode, const InstructionModifier &mod, const RegData &dst, EncodingTag12 tag);
 struct EncodingTagXeHPC;
@@ -210,6 +213,10 @@ public:
 class asm_unsupported_message : public std::runtime_error {
 public:
     asm_unsupported_message() : std::runtime_error("Cannot format this message as assembly text") {}
+};
+class unimplemented_exception : public std::runtime_error {
+public:
+    unimplemented_exception(SourceLocation loc = {}) : std::runtime_error("Operation is not implemented" + loc.str(" at ")) {}
 };
 class iga_align16_exception : public std::runtime_error {
 public:
@@ -390,23 +397,37 @@ enum {
 // Data types. Bits[0:4] are the ID, bits[5:7] hold log2(width in bits).
 enum class DataType : uint8_t {
     ud = 0xA0,
+    u32 = ud,
     d  = 0xA1,
+    s32 = d,
     uw = 0x82,
+    u16 = uw,
     w  = 0x83,
+    s16 = w,
     ub = 0x64,
+    u8 = ub,
     b  = 0x65,
+    s8 = b,
     df = 0xC6,
+    f64 = df,
     f  = 0xA7,
+    f32 = f,
     uq = 0xC8,
+    u64 = uq,
     q  = 0xC9,
+    s64 = q,
     hf = 0x8A,
+    f16 = hf,
     bf = 0x8B,
+    bf16 = bf,
     uv = 0xAD,
     v  = 0xAE,
     vf = 0xAF,
     bf8 = 0x6C,
+    e5m2 = bf8,
     tf32 = 0xB0,
     hf8 = 0x71,
+    e4m3 = hf8,
     u4 = 0x5C,
     s4 = 0x5D,
     u2 = 0x3E,
@@ -495,13 +516,12 @@ template <> inline DataType getDataType<e2m1>() { return DataType::e2m1; }
 template <> inline DataType getDataType<e3m0>() { return DataType::e3m0; }
 #endif
 
-
 static inline constexpr14 DataType rawType(DataType dt) {
     switch (getLog2Bits(dt)) {
-        case 6:  return DataType::uq;
-        case 5:  return DataType::ud;
-        case 4:  return DataType::uw;
-        case 3:  return DataType::ub;
+        case 6:  return DataType::u64;
+        case 5:  return DataType::u32;
+        case 4:  return DataType::u16;
+        case 3:  return DataType::u8;
         default: return dt;
     }
 }
@@ -894,6 +914,7 @@ public:
         return static_cast<RegFile8>(rf);
     }
     constexpr bool isARF()             const { return rf == RegFileARF; }
+    constexpr bool isGRF()             const { return rf == RegFileGRF; }
     constexpr int getARFBase()         const { return base & 0xF; }
     constexpr ARFType getARFType()     const { return static_cast<ARFType>(base >> 4); }
     constexpr bool isIndirect()        const { return indirect; }
@@ -1368,7 +1389,7 @@ public:
     static constexpr int maxRegs()                         { return 512; }
     static constexpr int maxRegs(HW hw) {
         return (hw < HW::XeHP) ? 128
-            : (hw >= HW::Xe3p) ? 512
+            : (hw == HW::Xe3p) ? 512
             : 256;
     }
 };
@@ -1519,6 +1540,10 @@ public:
     }
 
     int index() const { return (getARFBase() << 1) + getOffset(); }
+
+    int index(ngen::HW hw) const {
+        return index();
+    }
 
     static inline constexpr14 int count(HW hw) {
         return (hw >= HW::XeHPC) ? 4 : 2;
@@ -1680,7 +1705,6 @@ inline GRFDisp operator+(ScalarRegister s, GRFDisp addr) {
 inline GRFDisp operator+(GRF base,     ScalarRegister s) { return s + base; }
 inline GRFDisp operator+(GRFDisp addr, ScalarRegister s) { return s + addr; }
 
-
 GRFDisp Subregister::operator+(int offset) const
 {
 #ifdef NGEN_SAFE
@@ -1788,15 +1812,19 @@ protected:
     uint16_t len;
 
     static constexpr uint16_t invalidLen = 0xFFFF;
+    DataType type;
 
 public:
     GRFRange() : GRFRange(0, invalidLen) {}
-    GRFRange(int base_, int len_) : base(base_), len(len_) {}
+    GRFRange(int base_, int len_) : base(base_), len(len_), type(DataType::invalid) {}
+    GRFRange(int base_, int len_, DataType type_) : base(base_), len(len_), type(type_) {}
     GRFRange(RegData base_, int len_) : base(base_.getBase())
-                                      , len(base_.isValid() ? len_ : invalidLen) {}
+                                      , len(base_.isValid() ? len_ : invalidLen)
+                                      , type(base_.getType()) {}
 
     int getBase()    const { return base; }
     int getLen()     const { return len; }
+    DataType getDataType()     const { return type; }
     bool isEmpty()   const { return len == 0; }
     bool isNull()    const { return false; }
 
@@ -1810,10 +1838,11 @@ public:
 #ifdef NGEN_SAFE
         if (isInvalid()) throw invalid_object_exception();
 #endif
-        return GRF(base + i);
+
+        return GRF(base + i).retype(type);
     }
 
-    operator GRF() const { return (*this)[0]; }
+    operator GRF() const { return isInvalid() ? GRF() : (*this)[0]; }
 
     inline Subregister sub(HW hw, int offset, DataType type) const;
 
@@ -2039,7 +2068,6 @@ enum class Opcode {
     nop = 0x7E,
     directive = 0x7F,   /* not a valid opcode; used internally by nGEN */
 };
-
 
 enum class Operand {dst = 0, src0 = 1, src1 = 2, src2 = 3, src3 = 4, src4 = 5};
 
@@ -2960,7 +2988,8 @@ class AddressBase {
 protected:
     uint32_t index;
     AddressModel model;
-    uint8_t pad0[3] = {};
+    uint8_t bsoReg = 0;
+    uint8_t pad0[2] = {};
 
     constexpr AddressBase(uint8_t index_, AddressModel model_) : index(index_), model(model_) {}
 
@@ -2969,8 +2998,9 @@ protected:
 public:
     constexpr AddressBase() : AddressBase(invalidIndex, ModelInvalid) {}
 
-    constexpr uint32_t getIndex()     const { return index; }
-    constexpr AddressModel getModel() const { return model; }
+    constexpr uint32_t getIndex()      const { return index; }
+    constexpr AddressModel getModel()  const { return model; }
+    constexpr uint8_t getBSORegister() const { return bsoReg; }
 
     void setIndex(uint8_t newIndex)         { index = newIndex; }
 
@@ -3001,8 +3031,13 @@ public:
     static constexpr AddressBase createSS(uint32_t index) {
         return AddressBase(index, ModelSS);
     }
-    static constexpr AddressBase createBSS(uint32_t index) {
-        return AddressBase(index, ModelBSS);
+    static constexpr14 AddressBase createBSS(uint32_t index, uint8_t bsoSubreg = 0) {
+        AddressBase a(index, ModelBSS);
+        a.bsoReg = bsoSubreg;
+        return a;
+    }
+    static constexpr AddressBase createScratch() {
+        return AddressBase(0, ModelScratch);
     }
 
     inline constexpr bool isRO() const {
@@ -3729,7 +3764,6 @@ enum GatewayOpcode {
     sip_bar = 12,
 };
 
-
 union SendgMessageDescriptor {
     uint64_t all;
     struct {
@@ -3813,7 +3847,6 @@ union SendgMessageDescriptor {
         return dsDecode[mem.dataSize];
     }
 
-
     // Return # destination registers if known, and -1 if not.
     inline int dstLen(HW hw, int execSize, SharedFunction sfid) const
     {
@@ -3866,7 +3899,7 @@ union SendgMessageDescriptor {
                     case LSCOpcode::atomic_bfmin:
                     case LSCOpcode::atomic_bfmax:
                     case LSCOpcode::atomic_bfcmpxchg:
-                         return effSIMDGRFs * (1 + (elementBytesReg() >> 3));
+                        return effSIMDGRFs * (1 + (elementBytesReg() >> 3));
                     default:
                         return 0;
                 }
@@ -4055,7 +4088,7 @@ void DataSpecLSC::getDescriptor(HW hw, int execSize, SharedFunction &sfid, Addre
         dataLen = GRF::bytesToGRFs(hw, dbytes() * vc);
     } else {
         auto effSIMDGRFs = 1 + (execSize >> (GRF::log2Bytes(hw) - 1));
-        addrLen = effSIMDGRFs * (base.isA64() ? 2 : 1);
+        addrLen = effSIMDGRFs * (model == ModelA64 ? 2 : 1);
         dataLen = effSIMDGRFs * vc * (1 + (dbytes() >> 3));
     }
 
@@ -4116,6 +4149,19 @@ static inline void encodeAtomicDescriptor(HW hw, SendgMessageDescriptor &desc, S
     spec.template getDescriptor<Access::AtomicInteger>(hw, mod.getExecSize(), sfid, base, desc, src0Len, src1Len, addr);
     spec.applyAtomicOp(op, desc);
 }
+
+inline void unimplemented() {
+#ifdef NGEN_SAFE
+    throw unimplemented_exception();
+#endif
+}
+
+inline void unsupported() {
+#ifdef NGEN_SAFE
+    throw unsupported_instruction();
+#endif
+}
+
 
 } /* namespace NGEN_NAMESPACE */
 

--- a/third_party/ngen/ngen_debuginfo.hpp
+++ b/third_party/ngen/ngen_debuginfo.hpp
@@ -156,8 +156,21 @@ struct DebugLine {
         uint8_t defaultIsStmt = 1;
         int8_t lineBase = -32;
         uint8_t lineRange = 192;
-        uint8_t opcodeBase = 5;
-        uint8_t opCodeLengths[4] = {0, 1, 1, 1};
+        uint8_t opcodeBase = 13;
+        uint8_t opCodeLengths[12] = {
+            0, // copy
+            1, // advance_pc
+            1, // advance_line
+            1, // set_file
+            1, // set_column
+            0, // negate_stmt
+            0, // set_basic_block
+            0, // const_add_pc
+            1, // fixed_advance_pc, standard specifies number of LEB128 operands, but this takes a u16 operand. Value is aligned with GCC.
+            0, // set_prologue_end
+            0, // set_epilogue_begin
+            1, // set_isa
+        };
 
         enum DWARF_FORM : uint8_t {
             DATA2 = 0x05,
@@ -227,7 +240,7 @@ struct DebugLine {
         return ret;
     };
 
-    std::pair<std::vector<char>, uint64_t> encodeLineStatements(const DebugLineHeaderBase & base) const {
+    std::pair<std::vector<char>, uint64_t> encodeLineStatements(const DebugLineHeaderBase & base, size_t prologueEnd) const {
         struct {
             uint64_t address = 0;
             uint64_t line = 1;
@@ -236,6 +249,7 @@ struct DebugLine {
             uint32_t isa = 0;
             uint32_t discriminator = 0;
 
+            uint64_t prologueEnd = 0;
             int8_t lineBase;
             uint8_t lineRange;
             uint8_t opcodeBase;
@@ -247,6 +261,7 @@ struct DebugLine {
                 advancePC = 2,
                 advanceLine = 3,
                 setFile = 4,
+                setPrologueEnd = 10,
             };
 
             enum ExtendedOps { endSequence = 1, setAddress = 2 };
@@ -279,6 +294,10 @@ struct DebugLine {
                     file = l.fileEntry;
                 }
 
+                if (prologueEnd && l.address == prologueEnd) {
+                    out.emplace_back(setPrologueEnd);
+                }
+
                 if (l.line >= line + lineBase &&
                     l.line < line + lineBase + lineRange) {
                     int64_t specialOp = (l.line - line) - lineBase +
@@ -308,6 +327,7 @@ struct DebugLine {
             }
         } encodeState;
 
+        encodeState.prologueEnd=prologueEnd;
         encodeState.isStmt = base.defaultIsStmt;
         encodeState.lineBase = base.lineBase;
         encodeState.lineRange = base.lineRange;
@@ -324,7 +344,7 @@ struct DebugLine {
         return {ret, relocation_offset};
     }
 
-    std::pair<std::vector<char>, uint64_t> createDebugLine() const {
+    std::pair<std::vector<char>, uint64_t> createDebugLine(size_t prologueEnd) const {
 
         DebugLineHeaderBase base;
         DebugLineHeaderBase::DirEntriesHeader dirHeader;
@@ -333,7 +353,7 @@ struct DebugLine {
         DebugLineHeaderBase::FileEntriesHeader fileHeader;
         std::vector<char> filenamesCount = toULEB128(fileEntries.size());
         uint32_t fileEntriesBytes = static_cast<uint32_t>(fileEntries.size() * sizeof(fileEntries[0]));
-        auto encode = encodeLineStatements(base);
+        auto encode = encodeLineStatements(base, prologueEnd);
         std::vector<char> lineStatements = encode.first;
         uint64_t relocation_offset = encode.second;
 

--- a/third_party/ngen/ngen_decoder.hpp
+++ b/third_party/ngen/ngen_decoder.hpp
@@ -38,10 +38,6 @@ class unsupported_compaction : public std::runtime_error {
 public:
     unsupported_compaction() : std::runtime_error("Compacted instructions are not supported") {}
 };
-class unimplemented : public std::runtime_error {
-public:
-    unimplemented() : std::runtime_error("Operation is not implemented") {}
-};
 #endif
 
 class Decoder
@@ -86,11 +82,8 @@ bool Decoder::getOperandRegion(autoswsb::DependencyRegion &region, int opNum) co
         return get<InstructionXeHPC>().getOperandRegion(region, opNum);
     if (hw >= HW::Gen12LP)
         return get<Instruction12>().getOperandRegion(region, opNum);
-#ifdef NGEN_SAFE
-    throw unimplemented();
-#else
+    unimplemented();
     return false;
-#endif
 }
 
 } /* namespace NGEN_NAMESPACE */

--- a/third_party/ngen/ngen_elf.hpp
+++ b/third_party/ngen/ngen_elf.hpp
@@ -22,7 +22,38 @@
 
 #include "npack/neo_packager.hpp"
 
+#if defined(NGEN_DUMP) && !defined(NGEN_DISABLE_GETENV)
+#include <atomic>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#endif
+
 namespace NGEN_NAMESPACE {
+
+#if defined(NGEN_DUMP) && !defined(NGEN_DISABLE_GETENV)
+inline void dumpKernelBinary(const std::string &name,
+                             const std::vector<uint8_t> &kernel,
+                             const std::vector<uint8_t> &program)
+{
+    static const bool dumpEnabled = []() {
+        if (auto e = ::getenv("NGEN_DUMP"))
+            return !(e[0] == '\0' || (e[0] == '0' && e[1] == '\0'));
+        return false;
+    }();
+    if (!dumpEnabled) return;
+    static std::atomic<size_t> dumpCounter{0};
+    std::string base = "ngen_" + name + "." + std::to_string(dumpCounter++);
+    auto write = [](const std::string &fname, const std::vector<uint8_t> &data) {
+        std::ofstream ofs(fname, std::ios::binary);
+        if (ofs)
+            ofs.write(reinterpret_cast<const char *>(data.data()),
+                      static_cast<std::streamsize>(data.size()));
+    };
+    write(base + ".bin", kernel);
+    write(base + ".elf", program);
+}
+#endif
 
 // ELF binary format generator class.
 template <HW hw>
@@ -103,6 +134,9 @@ public:
     Subregister getSIMD1LocalID(int dim) const                           { return interface_.getSIMD1LocalID(dim); }
     Subregister getLocalSize(int dim) const                              { return interface_.getLocalSize(dim); }
     Subregister getGroupID(int dim) const                                { return interface_.getGroupID(dim); }
+    AddressBase getScratchSurface() const                                { return BinaryCodeGenerator<hw>::getScratchSurface(); }
+    RegData getScratchPointer() const                                    { return interface_.getScratchPointer(); }
+    size_t getScratchSize() const                                        { return interface_.getScratchSize(); }
 
     void prologue()                                                      { interface_.generatePrologue(*this); }
     void epilogue(RegData r0_info = RegData())
@@ -552,6 +586,9 @@ const std::string &getExternalName() const { return NGEN_NAMESPACE::ELFCodeGener
 int getSIMD() const { return NGEN_NAMESPACE::ELFCodeGenerator<hw>::getSIMD(); } \
 int getGRFCount() const { return NGEN_NAMESPACE::ELFCodeGenerator<hw>::getGRFCount(); } \
 size_t getSLMSize() const { return NGEN_NAMESPACE::ELFCodeGenerator<hw>::getSLMSize(); } \
+NGEN_NAMESPACE::AddressBase getScratchSurface() const { return NGEN_NAMESPACE::ELFCodeGenerator<hw>::getScratchSurface(); } \
+NGEN_NAMESPACE::RegData getScratchPointer() const { return NGEN_NAMESPACE::ELFCodeGenerator<hw>::getScratchPointer(); } \
+size_t getScratchSize() const { return NGEN_NAMESPACE::ELFCodeGenerator<hw>::getScratchSize(); } \
 template <typename... Targs> void require32BitBuffers(Targs&&... args) { NGEN_NAMESPACE::ELFCodeGenerator<hw>::require32BitBuffers(std::forward<Targs>(args)...); } \
 template <typename... Targs> void requireArbitrationMode(Targs&&... args) { NGEN_NAMESPACE::ELFCodeGenerator<hw>::requireArbitrationMode(std::forward<Targs>(args)...); } \
 template <typename... Targs> void requireBarrier(Targs&&... args) { NGEN_NAMESPACE::ELFCodeGenerator<hw>::requireBarrier(std::forward<Targs>(args)...); } \
@@ -610,7 +647,7 @@ std::vector<uint8_t> ELFCodeGenerator<hw>::getBinary(const std::vector<uint8_t> 
     // Generate metadata.
     metadata = interface_.generateZeInfo();
 
-    auto debugLine_ = super::debugLine.createDebugLine();
+    auto debugLine_ = super::debugLine.createDebugLine(interface_.prologueEnd());
     std::vector<char> debugLine = debugLine_.first;
     uint64_t kernelRela = 1 | (1ull << 32);
     typename ZebinELF::Rela debugLineRelocation = {
@@ -652,6 +689,11 @@ std::vector<uint8_t> ELFCodeGenerator<hw>::getBinary(const std::vector<uint8_t> 
     utils::copy_into(binary, offset, debugLineRelocation);
     offset += paddedSzRelDebugLine;
     utils::copy_into(binary, offset, debugInfoRelocation);
+
+#if defined(NGEN_DUMP) && !defined(NGEN_DISABLE_GETENV)
+    dumpKernelBinary(interface_.getExternalName(), kernel, binary);
+#endif
+
     return binary;
 }
 
@@ -668,6 +710,8 @@ inline Product ELFCodeGenerator<hw>::getBinaryHWInfo(const std::vector<uint8_t> 
 
     Product outProduct;
     HW hw_ = HW::Unknown;
+    outProduct.family = ProductFamily::Unknown;
+    outProduct.stepping = 0;
 
     auto zebinELF = reinterpret_cast<const ZebinELF *>(binary.data());
     if (zebinELF->valid()) {

--- a/third_party/ngen/ngen_emulation.hpp
+++ b/third_party/ngen/ngen_emulation.hpp
@@ -732,20 +732,21 @@ struct EmulationImplementation {
     static void emul(Generator &g, const InstructionModifier &mod, const RegData &dst, const RegData &src0, Immediate src1, const EmulationStrategy &strategy, const EmulationState &state, SourceLocation loc = {})
     {
         DataType t = src1.getType();
-        if(t == DataType::ud || t == DataType::d || t == DataType::uw || t == DataType::w) {
-            int64_t value = static_cast<int64_t>(uint64_t(src1.cast(DataType::q)));
-            if (value == 0) {
-                emov<DT>(g, mod, dst, uint16_t(0), strategy, loc);
-                return;
-            } else if (value == 1) {
-                if (dst != src0) emov<DT>(g, mod, dst, src0, strategy, loc);
-                return;
-            } else if (utils::is_zero_or_pow2(value)) {
-                eshl<DT>(g, mod, dst, src0, uint16_t(utils::log2(value)), strategy, state, loc);
-                return;
+        {
+            if(t == DataType::ud || t == DataType::d || t == DataType::uw || t == DataType::w) {
+                int64_t value = static_cast<int64_t>(uint64_t(src1.cast(DataType::q)));
+                if (value == 0) {
+                    emov<DT>(g, mod, dst, uint16_t(0), strategy, loc);
+                    return;
+                } else if (value == 1) {
+                    if (dst != src0) emov<DT>(g, mod, dst, src0, strategy, loc);
+                    return;
+                } else if (utils::is_zero_or_pow2(value)) {
+                    eshl<DT>(g, mod, dst, src0, uint16_t(utils::log2(value)), strategy, state, loc);
+                    return;
+                }
             }
         }
-
         emulInternal<DT>(g, mod, dst, src0, src1, strategy, state, loc);
     }
 
@@ -853,10 +854,12 @@ struct EmulationImplementation {
     template <typename DT = void, typename Generator>
     static void emulConstant(Generator &g, const InstructionModifier &mod, const RegData &dst, const RegData &src0, int32_t src1, const EmulationStrategy &strategy, const EmulationState &state, SourceLocation loc = {})
     {
-        if (src1 > 0)
-            emul<DT>(g, mod, dst, src0, uint32_t(src1), strategy, state, loc);
-        else
-            emul<DT>(g, mod, dst, src0, int32_t(src1), strategy, state, loc);
+        {
+            if (src1 > 0)
+                emul<DT>(g, mod, dst, src0, uint32_t(src1), strategy, state, loc);
+            else
+                emul<DT>(g, mod, dst, src0, int32_t(src1), strategy, state, loc);
+        }
     }
 }; // struct EmulationHelper
 

--- a/third_party/ngen/ngen_gen12.hpp
+++ b/third_party/ngen/ngen_gen12.hpp
@@ -1236,7 +1236,7 @@ bool Instruction12::getOperandRegion(autoswsb::DependencyRegion &region, int opN
                     break;
                 }
                 case 3: {
-                    if(op != Opcode::bdpas) return false;
+                    if (op != Opcode::bdpas) return false;
                     unsigned reg = bdpas.src3Reg0;
                     reg |= bdpas.src3Reg1_2 << 1;
                     reg |= bdpas.src3Reg3_6 << 3;
@@ -1247,7 +1247,7 @@ bool Instruction12::getOperandRegion(autoswsb::DependencyRegion &region, int opN
                     break;
                 }
                 case 4: {
-                    if(op != Opcode::bdpas) return false;
+                    if (op != Opcode::bdpas) return false;
                     unsigned reg = bdpas.src4Reg0_3;
                     reg |= bdpas.src4Reg4_8 << 4;
                     o.direct.regNum = reg;      // low 8 bits

--- a/third_party/ngen/ngen_interface.hpp
+++ b/third_party/ngen/ngen_interface.hpp
@@ -106,12 +106,14 @@ public:
     inline Subregister getSIMD1LocalID(int dim) const;
     inline Subregister getLocalSize(int dim) const;
     inline Subregister getGroupID(int dim) const;
+    inline RegData getScratchPointer() const;
 
     const std::string &getExternalName() const           { return kernelName; }
     int getSIMD() const                                  { return simd; }
     int getBarrierCount() const                          { return barrierCount; }
     int getGRFCount() const                              { return needGRF; }
     size_t getSLMSize() const                            { return slmSize; }
+    size_t getScratchSize() const                        { return scratchSize; }
     bool getEfficient64Bit() const                       { return useEfficient64Bit; }
 
     void require32BitBuffers()                           { allow64BitBuffers = false; }
@@ -153,6 +155,7 @@ public:
     inline void generatePrologue(CodeGenerator &generator, const GRF &temp = GRF(127)) const;
 
     inline void setPrologueLabels(InterfaceLabels &labels, LabelManager &man);
+    inline int32_t prologueEnd() const { return offsetSkipPerThread; };
 
     inline void generateDummyCL(std::ostream &stream) const;
     inline std::string generateZeInfo() const;
@@ -176,8 +179,12 @@ public:
         bool globalStatelessAccess() const { return (static_cast<int>(access) & static_cast<int>(GlobalAccessType::Stateless)); }
     };
 
-    const Assignment &getAssignment(int idx) const   { return assignments[idx]; }
-    size_t numAssignments() const   { return assignments.size(); }
+    const Assignment &getAssignment(int idx)           const { return assignments[idx]; }
+
+    ExternalArgumentType getAssignmentExtType(int idx) const { return assignments[idx].exttype; }
+    DataType getAssignmentType(int idx)                const { return assignments[idx].type; }
+    const std::string& getAssignmentName(int idx)      const { return assignments[idx].name; }
+    size_t numAssignments()                            const { return assignments.size(); }
 
 protected:
     HW hw;
@@ -341,6 +348,15 @@ Subregister InterfaceHandler::getGroupID(int dim) const
     }
 
     return Subregister();
+}
+
+RegData InterfaceHandler::getScratchPointer() const
+{
+#ifdef NGEN_SAFE
+    if (scratchSize == 0) throw unknown_argument_exception();
+    if (!useEfficient64Bit) throw unknown_argument_exception();
+#endif
+    return GRF(getCrossthreadBase().getBase()).uq(24 / 8);
 }
 
 void InterfaceHandler::requireSIMD(int simd_)
@@ -508,10 +524,12 @@ void InterfaceHandler::finalize()
                     }
                 }
 
-                offset = (offset + size - 1) & -size;
-                if (offset >= regSize) {
-                    base += offset / regSize;
-                    offset = 0;
+                {
+                    offset = (offset + size - 1) & -size;
+                    if (offset >= regSize) {
+                        base += offset / regSize;
+                        offset = 0;
+                    }
                 }
 
                 assignment.reg = base.sub(offset / bytes, assignment.type);
@@ -641,7 +659,7 @@ void InterfaceHandler::setPrologueLabels(InterfaceLabels &labels, LabelManager &
     };
 
     int immOffset = 0xC;
-    if (hw >= HW::Xe3p) immOffset = 0x8;
+    if (hw == HW::Xe3p) immOffset = 0x8;
 
     setOffset(labels.localIDsLoaded, offsetSkipPerThread);
     setOffset(labels.argsLoaded, offsetSkipCrossThread);
@@ -694,6 +712,8 @@ std::string InterfaceHandler::generateZeInfo() const
         md << "      has_global_atomics: true\n";
     if (slmSize > 0)
         md << "      slm_size: " << slmSize << '\n';
+    if (scratchSize > 0)
+        md << "      private_size: " << scratchSize << '\n';
     if (!needStatelessWrites)
         md << "      has_no_stateless_write: true\n";
     if (needNoPreemption)
@@ -731,6 +751,11 @@ std::string InterfaceHandler::generateZeInfo() const
     if (useEfficient64Bit) {
         md << "      - arg_type: indirect_data_pointer\n"
               "        offset: 0\n"
+              "        size: 8\n";
+    }
+    if (useEfficient64Bit && scratchSize > 0) {
+        md << "      - arg_type: scratch_pointer\n"
+              "        offset: 24\n"
               "        size: 8\n";
     }
     for (auto &assignment : assignments) {
@@ -837,6 +862,16 @@ std::string InterfaceHandler::generateZeInfo() const
                   "        size: " << localIDBytes << "\n"
                   "  \n";
         }
+    }
+
+    // Per-thread scratch allocation (drives HW surface sizing).
+    if (scratchSize > 0) {
+        md << "\n"
+              "    per_thread_memory_buffers: \n"
+              "      - type: scratch\n"
+              "        usage: spill_fill_space\n"
+              "        size: " << scratchSize << "\n"
+              "\n";
     }
 
     md << "\n"; // ensure file ends with newline

--- a/third_party/ngen/ngen_level_zero.hpp
+++ b/third_party/ngen/ngen_level_zero.hpp
@@ -19,7 +19,12 @@
 
 #include "ngen_config_internal.hpp"
 
-#include "level_zero/ze_api.h"
+
+#if defined(__has_include) && __has_include(<ze_api.h>)
+#include <ze_api.h>
+#else
+#include <level_zero/ze_api.h>
+#endif
 
 #include <sstream>
 
@@ -100,7 +105,7 @@ public:
 
     DEPRECATED explicit LevelZeroCodeGenerator(int stepping_ = 0, DebugConfig debugConfig = {}) : LevelZeroCodeGenerator({genericProductFamily(hw), stepping_, PlatformType::Unknown}, debugConfig) {}
 
-    explicit LevelZeroCodeGenerator(DebugConfig debugConfig) : LevelZeroCodeGenerator({genericProductFamily(hw), 0}, debugConfig) {}
+    explicit LevelZeroCodeGenerator(DebugConfig debugConfig) : LevelZeroCodeGenerator({genericProductFamily(hw), 0, PlatformType::Unknown}, debugConfig) {}
     LevelZeroCodeGenerator(LevelZeroCodeGenerator&&) = default;
 
     inline std::pair<ze_module_handle_t, ze_kernel_handle_t> getModuleAndKernel(ze_context_handle_t context, ze_device_handle_t device, const std::string &options = "");

--- a/third_party/ngen/ngen_opencl.hpp
+++ b/third_party/ngen/ngen_opencl.hpp
@@ -19,13 +19,8 @@
 
 #include "ngen_config_internal.hpp"
 
-#ifndef __OPENCL_CL_H
 #include <CL/cl.h>
-#endif
-
-#ifndef OPENCL_CL_EXT_H_
 #include <CL/cl_ext.h>
-#endif
 
 #include <atomic>
 #include <sstream>
@@ -334,7 +329,8 @@ Product OpenCLCodeGenerator<hw>::detectHWInfo(cl_device_id device)
 template <HW hw>
 Product OpenCLCodeGenerator<hw>::detectHWInfo(cl_context context, cl_device_id device)
 {
-    Product product;
+    Product product{};
+    product.family = ProductFamily::Unknown;
 
     // Try CL_DEVICE_IP_VERSION_INTEL query first.
     cl_uint ipVersion = 0;      /* should be cl_version, but older CL/cl.h may not define cl_version */

--- a/third_party/ngen/ngen_pseudo.hpp
+++ b/third_party/ngen/ngen_pseudo.hpp
@@ -593,6 +593,7 @@ void fencewait(SourceLocation loc = {})
         mov<uint32_t>(8 | NoMask, null, _lastFenceDst, loc);
 }
 
+
 // XeHP+ prologues.
 void loadlid(int argBytes, int dims = 3, int simd = 8, const GRF &temp = GRF(127), int paddedSize = 0, SourceLocation loc = {})
 {
@@ -825,7 +826,13 @@ struct Load {
             encodeLoadDescriptors(parent.hardware, desc, exdesc, mod, dst, spec, base, addr);
             if (sfid != SharedFunction::automatic)
                 exdesc.parts.sfid = static_cast<unsigned>(sfid);
-            parent.send(mod, dst, addr.getBase(), exdesc.all, desc.all, loc);
+            if (base.getModel() == ModelBSS) {
+                auto bso_sfid = static_cast<SharedFunction>(exdesc.parts.sfid);
+                parent.send(mod | ExBSO, bso_sfid, dst, addr.getBase(), GRFRange(NullRegister(), 0),
+                            AddressRegister(0).ud(base.getBSORegister()), desc.all, loc);
+            } else {
+                parent.send(mod, dst, addr.getBase(), exdesc.all, desc.all, loc);
+            }
         }
     }
 
@@ -906,7 +913,14 @@ struct Store {
             encodeStoreDescriptors(parent.hardware, desc, exdesc, mod, spec, base, addr);
             if (sfid != SharedFunction::automatic)
                 exdesc.parts.sfid = static_cast<unsigned>(sfid);
-            parent.sends(mod, NullRegister(), addr.getBase(), data, exdesc.all, desc.all, loc);
+            if (base.getModel() == ModelBSS) {
+                auto bso_sfid = static_cast<SharedFunction>(exdesc.parts.sfid);
+                int dataLen = exdesc.parts.extMessageLen;
+                parent.send(mod | ExBSO, bso_sfid, NullRegister(), addr.getBase(), GRFRange(data, dataLen),
+                            AddressRegister(0).ud(base.getBSORegister()), desc.all, loc);
+            } else {
+                parent.sends(mod, NullRegister(), addr.getBase(), data, exdesc.all, desc.all, loc);
+            }
         }
     }
 

--- a/third_party/ngen/ngen_register_allocator.hpp
+++ b/third_party/ngen/ngen_register_allocator.hpp
@@ -215,8 +215,8 @@ protected:
     using mtype = uint16_t;
 
     HW hw;                                      // HW generation.
-    uint8_t freeGRF[GRF::maxRegs() / 8]{};      // Bitmap of free whole GRFs.
-    mtype freeSub[GRF::maxRegs()]{};            // Bitmap of free partial GRFs, at dword granularity.
+    uint8_t freeGRF[GRF::maxRegs() / 8]{};        // Bitmap of free whole GRFs.
+    mtype freeSub[GRF::maxRegs()]{};              // Bitmap of free partial GRFs, at dword granularity.
     uint16_t regCount;                          // # of registers.
     uint8_t freeFlag;                           // Bitmap of free flag registers.
     mtype fullSubMask;
@@ -380,6 +380,7 @@ void RegisterAllocator::init()
 
     freeFlag = (1u << FlagRegister::subcount(hw)) - 1;
     regCount = maxRegs;
+
 }
 
 void RegisterAllocator::claim(GRF reg)
@@ -571,6 +572,7 @@ GRFRange RegisterAllocator::tryAllocRange(int nregs, BundleGroup baseBundle, Bun
             // Find the first free base register.
             int firstBit = utils::bsf(freeBase);
             int rbase = firstBit + (rchunk << 6);
+            if (rbase + nregs > regCount) break;
 
             // Check if required # of registers are available.
             bool ok = true;

--- a/third_party/ngen/npack/neo_packager.hpp
+++ b/third_party/ngen/npack/neo_packager.hpp
@@ -182,20 +182,20 @@ inline void replaceKernel(std::vector<uint8_t> &binary, const std::vector<uint8_
 inline HW decodeGfxCoreFamily(GfxCoreFamily family)
 {
     switch (family) {
-        case GfxCoreFamily::Gen9:         return HW::Gen9;
-        case GfxCoreFamily::Gen10:        return HW::Gen10;
-        case GfxCoreFamily::Gen10LP:      return HW::Gen10;
-        case GfxCoreFamily::Gen11:        return HW::Gen11;
-        case GfxCoreFamily::Gen11LP:      return HW::Gen11;
-        case GfxCoreFamily::Gen12LP:      return HW::Gen12LP;
+        case GfxCoreFamily::Gen9:     return HW::Gen9;
+        case GfxCoreFamily::Gen10:    return HW::Gen10;
+        case GfxCoreFamily::Gen10LP:  return HW::Gen10;
+        case GfxCoreFamily::Gen11:    return HW::Gen11;
+        case GfxCoreFamily::Gen11LP:  return HW::Gen11;
+        case GfxCoreFamily::Gen12LP:  return HW::Gen12LP;
         case GfxCoreFamily::Gen12:
-        case GfxCoreFamily::XeHP:         return HW::XeHP;
-        case GfxCoreFamily::XeHPG:        return HW::XeHPG;
-        case GfxCoreFamily::XeHPC:        return HW::XeHPC;
-        case GfxCoreFamily::Xe2:          return HW::Xe2;
-        case GfxCoreFamily::Xe3:          return HW::Xe3;
-        case GfxCoreFamily::Xe3p:         return HW::Xe3p;
-        default:                          return HW::Unknown;
+        case GfxCoreFamily::XeHP:     return HW::XeHP;
+        case GfxCoreFamily::XeHPG:    return HW::XeHPG;
+        case GfxCoreFamily::XeHPC:    return HW::XeHPC;
+        case GfxCoreFamily::Xe2:      return HW::Xe2;
+        case GfxCoreFamily::Xe3:      return HW::Xe3;
+        case GfxCoreFamily::Xe3p:     return HW::Xe3p;
+        default:                      return HW::Unknown;
     }
 }
 
@@ -242,7 +242,6 @@ inline NGEN_NAMESPACE::ProductFamily decodeProductFamily(ProductFamily family)
     if (family == ProductFamily::PTL) return NGEN_NAMESPACE::ProductFamily::GenericXe3;
     if (family == ProductFamily::NVLP) return NGEN_NAMESPACE::ProductFamily::NVLP;
     if (family == ProductFamily::CRI) return NGEN_NAMESPACE::ProductFamily::CRI;
-    if (family >= ProductFamily::CRI) return NGEN_NAMESPACE::ProductFamily::GenericXe3p;
     return NGEN_NAMESPACE::ProductFamily::Unknown;
 }
 
@@ -298,7 +297,7 @@ inline NGEN_NAMESPACE::Product decodeHWIPVersion(uint32_t rawVersion)
         };
     } version;
 
-    NGEN_NAMESPACE::Product outProduct;
+    NGEN_NAMESPACE::Product outProduct = {NGEN_NAMESPACE::ProductFamily::Unknown, 0, NGEN_NAMESPACE::PlatformType::Unknown};
 
     version.raw = rawVersion;
     switch (version.architecture) {


### PR DESCRIPTION
The PR pulls down `third_party/ngen` from upstream.