### PR TITLE
[do-not-merge] [WIP] aarch64: brgemm: enable SMMLA for S8S8 BRGEMM and BRGCONV

### DIFF
--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -386,6 +386,11 @@ status_t brgemm_desc_set_attr(
             && brg->layout != brgemm_row_major)
         return status::unimplemented;
 
+    if (brgattr.use_mmla_packed_a && !brgattr.use_mmla)
+        return status::unimplemented;
+
+    if (brgattr.use_mmla) CHECK(validate_mmla_compute(*brg));
+
     brg->brgattr = brgattr;
 
     if (brgattr.fpmath_mode != fpmath_mode::strict) maybe_try_bf32(brg);
@@ -398,7 +403,8 @@ status_t brgemm_desc_set_attr(
                     || brgattr.hint_load_nt_A != brgemm_hint_nt_undef
                     || brgattr.hint_load_nt_B != brgemm_hint_nt_undef);
     if (brgattr.use_uker || hint_blocking_set || brgattr.bd_mask_level
-            || brgattr.fpmath_mode != fpmath_mode::strict || max_vpad > 0) {
+            || brgattr.fpmath_mode != fpmath_mode::strict || max_vpad > 0
+            || brgattr.use_mmla) {
         if (brg->is_dgmm)
             CHECK(brdgmm_blocking(brg));
         else
@@ -413,6 +419,20 @@ status_t brgemm_desc_set_attr(
         if ((max_vpad > min_bd_block)) return status::unimplemented;
     }
 
+    if (brgattr.use_mmla) {
+        constexpr int max_mmla_acc_regs = 24;
+        constexpr int max_mmla_bd_block = 12;
+        const int compute_ld_blocks = brg->ld_block2;
+        const int acc_regs = rnd_up(brg->bd_block, brgemm_utils::mmla_bd_blk())
+                * compute_ld_blocks;
+        if (brg->rd_block != brgemm_utils::mmla_rd_block()
+                || brg->bd_block > max_mmla_bd_block
+                || !is_mmla_ld_blocks_supported(compute_ld_blocks)
+                || acc_regs > max_mmla_acc_regs)
+            return status::unimplemented;
+        return status::unimplemented;
+    }
+
     brg->LDA2 = (brgattr.LDA2 != 0) ? brgattr.LDA2 : brg->LDA;
     brg->LDB2 = (brgattr.LDB2 != 0) ? brgattr.LDB2 : brg->LDB;
     brg->LDC2_M = (brgattr.LDC2_M != 0) ? brgattr.LDC2_M : brg->LDC;
@@ -421,7 +441,7 @@ status_t brgemm_desc_set_attr(
     brg->is_blocked = (brg->LDA2 != brg->LDA || brg->LDB2 != brg->LDB
             || brg->LDC2_M != brg->LDC || brg->LDC2_N != brg->ld_block);
 
-    if (!IMPLICATION(brg->is_blocked, brg->layout = brgemm_row_major))
+    if (!IMPLICATION(brg->is_blocked, brg->layout == brgemm_row_major))
         return status::invalid_arguments;
 
     brg->prfA = brgattr.hint_prfA;
@@ -550,6 +570,8 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(brgattr.bd_mask_level);
     CMP_BRGEMM_FIELD(brgattr.use_uker);
     CMP_BRGEMM_FIELD(brgattr.use_interleave_stores);
+    CMP_BRGEMM_FIELD(brgattr.use_mmla);
+    CMP_BRGEMM_FIELD(brgattr.use_mmla_packed_a);
     CMP_BRGEMM_FIELD(brgattr.b_is_vnni);
     CMP_BRGEMM_FIELD(brgattr.fpmath_mode);
     CMP_BRGEMM_FIELD(brgattr.LDA2);

--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -430,7 +430,6 @@ status_t brgemm_desc_set_attr(
                 || !is_mmla_ld_blocks_supported(compute_ld_blocks)
                 || acc_regs > max_mmla_acc_regs)
             return status::unimplemented;
-        return status::unimplemented;
     }
 
     brg->LDA2 = (brgattr.LDA2 != 0) ? brgattr.LDA2 : brg->LDA;

--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -467,9 +467,9 @@ status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
     const bool has_per_m_zp_comp = brg->has_zp_a_compensation_per_m();
     if (has_per_m_zp_comp) {
         const bool per_m_compensation_ok = brg->brgattr.use_mmla && brg->is_int8
-                && brg->dt_a == data_type::u8 && brg->dt_b == data_type::s8
-                && has_src_zp && !brg->req_s8s8_compensation
-                && !brg->req_cal_comp_pads
+                && utils::one_of(brg->dt_a, data_type::u8, data_type::s8)
+                && brg->dt_b == data_type::s8 && has_src_zp
+                && !brg->req_s8s8_compensation && !brg->req_cal_comp_pads
                 && brg->zp_a_compensation_m_stride >= brg->load_dim;
         if (!per_m_compensation_ok) return status::unimplemented;
     }

--- a/src/cpu/aarch64/brgemm/brgemm.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm.cpp
@@ -425,7 +425,7 @@ status_t brgemm_desc_set_attr(
         const int compute_ld_blocks = brg->ld_block2;
         const int acc_regs = rnd_up(brg->bd_block, brgemm_utils::mmla_bd_blk())
                 * compute_ld_blocks;
-        if (brg->rd_block != brgemm_utils::mmla_rd_block()
+        if (brg->rd_block != brgemm_utils::mmla_rd_block(brg->typesize_A)
                 || brg->bd_block > max_mmla_bd_block
                 || !is_mmla_ld_blocks_supported(compute_ld_blocks)
                 || acc_regs > max_mmla_acc_regs)
@@ -460,7 +460,31 @@ status_t brgemm_desc_set_attr(
 }
 
 status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
-    // TODO: implement functionality here similar to corresponding one in x64
+    if (brg == nullptr) return status::invalid_arguments;
+    if (brg->zp_a_compensation_m_stride < 0) return status::invalid_arguments;
+
+    const bool has_src_zp = brg->zp_type_a != brgemm_broadcast_t::none;
+    const bool has_per_m_zp_comp = brg->has_zp_a_compensation_per_m();
+    if (has_per_m_zp_comp) {
+        const bool per_m_compensation_ok = brg->brgattr.use_mmla && brg->is_int8
+                && brg->dt_a == data_type::u8 && brg->dt_b == data_type::s8
+                && has_src_zp && !brg->req_s8s8_compensation
+                && !brg->req_cal_comp_pads
+                && brg->zp_a_compensation_m_stride >= brg->load_dim;
+        if (!per_m_compensation_ok) return status::unimplemented;
+    }
+
+    const bool with_vpad
+            = brg->brgattr.max_top_vpad > 0 || brg->brgattr.max_bottom_vpad > 0;
+    const bool needs_int8_comp_pads = brg->req_cal_comp_pads
+            || (with_vpad && (brg->req_s8s8_compensation || has_src_zp));
+    // Integer MMLA does not use BRGEMM's in-loop padding compensation. A
+    // virtual-padding caller with a source zero point may instead supply
+    // source zero-point compensation per M row.
+    if (brg->brgattr.use_mmla && brg->is_int8 && needs_int8_comp_pads
+            && !has_per_m_zp_comp)
+        return status::unimplemented;
+
     return status::success;
 }
 
@@ -532,6 +556,7 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(is_dgmm);
     CMP_BRGEMM_FIELD(with_sum);
     CMP_BRGEMM_FIELD(req_cal_comp_pads);
+    CMP_BRGEMM_FIELD(zp_a_compensation_m_stride);
 
     CMP_BRGEMM_FIELD(sum_scale);
     CMP_BRGEMM_FIELD(sum_zp);

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -150,6 +150,11 @@ struct DNNL_API brgemm_attr_t {
     // use_interleave_stores is a value that determines whether to use the
     // interleave stores or not
     bool use_interleave_stores;
+    // use_mmla requests the mmla compute path explicitly
+    // currently supported mmla is only bf16 mmla
+    bool use_mmla;
+    // use_mmla_packed_a expects A to use the mmla pack
+    bool use_mmla_packed_a;
     impl::fpmath_mode_t fpmath_mode = fpmath_mode::strict;
     bool b_is_vnni {false};
     // Second level leading dimension describing distance between 16-line

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2023 FUJITSU LIMITED
-* Copyright 2025, 2026 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -150,10 +150,10 @@ struct DNNL_API brgemm_attr_t {
     // use_interleave_stores is a value that determines whether to use the
     // interleave stores or not
     bool use_interleave_stores;
-    // use_mmla requests the mmla compute path explicitly
-    // currently supported mmla is only bf16 mmla
+    // use_mmla requests the MMLA compute path explicitly.
+    // Supported inputs are bf16 x bf16 and u8 x s8.
     bool use_mmla;
-    // use_mmla_packed_a expects A to use the mmla pack
+    // use_mmla_packed_a expects A to use the MMLA packed layout.
     bool use_mmla_packed_a;
     impl::fpmath_mode_t fpmath_mode = fpmath_mode::strict;
     bool b_is_vnni {false};
@@ -224,6 +224,9 @@ struct brgemm_desc_t {
     bool is_dgmm = false; // set to true in brdgmm_desc_init
     bool with_sum = false;
     bool req_cal_comp_pads = false;
+    // A positive value enables per-M source zero-point compensation and gives
+    // the distance between M rows in int32_t elements. Zero disables it.
+    int zp_a_compensation_m_stride = 0;
 
     float sum_scale = 0.0f;
     int32_t sum_zp = 0;
@@ -295,6 +298,10 @@ struct brgemm_desc_t {
     bool is_col_major() const {
         assert(layout != brgemm_layout_undef);
         return layout == brgemm_col_major;
+    }
+
+    bool has_zp_a_compensation_per_m() const {
+        return zp_a_compensation_m_stride > 0;
     }
 
     int get_wsp_buffer_size() const noexcept {

--- a/src/cpu/aarch64/brgemm/brgemm_types.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_types.hpp
@@ -151,7 +151,7 @@ struct DNNL_API brgemm_attr_t {
     // interleave stores or not
     bool use_interleave_stores;
     // use_mmla requests the MMLA compute path explicitly.
-    // Supported inputs are bf16 x bf16 and u8 x s8.
+    // Supported inputs are bf16 x bf16, u8 x s8, and s8 x s8.
     bool use_mmla;
     // use_mmla_packed_a expects A to use the MMLA packed layout.
     bool use_mmla_packed_a;

--- a/src/cpu/aarch64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.cpp
@@ -93,6 +93,14 @@ void maybe_try_bf32(brgemm_desc_t *brg) {
     //
 }
 
+// only bf16 mmla is currently supported
+status_t validate_mmla_compute(const brgemm_desc_t &brg) {
+    const bool is_valid = brg.is_bf16 && !brg.is_bf16_emu && !brg.is_dgmm
+            && brg.is_row_major()
+            && utils::one_of(brg.isa_impl, sve_128, sve_256);
+    return is_valid ? status::success : status::unimplemented;
+}
+
 status_t set_isa_impl(brgemm_desc_t *brg) {
     auto is_isa_ok = [&](cpu_isa_t isa) {
         return mayiuse(isa) &&
@@ -168,6 +176,21 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     return max_bcast_block;
 }
 
+int default_mmla_ld_block2(const brgemm_desc_t *brg) {
+    constexpr int heur_max_acc_regs = 24;
+    constexpr int heur_min_ld_block2 = 3;
+    constexpr int heur_max_ld_block2 = 6;
+
+    if (brg->bcast_dim <= 2) return 12;
+    if (!brg->brgattr.use_mmla_packed_a && brg->bcast_dim > 8) return 4;
+
+    const int bd_block = nstl::min(brg->bcast_dim, 8);
+    const int bd_pairs = utils::div_up(bd_block, mmla_bd_blk());
+    const int max_ld_block2 = heur_max_acc_regs / (2 * bd_pairs);
+    return nstl::min(
+            heur_max_ld_block2, nstl::max(heur_min_ld_block2, max_ld_block2));
+}
+
 inline size_t data_type_vnni_granularity(data_type_t data_type) {
     using namespace data_type;
     switch (data_type) {
@@ -182,6 +205,7 @@ inline size_t data_type_vnni_granularity(data_type_t data_type) {
     }
     return size_t(0); /* should not be reachable */
 }
+
 status_t brgemm_blocking(brgemm_desc_t *brg) {
 
     CHECK(set_isa_impl(brg));
@@ -189,37 +213,70 @@ status_t brgemm_blocking(brgemm_desc_t *brg) {
     assert(!brg->is_dgmm); // should not be called from brdgmm
     set_brg_vmm(brg);
 
+    const bool use_mmla = brg->brgattr.use_mmla;
     brg->ld_block = simd_elems(brg->dt_c, brg->isa_impl);
-    brg->ldb = brg->load_dim / brg->ld_block;
+    brg->ldb = use_mmla ? utils::div_up(brg->load_dim, brg->ld_block)
+                        : brg->load_dim / brg->ld_block;
     brg->ldb_tail = brg->load_dim % brg->ld_block;
 
-    int adj_ld_block2 = calculate_ldb_params(brg, 4);
-    int max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
-
-    // reduce 'ld_block2' to allow a larger 'bd_block'
+    const int min_block = 1;
     const int max_vpad = nstl::max(
             brg->brgattr.max_top_vpad, brg->brgattr.max_bottom_vpad);
-    if (max_bcast_block < max_vpad) {
-        adj_ld_block2 = calculate_ldb_params(brg, 2);
-        max_bcast_block = calculate_max_bcast_block(brg, adj_ld_block2);
+    const int mmla_max_bd_block = 8;
+
+    auto calc_max_bcast_block = [&](int try_ld_block2) {
+        const int adj_ld_block2 = calculate_ldb_params(brg, try_ld_block2);
+        return calculate_max_bcast_block(brg, adj_ld_block2);
+    };
+
+    if (use_mmla) {
+        const int ld_block2 = brg->brgattr.hint_ld_block2 != 0
+                ? brg->brgattr.hint_ld_block2
+                : default_mmla_ld_block2(brg);
+        calculate_ldb_params(brg, ld_block2);
+        auto set_mmla_blocking = [&]() {
+            brg->bdb = brg->bcast_dim / brg->bd_block;
+            brg->bdb_tail = brg->bcast_dim % brg->bd_block;
+            brg->rd_block = mmla_rd_block();
+            brg->rdb = brg->reduce_dim / brg->rd_block;
+            brg->rdb_tail = brg->reduce_dim % brg->rd_block;
+            brg->is_M_tail = false;
+        };
+        brg->bd_block = brg->brgattr.hint_bd_block != 0
+                ? brg->brgattr.hint_bd_block
+                : (brg->brgattr.use_mmla_packed_a
+                                          || brg->bcast_dim <= mmla_max_bd_block
+                                  ? nstl::min(brg->bcast_dim, mmla_max_bd_block)
+                                  : nstl::min(brg->bcast_dim, 6));
+        set_mmla_blocking();
+        return status::success;
     }
 
-    const int min_block = 1;
+    int max_bcast_block = calc_max_bcast_block(4);
+    if (max_bcast_block < max_vpad) {
+        max_bcast_block = calc_max_bcast_block(2);
+    }
+
     float best_bd_block_eff = 0.f;
     brg->bd_block = 1;
     for (int bd_block = max_bcast_block; bd_block >= min_block; bd_block--) {
+        const int min_bd_block = brg->bcast_dim % bd_block != 0
+                ? brg->bcast_dim % bd_block
+                : bd_block;
+        if (max_vpad > min_bd_block) continue;
+
         const auto bd_block_disb = static_cast<float>(brg->bcast_dim)
                 / rnd_up(brg->bcast_dim, bd_block);
         const auto brgemm_microkernel_eff
-                = (static_cast<float>(adj_ld_block2) * bd_block)
-                / (((adj_ld_block2) + bd_block) * max_bcast_block);
+                = (static_cast<float>(brg->ld_block2) * bd_block)
+                / (((brg->ld_block2) + bd_block) * max_bcast_block);
         const auto bd_block_eff = bd_block_disb * brgemm_microkernel_eff;
 
         float block_foot_print = static_cast<float>(brg->typesize_A)
                 * (bd_block * brg->reduce_dim);
         if (block_foot_print <= static_cast<float>(
                     platform::get_per_core_cache_size(1))
-                && (bd_block_eff > best_bd_block_eff)) {
+                && bd_block_eff > best_bd_block_eff) {
             brg->bd_block = bd_block;
             best_bd_block_eff = bd_block_eff;
         }

--- a/src/cpu/aarch64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.cpp
@@ -139,7 +139,8 @@ void maybe_try_bf32(brgemm_desc_t *brg) {
 status_t validate_mmla_compute(const brgemm_desc_t &brg) {
     const bool isa_ok = utils::one_of(brg.isa_impl, sve_128, sve_256);
     const bool is_bf16_mmla = brg.is_bf16 && !brg.is_bf16_emu;
-    const bool is_int8_mmla = brg.is_int8 && brg.dt_a == data_type::u8
+    const bool is_int8_mmla = brg.is_int8
+            && utils::one_of(brg.dt_a, data_type::u8, data_type::s8)
             && brg.dt_b == data_type::s8 && mayiuse_sve_i8mm();
     const bool is_valid = isa_ok && (is_bf16_mmla || is_int8_mmla)
             && !brg.is_dgmm && brg.is_row_major();

--- a/src/cpu/aarch64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.cpp
@@ -87,11 +87,20 @@ void init_common_conf(brgemm_desc_t *brg, brgemm_batch_kind_t type, float alpha,
 namespace brgemm_utils {
 
 status_t init_mmla_wei_md(
-        memory_desc_t &md, int k_dim, int n_dim, int n_block) {
+        memory_desc_t &md, int k_dim, int n_dim, int n_block, int k_block) {
+    const bool dt_ok
+            = utils::one_of(md.data_type, data_type::bf16, data_type::s8);
     const int dt_sz = types::data_type_size(md.data_type);
+    if (!dt_ok || dt_sz <= 0 || mmla_rd_chunk_bytes() % dt_sz != 0)
+        return status::invalid_arguments;
+
+    const int k_chunk = mmla_rd_chunk_elems(dt_sz);
+    const int full_k_block = mmla_rd_block(dt_sz);
+    const bool single_chunk = md.data_type == data_type::s8;
+    const int expected_k_block = single_chunk ? k_chunk : full_k_block;
+    if (k_block == 0) k_block = expected_k_block;
     if (k_dim < 0 || k_dim >= md.ndims || n_dim < 0 || n_dim >= md.ndims
-            || k_dim == n_dim || n_block <= 0 || dt_sz <= 0
-            || mmla_rd_chunk_bytes() % dt_sz != 0)
+            || k_dim == n_dim || n_block <= 0 || k_block != expected_k_block)
         return status::invalid_arguments;
 
     blocking_desc_t blk {};
@@ -100,13 +109,21 @@ status_t init_mmla_wei_md(
     for (int d = 0; d < md.ndims; ++d)
         if (d != k_dim) blk.strides[d] = order--;
     blk.strides[k_dim] = order;
-    blk.inner_nblks = 3;
-    blk.inner_blks[0] = mmla_rd_chunks_per_block(dt_sz);
-    blk.inner_idxs[0] = k_dim;
-    blk.inner_blks[1] = n_block;
-    blk.inner_idxs[1] = n_dim;
-    blk.inner_blks[2] = mmla_rd_chunk_elems(dt_sz);
-    blk.inner_idxs[2] = k_dim;
+    if (single_chunk) {
+        blk.inner_nblks = 2;
+        blk.inner_blks[0] = n_block;
+        blk.inner_idxs[0] = n_dim;
+        blk.inner_blks[1] = k_chunk;
+        blk.inner_idxs[1] = k_dim;
+    } else {
+        blk.inner_nblks = 3;
+        blk.inner_blks[0] = mmla_rd_chunks_per_block();
+        blk.inner_idxs[0] = k_dim;
+        blk.inner_blks[1] = n_block;
+        blk.inner_idxs[1] = n_dim;
+        blk.inner_blks[2] = k_chunk;
+        blk.inner_idxs[2] = k_dim;
+    }
     return memory_desc_init_by_blocking_desc(md, blk);
 }
 
@@ -120,9 +137,12 @@ void maybe_try_bf32(brgemm_desc_t *brg) {
 // FMMLA requires FEAT_F32MM, which the current AArch64 ISA dispatch does not
 // enable. FP32 BRGEMM therefore retains the existing SVE FMLA path.
 status_t validate_mmla_compute(const brgemm_desc_t &brg) {
-    const bool is_valid = brg.is_bf16 && !brg.is_bf16_emu && !brg.is_dgmm
-            && brg.is_row_major()
-            && utils::one_of(brg.isa_impl, sve_128, sve_256);
+    const bool isa_ok = utils::one_of(brg.isa_impl, sve_128, sve_256);
+    const bool is_bf16_mmla = brg.is_bf16 && !brg.is_bf16_emu;
+    const bool is_int8_mmla = brg.is_int8 && brg.dt_a == data_type::u8
+            && brg.dt_b == data_type::s8 && mayiuse_sve_i8mm();
+    const bool is_valid = isa_ok && (is_bf16_mmla || is_int8_mmla)
+            && !brg.is_dgmm && brg.is_row_major();
     return is_valid ? status::success : status::unimplemented;
 }
 
@@ -259,21 +279,18 @@ status_t brgemm_blocking(brgemm_desc_t *brg) {
                 ? brg->brgattr.hint_ld_block2
                 : default_mmla_ld_block2(brg);
         calculate_ldb_params(brg, ld_block2);
-        auto set_mmla_blocking = [&]() {
-            brg->bdb = brg->bcast_dim / brg->bd_block;
-            brg->bdb_tail = brg->bcast_dim % brg->bd_block;
-            brg->rd_block = mmla_rd_block();
-            brg->rdb = brg->reduce_dim / brg->rd_block;
-            brg->rdb_tail = brg->reduce_dim % brg->rd_block;
-            brg->is_M_tail = false;
-        };
         brg->bd_block = brg->brgattr.hint_bd_block != 0
                 ? brg->brgattr.hint_bd_block
                 : (brg->brgattr.use_mmla_packed_a
                                           || brg->bcast_dim <= mmla_max_bd_block
                                   ? nstl::min(brg->bcast_dim, mmla_max_bd_block)
                                   : nstl::min(brg->bcast_dim, 6));
-        set_mmla_blocking();
+        brg->bdb = brg->bcast_dim / brg->bd_block;
+        brg->bdb_tail = brg->bcast_dim % brg->bd_block;
+        brg->rd_block = mmla_rd_block(brg->typesize_A);
+        brg->rdb = brg->reduce_dim / brg->rd_block;
+        brg->rdb_tail = brg->reduce_dim % brg->rd_block;
+        brg->is_M_tail = false;
         return status::success;
     }
 

--- a/src/cpu/aarch64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.cpp
@@ -86,6 +86,30 @@ void init_common_conf(brgemm_desc_t *brg, brgemm_batch_kind_t type, float alpha,
 
 namespace brgemm_utils {
 
+status_t init_mmla_wei_md(
+        memory_desc_t &md, int k_dim, int n_dim, int n_block) {
+    const int dt_sz = types::data_type_size(md.data_type);
+    if (k_dim < 0 || k_dim >= md.ndims || n_dim < 0 || n_dim >= md.ndims
+            || k_dim == n_dim || n_block <= 0 || dt_sz <= 0
+            || mmla_rd_chunk_bytes() % dt_sz != 0)
+        return status::invalid_arguments;
+
+    blocking_desc_t blk {};
+    // memory_desc_init_by_blocking_desc interprets strides as ordering ranks.
+    int order = md.ndims;
+    for (int d = 0; d < md.ndims; ++d)
+        if (d != k_dim) blk.strides[d] = order--;
+    blk.strides[k_dim] = order;
+    blk.inner_nblks = 3;
+    blk.inner_blks[0] = mmla_rd_chunks_per_block(dt_sz);
+    blk.inner_idxs[0] = k_dim;
+    blk.inner_blks[1] = n_block;
+    blk.inner_idxs[1] = n_dim;
+    blk.inner_blks[2] = mmla_rd_chunk_elems(dt_sz);
+    blk.inner_idxs[2] = k_dim;
+    return memory_desc_init_by_blocking_desc(md, blk);
+}
+
 bool can_dispatch_uker(const brgemm_desc_t *brg) {
     return false;
 }
@@ -93,7 +117,8 @@ void maybe_try_bf32(brgemm_desc_t *brg) {
     //
 }
 
-// only bf16 mmla is currently supported
+// FMMLA requires FEAT_F32MM, which the current AArch64 ISA dispatch does not
+// enable. FP32 BRGEMM therefore retains the existing SVE FMLA path.
 status_t validate_mmla_compute(const brgemm_desc_t &brg) {
     const bool is_valid = brg.is_bf16 && !brg.is_bf16_emu && !brg.is_dgmm
             && brg.is_row_major()

--- a/src/cpu/aarch64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2024-2025 Arm Ltd. and affiliates
+* Copyright 2024-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -34,6 +34,31 @@ status_t init_kernel_datatype(
         brgemm_desc_t *brg, data_type_t dt_a, data_type_t dt_b);
 
 namespace brgemm_utils {
+inline constexpr int mmla_bd_blk() {
+    return 2;
+}
+inline constexpr int mmla_ld_blk() {
+    return 2;
+}
+inline constexpr int mmla_rd_chunk_bytes() {
+    return 8;
+}
+inline constexpr int mmla_rd_block() {
+    return 8;
+}
+
+inline constexpr int mmla_rd_chunk_elems(int dt_a_sz) {
+    return mmla_rd_chunk_bytes() / dt_a_sz;
+}
+inline constexpr int mmla_rd_chunks_per_block(int dt_a_sz) {
+    return mmla_rd_block() / mmla_rd_chunk_elems(dt_a_sz);
+}
+
+status_t validate_mmla_compute(const brgemm_desc_t &brg);
+
+inline bool is_mmla_ld_blocks_supported(dim_t ld_blocks) {
+    return ld_blocks >= 1 && ld_blocks <= 12;
+}
 
 bool can_dispatch_uker(const brgemm_desc_t *brg);
 

--- a/src/cpu/aarch64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.hpp
@@ -54,6 +54,23 @@ inline constexpr int mmla_rd_chunks_per_block(int dt_a_sz) {
     return mmla_rd_block() / mmla_rd_chunk_elems(dt_a_sz);
 }
 
+// MMLA BRGEMM and its weight reorder share a four-vector N tile. Keep the
+// packed-weight layout and kernel blocking derived from this value.
+inline constexpr int mmla_ld_block2() {
+    return 4;
+}
+// With four N vectors, native-A kernels can keep at most six M rows within
+// the 24-register accumulator budget.
+inline constexpr int mmla_max_native_bd_block() {
+    return 6;
+}
+inline int mmla_n_block(cpu_isa_t isa) {
+    return mmla_ld_block2() * simd_elems(data_type::f32, isa);
+}
+
+// Build the packed-weight layout consumed by MMLA BRGEMM and reorders.
+status_t init_mmla_wei_md(memory_desc_t &md, int k_dim, int n_dim, int n_block);
+
 status_t validate_mmla_compute(const brgemm_desc_t &brg);
 
 inline bool is_mmla_ld_blocks_supported(dim_t ld_blocks) {

--- a/src/cpu/aarch64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/aarch64/brgemm/brgemm_utils.hpp
@@ -40,18 +40,19 @@ inline constexpr int mmla_bd_blk() {
 inline constexpr int mmla_ld_blk() {
     return 2;
 }
+// Each packed MMLA K chunk contributes 64 bits per input row.
 inline constexpr int mmla_rd_chunk_bytes() {
     return 8;
 }
-inline constexpr int mmla_rd_block() {
-    return 8;
-}
-
 inline constexpr int mmla_rd_chunk_elems(int dt_a_sz) {
     return mmla_rd_chunk_bytes() / dt_a_sz;
 }
-inline constexpr int mmla_rd_chunks_per_block(int dt_a_sz) {
-    return mmla_rd_block() / mmla_rd_chunk_elems(dt_a_sz);
+// A kernel reduction block comprises two 64-bit K chunks.
+inline constexpr int mmla_rd_chunks_per_block() {
+    return 2;
+}
+inline constexpr int mmla_rd_block(int dt_a_sz) {
+    return mmla_rd_chunks_per_block() * mmla_rd_chunk_elems(dt_a_sz);
 }
 
 // MMLA BRGEMM and its weight reorder share a four-vector N tile. Keep the
@@ -68,8 +69,11 @@ inline int mmla_n_block(cpu_isa_t isa) {
     return mmla_ld_block2() * simd_elems(data_type::f32, isa);
 }
 
-// Build the packed-weight layout consumed by MMLA BRGEMM and reorders.
-status_t init_mmla_wei_md(memory_desc_t &md, int k_dim, int n_dim, int n_block);
+// Build the packed-weight layout consumed by MMLA BRGEMM and reorders. A zero
+// K block selects the canonical layout: two K chunks for BF16 and one K chunk
+// for int8. An explicit K block must match that datatype-specific layout.
+status_t init_mmla_wei_md(
+        memory_desc_t &md, int k_dim, int n_dim, int n_block, int k_block = 0);
 
 status_t validate_mmla_compute(const brgemm_desc_t &brg);
 

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -23,6 +23,7 @@
 #include "common/utils.hpp"
 
 #include "cpu/aarch64/brgemm/brgemm_types.hpp"
+#include "cpu/aarch64/brgemm/brgemm_utils.hpp"
 #include "cpu/aarch64/cpu_barrier.hpp"
 #include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/aarch64/jit_generator.hpp"
@@ -67,6 +68,9 @@ struct jit_brgemm_kernel_t : public jit_generator_t {
         : jit_generator_t(nullptr, MAX_CODE_SIZE, true, sve_512)
         , brg(abrg)
         , postops_injector_(nullptr)
+        , use_mmla(abrg.brgattr.use_mmla)
+        , use_mmla_packed_a(abrg.brgattr.use_mmla_packed_a)
+        , use_gemv_path(abrg.is_gemv && !abrg.brgattr.use_mmla)
         , max_effective_vregs(
                   max_vregs - ((brg.is_int8 && !brg.has_int8_vnni) ? 2 : 0)) {
 
@@ -75,7 +79,10 @@ struct jit_brgemm_kernel_t : public jit_generator_t {
         assert(!utils::one_of(brg.isa_impl, isa_all, isa_undef));
         const int is_ldb2_tail = brg.ldb2_tail ? 1 : 0;
         const int is_ldb_tail = brg.ldb_tail ? 1 : 0;
-        is_ldb_loop_ = brg.ldb2 + is_ldb2_tail + is_ldb_tail > 1;
+        const int n_ldb_loops = use_mmla
+                ? brg.ldb2 + is_ldb2_tail
+                : brg.ldb2 + is_ldb2_tail + is_ldb_tail;
+        is_ldb_loop_ = n_ldb_loops > 1;
 
         if (brg.with_eltwise || brg.with_binary || brg.with_sum) {
 
@@ -220,14 +227,33 @@ private:
     bool is_ldb_loop_ = false;
     bool with_binary_non_scalar_bcast_ = false;
     constexpr static int max_vregs = 32;
+    const bool use_mmla;
+    const bool use_mmla_packed_a;
+    const bool use_gemv_path;
     const int max_effective_vregs;
 
+    int mmla_bd_blk() const { return brgemm_utils::mmla_bd_blk(); }
+    int mmla_ld_regs_per_block() const { return brgemm_utils::mmla_ld_blk(); }
+    int mmla_rd_chunk_elems() const {
+        return brgemm_utils::mmla_rd_chunk_elems(brg.typesize_A);
+    }
+    int mmla_rd_chunks_per_block() const {
+        return brgemm_utils::mmla_rd_chunks_per_block(brg.typesize_A);
+    }
+    int mmla_rd_block() const { return brgemm_utils::mmla_rd_block(); }
     PReg rd_tail_mask = PReg(2);
     PReg ld_tail_mask = PReg(3);
 
     ZReg accm(int ld_block, int bd, int ld) const {
         // Starts at the highest (e.g. 31), descending and using ld_block * bd_block registers as accumulators
         return ZReg(max_effective_vregs - 1 - (bd * ld_block + ld));
+    }
+    ZReg accm_mmla(int ld_block, int bd_pair, int ld4) const {
+        return accm(ld_block, mmla_bd_blk() * bd_pair + (ld4 % mmla_bd_blk()),
+                ld4 / mmla_bd_blk());
+    }
+    int mmla_bd_pairs(int bd_block) const {
+        return div_up(bd_block, mmla_bd_blk());
     }
 
     ZReg bcst(int bd = 0) const {
@@ -298,8 +324,8 @@ private:
 
     void store_accumulators(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_ld_tail, bool skip_accumulation);
-    void store_accumulators_without_post_ops(
-            int bd_block, int ld_block, bool is_ld_tail);
+    void store_accumulators_without_post_ops(int bd_block, int ld_block,
+            bool is_ld_tail, bool mmla_deinterleave_on_store = false);
     void store_accumulators_apply_post_ops(int bd_block, int ld_block,
             int ldb_and_bdb_offset, bool is_ld_tail);
     void apply_compensation(int bd_block, int ld_block, bool is_ld_tail);
@@ -328,13 +354,28 @@ private:
             const PReg &mask, const XReg &reg_stride_bytes,
             const int32_t stride_bytes, const int32_t n, const data_type_t dt);
 
+    void mmla_deinterleave_accumulators(int bd_block, int ld_block2);
+    int mmla_rd_chunk_B_offset(int ld_blocks) const noexcept;
+    int mmla_rdb_B_offset(int ld_blocks) const noexcept;
+    void mmla_load_packed_a(int rd_chunk, int bd_pair, const ZReg &z_a,
+            const ZReg &z_a_tmp, int bd_block, bool row0_valid,
+            bool row1_valid);
+    void mmla_load_plain_a(int rd_chunk, int bd_pair, const ZReg &z_a,
+            const ZReg &z_a_tmp, int rd_tail, bool row0_valid, bool row1_valid);
+    void mmla_load_b(const XReg &b_base, int ld, int z_idx);
+
     // FMLA/DOT
     void dot_product(ZReg v_acc, ZReg v_a, ZReg v_b);
     // FMLA/DOT with indexed b vector
     void dot_product(ZReg v_acc, ZReg v_a, ZReg v_b, const int16_t index);
 
+    // MMLA
+    void mmla(ZReg v_acc, ZReg v_a, ZReg v_b);
+
     void gemm_microkernel(int bd_block2, bool is_bdb_tail, int ld_block,
             bool is_rd_tail, bool is_ld_tail, int vpad, int rows_for_rd_tail);
+    void gemm_microkernel_mmla(bool is_bdb_tail, int ld_block,
+            int b_panel_ld_block, bool is_rd_tail, bool advance_a_b, int vpad);
     // GEMV microkernel is distinct from GEMM in that it loads vectors from A and B
     // and assumes that we will sum all the elements after the microkernel
     void gemv_microkernel(
@@ -354,8 +395,8 @@ private:
     int D_offset(int bd, int ld) const noexcept;
     int po_offset(int bd, int ld) const noexcept;
 
-    int rdb_A_offset() const noexcept;
-    int rdb_B_offset() const noexcept;
+    int rdb_A_offset(int bd_block) const noexcept;
+    int rdb_B_offset(int ld_block2) const noexcept;
 
     int ldb_B_offset(int ld_block2, bool is_tail = false) const noexcept;
     int ldb_C_offset(int ld_block2, bool is_tail = false) const noexcept;
@@ -390,7 +431,7 @@ int jit_brgemm_kernel_t::A_offset(int bd, int rd) const noexcept {
     return brg.typesize_A * (bd * brg.LDA + rd);
 }
 int jit_brgemm_kernel_t::B_offset(int ld, int rd) const noexcept {
-    if (brg.is_gemv) {
+    if (use_gemv_path) {
         return (ld + rd * brg.ld_block2) * brg.typesize_B;
     } else {
         const int data_vnni_granularity = brg.ld_step;
@@ -401,14 +442,14 @@ int jit_brgemm_kernel_t::B_offset(int ld, int rd) const noexcept {
     }
 }
 int jit_brgemm_kernel_t::C_offset(int bd, int ld) const noexcept {
-    if (brg.is_gemv) {
+    if (use_gemv_path) {
         return (ld + bd * brg.ld_block2) * brg.typesize_C;
     } else {
         return brg.typesize_C * (bd * brg.LDC + ld * brg.ld_block);
     }
 }
 int jit_brgemm_kernel_t::D_offset(int bd, int ld) const noexcept {
-    if (brg.is_gemv) {
+    if (use_gemv_path) {
         return (ld + bd * brg.ld_block2) * brg.typesize_D;
     } else {
         return brg.typesize_D * (bd * brg.LDD + ld * brg.ld_block);
@@ -418,15 +459,37 @@ int jit_brgemm_kernel_t::po_offset(int bd, int ld) const noexcept {
     return bd * brg.LDD + ld * brg.ld_block;
 }
 
-int jit_brgemm_kernel_t::rdb_A_offset() const noexcept {
+int jit_brgemm_kernel_t::mmla_rd_chunk_B_offset(int ld_blocks) const noexcept {
+    return ld_blocks * mmla_ld_regs_per_block()
+            * static_cast<int>(simd_bytes(brg.isa_impl));
+}
+
+int jit_brgemm_kernel_t::mmla_rdb_B_offset(int ld_blocks) const noexcept {
+    return mmla_rd_chunk_B_offset(ld_blocks) * mmla_rd_chunks_per_block();
+}
+
+int jit_brgemm_kernel_t::rdb_A_offset(int bd_block) const noexcept {
+    if (use_mmla) {
+        if (use_mmla_packed_a)
+            return brg.typesize_A * mmla_bd_blk() * mmla_rd_block();
+        return brg.typesize_A * mmla_rd_block();
+    }
+
     return brg.typesize_A * brg.rd_block;
 }
-int jit_brgemm_kernel_t::rdb_B_offset() const noexcept {
+int jit_brgemm_kernel_t::rdb_B_offset(int ld_block2) const noexcept {
+    if (use_mmla) return mmla_rdb_B_offset(ld_block2);
+
     return brg.typesize_B * brg.rd_block * brg.LDB;
 }
 
 int jit_brgemm_kernel_t::ldb_B_offset(
         int ld_block2, bool is_tail) const noexcept {
+    if (use_mmla) {
+        return mmla_rdb_B_offset(ld_block2)
+                * div_up(brg.reduce_dim, mmla_rd_block());
+    }
+
     return (is_tail) ? brg.typesize_B * brg.ldb_tail * brg.ld_step
                      : brg.typesize_B * ld_block2 * brg.ld_block * brg.ld_step;
 }
@@ -446,6 +509,10 @@ int jit_brgemm_kernel_t::ldb_po_offset(
 }
 
 int jit_brgemm_kernel_t::bdb_A_offset(int bd_block2) const noexcept {
+    if (use_mmla && use_mmla_packed_a)
+        return bd_block2 * rnd_up(brg.reduce_dim, mmla_rd_chunk_elems())
+                * brg.bd_block * brg.typesize_A;
+
     return brg.typesize_A * bd_block2 * brg.bd_block * brg.LDA;
 }
 int jit_brgemm_kernel_t::bdb_C_offset(int bd_block2) const noexcept {
@@ -682,9 +749,9 @@ void jit_brgemm_kernel_t::read_params() {
 
     ldr(reg_C, ptr(param1, GET_OFF(ptr_C)));
     ldr(reg_D, ptr(param1, GET_OFF(ptr_D)));
-    ldr(reg_BS, ptr(param1, GET_OFF(BS)));
+    if (brg.brgattr.max_bs > 1) ldr(reg_BS, ptr(param1, GET_OFF(BS)));
 
-    mov_imm(reg_stride_bytes_A, brg.typesize_A * brg.LDA);
+    if (!use_mmla) mov_imm(reg_stride_bytes_A, brg.typesize_A * brg.LDA);
 
     // ptr_buf is re-used for passing compensations for
     // brg.req_s8s8_compensation case
@@ -752,15 +819,17 @@ void jit_brgemm_kernel_t::read_params() {
 void jit_brgemm_kernel_t::zero_accumulators(int bd_block2, bool is_bdb_tail,
         int ld_block2, bool is_ld_tail, bool skip_accumulation) {
     int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+    const int acc_bd_block
+            = use_mmla ? rnd_up(bd_block, mmla_bd_blk()) : bd_block;
     const bool need_to_apply_beta = brg.beta != 0.f;
     int base_offset = 0;
     auto x_addr = reg_aux_C;
-    for_(int bd = 0; bd < bd_block; bd++)
+    for_(int bd = 0; bd < acc_bd_block; bd++)
     for (int ld = 0; ld < ld_block2; ld++) {
         auto zmm = accm(ld_block2, bd, ld);
         // This part is moved here from apply_alpha_beta function so that fadd instruction can be avoided.
         // This is also required only when K is blocked.
-        if (need_to_apply_beta && !brg.is_gemv) {
+        if (need_to_apply_beta && !brg.is_gemv && !use_mmla) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
             const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
 
@@ -790,7 +859,9 @@ void jit_brgemm_kernel_t::zero_accumulators(int bd_block2, bool is_bdb_tail,
 void jit_brgemm_kernel_t::apply_alpha_beta(
         int bd_block, int ld_block2, bool is_ld_tail) {
     const bool apply_alpha = brg.alpha != 1.f;
+    const bool apply_beta = brg.beta != 0.f;
     const bool dq2ps_required = brg.is_int8 && (apply_alpha || brg.beta != 1.f);
+    const bool apply_beta_after_norm = apply_beta && use_mmla;
 
     auto vmm_alpha = z_tmp_1();
     if (apply_alpha) {
@@ -798,11 +869,35 @@ void jit_brgemm_kernel_t::apply_alpha_beta(
         mov_imm(wreg_tmp, float2int(static_cast<float>(brg.alpha)));
         dup(vmm_alpha.s, wreg_tmp);
     }
+    auto vmm_beta = z_tmp_3();
+    if (apply_beta_after_norm && brg.beta != 1.f) {
+        auto wreg_tmp = WReg(reg_tmp_gpr.getIdx());
+        mov_imm(wreg_tmp, float2int(static_cast<float>(brg.beta)));
+        dup(vmm_beta.s, wreg_tmp);
+    }
+    int base_offset = 0;
+    auto x_addr = reg_aux_C;
     for_(int bd = 0; bd < bd_block; bd++)
     for (int ld = 0; ld < ld_block2; ld++) {
         auto vmm = accm(ld_block2, bd, ld);
         if (dq2ps_required) { scvtf(vmm.s, P_ALL_ONE / T_m, vmm.s); }
         if (apply_alpha) { fmul(vmm.s, vmm.s, vmm_alpha.s); }
+        if (apply_beta_after_norm) {
+            const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
+            const int offset = C_offset(bd, ld);
+            auto vmm_c = z_tmp_2();
+
+            if (!use_mul_vl(offset - base_offset, 4, cpu_sveLen)) {
+                add_vl_or_imm(reg_tmp_, x_addr, offset - base_offset, X_TMP_0);
+                base_offset = offset;
+                x_addr = reg_tmp_;
+            }
+            LD_MUL_VL(ld1w, vmm_c.s, k_mask, x_addr, offset - base_offset, 4);
+
+            if (brg.beta != 1.f) { fmul(vmm_c.s, vmm_c.s, vmm_beta.s); }
+            fadd(vmm.s, vmm.s, vmm_c.s);
+        }
     }
 }
 
@@ -825,7 +920,8 @@ void jit_brgemm_kernel_t::apply_post_ops(
                 rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_aux_D);
                 rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
                         vmm_idx, D_offset(bd, ld));
-                if (is_ld_tail) rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
+                if (is_ld_tail && ld + 1 == ld_block2)
+                    rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
             }
         }
     }
@@ -898,8 +994,6 @@ static inline bool isa_has_masks(cpu_isa_t isa) {
 void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
         int bd_block, int ld_block2, int ldb_and_bdb_offset, bool is_ld_tail) {
 
-    auto k_mask = (!is_ld_tail) ? P_ALL_ONE : ld_tail_mask;
-
     // if (brg.is_int8 && alpha_or_beta_applicable && !beta_uses_vadd) ->
     // accumulated values are already converted to ps in apply_alpha_beta()
     const bool alpha_or_beta_applicable = brg.alpha != 1.0f || brg.beta != 0.f;
@@ -925,6 +1019,7 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                     offset = (ld + bd * ld_block2) * sizeof(float);
                     add_imm(addr, reg_aux_scales, offset, X_TMP_0);
                     const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                    const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
                     auto vmm_scales = z_tmp_1();
                     if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
                         ld1w(vmm_scales.s, k_mask / T_z, ptr(addr));
@@ -948,6 +1043,7 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                 const auto addr = X_DEFAULT_ADDR;
                 add_imm(addr, reg_aux_scales, scales_offset(ld), X_TMP_0);
                 const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
                 auto vmm_scales = z_tmp_1();
                 if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
                     ld1w(vmm_scales.s, k_mask / T_z, ptr(addr));
@@ -1000,7 +1096,9 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                         base_offset = offset;
                         x_addr = reg_tmp_;
                     }
-                    cvt2ps(brg.dt_bias, zmm_bias, x_addr, is_ld_tail, false,
+                    const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                    const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
+                    cvt2ps(brg.dt_bias, zmm_bias, x_addr, is_tail, false,
                             k_mask, offset, base_offset);
                     auto zmm = accm(ld_block2, bd, ld);
                     fadd(zmm.s, zmm.s, zmm_bias.s);
@@ -1022,7 +1120,9 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                     base_offset = offset;
                     x_addr = reg_tmp_;
                 }
-                cvt2ps(brg.dt_bias, zmm_bias, x_addr, is_ld_tail, false, k_mask,
+                const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
+                cvt2ps(brg.dt_bias, zmm_bias, x_addr, is_tail, false, k_mask,
                         offset, base_offset);
 
                 for (int bd = 0; bd < bd_block; bd++) {
@@ -1057,10 +1157,11 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
         if (brg.zp_type_c == brgemm_broadcast_t::per_tensor) {
             add_imm(X_DEFAULT_ADDR, reg_aux_zp_c_values, 0, X_TMP_0);
             ld1rw(z_tmp_2().s, P_ALL_ONE, ptr(X_DEFAULT_ADDR));
-            scvtf(vmm_zp_c.s, k_mask / T_m, z_tmp_2().s);
+            scvtf(vmm_zp_c.s, P_ALL_ONE / T_m, z_tmp_2().s);
         }
         for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             if (brg.zp_type_c == brgemm_broadcast_t::per_n) {
                 int zp_c_off = zp_c_values_offset(ld);
                 add_imm(X_DEFAULT_ADDR, reg_aux_zp_c_values, zp_c_off, X_TMP_0);
@@ -1084,6 +1185,8 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
                 zmm_lbound, zmm_ubound, reg_tmp_gpr, data_type::f32, brg.dt_d);
         for (int bd = 0; bd < bd_block; bd++) {
             for (int ld = 0; ld < ld_block2; ld++) {
+                const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
                 auto zmm = accm(ld_block2, bd, ld);
                 saturate_f32(zmm, zmm_lbound, zmm_ubound, brg.dt_d, k_mask);
                 frinti(zmm.s, k_mask, zmm.s);
@@ -1098,6 +1201,8 @@ void jit_brgemm_kernel_t::store_accumulators_apply_post_ops(
     for (int bd = 0; bd < bd_block; bd++) {
         for (int ld = 0; ld < ld_block2; ld++) {
             auto zmm = accm(ld_block2, bd, ld);
+            const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             const int offset = D_offset(bd, ld);
             if (!use_mul_vl(offset - base_offset,
                         types::data_type_size(brg.dt_d), cpu_sveLen)) {
@@ -1138,7 +1243,6 @@ void jit_brgemm_kernel_t::apply_compensation(
         int bd_block, int ld_block2, bool is_ld_tail) {
     // apply compensation to accumulated values
     // to avoid the loss of accuracy when converting s32 to f32
-    auto k_mask = (!is_ld_tail) ? P_ALL_ONE : ld_tail_mask;
 
     if (!brg.req_cal_comp_pads && brg.zp_type_a != brgemm_broadcast_t::none) {
         auto vmm_zp_a_val = z_tmp_2();
@@ -1151,6 +1255,7 @@ void jit_brgemm_kernel_t::apply_compensation(
         ldr(reg_aux_zp_comp_a, ptr(X_DEFAULT_ADDR));
         for (int ld = 0; ld < ld_block2; ld++) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             auto vmm_zp_comp_a = z_tmp_1();
             int zp_comp_a_off = zp_comp_a_offset(ld);
             // apply src zero points value to the accumulated values
@@ -1189,11 +1294,11 @@ void jit_brgemm_kernel_t::apply_compensation(
             auto vmm_comp = z_tmp_1();
             int comp_offset = compensations_offset(ld);
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             if (IMPLICATION(is_tail, is_superset(brg.isa_impl, sve_512))) {
-                const auto mask = is_tail ? k_mask : P_ALL_ONE;
                 add_imm(X_DEFAULT_ADDR, reg_aux_compensation, comp_offset,
                         X_TMP_1);
-                ld1w(vmm_comp.s, mask / T_z, ptr(X_DEFAULT_ADDR));
+                ld1w(vmm_comp.s, k_mask / T_z, ptr(X_DEFAULT_ADDR));
             } else {
                 not_(P_TMP.b, P_ALL_ONE, P_NOT_256.b);
                 cmplt(P_TMP.s, P_TMP / T_z, z_tail_mask().s, 0);
@@ -1210,8 +1315,8 @@ void jit_brgemm_kernel_t::apply_compensation(
     }
 }
 
-void jit_brgemm_kernel_t::store_accumulators_without_post_ops(
-        int bd_block, int ld_block2, bool is_ld_tail) {
+void jit_brgemm_kernel_t::store_accumulators_without_post_ops(int bd_block,
+        int ld_block2, bool is_ld_tail, bool mmla_deinterleave_on_store) {
 
     // if (brg.is_int8 && alpha_or_beta_applicable && !beta_uses_vadd) ->
     // accumulated values are converted to ps in apply_alpha_beta()
@@ -1238,22 +1343,55 @@ void jit_brgemm_kernel_t::store_accumulators_without_post_ops(
     auto x_addr = reg_aux_C;
     int base_offset = 0;
 
-    auto scalar_reg = SReg(0);
-
-    for (int bd = 0; bd < bd_block; bd++) {
-        for (int ld = 0; ld < ld_block2; ld++) {
-            auto zmm = accm(ld_block2, bd, ld);
-            const auto mask = is_ld_tail ? ld_tail_mask : P_ALL_ONE;
+    if (mmla_deinterleave_on_store) {
+        const auto store_acc = [&](const ZReg &zmm, int bd, int ld) {
+            const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto mask = is_tail ? ld_tail_mask : P_ALL_ONE;
             const int offset = C_offset(bd, ld);
             if (!use_mul_vl(offset - base_offset, 4, cpu_sveLen)) {
                 add_vl_or_imm(reg_tmp_, x_addr, offset - base_offset, X_TMP_0);
                 base_offset = offset;
                 x_addr = reg_tmp_;
             }
-            if (brg.is_gemv && brg.beta == 0.f) {
+            ST_MUL_VL(st1w, zmm.s, mask, x_addr, offset - base_offset, 4);
+        };
+
+        for (int bd_pair = 0; bd_pair < mmla_bd_pairs(bd_block); bd_pair++) {
+            for (int ld = 0; ld < ld_block2; ld++) {
+                auto zmm_even = accm_mmla(ld_block2, bd_pair, 2 * ld);
+                auto zmm_odd = accm_mmla(ld_block2, bd_pair, 2 * ld + 1);
+                uzp1(ZReg(ld).d, zmm_even.d, zmm_odd.d);
+                uzp2(zmm_odd.d, zmm_even.d, zmm_odd.d);
+            }
+            const int bd = mmla_bd_blk() * bd_pair;
+            for (int ld = 0; ld < ld_block2; ld++)
+                store_acc(ZReg(ld), bd, ld);
+            if ((bd + 1) < bd_block) {
+                for (int ld = 0; ld < ld_block2; ld++)
+                    store_acc(accm_mmla(ld_block2, bd_pair, 2 * ld + 1), bd + 1,
+                            ld);
+            }
+        }
+        return;
+    }
+
+    auto scalar_reg = SReg(0);
+
+    for (int bd = 0; bd < bd_block; bd++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
+            auto zmm = accm(ld_block2, bd, ld);
+            const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+            const auto mask = is_tail ? ld_tail_mask : P_ALL_ONE;
+            const int offset = C_offset(bd, ld);
+            if (!use_mul_vl(offset - base_offset, 4, cpu_sveLen)) {
+                add_vl_or_imm(reg_tmp_, x_addr, offset - base_offset, X_TMP_0);
+                base_offset = offset;
+                x_addr = reg_tmp_;
+            }
+            if (use_gemv_path && brg.beta == 0.f) {
                 faddv(scalar_reg, P_ALL_ONE, zmm.s);
                 STR_IMM(scalar_reg, x_addr, (offset - base_offset));
-            } else if (brg.is_gemv && brg.beta != 0.f) {
+            } else if (use_gemv_path && brg.beta != 0.f) {
                 LDR_IMM(scalar_reg, x_addr, (offset - base_offset));
                 fadda(scalar_reg, P_ALL_ONE, zmm.s);
                 STR_IMM(scalar_reg, x_addr, (offset - base_offset));
@@ -1274,6 +1412,13 @@ void jit_brgemm_kernel_t::store_accumulators(int bd_block2, bool is_bdb_tail,
             brg.req_s8s8_compensation, has_zero_points);
     const bool need_to_apply_alpha_beta = brg.beta != 0.f || brg.alpha != 1.f;
     int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+    const bool mmla_deinterleave_on_store = use_mmla
+            && brg.dt_c == data_type::f32 && brg.dt_d == data_type::f32
+            && ld_block2 <= 6 && !need_to_apply_alpha_beta
+            && !are_post_ops_applicable;
+
+    if (use_mmla && !mmla_deinterleave_on_store)
+        mmla_deinterleave_accumulators(bd_block, ld_block2);
 
     if (brg.is_int8 && (brg.req_s8s8_compensation || has_zero_points)) {
         Label label_store_without_comp;
@@ -1294,13 +1439,16 @@ void jit_brgemm_kernel_t::store_accumulators(int bd_block2, bool is_bdb_tail,
         LDR_IMM(reg_do_post_ops, sp, reg_do_post_ops_offs_);
         cmp_imm(reg_do_post_ops, 0, X_TMP_0);
         b(EQ, label_store_without_post_ops);
-        if (brg.is_gemv) { sum_into_one_lane(bd_block, ld_block2, is_ld_tail); }
+        if (use_gemv_path) {
+            sum_into_one_lane(bd_block, ld_block2, is_ld_tail);
+        }
         store_accumulators_apply_post_ops(bd_block, ld_block2, 0, is_ld_tail);
         bl(label_done);
 
         L(label_store_without_post_ops);
     }
-    store_accumulators_without_post_ops(bd_block, ld_block2, is_ld_tail);
+    store_accumulators_without_post_ops(
+            bd_block, ld_block2, is_ld_tail, mmla_deinterleave_on_store);
     L(label_done);
 }
 
@@ -1412,6 +1560,19 @@ void jit_brgemm_kernel_t::set_A_B_matrices() {
     add(reg_aux_B, reg_aux_B, reg_b_offset);
 }
 
+void jit_brgemm_kernel_t::mmla_deinterleave_accumulators(
+        int bd_block, int ld_block2) {
+    for (int bd_pair = 0; bd_pair < mmla_bd_pairs(bd_block); bd_pair++) {
+        for (int ld = 0; ld < ld_block2; ld++) {
+            auto zmm_even = accm_mmla(ld_block2, bd_pair, 2 * ld);
+            auto zmm_odd = accm_mmla(ld_block2, bd_pair, 2 * ld + 1);
+            uzp1(z_tmp_1().d, zmm_even.d, zmm_odd.d);
+            uzp2(zmm_odd.d, zmm_even.d, zmm_odd.d);
+            mov(zmm_even.d, z_tmp_1().d);
+        }
+    }
+}
+
 void jit_brgemm_kernel_t::dot_product(ZReg v_acc, ZReg v_a, ZReg v_b) {
     if (brg.is_f32) {
         fmla(v_acc.s, P_ALL_ONE / T_m, v_a.s, v_b.s);
@@ -1459,6 +1620,14 @@ void jit_brgemm_kernel_t::dot_product(
             assert(!"unsupported\n");
     } else {
         assert(!"unsupported\n");
+    }
+}
+
+void jit_brgemm_kernel_t::mmla(ZReg v_acc, ZReg v_a, ZReg v_b) {
+    if (brg.is_bf16) {
+        bfmmla(v_acc.s, v_a.h, v_b.h);
+    } else {
+        assert(!"unsupported");
     }
 }
 
@@ -1603,6 +1772,205 @@ void jit_brgemm_kernel_t::load_quadword_for_bcast(const ZReg &dst,
     }
     // Note that we could use ld1rq* register + register, but it is quite complicated and
     // slower on V1. Perf uplift (~0.5%) on V2 did not justify complexity
+}
+
+void jit_brgemm_kernel_t::mmla_load_packed_a(int rd_chunk, int bd_pair,
+        const ZReg &z_a, const ZReg &z_a_tmp, int bd_block, bool row0_valid,
+        bool row1_valid) {
+    const XReg base = (rd_chunk == 0 && bd_pair == 0) ? reg_aux_A : reg_tmp_;
+    if (row0_valid && row1_valid) {
+        ld1rqh(z_a.h, P_ALL_ONE / T_z, ptr(base));
+    } else if (row0_valid) {
+        ld1rd(z_a.d, P_ALL_ONE / T_z, ptr(base));
+        eor(z_a_tmp.d, z_a_tmp.d, z_a_tmp.d);
+        zip1(z_a.d, z_a.d, z_a_tmp.d);
+    } else if (row1_valid) {
+        eor(z_a.d, z_a.d, z_a.d);
+        ld1rd(z_a_tmp.d, P_ALL_ONE / T_z,
+                ptr(base, mmla_rd_chunk_elems() * brg.typesize_A));
+        zip1(z_a.d, z_a.d, z_a_tmp.d);
+    } else {
+        eor(z_a.d, z_a.d, z_a.d);
+    }
+    if (bd_pair != mmla_bd_pairs(bd_block) - 1) {
+        const int packed_a_pair_stride
+                = div_up(brg.reduce_dim, mmla_rd_chunk_elems()) * mmla_bd_blk()
+                * mmla_rd_chunk_elems() * brg.typesize_A;
+        add_imm(reg_tmp_, base, packed_a_pair_stride, X_TMP_0);
+    }
+}
+
+void jit_brgemm_kernel_t::mmla_load_plain_a(int rd_chunk, int bd_pair,
+        const ZReg &z_a, const ZReg &z_a_tmp, int rd_tail, bool row0_valid,
+        bool row1_valid) {
+    const int bd = mmla_bd_blk() * bd_pair;
+    const int rd_off = rd_chunk * mmla_rd_chunk_elems();
+    const int valid_rd_elems
+            = nstl::min(mmla_rd_chunk_elems(), rd_tail - rd_off);
+    const bool is_full_rd_chunk = valid_rd_elems == mmla_rd_chunk_elems();
+
+    const auto add_a_offset = [&](const XReg &dst, const XReg &src, int off) {
+        constexpr int add_imm12_max = (1 << 12) - 1;
+        if (off >= 0 && off <= add_imm12_max) {
+            add(dst, src, off);
+        } else if (off >= 0 && off % (1 << 12) == 0
+                && (off >> 12) <= add_imm12_max) {
+            add(dst, src, off >> 12, 12);
+        } else {
+            add_imm(dst, src, off, X_TMP_0);
+        }
+    };
+
+    if (!is_full_rd_chunk) set_preg(rd_tail_mask.h, valid_rd_elems, X_TMP_0);
+
+    const auto load_a_row = [&](const ZReg &z, bool row_valid, int row) {
+        if (!row_valid) {
+            eor(z.d, z.d, z.d);
+            return;
+        }
+
+        const int off = A_offset(row, rd_off);
+        if (is_full_rd_chunk && off <= 504 && off % 8 == 0) {
+            ld1rd(z.d, P_ALL_ONE / T_z, ptr(reg_aux_A, off));
+        } else {
+            add_a_offset(X_TMP_1, reg_aux_A, off);
+            if (is_full_rd_chunk) {
+                ld1rd(z.d, P_ALL_ONE / T_z, ptr(X_TMP_1));
+            } else {
+                ld1h(z.h, rd_tail_mask / T_z, ptr(X_TMP_1));
+                dup(z.d, z.d[0]);
+            }
+        }
+    };
+
+    load_a_row(z_a, row0_valid, bd);
+    load_a_row(z_a_tmp, row1_valid, bd + 1);
+    zip1(z_a.d, z_a.d, z_a_tmp.d);
+}
+
+void jit_brgemm_kernel_t::mmla_load_b(const XReg &b_base, int ld, int z_idx) {
+    const int ld_off = ld * mmla_ld_regs_per_block();
+    if (ld_off + 1 <= 7) {
+        ld1h(ZReg(z_idx).h, P_ALL_ONE / T_z, ptr(b_base, ld_off, MUL_VL));
+        ld1h(ZReg(z_idx + 1).h, P_ALL_ONE / T_z,
+                ptr(b_base, ld_off + 1, MUL_VL));
+    } else {
+        const int simd_size = static_cast<int>(simd_bytes(brg.isa_impl));
+        add_vl_or_imm(reg_tmp_, b_base, ld_off * simd_size, X_TMP_0);
+        ld1h(ZReg(z_idx).h, P_ALL_ONE / T_z, ptr(reg_tmp_));
+        ld1h(ZReg(z_idx + 1).h, P_ALL_ONE / T_z, ptr(reg_tmp_, 1, MUL_VL));
+    }
+}
+
+void jit_brgemm_kernel_t::gemm_microkernel_mmla(bool is_bdb_tail, int ld_block2,
+        int b_panel_ld_block2, bool is_rd_tail, bool advance_a_b, int vpad) {
+    const int bd_block = (is_bdb_tail) ? brg.bdb_tail : brg.bd_block;
+    const int bd_b = nstl::max(0, vpad);
+    const int bd_e = nstl::min(bd_block, bd_block + vpad);
+    if (bd_b >= bd_e) return;
+
+    const int bd_pair_count = mmla_bd_pairs(bd_block);
+    const int rd_tail = is_rd_tail ? brg.rdb_tail : mmla_rd_block();
+    // mmla traverses the rd dimension in 64-bit chunks
+    const int rd_chunks = is_rd_tail ? div_up(rd_tail, mmla_rd_chunk_elems())
+                                     : mmla_rd_chunks_per_block();
+
+    const int tmp_reg_count
+            = max_effective_vregs - mmla_bd_blk() * bd_pair_count * ld_block2;
+    const int all_a_reg_count = rd_chunks * bd_pair_count;
+    const bool all_a_in_regs
+            = all_a_reg_count + mmla_ld_regs_per_block() <= tmp_reg_count;
+    const int tmp_reg_0 = all_a_in_regs ? all_a_reg_count : bd_pair_count;
+    const int ld_blocks = nstl::min(
+            ld_block2, (tmp_reg_count - tmp_reg_0) / mmla_ld_regs_per_block());
+
+    const auto prepare_packed_a_base = [&](int rd_chunk) {
+        if (rd_chunk == 0) return;
+        const int a_offset = rd_chunk * mmla_bd_blk() * mmla_rd_chunk_elems()
+                * brg.typesize_A;
+        add_imm(reg_tmp_, reg_aux_A, a_offset, X_TMP_0);
+    };
+
+    const auto load_a = [&](int rd_chunk, int bd_pair, const ZReg &z_a,
+                                const ZReg &z_a_tmp) {
+        const int bd = mmla_bd_blk() * bd_pair;
+        const bool row0_valid = bd_b <= bd && bd < bd_e;
+        const bool row1_valid = bd_b <= bd + 1 && bd + 1 < bd_e;
+        if (!use_mmla_packed_a) {
+            mmla_load_plain_a(rd_chunk, bd_pair, z_a, z_a_tmp, rd_tail,
+                    row0_valid, row1_valid);
+        } else {
+            mmla_load_packed_a(rd_chunk, bd_pair, z_a, z_a_tmp, bd_block,
+                    row0_valid, row1_valid);
+        }
+    };
+
+    const auto advance_after_rd_chunk = [&](int rd_chunk) {
+        const bool is_last_rd_chunk = (rd_chunk == rd_chunks - 1);
+        if (is_last_rd_chunk)
+            add_vl_or_imm(reg_aux_A, reg_aux_A,
+                    rdb_A_offset(bd_pair_count * mmla_bd_blk()), X_TMP_0);
+
+        const int b_rd_chunk_offset = mmla_rd_chunk_B_offset(b_panel_ld_block2);
+        const int b_advance = is_last_rd_chunk
+                ? mmla_rdb_B_offset(b_panel_ld_block2)
+                        - rd_chunk * b_rd_chunk_offset
+                : b_rd_chunk_offset;
+        add_vl_or_imm(reg_aux_B, reg_aux_B, b_advance, X_TMP_0);
+    };
+
+    if (all_a_in_regs) {
+        for (int rd_chunk = 0; rd_chunk < rd_chunks; ++rd_chunk) {
+            if (use_mmla_packed_a) prepare_packed_a_base(rd_chunk);
+            for (int bd_pair = 0; bd_pair < bd_pair_count; ++bd_pair) {
+                const int a_reg_idx = rd_chunk * bd_pair_count + bd_pair;
+                load_a(rd_chunk, bd_pair, ZReg(a_reg_idx), ZReg(tmp_reg_0));
+            }
+        }
+    }
+
+    for (int rd_chunk = 0; rd_chunk < rd_chunks; ++rd_chunk) {
+        const XReg b_base
+                = (rd_chunk == 0 || advance_a_b) ? reg_aux_B : X_TMP_4;
+        if (rd_chunk > 0 && !advance_a_b) {
+            add_vl_or_imm(X_TMP_4, reg_aux_B,
+                    rd_chunk * mmla_rd_chunk_B_offset(b_panel_ld_block2),
+                    X_TMP_0);
+        }
+
+        if (!all_a_in_regs) {
+            if (use_mmla_packed_a) prepare_packed_a_base(rd_chunk);
+            for (int bd_pair = 0; bd_pair < bd_pair_count; ++bd_pair)
+                load_a(rd_chunk, bd_pair, ZReg(bd_pair), ZReg(tmp_reg_0));
+        }
+
+        for (int ld_reg_idx = 0; ld_reg_idx < ld_blocks; ++ld_reg_idx) {
+            mmla_load_b(b_base, ld_reg_idx,
+                    tmp_reg_0 + mmla_ld_regs_per_block() * ld_reg_idx);
+        }
+
+        if (advance_a_b && ld_blocks == ld_block2)
+            advance_after_rd_chunk(rd_chunk);
+
+        for (int ld_idx = 0; ld_idx < ld_block2; ++ld_idx) {
+            const int ld_reg_idx = ld_idx % ld_blocks;
+            const int z_b = tmp_reg_0 + mmla_ld_regs_per_block() * ld_reg_idx;
+            for (int bd_pair = 0; bd_pair < bd_pair_count; ++bd_pair) {
+                const ZReg z_a = all_a_in_regs
+                        ? ZReg(rd_chunk * bd_pair_count + bd_pair)
+                        : ZReg(bd_pair);
+                mmla(accm_mmla(ld_block2, bd_pair, 2 * ld_idx), z_a, ZReg(z_b));
+                mmla(accm_mmla(ld_block2, bd_pair, 2 * ld_idx + 1), z_a,
+                        ZReg(z_b + 1));
+            }
+            const int next_ld = ld_idx + ld_blocks;
+            if (next_ld < ld_block2) {
+                mmla_load_b(b_base, next_ld, z_b);
+                if (advance_a_b && next_ld + 1 == ld_block2)
+                    advance_after_rd_chunk(rd_chunk);
+            }
+        }
+    }
 }
 
 void jit_brgemm_kernel_t::gemm_microkernel(int bd_block2, bool is_bdb_tail,
@@ -1782,6 +2150,8 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
     Label BS_loop_label;
 
     copy_post_ops_stack_values_to_aux(is_reg_tail);
+    const int b_panel_ld_block2
+            = use_mmla && is_reg_tail ? brg.ld_block2 : ld_block2;
 
     auto ld_loop_body = [=](int vpad) {
         set_A_B_matrices();
@@ -1795,8 +2165,7 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
 
         int rdb_val = brg.rdb;
         int rdb_tail = brg.rdb_tail;
-        MAYBE_UNUSED(rdb_tail);
-        if (brg.is_gemv) {
+        if (use_gemv_path) {
             rdb_val = (brg.rd_block * brg.rdb + brg.rdb_tail)
                     / (cpu_sveLen / sizeof(float));
             rdb_tail = (brg.rd_block * brg.rdb + brg.rdb_tail)
@@ -1810,7 +2179,10 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
             {
                 const bool is_rd_tail = false;
 
-                if (brg.is_gemv) {
+                if (use_mmla) {
+                    gemm_microkernel_mmla(is_bdb_tail, ld_block2,
+                            b_panel_ld_block2, is_rd_tail, true, vpad);
+                } else if (use_gemv_path) {
                     gemv_microkernel(is_bdb_tail, ld_block2, is_rd_tail, vpad);
                 } else {
                     if (n_bcast_1_load
@@ -1834,10 +2206,14 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
                             is_rd_tail, is_ld_tail, vpad, rows_for_rd_tail);
                 }
 
-                add_vl_or_imm(reg_aux_A, reg_aux_A,
-                        brg.is_gemv ? cpu_sveLen : rdb_A_offset(), X_TMP_0);
-                add_vl_or_imm(reg_aux_B, reg_aux_B,
-                        brg.is_gemv ? cpu_sveLen : rdb_B_offset(), X_TMP_0);
+                if (!use_mmla) {
+                    int A_rdb_off = use_gemv_path ? cpu_sveLen
+                                                  : rdb_A_offset(bd_block);
+                    add_vl_or_imm(reg_aux_A, reg_aux_A, A_rdb_off, X_TMP_0);
+                    int B_rdb_off = use_gemv_path ? cpu_sveLen
+                                                  : rdb_B_offset(ld_block2);
+                    add_vl_or_imm(reg_aux_B, reg_aux_B, B_rdb_off, X_TMP_0);
+                }
 
                 subs(reg_rdb_loop, reg_rdb_loop, 1);
             }
@@ -1846,7 +2222,10 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
         if (rdb_tail != 0) {
             const bool is_rd_tail = true;
 
-            if (brg.is_gemv) {
+            if (use_mmla) {
+                gemm_microkernel_mmla(is_bdb_tail, ld_block2, b_panel_ld_block2,
+                        is_rd_tail, false, vpad);
+            } else if (use_gemv_path) {
                 // GEMV loads whole vector from left hand side
                 const int k_tail
                         = brg.LDA % simd_elems(data_type::f32, brg.isa_impl);
@@ -1996,7 +2375,7 @@ void jit_brgemm_kernel_t::ldb_loop(int bd_block2, bool is_bdb_tail,
         store_accumulators(bd_block2, is_bdb_tail, ld_block2, is_ld_tail,
                 skip_accumulation);
         if (is_ldb_loop_) {
-            if (!is_ld_tail) {
+            if (!is_ld_tail || use_mmla) {
                 ldb_regs_shift(ld_block2);
             } else {
                 ldb_regs_shift(1, true);
@@ -2012,27 +2391,44 @@ void jit_brgemm_kernel_t::bdb_loop() {
     auto do_ldb_loop = [=](int bd_block2, bool is_bdb_tail, bool check_top_vpad,
                                bool check_bottom_vpad, int rows_for_rd_tail,
                                bool skip_accumulation) {
-        if (brg.ldb2 > 0) {
-            const bool is_ld_reg_tail = false;
-            const bool is_ld_tail = false;
-            ldb_loop(bd_block2, is_bdb_tail, brg.ld_block2, brg.ldb2,
+        auto call_ldb_loop = [&](int ld_block2, int ldb_loop_length,
+                                     bool is_ld_reg_tail, bool is_ld_tail) {
+            ldb_loop(bd_block2, is_bdb_tail, ld_block2, ldb_loop_length,
                     is_ld_reg_tail, is_ld_tail, check_top_vpad,
                     check_bottom_vpad, rows_for_rd_tail, skip_accumulation);
+        };
+
+        if (use_mmla) {
+            if (brg.ldb2_tail > 0) {
+                if (brg.ldb2 > 0) {
+                    call_ldb_loop(brg.ld_block2, brg.ldb2, false, false);
+                }
+                const bool is_ld_reg_tail = brg.ldb2 > 0;
+                const bool is_ld_tail = brg.ldb_tail > 0;
+                call_ldb_loop(brg.ldb2_tail, 1, is_ld_reg_tail, is_ld_tail);
+            } else if (brg.ldb2 > 0) {
+                if (brg.ldb_tail > 0 && brg.ldb2 > 1) {
+                    call_ldb_loop(brg.ld_block2, brg.ldb2 - 1, false, false);
+                }
+                const bool is_ld_reg_tail = brg.ldb_tail > 0 && brg.ldb2 > 1;
+                const bool is_ld_tail = brg.ldb_tail > 0;
+                const int ldb_loop_length = is_ld_tail ? 1 : brg.ldb2;
+                call_ldb_loop(brg.ld_block2, ldb_loop_length, is_ld_reg_tail,
+                        is_ld_tail);
+            }
+            return;
+        }
+
+        if (brg.ldb2 > 0) {
+            call_ldb_loop(brg.ld_block2, brg.ldb2, false, false);
         }
         if (brg.ldb2_tail > 0) {
-            const bool is_ld_reg_tail = (brg.ldb2 == 0) ? false : true;
-            const bool is_ld_tail = false;
-            ldb_loop(bd_block2, is_bdb_tail, brg.ldb2_tail, 1, is_ld_reg_tail,
-                    is_ld_tail, check_top_vpad, check_bottom_vpad,
-                    rows_for_rd_tail, skip_accumulation);
+            const bool is_ld_reg_tail = brg.ldb2 != 0;
+            call_ldb_loop(brg.ldb2_tail, 1, is_ld_reg_tail, false);
         }
         if (brg.ldb_tail > 0) {
-            const bool is_ld_reg_tail
-                    = (brg.ldb2 == 0 && brg.ldb2_tail == 0) ? false : true;
-            const bool is_ld_tail = true;
-            ldb_loop(bd_block2, is_bdb_tail, 1, 1, is_ld_reg_tail, is_ld_tail,
-                    check_top_vpad, check_bottom_vpad, rows_for_rd_tail,
-                    skip_accumulation);
+            const bool is_ld_reg_tail = brg.ldb2 != 0 || brg.ldb2_tail != 0;
+            call_ldb_loop(1, 1, is_ld_reg_tail, true);
         }
     };
 
@@ -2043,26 +2439,24 @@ void jit_brgemm_kernel_t::bdb_loop() {
                 rows_for_rd_tail, skip_accumulation);
 
         add_imm(reg_C, reg_C,
-                brg.is_gemv ? brg.bd_block * brg.typesize_C
-                            : bdb_C_offset(bd_block2),
+                use_gemv_path ? brg.bd_block * brg.typesize_C
+                              : bdb_C_offset(bd_block2),
                 X_TMP_0);
         add_imm(reg_D, reg_D,
-                brg.is_gemv ? brg.bd_block * brg.typesize_D
-                            : bdb_D_offset(bd_block2),
+                use_gemv_path ? brg.bd_block * brg.typesize_D
+                              : bdb_D_offset(bd_block2),
                 X_TMP_0);
         add_imm(reg_a_offset, reg_a_offset, bdb_A_offset(bd_block2), X_TMP_0);
     };
 
-    int rows_for_rd_tail, bd_blocks_for_rd_tail;
-
-    rows_for_rd_tail = 0;
-    if (brg.rdb_tail != 0 && (brg.is_bf16 || brg.is_int8)) {
+    int rows_for_rd_tail = 0;
+    if (!use_mmla && brg.rdb_tail != 0 && (brg.is_bf16 || brg.is_int8)) {
         const auto rd_tail_size = brg.rdb_tail % brg.rd_step;
         rows_for_rd_tail = rd_tail_size
                 ? div_up(brg.rd_step - rd_tail_size, brg.reduce_dim)
                 : 0;
     }
-    bd_blocks_for_rd_tail
+    const int bd_blocks_for_rd_tail
             = div_up(nstl::max(0,
                              rows_for_rd_tail - brg.bdb_tail
                                      + brg.brgattr.max_bottom_vpad),
@@ -2224,7 +2618,6 @@ void jit_brgemm_kernel_t::generate() {
 
     mov(x7, x0);
     mov(x6, x1);
-    mov(x2, x2);
     mov(x1, x3);
     mov(x8, x4);
     mov(x9, x5);
@@ -2264,6 +2657,8 @@ brgemm_attr_t::brgemm_attr_t()
     , bd_mask_level(0)
     , use_uker(false)
     , use_interleave_stores(false)
+    , use_mmla(false)
+    , use_mmla_packed_a(false)
     , LDA2(0)
     , LDB2(0)
     , LDC2_M(0)

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -1658,6 +1658,9 @@ void jit_brgemm_kernel_t::mmla(ZReg v_acc, ZReg v_a, ZReg v_b) {
     } else if (brg.is_int8 && brg.dt_a == data_type::u8
             && brg.dt_b == data_type::s8) {
         usmmla(v_acc.s, v_a.b, v_b.b);
+    } else if (brg.is_int8 && brg.dt_a == data_type::s8
+            && brg.dt_b == data_type::s8) {
+        smmla(v_acc.s, v_a.b, v_b.b);
     } else {
         assert(!"unsupported");
     }
@@ -1917,6 +1920,8 @@ void jit_brgemm_kernel_t::mmla_load_plain_a_k16(int bd_pair, const ZReg &z_a_lo,
     const int bd = mmla_bd_blk() * bd_pair;
     load_a_row(QReg(z_a_tmp.getIdx()), row0_valid, bd);
     load_a_row(QReg(z_a_hi.getIdx()), row1_valid, bd + 1);
+    // A Q load fetches K16 from each row. TRN1 forms the low-K8 row pair and
+    // TRN2 forms the high-K8 pair expected by the two byte-MMLA steps.
     trn1(z_a_lo.d, z_a_tmp.d, z_a_hi.d);
     trn2(z_a_hi.d, z_a_tmp.d, z_a_hi.d);
 }

--- a/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/aarch64/brgemm/jit_brgemm_kernel.cpp
@@ -238,9 +238,11 @@ private:
         return brgemm_utils::mmla_rd_chunk_elems(brg.typesize_A);
     }
     int mmla_rd_chunks_per_block() const {
-        return brgemm_utils::mmla_rd_chunks_per_block(brg.typesize_A);
+        return brgemm_utils::mmla_rd_chunks_per_block();
     }
-    int mmla_rd_block() const { return brgemm_utils::mmla_rd_block(); }
+    int mmla_rd_block() const {
+        return brgemm_utils::mmla_rd_block(brg.typesize_A);
+    }
     PReg rd_tail_mask = PReg(2);
     PReg ld_tail_mask = PReg(3);
 
@@ -362,6 +364,9 @@ private:
             bool row1_valid);
     void mmla_load_plain_a(int rd_chunk, int bd_pair, const ZReg &z_a,
             const ZReg &z_a_tmp, int rd_tail, bool row0_valid, bool row1_valid);
+    void mmla_load_plain_a_k16(int bd_pair, const ZReg &z_a_lo,
+            const ZReg &z_a_hi, const ZReg &z_a_tmp, bool row0_valid,
+            bool row1_valid);
     void mmla_load_b(const XReg &b_base, int ld, int z_idx);
 
     // FMLA/DOT
@@ -416,8 +421,8 @@ private:
     int compensation_vpad_offset(int ld, int bd) const noexcept;
     int scales_offset(int ld, bool is_tail = false) const noexcept;
     int zp_comp_a_offset(int ld, bool is_tail = false) const noexcept;
-    int zp_comp_a_vpad_offset(int ld, int bd) const noexcept;
-    int bdb_zp_comp_a_offset(int bd_block2) const noexcept;
+    int zp_comp_a_per_m_offset(int ld, int bd) const noexcept;
+    int bdb_zp_comp_a_per_m_offset(int bd_block2) const noexcept;
     int zp_comp_b_offset(int bd) const noexcept;
     int bdb_zp_comp_b_offset(int bd_block2) const noexcept;
     int zp_c_values_offset(int ld, bool is_tail = false) const noexcept;
@@ -486,6 +491,11 @@ int jit_brgemm_kernel_t::rdb_B_offset(int ld_block2) const noexcept {
 int jit_brgemm_kernel_t::ldb_B_offset(
         int ld_block2, bool is_tail) const noexcept {
     if (use_mmla) {
+        // INT8 MMLA permits a compact final K8 panel. BF16 keeps its final
+        // K4 chunk inside a padded two-chunk reduction block.
+        if (brg.is_int8)
+            return mmla_rd_chunk_B_offset(ld_block2)
+                    * div_up(brg.reduce_dim, mmla_rd_chunk_elems());
         return mmla_rdb_B_offset(ld_block2)
                 * div_up(brg.reduce_dim, mmla_rd_block());
     }
@@ -560,12 +570,14 @@ int jit_brgemm_kernel_t::zp_comp_a_offset(int ld, bool is_tail) const noexcept {
                      : sizeof(int32_t) * ld * brg.ld_block;
 }
 
-int jit_brgemm_kernel_t::bdb_zp_comp_a_offset(int bd_block2) const noexcept {
-    return sizeof(int32_t) * bd_block2 * brg.bd_block * brg.LDB;
+int jit_brgemm_kernel_t::zp_comp_a_per_m_offset(int ld, int bd) const noexcept {
+    return sizeof(int32_t)
+            * (bd * brg.zp_a_compensation_m_stride + ld * brg.ld_block);
 }
 
-int jit_brgemm_kernel_t::zp_comp_a_vpad_offset(int ld, int bd) const noexcept {
-    return sizeof(int32_t) * (ld * brg.ld_block + bd * brg.LDB);
+int jit_brgemm_kernel_t::bdb_zp_comp_a_per_m_offset(
+        int bd_block2) const noexcept {
+    return zp_comp_a_per_m_offset(0, bd_block2 * brg.bd_block);
 }
 
 int jit_brgemm_kernel_t::zp_comp_b_offset(int bd) const noexcept {
@@ -895,8 +907,14 @@ void jit_brgemm_kernel_t::apply_alpha_beta(
             }
             LD_MUL_VL(ld1w, vmm_c.s, k_mask, x_addr, offset - base_offset, 4);
 
-            if (brg.beta != 1.f) { fmul(vmm_c.s, vmm_c.s, vmm_beta.s); }
-            fadd(vmm.s, vmm.s, vmm_c.s);
+            if (brg.is_int8 && !dq2ps_required) {
+                // alpha == beta == 1 permits an exact s32 accumulation.
+                add(vmm.s, vmm.s, vmm_c.s);
+            } else {
+                if (brg.is_int8) scvtf(vmm_c.s, P_ALL_ONE / T_m, vmm_c.s);
+                if (brg.beta != 1.f) fmul(vmm_c.s, vmm_c.s, vmm_beta.s);
+                fadd(vmm.s, vmm.s, vmm_c.s);
+            }
         }
     }
 }
@@ -1246,31 +1264,42 @@ void jit_brgemm_kernel_t::apply_compensation(
 
     if (!brg.req_cal_comp_pads && brg.zp_type_a != brgemm_broadcast_t::none) {
         auto vmm_zp_a_val = z_tmp_2();
-        add_imm(X_DEFAULT_ADDR, sp, reg_zp_a_val_offs_, X_TMP_0);
         add_imm(reg_zp_a_val, sp, reg_zp_a_val_offs_, X_TMP_0);
         ldr(W_TMP_0, ptr(reg_zp_a_val));
         dup(vmm_zp_a_val.s, W_TMP_0);
 
         add_imm(X_DEFAULT_ADDR, sp, reg_aux_zp_comp_a_offs_, X_TMP_1);
         ldr(reg_aux_zp_comp_a, ptr(X_DEFAULT_ADDR));
-        for (int ld = 0; ld < ld_block2; ld++) {
+        auto vmm_zp_comp_a = z_tmp_1();
+        const auto load_zp_a_compensation = [&](int offset, int ld) {
             const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
             const auto k_mask = is_tail ? ld_tail_mask : P_ALL_ONE;
-            auto vmm_zp_comp_a = z_tmp_1();
-            int zp_comp_a_off = zp_comp_a_offset(ld);
-            // apply src zero points value to the accumulated values
             if (IMPLICATION(is_tail, isa_has_masks(brg.isa_impl))) {
-                add_imm(X_DEFAULT_ADDR, reg_aux_zp_comp_a, zp_comp_a_off,
-                        X_TMP_1);
+                add_imm(X_DEFAULT_ADDR, reg_aux_zp_comp_a, offset, X_TMP_1);
                 ld1w(vmm_zp_comp_a.s, k_mask / T_z, ptr(X_DEFAULT_ADDR));
             } else {
                 assert(!"Unreachable\n");
             }
             mul(vmm_zp_comp_a.s, P_ALL_ONE / T_m, vmm_zp_a_val.s);
+        };
 
+        if (brg.has_zp_a_compensation_per_m()) {
+            // Each M row has its own N-vector because virtual padding changes
+            // the valid K range at the spatial boundaries.
             for (int bd = 0; bd < bd_block; bd++) {
-                auto vmm = accm(ld_block2, bd, ld);
-                add(vmm.s, vmm.s, vmm_zp_comp_a.s);
+                for (int ld = 0; ld < ld_block2; ld++) {
+                    load_zp_a_compensation(zp_comp_a_per_m_offset(ld, bd), ld);
+                    auto vmm = accm(ld_block2, bd, ld);
+                    add(vmm.s, vmm.s, vmm_zp_comp_a.s);
+                }
+            }
+        } else {
+            for (int ld = 0; ld < ld_block2; ld++) {
+                load_zp_a_compensation(zp_comp_a_offset(ld), ld);
+                for (int bd = 0; bd < bd_block; bd++) {
+                    auto vmm = accm(ld_block2, bd, ld);
+                    add(vmm.s, vmm.s, vmm_zp_comp_a.s);
+                }
             }
         }
     }
@@ -1626,6 +1655,9 @@ void jit_brgemm_kernel_t::dot_product(
 void jit_brgemm_kernel_t::mmla(ZReg v_acc, ZReg v_a, ZReg v_b) {
     if (brg.is_bf16) {
         bfmmla(v_acc.s, v_a.h, v_b.h);
+    } else if (brg.is_int8 && brg.dt_a == data_type::u8
+            && brg.dt_b == data_type::s8) {
+        usmmla(v_acc.s, v_a.b, v_b.b);
     } else {
         assert(!"unsupported");
     }
@@ -1821,7 +1853,12 @@ void jit_brgemm_kernel_t::mmla_load_plain_a(int rd_chunk, int bd_pair,
         }
     };
 
-    if (!is_full_rd_chunk) set_preg(rd_tail_mask.h, valid_rd_elems, X_TMP_0);
+    if (!is_full_rd_chunk) {
+        if (brg.is_int8)
+            set_preg(rd_tail_mask.b, valid_rd_elems, X_TMP_0);
+        else
+            set_preg(rd_tail_mask.h, valid_rd_elems, X_TMP_0);
+    }
 
     const auto load_a_row = [&](const ZReg &z, bool row_valid, int row) {
         if (!row_valid) {
@@ -1837,7 +1874,10 @@ void jit_brgemm_kernel_t::mmla_load_plain_a(int rd_chunk, int bd_pair,
             if (is_full_rd_chunk) {
                 ld1rd(z.d, P_ALL_ONE / T_z, ptr(X_TMP_1));
             } else {
-                ld1h(z.h, rd_tail_mask / T_z, ptr(X_TMP_1));
+                if (brg.is_int8)
+                    ld1b(z.b, rd_tail_mask / T_z, ptr(X_TMP_1));
+                else
+                    ld1h(z.h, rd_tail_mask / T_z, ptr(X_TMP_1));
                 dup(z.d, z.d[0]);
             }
         }
@@ -1848,17 +1888,61 @@ void jit_brgemm_kernel_t::mmla_load_plain_a(int rd_chunk, int bd_pair,
     zip1(z_a.d, z_a.d, z_a_tmp.d);
 }
 
+void jit_brgemm_kernel_t::mmla_load_plain_a_k16(int bd_pair, const ZReg &z_a_lo,
+        const ZReg &z_a_hi, const ZReg &z_a_tmp, bool row0_valid,
+        bool row1_valid) {
+    constexpr int qreg_bytes = 16;
+    assert(brg.is_int8
+            && static_cast<int>(simd_bytes(brg.isa_impl)) == qreg_bytes);
+    assert(mmla_rd_block() * brg.typesize_A == qreg_bytes);
+    assert(brg.LDA % mmla_rd_block() == 0);
+
+    const auto load_a_row = [&](const QReg &q, bool row_valid, int row) {
+        if (!row_valid) {
+            const auto z = ZReg(q.getIdx());
+            eor(z.d, z.d, z.d);
+            return;
+        }
+
+        const int off = A_offset(row, 0);
+        constexpr int ldr_q_imm_max = ((1 << 12) - 1) * qreg_bytes;
+        if (off >= 0 && off <= ldr_q_imm_max && off % qreg_bytes == 0) {
+            ldr(q, ptr(reg_aux_A, off));
+        } else {
+            add_imm(X_TMP_1, reg_aux_A, off, X_TMP_0);
+            ldr(q, ptr(X_TMP_1));
+        }
+    };
+
+    const int bd = mmla_bd_blk() * bd_pair;
+    load_a_row(QReg(z_a_tmp.getIdx()), row0_valid, bd);
+    load_a_row(QReg(z_a_hi.getIdx()), row1_valid, bd + 1);
+    trn1(z_a_lo.d, z_a_tmp.d, z_a_hi.d);
+    trn2(z_a_hi.d, z_a_tmp.d, z_a_hi.d);
+}
+
 void jit_brgemm_kernel_t::mmla_load_b(const XReg &b_base, int ld, int z_idx) {
     const int ld_off = ld * mmla_ld_regs_per_block();
     if (ld_off + 1 <= 7) {
-        ld1h(ZReg(z_idx).h, P_ALL_ONE / T_z, ptr(b_base, ld_off, MUL_VL));
-        ld1h(ZReg(z_idx + 1).h, P_ALL_ONE / T_z,
-                ptr(b_base, ld_off + 1, MUL_VL));
+        if (brg.is_int8) {
+            ld1b(ZReg(z_idx).b, P_ALL_ONE / T_z, ptr(b_base, ld_off, MUL_VL));
+            ld1b(ZReg(z_idx + 1).b, P_ALL_ONE / T_z,
+                    ptr(b_base, ld_off + 1, MUL_VL));
+        } else {
+            ld1h(ZReg(z_idx).h, P_ALL_ONE / T_z, ptr(b_base, ld_off, MUL_VL));
+            ld1h(ZReg(z_idx + 1).h, P_ALL_ONE / T_z,
+                    ptr(b_base, ld_off + 1, MUL_VL));
+        }
     } else {
         const int simd_size = static_cast<int>(simd_bytes(brg.isa_impl));
         add_vl_or_imm(reg_tmp_, b_base, ld_off * simd_size, X_TMP_0);
-        ld1h(ZReg(z_idx).h, P_ALL_ONE / T_z, ptr(reg_tmp_));
-        ld1h(ZReg(z_idx + 1).h, P_ALL_ONE / T_z, ptr(reg_tmp_, 1, MUL_VL));
+        if (brg.is_int8) {
+            ld1b(ZReg(z_idx).b, P_ALL_ONE / T_z, ptr(reg_tmp_));
+            ld1b(ZReg(z_idx + 1).b, P_ALL_ONE / T_z, ptr(reg_tmp_, 1, MUL_VL));
+        } else {
+            ld1h(ZReg(z_idx).h, P_ALL_ONE / T_z, ptr(reg_tmp_));
+            ld1h(ZReg(z_idx + 1).h, P_ALL_ONE / T_z, ptr(reg_tmp_, 1, MUL_VL));
+        }
     }
 }
 
@@ -1871,7 +1955,7 @@ void jit_brgemm_kernel_t::gemm_microkernel_mmla(bool is_bdb_tail, int ld_block2,
 
     const int bd_pair_count = mmla_bd_pairs(bd_block);
     const int rd_tail = is_rd_tail ? brg.rdb_tail : mmla_rd_block();
-    // mmla traverses the rd dimension in 64-bit chunks
+    // MMLA traverses the reduction dimension in 64-bit chunks.
     const int rd_chunks = is_rd_tail ? div_up(rd_tail, mmla_rd_chunk_elems())
                                      : mmla_rd_chunks_per_block();
 
@@ -1919,7 +2003,21 @@ void jit_brgemm_kernel_t::gemm_microkernel_mmla(bool is_bdb_tail, int ld_block2,
         add_vl_or_imm(reg_aux_B, reg_aux_B, b_advance, X_TMP_0);
     };
 
-    if (all_a_in_regs) {
+    const bool use_plain_int8_k16 = all_a_in_regs && brg.is_int8
+            && !use_mmla_packed_a && !is_rd_tail && rd_chunks == 2
+            && static_cast<int>(simd_bytes(brg.isa_impl))
+                    == mmla_rd_block() * brg.typesize_A
+            && brg.LDA % mmla_rd_block() == 0;
+    if (use_plain_int8_k16) {
+        for (int bd_pair = 0; bd_pair < bd_pair_count; ++bd_pair) {
+            const int bd = mmla_bd_blk() * bd_pair;
+            const bool row0_valid = bd_b <= bd && bd < bd_e;
+            const bool row1_valid = bd_b <= bd + 1 && bd + 1 < bd_e;
+            mmla_load_plain_a_k16(bd_pair, ZReg(bd_pair),
+                    ZReg(bd_pair_count + bd_pair), ZReg(tmp_reg_0), row0_valid,
+                    row1_valid);
+        }
+    } else if (all_a_in_regs) {
         for (int rd_chunk = 0; rd_chunk < rd_chunks; ++rd_chunk) {
             if (use_mmla_packed_a) prepare_packed_a_base(rd_chunk);
             for (int bd_pair = 0; bd_pair < bd_pair_count; ++bd_pair) {
@@ -1929,6 +2027,8 @@ void jit_brgemm_kernel_t::gemm_microkernel_mmla(bool is_bdb_tail, int ld_block2,
         }
     }
 
+    // These C++ loops generate a straight-line K-chunk -> N-group -> M-pair
+    // MMLA sequence; they are not runtime loops.
     for (int rd_chunk = 0; rd_chunk < rd_chunks; ++rd_chunk) {
         const XReg b_base
                 = (rd_chunk == 0 || advance_a_b) ? reg_aux_B : X_TMP_4;
@@ -1999,7 +2099,8 @@ void jit_brgemm_kernel_t::gemm_microkernel(int bd_block2, bool is_bdb_tail,
 
     const bool comp_vpad = vpad != 0
             && (brg.req_s8s8_compensation
-                    || brg.zp_type_a != brgemm_broadcast_t::none);
+                    || (brg.zp_type_a != brgemm_broadcast_t::none
+                            && !brg.has_zp_a_compensation_per_m()));
     if (brg.req_cal_comp_pads || comp_vpad) {
         compute_int8_compensation(
                 rd_loop, bd_b, bd_e, bd_block, ld_block2, is_ld_tail, vpad);
@@ -2438,6 +2539,13 @@ void jit_brgemm_kernel_t::bdb_loop() {
         do_ldb_loop(bd_block2, is_bdb_tail, check_top_vpad, check_bottom_vpad,
                 rows_for_rd_tail, skip_accumulation);
 
+        if (brg.has_zp_a_compensation_per_m()) {
+            LDR_IMM(reg_zp_comp_a, sp, reg_zp_comp_a_offs_);
+            add_imm(reg_zp_comp_a, reg_zp_comp_a,
+                    bdb_zp_comp_a_per_m_offset(bd_block2), X_TMP_0);
+            STR_IMM(reg_zp_comp_a, sp, reg_zp_comp_a_offs_);
+        }
+
         add_imm(reg_C, reg_C,
                 use_gemv_path ? brg.bd_block * brg.typesize_C
                               : bdb_C_offset(bd_block2),
@@ -2624,9 +2732,10 @@ void jit_brgemm_kernel_t::generate() {
 
     vpad_exist
             = brg.brgattr.max_top_vpad > 0 || brg.brgattr.max_bottom_vpad > 0;
-    need_comp_pads = IMPLICATION(brg.zp_type_a == brgemm_broadcast_t::none,
-                             brg.req_s8s8_compensation)
-            && IMPLICATION(!vpad_exist, brg.req_cal_comp_pads);
+    const bool has_int8_compensation = brg.req_s8s8_compensation
+            || brg.zp_type_a != brgemm_broadcast_t::none;
+    need_comp_pads = !brg.has_zp_a_compensation_per_m() && has_int8_compensation
+            && (vpad_exist || brg.req_cal_comp_pads);
 
     set_preg(ld_tail_mask.s, brg.ldb_tail, X_TMP_0);
     if (brg.is_int8 && !brg.has_int8_vnni) { assert(!"unsupported\n"); }

--- a/src/cpu/aarch64/cpu_isa_traits.hpp
+++ b/src/cpu/aarch64/cpu_isa_traits.hpp
@@ -265,6 +265,11 @@ inline bool mayiuse_bf16() {
     return cpu().isBf16Supported();
 }
 
+inline bool mayiuse_sve_i8mm() {
+    using namespace Xbyak_aarch64::util;
+    return mayiuse(sve) && cpu().has(XBYAK_AARCH64_HWCAP_SVEI8MM);
+}
+
 inline bool mayiuse_f16() {
     using namespace Xbyak_aarch64::util;
     return cpu().isF16Supported();

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -209,7 +209,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
     const auto src_type = pd()->src_md(0)->data_type;
 
     const auto last_ic_block = jcp.use_mmla
-            ? brgemm_utils::mmla_rd_block()
+            ? brgemm_utils::mmla_rd_block(jcp.wei_dsz)
             : data_type_vnni_granularity(src_type);
 
     wei_ic_stride = jcp.wei_plain ? jcp.oc_without_padding : jcp.oc_block;

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -208,8 +208,11 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
 
     const auto src_type = pd()->src_md(0)->data_type;
 
+    const auto mmla_wei_k_block = jcp.wei_dt == data_type::s8
+            ? brgemm_utils::mmla_rd_chunk_elems(jcp.wei_dsz)
+            : brgemm_utils::mmla_rd_block(jcp.wei_dsz);
     const auto last_ic_block = jcp.use_mmla
-            ? brgemm_utils::mmla_rd_block(jcp.wei_dsz)
+            ? mmla_wei_k_block
             : data_type_vnni_granularity(src_type);
 
     wei_ic_stride = jcp.wei_plain ? jcp.oc_without_padding : jcp.oc_block;

--- a/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_1x1_conv.cpp
@@ -25,6 +25,7 @@
 #include "cpu/cpu_primitive.hpp"
 #include "cpu/scale_utils.hpp"
 
+#include "cpu/aarch64/brgemm/brgemm_utils.hpp"
 #include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
 #include "cpu/aarch64/jit_brgemm_1x1_conv.hpp"
 
@@ -145,6 +146,16 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(engine_t *engine) {
                 false, false, brgemm_row_major, alpha, vbeta, jcp_.LDA,
                 jcp_.LDB, jcp_.LDC, vM, vN, vK, strides_ptr));
 
+        if (jcp_.use_mmla) {
+            brgemm_attr_t brgattr;
+            brgattr.use_mmla = true;
+            brgattr.hint_ld_block2 = brgemm_utils::mmla_ld_block2();
+            brgattr.hint_bd_block
+                    = nstl::min(brgemm_utils::mmla_max_native_bd_block(), vM);
+            brgattr.max_bs = jcp_.max_batch;
+            CHECK(brgemm_desc_set_attr(&brg, brgattr));
+        }
+
         auto LDD = jcp_.oc_without_padding;
         brg.with_sum = with_sum;
         brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
@@ -197,7 +208,9 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
 
     const auto src_type = pd()->src_md(0)->data_type;
 
-    const auto last_ic_block = data_type_vnni_granularity(src_type);
+    const auto last_ic_block = jcp.use_mmla
+            ? brgemm_utils::mmla_rd_block()
+            : data_type_vnni_granularity(src_type);
 
     wei_ic_stride = jcp.wei_plain ? jcp.oc_without_padding : jcp.oc_block;
     wei_ocb_stride = jcp.wei_plain

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -22,6 +22,7 @@
 #include "common/dnnl_thread.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
+#include "cpu/aarch64/brgemm/brgemm_utils.hpp"
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 #include "cpu/aarch64/jit_brgemm_conv.hpp"
 #include "cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp"
@@ -261,6 +262,12 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
     // remove the dead code.
     brgattr.use_uker = jcp_.use_uker;
     brgattr.use_interleave_stores = jcp_.use_interleave_stores;
+    if (jcp_.use_mmla) {
+        brgattr.use_mmla = true;
+        brgattr.hint_ld_block2 = brgemm_utils::mmla_ld_block2();
+        brgattr.hint_bd_block
+                = nstl::min(brgemm_utils::mmla_max_native_bd_block(), vbrgM);
+    }
     brgattr.hint_prefetching = jcp_.hint_prefetching;
     brgattr.max_bs = bs;
     brgattr.hint_ununroll_bd_loop = jcp_.ununroll_bd_loop;

--- a/src/cpu/aarch64/jit_brgemm_conv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.cpp
@@ -17,6 +17,7 @@
 *******************************************************************************/
 
 #include <cassert>
+#include <cstring>
 
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
@@ -292,6 +293,9 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
     brg.with_sum = with_sum;
     brg.with_weights_scale_adjust = jcp_.scale_adjust_factor != 1.0f;
     CHECK(brgemm_desc_set_postops(&brg, attr(), &dst_md_, LDD, jcp_.bia_dt));
+
+    brg.zp_a_compensation_m_stride
+            = jcp_.use_mmla_vpad_comp ? jcp_.oc_block : 0;
 
     CHECK(brgemm_desc_finalize(&brg));
 
@@ -734,9 +738,13 @@ inline int brgemm_convolution_fwd_t<isa>::get_comp_offset(const int g,
     const auto comp_idx = get_comp_ker_idx(kd_b, kd_e, kh_b, kh_e, kw_b, kw_e);
     assert(IMPLICATION(jcp.req_cal_comp_pad, comp_idx >= 0));
 
-    return jcp.req_cal_comp_pad
-            ? g * comp_ocb_sz + ocb * comp_ker_sz + comp_idx * comp_kw_sz
-            : (g * jcp.nb_oc + ocb) * jcp.oc_block;
+    if (!jcp.req_cal_comp_pad) return (g * jcp.nb_oc + ocb) * jcp.oc_block;
+
+    const auto ow_off = jcp.use_mmla_vpad_comp
+            ? static_cast<dim_t>(ow) * jcp.oc_block
+            : 0;
+    return g * comp_group_stride + ocb * comp_ocb_stride
+            + comp_idx * comp_range_stride + ow_off;
 }
 
 template <cpu_isa_t isa>
@@ -796,9 +804,10 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
     dst_h_sz = OH * dst_w_sz;
     dst_d_sz = OD * dst_h_sz;
 
-    comp_kw_sz = static_cast<dim_t>(jcp.oc_block);
-    comp_ker_sz = jcp.ker_ranges_size * comp_kw_sz;
-    comp_ocb_sz = jcp.nb_oc * comp_ker_sz;
+    comp_range_stride = static_cast<dim_t>(jcp.oc_block)
+            * (jcp.use_mmla_vpad_comp ? OW : 1);
+    comp_ocb_stride = jcp.ker_ranges_size * comp_range_stride;
+    comp_group_stride = jcp.nb_oc * comp_ocb_stride;
 
     need_compensation = (jcp.src_zero_point || jcp.s8s8_compensation_required)
             && !jcp.req_brg_comp_pad;
@@ -1285,6 +1294,9 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
     const auto &jcp = _pd->jcp_;
 
     if (!jcp.req_cal_comp_pad) return status::success;
+    assert(IMPLICATION(jcp.use_mmla_vpad_comp,
+            jcp.oc_block == brgemm_utils::mmla_n_block(jcp.isa)
+                    && !jcp.s8s8_compensation_required));
 
     if (jcp.src_zero_point)
         std::memset(src_zp_buffer, 0, sizeof(int32_t) * jcp.comp_a_buffer_size);
@@ -1294,7 +1306,8 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
 
     const auto work_amount
             = static_cast<dim_t>(jcp.ngroups) * jcp.nb_oc * ker_vpad_sz;
-    const auto is_small_shape = work_amount <= jcp.nthr
+    const auto is_small_shape = !jcp.use_mmla_vpad_comp
+            && work_amount <= jcp.nthr
             && (work_amount * jcp.oc_block * jcp.icp
                     <= platform::get_per_core_cache_size(1));
     const int nthr = is_small_shape ? 1 : jcp.nthr;
@@ -1308,34 +1321,69 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
         nd_iterator_init(start, g, jcp.ngroups, ocb, jcp.nb_oc, k, ker_vpad_sz);
         for (auto work = start; work < end; work++) {
             const dim_t kd_bb {kd_bs[k]}, kd_ee {kd_es[k]}, kh_bb {kh_bs[k]},
-                    kh_ee {kh_es[k]}, kw_bb {kw_bs[k]}, kw_ee {kw_es[k]};
-            assert(kd_ee > kd_bb && kh_ee > kh_bb && kw_ee > kw_bb);
+                    kh_ee {kh_es[k]};
+            assert(kd_ee > kd_bb && kh_ee > kh_bb);
 
             const auto kd_b = maybe_invert_range(kd_bb, kd_ee, KD);
             const auto kd_e = maybe_invert_range(kd_ee, kd_bb, KD);
             const auto kh_b = maybe_invert_range(kh_bb, kh_ee, KH);
             const auto kh_e = maybe_invert_range(kh_ee, kh_bb, KH);
-            const auto kw_b = maybe_invert_range(kw_bb, kw_ee, KW);
-            const auto kw_e = maybe_invert_range(kw_ee, kw_bb, KW);
+            const auto base_buffer_offs = g * comp_group_stride
+                    + ocb * comp_ocb_stride + k * comp_range_stride;
 
-            const auto buffer_offs
-                    = g * comp_ocb_sz + ocb * comp_ker_sz + k * comp_kw_sz;
-            const auto wei_offs = g * _pd->wei_g_stride
-                    + ocb * _pd->wei_ocb_stride + kd_b * _pd->wei_kd_stride
-                    + kh_b * _pd->wei_kh_stride + kw_b * _pd->wei_kw_stride;
+            const auto run_comp = [&](dim_t kw_bb, dim_t kw_ee, int32_t *zp_out,
+                                          int32_t *cp_out) {
+                assert(kw_ee > kw_bb);
+                const auto kw_b = maybe_invert_range(kw_bb, kw_ee, KW);
+                const auto kw_e = maybe_invert_range(kw_ee, kw_bb, KW);
+                const auto wei_offs = g * _pd->wei_g_stride
+                        + ocb * _pd->wei_ocb_stride + kd_b * _pd->wei_kd_stride
+                        + kh_b * _pd->wei_kh_stride + kw_b * _pd->wei_kw_stride;
 
-            jit_brgemm_conv_comp_pad_args_t p;
+                jit_brgemm_conv_comp_pad_args_t p {};
+                p.kd_l = kd_e - kd_b;
+                p.kh_l = kh_e - kh_b;
+                p.kw_l = kw_e - kw_b;
+                p.ptr_in = &weights[wei_offs];
+                p.ptr_zp_out = zp_out;
+                p.ptr_cp_out = cp_out;
+                (*comp_vpad_pbuffer_)(&p);
+            };
 
-            p.kd_l = kd_e - kd_b;
-            p.kh_l = kh_e - kh_b;
-            p.kw_l = kw_e - kw_b;
-            p.ptr_in = &weights[wei_offs];
-            p.ptr_zp_out = jcp.src_zero_point ? &src_zp_buffer[buffer_offs]
-                                              : nullptr;
-            p.ptr_cp_out = jcp.s8s8_compensation_required
-                    ? &s8s8_comp_buffer[buffer_offs]
-                    : nullptr;
-            (*comp_vpad_pbuffer_)(&p);
+            if (jcp.use_mmla_vpad_comp) {
+                // Virtual padding changes the valid KW range by output column.
+                // Reuse the full range for interior columns and recompute only
+                // the boundary columns.
+                constexpr int mmla_oc_block = brgemm_utils::mmla_ld_block2()
+                        * cpu_isa_traits<isa>::vlen / sizeof(int32_t);
+                alignas(64) int32_t full_comp[mmla_oc_block] = {};
+                run_comp(0, KW, full_comp, nullptr);
+
+                for (int ow = 0; ow < OW; ow++) {
+                    const int iw = ow * SW - LP;
+                    const dim_t kw_bb = div_up(nstl::max(0, -iw), DW);
+                    const dim_t kw_ee = KW
+                            - div_up(nstl::max(0, iw - IW + (KW - 1) * DW + 1),
+                                    DW);
+                    auto *const row_out = &src_zp_buffer[base_buffer_offs
+                            + static_cast<dim_t>(ow) * jcp.oc_block];
+                    if (kw_bb == 0 && kw_ee == KW) {
+                        std::memcpy(row_out, full_comp,
+                                sizeof(int32_t) * jcp.oc_block);
+                    } else if (kw_ee > kw_bb) {
+                        run_comp(kw_bb, kw_ee, row_out, nullptr);
+                    } else {
+                        std::memset(row_out, 0, sizeof(int32_t) * jcp.oc_block);
+                    }
+                }
+            } else {
+                run_comp(kw_bs[k], kw_es[k],
+                        jcp.src_zero_point ? &src_zp_buffer[base_buffer_offs]
+                                           : nullptr,
+                        jcp.s8s8_compensation_required
+                                ? &s8s8_comp_buffer[base_buffer_offs]
+                                : nullptr);
+            }
 
             nd_iterator_step(g, jcp.ngroups, ocb, jcp.nb_oc, k, ker_vpad_sz);
         }

--- a/src/cpu/aarch64/jit_brgemm_conv.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv.hpp
@@ -271,7 +271,9 @@ private:
             KD_BLOCK_PAD, KH_BLOCK_PAD, ID, IH, IW, IDP, IHP, IWP, OD, OH, OW,
             SD, SH, SW, FP, TP, LP, DD, DH, DW;
     dim_t src_w_sz, src_h_sz, src_d_sz, dst_w_sz, dst_h_sz, dst_d_sz;
-    dim_t ker_vpad_sz, comp_ocb_sz, comp_ker_sz, comp_kw_sz;
+    dim_t ker_vpad_sz;
+    // Compensation-buffer strides in int32_t elements.
+    dim_t comp_group_stride, comp_ocb_stride, comp_range_stride;
 
     bool need_compensation;
 };

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -36,7 +36,9 @@ namespace jit_uni_brgemm_conv_comp_pad_kernel {
     (uint32_t) offsetof(jit_brgemm_conv_comp_pad_args_t, field)
 
 static bool is_int8_mmla(const jit_brgemm_conv_conf_t &jcp) noexcept {
-    return jcp.use_mmla && jcp.src_dt == data_type::u8;
+    return jcp.use_mmla
+            && utils::one_of(jcp.src_dt, data_type::u8, data_type::s8)
+            && jcp.wei_dt == data_type::s8;
 }
 
 static int comp_pad_ic_block(const jit_brgemm_conv_conf_t &jcp) noexcept {
@@ -149,6 +151,11 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::compute(const int ic_step,
             if (is_int8_mmla(jcp_)) {
                 const auto sum01 = zmm_one_words;
                 const auto sum23 = zmm_int8_temp;
+                // USMMLA against an all-ones u8 row reduces one packed K8
+                // weight slice for either u8 or s8 source convolution. This
+                // computes a weight sum, so source signedness is irrelevant.
+                // Each result duplicates a pair of OC sums; UZP1 below joins
+                // the two loads into four consecutive sums.
                 ldr(vmm_tmp, ptr(X_DEFAULT_ADDR));
                 eor(sum01.d, sum01.d, sum01.d);
                 usmmla(sum01.s, vmm_one_bytes.b, vmm_tmp.b);

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -18,6 +18,8 @@
 
 #include "cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp"
 
+#include "cpu/aarch64/brgemm/brgemm_utils.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -33,6 +35,16 @@ namespace jit_uni_brgemm_conv_comp_pad_kernel {
 #define GET_OFF(field) \
     (uint32_t) offsetof(jit_brgemm_conv_comp_pad_args_t, field)
 
+static bool is_int8_mmla(const jit_brgemm_conv_conf_t &jcp) noexcept {
+    return jcp.use_mmla && jcp.src_dt == data_type::u8;
+}
+
+static int comp_pad_ic_block(const jit_brgemm_conv_conf_t &jcp) noexcept {
+    return is_int8_mmla(jcp)
+            ? brgemm_utils::mmla_rd_chunk_elems(jcp.wei_dsz)
+            : static_cast<int>(data_type_vnni_granularity(data_type::s8));
+}
+
 template <cpu_isa_t isa>
 jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::
         jit_uni_brgemm_conv_comp_pad_kernel_t(
@@ -40,12 +52,14 @@ jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::
     : jcp_(ajcp)
     , inp_dsz_(jcp_.wei_dsz)
     , out_dsz_(jcp_.acc_dsz)
-    , nb_ic_(utils::div_up(jcp_.ic, 4))
-    , inp_ic_sz_(static_cast<size_t>(inp_dsz_) * jcp_.oc_block * 4)
+    , nb_ic_(utils::div_up(jcp_.ic, comp_pad_ic_block(jcp_)))
+    , inp_ic_sz_(static_cast<size_t>(inp_dsz_) * jcp_.oc_block
+              * comp_pad_ic_block(jcp_))
     , inp_kw_sz_(static_cast<size_t>(inp_dsz_) * jcp_.icp * jcp_.oc_block)
     , inp_kh_sz_(static_cast<size_t>(jcp_.kw) * inp_kw_sz_)
     , inp_kd_sz_(static_cast<size_t>(jcp_.kh) * inp_kh_sz_)
-    , isa_max_regs(isa_num_vregs(jcp_.isa)) {}
+    , isa_max_regs(isa_num_vregs(jcp_.isa))
+    , ic_block_(comp_pad_ic_block(jcp_)) {}
 
 template <cpu_isa_t isa>
 size_t jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::out_oc_offset(
@@ -56,7 +70,7 @@ size_t jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::out_oc_offset(
 template <cpu_isa_t isa>
 size_t jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::inp_ic_offset(
         const int m_block, const int icb, const int m, const int n) const {
-    return static_cast<size_t>(inp_dsz_) * n * m_block2_ * last_ic_block_
+    return static_cast<size_t>(inp_dsz_) * n * m_block2_ * ic_block_
             + ((icb * m_block) + m) * inp_ic_sz_;
 }
 
@@ -132,8 +146,21 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::compute(const int ic_step,
             auto vmm = accum(n_block, m, n);
             const auto oc_offset = inp_ic_offset(m_block, ic, m, n);
             add_imm(X_DEFAULT_ADDR, reg_aux_in, oc_offset, X_TMP_0);
-            ldr(vmm_tmp, ptr(X_DEFAULT_ADDR));
-            sdot(vmm.s, vmm_one_bytes.b, vmm_tmp.b);
+            if (is_int8_mmla(jcp_)) {
+                const auto sum01 = zmm_one_words;
+                const auto sum23 = zmm_int8_temp;
+                ldr(vmm_tmp, ptr(X_DEFAULT_ADDR));
+                eor(sum01.d, sum01.d, sum01.d);
+                usmmla(sum01.s, vmm_one_bytes.b, vmm_tmp.b);
+                ldr(vmm_tmp, ptr(X_DEFAULT_ADDR, 1, MUL_VL));
+                eor(sum23.d, sum23.d, sum23.d);
+                usmmla(sum23.s, vmm_one_bytes.b, vmm_tmp.b);
+                uzp1(vmm_tmp.d, sum01.d, sum23.d);
+                add(vmm.s, vmm.s, vmm_tmp.s);
+            } else {
+                ldr(vmm_tmp, ptr(X_DEFAULT_ADDR));
+                sdot(vmm.s, vmm_one_bytes.b, vmm_tmp.b);
+            }
         }
     }
 }
@@ -221,7 +248,7 @@ int jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::compute_ic_step(
                 / ((n_block + blocks) * max_ic_step);
         const float block_eff = block_disb * eff;
         float block_footprint = static_cast<float>(inp_dsz_) * blocks
-                * jcp_.oc_block * last_ic_block_;
+                * jcp_.oc_block * ic_block_;
         if (block_footprint <= static_cast<float>(
                     platform::get_per_core_cache_size(1))
                 && (block_eff > best_block_eff)) {
@@ -258,8 +285,11 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<isa>::generate() {
         dup(zmm_one_words.h, reg32_scratch);
     }
 
-    const int max_regs = isa_max_regs
-            - (is_int8_sve ? 6 : (jcp_.s8s8_compensation_required ? 4 : 3));
+    // MMLA reserves z26-z27 for the two K8 partial weight sums.
+    const int max_regs = is_int8_mmla(jcp_) ? zmm_int8_temp.getIdx()
+                                            : isa_max_regs
+                    - (is_int8_sve ? 6
+                                   : (jcp_.s8s8_compensation_required ? 4 : 3));
     const int nb = div_up(nstl::min(jcp_.oc, jcp_.oc_block), m_block2_);
     const int nb2 = nb / n_max_regs_;
     const int nb2_tail = nb % n_block2_;

--- a/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
 * Copyright 2024 FUJITSU LIMITED
-* Copyright 2024-2025 Arm Ltd. and affiliates
+* Copyright 2024-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ protected:
     Xbyak_aarch64::ZReg zmm_one_words = Xbyak_aarch64::ZReg(27);
     Xbyak_aarch64::ZReg zmm_int8_temp = Xbyak_aarch64::ZReg(26);
 
-    const int last_ic_block_ = 4;
+    const int ic_block_;
     const int n_block2_ = 4;
     const int m_block2_ = cpu_isa_traits<isa>::vlen / sizeof(int32_t);
     const int n_max_regs_ = 4;

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -119,7 +119,8 @@ bool use_int8_mmla_3x3(
     const bool isa_ok
             = mayiuse_sve_i8mm() && utils::one_of(jcp.isa, sve_128, sve_256);
     const bool problem_ok = jcp.prop_kind == prop_kind::forward_inference
-            && jcp.ndims == 4 && jcp.ngroups == 1 && jcp.src_dt == data_type::u8
+            && jcp.ndims == 4 && jcp.ngroups == 1
+            && utils::one_of(jcp.src_dt, data_type::u8, data_type::s8)
             && jcp.wei_dt == data_type::s8;
     const bool shape_ok = jcp.kd == 1 && jcp.kh == 3 && jcp.kw == 3
             && jcp.dilate_d == 0 && jcp.dilate_h == 0 && jcp.dilate_w == 0
@@ -138,7 +139,8 @@ bool use_int8_mmla_1x1(const jit_brgemm_conv_conf_t &jcp,
     const bool isa_ok
             = mayiuse_sve_i8mm() && utils::one_of(jcp.isa, sve_128, sve_256);
     const bool problem_ok = jcp.prop_kind == prop_kind::forward_inference
-            && jcp.ndims == 4 && jcp.ngroups == 1 && jcp.src_dt == data_type::u8
+            && jcp.ndims == 4 && jcp.ngroups == 1
+            && utils::one_of(jcp.src_dt, data_type::u8, data_type::s8)
             && jcp.wei_dt == data_type::s8;
     const bool shape_ok = jcp.is_1x1 && jcp.kd == 1 && jcp.kh == 1
             && jcp.kw == 1 && jcp.dilate_d == 0 && jcp.dilate_h == 0
@@ -2225,7 +2227,8 @@ static status_t init_conf_impl(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                     >= int8_mmla_vpad_comp_min_work_ratio * vpad_comp_table_work
             && vpad_comp_spatial_work >= int8_mmla_vpad_comp_min_spatial_work
             && vpad_comp_compute_work >= vpad_comp_thread_work;
-    const bool is_int8_mmla = jcp.use_mmla && jcp.src_dt == data_type::u8
+    const bool is_int8_mmla = jcp.use_mmla
+            && utils::one_of(jcp.src_dt, data_type::u8, data_type::s8)
             && jcp.wei_dt == data_type::s8;
     jcp.use_mmla_vpad_comp = is_int8_mmla && jcp.exec_type == exec_vpad
             && jcp.src_zero_point && !jcp.s8s8_compensation_required

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -58,7 +58,7 @@ bool allow_perf_heuristics(const jit_brgemm_conv_conf_t &jcp) {
 bool use_bf16_mmla(const jit_brgemm_conv_conf_t &jcp,
         const memory_desc_t &weights_md, bool is_1x1_path) {
     const int n_block = brgemm_utils::mmla_n_block(jcp.isa);
-    const int k_block = brgemm_utils::mmla_rd_block();
+    const int k_block = brgemm_utils::mmla_rd_block(jcp.wei_dsz);
     const bool isa_ok
             = mayiuse_bf16() && utils::one_of(jcp.isa, sve_128, sve_256);
     const bool problem_ok = jcp.prop_kind == prop_kind::forward_inference
@@ -92,7 +92,7 @@ bool use_bf16_mmla(const jit_brgemm_conv_conf_t &jcp,
 bool native_mmla_blocking_ok(
         const jit_brgemm_conv_conf_t &jcp, bool require_vpad) {
     const int n_block = brgemm_utils::mmla_n_block(jcp.isa);
-    const int k_block = brgemm_utils::mmla_rd_block();
+    const int k_block = brgemm_utils::mmla_rd_block(jcp.wei_dsz);
     const bool execution_ok
             = IMPLICATION(require_vpad, jcp.exec_type == exec_vpad)
             && !jcp.use_M_mask;
@@ -1809,7 +1809,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     jcp.use_mmla = allow_mmla && use_bf16_mmla(jcp, weights_md, false);
     brg_blocking_t::last_ic_block_size = jcp.use_mmla
-            ? brgemm_utils::mmla_rd_block()
+            ? brgemm_utils::mmla_rd_block(jcp.wei_dsz)
             : data_type_vnni_granularity(jcp.wei_dt);
 
     // TODO: optimize depthwise convolutions (for now direct approach is faster)
@@ -2205,7 +2205,7 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     jcp.use_mmla = use_bf16_mmla(jcp, weights_md, true);
     brg_blocking_t::last_ic_block_size = jcp.use_mmla
-            ? brgemm_utils::mmla_rd_block()
+            ? brgemm_utils::mmla_rd_block(jcp.wei_dsz)
             : data_type_vnni_granularity(jcp.wei_dt);
 
     using namespace data_type;

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -55,10 +55,16 @@ bool allow_perf_heuristics(const jit_brgemm_conv_conf_t &jcp) {
     return true;
 }
 
+int mmla_conv_wei_k_block(const jit_brgemm_conv_conf_t &jcp) {
+    return jcp.wei_dt == data_type::s8
+            ? brgemm_utils::mmla_rd_chunk_elems(jcp.wei_dsz)
+            : brgemm_utils::mmla_rd_block(jcp.wei_dsz);
+}
+
 bool use_bf16_mmla(const jit_brgemm_conv_conf_t &jcp,
         const memory_desc_t &weights_md, bool is_1x1_path) {
     const int n_block = brgemm_utils::mmla_n_block(jcp.isa);
-    const int k_block = brgemm_utils::mmla_rd_block(jcp.wei_dsz);
+    const int k_block = mmla_conv_wei_k_block(jcp);
     const bool isa_ok
             = mayiuse_bf16() && utils::one_of(jcp.isa, sve_128, sve_256);
     const bool problem_ok = jcp.prop_kind == prop_kind::forward_inference
@@ -86,13 +92,72 @@ bool use_bf16_mmla(const jit_brgemm_conv_conf_t &jcp,
     return layout_ok;
 }
 
-// MMLA convolution requires packed weights and complete N/K tiles. It does
-// not support BRGEMM masks for irregular output-spatial rows or internally
-// padded input channels. The 3x3 path handles borders through virtual padding.
+// These are conservative dispatch-policy thresholds, not correctness limits.
+// MMLA needs enough reduction and spatial work to amortize its setup; DOT can
+// be faster when scheduling and setup dominate a small problem. Keep a
+// portable fallback because the exact crossover varies by ISA and platform.
+constexpr int int8_mmla_1x1_min_ic = 64;
+constexpr int int8_mmla_1x1_min_os = 400;
+
+// Byte-MMLA currently requires the default weight zero point (zero). Keep
+// nonzero weight zero points off this path until compensation is validated.
+bool use_int8_mmla_3x3(
+        const jit_brgemm_conv_conf_t &jcp, const primitive_attr_t &attr) {
+    const int n_block = brgemm_utils::mmla_n_block(jcp.isa);
+    const int k_block = mmla_conv_wei_k_block(jcp);
+    const bool isa_ok
+            = mayiuse_sve_i8mm() && utils::one_of(jcp.isa, sve_128, sve_256);
+    const bool problem_ok = jcp.prop_kind == prop_kind::forward_inference
+            && jcp.ndims == 4 && jcp.ngroups == 1 && jcp.src_dt == data_type::u8
+            && jcp.wei_dt == data_type::s8;
+    const bool shape_ok = jcp.kd == 1 && jcp.kh == 3 && jcp.kw == 3
+            && jcp.dilate_d == 0 && jcp.dilate_h == 0 && jcp.dilate_w == 0
+            && jcp.ic % k_block == 0 && jcp.oc % n_block == 0
+            && utils::one_of(jcp.stride_h, 1, 2)
+            && jcp.stride_w == jcp.stride_h;
+    const bool attr_ok = attr.zero_points_.has_default_values(DNNL_ARG_WEIGHTS);
+    return isa_ok && problem_ok && shape_ok && attr_ok;
+}
+
+bool use_int8_mmla_1x1(const jit_brgemm_conv_conf_t &jcp,
+        const primitive_attr_t &attr, const memory_desc_t &weights_md) {
+    const int n_block = brgemm_utils::mmla_n_block(jcp.isa);
+    const int k_block = brgemm_utils::mmla_rd_block(jcp.wei_dsz);
+    const int wei_k_block = mmla_conv_wei_k_block(jcp);
+    const bool isa_ok
+            = mayiuse_sve_i8mm() && utils::one_of(jcp.isa, sve_128, sve_256);
+    const bool problem_ok = jcp.prop_kind == prop_kind::forward_inference
+            && jcp.ndims == 4 && jcp.ngroups == 1 && jcp.src_dt == data_type::u8
+            && jcp.wei_dt == data_type::s8;
+    const bool shape_ok = jcp.is_1x1 && jcp.kd == 1 && jcp.kh == 1
+            && jcp.kw == 1 && jcp.dilate_d == 0 && jcp.dilate_h == 0
+            && jcp.dilate_w == 0 && jcp.stride_d == 1 && jcp.stride_h == 1
+            && jcp.stride_w == 1 && jcp.ic % k_block == 0
+            && jcp.oc % n_block == 0;
+    auto want_weights_md = weights_md;
+    const memory_desc_wrapper weights_d(&weights_md);
+    const bool weights_any = weights_d.format_kind() == format_kind::any;
+    const bool explicit_mmla_weights = !weights_any
+            && brgemm_utils::init_mmla_wei_md(
+                       want_weights_md, 1, 0, n_block, wei_k_block)
+                    == status::success
+            && weights_md == want_weights_md;
+    const bool profitable
+            = jcp.ic >= int8_mmla_1x1_min_ic && jcp.os >= int8_mmla_1x1_min_os;
+    const bool attr_ok = attr.zero_points_.has_default_values(DNNL_ARG_WEIGHTS);
+    return isa_ok && problem_ok && shape_ok
+            && (weights_any || explicit_mmla_weights)
+            && (profitable || explicit_mmla_weights) && attr_ok;
+}
+
+// MMLA convolution requires packed weights, complete N tiles, and complete K
+// subpanels. BRGEMM masks for irregular output-spatial rows and implicit input
+// channel padding are not supported. The 3x3 path handles borders through
+// virtual padding.
 bool native_mmla_blocking_ok(
         const jit_brgemm_conv_conf_t &jcp, bool require_vpad) {
     const int n_block = brgemm_utils::mmla_n_block(jcp.isa);
-    const int k_block = brgemm_utils::mmla_rd_block(jcp.wei_dsz);
+    const int k_block = mmla_conv_wei_k_block(jcp);
     const bool execution_ok
             = IMPLICATION(require_vpad, jcp.exec_type == exec_vpad)
             && !jcp.use_M_mask;
@@ -101,7 +166,7 @@ bool native_mmla_blocking_ok(
             = jcp.oc_block == n_block && jcp.N == n_block && jcp.N_tail == 0;
     const bool k_blocking_ok = jcp.K % k_block == 0
             && (jcp.K_tail == 0 || jcp.K_tail % k_block == 0)
-            && jcp.ic_block % k_block == 0;
+            && jcp.ic_block % k_block == 0 && jcp.icp % k_block == 0;
     return execution_ok && weights_ok && n_blocking_ok && k_blocking_ok;
 }
 
@@ -225,8 +290,8 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
                     && jcp.oc_block == brgemm_utils::mmla_n_block(jcp.isa);
             if (!layout_ok) return status::unimplemented;
             auto want_weights_md = weights_md;
-            CHECK(brgemm_utils::init_mmla_wei_md(
-                    want_weights_md, 1, 0, jcp.oc_block));
+            CHECK(brgemm_utils::init_mmla_wei_md(want_weights_md, 1, 0,
+                    jcp.oc_block, mmla_conv_wei_k_block(jcp)));
             if (weights_d.format_kind() == format_kind::any)
                 weights_md = want_weights_md;
             else if (weights_md != want_weights_md)
@@ -1807,9 +1872,11 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         }
     }
 
-    jcp.use_mmla = allow_mmla && use_bf16_mmla(jcp, weights_md, false);
+    jcp.use_mmla = allow_mmla
+            && (use_bf16_mmla(jcp, weights_md, false)
+                    || use_int8_mmla_3x3(jcp, attr));
     brg_blocking_t::last_ic_block_size = jcp.use_mmla
-            ? brgemm_utils::mmla_rd_block(jcp.wei_dsz)
+            ? mmla_conv_wei_k_block(jcp)
             : data_type_vnni_granularity(jcp.wei_dt);
 
     // TODO: optimize depthwise convolutions (for now direct approach is faster)
@@ -2120,9 +2187,8 @@ static status_t init_conf_impl(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     if (one_of(jcp.src_dt, u8, s8) && !is_ok_large_spatial)
         if (allow_perf_heuristics(jcp)) return status::unimplemented;
 
-    // For padding shapes, we calculate the comp along with the computation
-    // inside brgemm kernel when output size is small to get optimal perf
-    // Or we calculate the comp using brgemm_coomp_pad kernel
+    // Small padded problems calculate compensation inside BRGEMM. Larger
+    // problems use the separate compensation kernel.
     const auto output_sz = static_cast<dim_t>(jcp.mb) * jcp.ngroups * jcp.oc
             * jcp.od * jcp.oh * jcp.ow;
     const auto comp_with_pads
@@ -2130,6 +2196,13 @@ static status_t init_conf_impl(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             && IMPLICATION(jcp.exec_type == exec_vpad, with_pad);
     jcp.req_brg_comp_pad = comp_with_pads && output_sz <= 8192 && jcp.oc < 512;
     jcp.req_cal_comp_pad = comp_with_pads && !jcp.req_brg_comp_pad;
+    const bool is_int8_mmla = jcp.use_mmla && jcp.src_dt == data_type::u8
+            && jcp.wei_dt == data_type::s8;
+    // Source-zero-point virtual padding requires row-specific compensation,
+    // which is added separately from basic byte-MMLA convolution support.
+    if (is_int8_mmla && jcp.src_zero_point
+            && (jcp.req_brg_comp_pad || jcp.max_vpad > 0))
+        return status::unimplemented;
 
     // estimate the number of kernel range combination for compensation
     const auto kd_cnt = 1 + utils::div_up(abs(jcp.f_pad), jcp.dilate_d + 1)
@@ -2164,7 +2237,7 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
         memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
     // MMLA constrains the selected blocking. Preserve the user descriptors so
-    // a rejected MMLA candidate can retry through the existing BFDOT path.
+    // a rejected MMLA candidate can retry through the existing DOT path.
     const auto src_md_orig = src_md;
     const auto weights_md_orig = weights_md;
     const auto dst_md_orig = dst_md;
@@ -2203,9 +2276,10 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     if (!jcp.is_1x1) return status::unimplemented;
 
-    jcp.use_mmla = use_bf16_mmla(jcp, weights_md, true);
+    jcp.use_mmla = use_bf16_mmla(jcp, weights_md, true)
+            || use_int8_mmla_1x1(jcp, attr, weights_md);
     brg_blocking_t::last_ic_block_size = jcp.use_mmla
-            ? brgemm_utils::mmla_rd_block(jcp.wei_dsz)
+            ? mmla_conv_wei_k_block(jcp)
             : data_type_vnni_granularity(jcp.wei_dt);
 
     using namespace data_type;

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -99,6 +99,17 @@ bool use_bf16_mmla(const jit_brgemm_conv_conf_t &jcp,
 constexpr int int8_mmla_1x1_min_ic = 64;
 constexpr int int8_mmla_1x1_min_os = 400;
 
+// Source-zero-point MMLA builds per-M virtual-padding compensation outside
+// BRGEMM. The work ratio amortizes the compensation table, the spatial floor
+// rejects short M dimensions, and the normalized work-per-thread floor avoids
+// spreading too little compute across the configured workers. These are
+// performance-policy guards derived from SVE128 and SVE256 measurements, not
+// kernel correctness constraints. Normalized work omits the fixed 3x3 factor.
+constexpr int int8_mmla_vpad_comp_min_ic = 16;
+constexpr int int8_mmla_vpad_comp_min_work_ratio = 8;
+constexpr dim_t int8_mmla_vpad_comp_min_spatial_work = 160;
+constexpr dim_t int8_mmla_vpad_comp_min_work_per_thread = 192 * 1024;
+
 // Byte-MMLA currently requires the default weight zero point (zero). Keep
 // nonzero weight zero points off this path until compensation is validated.
 bool use_int8_mmla_3x3(
@@ -2196,12 +2207,33 @@ static status_t init_conf_impl(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             && IMPLICATION(jcp.exec_type == exec_vpad, with_pad);
     jcp.req_brg_comp_pad = comp_with_pads && output_sz <= 8192 && jcp.oc < 512;
     jcp.req_cal_comp_pad = comp_with_pads && !jcp.req_brg_comp_pad;
+    // Integer MMLA cannot calculate padding compensation in its reduction
+    // loop. Build per-M compensation when profitable; otherwise init_conf
+    // retries DOT.
+    const auto vpad_comp_boundary_work
+            = static_cast<dim_t>(jcp.mb) * jcp.oh * jcp.ic;
+    const auto vpad_comp_table_work = static_cast<dim_t>(jcp.ic) + jcp.ow;
+    const auto vpad_comp_spatial_work
+            = static_cast<dim_t>(jcp.mb) * jcp.oh * jcp.ow;
+    const auto vpad_comp_compute_work
+            = vpad_comp_spatial_work * jcp.ic * jcp.oc;
+    const auto vpad_comp_thread_work
+            = static_cast<dim_t>(nstl::max(1, jcp.nthr))
+            * int8_mmla_vpad_comp_min_work_per_thread;
+    const bool is_vpad_comp_profitable = jcp.ic >= int8_mmla_vpad_comp_min_ic
+            && vpad_comp_boundary_work
+                    >= int8_mmla_vpad_comp_min_work_ratio * vpad_comp_table_work
+            && vpad_comp_spatial_work >= int8_mmla_vpad_comp_min_spatial_work
+            && vpad_comp_compute_work >= vpad_comp_thread_work;
     const bool is_int8_mmla = jcp.use_mmla && jcp.src_dt == data_type::u8
             && jcp.wei_dt == data_type::s8;
-    // Source-zero-point virtual padding requires row-specific compensation,
-    // which is added separately from basic byte-MMLA convolution support.
+    jcp.use_mmla_vpad_comp = is_int8_mmla && jcp.exec_type == exec_vpad
+            && jcp.src_zero_point && !jcp.s8s8_compensation_required
+            && jcp.req_cal_comp_pad && jcp.max_vpad > 0
+            && is_vpad_comp_profitable;
     if (is_int8_mmla && jcp.src_zero_point
-            && (jcp.req_brg_comp_pad || jcp.max_vpad > 0))
+            && (jcp.req_brg_comp_pad
+                    || (jcp.max_vpad > 0 && !jcp.use_mmla_vpad_comp)))
         return status::unimplemented;
 
     // estimate the number of kernel range combination for compensation
@@ -2218,9 +2250,11 @@ static status_t init_conf_impl(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     jcp.ker_ranges_size = jcp.exec_type == exec_base ? kd_cnt * kh_cnt * kw_cnt
                                                      : kd_cnt * kh_cnt;
-    jcp.comp_a_buffer_size
+    const auto comp_a_spatial_size = jcp.use_mmla_vpad_comp ? jcp.ow : 1;
+    jcp.comp_a_buffer_size = jcp.ngroups * jcp.nb_oc * jcp.ker_ranges_size
+            * comp_a_spatial_size * jcp.oc_block;
+    jcp.s8s8_comp_buffer_size
             = jcp.ngroups * jcp.nb_oc * jcp.ker_ranges_size * jcp.oc_block;
-    jcp.s8s8_comp_buffer_size = jcp.comp_a_buffer_size;
 
     // enable ununroll_bd_loop for big shapes to reduce kernel sizes
     jcp.ununroll_bd_loop

--- a/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_utils.cpp
@@ -54,6 +54,65 @@ bool allow_perf_heuristics(const jit_brgemm_conv_conf_t &jcp) {
     if (jcp.wei_plain) return false;
     return true;
 }
+
+bool use_bf16_mmla(const jit_brgemm_conv_conf_t &jcp,
+        const memory_desc_t &weights_md, bool is_1x1_path) {
+    const int n_block = brgemm_utils::mmla_n_block(jcp.isa);
+    const int k_block = brgemm_utils::mmla_rd_block();
+    const bool isa_ok
+            = mayiuse_bf16() && utils::one_of(jcp.isa, sve_128, sve_256);
+    const bool problem_ok = jcp.prop_kind == prop_kind::forward_inference
+            && jcp.ndims == 4 && jcp.ngroups == 1
+            && jcp.src_dt == data_type::bf16 && jcp.wei_dt == data_type::bf16
+            && jcp.kd == 1 && jcp.dilate_d == 0 && jcp.dilate_h == 0
+            && jcp.dilate_w == 0 && jcp.stride_d == 1 && jcp.ic % k_block == 0
+            && jcp.oc % n_block == 0;
+    const bool shape_ok = is_1x1_path ? jcp.is_1x1 && jcp.kh == 1 && jcp.kw == 1
+                    && jcp.stride_h == 1 && jcp.stride_w == 1
+                                      : !jcp.is_1x1 && jcp.kh == 3
+                    && jcp.kw == 3 && utils::one_of(jcp.stride_h, 1, 2)
+                    && jcp.stride_w == jcp.stride_h;
+    if (!isa_ok || !problem_ok || !shape_ok) return false;
+
+    auto want_weights_md = weights_md;
+    const memory_desc_wrapper weights_d(&weights_md);
+    // Any weights permit MMLA selection; an explicit descriptor must already
+    // match the packed layout consumed by the kernel.
+    const bool layout_ok
+            = brgemm_utils::init_mmla_wei_md(want_weights_md, 1, 0, n_block)
+                    == status::success
+            && (weights_d.format_kind() == format_kind::any
+                    || weights_md == want_weights_md);
+    return layout_ok;
+}
+
+// MMLA convolution requires packed weights and complete N/K tiles. It does
+// not support BRGEMM masks for irregular output-spatial rows or internally
+// padded input channels. The 3x3 path handles borders through virtual padding.
+bool native_mmla_blocking_ok(
+        const jit_brgemm_conv_conf_t &jcp, bool require_vpad) {
+    const int n_block = brgemm_utils::mmla_n_block(jcp.isa);
+    const int k_block = brgemm_utils::mmla_rd_block();
+    const bool execution_ok
+            = IMPLICATION(require_vpad, jcp.exec_type == exec_vpad)
+            && !jcp.use_M_mask;
+    const bool weights_ok = !jcp.wei_plain && !jcp.is_ic_padded;
+    const bool n_blocking_ok
+            = jcp.oc_block == n_block && jcp.N == n_block && jcp.N_tail == 0;
+    const bool k_blocking_ok = jcp.K % k_block == 0
+            && (jcp.K_tail == 0 || jcp.K_tail % k_block == 0)
+            && jcp.ic_block % k_block == 0;
+    return execution_ok && weights_ok && n_blocking_ok && k_blocking_ok;
+}
+
+void set_native_mmla_attr(brgemm_attr_t &brgattr, bool use_mmla, int M) {
+    if (!use_mmla) return;
+    brgattr.use_mmla = true;
+    brgattr.use_mmla_packed_a = false;
+    brgattr.hint_ld_block2 = brgemm_utils::mmla_ld_block2();
+    brgattr.hint_bd_block
+            = nstl::min(brgemm_utils::mmla_max_native_bd_block(), M);
+}
 } // namespace
 
 namespace brgemm_convolution_utils {
@@ -161,7 +220,18 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
         }
     } else {
         jcp.LDB = jcp.oc_block;
-        if (jcp.oc_block == 64) {
+        if (jcp.use_mmla) {
+            const bool layout_ok = is_2d && !with_groups && !jcp.is_ic_padded
+                    && jcp.oc_block == brgemm_utils::mmla_n_block(jcp.isa);
+            if (!layout_ok) return status::unimplemented;
+            auto want_weights_md = weights_md;
+            CHECK(brgemm_utils::init_mmla_wei_md(
+                    want_weights_md, 1, 0, jcp.oc_block));
+            if (weights_d.format_kind() == format_kind::any)
+                weights_md = want_weights_md;
+            else if (weights_md != want_weights_md)
+                return status::unimplemented;
+        } else if (jcp.oc_block == 64) {
             if (is_3d) {
                 switch (vnni_granularity) {
                     case 1: wei_tag = with_groups ? gOdhwi64o : Odhwi64o; break;
@@ -470,7 +540,12 @@ status_t pick_tags(jit_brgemm_conv_conf_t &jcp, memory_desc_t &src_md,
     const bool any_eligible = is_any_eligible(jcp);
     CHECK(init_tag(jcp.src_tag, src_md, src_d, src_tag, any_eligible));
     CHECK(init_tag(jcp.dst_tag, dst_md, dst_d, dst_tag, any_eligible));
-    CHECK(init_tag(jcp.wei_tag, weights_md, weights_d, wei_tag, true));
+    if (jcp.use_mmla) {
+        // MMLA uses a dynamic packed descriptor rather than a format tag.
+        jcp.wei_tag = format_tag::undef;
+    } else {
+        CHECK(init_tag(jcp.wei_tag, weights_md, weights_d, wei_tag, true));
+    }
 
     return status::success;
 }
@@ -729,7 +804,16 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
             is_bf32));
-    CHECK(brgemm_utils::brgemm_blocking(&brg));
+    if (use_mmla) {
+        brgemm_attr_t brgattr;
+        set_native_mmla_attr(brgattr, true, vM);
+        brgattr.max_top_vpad
+                = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
+        brgattr.max_bottom_vpad = brgattr.max_top_vpad;
+        CHECK(brgemm_desc_set_attr(&brg, brgattr));
+    } else {
+        CHECK(brgemm_utils::brgemm_blocking(&brg));
+    }
     ur = brg.bd_block;
     ur_block = brg.bd_block;
     ur_block_tail = 0;
@@ -775,9 +859,10 @@ status_t brg_blocking_t::get_brgemm_ur(
                 CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brg_type,
                         src_dt, wei_dt, brgemm_row_major, alpha, vbeta, LDA,
                         LDB, LDC, vM, vN, vK, strides_ptr, is_bf32));
-                CHECK(brgemm_utils::brgemm_blocking(&brg));
 
                 brgemm_attr_t brgattr;
+                set_native_mmla_attr(brgattr, use_mmla, vM);
+                if (!use_mmla) CHECK(brgemm_utils::brgemm_blocking(&brg));
                 brgattr.max_bs = max_batch;
                 max_vpad = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
                 brgattr.max_top_vpad = max_vpad;
@@ -1594,7 +1679,8 @@ brgemm_broadcast_t get_zp_type(const primitive_attr_t &attr, int arg) {
 status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         const convolution_desc_t &cd, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
-        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads,
+        bool allow_mmla) {
     using namespace prop_kind;
 
     brg_blocking_t::L1 = platform::get_per_core_cache_size(1);
@@ -1721,7 +1807,10 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         }
     }
 
-    brg_blocking_t::last_ic_block_size = data_type_vnni_granularity(jcp.wei_dt);
+    jcp.use_mmla = allow_mmla && use_bf16_mmla(jcp, weights_md, false);
+    brg_blocking_t::last_ic_block_size = jcp.use_mmla
+            ? brgemm_utils::mmla_rd_block()
+            : data_type_vnni_granularity(jcp.wei_dt);
 
     // TODO: optimize depthwise convolutions (for now direct approach is faster)
     const bool is_depthwise
@@ -1810,16 +1899,17 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     return status::success;
 }
 
-status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
+static status_t init_conf_impl(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         const convolution_desc_t &cd, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
-        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads,
+        bool allow_mmla) {
 
     using namespace prop_kind;
     if (!mayiuse(isa)) return status::unimplemented;
 
-    CHECK(init_jcp(
-            jcp, isa, cd, src_md, weights_md, dst_md, bias_md, attr, nthreads));
+    CHECK(init_jcp(jcp, isa, cd, src_md, weights_md, dst_md, bias_md, attr,
+            nthreads, allow_mmla));
 
     if (jcp.is_1x1)
         if (allow_perf_heuristics(jcp)) return status::unimplemented;
@@ -1862,6 +1952,11 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             cur_brgb.get_from_jcp(jcp);
             cur_brgb.oc_block = ocb * jcp.acc_simd_w;
             cur_brgb.nb_oc = utils::div_up(jcp.oc, cur_brgb.oc_block);
+            // The packed MMLA weights fix each output-channel block to one
+            // ISA-sized N tile.
+            if (jcp.use_mmla
+                    && cur_brgb.oc_block != brgemm_utils::mmla_n_block(jcp.isa))
+                continue;
             if (!cur_brgb.fast_check_oc_block()) continue;
             // eff heuristics seem to be wrong for sve_128, <16 is always worse
             if (isa == sve_128 && cur_brgb.oc_block < 16) break;
@@ -1948,6 +2043,9 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     size_t sc_size = sizeof(brgemm_batch_element_t);
     jcp.adjusted_batch_size
             = div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size);
+
+    if (jcp.use_mmla && !native_mmla_blocking_ok(jcp, true))
+        return status::unimplemented;
 
     if (!jcp.wei_plain)
         CHECK(pick_tags(jcp, src_md, weights_md, dst_md, bias_md));
@@ -2061,6 +2159,32 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     return status::success;
 }
 
+status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
+        const convolution_desc_t &cd, memory_desc_t &src_md,
+        memory_desc_t &weights_md, memory_desc_t &dst_md,
+        memory_desc_t &bias_md, primitive_attr_t &attr, int nthreads) {
+    // MMLA constrains the selected blocking. Preserve the user descriptors so
+    // a rejected MMLA candidate can retry through the existing BFDOT path.
+    const auto src_md_orig = src_md;
+    const auto weights_md_orig = weights_md;
+    const auto dst_md_orig = dst_md;
+    const auto bias_md_orig = bias_md;
+    primitive_attr_t attr_orig;
+    CHECK(attr_orig.copy_from_and_reset(attr));
+
+    const auto st = init_conf_impl(jcp, isa, cd, src_md, weights_md, dst_md,
+            bias_md, attr, nthreads, true);
+    if (st != status::unimplemented || !jcp.use_mmla) return st;
+
+    src_md = src_md_orig;
+    weights_md = weights_md_orig;
+    dst_md = dst_md_orig;
+    bias_md = bias_md_orig;
+    CHECK(attr.copy_from_and_reset(attr_orig));
+    return init_conf_impl(jcp, isa, cd, src_md, weights_md, dst_md, bias_md,
+            attr, nthreads, false);
+}
+
 status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         const convolution_desc_t &cd, memory_desc_t &src_md,
         memory_desc_t &weights_md, memory_desc_t &dst_md,
@@ -2069,8 +2193,8 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     using namespace prop_kind;
     if (!mayiuse(isa)) return status::unimplemented;
 
-    CHECK(init_jcp(
-            jcp, isa, cd, src_md, weights_md, dst_md, bias_md, attr, nthreads));
+    CHECK(init_jcp(jcp, isa, cd, src_md, weights_md, dst_md, bias_md, attr,
+            nthreads, false));
 
     const memory_desc_wrapper src_d(&src_md);
     const memory_desc_wrapper weights_d(&weights_md);
@@ -2078,6 +2202,11 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     const memory_desc_wrapper bias_d(&bias_md);
 
     if (!jcp.is_1x1) return status::unimplemented;
+
+    jcp.use_mmla = use_bf16_mmla(jcp, weights_md, true);
+    brg_blocking_t::last_ic_block_size = jcp.use_mmla
+            ? brgemm_utils::mmla_rd_block()
+            : data_type_vnni_granularity(jcp.wei_dt);
 
     using namespace data_type;
     // ===================== blocking =================================
@@ -2114,6 +2243,11 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         cur_brgb.get_from_jcp(jcp);
         cur_brgb.oc_block = ocb * min_oc_block;
         cur_brgb.nb_oc = utils::div_up(jcp.oc, cur_brgb.oc_block);
+        // The packed MMLA weights fix each output-channel block to one
+        // ISA-sized N tile.
+        if (jcp.use_mmla
+                && cur_brgb.oc_block != brgemm_utils::mmla_n_block(jcp.isa))
+            continue;
 
         // eff heuristics seem to be wrong for sve_128, <16 is always worse
         if (isa == sve_128 && cur_brgb.oc_block < 16) break;
@@ -2161,6 +2295,9 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     // The following condition checks for shapes where down-convert execution
     // in brgemm fails
     if (jcp.is_bf32 && jcp.ic < 64 && jcp.ic % 32 != 0)
+        return status::unimplemented;
+
+    if (jcp.use_mmla && !native_mmla_blocking_ok(jcp, false))
         return status::unimplemented;
 
     if (jcp.use_uker)

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2016 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -667,6 +667,7 @@ struct jit_brgemm_conv_conf_t {
     bool brgemm_bd_loop_innermost;
 
     bool use_uker;
+    bool use_mmla {false};
     bool var_bs {false};
     bool use_interleave_stores;
     brgemm_kernel_prefetching_t hint_prefetching;

--- a/src/cpu/aarch64/jit_primitive_conf.hpp
+++ b/src/cpu/aarch64/jit_primitive_conf.hpp
@@ -668,6 +668,8 @@ struct jit_brgemm_conv_conf_t {
 
     bool use_uker;
     bool use_mmla {false};
+    // Use execution-precomputed source zero-point compensation per M row.
+    bool use_mmla_vpad_comp {false};
     bool var_bs {false};
     bool use_interleave_stores;
     brgemm_kernel_prefetching_t hint_prefetching;

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -192,6 +192,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
                                                     : bgmmc_.M_tail);
         auto vN = (i_N) ? bgmmc_.N_tail : bgmmc_.N_blk;
         auto vK = (i_K) ? bgmmc_.K_tail : bgmmc_.K_blk;
+        const int bs = get_brg_batchsize(bgmmc_, i_bs, i_K);
 
         int idx = get_brg_kernel_idx(i_bs, i_init, i_M, i_N, i_K);
         if (idx < 0) continue;
@@ -219,6 +220,9 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         if (bgmmc_.use_mmla) {
             // Matmul keeps A plain and supplies B in the packed MMLA layout.
             // Match the kernel's N tile and cap M blocking for register use.
+            // Full, batch-tail, and K-tail descriptors use their actual batch
+            // bound.
+            brgattr.max_bs = bs;
             brgattr.use_mmla = true;
             brgattr.hint_ld_block2 = brgemm_utils::mmla_ld_block2();
             brgattr.hint_bd_block = nstl::min<dim_t>(

--- a/src/cpu/aarch64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul.cpp
@@ -26,6 +26,7 @@
 #include "cpu/matmul/matmul_utils.hpp"
 #include "cpu/scale_utils.hpp"
 
+#include "cpu/aarch64/brgemm/brgemm_utils.hpp"
 #include "cpu/aarch64/injectors/jit_uni_binary_injector.hpp"
 #include "cpu/aarch64/matmul/brgemm_matmul.hpp"
 
@@ -215,6 +216,14 @@ status_t brgemm_matmul_t<isa>::pd_t::init(engine_t *engine) {
         brgemm_attr_t brgattr;
         brgattr.generate_skip_accumulation
                 = bgmmc_.post_ops_applicable && bgmmc_.nthr_k > 1;
+        if (bgmmc_.use_mmla) {
+            // Matmul keeps A plain and supplies B in the packed MMLA layout.
+            // Match the kernel's N tile and cap M blocking for register use.
+            brgattr.use_mmla = true;
+            brgattr.hint_ld_block2 = brgemm_utils::mmla_ld_block2();
+            brgattr.hint_bd_block = nstl::min<dim_t>(
+                    brgemm_utils::mmla_max_native_bd_block(), vM);
+        }
 
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
 

--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
@@ -566,6 +566,21 @@ struct matmul_brgemm_blocking_params_t {
     }
 };
 
+int get_mmla_brgemm_batch_size(const brgemm_matmul_conf_t &bgmmc,
+        const matmul_brgemm_blocking_params_t::matmul_params_t &matmul,
+        int k_blk) {
+    // Wider K tiles already amortize kernel entry and are more sensitive to
+    // working-set pressure, so keep one such tile per BRGEMM call.
+    constexpr int max_batched_k_block = 128;
+    if (!bgmmc.use_mmla || k_blk > max_batched_k_block) return 1;
+
+    // The packed-B panel is ISA-defined. Amortize driver and kernel-entry
+    // overhead across adjacent K blocks without changing that layout.
+    // Bound batch growth so larger problems remain split into compact K chunks.
+    constexpr int max_mmla_brgemm_batch_size = 16;
+    return nstl::min(max_mmla_brgemm_batch_size, matmul.K / k_blk);
+}
+
 float compute_blocking_heuristic_sve_512(brgemm_matmul_conf_t &bgmmc,
         const brgemm_matmul_conf_utils_t &bm_conf_utils,
         const matmul_brgemm_blocking_params_t::matmul_params_t &matmul,
@@ -668,6 +683,7 @@ float compute_blocking_heuristic_sve_256(brgemm_matmul_conf_t &bgmmc,
     //It is found that for M<512 k_blk of 128 works better than 1024 for most of the shapes.
     int default_k_blk = (matmul.M >= 512) ? 1024 : 128;
     int k_blk = nstl::min(matmul.K, default_k_blk);
+    const int batch_size = get_mmla_brgemm_batch_size(bgmmc, matmul, k_blk);
     int start_nthr_k = 1;
 
     // for cases with low parallel work, reduce 'min_m_blk' to
@@ -712,7 +728,7 @@ float compute_blocking_heuristic_sve_256(brgemm_matmul_conf_t &bgmmc,
 
         matmul_brgemm_blocking_params_t cur_params(matmul, nthr);
         cur_params.update_params(
-                1, m_blk, n_chunk_size, n_blk, 1, k_blk, nthr_k);
+                1, m_blk, n_chunk_size, n_blk, batch_size, k_blk, nthr_k);
 
         float cur_imbalance = cur_params.get_imbalance();
         if (cur_imbalance < best_imbalance) {
@@ -743,6 +759,7 @@ float compute_blocking_heuristic_sve_128(brgemm_matmul_conf_t &bgmmc,
 
     int default_k_blk = (matmul.M >= 256) ? 512 : 64;
     int k_blk = nstl::min(matmul.K, default_k_blk);
+    const int batch_size = get_mmla_brgemm_batch_size(bgmmc, matmul, k_blk);
     int start_nthr_k = 1;
 
     // for cases with low parallel work, reduce 'min_m_blk' to
@@ -787,7 +804,7 @@ float compute_blocking_heuristic_sve_128(brgemm_matmul_conf_t &bgmmc,
 
         matmul_brgemm_blocking_params_t cur_params(matmul, nthr);
         cur_params.update_params(
-                1, m_blk, n_chunk_size, n_blk, 1, k_blk, nthr_k);
+                1, m_blk, n_chunk_size, n_blk, batch_size, k_blk, nthr_k);
 
         float cur_imbalance = cur_params.get_imbalance();
         if (cur_imbalance < best_imbalance) {

--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
@@ -21,6 +21,7 @@
 #include "common/dnnl_thread.hpp"
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
+#include "cpu/aarch64/brgemm/brgemm_utils.hpp"
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 #include "cpu/aarch64/injectors/jit_uni_postops_injector.hpp"
 
@@ -51,6 +52,7 @@ using namespace format_tag;
 
 int get_default_n_block(
         format_tag_t matrix_b_tag, brgemm_matmul_conf_t &bgmmc) {
+    if (bgmmc.use_mmla) return brgemm_utils::mmla_n_block(bgmmc.isa);
     // Note: consider using weights mem_descriptor 'inner_blks' to
     // return B's inner block for non-default cases.
     switch (matrix_b_tag) {
@@ -191,6 +193,20 @@ brgemm_matmul_conf_utils_t::brgemm_matmul_conf_utils_t(
 status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(
         memory_desc_t &B_md, bool init_n_tag) const {
     using namespace data_type;
+    if (bgmmc.use_mmla) {
+        auto want_B_md = B_md;
+        CHECK(brgemm_utils::init_mmla_wei_md(want_B_md, bgmmc.ndims - 2,
+                bgmmc.ndims - 1, brgemm_utils::mmla_n_block(bgmmc.isa)));
+        if (B_any_layout)
+            B_md = want_B_md;
+        else if (B_md != want_B_md)
+            return status::unimplemented;
+        // The custom MMLA blocking is described by B_md rather than a public
+        // format tag.
+        bgmmc.wei_tag = format_tag::undef;
+        return status::success;
+    }
+
     if (B_any_layout) {
         const int default_n_block = init_n_tag
                 ? get_default_n_block(format_tag::undef, bgmmc)
@@ -273,6 +289,12 @@ status_t brgemm_matmul_conf_utils_t::set_or_check_B_tag(
 
 status_t brgemm_matmul_conf_utils_t::update_and_check_B_tag(
         memory_desc_t &B_md, int n_blk_size) const {
+
+    // Packed MMLA weights fix N blocking, so the heuristic cannot shrink it.
+    if (bgmmc.use_mmla)
+        return n_blk_size == brgemm_utils::mmla_n_block(bgmmc.isa)
+                ? status::success
+                : status::unimplemented;
 
     if (n_blk_fixed && n_blk_size != bgmmc.wei_n_blk)
         return status::unimplemented;
@@ -960,15 +982,39 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
     bgmmc.bcast_B_desc.set_params(
             weights_d.dims(), dst_d.dims(), bgmmc.batch_ndims, bgmmc.batch);
 
+    const int mmla_m_block = brgemm_utils::mmla_bd_blk();
+    const int mmla_n_block = brgemm_utils::mmla_n_block(isa);
+    const int mmla_k_block = brgemm_utils::mmla_rd_block();
+    // Matmul handles batch dimensions outside the BRGEMM kernel. Select MMLA
+    // when each BF16 matrix has complete N and K tiles; M tails are supported.
+    const bool mmla_shape_ok = utils::one_of(isa, sve_128, sve_256)
+            && bm_conf_utils.is_bf16() && bgmmc.M >= mmla_m_block
+            && bgmmc.N >= mmla_n_block && bgmmc.K >= mmla_k_block
+            && bgmmc.N % mmla_n_block == 0 && bgmmc.K % mmla_k_block == 0;
+    bool mmla_layout_ok = false;
+    if (mmla_shape_ok) {
+        auto mmla_weights_md = weights_md;
+        const bool mmla_md_ok
+                = brgemm_utils::init_mmla_wei_md(mmla_weights_md,
+                          bgmmc.ndims - 2, bgmmc.ndims - 1, mmla_n_block)
+                == status::success;
+        mmla_layout_ok = mmla_md_ok
+                && (weights_d.format_kind() == format_kind::any
+                        || weights_md == mmla_weights_md);
+    }
+    bgmmc.use_mmla = mmla_shape_ok && mmla_layout_ok;
+
     // Dispatch small shapes to VNNI for better performance
     bool is_small_shapes = false;
 
     VCONDCHECK_BG(!is_small_shapes, VERBOSE_SMALL_SHAPES);
 
     // required granularity for k dimension
-    bgmmc.required_k_granularity = 1;
+    bgmmc.required_k_granularity = bgmmc.use_mmla ? mmla_k_block : 1;
     VCONDCHECK_BG(bgmmc.required_k_granularity > 0, VERBOSE_BLOCKING_FAIL, "");
-    bgmmc.wei_k_blk = data_type_vnni_simd_elems<sve_512>(bgmmc.wei_dt);
+    bgmmc.wei_k_blk = bgmmc.use_mmla
+            ? mmla_k_block
+            : data_type_vnni_simd_elems<sve_512>(bgmmc.wei_dt);
 
     VCHECK_BG(bm_conf_utils.set_or_check_tags(src_md, dst_md, bias_md),
             VERBOSE_UNSUPPORTED_TAG);

--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.cpp
@@ -1001,7 +1001,10 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     const int mmla_m_block = brgemm_utils::mmla_bd_blk();
     const int mmla_n_block = brgemm_utils::mmla_n_block(isa);
-    const int mmla_k_block = brgemm_utils::mmla_rd_block();
+    const int mmla_k_block = brgemm_utils::mmla_rd_block(bgmmc.a_dt_sz);
+    // TODO: Extend this selector to U8S8 and S8S8 MMLA once byte-MMLA MatMul
+    // packing and primitive-level coverage are ready. Until then, INT8 MatMul
+    // retains its existing packed-B contract and BRGEMM path.
     // Matmul handles batch dimensions outside the BRGEMM kernel. Select MMLA
     // when each BF16 matrix has complete N and K tiles; M tails are supported.
     const bool mmla_shape_ok = utils::one_of(isa, sve_128, sve_256)

--- a/src/cpu/aarch64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/aarch64/matmul/brgemm_matmul_utils.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2023-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -171,6 +171,8 @@ struct brgemm_matmul_conf_t {
     bool transposed_A;
     bool transposed_B;
     bool blocked_B;
+    // MMLA consumes the primitive-selected packed B layout directly.
+    bool use_mmla {false};
 
     dim_t zp_a_comp_shift_n;
     dim_t zp_a_comp_elems_per_thr;
@@ -209,11 +211,13 @@ struct brgemm_matmul_conf_utils_t {
     }
 
     inline bool get_blocked_B() const {
-        return blocked_B_layouts_allowed
-                && check_b_layout_blocked_by_n(bgmmc.wei_tag);
+        return bgmmc.use_mmla
+                || (blocked_B_layouts_allowed
+                        && check_b_layout_blocked_by_n(bgmmc.wei_tag));
     }
 
     inline bool use_buffer_b(bool use_heuristic = true) const {
+        if (bgmmc.use_mmla) return false;
         // In the case of 1xK gemmv, we should avoid copying the weights if
         // they are in BA format, since the copy would be more expensive than
         // the gemv itself.
@@ -236,6 +240,7 @@ struct brgemm_matmul_conf_utils_t {
     }
 
     inline dim_t get_actual_LDB() const {
+        if (bgmmc.use_mmla) return bgmmc.wei_n_blk;
         if (bgmmc.wei_tag == format_tag::acbd && !bgmmc.use_buffer_b) {
             assert(bgmmc.b_dt_sz == bgmmc.tr_b_dt_sz);
             return bgmmc.B_strides[1] / bgmmc.b_dt_sz;
@@ -253,7 +258,9 @@ struct brgemm_matmul_conf_utils_t {
         return is_prime_num && IMPLICATION(bgmmc.M_blk < 48, maybe_ldb_tail);
     }
 
-    inline bool check_n_blk_fixed() const { return n_blk_fixed; }
+    inline bool check_n_blk_fixed() const {
+        return n_blk_fixed || bgmmc.use_mmla;
+    }
 
     inline bool check_is_transposed(format_tag_t tag) const {
         return tag == transposed_tensor_layout_tag;

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -143,6 +143,10 @@ dnnl_status_t brgemm_attr_init(
         // PROCESS_KEY_VAL(bd_mask_level);
         PROCESS_KEY_VAL(use_uker);
         PROCESS_KEY_VAL(use_interleave_stores);
+#if defined(brg_aarch64)
+        PROCESS_KEY_VAL(use_mmla);
+        PROCESS_KEY_VAL(use_mmla_packed_a);
+#endif
         PROCESS_KEY_VAL(b_is_vnni);
         PROCESS_KEY_VAL(postops_only);
         PROCESS_KEY_VAL(hint_bd_block);
@@ -203,6 +207,53 @@ std::string prepare_wei_format_string(
 
     return wtag;
 }
+
+#if defined(brg_aarch64)
+// packing helpers to test mmla brgemm kernel
+constexpr const char *mmla_src_tag = "AB2a4b";
+
+int get_mmla_ld_block() {
+    using namespace namespace_impl;
+    const bool use_sve256 = dnnl_get_effective_cpu_isa()
+            >= cpu_isa_traits<sve_256>::user_option_val;
+
+    return use_sve256 ? cpu_isa_traits<sve_256>::vlen / sizeof(float)
+                      : cpu_isa_traits<sve_128>::vlen / sizeof(float);
+}
+
+std::string prepare_mmla_wei_format_string(int ld_blocks) {
+    return std::string("BA2a") + std::to_string(ld_blocks * get_mmla_ld_block())
+            + "b4a";
+}
+
+int pack_for_mmla(const prb_t *prb, data_kind_t kind, const char *src_ptr,
+        std::vector<uint16_t> &packed_mem, size_t &batch_elems,
+        const dims_t &dims, const dims_t &strides, const std::string &tag,
+        size_t batch_offset, res_t *res) {
+    const size_t batch_offset_elems = batch_offset / sizeof(uint16_t);
+    auto src_md = dnn_mem_t::init_md(
+            2, dims.data(), prb->get_dt(kind), "", strides);
+    auto dst_md = dnn_mem_t::init_md(2, dims.data(), prb->get_dt(kind), tag);
+    dnn_mem_t dst_size_mem(dst_md, get_test_engine(), /* prefill = */ false);
+
+    batch_elems = dst_size_mem.size() / sizeof(uint16_t);
+    packed_mem.assign(prb->batch_size * batch_elems, 0);
+
+    const auto *src = reinterpret_cast<const uint16_t *>(src_ptr);
+    for (int bs = 0; bs < prb->batch_size; bs++) {
+        auto *src_batch = const_cast<uint16_t *>(src + bs * batch_offset_elems);
+        auto *dst_batch = packed_mem.data() + bs * batch_elems;
+
+        auto src_mem = dnn_mem_t::create_from_host_ptr(
+                src_md, get_test_engine(), src_batch);
+        auto dst_mem = dnn_mem_t::create_from_host_ptr(
+                dst_md, get_test_engine(), dst_batch);
+        SAFE(dst_mem.reorder(src_mem, res), WARN);
+    }
+
+    return OK;
+}
+#endif
 
 namespace_impl::brgemm_batch_kind_t str2batch_kind(const std::string &str) {
     if (str == "addr")
@@ -297,6 +348,11 @@ struct kernel_args_t {
 #endif
         , scratchpad_size_(0)
         , generate_skip_accumulation_(false)
+#if defined(brg_aarch64)
+        , mmla_ld_block2_(1)
+        , use_mmla_(false)
+        , use_mmla_packed_a_(false)
+#endif
         , prb_(prb) {
     }
 
@@ -314,6 +370,11 @@ struct kernel_args_t {
 #endif
     size_t scratchpad_size_;
     bool generate_skip_accumulation_;
+#if defined(brg_aarch64)
+    int mmla_ld_block2_;
+    bool use_mmla_;
+    bool use_mmla_packed_a_;
+#endif
 
     // Input members
     const prb_t *prb_;
@@ -378,6 +439,11 @@ int init_kernel(kernel_args_t &kernel_args, res_t *res) {
 
     kernel_args.generate_skip_accumulation_
             = brgemm_attr.generate_skip_accumulation;
+#if defined(brg_aarch64)
+    kernel_args.mmla_ld_block2_ = brgemm_desc.ld_block2;
+    kernel_args.use_mmla_ = brgemm_desc.brgattr.use_mmla;
+    kernel_args.use_mmla_packed_a_ = brgemm_desc.brgattr.use_mmla_packed_a;
+#endif
 
     // Create BRGeMM kernel, analogous to primitive creation.
     // ctx_init can here be used to select core type on hetero ISA with TBB.
@@ -579,11 +645,24 @@ void init_memory_args(
     // memory. Thus, it requires two memories and we need to pass a memory
     // handle from bigger one (where LDB is an actual dim value) to smaller, but
     // there's some reorder bug resulting in an error.
+#if defined(brg_aarch64)
+    const bool pack_mmla_wei_per_batch
+            = kernel_args.use_mmla_ && prb->batch_size > 1;
+    const auto wtag = kernel_args.use_mmla_
+            ? prepare_mmla_wei_format_string(kernel_args.mmla_ld_block2_)
+            : prepare_wei_format_string(prb->wei_dt(), prb->get_ldb(),
+                      kernel_args.is_b_data_layout_vnni_);
+    dims_t plain_wei_strides = {prb->get_ldb(), 1};
+    auto wei_md = pack_mmla_wei_per_batch
+            ? dnn_mem_t::init_md(prb->ndims, wei_dims, prb->wei_dt(), "",
+                      plain_wei_strides)
+            : dnn_mem_t::init_md(prb->ndims, wei_dims, prb->wei_dt(), wtag);
+#else
     const auto wtag = prepare_wei_format_string(
             prb->wei_dt(), prb->get_ldb(), kernel_args.is_b_data_layout_vnni_);
-    BENCHDNN_PRINT(6, "wtag: %s\n", wtag.c_str());
-
     auto wei_md = dnn_mem_t::init_md(prb->ndims, wei_dims, prb->wei_dt(), wtag);
+#endif
+    BENCHDNN_PRINT(6, "wtag: %s\n", wtag.c_str());
     kernel_args.original_wei_md_size_ = dnnl_memory_desc_get_size(wei_md);
 
     // Prepare and assign extra for wei_md when s8s8 compensation, or source
@@ -1083,17 +1162,47 @@ int doit(const prb_t *prb, res_t *res) {
             : nullptr;
 
 #if !defined(DNNL_EXPERIMENTAL_UKERNEL)
+    size_t src_batch_offset = prb->get_src_batch_offset();
+    size_t wei_batch_offset = prb->get_wei_batch_offset();
+#if defined(brg_aarch64)
+    std::vector<uint16_t> packed_src;
+    std::vector<uint16_t> packed_wei;
+    if (kernel_args.use_mmla_ && kernel_args.use_mmla_packed_a_) {
+        size_t src_batch_elems = 0;
+        const dims_t src_dims = {prb->m, prb->k};
+        const dims_t src_strides = {prb->get_lda(), 1};
+        BENCHDNN_PRINT(6, "stag: %s\n", mmla_src_tag);
+        SAFE(pack_for_mmla(prb, SRC, src_ptr, packed_src, src_batch_elems,
+                     src_dims, src_strides, mmla_src_tag,
+                     prb->get_src_batch_offset(), res),
+                WARN);
+        src_ptr = reinterpret_cast<const char *>(packed_src.data());
+        src_batch_offset = src_batch_elems * sizeof(uint16_t);
+    }
+    if (kernel_args.use_mmla_ && prb->batch_size > 1) {
+        size_t wei_batch_elems = 0;
+        const dims_t wei_dims = {prb->k, prb->n};
+        const dims_t wei_strides = {prb->get_ldb(), 1};
+        SAFE(pack_for_mmla(prb, WEI, wei_ptr, packed_wei, wei_batch_elems,
+                     wei_dims, wei_strides,
+                     prepare_mmla_wei_format_string(
+                             kernel_args.mmla_ld_block2_),
+                     prb->get_wei_batch_offset(), res),
+                WARN);
+        wei_ptr = reinterpret_cast<const char *>(packed_wei.data());
+        wei_batch_offset = wei_batch_elems * sizeof(uint16_t);
+    }
+#endif
+
     std::vector<namespace_impl::brgemm_batch_element_t> v_batch_element(
             prb->batch_size);
     for (size_t i = 0; i < v_batch_element.size(); i++) {
         if (prb->batch_kind == "addr") {
-            v_batch_element[i].ptr.A
-                    = src_ptr + i * prb->get_src_batch_offset();
-            v_batch_element[i].ptr.B
-                    = wei_ptr + i * prb->get_wei_batch_offset();
+            v_batch_element[i].ptr.A = src_ptr + i * src_batch_offset;
+            v_batch_element[i].ptr.B = wei_ptr + i * wei_batch_offset;
         } else if (prb->batch_kind == "offs") {
-            v_batch_element[i].offset.A = i * prb->get_src_batch_offset();
-            v_batch_element[i].offset.B = i * prb->get_wei_batch_offset();
+            v_batch_element[i].offset.A = i * src_batch_offset;
+            v_batch_element[i].offset.B = i * wei_batch_offset;
         }
     }
 

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -697,7 +697,15 @@ void init_memory_args(
     // zero point reduction values are needed.
     dnnl::impl::memory_extra_desc_t wei_md_extra {};
     wei_md_extra.flags = dnnl::impl::memory_extra_flags::none;
-    if (prb->get_dt(SRC) == dnnl_s8 && prb->get_dt(WEI) == dnnl_s8) {
+    bool needs_s8s8_compensation
+            = prb->get_dt(SRC) == dnnl_s8 && prb->get_dt(WEI) == dnnl_s8;
+#if defined(brg_aarch64)
+    // Native SMMLA consumes signed A and B directly. Attaching legacy S8S8
+    // compensation to its K8 packed descriptor is both unnecessary and not a
+    // supported reorder contract.
+    needs_s8s8_compensation = needs_s8s8_compensation && !kernel_args.use_mmla_;
+#endif
+    if (needs_s8s8_compensation) {
         wei_md_extra.flags
                 |= dnnl::impl::memory_extra_flags::compensation_conv_s8s8;
         wei_md_extra.compensation_mask = 2; // N dimension

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -26,6 +26,7 @@
 
 // TODO: refactor the driver to avoid using extra flags of a memory descriptor.
 #include "src/common/memory_desc.hpp"
+#include "src/common/memory_desc_wrapper.hpp"
 
 #include "tests/test_isa_common.hpp"
 
@@ -209,8 +210,15 @@ std::string prepare_wei_format_string(
 }
 
 #if defined(brg_aarch64)
-// packing helpers to test mmla brgemm kernel
-constexpr const char *mmla_src_tag = "AB2a4b";
+// Packing helpers for the MMLA BRGEMM kernels.
+const char *get_mmla_src_tag(dnnl_data_type_t dt) {
+    switch (dt) {
+        case dnnl_u8:
+        case dnnl_s8: return "AB2a8b";
+        case dnnl_bf16: return "AB2a4b";
+        default: assert(!"unsupported MMLA source data type"); return "";
+    }
+}
 
 int get_mmla_ld_block() {
     using namespace namespace_impl;
@@ -221,28 +229,33 @@ int get_mmla_ld_block() {
                       : cpu_isa_traits<sve_128>::vlen / sizeof(float);
 }
 
-std::string prepare_mmla_wei_format_string(int ld_blocks) {
-    return std::string("BA2a") + std::to_string(ld_blocks * get_mmla_ld_block())
-            + "b4a";
+std::string prepare_mmla_wei_format_string(int ld_blocks, dnnl_data_type_t dt) {
+    const int n_block = ld_blocks * get_mmla_ld_block();
+    switch (dt) {
+        case dnnl_s8:
+            return std::string("BA") + std::to_string(n_block) + "b8a";
+        case dnnl_bf16:
+            return std::string("BA2a") + std::to_string(n_block) + "b4a";
+        default: assert(!"unsupported MMLA weights data type"); return {};
+    }
 }
 
 int pack_for_mmla(const prb_t *prb, data_kind_t kind, const char *src_ptr,
-        std::vector<uint16_t> &packed_mem, size_t &batch_elems,
+        std::vector<uint8_t> &packed_mem, size_t &batch_bytes,
         const dims_t &dims, const dims_t &strides, const std::string &tag,
         size_t batch_offset, res_t *res) {
-    const size_t batch_offset_elems = batch_offset / sizeof(uint16_t);
     auto src_md = dnn_mem_t::init_md(
             2, dims.data(), prb->get_dt(kind), "", strides);
     auto dst_md = dnn_mem_t::init_md(2, dims.data(), prb->get_dt(kind), tag);
     dnn_mem_t dst_size_mem(dst_md, get_test_engine(), /* prefill = */ false);
 
-    batch_elems = dst_size_mem.size() / sizeof(uint16_t);
-    packed_mem.assign(prb->batch_size * batch_elems, 0);
+    batch_bytes = dst_size_mem.size();
+    packed_mem.assign(prb->batch_size * batch_bytes, 0);
 
-    const auto *src = reinterpret_cast<const uint16_t *>(src_ptr);
+    const auto *src = reinterpret_cast<const uint8_t *>(src_ptr);
     for (int bs = 0; bs < prb->batch_size; bs++) {
-        auto *src_batch = const_cast<uint16_t *>(src + bs * batch_offset_elems);
-        auto *dst_batch = packed_mem.data() + bs * batch_elems;
+        auto *src_batch = const_cast<uint8_t *>(src + bs * batch_offset);
+        auto *dst_batch = packed_mem.data() + bs * batch_bytes;
 
         auto src_mem = dnn_mem_t::create_from_host_ptr(
                 src_md, get_test_engine(), src_batch);
@@ -252,6 +265,20 @@ int pack_for_mmla(const prb_t *prb, data_kind_t kind, const char *src_ptr,
     }
 
     return OK;
+}
+
+void prepare_mmla_src_zp_compensation(const prb_t *prb,
+        const dnn_mem_t &weights_mem, std::vector<int32_t> &compensation) {
+    compensation.assign(prb->n, 0);
+    const dnnl::impl::memory_desc_wrapper weights_d(weights_mem.md_);
+    const auto *weights = (const int8_t *)weights_mem;
+    for_(int64_t bs = 0; bs < prb->batch_size; ++bs)
+    for_(int64_t k = 0; k < prb->k; ++k)
+    for (int64_t n = 0; n < prb->n; ++n) {
+        const auto logical_offset = (bs * prb->k + k) * prb->n + n;
+        const auto physical_offset = weights_d.off_l(logical_offset);
+        compensation[n] -= static_cast<int32_t>(weights[physical_offset]);
+    }
 }
 #endif
 
@@ -649,7 +676,8 @@ void init_memory_args(
     const bool pack_mmla_wei_per_batch
             = kernel_args.use_mmla_ && prb->batch_size > 1;
     const auto wtag = kernel_args.use_mmla_
-            ? prepare_mmla_wei_format_string(kernel_args.mmla_ld_block2_)
+            ? prepare_mmla_wei_format_string(
+                      kernel_args.mmla_ld_block2_, prb->wei_dt())
             : prepare_wei_format_string(prb->wei_dt(), prb->get_ldb(),
                       kernel_args.is_b_data_layout_vnni_);
     dims_t plain_wei_strides = {prb->get_ldb(), 1};
@@ -677,7 +705,15 @@ void init_memory_args(
     static_cast<dnnl_memory_desc_t>(wei_md)->extra = wei_md_extra;
 
     const bool need_src_comp = !prb->attr.zero_points.is_def(DNNL_ARG_SRC);
-    if (need_src_comp) {
+    bool prepare_src_comp_with_reorder = need_src_comp;
+#if defined(brg_aarch64)
+    // Custom MMLA tags do not support reorder-owned compensation buffers.
+    const bool mmla_uses_manual_src_comp
+            = kernel_args.use_mmla_ && prb->wei_dt() == dnnl_s8;
+    prepare_src_comp_with_reorder
+            = prepare_src_comp_with_reorder && !mmla_uses_manual_src_comp;
+#endif
+    if (prepare_src_comp_with_reorder) {
         wei_md_extra.flags |= dnnl::impl::memory_extra_flags::
                 compensation_conv_asymmetric_src;
         wei_md_extra.asymm_compensation_mask = 2; // N dimension
@@ -1165,32 +1201,33 @@ int doit(const prb_t *prb, res_t *res) {
     size_t src_batch_offset = prb->get_src_batch_offset();
     size_t wei_batch_offset = prb->get_wei_batch_offset();
 #if defined(brg_aarch64)
-    std::vector<uint16_t> packed_src;
-    std::vector<uint16_t> packed_wei;
+    std::vector<uint8_t> packed_src;
+    std::vector<uint8_t> packed_wei;
     if (kernel_args.use_mmla_ && kernel_args.use_mmla_packed_a_) {
-        size_t src_batch_elems = 0;
+        size_t src_batch_bytes = 0;
         const dims_t src_dims = {prb->m, prb->k};
         const dims_t src_strides = {prb->get_lda(), 1};
-        BENCHDNN_PRINT(6, "stag: %s\n", mmla_src_tag);
-        SAFE(pack_for_mmla(prb, SRC, src_ptr, packed_src, src_batch_elems,
-                     src_dims, src_strides, mmla_src_tag,
+        const char *src_tag = get_mmla_src_tag(prb->src_dt());
+        BENCHDNN_PRINT(6, "stag: %s\n", src_tag);
+        SAFE(pack_for_mmla(prb, SRC, src_ptr, packed_src, src_batch_bytes,
+                     src_dims, src_strides, src_tag,
                      prb->get_src_batch_offset(), res),
                 WARN);
         src_ptr = reinterpret_cast<const char *>(packed_src.data());
-        src_batch_offset = src_batch_elems * sizeof(uint16_t);
+        src_batch_offset = src_batch_bytes;
     }
     if (kernel_args.use_mmla_ && prb->batch_size > 1) {
-        size_t wei_batch_elems = 0;
+        size_t wei_batch_bytes = 0;
         const dims_t wei_dims = {prb->k, prb->n};
         const dims_t wei_strides = {prb->get_ldb(), 1};
-        SAFE(pack_for_mmla(prb, WEI, wei_ptr, packed_wei, wei_batch_elems,
+        SAFE(pack_for_mmla(prb, WEI, wei_ptr, packed_wei, wei_batch_bytes,
                      wei_dims, wei_strides,
                      prepare_mmla_wei_format_string(
-                             kernel_args.mmla_ld_block2_),
+                             kernel_args.mmla_ld_block2_, prb->wei_dt()),
                      prb->get_wei_batch_offset(), res),
                 WARN);
         wei_ptr = reinterpret_cast<const char *>(packed_wei.data());
-        wei_batch_offset = wei_batch_elems * sizeof(uint16_t);
+        wei_batch_offset = wei_batch_bytes;
     }
 #endif
 
@@ -1236,6 +1273,16 @@ int doit(const prb_t *prb, res_t *res) {
                             ? prb->get_ldb() * sizeof(int32_t)
                             : 0);
     char *src_comp_ptr = const_cast<char *>(wei_ptr) + wei_offset_zp;
+#if defined(brg_aarch64)
+    std::vector<int32_t> mmla_src_zp_compensation;
+    if (kernel_args.use_mmla_ && prb->wei_dt() == dnnl_s8
+            && !prb->attr.zero_points.is_def(DNNL_ARG_SRC)) {
+        prepare_mmla_src_zp_compensation(
+                prb, mem_map.at(DNNL_ARG_WEIGHTS), mmla_src_zp_compensation);
+        src_comp_ptr
+                = reinterpret_cast<char *>(mmla_src_zp_compensation.data());
+    }
+#endif
 
 #if defined(brg_x64)
     namespace_impl::brgemm_post_ops_data_t post_ops_data(

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_bf16
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_bf16
@@ -4,13 +4,14 @@
 --bia_dt=undef,f32,bf16
 --beta=0,1
 --attr-post-ops=,sum:2,relu
---brgemm-attr=,use_uker:1
+--brgemm-attr=,use_uker:1,use_mmla:1,use_mmla:1+use_mmla_packed_a:1
 --batch=option_set_bf16
 
 # Separate cases for non-default alpha
 --reset
 --dt=bf16
 --alpha=2
+--brgemm-attr=,use_mmla:1,use_mmla:1+use_mmla_packed_a:1
 --batch=shapes_2d_no_tail_bf16
 
 # Skip-acc feature

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_int8
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_int8
@@ -77,6 +77,21 @@
 --brgemm-attr=use_mmla:1
 5x15:15x17
 
+# AArch64 SVE-I8MM signed MMLA path. Aligned and tail shapes distinguish
+# SMMLA from the U8xS8 instruction path without repeating its full matrix.
+--reset
+--dt=s8:s8:s32
+--beta=0,2
+--brgemm-attr=use_mmla:1
+6x16:16x16 10x63:63x17
+
+--reset
+--dt=s8:s8:f32
+--alpha=0.5
+--beta=2
+--brgemm-attr=use_mmla:1
+5x15:15x17
+
 # s8 src
 ## Bias check
 --reset

--- a/tests/benchdnn/inputs/brgemm/test_brgemm_int8
+++ b/tests/benchdnn/inputs/brgemm/test_brgemm_int8
@@ -28,6 +28,55 @@
 --dt=u8:s8:f32
 --batch=shapes_2d_no_tail_int8
 
+# AArch64 SVE-I8MM MMLA path: aligned, exact-K8, and partial-tail shapes,
+# integer beta, and optional packed A.
+--reset
+--dt=u8:s8:s32
+--beta=0,1,2
+--brgemm-attr=use_mmla:1,use_mmla:1+use_mmla_packed_a:1
+6x8:8x33 6x16:16x16 10x63:63x17
+
+# Non-unit alpha and beta convert both the integer accumulator and C input.
+--reset
+--dt=u8:s8:f32
+--alpha=0.5,2
+--beta=2
+--brgemm-attr=use_mmla:1,use_mmla:1+use_mmla_packed_a:1
+5x15:15x17
+
+# Source zero point uses weight-sum compensation passed to the kernel.
+--reset
+--dt=u8:s8:s32
+--bs=3
+--batch-kind=addr,offs
+--attr-zero-points=src:common:3
+--brgemm-attr=use_mmla:1,use_mmla:1+use_mmla_packed_a:1
+10x63:63x17
+
+# The SVE128 Q-load shortcut must materialize non-encodable A row offsets.
+--reset
+--dt=u8:s8:s32
+--ld=20000:16:16
+--brgemm-attr=use_mmla:1,use_mmla:1+use_mmla_packed_a:1
+6x16:16x16
+
+# Fused bias, scales, eltwise, sum, conversion, and destination tails.
+--reset
+--dt=u8:s8:f32
+--bia_dt=f32
+--attr-post-ops=relu
+--attr-scales=src:common:0.5+wei:per_oc
+--brgemm-attr=use_mmla:1
+6x64:64x16
+
+--reset
+--dt=u8:s8:u8
+--bia_dt=f32
+--attr-post-ops=sum:2+relu
+--attr-scales=src:common:0.5+wei:per_oc+dst:common:5
+--brgemm-attr=use_mmla:1
+5x15:15x17
+
 # s8 src
 ## Bias check
 --reset

--- a/tests/benchdnn/inputs/conv/test_conv_bfloat16_nxc
+++ b/tests/benchdnn/inputs/conv/test_conv_bfloat16_nxc
@@ -58,3 +58,25 @@
 --skip-impl=ref,x64:gemm
 --dt=bf16 --dir=BWD_W
 --batch=shapes_src-transpose_padding
+
+# Native 1x1/3x3 paths, including stride and an input-channel block tail.
+--reset
+--dir=FWD_I
+--dt=bf16:bf16:f32
+--stag=nhwc
+--wtag=any
+--dtag=nhwc
+mb1ic64ih16oc64oh16kh3ph1
+mb1ic72ih17oc64oh9kh3sh2ph1
+mb1ic64ih11iw13oc64oh11ow13kh1kw1
+
+# Destination conversion, bias, sum, and eltwise share the same epilogue.
+--reset
+--dir=FWD_I
+--dt=bf16:bf16:bf16
+--bia-dt=bf16
+--stag=nhwc
+--wtag=any
+--dtag=nhwc
+--attr-post-ops=sum:1+relu
+mb1ic64ih16oc64oh16kh3ph1

--- a/tests/benchdnn/inputs/conv/test_conv_int8
+++ b/tests/benchdnn/inputs/conv/test_conv_int8
@@ -14,3 +14,24 @@
 --batch=harness_conv_depthwise_int8
 
 --batch=harness_conv_zero_points
+
+# Native 1x1/3x3 paths, including stride and an input-channel block tail.
+--reset
+--dir=FWD_I
+--dt=u8:s8:f32
+--stag=nhwc
+--wtag=any
+--dtag=nhwc
+mb1ic64ih16oc64oh16kh3ph1
+mb1ic72ih17oc64oh9kh3sh2ph1
+mb1ic64ih20oc64oh20kh1
+
+# 1x1 source zero point.
+--reset
+--dir=FWD_I
+--dt=u8:s8:f32
+--stag=nhwc
+--wtag=any
+--dtag=nhwc
+--attr-zero-points=src:common:5
+mb1ic64ih20oc64oh20kh1

--- a/tests/benchdnn/inputs/conv/test_conv_int8
+++ b/tests/benchdnn/inputs/conv/test_conv_int8
@@ -35,3 +35,27 @@ mb1ic64ih20oc64oh20kh1
 --dtag=nhwc
 --attr-zero-points=src:common:5
 mb1ic64ih20oc64oh20kh1
+
+# Source-zero-point virtual-padding compensation and epilogue.
+--reset
+--dir=FWD_I
+--dt=u8:s8:u8
+--bia-dt=f32
+--stag=nhwc
+--wtag=any
+--dtag=nhwc
+--attr-scales=src:common:0.5+wei:per_oc+dst:common:2
+--attr-zero-points=src:common:3+dst:common:5
+--attr-post-ops=swish:1
+mb1ic72ih31iw33oc64oh16ow17kh3kw3sh2sw2ph1pw1
+
+# Execution-owned compensation and one DOT fallback.
+--reset
+--dir=FWD_I
+--dt=u8:s8:f32
+--stag=nhwc
+--wtag=any
+--dtag=nhwc
+--attr-zero-points=src:common:3
+mb3ic64ih8oc64oh8kh3ph1
+mb1ic64ih8iw8oc64oh8ow6kh3kw3ph1pw0

--- a/tests/benchdnn/inputs/conv/test_conv_int8
+++ b/tests/benchdnn/inputs/conv/test_conv_int8
@@ -59,3 +59,16 @@ mb1ic72ih31iw33oc64oh16ow17kh3kw3sh2sw2ph1pw1
 --attr-zero-points=src:common:3
 mb3ic64ih8oc64oh8kh3ph1
 mb1ic64ih8iw8oc64oh8ow6kh3kw3ph1pw0
+
+# Signed source shares the K8 packed-weight layout with U8xS8.
+--reset
+--dir=FWD_I
+--dt=s8:s8:f32
+--stag=nhwc
+--wtag=any
+--dtag=nhwc
+mb1ic64ih16oc64oh16kh3ph1
+mb1ic64ih20oc64oh20kh1
+
+--attr-zero-points=src:common:-125
+mb1ic64ih16oc64oh16kh3ph1

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
@@ -70,6 +70,12 @@
 2x3x5x16:2x3x16x32_n"mmla_4d_batched_weights"
 2x1x5x16:1x3x16x32_n"mmla_4d_broadcast_weights"
 
+# Cross the 16-entry compact-K batch cap and exercise batch and K tails.
+--reset
+--dt=bf16:bf16:f32
+--stag=ab --wtag=any --dtag=ab
+17x2184:2184x64_n"mmla_compact_k_batch_tail"
+
 # Test that cases when M == 1 are handled correctly.
 --reset
 --stag=ba,ab --wtag=ab --dtag=ab --dt=bf16 1x2:2x256

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression_bf16
@@ -33,6 +33,43 @@
 --dtag=ab
 8x2664:2664x256_n"k_tail"
 
+# Low-parallel shapes must not shrink the packed MMLA N block.
+--reset
+--dt=bf16:bf16:f32
+--stag=ab --wtag=any --dtag=ab
+17x64:64x32_n"mmla_fixed_n_block_n32"
+17x64:64x64_n"mmla_fixed_n_block_n64"
+
+# Batch-specific and broadcast B descriptors preserve the packed layout.
+--reset
+--dt=bf16:bf16:f32
+--stag=abc --wtag=any --dtag=abc
+2x17x64:2x64x64_n"mmla_batched_weights"
+2x17x64:1x64x64_n"mmla_broadcast_weights"
+
+# Packed BF16 weights cover small K blocks, M tails, and multiple N tiles.
+--reset
+--dt=bf16:bf16:f32
+--stag=ab --wtag=any --dtag=ab
+2x8:8x32_n"mmla_small_k"
+5x16:16x32_n"mmla_m_tail"
+31x72:72x96_n"mmla_multiple_n_tiles"
+
+# Destination conversion, bias, sum, and eltwise use the shared epilogue.
+--reset
+--dt=bf16:bf16:bf16
+--bia-dt=bf16
+--stag=ab --wtag=any --dtag=ab
+--attr-post-ops=sum:1+relu
+5x16:16x32_n"mmla_epilogue_m_tail"
+
+# Multi-axis broadcasting preserves the packed weight layout.
+--reset
+--dt=bf16:bf16:f32
+--stag=abcd --wtag=any --dtag=abcd
+2x3x5x16:2x3x16x32_n"mmla_4d_batched_weights"
+2x1x5x16:1x3x16x32_n"mmla_4d_broadcast_weights"
+
 # Test that cases when M == 1 are handled correctly.
 --reset
 --stag=ba,ab --wtag=ab --dtag=ab --dt=bf16 1x2:2x256

--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -20,6 +20,10 @@
 
 #include "oneapi/dnnl/dnnl.hpp"
 
+#if DNNL_AARCH64
+#include "common/dnnl_thread.hpp"
+#endif
+
 #include "tests/test_isa_common.hpp"
 
 namespace dnnl {
@@ -318,5 +322,56 @@ TEST(AArch64MmlaConvolution, Int8SelectionAndExplicitWeights) {
     EXPECT_FALSE(is_int8_mmla_weights(explicit_dot.weights_desc()));
 }
 
+TEST(AArch64MmlaConvolution, Int8VpadCompensationBoundaries) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets the CPU convolution implementation.");
+
+    auto eng = get_test_engine();
+    SKIP_IF(!has_int8_mmla(eng), "This test targets AArch64 SVE-I8MM.");
+    const auto any
+            = memory::desc({64, 64, 3, 3}, memory::data_type::s8, tag::any);
+
+    // This shape uses BRGEMM-owned padding compensation, which integer MMLA
+    // cannot consume, so it must retry through DOT.
+    const auto inline_comp = make_int8_mmla_conv_pd(
+            eng, memory::data_type::u8, any, 8, 8, 1, 1, 2, true);
+    EXPECT_FALSE(is_int8_mmla_weights(inline_comp.weights_desc()));
+
+    // At one thread this sits exactly on the ratio boundary and has enough
+    // normalized work. With multiple threads, per-thread work is too small.
+    const auto any_ic16
+            = memory::desc({64, 16, 3, 3}, memory::data_type::s8, tag::any);
+    const auto thread_limited = make_int8_mmla_conv_pd(
+            eng, memory::data_type::u8, any_ic16, 16, 16, 1, 1, 1, true);
+    EXPECT_EQ(is_int8_mmla_weights(thread_limited.weights_desc()),
+            dnnl_get_max_threads() == 1);
+
+    // A large output-channel count alone does not amortize a short M
+    // dimension; retain DOT even though separate compensation is available.
+    const auto any_high_oc
+            = memory::desc({512, 64, 3, 3}, memory::data_type::s8, tag::any);
+    const auto short_m = make_int8_mmla_conv_pd(
+            eng, memory::data_type::u8, any_high_oc, 9, 8, 1, 1, 1, true);
+    EXPECT_FALSE(is_int8_mmla_weights(short_m.weights_desc()));
+
+    // This has enough spatial, compensation-amortization, and per-thread work
+    // to retain MMLA even on a many-core system.
+    const auto any_large
+            = memory::desc({256, 128, 3, 3}, memory::data_type::s8, tag::any);
+    const auto selected = make_int8_mmla_conv_pd(
+            eng, memory::data_type::u8, any_large, 28, 28, 1, 1, 4, true);
+    EXPECT_TRUE(is_int8_mmla_weights(selected.weights_desc()));
+
+    const auto src_md
+            = memory::desc({1, 64, 8, 8}, memory::data_type::u8, tag::nhwc);
+    const auto dst_md
+            = memory::desc({1, 64, 8, 6}, memory::data_type::f32, tag::nhwc);
+    primitive_attr attr;
+    attr.set_zero_points_mask(DNNL_ARG_SRC, 0);
+    const auto vertical_only = convolution_forward::primitive_desc(eng,
+            prop_kind::forward_inference, algorithm::convolution_direct, src_md,
+            any, memory::desc(), dst_md, {1, 1}, {1, 0}, {1, 0}, attr);
+    EXPECT_FALSE(is_int8_mmla_weights(vertical_only.weights_desc()));
+}
 #endif
 } // namespace dnnl

--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2016 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -136,5 +137,108 @@ TEST_P(conv_any_fmt_test_float, TestsConvolutionAnyFmt) {}
 
 CPU_INSTANTIATE_TEST_SUITE_P(TestConvolutionAlexnetAnyFmtForward,
         conv_any_fmt_test_float, ::testing::Values(ALEXNET_SUITE(BLK)));
+#endif
+
+#if DNNL_AARCH64
+namespace {
+
+convolution_forward::primitive_desc make_bf16_mmla_conv_pd(const engine &eng,
+        const memory::desc &weights_md, memory::dim ih = 16,
+        memory::dim iw = 16, memory::dim stride = 1, memory::dim padding = 1,
+        bool allow_empty = false) {
+    const auto weights_dims = weights_md.get_dims();
+    const auto oc = weights_dims[0];
+    const auto ic = weights_dims[1];
+    const auto kh = weights_dims[2];
+    const auto kw = weights_dims[3];
+    const auto oh = (ih + 2 * padding - kh) / stride + 1;
+    const auto ow = (iw + 2 * padding - kw) / stride + 1;
+    const auto src_md
+            = memory::desc({1, ic, ih, iw}, memory::data_type::bf16, tag::nhwc);
+    const auto dst_md
+            = memory::desc({1, oc, oh, ow}, memory::data_type::f32, tag::nhwc);
+    return convolution_forward::primitive_desc(eng,
+            prop_kind::forward_inference, algorithm::convolution_direct, src_md,
+            weights_md, memory::desc(), dst_md, {stride, stride},
+            {padding, padding}, {padding, padding}, primitive_attr(),
+            allow_empty);
+}
+
+bool is_bf16_mmla_weights(const memory::desc &desc) {
+    return aarch64_mmla_test::matches_weights_desc(desc, 1, 0);
+}
+
+bool has_bf16_mmla(const engine &eng) {
+    const auto any
+            = memory::desc({64, 64, 3, 3}, memory::data_type::bf16, tag::any);
+    const auto pd = make_bf16_mmla_conv_pd(eng, any, 16, 16, 1, 1, true);
+    return pd.get() != nullptr && is_bf16_mmla_weights(pd.weights_desc());
+}
+
+} // namespace
+
+TEST(AArch64MmlaConvolution, Bf16SelectionAndFallbacks) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets the CPU convolution implementation.");
+
+    auto eng = get_test_engine();
+    SKIP_IF(!has_bf16_mmla(eng), "This test targets AArch64 BF16 MMLA.");
+
+    const auto any_3x3
+            = memory::desc({64, 64, 3, 3}, memory::data_type::bf16, tag::any);
+    for (const auto &pd : {make_bf16_mmla_conv_pd(eng, any_3x3),
+                 make_bf16_mmla_conv_pd(eng, any_3x3, 17, 19, 2, 1)}) {
+        EXPECT_TRUE(is_bf16_mmla_weights(pd.weights_desc()));
+    }
+
+    const auto any_1x1
+            = memory::desc({64, 64, 1, 1}, memory::data_type::bf16, tag::any);
+    const auto selected_1x1
+            = make_bf16_mmla_conv_pd(eng, any_1x1, 11, 13, 1, 0);
+    EXPECT_TRUE(is_bf16_mmla_weights(selected_1x1.weights_desc()));
+
+    const auto stride_fallback
+            = make_bf16_mmla_conv_pd(eng, any_1x1, 16, 16, 2, 0);
+    EXPECT_FALSE(is_bf16_mmla_weights(stride_fallback.weights_desc()));
+
+    const auto odd_ic
+            = memory::desc({64, 66, 1, 1}, memory::data_type::bf16, tag::any);
+    const auto channel_fallback
+            = make_bf16_mmla_conv_pd(eng, odd_ic, 8, 8, 1, 0);
+    EXPECT_FALSE(is_bf16_mmla_weights(channel_fallback.weights_desc()));
+
+    // This padding bypasses virtual-padding execution after MMLA selection
+    // and exercises descriptor restoration before the fallback retry.
+    const auto retry_fallback
+            = make_bf16_mmla_conv_pd(eng, any_3x3, 16, 16, 1, 3);
+    EXPECT_FALSE(is_bf16_mmla_weights(retry_fallback.weights_desc()));
+    EXPECT_EQ(retry_fallback.src_desc(),
+            memory::desc({1, 64, 16, 16}, memory::data_type::bf16, tag::nhwc));
+    EXPECT_EQ(retry_fallback.dst_desc(),
+            memory::desc({1, 64, 20, 20}, memory::data_type::f32, tag::nhwc));
+}
+
+TEST(AArch64MmlaConvolution, Bf16ExplicitWeights) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets the CPU convolution implementation.");
+
+    auto eng = get_test_engine();
+    SKIP_IF(!has_bf16_mmla(eng), "This test targets AArch64 BF16 MMLA.");
+
+    const auto any_3x3
+            = memory::desc({64, 64, 3, 3}, memory::data_type::bf16, tag::any);
+    const auto packed = make_bf16_mmla_conv_pd(eng, any_3x3).weights_desc();
+    const auto packed_pd = make_bf16_mmla_conv_pd(eng, packed);
+    EXPECT_EQ(packed_pd.weights_desc(), packed);
+    EXPECT_TRUE(is_bf16_mmla_weights(packed_pd.weights_desc()));
+
+    const auto any_1x1
+            = memory::desc({64, 64, 1, 1}, memory::data_type::bf16, tag::any);
+    const auto dot
+            = make_bf16_mmla_conv_pd(eng, any_1x1, 16, 16, 2, 0).weights_desc();
+    const auto dot_pd = make_bf16_mmla_conv_pd(eng, dot, 16, 16, 1, 0);
+    EXPECT_EQ(dot_pd.weights_desc(), dot);
+    EXPECT_FALSE(is_bf16_mmla_weights(dot_pd.weights_desc()));
+}
 #endif
 } // namespace dnnl

--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -373,5 +373,24 @@ TEST(AArch64MmlaConvolution, Int8VpadCompensationBoundaries) {
             any, memory::desc(), dst_md, {1, 1}, {1, 0}, {1, 0}, attr);
     EXPECT_FALSE(is_int8_mmla_weights(vertical_only.weights_desc()));
 }
+
+TEST(AArch64MmlaConvolution, SmmlaSignedSelection) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets the CPU convolution implementation.");
+
+    auto eng = get_test_engine();
+    SKIP_IF(!has_int8_mmla(eng), "This test targets AArch64 SVE-I8MM.");
+    const auto any_3x3
+            = memory::desc({64, 64, 3, 3}, memory::data_type::s8, tag::any);
+    const auto conv_3x3
+            = make_int8_mmla_conv_pd(eng, memory::data_type::s8, any_3x3);
+    EXPECT_TRUE(is_int8_mmla_weights(conv_3x3.weights_desc()));
+
+    const auto any_1x1
+            = memory::desc({64, 64, 1, 1}, memory::data_type::s8, tag::any);
+    const auto conv_1x1 = make_int8_mmla_conv_pd(
+            eng, memory::data_type::s8, any_1x1, 20, 20, 1, 0);
+    EXPECT_TRUE(is_int8_mmla_weights(conv_1x1.weights_desc()));
+}
 #endif
 } // namespace dnnl

--- a/tests/gtests/test_convolution_format_any.cpp
+++ b/tests/gtests/test_convolution_format_any.cpp
@@ -175,6 +175,41 @@ bool has_bf16_mmla(const engine &eng) {
     return pd.get() != nullptr && is_bf16_mmla_weights(pd.weights_desc());
 }
 
+convolution_forward::primitive_desc make_int8_mmla_conv_pd(const engine &eng,
+        memory::data_type src_type, const memory::desc &weights_md,
+        memory::dim ih = 16, memory::dim iw = 16, memory::dim stride = 1,
+        memory::dim padding = 1, memory::dim mb = 1,
+        bool source_zero_point = false, bool allow_empty = false) {
+    const auto weights_dims = weights_md.get_dims();
+    const auto oc = weights_dims[0];
+    const auto ic = weights_dims[1];
+    const auto kh = weights_dims[2];
+    const auto kw = weights_dims[3];
+    const auto oh = (ih + 2 * padding - kh) / stride + 1;
+    const auto ow = (iw + 2 * padding - kw) / stride + 1;
+    const auto src_md = memory::desc({mb, ic, ih, iw}, src_type, tag::nhwc);
+    const auto dst_md
+            = memory::desc({mb, oc, oh, ow}, memory::data_type::f32, tag::nhwc);
+    primitive_attr attr;
+    if (source_zero_point) attr.set_zero_points_mask(DNNL_ARG_SRC, 0);
+    return convolution_forward::primitive_desc(eng,
+            prop_kind::forward_inference, algorithm::convolution_direct, src_md,
+            weights_md, memory::desc(), dst_md, {stride, stride},
+            {padding, padding}, {padding, padding}, attr, allow_empty);
+}
+
+bool is_int8_mmla_weights(const memory::desc &desc) {
+    return aarch64_mmla_test::matches_weights_desc(desc, 1, 0, 8);
+}
+
+bool has_int8_mmla(const engine &eng) {
+    const auto any
+            = memory::desc({64, 64, 3, 3}, memory::data_type::s8, tag::any);
+    const auto pd = make_int8_mmla_conv_pd(
+            eng, memory::data_type::u8, any, 16, 16, 1, 1, 1, false, true);
+    return pd.get() != nullptr && is_int8_mmla_weights(pd.weights_desc());
+}
+
 } // namespace
 
 TEST(AArch64MmlaConvolution, Bf16SelectionAndFallbacks) {
@@ -240,5 +275,48 @@ TEST(AArch64MmlaConvolution, Bf16ExplicitWeights) {
     EXPECT_EQ(dot_pd.weights_desc(), dot);
     EXPECT_FALSE(is_bf16_mmla_weights(dot_pd.weights_desc()));
 }
+
+TEST(AArch64MmlaConvolution, Int8SelectionAndExplicitWeights) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets the CPU convolution implementation.");
+
+    auto eng = get_test_engine();
+    SKIP_IF(!has_int8_mmla(eng), "This test targets AArch64 SVE-I8MM.");
+
+    const auto any_3x3
+            = memory::desc({64, 64, 3, 3}, memory::data_type::s8, tag::any);
+    const auto selected_3x3
+            = make_int8_mmla_conv_pd(eng, memory::data_type::u8, any_3x3);
+    EXPECT_TRUE(is_int8_mmla_weights(selected_3x3.weights_desc()));
+
+    const auto any_5x5
+            = memory::desc({64, 64, 5, 5}, memory::data_type::s8, tag::any);
+    const auto kernel_fallback = make_int8_mmla_conv_pd(
+            eng, memory::data_type::u8, any_5x5, 16, 16, 1, 2);
+    EXPECT_FALSE(is_int8_mmla_weights(kernel_fallback.weights_desc()));
+
+    const auto any_1x1
+            = memory::desc({64, 64, 1, 1}, memory::data_type::s8, tag::any);
+    const auto below_threshold = make_int8_mmla_conv_pd(
+            eng, memory::data_type::u8, any_1x1, 21, 19, 1, 0);
+    EXPECT_FALSE(is_int8_mmla_weights(below_threshold.weights_desc()));
+
+    const auto at_threshold = make_int8_mmla_conv_pd(
+            eng, memory::data_type::u8, any_1x1, 20, 20, 1, 0);
+    EXPECT_TRUE(is_int8_mmla_weights(at_threshold.weights_desc()));
+
+    // Explicit layouts remain authoritative across the profitability
+    // boundary in either direction.
+    const auto explicit_mmla = make_int8_mmla_conv_pd(eng,
+            memory::data_type::u8, at_threshold.weights_desc(), 21, 19, 1, 0);
+    EXPECT_EQ(explicit_mmla.weights_desc(), at_threshold.weights_desc());
+    EXPECT_TRUE(is_int8_mmla_weights(explicit_mmla.weights_desc()));
+
+    const auto explicit_dot = make_int8_mmla_conv_pd(eng, memory::data_type::u8,
+            below_threshold.weights_desc(), 20, 20, 1, 0);
+    EXPECT_EQ(explicit_dot.weights_desc(), below_threshold.weights_desc());
+    EXPECT_FALSE(is_int8_mmla_weights(explicit_dot.weights_desc()));
+}
+
 #endif
 } // namespace dnnl

--- a/tests/gtests/test_convolution_forward_u8s8fp.cpp
+++ b/tests/gtests/test_convolution_forward_u8s8fp.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2016 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -17,8 +18,11 @@
 #include "dnnl_test_common.hpp"
 #include "gtest/gtest.h"
 
+#include <algorithm>
+
 #include "oneapi/dnnl/dnnl.hpp"
 #include "test_convolution_forward_common.hpp"
+#include "tests/test_isa_common.hpp"
 namespace dnnl {
 
 using convolution_test
@@ -31,5 +35,105 @@ TEST_P(convolution_test, TestConvolution) {}
 #define DIRECTION_FORWARD
 #include "convolution_common.h"
 #undef TEST_PARAM_ATTR
+
+#if DNNL_AARCH64
+TEST(AArch64MmlaConvolution, Int8SourceZeroPointUsesCurrentWeights) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets the CPU convolution implementation.");
+
+    constexpr memory::dim mb = 1;
+    constexpr memory::dim ic = 64;
+    constexpr memory::dim ih = 16;
+    constexpr memory::dim iw = 16;
+    constexpr memory::dim oc = 64;
+    constexpr memory::dim oh = 16;
+    constexpr memory::dim ow = 16;
+    constexpr memory::dim kh = 3;
+    constexpr memory::dim kw = 3;
+    constexpr int32_t src_value = 5;
+    constexpr int32_t src_zero_point = 3;
+
+    auto eng = get_test_engine();
+    auto strm = stream(eng);
+    const auto src_md = memory::desc(
+            {mb, ic, ih, iw}, memory::data_type::u8, memory::format_tag::nhwc);
+    const auto wei_any_md = memory::desc(
+            {oc, ic, kh, kw}, memory::data_type::s8, memory::format_tag::any);
+    const auto wei_plain_md = memory::desc(
+            {oc, ic, kh, kw}, memory::data_type::s8, memory::format_tag::oihw);
+    const auto dst_md = memory::desc(
+            {mb, oc, oh, ow}, memory::data_type::f32, memory::format_tag::nhwc);
+    const auto zero_point_md
+            = memory::desc({1}, memory::data_type::s32, memory::format_tag::x);
+    const memory::dims strides = {1, 1};
+    const memory::dims padding = {1, 1};
+
+    primitive_attr attr;
+    attr.set_zero_points_mask(DNNL_ARG_SRC, 0);
+    const auto pd = convolution_forward::primitive_desc(eng,
+            prop_kind::forward_inference, algorithm::convolution_direct, src_md,
+            wei_any_md, memory::desc(), dst_md, strides, padding, padding, attr,
+            true);
+    SKIP_IF(pd.get() == nullptr
+                    || !aarch64_mmla_test::matches_weights_desc(
+                            pd.weights_desc(), 1, 0, 8),
+            "This test targets AArch64 SVE-I8MM.");
+    const auto conv = convolution_forward(pd);
+
+    auto src = memory(src_md, eng);
+    auto *src_ptr = src.map_data<uint8_t>();
+    ASSERT_NE(src_ptr, nullptr);
+    std::fill(src_ptr, src_ptr + mb * ic * ih * iw, src_value);
+    src.unmap_data(src_ptr);
+
+    auto zero_point = memory(zero_point_md, eng);
+    auto *zero_point_ptr = zero_point.map_data<int32_t>();
+    ASSERT_NE(zero_point_ptr, nullptr);
+    zero_point_ptr[0] = src_zero_point;
+    zero_point.unmap_data(zero_point_ptr);
+
+    auto wei_plain = memory(wei_plain_md, eng);
+    auto weights = memory(pd.weights_desc(), eng);
+    auto dst = memory(dst_md, eng);
+    for (int8_t weight_value : {int8_t(1), int8_t(-2)}) {
+        auto *wei_plain_ptr = wei_plain.map_data<int8_t>();
+        ASSERT_NE(wei_plain_ptr, nullptr);
+        std::fill(
+                wei_plain_ptr, wei_plain_ptr + oc * ic * kh * kw, weight_value);
+        wei_plain.unmap_data(wei_plain_ptr);
+
+        reorder(wei_plain, weights).execute(strm, wei_plain, weights);
+        conv.execute(strm,
+                {{DNNL_ARG_SRC, src}, {DNNL_ARG_WEIGHTS, weights},
+                        {DNNL_ARG_DST, dst},
+                        {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC,
+                                zero_point}});
+        strm.wait();
+
+        auto *dst_ptr = dst.map_data<float>();
+        ASSERT_NE(dst_ptr, nullptr);
+        for (memory::dim output_h = 0; output_h < oh; ++output_h) {
+            const int valid_kernel_h
+                    = output_h == 0 || output_h == oh - 1 ? 2 : 3;
+            for (memory::dim output_w = 0; output_w < ow; ++output_w) {
+                const int valid_kernel_w
+                        = output_w == 0 || output_w == ow - 1 ? 2 : 3;
+                const auto expected = static_cast<float>(
+                        (src_value - src_zero_point) * weight_value * ic
+                        * valid_kernel_h * valid_kernel_w);
+                for (memory::dim output_channel = 0; output_channel < oc;
+                        ++output_channel) {
+                    const auto offset
+                            = (output_h * ow + output_w) * oc + output_channel;
+                    EXPECT_EQ(dst_ptr[offset], expected)
+                            << "weight=" << static_cast<int>(weight_value)
+                            << ", index=" << offset;
+                }
+            }
+        }
+        dst.unmap_data(dst_ptr);
+    }
+}
+#endif
 
 } // namespace dnnl

--- a/tests/gtests/test_matmul.cpp
+++ b/tests/gtests/test_matmul.cpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2019 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +19,7 @@
 #include "gtest/gtest.h"
 
 #include "oneapi/dnnl/dnnl.hpp"
+#include "tests/test_isa_common.hpp"
 
 #include <vector>
 
@@ -688,5 +690,91 @@ INSTANTIATE_TEST_SUITE_P(TensorDims, attr_test_t,
                 std::make_tuple(memory::dims {2, 10, 10, 10},
                         memory::dims {2, 10, 10, 10}, tag::abcd,
                         memory::data_type::f16, 4)));
+
+#if DNNL_AARCH64
+namespace {
+
+bool is_bf16_mmla_matmul_weights(const memory::desc &desc) {
+    const int k_dim = desc.get_ndims() - 2;
+    return k_dim >= 0
+            && aarch64_mmla_test::matches_weights_desc(desc, k_dim, k_dim + 1);
+}
+
+bool has_bf16_mmla_matmul(const engine &eng) {
+    try {
+        const auto src = memory::desc(
+                {17, 64}, data_type::bf16, memory::format_tag::ab);
+        const auto weights = memory::desc(
+                {64, 64}, data_type::bf16, memory::format_tag::any);
+        const auto dst = memory::desc(
+                {17, 64}, data_type::f32, memory::format_tag::ab);
+        const auto pd = matmul::primitive_desc(eng, src, weights, dst);
+        return is_bf16_mmla_matmul_weights(pd.weights_desc());
+    } catch (const error &) { return false; }
+}
+
+} // namespace
+
+TEST(AArch64MmlaMatmul, Bf16SelectionAndFallbacks) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets the CPU matmul implementation.");
+
+    auto eng = get_test_engine();
+    SKIP_IF(!has_bf16_mmla_matmul(eng), "This test targets AArch64 BF16 MMLA.");
+
+    const auto src
+            = memory::desc({17, 64}, data_type::bf16, memory::format_tag::ab);
+    const auto dst
+            = memory::desc({17, 64}, data_type::f32, memory::format_tag::ab);
+    const auto any_weights
+            = memory::desc({64, 64}, data_type::bf16, memory::format_tag::any);
+    const auto selected = matmul::primitive_desc(eng, src, any_weights, dst);
+    ASSERT_TRUE(is_bf16_mmla_matmul_weights(selected.weights_desc()));
+
+    const auto packed = selected.weights_desc();
+    EXPECT_EQ(matmul::primitive_desc(eng, src, packed, dst).weights_desc(),
+            packed);
+
+    const auto n_tail_weights
+            = memory::desc({64, 49}, data_type::bf16, memory::format_tag::any);
+    const auto n_tail_dst
+            = memory::desc({17, 49}, data_type::f32, memory::format_tag::ab);
+    EXPECT_FALSE(is_bf16_mmla_matmul_weights(
+            matmul::primitive_desc(eng, src, n_tail_weights, n_tail_dst)
+                    .weights_desc()));
+
+    const auto k_tail_src
+            = memory::desc({17, 66}, data_type::bf16, memory::format_tag::ab);
+    const auto k_tail_weights
+            = memory::desc({66, 64}, data_type::bf16, memory::format_tag::any);
+    EXPECT_FALSE(is_bf16_mmla_matmul_weights(
+            matmul::primitive_desc(eng, k_tail_src, k_tail_weights, dst)
+                    .weights_desc()));
+
+    const auto gemv_src
+            = memory::desc({1, 64}, data_type::bf16, memory::format_tag::ab);
+    const auto gemv_dst
+            = memory::desc({1, 64}, data_type::f32, memory::format_tag::ab);
+    EXPECT_FALSE(is_bf16_mmla_matmul_weights(
+            matmul::primitive_desc(eng, gemv_src, any_weights, gemv_dst)
+                    .weights_desc()));
+
+    const auto batch_src = memory::desc(
+            {2, 17, 64}, data_type::bf16, memory::format_tag::abc);
+    const auto batch_weights = memory::desc(
+            {2, 64, 64}, data_type::bf16, memory::format_tag::any);
+    const auto batch_dst = memory::desc(
+            {2, 17, 64}, data_type::f32, memory::format_tag::abc);
+    const auto batched
+            = matmul::primitive_desc(eng, batch_src, batch_weights, batch_dst);
+    EXPECT_TRUE(is_bf16_mmla_matmul_weights(batched.weights_desc()));
+
+    const auto broadcast_weights = memory::desc(
+            {1, 64, 64}, data_type::bf16, memory::format_tag::any);
+    EXPECT_TRUE(is_bf16_mmla_matmul_weights(
+            matmul::primitive_desc(eng, batch_src, broadcast_weights, batch_dst)
+                    .weights_desc()));
+}
+#endif
 
 } // namespace dnnl

--- a/tests/gtests/test_reorder.cpp
+++ b/tests/gtests/test_reorder.cpp
@@ -62,11 +62,12 @@ TEST_P(reorder_simple_test_t_s8_s8, TestsReorder) {
 #if DNNL_AARCH64
 namespace {
 
-memory::desc make_bf16_mmla_conv_weights_desc(const engine &eng) {
-    const auto src_md = memory::desc(
-            {1, 64, 16, 16}, memory::data_type::bf16, memory::format_tag::nhwc);
+memory::desc make_mmla_conv_weights_desc(const engine &eng,
+        memory::data_type src_type, memory::data_type weights_type) {
+    const auto src_md
+            = memory::desc({1, 64, 16, 16}, src_type, memory::format_tag::nhwc);
     const auto weights_md = memory::desc(
-            {64, 64, 3, 3}, memory::data_type::bf16, memory::format_tag::any);
+            {64, 64, 3, 3}, weights_type, memory::format_tag::any);
     const auto dst_md = memory::desc(
             {1, 64, 16, 16}, memory::data_type::f32, memory::format_tag::nhwc);
     const auto pd = convolution_forward::primitive_desc(eng,
@@ -79,13 +80,13 @@ memory::desc make_bf16_mmla_conv_weights_desc(const engine &eng) {
 template <typename data_t>
 void check_mmla_weights_round_trip(const engine &eng,
         const memory::desc &packed_md, memory::format_tag plain_tag, int k_dim,
-        int n_dim) {
+        int n_dim, int k_block = 0) {
     using namespace aarch64_mmla_test;
 
     auto strm = stream(eng);
     const auto plain_md = memory::desc(
             packed_md.get_dims(), packed_md.get_data_type(), plain_tag);
-    EXPECT_TRUE(matches_weights_desc(packed_md, k_dim, n_dim));
+    EXPECT_TRUE(matches_weights_desc(packed_md, k_dim, n_dim, k_block));
     EXPECT_EQ(packed_md.get_size(), plain_md.get_size());
 
     auto plain = memory(plain_md, eng);
@@ -114,18 +115,34 @@ void check_mmla_weights_round_trip(const engine &eng,
 
 } // namespace
 
-TEST(AArch64MmlaWeights, DescriptorSizeAndRoundTrip) {
+TEST(AArch64MmlaWeights, Bf16DescriptorSizeAndRoundTrip) {
     SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
             "This test targets AArch64 CPU weight preparation.");
 
     using namespace aarch64_mmla_test;
     auto eng = get_test_engine();
-    const auto packed_md = make_bf16_mmla_conv_weights_desc(eng);
+    const auto packed_md = make_mmla_conv_weights_desc(
+            eng, memory::data_type::bf16, memory::data_type::bf16);
     SKIP_IF(packed_md.is_zero() || !matches_weights_desc(packed_md, 1, 0),
             "This test targets AArch64 BF16 MMLA.");
 
     check_mmla_weights_round_trip<bfloat16_t>(
             eng, packed_md, memory::format_tag::oihw, 1, 0);
+}
+
+TEST(AArch64MmlaWeights, Int8DescriptorSizeAndRoundTrip) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets AArch64 CPU weight preparation.");
+
+    using namespace aarch64_mmla_test;
+    auto eng = get_test_engine();
+    const auto packed_md = make_mmla_conv_weights_desc(
+            eng, memory::data_type::u8, memory::data_type::s8);
+    SKIP_IF(packed_md.is_zero() || !matches_weights_desc(packed_md, 1, 0, 8),
+            "This test targets AArch64 SVE-I8MM.");
+
+    check_mmla_weights_round_trip<int8_t>(
+            eng, packed_md, memory::format_tag::oihw, 1, 0, 8);
 }
 #endif
 

--- a/tests/gtests/test_reorder.cpp
+++ b/tests/gtests/test_reorder.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2016 Intel Corporation
-* Copyright 2023 Arm Ltd. and affiliates
+* Copyright 2023-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@
 #include "oneapi/dnnl/dnnl.hpp"
 
 #include "test_reorder_common.hpp"
+
+#include "tests/test_isa_common.hpp"
 
 namespace dnnl {
 
@@ -56,6 +58,76 @@ TEST_P(reorder_simple_test_t_f32_f32, TestsReorder) {
 TEST_P(reorder_simple_test_t_s8_s8, TestsReorder) {
     Test();
 }
+
+#if DNNL_AARCH64
+namespace {
+
+memory::desc make_bf16_mmla_conv_weights_desc(const engine &eng) {
+    const auto src_md = memory::desc(
+            {1, 64, 16, 16}, memory::data_type::bf16, memory::format_tag::nhwc);
+    const auto weights_md = memory::desc(
+            {64, 64, 3, 3}, memory::data_type::bf16, memory::format_tag::any);
+    const auto dst_md = memory::desc(
+            {1, 64, 16, 16}, memory::data_type::f32, memory::format_tag::nhwc);
+    const auto pd = convolution_forward::primitive_desc(eng,
+            prop_kind::forward_inference, algorithm::convolution_direct, src_md,
+            weights_md, memory::desc(), dst_md, {1, 1}, {1, 1}, {1, 1},
+            primitive_attr(), true);
+    return pd.get() == nullptr ? memory::desc() : pd.weights_desc();
+}
+
+template <typename data_t>
+void check_mmla_weights_round_trip(const engine &eng,
+        const memory::desc &packed_md, memory::format_tag plain_tag, int k_dim,
+        int n_dim) {
+    using namespace aarch64_mmla_test;
+
+    auto strm = stream(eng);
+    const auto plain_md = memory::desc(
+            packed_md.get_dims(), packed_md.get_data_type(), plain_tag);
+    EXPECT_TRUE(matches_weights_desc(packed_md, k_dim, n_dim));
+    EXPECT_EQ(packed_md.get_size(), plain_md.get_size());
+
+    auto plain = memory(plain_md, eng);
+    auto packed = memory(packed_md, eng);
+    auto round_trip = memory(plain_md, eng);
+    const auto logical_elements = plain_md.get_size() / sizeof(data_t);
+    std::vector<float> expected(logical_elements);
+    auto *plain_ptr = plain.map_data<data_t>();
+    ASSERT_NE(plain_ptr, nullptr);
+    for (size_t i = 0; i < logical_elements; ++i) {
+        expected[i] = static_cast<float>(static_cast<int>((i + 5) % 13) - 6);
+        plain_ptr[i] = static_cast<data_t>(expected[i]);
+    }
+    plain.unmap_data(plain_ptr);
+
+    reorder(plain, packed).execute(strm, plain, packed);
+    reorder(packed, round_trip).execute(strm, packed, round_trip);
+    strm.wait();
+
+    auto *round_trip_ptr = round_trip.map_data<data_t>();
+    ASSERT_NE(round_trip_ptr, nullptr);
+    for (size_t i = 0; i < logical_elements; ++i)
+        EXPECT_EQ(static_cast<float>(round_trip_ptr[i]), expected[i]) << i;
+    round_trip.unmap_data(round_trip_ptr);
+}
+
+} // namespace
+
+TEST(AArch64MmlaWeights, DescriptorSizeAndRoundTrip) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "This test targets AArch64 CPU weight preparation.");
+
+    using namespace aarch64_mmla_test;
+    auto eng = get_test_engine();
+    const auto packed_md = make_bf16_mmla_conv_weights_desc(eng);
+    SKIP_IF(packed_md.is_zero() || !matches_weights_desc(packed_md, 1, 0),
+            "This test targets AArch64 BF16 MMLA.");
+
+    check_mmla_weights_round_trip<bfloat16_t>(
+            eng, packed_md, memory::format_tag::oihw, 1, 0);
+}
+#endif
 
 INSTANTIATE_TEST_SUITE_P(ACLCases, reorder_simple_test_t_f32_bf16,
         ::testing::Values(cfg_bf16 {fmt::ab, fmt::BA4b4a, {128, 128}},

--- a/tests/test_isa_common.hpp
+++ b/tests/test_isa_common.hpp
@@ -241,27 +241,46 @@ inline bool is_superset(dnnl_cpu_isa_t isa_1, dnnl_cpu_isa_t isa_2) {
 namespace aarch64_mmla_test {
 
 inline memory::dim weights_n_block(
-        const memory::desc &desc, int k_dim, int n_dim) {
-    if (desc.get_data_type() != memory::data_type::bf16
-            || desc.get_format_kind() != memory::format_kind::blocked)
-        return 0;
+        const memory::desc &desc, int k_dim, int n_dim, int k_block = 0) {
+    if (desc.get_format_kind() != memory::format_kind::blocked) return 0;
 
-    // BF16 MMLA packs each K8 block as K2 x N x K4, where N is one
-    // ISA-sized output-channel tile.
+    int k_chunk = 0;
+    switch (desc.get_data_type()) {
+        case memory::data_type::bf16: k_chunk = 4; break;
+        case memory::data_type::s8: k_chunk = 8; break;
+        default: return 0;
+    }
+    if (k_block == 0)
+        k_block = desc.get_data_type() == memory::data_type::s8 ? k_chunk
+                                                                : 2 * k_chunk;
+
+    // BF16 packs two K chunks around one N tile; INT8 packs a single K chunk
+    // after N.
     const auto inner_blks = desc.get_inner_blks();
     const auto inner_idxs = desc.get_inner_idxs();
-    if (inner_blks.size() != 3 || inner_idxs.size() != 3 || inner_blks[0] != 2
-            || inner_idxs[0] != k_dim || inner_idxs[1] != n_dim
-            || inner_blks[2] != 4 || inner_idxs[2] != k_dim)
+    memory::dim n_block = 0;
+    if (k_block == k_chunk) {
+        if (inner_blks.size() != 2 || inner_idxs.size() != 2
+                || inner_idxs[0] != n_dim || inner_blks[1] != k_chunk
+                || inner_idxs[1] != k_dim)
+            return 0;
+        n_block = inner_blks[0];
+    } else if (k_block == 2 * k_chunk) {
+        if (inner_blks.size() != 3 || inner_idxs.size() != 3
+                || inner_blks[0] != 2 || inner_idxs[0] != k_dim
+                || inner_idxs[1] != n_dim || inner_blks[2] != k_chunk
+                || inner_idxs[2] != k_dim)
+            return 0;
+        n_block = inner_blks[1];
+    } else {
         return 0;
-
-    const auto n_block = inner_blks[1];
+    }
     return n_block == 16 || n_block == 32 ? n_block : 0;
 }
 
 inline bool matches_weights_desc(
-        const memory::desc &desc, int k_dim, int n_dim) {
-    return weights_n_block(desc, k_dim, n_dim) != 0;
+        const memory::desc &desc, int k_dim, int n_dim, int k_block = 0) {
+    return weights_n_block(desc, k_dim, n_dim, k_block) != 0;
 }
 
 } // namespace aarch64_mmla_test

--- a/tests/test_isa_common.hpp
+++ b/tests/test_isa_common.hpp
@@ -1,5 +1,6 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
+* Copyright 2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -234,6 +235,36 @@ inline bool is_superset(dnnl_cpu_isa_t isa_1, dnnl_cpu_isa_t isa_2) {
     return false;
 }
 
+#endif
+
+#if DNNL_AARCH64
+namespace aarch64_mmla_test {
+
+inline memory::dim weights_n_block(
+        const memory::desc &desc, int k_dim, int n_dim) {
+    if (desc.get_data_type() != memory::data_type::bf16
+            || desc.get_format_kind() != memory::format_kind::blocked)
+        return 0;
+
+    // BF16 MMLA packs each K8 block as K2 x N x K4, where N is one
+    // ISA-sized output-channel tile.
+    const auto inner_blks = desc.get_inner_blks();
+    const auto inner_idxs = desc.get_inner_idxs();
+    if (inner_blks.size() != 3 || inner_idxs.size() != 3 || inner_blks[0] != 2
+            || inner_idxs[0] != k_dim || inner_idxs[1] != n_dim
+            || inner_blks[2] != 4 || inner_idxs[2] != k_dim)
+        return 0;
+
+    const auto n_block = inner_blks[1];
+    return n_block == 16 || n_block == 32 ? n_block : 0;
+}
+
+inline bool matches_weights_desc(
+        const memory::desc &desc, int k_dim, int n_dim) {
+    return weights_n_block(desc, k_dim, n_dim) != 0;
+}
+
+} // namespace aarch64_mmla_test
 #endif
 
 } // namespace dnnl

--- a/third_party/xbyak_aarch64/src/util_impl_linux.h
+++ b/third_party/xbyak_aarch64/src/util_impl_linux.h
@@ -45,6 +45,9 @@
 #ifndef HWCAP2_BF16
 #define HWCAP2_BF16 (1UL << 14)
 #endif
+#ifndef HWCAP2_SVEI8MM
+#define HWCAP2_SVEI8MM (1UL << 9)
+#endif
 #ifndef HWCAP2_SME
 #define HWCAP2_SME (1UL << 23)
 #endif
@@ -431,6 +434,8 @@ private:
     const unsigned long hwcap2 = getauxval(AT_HWCAP2);
     if (hwcap2 & HWCAP2_BF16)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_BF16;
+    if (hwcap2 & HWCAP2_SVEI8MM)
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_SVEI8MM;
     if (hwcap2 & HWCAP2_SME)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_SME;
     if (hwcap2 & HWCAP2_SME_I16I64)

--- a/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h
@@ -72,6 +72,7 @@ enum hwCap_t {
   XBYAK_AARCH64_HWCAP_SME_F16F16 = 1 << 10,
   XBYAK_AARCH64_HWCAP_SME_F64F64 = 1 << 11,
   XBYAK_AARCH64_HWCAP_FPHP = 1 << 12,
+  XBYAK_AARCH64_HWCAP_SVEI8MM = 1 << 13,
 };
 
 struct implementer_t {


### PR DESCRIPTION
## Description

Extends the AArch64 MMLA path from U8-by-S8 USMMLA to S8-by-S8 SMMLA for
direct BRGEMM and forward BRGCONV. This PR builds on #5795 5795. (must be merged before we review and merge this one).

### Changes

- Accept S8-by-S8 operands in the shared K8 MMLA path.
- Emit SMMLA for signed inputs and disable legacy DOT-path S8S8 compensation.
- Enable supported signed 1x1 and 3x3 BRGCONV shapes while preserving existing
  fallbacks.
- Keep source-zero-point virtual-padding compensation valid for signed input.
- Add signed BRGEMM, BRGCONV, selector, and source-zero-point coverage.

Note: Can be extended to BRGMatMul in the future

<img width="2640" height="1280" alt="pr3_v2_smmla_direct_brgemm_speedup" src="https://github.com/user-attachments/assets/b2b77b5d-3afe-44d9-b7b2-84357dff3103" />

<img width="2340" height="3130" alt="pr3_v2_smmla_brgconv_speedup" src="https://github.com/user-attachments/assets/895b98d9-7ff6-4198-a331-314c1bdc46fd" />


