### PR TITLE
cpu: conv: eliminate implicit narrowings

### DIFF
--- a/src/cpu/gemm_convolution.cpp
+++ b/src/cpu/gemm_convolution.cpp
@@ -116,8 +116,8 @@ status_t gemm_convolution_fwd_t::execute_forward_thr_nspc(const exec_ctx_t &ctx,
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const data_t *__restrict wei = wei_base + g * wei_g_stride;
 
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const dim_t h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
+        const dim_t w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
         if (jcp.im2col_sz && is_problem_3d) {
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
         }
@@ -264,8 +264,9 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
             for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
                 _col[i] = (data_t)0;
         }
-        auto inner_ker = [&](int spatial, const im_pos_t &curr, im_pos_t &prev,
-                                 im_pos_t &step, const im_pos_t &end) {
+        auto inner_ker
+                = [&](dim_t spatial, const im_pos_t &curr, im_pos_t &prev,
+                          im_pos_t &step, const im_pos_t &end) {
             const data_t *_src
                     = src + curr.n * src_mb_stride + curr.g * src_g_stride;
             step.oc = nstl::min(
@@ -312,7 +313,7 @@ status_t gemm_convolution_fwd_t::execute_forward_ncsp(
                 // TODO: for "outer threading" we have parallel section within
                 // outermost "parallel". It is not good. Consider to use
                 // "parallel" here with number of threads passed as parameter
-                const int oc_start = curr.g * jcp.oc + curr.oc;
+                const dim_t oc_start = curr.g * jcp.oc + curr.oc;
                 if (jcp.with_eltwise || jcp.with_binary) {
                     bool fast_relu_done = false;
                     if (jcp.with_eltwise && jcp.post_ops.len() == 1) {
@@ -550,7 +551,7 @@ status_t gemm_convolution_bwd_data_t::execute_backward_data_ncsp(
     const dim_t K = jcp.oc;
     const dim_t N = jcp.ic * jcp.ks;
 
-    const dim_t work_amount = (size_t)jcp.ngroups * jcp.mb;
+    const dim_t work_amount = jcp.ngroups * jcp.mb;
     const bool is_problem_3d = pd()->ndims() == 5;
 
     std::atomic<status_t> st(status::success);
@@ -636,11 +637,13 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
     std::atomic<status_t> st(status::success);
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                ithr_mb, nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
 
@@ -651,8 +654,8 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                 + (ptrdiff_t)ithr * jcp.id * jcp.ic * jcp.is;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -670,11 +673,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
             data_t *weights_reduce = weights_reduce_base
                     + ithr_mb * weights_g_size * jcp.ks * jcp.ic;
 
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 data_t *_diff_weights = need_reduction
                         ? weights_reduce
                         : diff_weights + g * weights_g_size;
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const data_t *_src
                             = src + mb * jcp.ngroups * src_step + g * jcp.ic;
                     if (jcp.im2col_sz && is_problem_3d)
@@ -730,10 +733,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0};
             size_t mb_start {0}, mb_end {0};
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g,
+                    nthr_g, ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
@@ -765,7 +769,7 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_nspc(
                         + ((static_cast<size_t>(mb) * jcp.od + od) * jcp.oh
                                   + oh)
                                 * jcp.ow * jcp.ngroups * jcp.oc;
-                const int width_stride = jcp.ngroups * jcp.oc;
+                const dim_t width_stride = jcp.ngroups * jcp.oc;
 
                 PRAGMA_OMP_SIMD(reduction(+ : db))
                 for (dim_t ow = 0; ow < jcp.ow; ++ow) {
@@ -806,9 +810,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
         size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g, nthr_g,
+                ithr_mb, nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
         const int need_reduction = nthr_mb != 1;
@@ -897,10 +903,11 @@ status_t gemm_convolution_bwd_weights_t::execute_backward_weights_ncsp(
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
             size_t g_start {0}, g_end {0};
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    static_cast<int>(jcp.ngroups), mb_for_balance, ithr_g,
+                    nthr_g, ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;

--- a/src/cpu/gemm_convolution_utils.cpp
+++ b/src/cpu/gemm_convolution_utils.cpp
@@ -55,7 +55,7 @@ namespace jit_gemm_convolution_utils {
 
 template <typename data_type_t>
 void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
-        data_type_t *col, dim_t od, int spatial_step, int spatial_block) {
+        data_type_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block) {
     using data_t =
             typename conditional<data_traits_t<data_type_t>::data_type == bf16,
                     uint16_t, data_type_t>::type;
@@ -226,10 +226,10 @@ void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
 }
 
 template void im2col_3d(const conv_gemm_conf_t &jcp, const float *im,
-        float *col, dim_t od, int spatial_step, int spatial_block);
+        float *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 template void im2col_3d(const conv_gemm_conf_t &jcp, const bfloat16_t *im,
-        bfloat16_t *col, dim_t od, int spatial_step, int spatial_block);
+        bfloat16_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 /* imtr[ic][od][oh][ow] <-- im[id][ih][iw][ic]*/
 template <typename T>
@@ -253,11 +253,12 @@ void transpose_dt(const conv_gemm_conf_t &jcp, const T *__restrict im,
                 T *__restrict imtr_icb = imtr_w + icb * ic_block * ic_stride;
                 PRAGMA_OMP_SIMD()
                 for (dim_t ic = 0; ic < ic_block; ic++) {
-                    imtr_icb[ic * ic_stride] = im_icb[ic] + shift;
+                    imtr_icb[ic * ic_stride]
+                            = static_cast<T>(im_icb[ic] + shift);
                 }
             }
             for (dim_t ic = ic_blocked; ic < jcp.ic; ic++) {
-                imtr_w[ic * ic_stride] = im_w[ic] + shift;
+                imtr_w[ic * ic_stride] = static_cast<T>(im_w[ic] + shift);
             }
         }
     });
@@ -647,8 +648,8 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
                         for (dim_t ow = 0; ow < ow_start; ++ow)
                             col[col_idx_oh + ow] = shift;
                         for (dim_t ow = ow_start; ow < ow_end; ++ow)
-                            col[col_idx_oh + ow]
-                                    = imtr[imtr_idx_oh + ow] + shift;
+                            col[col_idx_oh + ow] = static_cast<col_dt>(
+                                    imtr[imtr_idx_oh + ow] + shift);
                         for (dim_t ow = ow_end; ow < wb; ++ow)
                             col[col_idx_oh + ow] = shift;
                     }
@@ -683,7 +684,8 @@ void im2col_dt(const conv_gemm_conf_t &jcp, const void *__restrict _im,
                 for (dim_t ow = ow_start; ow < ow_end; ow++) {
                     const dim_t iw = iw_base + ow * sw;
                     const ptrdiff_t im_idx = im_idx_base + iw * im_iw_stride;
-                    col[col_idx_base + ow] = im[im_idx] + shift;
+                    col[col_idx_base + ow]
+                            = static_cast<col_dt>(im[im_idx] + shift);
                 }
                 for (dim_t ow = ow_end; ow < wb; ow++)
                     col[col_idx_base + ow] = shift;
@@ -790,7 +792,7 @@ template void col2im_dt<bfloat16_t>(const conv_gemm_conf_t &jcp,
         const bfloat16_t *__restrict col, bfloat16_t *__restrict im);
 
 void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        dim_t od, int spatial_step, int spatial_block) {
+        dim_t od, dim_t spatial_step, dim_t spatial_block) {
 
     auto sp_blocked_ker = [&](dim_t ic) {
         const size_t col_step = jcp.ks * spatial_block;
@@ -892,7 +894,7 @@ void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
 }
 
 void col2im(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        int spatial_step, int spatial_block) {
+        dim_t spatial_step, dim_t spatial_block) {
     const size_t col_step = jcp.ks * spatial_block;
     const size_t im_step = jcp.ih * jcp.iw;
     const dim_t iS = jcp.ih * jcp.iw;
@@ -1297,8 +1299,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         dim_t nb_h = div_up(oh, h_block);
                         dim_t work = jcp.ngroups * jcp.mb * jcp.od * nb_h;
-                        float disb = (float)oh / rnd_up(oh, h_block);
-                        thr_eff = (float)work / rnd_up(work, max_threads);
+                        float disb = (float)oh / (float)rnd_up(oh, h_block);
+                        thr_eff = (float)work
+                                / (float)rnd_up(work, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff >= thr_eff_treshold) break;
                         h_block = rnd_dn(h_block - 4, 4);
@@ -1308,13 +1311,13 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                         < thr_eff_treshold) // we didn't find suitable h_block
                 {
                     h_block = 1;
-                    int nb_h = oh;
+                    dim_t nb_h = oh;
                     do {
                         dim_t nb_w = div_up(ow, w_block);
                         dim_t work_amount = jcp.ngroups * jcp.mb * nb_h * nb_w;
-                        float disb = (float)ow / rnd_up(ow, w_block);
+                        float disb = (float)ow / (float)rnd_up(ow, w_block);
                         thr_eff = (float)work_amount
-                                / rnd_up(work_amount, max_threads);
+                                / (float)rnd_up(work_amount, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff > thr_eff_treshold) break;
                         w_block = rnd_dn(w_block - simd_w, simd_w);
@@ -1323,8 +1326,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 h_block = nstl::max(dim_t(1), h_block);
                 w_block = nstl::max(dim_t(1), w_block);
                 dim_t inner_work = div_up(os, simd_w) * div_up(oc, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 if (thr_eff >= inner_thr_eff / 2 && h_block > 0
                         && w_block > 0) {
                     jcp.oh_block = h_block;
@@ -1346,12 +1349,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 bool is_depthwise
                         = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
                 const dim_t outer_work = jcp.ngroups * jcp.mb;
-                const float outer_thr_eff
-                        = (float)outer_work / rnd_up(outer_work, max_threads);
+                const float outer_thr_eff = (float)outer_work
+                        / (float)rnd_up(outer_work, max_threads);
                 const size_t inner_work
                         = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 jcp.outer_threading
                         = (is_depthwise
                                   || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1377,12 +1380,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
 
             bool is_depthwise = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
             const size_t outer_work = jcp.ngroups * jcp.mb;
-            const float outer_thr_eff
-                    = (float)outer_work / rnd_up(outer_work, max_threads);
+            const float outer_thr_eff = (float)outer_work
+                    / (float)rnd_up(outer_work, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = !is_3d
                     && (is_depthwise
                             || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1459,8 +1462,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         size_t nb_h = div_up(oh, h_block);
                         size_t work = jcp.ngroups * jcp.mb * jcp.od * nb_h;
-                        float disb = (float)oh / rnd_up(oh, h_block);
-                        thr_eff = (float)work / rnd_up(work, max_threads);
+                        float disb = (float)oh / (float)rnd_up(oh, h_block);
+                        thr_eff = (float)work
+                                / (float)rnd_up(work, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff >= thr_eff_treshold) break;
 
@@ -1478,9 +1482,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     do {
                         size_t nb_w = div_up(ow, w_block);
                         size_t work_amount = jcp.ngroups * jcp.mb * nb_h * nb_w;
-                        float disb = (float)ow / rnd_up(ow, w_block);
+                        float disb = (float)ow / (float)rnd_up(ow, w_block);
                         thr_eff = (float)work_amount
-                                / rnd_up(work_amount, max_threads);
+                                / (float)rnd_up(work_amount, max_threads);
                         thr_eff = (thr_eff + disb) / 2.f;
                         if (thr_eff > thr_eff_treshold) break;
 
@@ -1494,8 +1498,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 w_block = nstl::max(size_t {1}, w_block);
                 const size_t inner_work
                         = div_up(os, simd_w) * div_up(oc, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 if (thr_eff >= inner_thr_eff / 2 && h_block > 0
                         && w_block > 0) {
                     jcp.oh_block = static_cast<int>(h_block);
@@ -1517,12 +1521,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                 bool is_depthwise
                         = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
                 const size_t outer_work = jcp.ngroups * jcp.mb;
-                const float outer_thr_eff
-                        = (float)outer_work / rnd_up(outer_work, max_threads);
+                const float outer_thr_eff = (float)outer_work
+                        / (float)rnd_up(outer_work, max_threads);
                 const size_t inner_work
                         = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-                const float inner_thr_eff
-                        = (float)inner_work / rnd_up(inner_work, max_threads);
+                const float inner_thr_eff = (float)inner_work
+                        / (float)rnd_up(inner_work, max_threads);
                 jcp.outer_threading
                         = (is_depthwise
                                   || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1571,7 +1575,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                             // threading work
                             || jcp.os < jcp.mb * jcp.ngroups * jcp.od
                             // im2col is big
-                            || (sw == 1 && K <= 0.05 * jcp.oc))
+                            || (sw == 1 && (double)K <= 0.05 * (double)jcp.oc))
                     // heuristic condition
                     && (jcp.im2col_sz
                             || (jcp.ic / jcp.oc < 42
@@ -1704,7 +1708,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                                     = nstl::min(oc_max_os_min, oc_min_os_max);
                         }
                     }
-                    auto thr_disb = (float)min_thr_size / max_thr_size;
+                    auto thr_disb = (float)min_thr_size / (float)max_thr_size;
 
                     const dim_t oc_per_thr = max_oc;
                     const dim_t os_per_thr = max_os;
@@ -1717,8 +1721,8 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                             nthr_oc, ocb, osb, oc_per_thr, os_per_thr);
                     // if we don't fit into cache then access to memory is
                     // expensive
-                    dim_t mem_access_cost
-                            = (max_ic_block < 1) ? non_cache_access : 1;
+                    dim_t mem_access_cost = static_cast<dim_t>(
+                            (max_ic_block < 1) ? non_cache_access : 1);
                     max_ic_block = nstl::max(dim_t(1), max_ic_block);
                     // "jcp.ic == 0 ? dim_t(1) : " is to avoid msvc warning 'potential divide by zero'
                     dim_t icb = nstl::max(dim_t(1),
@@ -1742,12 +1746,16 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     // TODO: simplify calculations
                     if (jcp.im2col_sz) {
                         inp_ops = mem_access_cost * jcp.ks * inp_size;
-                        const float col_tail_koeff = (float)osb_caligned / osb;
-                        col_ops = mem_access_cost
-                                * (jcp.ks * inp_size * col_tail_koeff
-                                        + jcp.ks * inp_size * col_tail_koeff);
+                        const float col_tail_koeff
+                                = (float)osb_caligned / (float)osb;
+                        col_ops = static_cast<size_t>((float)mem_access_cost
+                                * ((float)jcp.ks * (float)inp_size
+                                                * col_tail_koeff
+                                        + (float)jcp.ks * (float)inp_size
+                                                * col_tail_koeff));
                         if (sw != 1) // im2col with strides is much slower
-                            col_ops *= strided_im2col_k;
+                            col_ops = static_cast<size_t>(
+                                    (float)col_ops * strided_im2col_k);
                     } else {
                         inp_ops = mem_access_cost * jcp.ks * inp_size;
                     }
@@ -1756,23 +1764,28 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     const size_t wei_ops = mem_access_cost * wei_size;
                     // ratio of real FMA to number of memory ops
                     const float thr_mem_eff
-                            = (((float)os_per_thr / simd_w) * oc_per_thr * K)
-                            / (inp_ops + col_ops + wei_ops + out_ops);
+                            = (((float)os_per_thr / (float)simd_w)
+                                      * (float)oc_per_thr * (float)K)
+                            / (float)(inp_ops + col_ops + wei_ops + out_ops);
 
-                    auto oc_disb = (float)oc_per_thr / rnd_up(oc_per_thr, ocb);
-                    auto os_disb = (float)os_max / rnd_up(os_max, osb);
-                    auto ic_disb = (float)jcp.ic / rnd_up(jcp.ic, icb);
+                    auto oc_disb = (float)oc_per_thr
+                            / (float)rnd_up(oc_per_thr, ocb);
+                    auto os_disb = (float)os_max / (float)rnd_up(os_max, osb);
+                    auto ic_disb = (float)jcp.ic / (float)rnd_up(jcp.ic, icb);
 
-                    auto reg_osb_disb = (float)osb / rnd_up(osb, 3 * simd_w);
+                    auto reg_osb_disb
+                            = (float)osb / (float)rnd_up(osb, 3 * simd_w);
 
                     // Heuristics
-                    const float gemm_eff = ((float)osb * ocb * kb)
-                            / ((float)oc_per_thr * os_per_thr * K);
+                    const float gemm_eff = ((float)osb * (float)ocb * (float)kb)
+                            / ((float)oc_per_thr * (float)os_per_thr
+                                    * (float)K);
 
                     // number of FMA to memory size
                     const float gemm_calc_eff
-                            = (((float)osb / simd_w) * ocb * kb)
-                            / (osb_caligned * kb + ocb * kb_caligned
+                            = (((float)osb / (float)simd_w) * (float)ocb
+                                      * (float)kb)
+                            / (float)(osb_caligned * kb + ocb * kb_caligned
                                     + ocb * osb_caligned);
                     // optimization: remove pow, when corresponding weight is 1
                     const float res_eff = pow(pow(thr_disb, thr_disb_k)
@@ -1900,7 +1913,7 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     }
                 }
                 jcp.outer_threading = true;
-                jcp.nthr_oc = best_nthr_oc;
+                jcp.nthr_oc = static_cast<int>(best_nthr_oc);
                 jcp.oc_block = best_ocb;
                 jcp.os_block = best_osb;
                 jcp.ic_block = best_icb;
@@ -1912,11 +1925,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
             } else {
                 const size_t outer_work_amount = jcp.ngroups * jcp.mb * jcp.od;
                 const float outer_thr_eff = (float)outer_work_amount
-                        / rnd_up(outer_work_amount, max_threads);
+                        / (float)rnd_up(outer_work_amount, max_threads);
                 const size_t inner_work_amount
                         = div_up(jcp.os, simd_w) * div_up(jcp.oc, simd_w);
                 const float inner_thr_eff = (float)inner_work_amount
-                        / rnd_up(inner_work_amount, max_threads);
+                        / (float)rnd_up(inner_work_amount, max_threads);
                 jcp.outer_threading = jcp.os / max_threads < 512
                         && IMPLICATION(
                                 jcp.od == 1, jcp.mb != 1 || jcp.ngroups > 2)
@@ -1944,12 +1957,12 @@ status_t init_conf(conv_gemm_conf_t &jcp,
 
             bool is_depthwise = jcp.ic == 1 && jcp.oc == 1 && jcp.ngroups != 1;
             const size_t outer_work = jcp.ngroups * jcp.mb;
-            const float outer_thr_eff
-                    = (float)outer_work / rnd_up(outer_work, max_threads);
+            const float outer_thr_eff = (float)outer_work
+                    / (float)rnd_up(outer_work, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = !is_3d
                     && (is_depthwise
                             || (jcp.is / max_threads < 64 && jcp.mb != 1))
@@ -1967,11 +1980,11 @@ status_t init_conf(conv_gemm_conf_t &jcp,
         } else if (!jcp.is_nspc && is_bwd_d) {
             const size_t outer_work_amount = jcp.ngroups * jcp.mb;
             const float outer_thr_eff = (float)outer_work_amount
-                    / rnd_up(outer_work_amount, max_threads);
+                    / (float)rnd_up(outer_work_amount, max_threads);
             const size_t inner_work
                     = div_up(jcp.is, simd_w) * div_up(jcp.ic, simd_w);
-            const float inner_thr_eff
-                    = (float)inner_work / rnd_up(inner_work, max_threads);
+            const float inner_thr_eff = (float)inner_work
+                    / (float)rnd_up(inner_work, max_threads);
             jcp.outer_threading = (jcp.os / max_threads < 512 || jcp.ks < 64)
                     && (jcp.mb != 1 || jcp.ngroups > 2)
                     && (outer_thr_eff / inner_thr_eff >= 1.f
@@ -2107,9 +2120,9 @@ status_t init_conf(conv_gemm_conf_t &jcp,
                     // dimensions.
                     // TODO: better heuristic to determine os_block based
                     // on cache efficiency
-                    float _coef = is_bwd_w ? 0.05 : 0.1;
+                    float _coef = is_bwd_w ? 0.05f : 0.1f;
                     jcp.os_block = nstl::max(
-                            min_os_block, (int)(max_os_block * _coef));
+                            min_os_block, (int)((float)max_os_block * _coef));
                     jcp.os_nb_block = div_up(jcp.os, jcp.os_block);
                     jcp.im2col_sz = (ptrdiff_t)jcp.ic * jcp.ks * jcp.os_block;
                     gemm_col_memory_sz = jcp.nthr * jcp.im2col_sz;

--- a/src/cpu/gemm_convolution_utils.hpp
+++ b/src/cpu/gemm_convolution_utils.hpp
@@ -87,7 +87,7 @@ struct single_gemm_conv_chunk_desc_t {
 namespace jit_gemm_convolution_utils {
 template <typename data_type_t>
 void im2col_3d(const conv_gemm_conf_t &jcp, const data_type_t *im,
-        data_type_t *col, dim_t od, int spatial_step, int spatial_block);
+        data_type_t *col, dim_t od, dim_t spatial_step, dim_t spatial_block);
 
 template <typename T>
 void transpose_dt(const conv_gemm_conf_t &jcp, const T *__restrict im,
@@ -110,9 +110,9 @@ template <typename T>
 void col2im_dt(
         const conv_gemm_conf_t &jcp, const T *__restrict col, T *__restrict im);
 void col2im_3d(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        dim_t od, int spatial_step, int spatial_block);
+        dim_t od, dim_t spatial_step, dim_t spatial_block);
 void col2im(const conv_gemm_conf_t &jcp, const float *col, float *im,
-        int spatial_step, int spatial_block);
+        dim_t spatial_step, dim_t spatial_block);
 
 status_t init_conf(conv_gemm_conf_t &jcp,
         memory_tracking::registrar_t &scratchpad, const convolution_desc_t &cd,

--- a/src/cpu/gemm_x8s8s32x_convolution.cpp
+++ b/src/cpu/gemm_x8s8s32x_convolution.cpp
@@ -92,9 +92,9 @@ static zero_point_call_params_t prepare_zp_params(const conv_gemm_conf_t &jcp,
         const auto zp_comp_size = jcp.oc * jcp.ngroups;
 
         if (jcp.zp.src_is_common) {
-            zp_src_comp = mul_zp_src_comp_from_wei_by_zp_src(zp_comp_size,
-                    zp_src_comp_scratch, zp_src_comp_from_wei,
-                    *src_zero_points);
+            zp_src_comp = mul_zp_src_comp_from_wei_by_zp_src(
+                    static_cast<int>(zp_comp_size), zp_src_comp_scratch,
+                    zp_src_comp_from_wei, *src_zero_points);
         } else
             zp_src_comp = zp_src_comp_from_wei;
 
@@ -228,15 +228,15 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
     status_t st = status::success;
 
     for (dim_t iwork = start; iwork < end; ++iwork) {
-        const int oh = ohb * jcp.oh_block;
-        const int ow = owb * jcp.ow_block;
+        const dim_t oh = ohb * jcp.oh_block;
+        const dim_t ow = owb * jcp.ow_block;
         const char *__restrict src
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const int8_t *__restrict wei = wei_base + g * wei_g_stride;
         const int32_t *__restrict wei_comp
                 = _wei_comp ? _wei_comp + g * jcp.oc : nullptr;
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const dim_t h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
+        const dim_t w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt<char>(jcp, src, imtr);
 
@@ -308,7 +308,8 @@ status_t gemm_x8s8s32x_convolution_fwd_t::execute_forward_thr(const int ithr,
                 balance211(N * jcp.oc, nthr, ithr, _start, _end);
 
                 (*pp_ker_)(dst, acc, bia_base, scales, dst_scales[0], sum_scale,
-                        1.f / wei_adj_scale, g, n, _start, _end, zp,
+                        1.f / wei_adj_scale, static_cast<int>(g),
+                        static_cast<int>(n), _start, _end, zp,
                         post_ops_binary_rhs_arg_vec, dst_base, ctx,
                         *pd()->dst_md(), chunk_desc);
             });

--- a/src/cpu/ref_convolution.cpp
+++ b/src/cpu/ref_convolution.cpp
@@ -218,8 +218,8 @@ status_t ref_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         args.dst_md = pd()->dst_md();
         ref_post_ops->execute(d, args);
         if (dst_rnd_mode == rounding_mode::stochastic)
-            d = math::stochastic_round_fwd(
-                    d, dst_off, rnd_seed[0], dst_d.data_type());
+            d = math::stochastic_round_fwd(d, static_cast<uint32_t>(dst_off),
+                    rnd_seed[0], dst_d.data_type());
 
         io::store_float_value(dst_d.data_type(), d, dst, dst_off);
     });

--- a/src/cpu/ref_deconvolution.cpp
+++ b/src/cpu/ref_deconvolution.cpp
@@ -365,8 +365,8 @@ prepare_zp_pad_comp_ker(const dim_t ndims, const int32_t *src_zero_points,
     const memory_desc_wrapper wei_d(deconv_pd->weights_md());
     const auto get_wei_off
             = [=](dim_t g, dim_t oc, dim_t ic, dim_t kd, dim_t kh, dim_t kw) {
-        return get_weights_off(
-                wei_d, with_groups, ndims, g, oc, ic, kd, kh, kw);
+        return get_weights_off(wei_d, with_groups, static_cast<int>(ndims), g,
+                oc, ic, kd, kh, kw);
     };
 
     return [=](const dim_t g, const dim_t oc, const dim_t od, const dim_t oh,
@@ -452,8 +452,8 @@ static status_t apply_src_zero_point(const exec_ctx_t &ctx,
         const auto oc_off = g * OC + oc;
         const auto dst_off = ref_conv_utils::get_data_off(
                 dst_d, ndims, mb, oc_off, od, oh, ow);
-        int32_t conv_result
-                = conv_output[dst_off] - zp_src_compensation[oc_off];
+        int32_t conv_result = static_cast<int32_t>(
+                conv_output[dst_off] - zp_src_compensation[oc_off]);
 
         if (const auto zp_pad_compensation
                 = zp_pad_comp_ker(g, oc, od, oh, ow)) {

--- a/src/cpu/x64/gemm_bf16_convolution.cpp
+++ b/src/cpu/x64/gemm_bf16_convolution.cpp
@@ -41,9 +41,9 @@ using namespace dnnl::impl::cpu::x64::bf16_support;
 // "declared with greater visibility than the type of its field"
 // when one lambda function is delcared whithin the other one
 void store_bfloat16_in_parallel(bfloat16_t *output_data, const float *acc_data,
-        size_t parallel_work, size_t parallel_work_size, bool do_in_parallel) {
+        dim_t parallel_work, dim_t parallel_work_size, bool do_in_parallel) {
     parallel(do_in_parallel ? 0 : 1, [&](const int ithr, const int nthr) {
-        size_t start = 0, end = 0;
+        dim_t start = 0, end = 0;
         balance211(parallel_work, nthr, ithr, start, end);
         if (start < end)
             cvt_float_to_bfloat16(&output_data[start * parallel_work_size],
@@ -52,11 +52,11 @@ void store_bfloat16_in_parallel(bfloat16_t *output_data, const float *acc_data,
     });
 }
 
-void cvt_acc_to_dst(const conv_gemm_conf_t &jcp, size_t g_start, size_t g_end,
+void cvt_acc_to_dst(const conv_gemm_conf_t &jcp, dim_t g_start, dim_t g_end,
         const float *acc_base, bfloat16_t *diff_weights) {
-    const size_t parallel_work_size = jcp.ic * jcp.ks;
+    const dim_t parallel_work_size = jcp.ic * jcp.ks;
     parallel(jcp.nthr == 1 ? 0 : 1, [&](const int ithr, const int nthr) {
-        size_t w_start = 0, w_end = 0;
+        dim_t w_start = 0, w_end = 0;
         balance211(parallel_work_size, nthr, ithr, w_start, w_end);
         for_(auto w = w_start; w < w_end; ++w)
         for (auto g = g_start; g < g_end; ++g) {
@@ -138,7 +138,7 @@ gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::pp_ker_t(const pd_t *pd)
 
 template <data_type_t dst_data_type>
 void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::apply_postops(
-        const bool apply_mask, const size_t out_offset, const int vmm_idx) {
+        const bool apply_mask, const dim_t out_offset, const int vmm_idx) {
 #define PARAM_OFF(x) offsetof(ker_args_t, x)
     if (jcp_.with_eltwise || jcp_.with_binary) {
         if (jcp_.with_binary) {
@@ -181,7 +181,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
 
     // Load accumulated value, apply sum (if any), bias (if any)
     // and relu (if any); then convert to destination type and store
-    auto compute = [&](size_t offset, int idx, bool apply_mask) {
+    auto compute = [&](dim_t offset, int idx, bool apply_mask) {
         auto acc_addr = ptr[reg_acc + offset * sizeof(acc_data_t)];
         auto vreg_dst_ = vreg_dst(idx);
 
@@ -234,9 +234,9 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
     };
 
     // Advance all pointers by an immediate
-    auto advance_ptrs_imm = [&](size_t offset) {
-        add(reg_dst, offset * sizeof(dst_data_t));
-        add(reg_acc, offset * sizeof(acc_data_t));
+    auto advance_ptrs_imm = [&](dim_t offset) {
+        add(reg_dst, offset * static_cast<dim_t>(sizeof(dst_data_t)));
+        add(reg_acc, offset * static_cast<dim_t>(sizeof(acc_data_t)));
     };
 
     Xbyak::Label oc_loop, oc_loop_end;
@@ -261,7 +261,7 @@ void gemm_bf16_convolution_fwd_t<dst_data_type>::pp_ker_t::generate() {
         const int unroll = 1 << i; // 4, 2, 1
         L(l_simd_loop[i + 1]);
         {
-            const int loop_len = unroll * vlen_;
+            const int loop_len = static_cast<int>(unroll * vlen_);
             cmp(reg_len_iter, loop_len);
             jl(l_simd_loop[i], T_NEAR);
             for (int j = 0; j < unroll; j++)
@@ -396,17 +396,15 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
     const conv_gemm_conf_t &jcp = pd()->jcp_;
 
     // Src Format: mb-spatial-groups-input_channels
-    const size_t src_mb_stride = static_cast<size_t>(jcp.id) * jcp.ih * jcp.iw
-            * jcp.ngroups * jcp.ic;
-    const size_t src_g_stride = jcp.ic;
+    const dim_t src_mb_stride = jcp.id * jcp.ih * jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t src_g_stride = jcp.ic;
     // Wei Format: spatial-input_channels-groups-output_channels
-    const size_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
+    const dim_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
 
     // Dst Format: mb-spatial-groups-output_channels
-    const size_t dst_mb_stride = static_cast<size_t>(jcp.od) * jcp.oh * jcp.ow
-            * jcp.ngroups * jcp.oc;
-    const size_t dst_g_stride = jcp.oc;
-    const size_t dst_os_stride = jcp.ngroups * jcp.oc;
+    const dim_t dst_mb_stride = jcp.od * jcp.oh * jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t dst_g_stride = jcp.oc;
+    const dim_t dst_os_stride = jcp.ngroups * jcp.oc;
 
     src_data_t *__restrict col = scratchpad.get<src_data_t>(key_conv_gemm_col)
             + (ptrdiff_t)ithr * jcp.im2col_sz;
@@ -442,18 +440,18 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
         constexpr uint16_t zero_val = 0;
 
         PRAGMA_OMP_SIMD()
-        for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+        for (dim_t i = 0; i < jcp.im2col_sz; i++)
             col_r[i] = zero_val;
     }
     for (dim_t iwork = start; iwork < end; ++iwork) {
-        int oh = ohb * jcp.oh_block;
-        int ow = owb * jcp.ow_block;
+        dim_t oh = ohb * jcp.oh_block;
+        dim_t ow = owb * jcp.ow_block;
         const src_data_t *__restrict src
                 = src_base + n * src_mb_stride + g * src_g_stride;
         const wei_data_t *__restrict wei = wei_base + g * wei_g_stride;
 
-        const int h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
-        const int w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
+        const dim_t h_step = nstl::min(jcp.oh_block, jcp.oh - oh);
+        const dim_t w_step = nstl::min(jcp.ow_block, jcp.ow - ow);
         if (jcp.im2col_sz && is_problem_3d)
             jit_gemm_convolution_utils::transpose_dt(jcp, src, imtr);
 
@@ -491,7 +489,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_thr_nspc(
             const bool do_postprocess = pd()->is_postprocess_required();
             if (do_postprocess) {
                 parallel_nd_ext(jcp.nthr == 1 ? 0 : 1, N,
-                        [&](size_t ithr, size_t nthr, size_t os) {
+                        [&](int ithr, int nthr, dim_t os) {
                     const float *__restrict acc_arr = acc + os * jcp.oc;
                     const float *__restrict bia_arr = (bia_base == nullptr)
                             ? nullptr
@@ -553,22 +551,21 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
     const float sum_scale = do_sum ? post_ops.entry_[0].sum.scale : 0;
 
     const dim_t M = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * M;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-    const size_t weights_oc_size = jcp.ic * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * M;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+    const dim_t weights_oc_size = jcp.ic * jcp.ks;
 
     const dim_t LDB = weights_oc_size;
-    const dim_t work_amount
-            = (size_t)jcp.ngroups * jcp.mb * jcp.od * jcp.os_nb_block;
+    const dim_t work_amount = jcp.ngroups * jcp.mb * jcp.od * jcp.os_nb_block;
     const bool is_problem_3d = pd()->ndims() == 5;
     std::atomic<status_t> st(status::success);
 
-    auto inner_ker = [&](const int ic, const int oc, const int groups,
-                             const int od, const int spatial,
+    auto inner_ker = [&](const dim_t ic, const dim_t oc, const dim_t groups,
+                             const dim_t od, const dim_t spatial,
                              const src_data_t *src, const wei_data_t *weights,
                              src_data_t *col, dst_data_t *dst_im,
-                             acc_data_t *acc, int ic_block, int oc_block) {
+                             acc_data_t *acc, dim_t ic_block, dim_t oc_block) {
         const dim_t os_block = nstl::min(
                 (dim_t)jcp.os_block, (dim_t)jcp.os - spatial * jcp.os_block);
 
@@ -603,8 +600,8 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
         }
 
         if (this->pd()->is_postprocess_required() && ic + ic_block >= jcp.ic) {
-            size_t acc_str = LDC;
-            size_t dst_str = M;
+            const dim_t acc_str = LDC;
+            const dim_t dst_str = M;
             float *bias_ptr = bias ? bias + groups * jcp.oc + oc : nullptr;
             (*pp_ker_)(dst_local, acc, bias_ptr, sum_scale, dst_str, acc_str, m,
                     oc_block, post_ops_binary_rhs_arg_vec.data(), dst,
@@ -617,7 +614,7 @@ status_t gemm_bf16_convolution_fwd_t<dst_data_type>::execute_forward_ncsp(
         if (is_problem_3d) {
             // jit_gemm_convolution_utils::im2col_3d() requires external
             // data initialization by zeroes
-            for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+            for (dim_t i = 0; i < jcp.im2col_sz; i++)
                 _col[i] = (src_data_t)0;
         }
         dim_t g {0}, n {0}, od {0}, nb_os {0};
@@ -694,18 +691,18 @@ status_t gemm_bf16_convolution_bwd_data_t<
     const conv_gemm_conf_t &jcp = pd()->jcp_;
 
     // Diff_dst Format: mb-spatial-groups-output_channels
-    const size_t diff_dst_mb_stride = static_cast<size_t>(jcp.od) * jcp.oh
-            * jcp.ow * jcp.ngroups * jcp.oc;
-    const size_t diff_dst_g_stride = jcp.oc;
+    const dim_t diff_dst_mb_stride
+            = jcp.od * jcp.oh * jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t diff_dst_g_stride = jcp.oc;
 
     // Wei Format: spatial-input_channels-groups-output_channels
-    const size_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
+    const dim_t wei_g_stride = pd()->with_groups() ? jcp.oc : 0;
 
     // Diff_src Format: mb-spatial-groups-input_channels
-    const size_t diff_src_mb_stride = static_cast<size_t>(jcp.id) * jcp.ih
-            * jcp.iw * jcp.ngroups * jcp.ic;
-    const size_t diff_src_g_stride = jcp.ic;
-    const size_t diff_src_os_stride = jcp.ngroups * jcp.ic;
+    const dim_t diff_src_mb_stride
+            = jcp.id * jcp.ih * jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t diff_src_g_stride = jcp.ic;
+    const dim_t diff_src_os_stride = jcp.ngroups * jcp.ic;
 
     // threads share work across mini-batch and groups
     const dim_t work_amount = jcp.ngroups * jcp.mb;
@@ -746,11 +743,10 @@ status_t gemm_bf16_convolution_bwd_data_t<
 
         if (is_diff_src_bf16 && jcp.ngroups == 1 && jcp.nthr != 1) {
             cvt_float_to_bfloat16((bfloat16_t *)diff_src, (const float *)acc,
-                    static_cast<size_t>(jcp.is) * jcp.id * jcp.ic);
+                    jcp.is * jcp.id * jcp.ic);
         } else if (is_diff_src_bf16) {
-            parallel_nd_ext(jcp.nthr == 1 ? 0 : 1,
-                    static_cast<size_t>(jcp.is) * jcp.id,
-                    [&](size_t ithr, size_t nthr, size_t is) {
+            parallel_nd_ext(jcp.nthr == 1 ? 0 : 1, jcp.is * jcp.id,
+                    [&](int ithr, int nthr, dim_t is) {
                 diff_src_data_t *__restrict diff_src_loc
                         = diff_src + is * diff_src_os_stride;
                 const acc_data_t *__restrict acc_loc = acc + is * jcp.ic;
@@ -759,9 +755,8 @@ status_t gemm_bf16_convolution_bwd_data_t<
             });
         } else {
             assert(diff_src_data_type == data_type::f32);
-            parallel_nd_ext(jcp.nthr == 1 ? 0 : 1,
-                    static_cast<size_t>(jcp.is) * jcp.id,
-                    [&](size_t ithr, size_t nthr, size_t is) {
+            parallel_nd_ext(jcp.nthr == 1 ? 0 : 1, jcp.is * jcp.id,
+                    [&](int ithr, int nthr, dim_t is) {
                 diff_src_data_t *__restrict diff_src_loc
                         = diff_src + is * diff_src_os_stride;
                 const acc_data_t *__restrict acc_loc = acc + is * jcp.ic;
@@ -792,15 +787,15 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
     const conv_gemm_conf_t &jcp = this->pd()->jcp_;
 
     const dim_t M = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * M;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * M;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
 
     const dim_t m = jcp.os_block;
     const dim_t K = jcp.oc;
     const dim_t N = jcp.ic * jcp.ks;
 
-    const dim_t work_amount = (size_t)jcp.ngroups * jcp.mb;
+    const dim_t work_amount = jcp.ngroups * jcp.mb;
     const bool is_problem_3d = pd()->ndims() == 5;
 
     std::atomic<status_t> st(status::success);
@@ -823,7 +818,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
             if (is_problem_3d && jcp.im2col_sz > 0) {
                 // jit_gemm_convolution_utils::col2im_3d() assumes that the
                 // accumulator is initialized by zeroes
-                for (size_t i = 0; i < src_step; i++)
+                for (dim_t i = 0; i < src_step; i++)
                     acc[i] = (acc_data_t)0;
             }
 
@@ -857,7 +852,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
                 }
             }
             if (diff_src_data_type == data_type::bf16) {
-                size_t spatial_size = (size_t)jcp.ih * jcp.iw * jcp.id;
+                const dim_t spatial_size = jcp.ih * jcp.iw * jcp.id;
                 store_bfloat16_in_parallel((bfloat16_t *)diff_src_local,
                         (const float *)acc, jcp.ic, spatial_size,
                         jcp.nthr == 1);
@@ -872,7 +867,7 @@ status_t gemm_bf16_convolution_bwd_data_t<diff_src_data_type>::
 template <data_type_t diff_wei_data_type>
 void gemm_bf16_convolution_bwd_weights_t<
         diff_wei_data_type>::bf16_bwd_weights_reduction_par_nspc(int ithr_mb,
-        int nthr_mb, size_t g_start, size_t g_end, const conv_gemm_conf_t &jcp,
+        int nthr_mb, dim_t g_start, dim_t g_end, const conv_gemm_conf_t &jcp,
         const acc_data_t *weights_reduce_base,
         diff_wei_data_t *weights_base) const {
     assert(nthr_mb > 1); // no reduction for nthr_mb == 1
@@ -914,20 +909,20 @@ void gemm_bf16_convolution_bwd_weights_t<
     assert(nthr_mb > 1); // no reduction for nthr_mb == 1
 
     const bool is_bf16_out = diff_wei_data_type == data_type::bf16;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-    size_t weights_start {0}, weights_end {0};
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+    dim_t weights_start {0}, weights_end {0};
     balance211(weights_g_size, nthr_mb, ithr_mb, weights_start, weights_end);
 
     if (weights_start >= weights_end) return; // nothing to do
 
-    size_t acc_size = weights_end - weights_start;
+    const dim_t acc_size = weights_end - weights_start;
     float *wei_reduced = is_bf16_out
             ? (float *)weights_reduce_base + weights_start
             : (float *)weights_base + weights_start;
     if (!is_bf16_out) {
         // f32 diff_weights require initialization by weights_reduce
         // for thr_mb = 0
-        for (size_t i = 0; i < acc_size; i++)
+        for (dim_t i = 0; i < acc_size; i++)
             wei_reduced[i] = ((float *)weights_reduce_base + weights_start)[i];
     }
 
@@ -973,11 +968,10 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             diff_bias = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
     }
 
-    const dim_t K = jcp.os * static_cast<size_t>(jcp.od);
-    const size_t src_step
-            = static_cast<size_t>(jcp.ic) * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = jcp.oc * K;
-    const size_t weights_g_size = jcp.oc;
+    const dim_t K = jcp.os * jcp.od;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * K;
+    const dim_t weights_g_size = jcp.oc;
 
     const dim_t k = jcp.os;
     const dim_t M = jcp.oc;
@@ -990,11 +984,14 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
 
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                ngroups_for_balance, mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
 
@@ -1005,8 +1002,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 + (ptrdiff_t)ithr * jcp.id * jcp.ic * jcp.is;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1020,7 +1017,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 constexpr uint16_t zero_val = 0;
 
                 PRAGMA_OMP_SIMD()
-                for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+                for (dim_t i = 0; i < jcp.im2col_sz; i++)
                     _col_r[i] = zero_val;
             }
 
@@ -1031,7 +1028,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
 
             const bool use_diff_wei
                     = ithr_mb == 0 && diff_wei_data_type == data_type::f32;
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 acc_data_t *_diff_weights = use_diff_wei
                         ? (acc_data_t *)diff_weights + g * weights_g_size
                         : need_reduction ? weights_reduce
@@ -1039,7 +1036,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                 const dim_t LDC = use_diff_wei ? jcp.ngroups * jcp.oc
                         : need_reduction       ? jcp.oc
                                                : jcp.ngroups * jcp.oc;
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const src_data_t *_src
                             = src + mb * jcp.ngroups * src_step + g * jcp.ic;
                     if (jcp.im2col_sz && is_problem_3d)
@@ -1097,19 +1094,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     if (jcp.need_wei_reduction && !dnnl_thr_syncable()) {
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
-            size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+            dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    ngroups_for_balance, mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
 
             if (need_reduction && ithr_g != -1 && ithr_mb != -1) {
-                balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-                balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+                balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+                balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
                 assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1181,9 +1180,9 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     }
 
     const dim_t K = jcp.os * jcp.od;
-    const size_t src_step = (size_t)jcp.ic * jcp.ih * jcp.iw * jcp.id;
-    const size_t dst_step = (size_t)jcp.oc * K;
-    const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
+    const dim_t src_step = jcp.ic * jcp.ih * jcp.iw * jcp.id;
+    const dim_t dst_step = jcp.oc * K;
+    const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
 
     const dim_t k = jcp.os_block;
     const dim_t N = jcp.oc;
@@ -1193,18 +1192,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     std::atomic<status_t> st(status::success);
     parallel(jcp.nthr, [&](const int ithr, const int nthr) {
         int ithr_g, nthr_g, ithr_mb, nthr_mb;
-        size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+        dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-        const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
-        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr, jcp.ngroups,
-                mb_for_balance, ithr_g, nthr_g, ithr_mb, nthr_mb);
+        const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+        const int mb_for_balance
+                = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
+        jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
+                ngroups_for_balance, mb_for_balance, ithr_g, nthr_g, ithr_mb,
+                nthr_mb);
 
         assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
         const int need_reduction = nthr_mb != 1;
 
         if (ithr_g != -1 && ithr_mb != -1) {
-            balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-            balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+            balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+            balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
             assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1213,7 +1215,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             // external data initialization by zeroes
             const bool outer_padding = jcp.os_nb_block == 1;
             if (outer_padding && is_problem_3d) {
-                for (ptrdiff_t i = 0; i < jcp.im2col_sz; i++)
+                for (dim_t i = 0; i < jcp.im2col_sz; i++)
                     _col[i] = (src_data_t)0;
             }
 
@@ -1222,11 +1224,11 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
             acc_data_t *weights_reduce
                     = weights_reduce_base + ithr_mb * weights_g_size;
 
-            for (size_t g = g_start; g < g_end; ++g) {
+            for (dim_t g = g_start; g < g_end; ++g) {
                 acc_data_t *acc = need_reduction
                         ? weights_reduce
                         : (acc_base + g * weights_g_size);
-                for (size_t mb = mb_start; mb < mb_end; ++mb) {
+                for (dim_t mb = mb_start; mb < mb_end; ++mb) {
                     const src_data_t *_src
                             = src + (mb * jcp.ngroups + g) * src_step;
                     for_(dim_t od = 0; od < jcp.od; ++od)
@@ -1278,8 +1280,8 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
                         weights_reduce_base, weights_base);
             } else if (diff_wei_data_type == data_type::bf16
                     && g_end > g_start) {
-                const size_t weights_g_size = (size_t)jcp.ic * jcp.oc * jcp.ks;
-                const size_t work_size = (g_end - g_start) * weights_g_size;
+                const dim_t weights_g_size = jcp.ic * jcp.oc * jcp.ks;
+                const dim_t work_size = (g_end - g_start) * weights_g_size;
                 bfloat16_t *diff_weights_local
                         = (bfloat16_t *)diff_weights + g_start * weights_g_size;
                 const float *acc_local
@@ -1297,19 +1299,21 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     if (jcp.need_wei_reduction && !dnnl_thr_syncable()) {
         parallel(jcp.nthr, [&](const int ithr, const int nthr) {
             int ithr_g, nthr_g, ithr_mb, nthr_mb;
-            size_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
+            dim_t g_start {0}, g_end {0}, mb_start {0}, mb_end {0};
 
-            const int mb_for_balance = jcp.need_wei_reduction ? jcp.mb : 1;
+            const int ngroups_for_balance = static_cast<int>(jcp.ngroups);
+            const int mb_for_balance
+                    = jcp.need_wei_reduction ? static_cast<int>(jcp.mb) : 1;
             jit_gemm_convolution_utils::bwd_weights_balance(ithr, nthr,
-                    jcp.ngroups, mb_for_balance, ithr_g, nthr_g, ithr_mb,
-                    nthr_mb);
+                    ngroups_for_balance, mb_for_balance, ithr_g, nthr_g,
+                    ithr_mb, nthr_mb);
 
             assert(IMPLICATION(!jcp.need_wei_reduction, nthr_mb == 1));
             const int need_reduction = nthr_mb != 1;
 
             if (need_reduction && ithr_g != -1 && ithr_mb != -1) {
-                balance211((size_t)jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
-                balance211((size_t)jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
+                balance211(jcp.ngroups, nthr_g, ithr_g, g_start, g_end);
+                balance211(jcp.mb, nthr_mb, ithr_mb, mb_start, mb_end);
 
                 assert(IMPLICATION((g_end - g_start) > 1, need_reduction == 0));
 
@@ -1325,7 +1329,7 @@ status_t gemm_bf16_convolution_bwd_weights_t<diff_wei_data_type>::
     }
 
     if (jcp.with_bias) {
-        parallel_nd(jcp.ngroups, jcp.oc, [&](size_t g, size_t oc) {
+        parallel_nd(jcp.ngroups, jcp.oc, [&](dim_t g, dim_t oc) {
             acc_data_t db = 0;
             dim_t offset_ = g * dst_step + oc * K;
             for (dim_t mb = 0; mb < jcp.mb; ++mb) {

--- a/src/cpu/x64/gemm_bf16_convolution.hpp
+++ b/src/cpu/x64/gemm_bf16_convolution.hpp
@@ -205,7 +205,7 @@ private:
         std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
                 postops_injector_;
 
-        void apply_postops(const bool apply_mask, const size_t out_offset,
+        void apply_postops(const bool apply_mask, const dim_t out_offset,
                 const int vmm_idx);
         void generate() override;
         int vreg_dst_idx(int iter) {
@@ -369,7 +369,7 @@ private:
             const conv_gemm_conf_t &jcp, const acc_data_t *weights_reduce_base,
             diff_wei_data_t *weights_base) const;
     void bf16_bwd_weights_reduction_par_nspc(int ithr_mb, int nthr_mb,
-            size_t g_start, size_t g_end, const conv_gemm_conf_t &jcp,
+            dim_t g_start, dim_t g_end, const conv_gemm_conf_t &jcp,
             const acc_data_t *weights_reduce_base,
             diff_wei_data_t *weights_base) const;
 

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -84,9 +84,9 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        const int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             if (i == num_substeps - 1) L(large_tail);
             generate_reduce_loop(load_loop_blk, jcp.ur);
             if (i < num_substeps - 1) {
@@ -234,24 +234,24 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
         return ptr[reg_bias_data + sizeof(float) * jcp.oc_block * i];
     };
 
-    auto bcast_ptr = [this](int u, int j) {
+    auto bcast_ptr = [this](dim_t u, int j) {
         assert(j < jcp.ur);
         assert(u <= jcp.reduce_loop_unroll);
-        const size_t offset = get_bcast_offset(jcp, u, j);
+        const size_t offset = get_bcast_offset(jcp, static_cast<int>(u), j);
         return make_safe_addr(aux_reg_bcast_data, offset, reg_long_offt);
     };
 
-    auto get_load_offset_bwd_w = [this](int u, int i) {
-        size_t u0 = u % jcp.reduce_loop_unroll;
-        size_t u1 = u / jcp.reduce_loop_unroll;
+    auto get_load_offset_bwd_w = [this](dim_t u, int i) {
+        const int u0 = static_cast<int>(u % jcp.reduce_loop_unroll);
+        const dim_t u1 = u / jcp.reduce_loop_unroll;
         return u1 * jcp.reduce_loop_load_step
                 + sizeof(float) * get_load_bwd_w_offset(jcp, i, u0);
     };
 
-    auto load_ptr = [this](int u, int i) {
+    auto load_ptr = [this](dim_t u, int i) {
         size_t offt;
-        size_t u0 = u % jcp.reduce_loop_unroll;
-        size_t u1 = u / jcp.reduce_loop_unroll;
+        const int u0 = static_cast<int>(u % jcp.reduce_loop_unroll);
+        const dim_t u1 = u / jcp.reduce_loop_unroll;
         switch (jcp.prop_kind) {
             case backward_data:
                 offt = (i * jcp.oc_block + u0) * jcp.ic_block;
@@ -311,7 +311,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                         L(load_bias_tail);
                         load_bytes(vreg_accum(load_loop_blk, i, j),
                                 reg_bias_data, i * jcp.oc_block * sizeof(float),
-                                load_dim_tail * sizeof(float));
+                                static_cast<int>(
+                                        load_dim_tail * sizeof(float)));
                         L(load_bias_done);
                     } else {
                         vmovups(vreg_accum(load_loop_blk, i, j), bias_ptr(i));
@@ -342,7 +343,7 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                 L(load_init_tail);
                 load_bytes(vreg_load(i), aux_reg_load_data,
                         get_load_offset_bwd_w(0, i),
-                        load_dim_tail * sizeof(float));
+                        static_cast<int>(load_dim_tail * sizeof(float)));
                 L(load_init_done);
             } else {
                 vmovups(vreg_load(i), load_ptr(0, i));
@@ -374,7 +375,7 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                     L(sum_tail);
                     load_bytes(vtmp, aux_reg_output_data,
                             get_output_offset(i, j),
-                            load_dim_tail * sizeof(float));
+                            static_cast<int>(load_dim_tail * sizeof(float)));
                     vaddps(r, r, vtmp);
                     L(sum_done);
                 } else {
@@ -426,7 +427,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                         }
                         store_bytes(vreg_accum(load_loop_blk, i, j),
                                 aux_reg_output_data, get_output_offset(i, j),
-                                load_dim_tail * sizeof(float));
+                                static_cast<int>(
+                                        load_dim_tail * sizeof(float)));
                     }
                     L(store_done);
                 } else {
@@ -467,7 +469,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_reduce_loop(
                             L(fma_load_tail);
                             load_bytes(vreg_load(i), aux_reg_load_data,
                                     get_load_offset_bwd_w(u + 1, i),
-                                    load_dim_tail * sizeof(float));
+                                    static_cast<int>(
+                                            load_dim_tail * sizeof(float)));
                             L(fma_load_done);
                         } else {
                             vmovups(vreg_load(i), load_ptr(u + 1, i));
@@ -558,7 +561,9 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate_diff_bias_loop(
 
     for (int i = 0; i < load_loop_blk; i++)
         vmovups(diff_bias_ptr(i), diff_bias_reg(i));
-    add(reg_diff_bias_data, load_loop_blk * jcp.oc_block * sizeof(float));
+    add(reg_diff_bias_data,
+            static_cast<uint32_t>(
+                    load_loop_blk * jcp.oc_block * sizeof(float)));
     mov(ptr[rsp + reg_diff_bias_data_stack_offt], reg_diff_bias_data);
 
     L(diff_bias_loop_out);
@@ -599,7 +604,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate() {
 
     auto generate_load_loop_body = [&](int load_loop_blk) {
         generate_bcast_loop(load_loop_blk);
-        add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
+        add(reg_load_data,
+                static_cast<uint32_t>(load_loop_blk * jcp.load_loop_load_step));
         const size_t offst_with_dw_conv
                 = get_load_loop_output_fwd_offset(jcp, load_loop_blk);
         const size_t offst_wo_dw_conv
@@ -608,7 +614,8 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate() {
             case forward_training:
             case forward_inference:
                 add(reg_bias_data,
-                        load_loop_blk * jcp.oc_block * sizeof(float));
+                        static_cast<uint32_t>(
+                                load_loop_blk * jcp.oc_block * sizeof(float)));
                 safe_add(reg_output_data, offst_with_dw_conv, reg_long_offt);
                 if (jcp.with_binary && jcp.with_dw_conv) {
                     mov(aux_reg_load_data, ptr[rsp + reg_dw_binary_output_off]);
@@ -692,8 +699,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     if (!mayiuse(avx)) return status::unimplemented;
     jcp.isa = mayiuse(avx2) ? avx2 : avx;
 
-    // Big int (> INT_MAX) values are unsupported and jcp fields may overflow
-    // TODO: change data type of jcp fields to size_t
+    // Values larger than INT_MAX are unsupported at JIT/API boundaries.
     VDISPATCH_CONV_IC(!has_large_size(cd, src_d, weights_d, dst_d),
             VERBOSE_BAD_PARAM, "large size is not supported");
 
@@ -737,8 +743,8 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                             format_kind::undef, cd.diff_bias_desc.format_kind)
             != format_kind::undef;
 
-    jcp.os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
-    jcp.is = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw;
+    jcp.os = jcp.od * jcp.oh * jcp.ow;
+    jcp.is = jcp.id * jcp.ih * jcp.iw;
 
     jcp.typesize_in = sizeof(prec_traits_t<data_type::f32>::type);
     jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
@@ -837,14 +843,15 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.ic_block = jcp.oc_block = simd_w;
 
     jcp.ur = jcp.isa == avx2 ? 4 : 3; // Intel AVX support
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
-    int load_blocking {0};
-    int load_blocking_max {0};
-    int bcast_blocking {0};
-    int bcast_blocking_max {0};
-    int reduce_blocking {0};
-    int reduce_blocking_max {0};
+    dim_t load_blocking {0};
+    dim_t load_blocking_max {0};
+    dim_t bcast_blocking {0};
+    dim_t bcast_blocking_max {0};
+    dim_t reduce_blocking {0};
+    dim_t reduce_blocking_max {0};
 
     if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
         jcp.reduce_dim = jcp.ic;
@@ -965,7 +972,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                 !is_data_layout_nxc, jcp.load_dim % load_blocking == 0));
 
         bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
-        const int bcast_blocking_lim = is_data_layout_nxc ? 17 : 9;
+        const dim_t bcast_blocking_lim = is_data_layout_nxc ? 17 : 9;
         const bool no_bcast_tail = jcp.bcast_dim % jcp.bcast_block == 0;
         const bool small_size_for_bcast
                 = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw <= 1024;
@@ -990,7 +997,7 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                 !is_data_layout_nxc, jcp.bcast_dim % bcast_blocking == 0));
 
         reduce_blocking = is_data_layout_nxc
-                ? rnd_up(nstl::min(jcp.ow, 128), jcp.reduce_block)
+                ? rnd_up(nstl::min<dim_t>(jcp.ow, 128), jcp.reduce_block)
                 : 128; // affects L1$ utilization
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
     } else
@@ -1003,7 +1010,8 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     assert(reduce_blocking);
 
     assert(jcp.bcast_block % jcp.ur == 0);
-    jcp.ur_tail = (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.bcast_block;
+    jcp.ur_tail = static_cast<int>(
+            (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) % jcp.bcast_block);
 
     jcp.nb_bcast_blocking = bcast_blocking / jcp.bcast_block;
     jcp.nb_bcast_blocking_max = bcast_blocking_max / jcp.bcast_block;

--- a/src/cpu/x64/jit_avx2_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.cpp
@@ -52,7 +52,8 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -101,32 +102,33 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
     const int ndims = dst_d.ndims();
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     auto p = jit_1x1_conv_args_t();
     auto rp = rtus_driver_t<avx2>::call_params_t();
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
     // Begin: declare Variables needed for dw conv.
     data_t *pbuf;
     size_t row_offset;
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     auto jcp_dw = pd()->jcp_dw_;
     std::vector<data_t *> addrs;
     jit_generator_t *dw_jit_ker = nullptr;
@@ -136,23 +138,23 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     const bool is_dst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
 
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os = osb * os_block;
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         od = os / (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
@@ -165,7 +167,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         // binary postop injector may override zero-padded areas, so proper
         // output masking needs to be performed base on exact number of channels
@@ -174,12 +176,13 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 ocb * jcp.oc_block, oc, load_step * jcp.oc_block);
     };
 
-    auto ker_1x1 = [&](int ocb, int icb, int ocb_start, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1 = [&](dim_t ocb, dim_t icb, dim_t ocb_start, dim_t n, dim_t g,
+                           dim_t od, dim_t oh, dim_t ow, dim_t id, dim_t ih,
+                           dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
         p.output_data = jcp.with_dw_conv ? pbuf + (oh % jcp_dw->kh) * row_offset
                                          : &dst[dst_off];
         p.bias_data
@@ -196,7 +199,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
 
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
 
@@ -220,19 +223,20 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
-        int iwork = bcast_start;
+        dim_t iwork = bcast_start;
         while (iwork < bcast_end) {
-            int n {0}, g {0}, bcast_step, od, oh, ow, id, ih, iw;
+            dim_t n {0}, g {0}, od, oh, ow, id, ih, iw;
+            dim_t bcast_step;
             init_bcast(
                     iwork, bcast_end, n, g, bcast_step, od, oh, ow, id, ih, iw);
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                     ker_1x1(ocb, icb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                 }
                 ocb += load_step;
@@ -241,41 +245,42 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw->kh) * row_offset;
 
         const ptrdiff_t wch_stride
                 = static_cast<ptrdiff_t>(is_src_layout_nxc ? 1 : jcp_dw->iw)
                 * jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         const auto ocb_end = ocb_start + load_step;
-        const int dil_h = jcp_dw->dilate_h + 1;
-        const int str_h = jcp_dw->stride_h;
-        const int ch_num = jcp_dw->nb_ch_blocking;
-        const int ow = 0;
-        const int kw = 0;
+        const dim_t dil_h = jcp_dw->dilate_h + 1;
+        const dim_t str_h = jcp_dw->stride_h;
+        const dim_t ch_num = jcp_dw->nb_ch_blocking;
+        const dim_t ow = 0;
+        const dim_t kw = 0;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw->t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw->ih,
-                              (int)(dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
-                                      - jcp_dw->t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw->t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw->ih,
+                              dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
+                                      - jcp_dw->t_pad + 1)
                     - jcp_dw->ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw->ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -287,9 +292,10 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw->ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw->nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw->nb_ch) - ch)
                     * jcp_dw->ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -298,7 +304,7 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
             (*dw_jit_ker)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += wch_stride;
         }
     };
@@ -318,33 +324,34 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, 1);
+                bcast_end, nb_oc, ocb_start, ocb_end, dim_t {1});
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -360,8 +367,8 @@ void jit_avx2_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
         balance211(work_amount, nthr, ithr, start, end);
         conv_1x1(start, end, 0, jcp.nb_load);
     }
@@ -388,18 +395,18 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
     assert(jcp.stride_w == 1 && jcp.stride_h == 1 && jcp.stride_d == 1);
     const int ndims = diff_dst_d.ndims();
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -408,11 +415,11 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
         auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx2>::call_params_t();
 
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int load_step = 0;
-        for (int icb = 0; icb < jcp.nb_load; icb += load_step) {
+        dim_t load_step = 0;
+        for (dim_t icb = 0; icb < jcp.nb_load; icb += load_step) {
             load_step = step(jcp.nb_load_blocking, jcp.nb_load - icb,
                     jcp.nb_load_blocking_max);
 
@@ -420,9 +427,9 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                     icb * jcp.ic_block, jcp.ic, load_step * jcp.ic_block);
             rp.icb = p.load_dim;
 
-            int bcast_step;
-            for (int iwork = start; iwork < end; iwork += bcast_step) {
-                int n {0}, g {0}, osb {0};
+            dim_t bcast_step;
+            for (dim_t iwork = start; iwork < end; iwork += bcast_step) {
+                dim_t n {0}, g {0}, osb {0};
                 nd_iterator_init(
                         iwork, n, jcp.mb, g, jcp.ngroups, osb, jcp.nb_bcast);
 
@@ -430,23 +437,23 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                         jcp.nb_bcast_blocking_max);
                 bcast_step = nstl::min(bcast_step, end - iwork);
 
-                const int os = osb * os_block;
+                const dim_t os = osb * os_block;
                 p.bcast_dim
                         = this_block_size(os, jcp.os, bcast_step * os_block);
                 rp.os = p.bcast_dim;
 
-                const int od = os / (jcp.oh * jcp.ow);
-                const int os_2d = os % (jcp.oh * jcp.ow);
-                const int oh = os_2d / jcp.ow;
-                const int ow = os_2d % jcp.ow;
-                const int id = od * stride_d;
-                const int ih = oh * stride_h;
-                const int iw = ow * stride_w;
+                const dim_t od = os / (jcp.oh * jcp.ow);
+                const dim_t os_2d = os % (jcp.oh * jcp.ow);
+                const dim_t oh = os_2d / jcp.ow;
+                const dim_t ow = os_2d % jcp.ow;
+                const dim_t id = od * stride_d;
+                const dim_t ih = oh * stride_h;
+                const dim_t iw = ow * stride_w;
                 rp.iw_start = iw;
 
                 const bool is_dsrc_layout_nxc = utils::one_of(jcp.src_tag,
                         format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g * nb_ic + icb;
                 rp.src = diff_src
@@ -457,15 +464,15 @@ void jit_avx2_1x1_convolution_bwd_data_t::execute_backward_data(
                 } else
                     p.output_data = rp.src;
 
-                for (int ocb = 0; ocb < jcp.nb_reduce;
+                for (dim_t ocb = 0; ocb < jcp.nb_reduce;
                         ocb += jcp.nb_reduce_blocking) {
                     const bool is_ddst_layout_nxc
                             = utils::one_of(jcp.dst_tag, format_tag::nwc,
                                     format_tag::nhwc, format_tag::ndhwc);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g * jcp.oc + ocb * jcp.oc_block
                             : g * nb_oc + ocb;
-                    size_t diff_dst_off = data_blk_off(
+                    dim_t diff_dst_off = data_blk_off(
                             diff_dst_d, n, oc_off_idx, od, oh, ow);
                     p.bcast_data = &diff_dst[diff_dst_off];
 
@@ -553,33 +560,33 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic = jcp.nb_bcast;
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
-    const int bcast_work = div_up(nb_ic, nb_ic_blocking);
+    const dim_t nb_ic = jcp.nb_bcast;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t bcast_work = div_up(nb_ic, nb_ic_blocking);
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
-    const int load_work = div_up(nb_oc, nb_oc_blocking);
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t load_work = div_up(nb_oc, nb_oc_blocking);
 
-    const int sp_dim = jcp.reduce_dim;
-    const int mb_sp_work = jcp.mb * sp_dim;
+    const dim_t sp_dim = jcp.reduce_dim;
+    const dim_t mb_sp_work = jcp.mb * sp_dim;
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     const bool is_src_layout_nxc = utils::one_of(
             jcp.src_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
     const bool is_ddst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
     auto oc_ic_sp_loop
-            = [= COMPAT_THIS_CAPTURE](int sp_start, int sp_end,
+            = [= COMPAT_THIS_CAPTURE](dim_t sp_start, dim_t sp_end,
                       bool first_image, data_t *store_to, size_t store_to_ld,
                       const data_t *diff_dst, const data_t *src, int ithr) {
         auto p = jit_1x1_conv_args_t();
@@ -587,15 +594,15 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
         p.output_stride = store_to_ld * sizeof(float);
 
-        int oc_b_step = 0;
-        for (int oc_b = 0; oc_b < nb_oc_blocking; oc_b += oc_b_step) {
+        dim_t oc_b_step = 0;
+        for (dim_t oc_b = 0; oc_b < nb_oc_blocking; oc_b += oc_b_step) {
             oc_b_step = step(nb_oc_blocking, nb_oc_blocking - oc_b,
                     jcp.nb_load_blocking_max);
             p.load_dim = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, oc_b_step * jcp.oc_block);
 
-            int ic_b_step = 0;
-            for (int ic_b = 0; ic_b < nb_ic_blocking; ic_b += ic_b_step) {
+            dim_t ic_b_step = 0;
+            for (dim_t ic_b = 0; ic_b < nb_ic_blocking; ic_b += ic_b_step) {
                 ic_b_step = step(nb_ic_blocking, nb_ic_blocking - ic_b,
                         jcp.nb_bcast_blocking_max);
                 p.bcast_dim = this_block_size(
@@ -606,8 +613,8 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                         + ic_b * jcp.ic_block * jcp.oc_block;
 
                 /* spatial reduction */
-                int sp_step = 0;
-                for (int sp = sp_start; sp < sp_end; sp += sp_step) {
+                dim_t sp_step = 0;
+                for (dim_t sp = sp_start; sp < sp_end; sp += sp_step) {
                     sp_step = step(jcp.nb_reduce_blocking, sp_end - sp,
                             jcp.nb_reduce_blocking_max);
                     p.reduce_dim = sp_step * jcp.reduce_block;
@@ -623,14 +630,14 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                                           : jcp.oc_block);
 
                     if (pd()->rtus_.reduce_src_) {
-                        const int od = sp / (jcp.oh * jcp.ow);
-                        const int sp_2d = sp % (jcp.oh * jcp.ow);
-                        const int oh = sp_2d / jcp.ow;
-                        const int ow = sp_2d % jcp.ow;
+                        const dim_t od = sp / (jcp.oh * jcp.ow);
+                        const dim_t sp_2d = sp % (jcp.oh * jcp.ow);
+                        const dim_t oh = sp_2d / jcp.ow;
+                        const dim_t ow = sp_2d % jcp.ow;
 
-                        const int id = od * stride_d;
-                        const int ih = oh * stride_h;
-                        const int iw = ow * stride_w;
+                        const dim_t id = od * stride_d;
+                        const dim_t ih = oh * stride_h;
+                        const dim_t iw = ow * stride_w;
                         rp.iw_start = iw;
 
                         rp.ws = rtus_space
@@ -662,23 +669,24 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
     };
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (is_ddst_layout_nxc && ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = nb_ic - 1;
-                const size_t off = pd()->with_groups()
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for_(dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb)
+            {
+                const dim_t z_icb = nb_ic - 1;
+                const dim_t off = pd()->with_groups()
                         ? diff_weights_d.blk_off(g, z_ocb, z_icb)
                         : diff_weights_d.blk_off(z_ocb, z_icb);
                 data_t *z_wei = diff_weights + off + ic_tail * jcp.oc_block;
-                const int zero_work
+                const dim_t zero_work
                         = (nb_ic * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -693,26 +701,26 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
         /* setup: independent work (oc, ic) */
         const int w_job_start = rw->balancer().ithr_job_off(ithr);
-        int g {0}, load_i {0}, bcast_i {0};
+        dim_t g {0}, load_i {0}, bcast_i {0};
         nd_iterator_init(w_job_start, g, jcp.ngroups, load_i, load_work,
                 bcast_i, bcast_work);
 
         /* setup: reduction work (mb, sp) */
-        int mb_sp_start {0}, mb_sp_end {0};
+        dim_t mb_sp_start {0}, mb_sp_end {0};
         balance211(mb_sp_work, rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), mb_sp_start, mb_sp_end);
-        int img_start {0}, sp_start {0};
+        dim_t img_start {0}, sp_start {0};
         nd_iterator_init(mb_sp_start, img_start, jcp.mb, sp_start, sp_dim);
 
         /* independent work */
         for (int iwork = 0; iwork < w_njobs; ++iwork) {
-            const int oc_b = nb_oc_blocking * load_i;
-            const int ic_b = nb_ic_blocking * bcast_i;
+            const dim_t oc_b = nb_oc_blocking * load_i;
+            const dim_t ic_b = nb_ic_blocking * bcast_i;
 
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * nb_oc + oc_b;
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * nb_ic + ic_b;
 
@@ -726,17 +734,19 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 store_to = &diff_weights[off];
                 store_to_ld = rnd_up(jcp.ic, jcp.ic_block) * jcp.oc_block;
             } else {
-                const size_t off = (size_t)iwork * rw->balancer().job_size_;
+                const dim_t off
+                        = static_cast<dim_t>(iwork) * rw->balancer().job_size_;
                 store_to
                         = rw->get_local_ptr(ithr, reducer_wei_scratchpad) + off;
                 store_to_ld = nb_ic_blocking * jcp.ic_block * jcp.oc_block;
             }
 
             /* reduction work */
-            int img = img_start;
-            int sp = sp_start;
-            int sp_step = 0;
-            for (int mb_sp = mb_sp_start; mb_sp < mb_sp_end; mb_sp += sp_step) {
+            dim_t img = img_start;
+            dim_t sp = sp_start;
+            dim_t sp_step = 0;
+            for (dim_t mb_sp = mb_sp_start; mb_sp < mb_sp_end;
+                    mb_sp += sp_step) {
                 sp_step = nstl::min(sp_dim - sp, mb_sp_end - mb_sp);
 
                 const bool first_image = img == img_start;
@@ -780,18 +790,18 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        int img_start {0}, img_end {0};
+        dim_t img_start {0}, img_end {0};
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */
-        int g_start {0}, ocb_start {0};
+        dim_t g_start {0}, ocb_start {0};
         nd_iterator_init(b_job_start, g_start, jcp.ngroups, ocb_start, nb_oc);
 
-        for (int img = img_start; img < img_end; ++img) {
-            int g = g_start, ocb = ocb_start;
+        for (dim_t img = img_start; img < img_end; ++img) {
+            dim_t g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g * nb_oc + ocb;
 
@@ -805,13 +815,13 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
                     for (int o = 0; o < 8; ++o)
                         d_bias[o] = 0.;
 
-                const int spatial_shift
+                const dim_t spatial_shift
                         = is_ddst_layout_nxc ? jcp.oc : jcp.oc_block;
-                const int max_oc = this_block_size(
+                const dim_t max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
                 for (dim_t hw = 0; hw < jcp.os; ++hw) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += spatial_shift;
                 }
@@ -857,9 +867,9 @@ void jit_avx2_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* TODO: put this in ker_bias */
         if (is_bias_padded) {
             assert(IMPLICATION(!is_ddst_layout_nxc, jcp.ngroups == 1));
-            const int padded_stride = utils::rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = utils::rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx2_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_1x1_convolution.hpp
@@ -278,8 +278,8 @@ struct jit_avx2_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw->nb_ch_blocking != 0)
                 --jcp_dw->nb_ch_blocking;
 
-            jcp_dw->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
 
             const auto dat_tag_nxc = utils::pick(ndims() - 3, format_tag::nwc,
                     format_tag::nhwc, format_tag::ndhwc);
@@ -553,34 +553,41 @@ struct jit_avx2_1x1_convolution_bwd_weights_t : public primitive_t {
 
     private:
         void init_balancers() {
-            const int ic_block = jcp_.bcast_block;
-            const int nb_ic = jcp_.nb_bcast;
-            const int nb_ic_blocking = jcp_.nb_bcast_blocking;
-            const int bcast_work = utils::div_up(nb_ic, nb_ic_blocking);
+            const dim_t ic_block = jcp_.bcast_block;
+            const dim_t nb_ic = jcp_.nb_bcast;
+            const dim_t nb_ic_blocking = jcp_.nb_bcast_blocking;
+            const dim_t bcast_work = utils::div_up(nb_ic, nb_ic_blocking);
 
-            const int oc_block = jcp_.load_block;
-            const int nb_oc = jcp_.nb_load;
-            const int nb_oc_blocking = jcp_.nb_load_blocking;
-            const int load_work = utils::div_up(nb_oc, nb_oc_blocking);
+            const dim_t oc_block = jcp_.load_block;
+            const dim_t nb_oc = jcp_.nb_load;
+            const dim_t nb_oc_blocking = jcp_.nb_load_blocking;
+            const dim_t load_work = utils::div_up(nb_oc, nb_oc_blocking);
 
-            const int job_size
+            const dim_t job_size
                     = nb_oc_blocking * nb_ic_blocking * ic_block * oc_block;
-            const int njobs_x = bcast_work;
-            const int njobs_y = jcp_.ngroups * load_work;
+            const dim_t njobs_x = bcast_work;
+            const dim_t njobs_y = jcp_.ngroups * load_work;
 
             const int max_threads = dnnl_get_max_threads();
             const size_t max_buffer_size = (size_t)max_threads * job_size * 8;
 
             if (with_bias()) {
-                reducer_bia_conf_.init(reduce_balancer_t(max_threads, oc_block,
-                        jcp_.ngroups * nb_oc, jcp_.mb, max_buffer_size, true));
+                reducer_bia_conf_.init(reduce_balancer_t(max_threads,
+                        static_cast<int>(oc_block),
+                        static_cast<int>(jcp_.ngroups * nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
 
             reducer_wei_conf_.init(
-                    reduce_balancer_t(max_threads, job_size, njobs_y * njobs_x,
-                            jcp_.mb * jcp_.nb_reduce, max_buffer_size, true),
-                    job_size / nb_oc_blocking, nb_oc_blocking, ic_block,
-                    nb_ic * ic_block * oc_block, nb_oc);
+                    reduce_balancer_t(max_threads, static_cast<int>(job_size),
+                            static_cast<int>(njobs_y * njobs_x),
+                            static_cast<int>(jcp_.mb * jcp_.nb_reduce),
+                            max_buffer_size, true),
+                    static_cast<int>(job_size / nb_oc_blocking),
+                    static_cast<int>(nb_oc_blocking),
+                    static_cast<int>(ic_block),
+                    static_cast<int>(nb_ic * ic_block * oc_block),
+                    static_cast<int>(nb_oc));
         }
     };
 

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.cpp
@@ -78,18 +78,19 @@ jit_avx2_conv_fwd_kernel_f32_t::jit_avx2_conv_fwd_kernel_f32_t(
 
 void jit_avx2_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int dilate_w = jcp.dilate_w + 1;
-    int ic_block = jcp.ic_block;
+    const int kw = static_cast<int>(jcp.kw);
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    int ic_block = static_cast<int>(jcp.ic_block);
     int ic_tail = jcp.ic_tail;
 
     for (int ki = 0; ki < kw; ki++) {
-        int jj_start = div_up(nstl::max(0, pad_l - ki * dilate_w), stride_w);
-        int jj_end = ur_w
-                - div_up(nstl::max(0,
+        int jj_start = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, pad_l - ki * dilate_w), stride_w));
+        int jj_end = static_cast<int>(ur_w
+                - div_up(nstl::max<dim_t>(0,
                                  ki * dilate_w + pad_r - (kw - 1) * dilate_w),
-                        stride_w);
+                        stride_w));
 
         auto compute = [&](int cur_ic_blk) {
             for (int ifm2 = 0; ifm2 < cur_ic_blk; ifm2++) {
@@ -145,8 +146,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::oh_step_nopad(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     Label kw_loop;
 
-    int kw = jcp.kw;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    int ic_blk = static_cast<int>(jcp.ic_block);
 
     xor_(ki_iter, ki_iter);
     L(kw_loop);
@@ -259,8 +260,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::apply_postops(
 
 void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int oc_blk = jcp.oc_block;
+    const int kw = static_cast<int>(jcp.kw);
+    int oc_blk = static_cast<int>(jcp.oc_block);
     int oc_tail = jcp.oc_tail;
 
     if (oc_tail) {
@@ -413,7 +414,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
     if (jcp.ndims == 5) {
         safe_add(aux_reg_inp_d, get_input_offset(0, filter_d_to_input(1)),
                 reg_long_offt);
-        safe_add(aux_reg_ker_d, get_kernel_offset(0, jcp.kw * jcp.kh, 0),
+        safe_add(aux_reg_ker_d,
+                get_kernel_offset(0, static_cast<int>(jcp.kw * jcp.kh), 0),
                 reg_long_offt);
 
         dec(reg_ki);
@@ -468,7 +470,8 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
     } else {
         Label regular_store;
         Label store_done;
-        const int tail = jcp.oc_without_padding % jcp.oc_block;
+        const int tail
+                = static_cast<int>(jcp.oc_without_padding % jcp.oc_block);
         if (jcp.with_binary && tail) {
             test(reg_ci_flag, FLAG_IC_LAST);
             je(regular_store, T_NEAR);
@@ -491,24 +494,28 @@ void jit_avx2_conv_fwd_kernel_f32_t::width_blk_step(
 inline void jit_avx2_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int n_oi = jcp.ow / ur_w;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int str_w = jcp.stride_w;
+    int n_oi = static_cast<int>(jcp.ow / ur_w);
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t str_w = jcp.stride_w;
 
-    int l_pad = jcp.l_pad;
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, str_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    const dim_t l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            str_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
     if (r_pad1 > 0) n_oi--;
 
     if (l_pad > 0) {
         n_oi--;
         if (n_oi < 0 && r_pad1 > 0)
-            width_blk_step(ur_w, l_pad, r_pad1, oc_blocks); // "lrpad"
+            width_blk_step(ur_w, static_cast<int>(l_pad), r_pad1,
+                    oc_blocks); // "lrpad"
         else
-            width_blk_step(ur_w, l_pad, 0, oc_blocks); // "lpad"
-        add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
+            width_blk_step(ur_w, static_cast<int>(l_pad), 0,
+                    oc_blocks); // "lpad"
+        add(reg_input,
+                get_input_offset(0,
+                        filter_w_to_input(0, ur_w, static_cast<int>(l_pad))));
         add(reg_output, get_output_offset(0, ur_w));
     }
 
@@ -632,9 +639,9 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -661,8 +668,10 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag_OIxio, wei_tag_Oxio);
     jcp.dst_tag = dst_d.mb_stride_relaxed_match(dat_tag_nxc, dat_tag_nCx8c);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     bool is_data_layout_nxc
             = everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
@@ -692,8 +701,9 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     /* Grouped channel offset to support 'non-blocked data' format for
      * convolution sizes with '(input_channel / ngroups) < simd' */
     jcp.nonblk_group_off
-            = one_of(jcp.src_tag, ncw, nchw, ncdhw) && jcp.ngroups > 1 ? jcp.ic
-                                                                       : 1;
+            = one_of(jcp.src_tag, ncw, nchw, ncdhw) && jcp.ngroups > 1
+            ? static_cast<int>(jcp.ic)
+            : 1;
 
     bool ok_to_pad_channels = true && !is_data_layout_nxc && jcp.ngroups == 1;
 
@@ -726,7 +736,7 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(flat,
                     jcp.wei_tag == wei_tag_Oxio
                             && ((tag_is_flat(jcp.src_tag, dat_tag_ncx,
-                                         dat_tag_nxc, jcp.ic)
+                                         dat_tag_nxc, static_cast<int>(jcp.ic))
                                         && jcp.dst_tag == dat_tag_nCx8c)
                                     || (jcp.src_tag == dat_tag_nxc
                                             && jcp.dst_tag == dat_tag_nxc)))
@@ -776,7 +786,7 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
         }
     }
 
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     VDISPATCH_CONV_IC(IMPLICATION(!is_data_layout_nxc, jcp.oc % simd_w == 0),
@@ -797,20 +807,22 @@ status_t jit_avx2_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             : (jcp.with_binary ? jcp.oc_without_padding % simd_w : 0);
 
     int r_pad_no_tail = nstl::max(0,
-            calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+            static_cast<int>(calculate_end_padding(jcp.l_pad,
+                    jcp.ow - jcp.ur_w_tail, jcp.iw, jcp.stride_w, ext_kw)));
 
     if (r_pad_no_tail > jcp.ur_w * jcp.stride_w && jcp.ow / jcp.ur_w > 1) {
         /* recalculate ur_w, nb_oc_blocking and ur_w_tail */
-        jcp.ur_w = nstl::min(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
-                nstl::min(jcp.ow, num_avail_regs / 2));
+        jcp.ur_w = static_cast<int>(
+                nstl::min<dim_t>(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
+                        nstl::min<dim_t>(jcp.ow, num_avail_regs / 2)));
         jcp.nb_oc_blocking = (num_avail_regs - jcp.ur_w) / jcp.ur_w;
         jcp.ur_w_tail = jcp.ow % jcp.ur_w;
         /* check again ... */
         r_pad_no_tail = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                        jcp.stride_w, ext_kw));
-        VDISPATCH_CONV_IC((jcp.ur_w >= nstl::max(jcp.l_pad, r_pad_no_tail)),
+                static_cast<int>(calculate_end_padding(jcp.l_pad,
+                        jcp.ow - jcp.ur_w_tail, jcp.iw, jcp.stride_w, ext_kw)));
+        VDISPATCH_CONV_IC(
+                (jcp.ur_w >= nstl::max<dim_t>(jcp.l_pad, r_pad_no_tail)),
                 VERBOSE_UNSUPPORTED_PAD_FEATURE,
                 "width unroll exceeds padding size");
     }
@@ -853,13 +865,13 @@ void jit_avx2_conv_fwd_kernel_f32_t::init_scratchpad(
 
 void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
         int ur_w, int l_overflow, int r_overflow) {
-    int kw = jcp.kw;
-    int ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t ow = jcp.ow;
 
-    int oc_block = jcp.oc_block;
+    int oc_block = static_cast<int>(jcp.oc_block);
     int nb_ic_block = jcp.nb_ic_blocking;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t stride_h = jcp.stride_h;
     int oc_tail = jcp.oc_tail;
     int ic_tail = jcp.ic_tail;
 
@@ -919,14 +931,18 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     L(kh_loop);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow); // 0;
-            int jj_end = get_iw_end(ur_w, ki, r_overflow); // ur_w;
+            const int jj_start
+                    = static_cast<int>(get_iw_start(ki, l_overflow)); // 0;
+            const int jj_end = static_cast<int>(
+                    get_iw_end(ur_w, ki, r_overflow)); // ur_w;
 
             auto compute = [&](int cur_oc_blk) {
                 for (int ofm2 = 0; ofm2 < cur_oc_blk; ofm2++) {
                     for (int jj = jj_start; jj < jj_end; jj += stride_w) {
-                        int aux_output_offset = get_ddst_offset(
-                                0, filter_w_to_ddst(ki, jj, jcp.l_pad), ofm2);
+                        dim_t aux_output_offset = get_ddst_offset(0,
+                                filter_w_to_ddst(
+                                        ki, jj, static_cast<int>(jcp.l_pad)),
+                                ofm2);
                         vbroadcastss(Ymm(nb_ic_block * ur_w + jj / stride_w),
                                 ptr[aux_reg_ddst + aux_output_offset]);
                     }
@@ -963,7 +979,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
             }
         }
 
-        add(aux_reg_kernel, get_kernel_offset(0, 0, stride_h * kw, 0));
+        add(aux_reg_kernel,
+                get_kernel_offset(0, 0, static_cast<int>(stride_h * kw), 0));
         sub(aux_reg_ddst, get_ddst_offset(0, (jcp.dilate_h + 1) * ow, 0));
 
         dec(kj);
@@ -975,7 +992,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     if (jcp.ndims == 5) {
         sub(aux_reg_dst_d,
                 get_ddst_offset(0, (jcp.dilate_d + 1) * jcp.oh * ow, 0));
-        add(aux_reg_ker_d, get_kernel_offset(0, 0, jcp.kw * jcp.kh, 0));
+        add(aux_reg_ker_d,
+                get_kernel_offset(0, 0, static_cast<int>(jcp.kw * jcp.kh), 0));
 
         dec(reg_ki);
         cmp(reg_ki, 0);
@@ -986,8 +1004,8 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::compute_loop(
     }
 
     if (one_of(jcp.ndims, 3, 4)) {
-        int ddst_oc_shift = get_ddst_offset(1, 0, 0);
-        int kernel_oc_shift = get_kernel_offset(1, 0, 0, 0);
+        dim_t ddst_oc_shift = get_ddst_offset(1, 0, 0);
+        dim_t kernel_oc_shift = get_kernel_offset(1, 0, 0, 0);
 
         add(aux_reg_ddst_oc_loop, ddst_oc_shift);
         add(aux_reg_kernel_oc_loop, kernel_oc_shift);
@@ -1063,18 +1081,20 @@ void jit_avx2_conv_bwd_data_kernel_f32_t::generate() {
     mov(reg_channel, ptr[param1 + GET_OFF(channel)]);
     mov(reg_channel_work, ptr[param1 + GET_OFF(ch_blocks)]);
 
-    int ddst_shift = get_ddst_offset(0, filter_w_to_ddst(0, jcp.ur_w), 0);
-    int dsrc_shift = get_dsrc_offset(0, jcp.ur_w);
+    dim_t ddst_shift = get_ddst_offset(0, filter_w_to_ddst(0, jcp.ur_w), 0);
+    dim_t dsrc_shift = get_dsrc_offset(0, jcp.ur_w);
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const int ext_kw = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
 
-    int l_overflow = nstl::max(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w);
-    int r_overflow = nstl::max(
-            0, (ext_kw - 1 - nstl::max(0, jcp.r_pad)) / jcp.stride_w);
-    int r_overflow1 = nstl::max(
-            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w));
+    int r_overflow = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - nstl::max<dim_t>(0, jcp.r_pad)) / jcp.stride_w));
+    int r_overflow1 = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w));
 
-    int n_oi = jcp.iw / jcp.ur_w;
+    int n_oi = static_cast<int>(jcp.iw / jcp.ur_w);
     if (r_overflow1 > 0) n_oi--;
 
     if (jcp.ur_w == jcp.iw) {
@@ -1194,8 +1214,10 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             = diff_dst_d.mb_stride_relaxed_match(dat_tag_nxc, dat_tag_nCx8c);
     jcp.wei_tag = weights_d.matches_one_of_tag(wei_tag);
 
-    jcp.typesize_in = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     bool is_data_layout_nxc
             = everyone_is(dat_tag_nxc, jcp.src_tag, jcp.dst_tag);
@@ -1245,9 +1267,9 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && jcp.src_tag == required_dat_tag && jcp.wei_tag == wei_tag;
     VDISPATCH_CONV_IC(tag_ok, VERBOSE_UNSUPPORTED_TAG);
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
@@ -1262,7 +1284,8 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!kernel_outside_src, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weights and src size mismatch");
 
-    int l_overflow = nstl::max(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, (ext_kw - 1 - jcp.l_pad) / jcp.stride_w));
 
     const int max_regs = 15; /* Maximum number of registers available for
                                 result accumulation and delta dst data.
@@ -1280,10 +1303,11 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     for (int b = 1; b <= 4; b++) {
         if (jcp.nb_ic % b != 0) continue;
 
-        for (int u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
+        for (int u = static_cast<int>(jcp.stride_w);
+                u * b + u / jcp.stride_w <= max_regs
                 && u < jcp.iw + jcp.stride_w;
                 u += jcp.stride_w) {
-            int ur_w = nstl::min(u, jcp.iw);
+            int ur_w = static_cast<int>(nstl::min<dim_t>(u, jcp.iw));
             /* maximum 1 step with l_overflow so far */
             if (l_overflow * jcp.stride_w > ur_w && ur_w != jcp.iw) continue;
             int nfmas = div_up(ur_w, jcp.stride_w) * b;
@@ -1300,8 +1324,8 @@ status_t jit_avx2_conv_bwd_data_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.ur_w_tail = jcp.iw % jcp.ur_w;
 
-    int r_overflow_no_tail = nstl::max(
-            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w);
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(
+            0, (ext_kw - 1 - jcp.r_pad - jcp.ur_w_tail) / jcp.stride_w));
 
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
@@ -1422,21 +1446,21 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
 
     const int simd_w = 8;
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
-    jcp.r_pad = nstl::max(0,
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
-    const int max_h_pad = ext_kh;
-    const int max_w_pad = ext_kw;
+    const dim_t max_h_pad = ext_kh;
+    const dim_t max_w_pad = ext_kw;
     const bool boundaries_ok = true && jcp.t_pad < max_h_pad
             && jcp.b_pad < max_h_pad && jcp.l_pad < max_w_pad
             && jcp.r_pad < max_w_pad && jcp.f_pad == 0 && jcp.back_pad == 0;
@@ -1457,7 +1481,7 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(flat,
                     jcp.wei_tag == wei_tag_Oxio
                             && ((tag_is_flat(jcp.src_tag, dat_tag_ncx,
-                                         dat_tag_nxc, jcp.ic)
+                                         dat_tag_nxc, static_cast<int>(jcp.ic))
                                         && jcp.dst_tag == dat_tag_nCx8c)
                                     || (jcp.src_tag == dat_tag_nxc
                                             && jcp.dst_tag == dat_tag_nxc)))
@@ -1488,8 +1512,10 @@ status_t jit_avx2_conv_bwd_weights_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
     jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     const bool is_src_layout_blocked = jcp.src_tag == dat_tag_nCx8c;
     const bool is_dst_layout_blocked = jcp.dst_tag == dat_tag_nCx8c;
@@ -1549,12 +1575,12 @@ jit_avx2_conv_bwd_weights_kernel_f32_t::oh_step_comeback_pointers() {
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset) {
 
     if (ic_block_step <= 0) return;
 
-    const int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     const int oc_tail = jcp.oc_tail;
 
     if (oc_tail) {
@@ -1585,7 +1611,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
                                 + output_offset]);
 
             for (int i_kw = 0; i_kw < kw; i_kw++) {
-                int i_iw = i_ur * jcp.stride_w + i_kw;
+                const dim_t i_iw = i_ur * jcp.stride_w + i_kw;
                 if (i_iw - pad_l < 0
                         || i_iw > (ur_w - 1) * jcp.stride_w + kw - 1 - pad_r)
                     continue;
@@ -1633,7 +1659,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
-    int ic_block_step;
+    dim_t ic_block_step;
     if (one_of(jcp.src_tag, ncw, nchw, ncdhw)) {
         ic_block_step = jcp.kw >= 5 ? 1 : jcp.ic_block;
     } else if (one_of(jcp.src_tag, nwc, nhwc, ndhwc)) {
@@ -1649,9 +1675,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_disp() {
     const int max_ur_w = jcp.ow > 56 ? 14 : 28;
 
     if (jcp.ow <= max_ur_w || one_of(jcp.src_tag, nwc, nhwc, ndhwc))
-        compute_oh_step_unroll_ow(ic_block_step, max_ur_w);
+        compute_oh_step_unroll_ow(static_cast<int>(ic_block_step), max_ur_w);
     else
-        compute_oh_step_common(ic_block_step, max_ur_w);
+        compute_oh_step_common(static_cast<int>(ic_block_step), max_ur_w);
 
     if (jcp.ndims == 5) {
         od_step_comeback_pointers();
@@ -1666,9 +1692,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         int ic_block_step, int max_ur_w) {
     UNUSED(max_ur_w);
 
-    const int r_pad = jcp.r_pad;
+    const dim_t r_pad = jcp.r_pad;
     const int ic_tail = jcp.ic_tail;
-    const int ic_block = jcp.ic_block;
+    const int ic_block = static_cast<int>(jcp.ic_block);
     const int ic_block_step_tail = jcp.ic % ic_block_step;
     const size_t inp_icblk_stride = get_input_offset(ic_block_step, 0);
 
@@ -1700,8 +1726,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         Label ic_block_loop;
         L(ic_block_loop);
         {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step, 0, 0, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
             add(reg_kernel, get_kernel_offset(0, ic_block_step));
             add(b_ic, ic_block_step);
@@ -1710,7 +1736,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         }
         add(reg_input,
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_block, 0));
-        add(reg_kernel, get_kernel_offset((jcp.kw - 1), 0));
+        add(reg_kernel, get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop, T_NEAR);
@@ -1727,8 +1753,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         mov(b_ic, ic_tail);
         L(ic_block_loop);
         {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step, 0, 0, 0);
             safe_add(reg_input, inp_icblk_stride, reg_long_offt);
             add(reg_kernel, get_kernel_offset(0, ic_block_step));
             sub(b_ic, ic_block_step);
@@ -1739,8 +1765,8 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
         L(ic_block_loop_done);
 
         if (ic_block_step_tail) {
-            compute_ic_block_step(
-                    jcp.ow, jcp.l_pad, r_pad, ic_block_step_tail, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(jcp.ow), jcp.l_pad, r_pad,
+                    ic_block_step_tail, 0, 0, 0);
             add(reg_input, get_input_offset(ic_block_step_tail, 0));
             add(reg_kernel, get_kernel_offset(0, ic_block_step_tail));
         }
@@ -1749,7 +1775,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_unroll_ow(
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_tail, 0));
         add(reg_kernel,
                 get_kernel_offset(0, ic_block - ic_tail)
-                        + get_kernel_offset((jcp.kw - 1), 0));
+                        + get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop_ic_tail, T_NEAR);
@@ -1771,14 +1797,14 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         int ic_block_step, int max_ur_w) {
     // TODO: suppport channel tails for nxc format
 
-    const int ic_block = jcp.ic_block;
-    const int stride_w = jcp.stride_w;
+    const int ic_block = static_cast<int>(jcp.ic_block);
+    const int stride_w = static_cast<int>(jcp.stride_w);
     Label kd_loop;
 
-    const int r_pad = jcp.r_pad;
+    const int r_pad = static_cast<int>(jcp.r_pad);
 
-    int ur_w = nstl::min(jcp.ow, max_ur_w);
-    int ur_w_trips = jcp.ow / ur_w;
+    int ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, max_ur_w));
+    int ur_w_trips = static_cast<int>(jcp.ow / ur_w);
     int ur_w_tail = jcp.ow % ur_w;
     if ((ur_w_tail == 0 && r_pad != 0) || r_pad >= ur_w_tail) {
         if (ur_w_trips > 1) {
@@ -1790,9 +1816,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         }
     }
 
-    int input_comeback
+    dim_t input_comeback
             = get_input_offset(0, ur_w_trips * ur_w * stride_w - jcp.l_pad);
-    int output_comeback = get_output_offset(0, ur_w_trips * ur_w);
+    dim_t output_comeback = get_output_offset(0, ur_w_trips * ur_w);
 
     if (jcp.ndims == 5) {
         mov(aux_reg_input, reg_input);
@@ -1852,7 +1878,7 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         }
         add(reg_input,
                 get_input_offset(0, jcp.iw) - get_input_offset(ic_block, 0));
-        add(reg_kernel, get_kernel_offset((jcp.kw - 1), 0));
+        add(reg_kernel, get_kernel_offset(jcp.kw - 1, 0));
         dec(kj);
         cmp(kj, 0);
         jg(kh_loop, T_NEAR);
@@ -1868,9 +1894,9 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 }
 
 inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
-    const int t_pad = jcp.t_pad;
-    const int stride_h = jcp.stride_h;
-    int b_pad = jcp.b_pad;
+    const dim_t t_pad = jcp.t_pad;
+    const dim_t stride_h = jcp.stride_h;
+    dim_t b_pad = jcp.b_pad;
 
     Label oh_tpad_loop, oh_loop, oh_loop_end;
 
@@ -1894,13 +1920,13 @@ inline void jit_avx2_conv_bwd_weights_kernel_f32_t::compute_oh_loop_common() {
 
             /* the overlap between input and kernel may not reach kernel size.
              * so far we do not support that (until we put constant here) */
-            const int final_inp_ker_overlap = jcp.kh; /* [bwd_w:r2] */
+            const dim_t final_inp_ker_overlap = jcp.kh; /* [bwd_w:r2] */
             cmp(reg_kh, final_inp_ker_overlap);
             jl(oh_tpad_loop, T_NEAR);
         }
 
         if (t_pad % stride_h != 0) {
-            int inp_corr = stride_h - t_pad % stride_h;
+            const dim_t inp_corr = stride_h - t_pad % stride_h;
             add(reg_kernel, get_kernel_offset(inp_corr * jcp.kw, 0));
             add(reg_input, get_input_offset(0, inp_corr * jcp.iw));
         }

--- a/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_avx2_conv_kernel_f32.hpp
@@ -98,16 +98,16 @@ private:
         return static_cast<dim_t>(ki) * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
     }
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(int i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
             offset = static_cast<dim_t>(i_ic) * jcp.id * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
@@ -190,8 +190,8 @@ private:
 
     void generate() override;
 
-    inline int get_iw_start(int ki, int l_overflow) const {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    inline dim_t get_iw_start(dim_t ki, dim_t l_overflow) const {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -200,10 +200,10 @@ private:
         return res;
     }
 
-    inline int get_iw_end(int ur_w, int ki, int r_overflow) const {
+    inline dim_t get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) const {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
@@ -215,12 +215,12 @@ private:
         return (oi + pad_l - ki * (jcp.dilate_w + 1)) / jcp.stride_w;
     }
 
-    inline dim_t get_ddst_offset(int i_oc_block, int i_ow, int i_oc) const {
+    inline dim_t get_ddst_offset(int i_oc_block, dim_t i_ow, int i_oc) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block + i_oc;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block
+                    + i_oc;
         } else {
             offset = static_cast<dim_t>(i_oc_block) * jcp.od * jcp.oh * jcp.ow
                             * jcp.oc_block
@@ -293,46 +293,43 @@ private:
 
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset);
     inline void compute_oh_step_disp();
     inline void compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w);
     inline void compute_oh_step_common(int ic_block_step, int max_ur_w);
     inline void compute_oh_loop_common();
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(int i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
             offset = static_cast<dim_t>(i_ic) * jcp.id * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_output_offset(int i_oc_block, int i_ow) const {
+    inline dim_t get_output_offset(dim_t i_oc_block, dim_t i_ow) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block;
         } else {
-            offset = static_cast<dim_t>(i_oc_block) * jcp.od * jcp.oh * jcp.ow
-                            * jcp.oc_block
+            offset = i_oc_block * jcp.od * jcp.oh * jcp.ow * jcp.oc_block
                     + i_ow * jcp.oc_block;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_kernel_offset(int ki, int i_ic) const {
+    inline dim_t get_kernel_offset(dim_t ki, dim_t i_ic) const {
         dim_t block_step_size = static_cast<dim_t>(jcp.ic_block) * jcp.oc_block;
-        dim_t offset = static_cast<dim_t>(ki) * block_step_size
-                + i_ic * jcp.oc_block;
+        dim_t offset = ki * block_step_size + i_ic * jcp.oc_block;
         return sizeof(float) * offset;
     }
     void generate() override;

--- a/src/cpu/x64/jit_avx2_convolution.cpp
+++ b/src/cpu/x64/jit_avx2_convolution.cpp
@@ -57,9 +57,8 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper weights_d(pd()->weights_md(0));
     const memory_desc_wrapper bias_d(pd()->weights_md(1));
 
-    const size_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
-    const size_t work_amount
-            = jcp.mb * jcp.ngroups * ocb_work * jcp.od * jcp.oh;
+    const dim_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
+    const dim_t work_amount = jcp.mb * jcp.ngroups * ocb_work * jcp.od * jcp.oh;
 
     // Lambda captures by copy, the bias logic must stay afront the lambda,
     // otherwise, `bias` will be captured unmodified and lead to a crash inside
@@ -74,61 +73,63 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     }
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
                 format_tag::nChw8c, format_tag::nCdhw8c);
-        int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-        int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+        dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+        dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
         bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
                 format_tag::nChw8c, format_tag::nCdhw8c);
-        int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-        int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
-        int oc_bias_scale = is_oc_physically_blocked ? jcp.oc_block : 1;
+        dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+        dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+        dim_t oc_bias_scale = is_oc_physically_blocked ? jcp.oc_block : 1;
 
-        int icbb = 0;
+        dim_t icbb = 0;
         while (icbb < jcp.nb_ic) {
-            int icb_step = jcp.nb_ic_blocking;
-            int icb_step_rem = jcp.nb_ic - icbb;
+            dim_t icb_step = jcp.nb_ic_blocking;
+            dim_t icb_step_rem = jcp.nb_ic - icbb;
             if (icb_step_rem < jcp.nb_ic_blocking_max) icb_step = icb_step_rem;
 
-            size_t n {0}, g {0}, ocbb {0}, oh {0}, od {0};
+            dim_t n {0}, g {0}, ocbb {0}, oh {0}, od {0};
             nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
                     od, jcp.od, oh, jcp.oh);
-            for (size_t iwork = start; iwork < end; ++iwork) {
-                int ocb = ocbb * jcp.nb_oc_blocking;
-                int ocb_num = jcp.nb_oc_blocking;
+            for (dim_t iwork = start; iwork < end; ++iwork) {
+                dim_t ocb = ocbb * jcp.nb_oc_blocking;
+                dim_t ocb_num = jcp.nb_oc_blocking;
 
-                for (int icb = icbb; icb < icbb + icb_step; ++icb) {
+                for (dim_t icb = icbb; icb < icbb + icb_step; ++icb) {
                     auto par_conv = jit_conv_args_t();
 
-                    const int ij = oh * jcp.stride_h;
-                    const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
-                    const int i_b_overflow
-                            = nstl::max(jcp.ih,
+                    const dim_t ij = oh * jcp.stride_h;
+                    const dim_t i_t_overflow
+                            = nstl::max<dim_t>(0, jcp.t_pad - ij);
+                    const dim_t i_b_overflow
+                            = nstl::max<dim_t>(jcp.ih,
                                       ij + (jcp.kh - 1) * (jcp.dilate_h + 1)
                                               - jcp.t_pad + 1)
                             - jcp.ih;
 
-                    const int dj = od * jcp.stride_d;
-                    const int d_t_overflow = nstl::max(0, jcp.f_pad - dj);
-                    const int d_b_overflow
-                            = nstl::max(jcp.id,
+                    const dim_t dj = od * jcp.stride_d;
+                    const dim_t d_t_overflow
+                            = nstl::max<dim_t>(0, jcp.f_pad - dj);
+                    const dim_t d_b_overflow
+                            = nstl::max<dim_t>(jcp.id,
                                       dj + (jcp.kd - 1) * (jcp.dilate_d + 1)
                                               - jcp.f_pad + 1)
                             - jcp.id;
 
-                    const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
-                    const size_t _ic = g * g_ic_offset + icb * icb_ic_scale;
+                    const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                    const dim_t _ic = g * g_ic_offset + icb * icb_ic_scale;
 
-                    const int ih = nstl::max(ij - jcp.t_pad
+                    const dim_t ih = nstl::max<dim_t>(ij - jcp.t_pad
                                     + div_up(i_t_overflow, (jcp.dilate_h + 1))
                                             * (jcp.dilate_h + 1),
                             0);
 
-                    const int id = nstl::max(dj - jcp.f_pad
+                    const dim_t id = nstl::max<dim_t>(dj - jcp.f_pad
                                     + div_up(d_t_overflow, (jcp.dilate_d + 1))
                                             * (jcp.dilate_d + 1),
                             0);
@@ -137,8 +138,8 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
                     par_conv.dst = &dst[src_blk_off(dst_d, n, _oc, od, oh, 0)];
 
-                    const int wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
-                    const int wd = div_up(d_t_overflow, (jcp.dilate_d + 1));
+                    const dim_t wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
+                    const dim_t wd = div_up(d_t_overflow, (jcp.dilate_d + 1));
                     par_conv.filt = &weights[wht_blk_off(
                             weights_d, g, ocb, icb, wd, wh, 0)];
 
@@ -158,20 +159,20 @@ void jit_avx2_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                             icb * jcp.ic_block, jcp.ic, jcp.ic_block);
 
                     par_conv.oc_blocks
-                            = nstl::min(ocb + ocb_num, jcp.nb_oc) - ocb;
+                            = nstl::min<dim_t>(ocb + ocb_num, jcp.nb_oc) - ocb;
 
                     if (ocbb == ocb_work - 1) par_conv.oc_flag |= FLAG_OC_LAST;
 
                     par_conv.kw_padding = 0;
-                    const int kh_padding = jcp.kh
+                    const dim_t kh_padding = jcp.kh
                             - div_up(i_t_overflow, (jcp.dilate_h + 1))
                             - div_up(i_b_overflow, (jcp.dilate_h + 1));
-                    par_conv.kh_padding = nstl::max(0, kh_padding);
+                    par_conv.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-                    const int kd_padding = jcp.kd
+                    const dim_t kd_padding = jcp.kd
                             - div_up(d_t_overflow, (jcp.dilate_d + 1))
                             - div_up(d_b_overflow, (jcp.dilate_d + 1));
-                    par_conv.kd_padding = nstl::max(0, kd_padding);
+                    par_conv.kd_padding = nstl::max<dim_t>(0, kd_padding);
 
                     par_conv.post_ops_binary_rhs_arg_vec
                             = post_ops_binary_rhs_arg_vec.data();
@@ -201,10 +202,10 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
 
     const auto &jcp = kernel_->jcp;
 
-    int icb_work = jcp.nb_ic / jcp.nb_ic_blocking;
-    int ih_block_size = jcp.ih;
-    int num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
-    size_t work_amount = jcp.mb * jcp.ngroups * icb_work * num_ih_blocks;
+    dim_t icb_work = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ih_block_size = jcp.ih;
+    dim_t num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
+    dim_t work_amount = jcp.mb * jcp.ngroups * icb_work * num_ih_blocks;
 
     const auto data_size = sizeof(data_t);
     const auto L2 = platform::get_per_core_cache_size(2) / data_size;
@@ -215,88 +216,95 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
             + (size_t)jcp.od * jcp.oh * jcp.ow * oc_chunk
             + (size_t)jcp.kd * jcp.kh * jcp.kw * ic_chunk * oc_chunk;
 
-    if (work_amount < (size_t)2 * jcp.nthr || iter_data_amount > L2) {
+    if (work_amount < 2 * static_cast<dim_t>(jcp.nthr)
+            || iter_data_amount > L2) {
         ih_block_size = 1;
         num_ih_blocks = utils::div_up(jcp.ih, ih_block_size);
         work_amount *= num_ih_blocks;
     }
 
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-    int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+    dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+    dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
     bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-    int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+    dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+    dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
 
     const bool is_ddst_layout_nxc = one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-    const int oc_step = is_ddst_layout_nxc ? jcp.nb_oc_blocking : 1;
+    const dim_t oc_step = is_ddst_layout_nxc ? jcp.nb_oc_blocking : 1;
 
     auto ker = [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        size_t n {0}, g {0}, icbb {0}, ihb {0};
+        dim_t n {0}, g {0}, icbb {0}, ihb {0};
         nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, icbb, icb_work, ihb,
                 num_ih_blocks);
-        for (size_t iwork = start; iwork < end; ++iwork) {
-            for_(int oc = 0; oc < jcp.nb_oc; oc += jcp.nb_oc_blocking)
-            for (int id = 0; id < jcp.id; ++id) {
-                int cur_nb_oc = nstl::min(jcp.nb_oc - oc, jcp.nb_oc_blocking);
+        for (dim_t iwork = start; iwork < end; ++iwork) {
+            for_(dim_t oc = 0; oc < jcp.nb_oc; oc += jcp.nb_oc_blocking)
+            for (dim_t id = 0; id < jcp.id; ++id) {
+                const dim_t cur_nb_oc
+                        = nstl::min<dim_t>(jcp.nb_oc - oc, jcp.nb_oc_blocking);
 
                 auto par_conv = jit_conv_args_t();
 
-                int d_t_overflow, d_b_overflow, od;
+                dim_t d_t_overflow, d_b_overflow, od;
                 if (jcp.dilate_d != 0) { // stride == 1
-                    const int dilate_d = jcp.dilate_d + 1;
-                    d_t_overflow
-                            = div_up(nstl::max(0, ext_kd - 1 - id - jcp.f_pad),
-                                    dilate_d);
+                    const dim_t dilate_d = jcp.dilate_d + 1;
+                    d_t_overflow = div_up(
+                            nstl::max<dim_t>(0, ext_kd - 1 - id - jcp.f_pad),
+                            dilate_d);
                     d_b_overflow = div_up(
-                            nstl::max(0, ext_kd - jcp.id + id - jcp.back_pad),
+                            nstl::max<dim_t>(
+                                    0, ext_kd - jcp.id + id - jcp.back_pad),
                             dilate_d);
                     od = id + jcp.f_pad - d_b_overflow * dilate_d;
                 } else {
-                    d_t_overflow = nstl::max(0, jcp.kd - 1 - id - jcp.f_pad);
-                    d_b_overflow = nstl::max(
+                    d_t_overflow
+                            = nstl::max<dim_t>(0, jcp.kd - 1 - id - jcp.f_pad);
+                    d_b_overflow = nstl::max<dim_t>(
                             0, jcp.kd - 1 - (jcp.id - 1 - id) - jcp.back_pad);
                     od = id + jcp.f_pad - d_b_overflow;
                 }
                 par_conv.kd_padding = jcp.kd - d_t_overflow - d_b_overflow;
 
-                int ih_start = ihb * ih_block_size;
-                int ih_end = nstl::min(jcp.ih, ih_start + ih_block_size);
-                for (int ih = ih_start; ih < ih_end; ++ih) {
+                dim_t ih_start = ihb * ih_block_size;
+                dim_t ih_end
+                        = nstl::min<dim_t>(jcp.ih, ih_start + ih_block_size);
+                for (dim_t ih = ih_start; ih < ih_end; ++ih) {
 
-                    int k_lo, oh;
+                    dim_t k_lo, oh;
                     if (jcp.dilate_h != 0) { // stride == 1
-                        const int dilate_h = jcp.dilate_h + 1;
-                        int i_t_overflow = div_up(
-                                nstl::max(0, ext_kh - 1 - ih - jcp.t_pad),
-                                dilate_h);
-                        int i_b_overflow = div_up(
-                                nstl::max(0, ext_kh - jcp.ih + ih - jcp.b_pad),
+                        const dim_t dilate_h = jcp.dilate_h + 1;
+                        dim_t i_t_overflow
+                                = div_up(nstl::max<dim_t>(0,
+                                                 ext_kh - 1 - ih - jcp.t_pad),
+                                        dilate_h);
+                        dim_t i_b_overflow = div_up(
+                                nstl::max<dim_t>(
+                                        0, ext_kh - jcp.ih + ih - jcp.b_pad),
                                 dilate_h);
                         par_conv.kh_padding
                                 = jcp.kh - i_t_overflow - i_b_overflow;
                         k_lo = i_b_overflow;
                         oh = ih + jcp.t_pad - k_lo * dilate_h;
                     } else {
-                        int i_t_overflow = nstl::max(0,
+                        dim_t i_t_overflow = nstl::max<dim_t>(0,
                                 (jcp.kh - 1 - ih - jcp.t_pad) / jcp.stride_h);
-                        int i_b_overflow = nstl::max(0,
+                        dim_t i_b_overflow = nstl::max<dim_t>(0,
                                 (jcp.kh - jcp.ih + ih - jcp.b_pad)
                                         / jcp.stride_h);
-                        int overflow_kh_hi = jcp.kh - 1
+                        dim_t overflow_kh_hi = jcp.kh - 1
                                 - modulo(jcp.ih - 1 + jcp.b_pad - ih,
                                         jcp.stride_h);
-                        int overflow_kh_lo = (ih + jcp.t_pad) % jcp.stride_h;
+                        dim_t overflow_kh_lo = (ih + jcp.t_pad) % jcp.stride_h;
 
                         par_conv.kh_padding = (overflow_kh_hi - overflow_kh_lo)
                                         / jcp.stride_h
@@ -325,8 +333,7 @@ void jit_avx2_convolution_bwd_data_t::execute_backward_data(
                     if (is_ddst_layout_nxc) {
                         par_conv.load_work = this_block_size(
                                 icbb * jcp.nb_ic_blocking * jcp.ic_block,
-                                (size_t)jcp.ic,
-                                jcp.nb_ic_blocking * jcp.ic_block);
+                                jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
                         par_conv.reduce_work
                                 = this_block_size(oc * jcp.oc_block, jcp.oc,
                                         oc_step * jcp.oc_block);
@@ -380,50 +387,52 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
 
     bool is_ic_physically_blocked = one_of(jcp.src_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
-    int g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
-    int icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
+    dim_t g_ic_offset = is_ic_physically_blocked ? jcp.nb_ic : jcp.ic;
+    dim_t icb_ic_scale = is_ic_physically_blocked ? 1 : jcp.ic_block;
 
     bool is_oc_physically_blocked = one_of(jcp.dst_tag, format_tag::nCw8c,
             format_tag::nChw8c, format_tag::nCdhw8c);
     bool is_ddst_layout_nxc = !is_oc_physically_blocked;
-    int g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
-    int ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
+    dim_t g_oc_offset = is_oc_physically_blocked ? jcp.nb_oc : jcp.oc;
+    dim_t ocb_oc_scale = is_oc_physically_blocked ? 1 : jcp.oc_block;
 
     auto ker = [= COMPAT_THIS_CAPTURE](int ithr, int nthr) {
         assert(nthr == rw->balancer().nthr_);
 
-        const int w_job_start = rw->balancer().ithr_job_off(ithr);
+        const dim_t w_job_start = rw->balancer().ithr_job_off(ithr);
         const int w_njobs = rw->balancer().ithr_njobs(ithr);
 
         if (w_njobs == 0) return;
 
         /* reduction dimension */
-        int img_od_start {0}, img_od_end {0}, img {0}, od_s {0};
+        dim_t img_od_start {0}, img_od_end {0};
+        dim_t img {0}, od_s {0};
         balance211(jcp.mb * jcp.od, rw->balancer().nthr_per_group_,
                 rw->balancer().id_in_group(ithr), img_od_start, img_od_end);
 
-        int img_start = img_od_start, img_end = img_od_end;
+        dim_t img_start = img_od_start;
+        dim_t img_end = img_od_end;
         nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
-        const int img_first = img;
+        const dim_t img_first = img;
 
         /* jobs */
-        int g_start {0}, ocb_start {0}, icb_start {0};
+        dim_t g_start {0}, ocb_start {0}, icb_start {0};
         nd_iterator_init(w_job_start, g_start, jcp.ngroups, ocb_start,
                 jcp.nb_oc, icb_start, jcp.nb_ic);
 
         while (img_start < img_end) {
-            int g = g_start, ocb = ocb_start, icb = icb_start;
+            dim_t g = g_start, ocb = ocb_start, icb = icb_start;
 
-            const int work_rem = img_end - img_start;
-            const int od_e
+            const dim_t work_rem = img_end - img_start;
+            const dim_t od_e
                     = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-            const int id_s = od_s * jcp.stride_d;
-            const int idp = jcp.id + jcp.f_pad + jcp.back_pad;
+            const dim_t id_s = od_s * jcp.stride_d;
+            const dim_t idp = jcp.id + jcp.f_pad + jcp.back_pad;
 
             if (id_s < idp - jcp.back_pad - jcp.kd + 1)
                 for (int w_job_loc = 0; w_job_loc < w_njobs; ++w_job_loc) {
-                    const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
-                    const size_t _ic = g * g_ic_offset + icb * icb_ic_scale;
+                    const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                    const dim_t _ic = g * g_ic_offset + icb * icb_ic_scale;
 
                     /* TODO: put dw <-- 0 in kernel */
                     if (img == img_first)
@@ -432,8 +441,8 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
                                         + w_job_loc * rw->balancer().job_size_,
                                 0, rw->balancer().job_size_);
 
-                    for (int od = od_s; od < od_e; ++od) {
-                        const int id = od * jcp.stride_d;
+                    for (dim_t od = od_s; od < od_e; ++od) {
+                        const dim_t id = od * jcp.stride_d;
                         if (id >= jcp.id - jcp.back_pad - jcp.kd + 1) break;
 
                         auto par_conv = jit_conv_args_t();
@@ -466,25 +475,25 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
     auto ker_bias = [=](int ithr, int nthr) {
         assert(nthr == rb->balancer().nthr_);
 
-        const int b_job_start = rb->balancer().ithr_job_off(ithr);
+        const dim_t b_job_start = rb->balancer().ithr_job_off(ithr);
         const int b_njobs = rb->balancer().ithr_njobs(ithr);
 
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        int img_start {0}, img_end {0};
+        dim_t img_start {0}, img_end {0};
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
 
         /* jobs */
-        int g_start {0}, ocb_start {0};
+        dim_t g_start {0}, ocb_start {0};
         nd_iterator_init(
                 b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_oc);
 
-        for (int img = img_start; img < img_end; ++img) {
-            int g = g_start, ocb = ocb_start;
+        for (dim_t img = img_start; img < img_end; ++img) {
+            dim_t g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const size_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
+                const dim_t _oc = g * g_oc_offset + ocb * ocb_oc_scale;
 
                 const data_t *d_dst = &diff_dst[diff_dst_d.blk_off(img, _oc)];
                 data_t *d_bias = rb->get_local_ptr(ithr, diff_bias,
@@ -492,15 +501,15 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
                         + b_job_loc * rb->balancer().job_size_;
 
                 if (img == img_start)
-                    for (int o = 0; o < jcp.oc_block; ++o)
+                    for (dim_t o = 0; o < jcp.oc_block; ++o)
                         d_bias[o] = 0.;
 
-                const int max_oc = this_block_size(
+                const dim_t max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
 
-                for (int dhw = 0; dhw < jcp.od * jcp.oh * jcp.ow; ++dhw) {
+                for (dim_t dhw = 0; dhw < jcp.od * jcp.oh * jcp.ow; ++dhw) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
                                                 : jcp.oc_block;
@@ -546,9 +555,9 @@ void jit_avx2_convolution_bwd_weights_t::execute_backward_weights(
     parallel(1, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         /* TODO: put this in ker_bias */
         if (pd()->with_bias() && (jcp.oc_without_padding % jcp.oc_block != 0)) {
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g)
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g)
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
         }

--- a/src/cpu/x64/jit_avx2_convolution.hpp
+++ b/src/cpu/x64/jit_avx2_convolution.hpp
@@ -307,14 +307,17 @@ struct jit_avx2_convolution_bwd_weights_t : public primitive_t {
 
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(max_threads,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_oc, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
 
             reducer_wei_conf_.init(reduce_balancer_t(max_threads,
-                    jcp_.kd * jcp_.kh * jcp_.kw * jcp_.ic_block * jcp_.oc_block,
-                    jcp_.ngroups * jcp_.nb_ic * jcp_.nb_oc, jcp_.mb * jcp_.od,
-                    max_buffer_size, true));
+                    static_cast<int>(jcp_.kd * jcp_.kh * jcp_.kw * jcp_.ic_block
+                            * jcp_.oc_block),
+                    static_cast<int>(jcp_.ngroups * jcp_.nb_ic * jcp_.nb_oc),
+                    static_cast<int>(jcp_.mb * jcp_.od), max_buffer_size,
+                    true));
         }
     };
 

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -74,7 +74,7 @@ jit_avx512_common_1x1_conv_kernel_t::jit_avx512_common_1x1_conv_kernel_t(
     }
 }
 
-void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
+void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(dim_t load_loop_blk) {
     mov(aux1_reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
     mov(aux_reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
 
@@ -91,9 +91,9 @@ void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             if (i + 1 == num_substeps) L(large_tail);
             reduce_loop(load_loop_blk, jcp.ur, i, false);
             if (i < num_substeps - 1) {
@@ -132,44 +132,45 @@ void jit_avx512_common_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
 }
 
 Address jit_avx512_common_1x1_conv_kernel_t::output_ptr(
-        const bool is_out_layout_nxc, const int i_load, const int i_ur) {
+        const bool is_out_layout_nxc, const dim_t i_load, const dim_t i_ur) {
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         auto i_load_shift = is_out_layout_nxc
                 ? jcp.load_block
                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
-        int i_ur_shift = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t i_ur_shift = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
         auto offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_out;
         return EVEX_compress_addr(aux_reg_output_data, offset);
     } else
         return ptr[aux_reg_output_data
-                + (i_load ? reg_output_stride * i_load
+                + (i_load ? reg_output_stride * static_cast<int>(i_load)
                           : 0) // TODO: Xbyak should allow 0 scale
                 + jcp.typesize_out * jcp.load_block * i_ur];
 }
 
 static int vreg_accum_idx(
-        const int load_loop_blk, const int i_load, const int i_ur) {
-    return (i_ur * load_loop_blk + i_load);
+        const dim_t load_loop_blk, const dim_t i_load, const dim_t i_ur) {
+    return static_cast<int>(i_ur * load_loop_blk + i_load);
 }
 
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const bool mask_tail,
-        const F &fun) {
-    for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur,
+        const bool mask_tail, const F &fun) {
+    for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
         const bool mask_flag = mask_tail && i_load + 1 == load_loop_blk;
-        for (int i_ur = 0; i_ur < ur; ++i_ur)
+        for (dim_t i_ur = 0; i_ur < ur; ++i_ur)
             fun(mask_flag, i_load, i_ur);
     }
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const F &fun) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur, const F &fun) {
     iterate(load_loop_blk, ur, false, fun);
 }
 
 void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
-        const bool is_out_layout_nxc, const int load_loop_blk, const int ur) {
+        const bool is_out_layout_nxc, const dim_t load_loop_blk,
+        const dim_t ur) {
     injector_utils::vmm_index_set_t vmm_idxs;
     if (jcp.with_binary) {
         binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
@@ -179,7 +180,8 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
                     EVEX_compress_addr(rsp, reg_dw_binary_output_off));
         }
         iterate(load_loop_blk, ur, mask_tail,
-                [&](const bool mask_flag, const int i_load, const int i_ur) {
+                [&](const bool mask_flag, const dim_t i_load,
+                        const dim_t i_ur) {
             const auto vmm_idx = vreg_accum_idx(load_loop_blk, i_load, i_ur);
             vmm_idxs.emplace(vmm_idx);
             const dim_t oft
@@ -199,7 +201,7 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
         }
     } else {
         iterate(load_loop_blk, ur,
-                [&](const bool, const int i_load, const int i_ur) {
+                [&](const bool, const dim_t i_load, const dim_t i_ur) {
             vmm_idxs.emplace(vreg_accum_idx(load_loop_blk, i_load, i_ur));
         });
         postops_injector_->compute_vector_range(vmm_idxs);
@@ -207,55 +209,55 @@ void jit_avx512_common_1x1_conv_kernel_t::apply_postops(
 }
 
 void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
-        int load_loop_blk, int ur, int substep, bool wraparound) {
+        dim_t load_loop_blk, dim_t ur, dim_t substep, bool wraparound) {
     const bool out_layout_nxc = is_out_layout_nxc(jcp);
     const bool load_layout_nxc = is_load_layout_nxc(jcp);
     const bool bcast_layout_nxc = is_bcast_layout_nxc(jcp);
-    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const dim_t reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+    const dim_t load_dim_tail = jcp.load_dim % jcp.load_block;
 
-    auto vreg_load = [ur, load_loop_blk](int i_load) {
-        return Zmm(ur * load_loop_blk + i_load);
+    auto vreg_load = [ur, load_loop_blk](dim_t i_load) {
+        return Zmm(static_cast<int>(ur * load_loop_blk + i_load));
     };
 
-    auto vreg_accum = [load_loop_blk](int i_load, int i_ur) {
+    auto vreg_accum = [load_loop_blk](dim_t i_load, dim_t i_ur) {
         return Zmm(vreg_accum_idx(load_loop_blk, i_load, i_ur));
     };
 
-    auto bias_ptr = [this](int i_load) {
+    auto bias_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_bias_data, jcp.typesize_out * jcp.oc_block * i_load);
     };
 
-    auto bcast_ptr = [&](int i_reduce, int i_ur, bool bcast) {
+    auto bcast_ptr = [&](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
         dim_t offt;
         if (one_of(jcp.prop_kind, forward_training, forward_inference,
                     backward_data)) {
             assert(jcp.reduce_loop_unroll == jcp.reduce_block);
-            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
-                                                    : jcp.reduce_loop_unroll;
+            const dim_t reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
+                                                      : jcp.reduce_loop_unroll;
             offt = (i_reduce == jcp.reduce_loop_unroll)
                     ? (jcp.bcast_dim + i_ur) * reduce_mul
                     : i_ur * reduce_mul + i_reduce;
         } else {
-            int rmul = bcast_layout_nxc ? jcp.ic : jcp.ic_block;
+            const dim_t rmul = bcast_layout_nxc ? jcp.ic : jcp.ic_block;
             offt = static_cast<dim_t>(i_reduce) * rmul + i_ur;
         }
         return EVEX_compress_addr(
                 aux_reg_bcast_data, jcp.typesize_in * offt, bcast);
     };
 
-    auto load_ptr = [&](int i_reduce, int i_load) {
-        int offt;
-        int u0 = i_reduce % jcp.reduce_loop_unroll;
-        int u1 = i_reduce / jcp.reduce_loop_unroll;
-        int lmul = jcp.load_block
+    auto load_ptr = [&](dim_t i_reduce, dim_t i_load) {
+        dim_t offt;
+        const dim_t u0 = i_reduce % jcp.reduce_loop_unroll;
+        const dim_t u1 = i_reduce / jcp.reduce_loop_unroll;
+        const dim_t lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
                                              jcp.reduce_dim, jcp.reduce_block));
-        int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
+        const dim_t rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
         offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
@@ -346,12 +348,12 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block = [&](bool last_block) {
-        const int i_reduce_end = reduce_dim_tail && last_block
+        const dim_t i_reduce_end = reduce_dim_tail && last_block
                 ? reduce_dim_tail
                 : jcp.reduce_loop_unroll;
 
-        for (int i_reduce = 0; i_reduce < i_reduce_end; i_reduce++) {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+        for (dim_t i_reduce = 0; i_reduce < i_reduce_end; i_reduce++) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 auto vreg = vreg_load(i_load);
                 if (i_load + 1 == load_loop_blk && load_dim_tail)
                     vreg = vreg | k_load_dim_mask | T_z;
@@ -359,10 +361,10 @@ void jit_avx512_common_1x1_conv_kernel_t::reduce_loop(
                 vmovups(vreg, load_ptr(i_reduce, i_load));
             }
 
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 if (jcp.expl_bcast && load_loop_blk > 1)
                     vbroadcastss(vreg_bcast, bcast_ptr(i_reduce, i_ur, false));
-                for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                     auto vreg_acc = vreg_accum(i_load, i_ur);
                     if (i_load + 1 == load_loop_blk && load_dim_tail)
                         vreg_acc = vreg_acc | k_load_dim_mask | T_z;
@@ -431,7 +433,7 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
     if (jcp.prop_kind == backward_weights)
         mov(reg_output_stride, ptr[param1 + GET_OFF(output_stride)]);
 
-    const int load_dim_tail
+    const dim_t load_dim_tail
             = (one_of(jcp.prop_kind, forward_training, forward_inference)
                               ? jcp.oc_without_padding
                               : jcp.load_dim)
@@ -442,7 +444,7 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
         kmovw(k_load_dim_tail_mask, reg_tail_32);
     }
 
-    auto load_loop_body = [&](int load_loop_blk) {
+    auto load_loop_body = [&](dim_t load_loop_blk) {
         if (load_dim_tail)
             kxnorw(k_load_dim_mask, k_load_dim_mask, k_load_dim_mask);
         sub(reg_load_loop_work, load_loop_blk * jcp.load_loop_iter_step);
@@ -454,12 +456,12 @@ void jit_avx512_common_1x1_conv_kernel_t::generate() {
         }
         bcast_loop(load_loop_blk);
         add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
-        const size_t offst_with_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_with_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc(jcp)
                                 ? 1
                                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim));
-        const size_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc(jcp) ? 1 : jcp.bcast_dim);
         switch (jcp.prop_kind) {
@@ -719,12 +721,12 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     const int BIG_REDUCE_DIM = 1024;
     const int BIG_LOAD_DIM = 256;
 
-    int load_blocking {0};
-    int load_blocking_max {0};
-    int bcast_blocking {0};
-    int bcast_blocking_max {0};
-    int reduce_blocking {0};
-    int reduce_blocking_max {0};
+    dim_t load_blocking {0};
+    dim_t load_blocking_max {0};
+    dim_t bcast_blocking {0};
+    dim_t bcast_blocking_max {0};
+    dim_t reduce_blocking {0};
+    dim_t reduce_blocking_max {0};
 
     jcp.load_grp_count = 1;
 
@@ -736,7 +738,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
-            if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+            if (jcp.with_dw_conv)
+                jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
             jcp.reduce_dim = jcp.ic;
             jcp.reduce_block = jcp.ic_block;
 
@@ -760,12 +763,12 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         jcp.reduce_loop_load_step
                 = jcp.reduce_loop_unroll * jcp.load_block * jcp.typesize_in;
         jcp.load_loop_load_step
-                = (utils::rnd_up(jcp.reduce_dim, jcp.reduce_block))
+                = utils::rnd_up(jcp.reduce_dim, jcp.reduce_block)
                 * jcp.load_block * jcp.typesize_in;
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold;
-        const int spatial
+        const dim_t spatial
                 = (one_of(jcp.prop_kind, forward_training, forward_inference))
                 ? jcp.od * jcp.oh
                 : jcp.id * jcp.ih;
@@ -798,10 +801,10 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
-            int os_tail = jcp.os % max_regs;
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
+            dim_t os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
-                int i_tail = jcp.os % i;
+                const dim_t i_tail = jcp.os % i;
                 if (i_tail > os_tail || i_tail == 0) {
                     jcp.ur = i;
                     os_tail = i_tail;
@@ -825,9 +828,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         else
             jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
-        int nb_load = div_up(jcp.load_dim, jcp.load_block);
+        const dim_t nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+        const dim_t nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+        const dim_t nb_load = div_up(jcp.load_dim, jcp.load_block);
         if (is_data_layout_nxc) {
             reduce_blocking = jcp.reduce_dim;
         } else if (jcp.expl_bcast) {
@@ -854,22 +857,22 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         // 64 * 1024 is chosen due to 1MB L2 16-way cache.
         // 7 is empirical value. It is about half of 16.
         // So we leave about half of the set for other data - weights, dst
-        int way_size = (64 * 1024) / jcp.typesize_in;
+        const dim_t way_size = (64 * 1024) / jcp.typesize_in;
         int max_hits = 7;
         if (!is_data_layout_nxc
                 && jcp.bcast_dim * reduce_blocking
                         > static_cast<dim_t>(way_size) * max_hits) {
-            int nrb = reduce_blocking / simd_w;
+            const dim_t nrb = reduce_blocking / simd_w;
             auto sp = jcp.bcast_dim;
-            int wl = way_size / simd_w;
-            for (int start_off = 0; start_off < jcp.ur; start_off++) {
+            const dim_t wl = way_size / simd_w;
+            for (dim_t start_off = 0; start_off < jcp.ur; start_off++) {
                 for (dim_t off = start_off, hits = 0; off < sp * nrb;
                         off += wl) {
                     if (off % sp >= jcp.ur || ++hits < max_hits) continue;
-                    int max_r_blocking
+                    const dim_t max_r_blocking
                             = simd_w * nstl::max<dim_t>(1, (off + wl) / sp);
                     reduce_blocking
-                            = nstl::min(reduce_blocking, max_r_blocking);
+                            = nstl::min<dim_t>(reduce_blocking, max_r_blocking);
                     break;
                 }
             }
@@ -883,7 +886,7 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         }
         load_blocking = jcp.load_dim;
 
-        int load_size = jcp.load_dim * jcp.reduce_dim;
+        const dim_t load_size = jcp.load_dim * jcp.reduce_dim;
         auto bcast_size
                 = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
 
@@ -894,20 +897,20 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int n_lgc = jcp.nthr;
             float ratio = (float)load_size / (float)bcast_size;
             int best_lgc = ratio > 1 ? n_lgc : 1;
-            auto calc_job_cost = [&](int lb, int tg, float mem_k) {
-                int bb_size = jcp.mb * div_up(nb_bcast, tg);
+            auto calc_job_cost = [&](dim_t lb, dim_t tg, float mem_k) {
+                const dim_t bb_size = jcp.mb * div_up(nb_bcast, tg);
                 float calc_size = (float)(bb_size * jcp.ur)
-                        * (lb * jcp.load_block) * jcp.reduce_dim;
+                        * (float)(lb * jcp.load_block) * (float)jcp.reduce_dim;
                 float mem_size = (float)(bb_size * jcp.ur + lb * jcp.load_block)
-                        * jcp.reduce_dim;
+                        * (float)jcp.reduce_dim;
                 return calc_koef * calc_size + mem_k * mem_size;
             };
             for (int lgc, ilgc = 0; ilgc < n_lgc; ilgc++) {
                 lgc = ratio > 1 ? n_lgc - ilgc : ilgc + 1;
-                int min_lb = nb_load / lgc;
-                int max_lb = div_up(nb_load, lgc);
-                int min_tg = jcp.nthr / lgc;
-                int max_tg = div_up(jcp.nthr, lgc);
+                const dim_t min_lb = nb_load / lgc;
+                const dim_t max_lb = div_up(nb_load, lgc);
+                const dim_t min_tg = jcp.nthr / lgc;
+                const dim_t max_tg = div_up(jcp.nthr, lgc);
                 // Some heuristic here
                 float mem_koef = (max_tg == 1) ? 1.f : 1.3f;
                 float job_cost = 0.;
@@ -942,21 +945,21 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             load_blocking = jcp.load_block;
         }
 
-        auto get_thr_eff = [&](int load_chunk, int nthr) {
-            int lgc = div_up(nb_load, load_chunk);
-            int thr_per_grp = div_up(nthr, lgc);
-            int bcast_per_thr
+        auto get_thr_eff = [&](dim_t load_chunk, int nthr) {
+            const dim_t lgc = div_up(nb_load, load_chunk);
+            const dim_t thr_per_grp = div_up(nthr, lgc);
+            const dim_t bcast_per_thr
                     = div_up(jcp.mb * nb_bcast, thr_per_grp) * jcp.bcast_block;
-            int load_per_thr = load_chunk * simd_w;
-            float data_norm = (bcast_per_thr + load_per_thr) / 2.f;
-            float data_eff
-                    = (bcast_per_thr * load_per_thr) / (data_norm * data_norm);
-            float thr_eff_over_grp
-                    = (float)nstl::max(1, nthr / lgc) / div_up(nthr, lgc);
-            float thr_eff_in_grp = ((float)jcp.mb * nb_bcast)
-                    / rnd_up(jcp.mb * nb_bcast, thr_per_grp);
+            const dim_t load_per_thr = load_chunk * simd_w;
+            float data_norm = (float)(bcast_per_thr + load_per_thr) / 2.f;
+            float data_eff = (float)(bcast_per_thr * load_per_thr)
+                    / (data_norm * data_norm);
+            float thr_eff_over_grp = (float)nstl::max<dim_t>(1, nthr / lgc)
+                    / (float)div_up(nthr, lgc);
+            float thr_eff_in_grp = ((float)jcp.mb * (float)nb_bcast)
+                    / (float)rnd_up(jcp.mb * nb_bcast, thr_per_grp);
             float thr_eff = thr_eff_over_grp * thr_eff_in_grp;
-            float load_eff = (float)nb_load / rnd_up(nb_load, lgc);
+            float load_eff = (float)nb_load / (float)rnd_up(nb_load, lgc);
             float overall_eff = data_eff + thr_eff + load_eff;
             return overall_eff;
         };
@@ -966,13 +969,13 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int best_lgc = 1;
             float eff;
 
-            for (int load_chunk = 1; load_chunk <= nb_load; load_chunk++) {
-                int lgc = div_up(nb_load, load_chunk);
+            for (dim_t load_chunk = 1; load_chunk <= nb_load; load_chunk++) {
+                const dim_t lgc = div_up(nb_load, load_chunk);
                 if (lgc > nthr) continue;
                 eff = get_thr_eff(load_chunk, nthr);
                 if (eff > best_eff) {
                     best_eff = eff;
-                    best_lgc = lgc;
+                    best_lgc = static_cast<int>(lgc);
                 }
             }
             return best_lgc;
@@ -989,7 +992,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
             int overall_lgc = jcp.load_grp_count;
             int lgc = 1;
             int best_nthr = jcp.nthr;
-            int end_nthr = with_groups ? jcp.ngroups : 1;
+            const int end_nthr
+                    = with_groups ? static_cast<int>(jcp.ngroups) : 1;
             for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
                 lgc = get_load_chunk(nthr);
                 thr_eff = get_thr_eff(lgc, nthr);
@@ -1011,15 +1015,15 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
         bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
-        int space_for_bcast = (L2_capacity - /* kernel_size - */
+        dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
                 2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
                 - 3 * 1024);
         if (jcp.reduce_dim * jcp.bcast_dim > static_cast<dim_t>(L2_capacity))
             space_for_bcast /= 2;
 
-        int bcast_in_cache
-                = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-        bcast_blocking = nstl::min(
+        const dim_t bcast_in_cache = nstl::max<dim_t>(
+                jcp.bcast_block, space_for_bcast / reduce_blocking);
+        bcast_blocking = nstl::min<dim_t>(
                 bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
         // NHWC perf
         if (is_data_layout_nxc) bcast_blocking = jcp.bcast_block;
@@ -1049,14 +1053,14 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
                 !(is_data_layout_nxc && jcp.load_dim <= jcp.load_block)) {
             // if reduce_block is big then generated JIT code may be big
             // for small values of ur because reduce_loop_unroll = reduce_block
-            jcp.ur = jcp.bcast_block / 2;
+            jcp.ur = static_cast<int>(jcp.bcast_block / 2);
             jcp.expl_bcast = true;
         } else {
-            jcp.ur = jcp.bcast_block;
+            jcp.ur = static_cast<int>(jcp.bcast_block);
             jcp.expl_bcast = false;
         }
 
-        jcp.ur_tail = jcp.bcast_dim % jcp.bcast_block;
+        jcp.ur_tail = static_cast<int>(jcp.bcast_dim % jcp.bcast_block);
         jcp.reduce_loop_unroll = jcp.reduce_block;
         jcp.reduce_loop_bcast_step = static_cast<dim_t>(jcp.typesize_in)
                 * jcp.reduce_loop_unroll
@@ -1090,8 +1094,8 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         assert(IMPLICATION(
                 !is_data_layout_nxc, jcp.load_dim % load_blocking == 0));
 
-        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int min_bcast_blocking = 5;
+        const dim_t max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        const dim_t min_bcast_blocking = 5;
 
         bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
         bcast_blocking = best_divider(
@@ -1104,17 +1108,19 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
         // for reduction balance
         if (is_data_layout_nxc && jcp.reduce_dim >= BIG_SPATIAL * BIG_SPATIAL
                 && jcp.load_dim >= BIG_LOAD_DIM / 2) {
-            reduce_blocking = rnd_up(nstl::min(jcp.ow, 256), jcp.reduce_block);
-        } else {
-            int max_reduce_blocking
-                    = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
-            int min_reduce_blocking = nstl::min(
-                    L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
-            reduce_blocking = best_divider(jcp.reduce_dim, min_reduce_blocking,
-                    max_reduce_blocking, true);
             reduce_blocking
-                    = nstl::max(rnd_dn(reduce_blocking, jcp.reduce_block),
-                            jcp.reduce_block);
+                    = rnd_up(nstl::min<dim_t>(jcp.ow, 256), jcp.reduce_block);
+        } else {
+            const dim_t max_reduce_blocking
+                    = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
+            const dim_t min_reduce_blocking = nstl::min<dim_t>(
+                    L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
+            reduce_blocking = best_divider(jcp.reduce_dim,
+                    static_cast<int>(min_reduce_blocking), max_reduce_blocking,
+                    true);
+            reduce_blocking = nstl::max<dim_t>(
+                    rnd_dn(reduce_blocking, jcp.reduce_block),
+                    jcp.reduce_block);
         }
 
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
@@ -1165,15 +1171,15 @@ void jit_avx512_common_1x1_conv_kernel_t::init_scratchpad(
                     || (jcp.prop_kind == backward_weights // nxc layout
                             && jcp.oc % jcp.oc_block != 0))) {
 
-        const size_t nelems_padded_bias
+        const dim_t nelems_padded_bias
                 = jcp.ngroups * utils::rnd_up(jcp.oc, jcp.oc_block);
         scratchpad.book(
                 key_conv_padded_bias, nelems_padded_bias, jcp.typesize_out);
     }
 
     if (jcp.prop_kind == backward_weights) {
-        const size_t wei_size = (size_t)jcp.ngroups
-                * rnd_up(jcp.oc, jcp.oc_block) * rnd_up(jcp.ic, jcp.ic_block);
+        const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+                * rnd_up(jcp.ic, jcp.ic_block);
         scratchpad.book(key_conv_wei_reduction, wei_size * (jcp.nthr_mb - 1),
                 jcp.typesize_out);
         if (dnnl_thr_syncable() && jcp.nthr_mb > 1) {
@@ -1191,11 +1197,11 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
         /* simplification... fortunately it doesn't hurt much */
         return;
     }
-    const int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    const int nb_load = div_up(jcp.load_dim, jcp.load_block);
-    const int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const dim_t nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
+    const dim_t nb_load = div_up(jcp.load_dim, jcp.load_block);
+    const dim_t nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
 
-    jcp.nthr_g = jcp.ngroups;
+    jcp.nthr_g = static_cast<int>(jcp.ngroups);
     const int nthr = nthreads / jcp.nthr_g;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -1227,12 +1233,15 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
     auto best_mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, jcp.mb * nb_reduce);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, jcp.mb * nb_reduce));
     for (nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, nb_load);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, nb_load));
         for (nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, nb_bcast);
+            nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, nb_bcast));
             auto mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
                 best_mem_cost = mem_cost;
@@ -1243,7 +1252,7 @@ void jit_avx512_common_1x1_conv_kernel_t::balance(jit_1x1_conv_conf_t &jcp) {
         }
     }
     if (jcp.nthr_mb > nthreads / 2 && jcp.nthr_mb < nthreads)
-        jcp.nthr_mb = nstl::min(jcp.mb, nthreads);
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(jcp.mb, nthreads));
 
     jcp.nthr = jcp.nthr_mb * jcp.nthr_g * jcp.nthr_oc_b * jcp.nthr_ic_b;
     assert(jcp.nthr <= nthreads);

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.hpp
@@ -87,24 +87,25 @@ private:
     constexpr static int reg_dw_binary_output_off = 3 * reg64_size_;
     constexpr static int stack_space_needed = 4 * reg64_size_;
 
-    void bcast_loop(int load_loop_blk);
-    void reduce_loop(int load_loop_blk, int ur, int substep, bool wraparound);
+    void bcast_loop(dim_t load_loop_blk);
+    void reduce_loop(
+            dim_t load_loop_blk, dim_t ur, dim_t substep, bool wraparound);
 
     inline size_t get_output_offset(const bool is_out_layout_nxc,
-            const int i_load, const int i_ur, bool ignore_dw_conv = false) {
-        const size_t i_load_shift = is_out_layout_nxc
+            const dim_t i_load, const dim_t i_ur, bool ignore_dw_conv = false) {
+        const dim_t i_load_shift = is_out_layout_nxc
                 ? jcp.load_block
                 : (!ignore_dw_conv && jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim)
                         * jcp.load_block;
-        const size_t i_ur_shift
+        const dim_t i_ur_shift
                 = is_out_layout_nxc ? jcp.load_dim : jcp.load_block;
         return jcp.typesize_out * (i_load * i_load_shift + i_ur * i_ur_shift);
     }
 
     Xbyak::Address output_ptr(
-            const bool out_layout_nxc, const int i_load, const int i_ur);
-    void apply_postops(const bool is_out_layout_nxc, const int load_loop_blk,
-            const int ur);
+            const bool out_layout_nxc, const dim_t i_load, const dim_t i_ur);
+    void apply_postops(const bool is_out_layout_nxc, const dim_t load_loop_blk,
+            const dim_t ur);
     void generate() override;
     static void balance(jit_1x1_conv_conf_t &jcp);
 };

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.cpp
@@ -55,7 +55,8 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_
             ? binary_injector::prepare_binary_args(
                       pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -102,11 +103,11 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
             : nullptr;
 
     const int ndims = src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -115,18 +116,19 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
     const bool is_dst_layout_nxc = utils::one_of(
@@ -138,23 +140,23 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
     memory_tracking::grantor_t dw_scratchpad(
             scratchpad, memory_tracking::names::prefix_fusion);
     dst_data_t *pbuf;
-    size_t row_offset;
-    const int nb_buffer = jcp.nb_load_blocking;
+    dim_t row_offset;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<dst_data_t *> addrs;
     // End
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
-        bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+        bcast_step = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -167,16 +169,16 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
-        const auto max_oc
-                = nstl::min(ocb_end * jcp.oc_block, jcp.oc_without_padding);
+        const auto max_oc = nstl::min<dim_t>(
+                ocb_end * jcp.oc_block, jcp.oc_without_padding);
         p.load_dim = this_block_size(
                 ocb * jcp.oc_block, max_oc, load_step * jcp.oc_block);
     };
 
-    auto init_reduce = [&](int icb) {
-        const int nb_ic_blocking_step
+    auto init_reduce = [&](dim_t icb) {
+        const dim_t nb_ic_blocking_step
                 = nstl::min(icb + nb_ic_blocking, nb_ic) - icb;
         p.first_last_flag = 0 | (icb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (icb + nb_ic_blocking_step >= nb_ic ? FLAG_REDUCE_LAST : 0);
@@ -186,12 +188,13 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int icb, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t icb, dim_t n, dim_t g,
+                           dim_t od, dim_t oh, dim_t ow, dim_t id, dim_t ih,
+                           dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
 
         p.output_data = jcp.with_dw_conv
                 ? pbuf + (oh % pd()->dw_conv_pd_->jcp_.kh) * row_offset
@@ -203,7 +206,7 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         p.load_data
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
         if (pd()->rtus_.reduce_src_) {
@@ -224,21 +227,22 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
 
         if (jcp.loop_order == loop_rlb) {
-            for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+            for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                 init_reduce(icb);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    int iwork = bcast_start;
+                    dim_t iwork = bcast_start;
                     while (iwork < bcast_end) {
-                        int n {0}, g {0}, bcast_step {0}, od {0}, oh {0},
-                                ow {0}, id {0}, ih {0}, iw {0};
+                        dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0},
+                                ih {0}, iw {0};
+                        dim_t bcast_step {0};
                         init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh,
                                 ow, id, ih, iw);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
@@ -249,17 +253,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 }
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -269,17 +274,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_rbl) {
-            for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+            for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                 init_reduce(icb);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    int ocb = ocb_start;
+                    dim_t ocb = ocb_start;
                     while (ocb < ocb_end) {
-                        int load_step;
+                        dim_t load_step;
                         init_load(ocb, ocb_end, load_step);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -289,17 +295,18 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 }
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                        id {0}, ih {0}, iw {0};
+                dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                        iw {0};
+                dim_t bcast_step {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -313,9 +320,10 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
 
         for (int i = 0; i < jcp_dw.kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw.kh) * row_offset;
@@ -323,31 +331,31 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         const auto ocb_end = ocb_start + load_step;
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw.iw)
                 * jcp_dw.nb_ch_blocking * jcp_dw.ch_block;
-        const int dil_h = jcp_dw.dilate_h + 1;
-        const int str_h = jcp_dw.stride_h;
-        const int ch_num = jcp_dw.nb_ch_blocking;
-        const int ow = 0;
-        const int kw = 0;
+        const dim_t dil_h = jcp_dw.dilate_h + 1;
+        const dim_t str_h = jcp_dw.stride_h;
+        const dim_t ch_num = jcp_dw.nb_ch_blocking;
+        const dim_t ow = 0;
+        const dim_t kw = 0;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw.t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw.ih,
-                              (int)(dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
-                                      - jcp_dw.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw.t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw.ih,
+                              dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
+                                      - jcp_dw.t_pad + 1)
                     - jcp_dw.ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw.ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -359,9 +367,10 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw.ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw.nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw.nb_ch) - ch)
                     * jcp_dw.ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -381,38 +390,41 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
                 = dw_scratchpad.get<dst_data_t>(key_fusion_inout_buffer);
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
 
-        const auto dw_conv_buffer_size_
-                = (size_t)jcp_dw.kh * jcp.ow * nb_buffer * jcp.oc_block;
-        pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size_;
-        row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
+        const dim_t dw_conv_buffer_size
+                = jcp_dw.kh * jcp.ow * nb_buffer * jcp.oc_block;
+        pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size;
+        row_offset = dw_conv_buffer_size / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+                bcast_end, nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw.oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw.kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_range
+                        = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw.kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -429,10 +441,10 @@ void jit_avx512_common_1x1_convolution_fwd_t<src_type, wei_type,
         conv_dw();
     } else {
 
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                ocb_start, ocb_end, jcp.load_grp_count);
+                ocb_start, ocb_end, static_cast<dim_t>(jcp.load_grp_count));
 
         conv_1x1(bcast_start, bcast_end, ocb_start, ocb_end);
     }
@@ -464,18 +476,18 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
 
     assert(jcp.stride_w == 1 && jcp.stride_h == 1 && jcp.stride_d == 1);
 
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -484,27 +496,27 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
         auto p = jit_1x1_conv_args_t();
         auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-        int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
-                icb_start, icb_end, jcp.load_grp_count);
+                icb_start, icb_end, static_cast<dim_t>(jcp.load_grp_count));
 
         bool reduce_outer
                 = (jcp.loop_order == loop_rbl || jcp.loop_order == loop_rlb);
-        int nboc_outer = reduce_outer ? nb_oc : 1;
-        int ocb_outer_step = reduce_outer ? nb_oc_blocking : 1;
+        const dim_t nboc_outer = reduce_outer ? nb_oc : 1;
+        const dim_t ocb_outer_step = reduce_outer ? nb_oc_blocking : 1;
 
-        int nboc_inner = reduce_outer ? 1 : nb_oc;
-        int ocb_inner_step = reduce_outer ? 1 : nb_oc_blocking;
-        const int max_ic = nstl::min(icb_end * jcp.ic_block, jcp.ic);
+        const dim_t nboc_inner = reduce_outer ? 1 : nb_oc;
+        const dim_t ocb_inner_step = reduce_outer ? 1 : nb_oc_blocking;
+        const dim_t max_ic = nstl::min<dim_t>(icb_end * jcp.ic_block, jcp.ic);
 
-        for (int ocb_outer = 0; ocb_outer < nboc_outer;
+        for (dim_t ocb_outer = 0; ocb_outer < nboc_outer;
                 ocb_outer += ocb_outer_step) {
-            size_t cur_ocb_outer
+            dim_t cur_ocb_outer
                     = nstl::min(ocb_outer + ocb_outer_step, nboc_outer)
                     - ocb_outer;
 
-            int load_step = 0;
-            for (int icb = icb_start; icb < icb_end; icb += load_step) {
+            dim_t load_step = 0;
+            for (dim_t icb = icb_start; icb < icb_end; icb += load_step) {
                 load_step = step(jcp.nb_load_blocking, jcp.nb_load - icb,
                         jcp.nb_load_blocking_max);
 
@@ -512,34 +524,35 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
                         icb * jcp.ic_block, max_ic, load_step * jcp.ic_block);
                 rp.icb = p.load_dim;
 
-                int bcast_step;
-                for (int iwork = bcast_start; iwork < bcast_end;
+                dim_t bcast_step;
+                for (dim_t iwork = bcast_start; iwork < bcast_end;
                         iwork += bcast_step) {
-                    int n {0}, g {0}, osb {0};
+                    dim_t n {0}, g {0}, osb {0};
                     nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb,
                             jcp.nb_bcast);
 
                     bcast_step = step(jcp.nb_bcast_blocking, jcp.nb_bcast - osb,
                             jcp.nb_bcast_blocking_max);
-                    bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+                    bcast_step
+                            = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-                    const int os = osb * os_block;
+                    const dim_t os = osb * os_block;
                     p.bcast_dim = this_block_size(
                             os, jcp.os, bcast_step * os_block);
                     rp.os = p.bcast_dim;
 
-                    const int od = os / (jcp.oh * jcp.ow);
-                    const int os_2d = os % (jcp.oh * jcp.ow);
-                    const int oh = os_2d / jcp.ow;
-                    const int ow = os_2d % jcp.ow;
-                    const int id = od * stride_d;
-                    const int ih = oh * stride_h;
-                    const int iw = ow * stride_w;
+                    const dim_t od = os / (jcp.oh * jcp.ow);
+                    const dim_t os_2d = os % (jcp.oh * jcp.ow);
+                    const dim_t oh = os_2d / jcp.ow;
+                    const dim_t ow = os_2d % jcp.ow;
+                    const dim_t id = od * stride_d;
+                    const dim_t ih = oh * stride_h;
+                    const dim_t iw = ow * stride_w;
                     rp.iw_start = iw;
                     const bool is_dsrc_layout_nxc
                             = utils::one_of(jcp.src_tag, format_tag::nwc,
                                     format_tag::nhwc, format_tag::ndhwc);
-                    const int ic_off_idx = is_dsrc_layout_nxc
+                    const dim_t ic_off_idx = is_dsrc_layout_nxc
                             ? g * jcp.ic + icb * jcp.ic_block
                             : g * nb_ic + icb;
                     rp.src = diff_src
@@ -552,23 +565,23 @@ void jit_avx512_common_1x1_convolution_bwd_data_t<diff_dst_type, wei_type,
                     } else
                         p.output_data = rp.src;
 
-                    for (int ocb_inner = 0; ocb_inner < nboc_inner;
+                    for (dim_t ocb_inner = 0; ocb_inner < nboc_inner;
                             ocb_inner += ocb_inner_step) {
-                        int cur_ocb_inner
+                        const dim_t cur_ocb_inner
                                 = nstl::min(ocb_inner + ocb_inner_step,
                                           nboc_inner)
                                 - ocb_inner;
 
-                        int ocb = reduce_outer ? ocb_outer : ocb_inner;
-                        int nb_oc_blocking_step
+                        const dim_t ocb = reduce_outer ? ocb_outer : ocb_inner;
+                        const dim_t nb_oc_blocking_step
                                 = reduce_outer ? cur_ocb_outer : cur_ocb_inner;
                         const bool is_ddst_layout_nxc
                                 = utils::one_of(jcp.dst_tag, format_tag::nwc,
                                         format_tag::nhwc, format_tag::ndhwc);
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + ocb * jcp.oc_block
                                 : g * nb_oc + ocb;
-                        size_t diff_dst_off = data_blk_off(
+                        dim_t diff_dst_off = data_blk_off(
                                 diff_dst_d, n, oc_off_idx, od, oh, ow);
                         p.bcast_data = &diff_dst[diff_dst_off];
 
@@ -643,7 +656,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
     auto wei_reduction = scratchpad.get<data_t>(key_conv_wei_reduction);
 
     const int ndims = src_d.ndims();
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block);
 
     simple_barrier::ctx_t *reduction_barrier
@@ -660,19 +673,19 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic = jcp.nb_bcast;
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t nb_ic = jcp.nb_bcast;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
 
-    const int sp_nb = jcp.nb_reduce;
-    const int mb_sp_work = jcp.mb * sp_nb;
+    const dim_t sp_nb = jcp.nb_reduce;
+    const dim_t mb_sp_work = jcp.mb * sp_nb;
 
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -683,22 +696,22 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (is_ddst_layout_nxc && ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = nb_ic - 1;
-                const size_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
+                const dim_t z_icb = nb_ic - 1;
+                const dim_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
                         + ic_tail * jcp.oc_block;
                 data_t *z_wei = diff_weights + off;
-                const int zero_work
+                const dim_t zero_work
                         = (nb_ic * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -714,30 +727,30 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* reduction dimension */
-        int mb_sp_b_start {0}, mb_sp_b_end {0};
+        dim_t mb_sp_b_start {0}, mb_sp_b_end {0};
         balance211(
                 mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start, mb_sp_b_end);
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
         balance211(
                 jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
 
-        const int g_work = g_end - g_start;
-        const int oc_b_work = oc_b_end - oc_b_start;
-        const int ic_b_work = ic_b_end - ic_b_start;
+        const dim_t g_work = g_end - g_start;
+        const dim_t oc_b_work = oc_b_end - oc_b_start;
+        const dim_t ic_b_work = ic_b_end - ic_b_start;
         const bool cache_aliasing
                 = (jcp.ic * jcp.ngroups * sizeof(float)) % 1024 == 0;
-        int reduce_step = jcp.nb_reduce_blocking;
-        int reduce_step_max = jcp.nb_reduce_blocking_max;
+        dim_t reduce_step = jcp.nb_reduce_blocking;
+        dim_t reduce_step_max = jcp.nb_reduce_blocking_max;
         if (is_src_layout_nxc && cache_aliasing) {
             // Experiments show 4 is a magic number with the tested shapes.
             // TODO: maybe tune for shapes with sp_dim%4 != 0
-            reduce_step = nstl::min(4, reduce_step);
+            reduce_step = nstl::min<dim_t>(4, reduce_step);
             reduce_step_max = reduce_step;
         }
 
@@ -745,19 +758,19 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 ? diff_weights
                 : wei_reduction + (ithr_mb - 1) * wei_size;
 
-        int sp_b_step = 0;
-        for (int mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
+        dim_t sp_b_step = 0;
+        for (dim_t mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
                 mb_sp_b += sp_b_step) {
-            int img {0}, sp_b {0};
+            dim_t img {0}, sp_b {0};
             nd_iterator_init(mb_sp_b, img, jcp.mb, sp_b, sp_nb);
             sp_b_step = step(reduce_step,
                     nstl::min(sp_nb - sp_b, mb_sp_b_end - mb_sp_b),
                     reduce_step_max);
 
-            for (int g = g_start; g < g_end; ++g) {
-                int load_step = 0;
-                int bcast_step = 0;
-                for (int ic_b = ic_b_start; ic_b < ic_b_end;
+            for (dim_t g = g_start; g < g_end; ++g) {
+                dim_t load_step = 0;
+                dim_t bcast_step = 0;
+                for (dim_t ic_b = ic_b_start; ic_b < ic_b_end;
                         ic_b += bcast_step) {
                     if (is_src_layout_nxc && cache_aliasing) {
                         bcast_step = ic_b_work;
@@ -766,28 +779,28 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                 jcp.nb_bcast_blocking_max);
                     }
 
-                    for (int oc_b = oc_b_start; oc_b < oc_b_end;
+                    for (dim_t oc_b = oc_b_start; oc_b < oc_b_end;
                             oc_b += load_step) {
                         load_step = step(nb_oc_blocking, oc_b_end - oc_b,
                                 jcp.nb_load_blocking_max);
-                        const int _ic_b = g * nb_ic + ic_b;
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t _ic_b = g * nb_ic + ic_b;
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + oc_b * jcp.oc_block
                                 : g * nb_oc + oc_b;
 
                         data_t *store_to;
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         store_to = diff_wei + off;
 
-                        const int ic_off_idx
+                        const dim_t ic_off_idx
                                 = (is_src_layout_nxc ? jcp.ic_block : 1)
                                 * _ic_b;
                         const data_t *diff_src
                                 = &src[src_d.blk_off(img, ic_off_idx)];
 
-                        int sp_b_end = sp_b + sp_b_step;
+                        const dim_t sp_b_end = sp_b + sp_b_step;
                         const data_t *pdiff_dst = &diff_dst[diff_dst_d.blk_off(
                                 img, oc_off_idx)];
                         const data_t *local_src = diff_src;
@@ -814,17 +827,17 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                                                             : 0)
                                 | (sp_b_end == sp_nb ? FLAG_SP_LAST : 0);
 
-                        int sp = sp_b * jcp.reduce_block;
-                        int oc_mult
+                        dim_t sp = sp_b * jcp.reduce_block;
+                        dim_t oc_mult
                                 = is_ddst_layout_nxc ? jcp.oc : jcp.oc_block;
                         p.load_data = pdiff_dst + sp * oc_mult;
 
                         if (pd()->rtus_.reduce_src_) {
-                            const int oh = sp / jcp.ow;
-                            const int ow = sp % jcp.ow;
+                            const dim_t oh = sp / jcp.ow;
+                            const dim_t ow = sp % jcp.ow;
 
-                            const int ih = oh * stride_h;
-                            const int iw = ow * stride_w;
+                            const dim_t ih = oh * stride_h;
+                            const dim_t iw = ow * stride_w;
                             rp.iw_start = iw;
 
                             rp.ws = rtus_space
@@ -842,7 +855,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
                             p.bcast_data = rp.ws;
                         } else {
-                            int ic_mult
+                            dim_t ic_mult
                                     = is_src_layout_nxc ? jcp.ic : jcp.ic_block;
                             p.bcast_data = local_src + sp * ic_mult;
                         }
@@ -860,29 +873,30 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* diff_weights[:] += sum(wei_reduction[thr_mb][:]) */
         if (dnnl_thr_syncable() && jcp.nthr_mb > 1) {
             simple_barrier::barrier(reduction_barrier, jcp.nthr);
-            const int work = g_work * oc_b_work * ic_b_work;
-            int start {0}, end {0};
+            const dim_t work = g_work * oc_b_work * ic_b_work;
+            dim_t start {0}, end {0};
             balance211(work, jcp.nthr_mb, ithr_mb, start, end);
             if (start == end) return;
 
             for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-                int w = start;
-                int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                dim_t w = start;
+                dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
                 nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
                         oc_b_work, sub_ic_b_start, ic_b_work);
                 while (w < end) {
-                    const int g = g_start + sub_g_start;
-                    const int oc_b = oc_b_start + sub_oc_b_start;
-                    const int ic_b = ic_b_start + sub_ic_b_start;
-                    const int ic_to_accumulate
-                            = nstl::min(end - w, ic_b_work - sub_ic_b_start)
-                            * jcp.ic_block;
-                    const int acc_size
-                            = this_block_size(ic_b * jcp.ic_block,
-                                      jcp.ic_without_padding, ic_to_accumulate)
-                            * jcp.oc_block;
+                    const dim_t g = g_start + sub_g_start;
+                    const dim_t oc_b = oc_b_start + sub_oc_b_start;
+                    const dim_t ic_b = ic_b_start + sub_ic_b_start;
+                    const int ic_to_accumulate = static_cast<int>(
+                            nstl::min<dim_t>(
+                                    end - w, ic_b_work - sub_ic_b_start)
+                            * jcp.ic_block);
+                    const int acc_size = static_cast<int>(
+                            this_block_size(ic_b * jcp.ic_block,
+                                    jcp.ic_without_padding, ic_to_accumulate)
+                            * jcp.oc_block);
 
-                    const size_t off
+                    const dim_t off
                             = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                     data_t *d = diff_weights + off;
                     data_t *s = wei_reduction + (thr_mb - 1) * wei_size + off;
@@ -906,7 +920,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         if (b_njobs == 0) return;
 
         /* reduction dimension */
-        int img_start {0}, img_end {0};
+        dim_t img_start {0}, img_end {0};
 
         balance211(jcp.mb, rb->balancer().nthr_per_group_,
                 rb->balancer().id_in_group(ithr), img_start, img_end);
@@ -916,10 +930,10 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         nd_iterator_init(
                 b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_load);
 
-        for (int img = img_start; img < img_end; ++img) {
+        for (dim_t img = img_start; img < img_end; ++img) {
             int g = g_start, ocb = ocb_start;
             for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g * jcp.nb_load + ocb;
                 const data_t *d_dst
@@ -928,8 +942,8 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 data_t *d_bias = rb->get_local_ptr(ithr, diff_bias,
                                          reducer_bia_scratchpad)
                         + b_job_loc * rb->balancer().job_size_;
-                const int sp_shift = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
-                                                        : jcp.oc_block;
+                const dim_t sp_shift = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
+                                                          : jcp.oc_block;
                 const auto max_oc = this_block_size(
                         ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
                 if (img == img_start)
@@ -938,7 +952,7 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
 
                 for (dim_t os = 0; os < jcp.os; ++os) {
                     PRAGMA_OMP_SIMD()
-                    for (int o = 0; o < max_oc; ++o)
+                    for (dim_t o = 0; o < max_oc; ++o)
                         d_bias[o] += d_dst[o];
                     d_dst += sp_shift;
                 }
@@ -971,8 +985,8 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                         = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
                 /* independent dimensions */
-                int g_start {0}, oc_b_start {0}, ic_b_start {0};
-                int g_end {0}, oc_b_end {0}, ic_b_end {0};
+                dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
+                dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
 
                 balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
                 balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start,
@@ -980,34 +994,35 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
                 balance211(jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start,
                         ic_b_end);
 
-                const int g_work = g_end - g_start;
-                const int oc_b_work = oc_b_end - oc_b_start;
-                const int ic_b_work = ic_b_end - ic_b_start;
+                const dim_t g_work = g_end - g_start;
+                const dim_t oc_b_work = oc_b_end - oc_b_start;
+                const dim_t ic_b_work = ic_b_end - ic_b_start;
 
-                const int work = g_work * oc_b_work * ic_b_work;
-                int start {0}, end {0};
+                const dim_t work = g_work * oc_b_work * ic_b_work;
+                dim_t start {0}, end {0};
                 balance211(work, jcp.nthr_mb, ithr_mb, start, end);
                 if (start == end) return;
 
                 for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-                    int w = start;
-                    int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                    dim_t w = start;
+                    dim_t sub_g_start {0}, sub_oc_b_start {0},
+                            sub_ic_b_start {0};
                     nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
                             oc_b_work, sub_ic_b_start, ic_b_work);
                     while (w < end) {
-                        const int g = g_start + sub_g_start;
-                        const int oc_b = oc_b_start + sub_oc_b_start;
-                        const int ic_b = ic_b_start + sub_ic_b_start;
-                        const int ic_to_accumulate
+                        const dim_t g = g_start + sub_g_start;
+                        const dim_t oc_b = oc_b_start + sub_oc_b_start;
+                        const dim_t ic_b = ic_b_start + sub_ic_b_start;
+                        const dim_t ic_to_accumulate
                                 = nstl::min(end - w, ic_b_work - sub_ic_b_start)
                                 * jcp.ic_block;
-                        const int acc_size
+                        const dim_t acc_size
                                 = this_block_size(ic_b * jcp.ic_block,
                                           jcp.ic_without_padding,
                                           ic_to_accumulate)
                                 * jcp.oc_block;
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         data_t *d = diff_weights + off;
                         data_t *s
@@ -1037,9 +1052,9 @@ void jit_avx512_common_1x1_convolution_bwd_weights_t::execute_backward_weights(
         /* TODO: put this in ker_bias */
         if (is_bias_padded) {
             assert(IMPLICATION(!is_ddst_layout_nxc, jcp.ngroups == 1));
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_convolution.hpp
@@ -293,11 +293,11 @@ struct jit_avx512_common_1x1_convolution_fwd_t : public primitive_t {
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);
 
-            size_t dw_conv_buffer_size_ = (size_t)nthr * jcp_dw.kh * jcp_dw.iw
-                    * jcp_dw.dw_conv_buffer_oc;
-            assert(dw_conv_buffer_size_);
+            const dim_t dw_conv_buffer_size = static_cast<dim_t>(nthr)
+                    * jcp_dw.kh * jcp_dw.iw * jcp_dw.dw_conv_buffer_oc;
+            assert(dw_conv_buffer_size);
             dw_scratchpad.book(memory_tracking::names::key_fusion_inout_buffer,
-                    dw_conv_buffer_size_,
+                    static_cast<size_t>(dw_conv_buffer_size),
                     types::data_type_size(dw_conv_pd_->src_md()->data_type));
 
             jit_uni_dw_conv_fwd_kernel_t<avx512_core,
@@ -554,11 +554,14 @@ struct jit_avx512_common_1x1_convolution_bwd_weights_t : public primitive_t {
 
     private:
         void init_balancers() {
-            const size_t max_buffer_size = jcp_.nthr * 3 * 5 * 5 * 16 * 16;
+            const dim_t max_buffer_size
+                    = static_cast<dim_t>(jcp_.nthr) * 3 * 5 * 5 * 16 * 16;
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(jcp_.nthr,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_load, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_load),
+                        static_cast<int>(jcp_.mb),
+                        static_cast<size_t>(max_buffer_size), true));
             }
         }
     };

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -209,7 +209,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::store_output(int ur_w) {
     L(no_update_label);
     if (jcp.with_bias) {
         for (int k = 0; k < jcp.nb_oc_blocking; k++) {
-            int bias_offset = jcp.typesize_out * k * jcp.oc_block;
+            const dim_t bias_offset = jcp.typesize_out * k * jcp.oc_block;
             for (int j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 // mask only needed for last oc_block
@@ -252,16 +252,16 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::store_output(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     const bool is_source_layout_nxc = is_src_layout_nxc();
     const bool icb_loop_in_compute_function = is_source_layout_nxc;
     const int ic_tail = jcp.ic_tail;
     const int oc_tail = jcp.oc == jcp.oc_without_padding ? jcp.oc_tail : 0;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_oc_block = jcp.nb_oc_blocking;
+    dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const int nb_oc_block = jcp.nb_oc_blocking;
     Label kh_label, kd_label;
     std::vector<Label> ic_tail_jmp(kw);
 
@@ -269,14 +269,15 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
     // assert if it is extended in future to catch unpadded_oc_tail.
     assert(IMPLICATION(oc_tail, nb_oc_block == 1));
 
-    int num_ker_loads = ic_block * nb_oc_block * kw;
-    int ker_pipeline_depth
-            = oc_tail || ic_tail ? 1 : nstl::min(4, num_ker_loads);
+    const dim_t num_ker_loads = ic_block * nb_oc_block * kw;
+    int ker_pipeline_depth = oc_tail || ic_tail
+            ? 1
+            : static_cast<int>(nstl::min<dim_t>(4, num_ker_loads));
     assert(ker_reg_base_idx + ker_pipeline_depth <= 32);
     assert(oc_block >= ker_pipeline_depth);
 
-    int inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
-                                       : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
+                                         : (!jcp.is_1stconv ? ic_block : 1);
 
     if (one_of(jcp.ndims, 3, 4)) {
         mov(aux_reg_inp, reg_inp);
@@ -323,7 +324,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                         je(ic_tail_jmp[ki], T_NEAR);
                     }
                 }
-                int aux_kernel_offset = 0;
+                dim_t aux_kernel_offset = 0;
                 if (step == 0) {
                     for (int i = 0; i < ker_pipeline_depth; i++) {
                         aux_kernel_offset = get_kernel_offset(ki, ic, 0, i);
@@ -332,7 +333,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                                         aux_reg_ker, aux_kernel_offset));
                     }
                 } else if (step < num_ker_loads - ker_pipeline_depth + 1) {
-                    int load_offset = ker_pipeline_depth - 1;
+                    const dim_t load_offset = ker_pipeline_depth - 1;
                     int ker_load_reg_idx
                             = (step + load_offset) % ker_pipeline_depth;
                     aux_kernel_offset
@@ -342,10 +343,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
                 }
 
                 Vmm vmm_kernel = vmm_ker(step % ker_pipeline_depth);
-                int j_start = get_ow_start(ki, pad_l);
-                int j_end = get_ow_end(ur_w, ki, pad_r);
+                const int j_start = get_ow_start(ki, pad_l);
+                const int j_end = get_ow_end(ur_w, ki, pad_r);
                 for (int j = j_start; j < j_end; j++) {
-                    size_t aux_input_offset
+                    const dim_t aux_input_offset
                             = get_input_offset(ki, ic, j, pad_l);
                     auto addr = EVEX_compress_addr_safe(
                             aux_reg_inp, aux_input_offset, reg_long_offt, true);
@@ -355,9 +356,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
             }
             L(ic_tail_jmp[ki]);
         }
-        int ker_shift = jcp.typesize_in * kw * oc_block * ic_block;
+        const dim_t ker_shift = jcp.typesize_in * kw * oc_block * ic_block;
         add(aux_reg_ker, ker_shift);
-        int inp_shift = jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mul;
+        const dim_t inp_shift
+                = jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mul;
         add(aux_reg_inp, inp_shift);
         dec(reg_kj);
         cmp(reg_kj, 0);
@@ -365,10 +367,10 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
     }
 
     if (jcp.ndims == 5) {
-        int inp_shift
+        const dim_t inp_shift
                 = typesize * (jcp.dilate_d + 1) * jcp.ih * jcp.iw * inp_mul;
         add(aux_reg_inp_d, inp_shift);
-        int ker_shift
+        const dim_t ker_shift
                 = typesize * jcp.kw * jcp.kh * jcp.oc_block * jcp.ic_block;
         add(aux_reg_ker_d, ker_shift);
 
@@ -383,23 +385,23 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
-        int ur_w, int pad_l, int pad_r) {
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_oc_block = jcp.nb_oc_blocking;
+        int ur_w, dim_t pad_l, dim_t pad_r) {
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const int nb_oc_block = jcp.nb_oc_blocking;
     const bool is_source_layout_nxc = is_src_layout_nxc();
     const bool icb_loop_in_compute_function = is_source_layout_nxc;
     const int ic_tail = jcp.ic_tail;
 
     Label kh_label, kd_label;
     std::vector<Label> ic_tail_jmp(kw);
-    int shift_kernel_ptr
+    dim_t shift_kernel_ptr
             = jcp.typesize_in * jcp.kw * jcp.oc_block * jcp.ic_block;
-    int inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
-                                       : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t inp_mul = is_source_layout_nxc ? jcp.ngroups * jcp.ic
+                                         : (!jcp.is_1stconv ? ic_block : 1);
 
-    int shift_input_ptr
+    dim_t shift_input_ptr
             = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mul;
 
     if (one_of(jcp.ndims, 3, 4)) {
@@ -436,8 +438,8 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_ow_start(ki, pad_l);
-            int jj_end = get_ow_end(ur_w, ki, pad_r);
+            const int jj_start = get_ow_start(ki, pad_l);
+            const int jj_end = get_ow_end(ur_w, ki, pad_r);
             for (int ic = 0; ic < ic_block; ic++) {
                 if (ic_tail && ic >= ic_tail) {
                     // if src has only tails to compute, skip early
@@ -450,7 +452,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                 }
                 if (jcp.kernel_kind == expl_bcast) {
                     for (int jj = jj_start; jj < jj_end; jj++) {
-                        size_t aux_input_offset
+                        dim_t aux_input_offset
                                 = get_input_offset(ki, ic, jj, pad_l);
                         vbroadcastss(vmm_inp(jj, nb_oc_block),
                                 EVEX_compress_addr_safe(aux_reg_inp,
@@ -458,7 +460,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                     }
                 }
                 for (int ii = 0; ii < nb_oc_block; ii++) {
-                    int aux_kernel_offset = jcp.typesize_in
+                    dim_t aux_kernel_offset = jcp.typesize_in
                             * (ii * jcp.nb_ic * jcp.kh * jcp.kw * jcp.kd
                                             * ic_block * oc_block
                                     + ki * ic_block * oc_block + ic * oc_block);
@@ -471,7 +473,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
                             vfmadd231ps(vmm_out(jj, ii),
                                     vmm_inp(jj, nb_oc_block), vmm_wei);
                         else {
-                            size_t aux_input_offset
+                            dim_t aux_input_offset
                                     = get_input_offset(ki, ic, jj, pad_l);
                             vfmadd231ps(vmm_out(jj, ii), vmm_wei,
                                     EVEX_compress_addr_safe(aux_reg_inp,
@@ -492,7 +494,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
     if (jcp.ndims == 5) {
         add(aux_reg_inp_d,
                 typesize * (jcp.dilate_d + 1) * jcp.ih * jcp.iw * inp_mul);
-        const int ker_shift
+        const dim_t ker_shift
                 = typesize * jcp.kw * jcp.kh * jcp.oc_block * jcp.ic_block;
         add(aux_reg_ker_d, ker_shift);
 
@@ -507,7 +509,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop_fma_core(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     if (jcp.ndims == 5) push(reg_oi);
 
     prepare_output(ur_w);
@@ -549,7 +551,7 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
     if (generate_icb_loop) {
         assert(is_src_layout_nxc());
-        const int inp_shift = jcp.ic_block * jcp.typesize_in;
+        const dim_t inp_shift = jcp.ic_block * jcp.typesize_in;
         add(reg_inp, inp_shift);
         const size_t ker_shift = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.ic_block
                 * jcp.oc_block * jcp.typesize_in;
@@ -568,22 +570,23 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int ow_block = jcp.ow_block;
-    int nb_ow = jcp.nb_ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    dim_t ow_block = jcp.ow_block;
+    dim_t nb_ow = jcp.nb_ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
-    int inp_mult = is_src_layout_nxc() ? jcp.ngroups * jcp.ic
-                                       : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    int inp_shift_pad = jcp.typesize_in * (ur_w * stride_w - l_pad) * inp_mult;
-    int inp_shift = jcp.typesize_in * ur_w * stride_w * inp_mult;
-    int inp_shift_pad_second_block = -1 * jcp.typesize_in * l_pad * inp_mult;
-    int out_shift = jcp.typesize_out * ur_w
+    dim_t inp_mult = is_src_layout_nxc() ? jcp.ngroups * jcp.ic
+                                         : (jcp.is_1stconv ? 1 : jcp.ic_block);
+    dim_t inp_shift_pad
+            = jcp.typesize_in * (ur_w * stride_w - l_pad) * inp_mult;
+    dim_t inp_shift = jcp.typesize_in * ur_w * stride_w * inp_mult;
+    dim_t inp_shift_pad_second_block = -1 * jcp.typesize_in * l_pad * inp_mult;
+    dim_t out_shift = jcp.typesize_out * ur_w
             * (is_dst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block);
 
     preamble();
@@ -613,9 +616,9 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
             kmovw(postops_mask, reg_tail_32);
         }
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+    const dim_t r_pad = nstl::max<dim_t>(0, jcp.r_pad);
+    dim_t n_oi = ow / ur_w;
+    const dim_t r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
             calculate_extended_filter_size(kw, jcp.dilate_w));
 
     if (!is_ow_threading_on(jcp)) {
@@ -667,14 +670,15 @@ void jit_avx512_common_conv_fwd_kernel_vmm_t<Vmm>::generate() {
         Label oi_loop_label, oi_loop_start_label, oi_loop_end_label;
 
         assert(ow_block % ur_w == 0);
-        int n_oi_not_last_ow_block = ow_block / ur_w;
+        int n_oi_not_last_ow_block = static_cast<int>(ow_block / ur_w);
         // to simplify code (and general regs usage),
         // size of ow block must be >= 2 * ur_w
         assert(n_oi_not_last_ow_block > 1);
         int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
         int n_oi_first_ow_block = n_oi_not_last_ow_block;
 
-        int n_oi_last_ow_block = (ow - ow_block * (nb_ow - 1)) / ur_w;
+        int n_oi_last_ow_block
+                = static_cast<int>((ow - ow_block * (nb_ow - 1)) / ur_w);
 
         // prepare right padding
         bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
@@ -829,9 +833,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -988,11 +992,11 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.typesize_out = typesize;
 
     if (jcp.is_1stconv) {
-        jcp.ur_w = nstl::min(jcp.ow, regs);
+        jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
     } else {
         // avx512_core guard - just to avoid possible regression for other archs
         if (mayiuse(avx512_core)) {
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
         } else {
             for (int ur_w = regs; ur_w > 0; --ur_w) {
                 if (jcp.ow % ur_w == 0) {
@@ -1002,15 +1006,15 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             }
         }
         if ((ndims == 5 && jcp.ur_w <= 8) || (jcp.ur_w <= 1)) {
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
         }
     }
     // TODO (Tanya): currently applied to Segnet convolutions only.
     // Need to try for other topologies
     if (jcp.ow > 150 && jcp.ur_w < regs / 2) jcp.ur_w = regs;
 
-    int n_oi = (jcp.ow / jcp.ur_w);
-    int r_pad = calculate_end_padding(
+    dim_t n_oi = jcp.ow / jcp.ur_w;
+    dim_t r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ur_w * n_oi, jcp.iw, jcp.stride_w, ext_kw);
     if (jcp.l_pad > 0 && r_pad > 0) n_oi--;
 
@@ -1019,12 +1023,12 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && ((jcp.l_pad <= 0 && n_oi > 0) || (jcp.l_pad > 0 && n_oi > 1));
     if (large_code_size) {
         const int max_code_size = 24 * 1024;
-        const int num_ops_per_reg = 6 + jcp.ic_block * jcp.kw;
+        const dim_t num_ops_per_reg = 6 + jcp.ic_block * jcp.kw;
         int mult = 1;
         if (jcp.l_pad > 0) mult += 1;
         if (r_pad > 0) mult += 1;
         for (int ur_w = jcp.ur_w; ur_w > regs / 2; --ur_w) {
-            if (ur_w * mult * num_ops_per_reg * 9.0 < max_code_size) {
+            if ((double)(ur_w * mult * num_ops_per_reg) * 9.0 < max_code_size) {
                 jcp.ur_w = ur_w;
                 break;
             }
@@ -1033,10 +1037,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     /* Grouped channel offset to support 'non-blocked data' format for
      * convolution sizes with '(input_channel / ngroups) < simd' */
-    jcp.nonblk_group_off
-            = (jcp.ngroups > 1 && one_of(jcp.src_tag, ncw, nchw, ncdhw))
-            ? jcp.ic
-            : 1;
+    jcp.nonblk_group_off = static_cast<int>(
+            (jcp.ngroups > 1 && one_of(jcp.src_tag, ncw, nchw, ncdhw)) ? jcp.ic
+                                                                       : 1);
 
     jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
@@ -1047,39 +1050,39 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.ow_block = jcp.ow;
 
-    auto get_thr_eff = [&](int nb_oc_blocking, int ow_block, int nthr) {
-        int nb_ow = div_up(jcp.ow, ow_block);
-        int nb_oc_chunks = div_up(jcp.nb_oc, nb_oc_blocking);
-        int work_amount = jcp.mb * jcp.oh * nb_oc_chunks * nb_ow;
-        float disbalance = (float)jcp.ow / rnd_up(jcp.ow, ow_block);
-        float thr_eff
-                = disbalance * (float)work_amount / rnd_up(work_amount, nthr);
+    auto get_thr_eff = [&](int nb_oc_blocking, dim_t ow_block, int nthr) {
+        const dim_t nb_ow = div_up(jcp.ow, ow_block);
+        const dim_t nb_oc_chunks = div_up(jcp.nb_oc, nb_oc_blocking);
+        const dim_t work_amount = jcp.mb * jcp.oh * nb_oc_chunks * nb_ow;
+        float disbalance = (float)jcp.ow / (float)rnd_up(jcp.ow, ow_block);
+        float thr_eff = disbalance * (float)work_amount
+                / (float)rnd_up(work_amount, nthr);
         return thr_eff;
     };
 
     auto get_ow_block = [&](int nb_oc_blocking, int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+        dim_t res_ow_block = jcp.ow;
         float eff = get_thr_eff(nb_oc_blocking, res_ow_block, nthr);
         if (!is_ow_threading_applicable()) return res_ow_block;
 
         int L2_part = (platform::get_per_core_cache_size(2) * 7 / 8) / typesize;
-        int size_src_chunk = jcp.ic_block * ur_w * jcp.kh;
-        int size_dst_chunk = jcp.oc_block * nb_oc_blocking * ur_w;
-        int size_wei_chunk = jcp.oc_block * nb_oc_blocking * jcp.ic_block
-                * jcp.kw * jcp.kh;
-        int nurw_cache = (L2_part - 2 * size_wei_chunk)
+        const dim_t size_src_chunk = jcp.ic_block * ur_w * jcp.kh;
+        const dim_t size_dst_chunk = jcp.oc_block * nb_oc_blocking * ur_w;
+        const dim_t size_wei_chunk = jcp.oc_block * nb_oc_blocking
+                * jcp.ic_block * jcp.kw * jcp.kh;
+        const dim_t nurw_cache = (L2_part - 2 * size_wei_chunk)
                 / (2 * size_dst_chunk + 2 * size_src_chunk);
         // current design of generate() requires ow_block >= 2 * ur_w
-        int ow_block_cache = ur_w * nstl::max(2, nurw_cache);
+        const dim_t ow_block_cache = ur_w * nstl::max<dim_t>(2, nurw_cache);
 
-        int ow_block_thr = ow_block_cache;
+        dim_t ow_block_thr = ow_block_cache;
         eff = get_thr_eff(nb_oc_blocking, ow_block_thr, nthr);
 
-        int max_nb_ow = div_up(jcp.ow, 2 * ur_w);
-        int start_nb_ow = div_up(jcp.ow, ow_block_thr);
-        for (int nb_ow = start_nb_ow; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, 2 * ur_w);
+        const dim_t start_nb_ow = div_up(jcp.ow, ow_block_thr);
+        for (dim_t nb_ow = start_nb_ow; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             float eff_threshold = 0.9f;
             if (ow_block < nb_oc_blocking * jcp.oc_block && eff > eff_threshold)
                 break;
@@ -1093,7 +1096,8 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             eff_threshold = 0.98f;
             if (eff > eff_threshold) break;
         }
-        res_ow_block = nstl::min(jcp.ow, nstl::max(2 * ur_w, ow_block_thr));
+        res_ow_block = nstl::min<dim_t>(
+                jcp.ow, nstl::max<dim_t>(2 * ur_w, ow_block_thr));
         eff = get_thr_eff(nb_oc_blocking, res_ow_block, nthr);
         return res_ow_block;
     };
@@ -1101,9 +1105,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const size_t L1_cache_size = platform::get_per_core_cache_size(1);
     if (mayiuse(avx512_core)) {
         int try_nb_oc_blocking = 2;
-        unsigned int ker_inp_size = typesize * div_up(jcp.iw, jcp.stride_w)
+        const size_t ker_inp_size = typesize * div_up(jcp.iw, jcp.stride_w)
                 * jcp.ic_block * jcp.kh * jcp.kd;
-        unsigned int ker_out_size
+        const size_t ker_out_size
                 = typesize * jcp.ow * jcp.oc_block * try_nb_oc_blocking;
         size_t ker_wei_size = static_cast<size_t>(typesize) * jcp.kh * jcp.kw
                 * jcp.ic_block * jcp.oc_block * try_nb_oc_blocking * jcp.kd;
@@ -1138,19 +1142,21 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                         || (jcp.ow <= 147 && jcp.oc <= 96))));
 
         if (jcp.mb == 1) {
-            unsigned int inp_size = jcp.mb * div_up(jcp.ih, jcp.stride_h)
+            const size_t inp_size = jcp.mb * div_up(jcp.ih, jcp.stride_h)
                     * div_up(jcp.iw, jcp.stride_w) * jcp.ic;
-            unsigned int wei_size = jcp.ic * jcp.oc * jcp.kh * jcp.kw;
+            const size_t wei_size = jcp.ic * jcp.oc * jcp.kh * jcp.kw;
 
             // Estimate whether we need to limit the number of threads
             // and calculate this number. Includes some heuristic.
-            int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-            int work_amount = jcp.mb * jcp.ngroups * oc_chunks * jcp.oh;
-            int job_size_min = work_amount / nthreads;
-            int job_size_max = div_up(work_amount, nthreads);
-            int ch_max = rnd_up(jcp.oh, job_size_max);
-            int ch_min = (job_size_min == 0) ? jcp.oh
-                                             : rnd_up(jcp.oh, job_size_min);
+            const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+            const dim_t work_amount = jcp.mb * jcp.ngroups * oc_chunks * jcp.oh;
+            const int job_size_min = static_cast<int>(work_amount / nthreads);
+            const int job_size_max
+                    = static_cast<int>(div_up(work_amount, nthreads));
+            const dim_t ch_max = rnd_up(jcp.oh, job_size_max);
+            const dim_t ch_min = (job_size_min == 0)
+                    ? jcp.oh
+                    : rnd_up(jcp.oh, job_size_min);
             bool not_aligned_max = ch_max % jcp.oh != 0 && ch_max / jcp.oh < 2
                     && (jcp.oh != 8 || ch_max / jcp.oh > 1);
             bool not_aligned_min = ch_min % jcp.oh != 0 && ch_min / jcp.oh < 2
@@ -1177,7 +1183,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         const int max_nb_oc = 5;
         if (embd_bcast_condition) {
             jcp.kernel_kind = embd_bcast;
-            jcp.ur_w = nstl::min(jcp.ow, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ow, regs));
             jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
             const unsigned int L1_cache_size
                     = platform::get_per_core_cache_size(1);
@@ -1186,7 +1192,8 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     && IMPLICATION(jcp.is_1stconv, jcp.mb == 1)
                     && IMPLICATION(jcp.mb == 1, jcp.ur_w < jcp.ow)) {
                 jcp.nb_oc_blocking = try_nb_oc_blocking;
-                jcp.ur_w = nstl::min(jcp.ow, 31 / (jcp.nb_oc_blocking + 1));
+                jcp.ur_w = static_cast<int>(nstl::min<dim_t>(
+                        jcp.ow, 31 / (jcp.nb_oc_blocking + 1)));
             }
         } else {
             jcp.kernel_kind = expl_bcast;
@@ -1195,14 +1202,17 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     || expl_bcast_condition) {
                 float best_thr_eff = 0.f;
                 int best_nb_oc_blocking = 1;
-                for (int i = nstl::min(jcp.nb_oc, max_nb_oc); i > 0; i--) {
+                for (int i = static_cast<int>(
+                             nstl::min<dim_t>(jcp.nb_oc, max_nb_oc));
+                        i > 0; i--) {
                     if (jcp.nb_oc % i == 0) {
                         if (expl_bcast_condition) {
                             best_nb_oc_blocking = i;
                             break;
                         } else {
-                            int ur_w = nstl::min(jcp.ow, 31 / (i + 1));
-                            int ow_block = get_ow_block(i, ur_w, jcp.nthr);
+                            int ur_w = static_cast<int>(
+                                    nstl::min<dim_t>(jcp.ow, 31 / (i + 1)));
+                            dim_t ow_block = get_ow_block(i, ur_w, jcp.nthr);
                             float thr_eff = get_thr_eff(i, ow_block, jcp.nthr);
                             if (thr_eff > 1.05f * best_thr_eff) {
                                 best_nb_oc_blocking = i;
@@ -1212,7 +1222,8 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                     }
                 }
                 jcp.nb_oc_blocking = best_nb_oc_blocking;
-                jcp.ur_w = nstl::min(jcp.ow, 31 / (jcp.nb_oc_blocking + 1));
+                jcp.ur_w = static_cast<int>(nstl::min<dim_t>(
+                        jcp.ow, 31 / (jcp.nb_oc_blocking + 1)));
             }
         }
     }
@@ -1227,9 +1238,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(args_ok, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weight and src size mismatch");
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(r_pad_no_tail <= jcp.ur_w,
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -1256,10 +1267,10 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     if (thr_eff < eff_threshold && jcp.ngroups < jcp.nthr
             && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        dim_t ow_block = jcp.ow_block;
         float best_thr_eff = -1.0f;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        const int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
             ow_block = get_ow_block(jcp.nb_oc_blocking, jcp.ur_w, nthr);
             eff = get_thr_eff(jcp.nb_oc_blocking, ow_block, nthr);
@@ -1276,10 +1287,11 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const int L2_size = platform::get_per_core_cache_size(2) / typesize;
     // Source and output data needs to fit in L2,
     // leaving some space for weights and prefetching.
-    int h_L2 = int(((0.6f * L2_size) / jcp.simd_w
-                           - nstl::min(0, jcp.kh - jcp.stride_h) * jcp.iw)
-            / (jcp.stride_h * jcp.iw + jcp.ow));
-    jcp.h_blocking = nstl::max(1, nstl::min(jcp.oh, h_L2));
+    int h_L2 = int(((0.6f * (float)L2_size) / (float)jcp.simd_w
+                           - (float)(nstl::min<dim_t>(0, jcp.kh - jcp.stride_h)
+                                   * jcp.iw))
+            / (float)(jcp.stride_h * jcp.iw + jcp.ow));
+    jcp.h_blocking = nstl::max<dim_t>(1, nstl::min<dim_t>(jcp.oh, h_L2));
 
     if (is_data_layout_nxc) {
         // TODO: improve L2 blocking for large IC
@@ -1287,7 +1299,7 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         if (jcp.nb_ic > nb_ic_theshold_L2 && jcp.nb_ic < 2 * nb_ic_theshold_L2)
             jcp.nb_ic_L2 = div_up(jcp.nb_ic, 2);
         else
-            jcp.nb_ic_L2 = nstl::min(nb_ic_theshold_L2, jcp.nb_ic);
+            jcp.nb_ic_L2 = nstl::min<dim_t>(nb_ic_theshold_L2, jcp.nb_ic);
     }
 
     // A rough check on code size
@@ -1296,9 +1308,9 @@ status_t jit_avx512_common_conv_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         const int max_code_size = 256 * 1024; // default size of jit generator
         int mult = 1 + (jcp.l_pad > 0) + (r_pad > 0);
         const float max_instruction_size = 15;
-        float ur_fac
-                = (float)jcp.kw * jcp.ic_block * jcp.nb_oc_blocking * jcp.ur_w;
-        float code_size = mult * ur_fac * max_instruction_size;
+        float ur_fac = (float)jcp.kw * (float)jcp.ic_block
+                * (float)jcp.nb_oc_blocking * (float)jcp.ur_w;
+        float code_size = (float)mult * ur_fac * max_instruction_size;
         VDISPATCH_CONV_IC(
                 code_size <= max_code_size, "code size limit exceeded");
     }
@@ -1359,23 +1371,23 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::store_output(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
-        int ur_w, int l_overflow, int r_overflow) {
+        int ur_w, dim_t l_overflow, dim_t r_overflow) {
     Label kh_label, kd_label;
-    int kw = jcp.kw;
-    int ow = jcp.ow;
+    dim_t kw = jcp.kw;
+    dim_t ow = jcp.ow;
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    dim_t stride_w = jcp.stride_w;
+    dim_t stride_h = jcp.stride_h;
 
     int ker_pipeline_depth = 4;
     assert(ker_reg_base_idx + ker_pipeline_depth <= 32);
     assert(oc_block >= ker_pipeline_depth);
 
-    int num_ker_loads = oc_block * kw;
+    const int num_ker_loads = static_cast<int>(oc_block * kw);
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
-    int oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
     const bool ocb_loop_in_compute_function = ddst_layout_nxc;
 
     const int ic_tail = jcp.ic_tail;
@@ -1429,7 +1441,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
                 }
                 if (step == 0) {
                     for (int i = 0; i < ker_pipeline_depth; i++) {
-                        int aux_kernel_offset = typesize
+                        dim_t aux_kernel_offset = typesize
                                 * ((oc + i) * oc_block
                                         + ki * ic_block * oc_block);
                         vmovups(vmm_ker(i),
@@ -1440,7 +1452,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
                     int load_offset = ker_pipeline_depth - 1;
                     int ker_load_reg_idx
                             = (step + load_offset) % ker_pipeline_depth;
-                    int aux_kernel_offset = typesize
+                    dim_t aux_kernel_offset = typesize
                             * ((oc + load_offset) * oc_block
                                     + ki * ic_block * oc_block);
                     vmovups(vmm_ker(ker_load_reg_idx),
@@ -1449,13 +1461,13 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
 
                 auto vmm_kernel = vmm_ker(step % ker_pipeline_depth);
 
-                int jj_start = get_iw_start(ki, l_overflow);
-                int jj_end = get_iw_end(ur_w, ki, r_overflow);
-                const int dil_w = jcp.dilate_w + 1;
-                const int ref_jj_start
-                        = nstl::max(0, l_overflow - (kw - 1 - ki) * dil_w);
-                const int ref_jj_end
-                        = ur_w - nstl::max(0, r_overflow - ki * dil_w);
+                const int jj_start = get_iw_start(ki, l_overflow);
+                const int jj_end = get_iw_end(ur_w, ki, r_overflow);
+                const dim_t dil_w = jcp.dilate_w + 1;
+                const dim_t ref_jj_start = nstl::max<dim_t>(
+                        0, l_overflow - (kw - 1 - ki) * dil_w);
+                const dim_t ref_jj_end
+                        = ur_w - nstl::max<dim_t>(0, r_overflow - ki * dil_w);
                 assert(IMPLICATION(stride_w == 1,
                         jj_start == ref_jj_start && jj_end == ref_jj_end));
                 UNUSED(dil_w);
@@ -1465,7 +1477,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
                 for (int jj = jj_start; jj < jj_end; jj += stride_w) {
                     assert((jj + jcp.l_pad - ki * (jcp.dilate_w + 1)) % stride_w
                             == 0);
-                    int aux_dst_offset = get_dst_offset(jj, oc, ki);
+                    dim_t aux_dst_offset = get_dst_offset(jj, oc, ki);
                     vfmadd231ps(vmm_out(jj, 0), vmm_kernel,
                             EVEX_compress_addr(
                                     aux_reg_dst, aux_dst_offset, true));
@@ -1475,9 +1487,9 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
             L(oc_tail_jmp[ki]);
         }
 
-        const int ker_shift = typesize * stride_h * kw * oc_block * ic_block;
+        const dim_t ker_shift = typesize * stride_h * kw * oc_block * ic_block;
         add(aux_reg_ker, ker_shift);
-        const int ddst_shift = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
+        const dim_t ddst_shift = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
         sub(aux_reg_dst, ddst_shift);
 
         dec(reg_kj);
@@ -1485,10 +1497,10 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
         jg(kh_label, T_NEAR);
     }
     if (jcp.ndims == 5) {
-        const int depth_ddst_shift
+        const dim_t depth_ddst_shift
                 = typesize * (jcp.dilate_d + 1) * jcp.oh * ow * oc_mult;
         sub(aux_reg_dst_d, depth_ddst_shift);
-        const int depth_ker_shift = typesize * jcp.stride_d * jcp.kw * jcp.kh
+        const dim_t depth_ker_shift = typesize * jcp.stride_d * jcp.kw * jcp.kh
                 * oc_block * ic_block;
         add(aux_reg_ker_d, depth_ker_shift);
 
@@ -1503,29 +1515,29 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop_fma(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
-        Vmm>::compute_loop_fma_core(int ur_w, int l_overflow, int r_overflow,
-        int k_offset) {
-    int kw = jcp.kw;
-    int ow = jcp.ow;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_ic_block = jcp.nb_ic_blocking;
+        Vmm>::compute_loop_fma_core(int ur_w, dim_t l_overflow,
+        dim_t r_overflow, int k_offset) {
+    dim_t kw = jcp.kw;
+    dim_t ow = jcp.ow;
+    dim_t stride_w = jcp.stride_w;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const int nb_ic_block = jcp.nb_ic_blocking;
     Label kh_label, kd_label;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
-    int shift_ker_ptr = typesize * kw * oc_block * ic_block;
-    int oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
-    int shift_dst_ptr = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
+    dim_t shift_ker_ptr = typesize * kw * oc_block * ic_block;
+    dim_t oc_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t shift_dst_ptr = typesize * (jcp.dilate_h + 1) * ow * oc_mult;
 
     const int oc_tail = jcp.oc_tail;
     const int max_filter_size = 20;
     Label oc_tail_jmp[max_filter_size];
 
-    auto kernel_offset = [this](int icb, int oc, int ki) {
-        int blk_idx = icb * jcp.kh * jcp.kw * jcp.kd + ki;
-        int blk_offset = blk_idx * jcp.oc_block * jcp.ic_block;
-        int oc_offset = oc * jcp.oc_block;
+    auto kernel_offset = [this](dim_t icb, dim_t oc, dim_t ki) -> dim_t {
+        const dim_t blk_idx = icb * jcp.kh * jcp.kw * jcp.kd + ki;
+        const dim_t blk_offset = blk_idx * jcp.oc_block * jcp.ic_block;
+        const dim_t oc_offset = oc * jcp.oc_block;
         return typesize * (blk_offset + oc_offset);
     };
 
@@ -1563,8 +1575,8 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow);
-            int jj_end = get_iw_end(ur_w, ki, r_overflow);
+            const int jj_start = get_iw_start(ki, l_overflow);
+            const int jj_end = get_iw_end(ur_w, ki, r_overflow);
             for (int oc = 0; oc < oc_block; oc++) {
                 if (oc_tail && oc >= oc_tail) {
                     // if src has only tails to compute, skip early
@@ -1577,13 +1589,13 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
                 }
                 if (jcp.kernel_kind == expl_bcast) {
                     for (int jj = jj_start; jj < jj_end; jj++) {
-                        int aux_output_offset = get_dst_offset(jj, oc, ki);
+                        dim_t aux_output_offset = get_dst_offset(jj, oc, ki);
                         vbroadcastss(vmm_inp(jj, nb_ic_block),
                                 ptr[aux_reg_dst + aux_output_offset]);
                     }
                 }
                 for (int ii = 0; ii < nb_ic_block; ii++) {
-                    int aux_kernel_offset
+                    dim_t aux_kernel_offset
                             = kernel_offset(ii, oc, ki + k_offset);
                     if (jj_end - jj_start > 0)
                         vmovups(vmm_wei,
@@ -1624,7 +1636,7 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<
 
 template <typename Vmm>
 inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
-        int ur_w, int l_overflow, int r_overflow, int k_offset) {
+        int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset) {
     if (jcp.ndims == 5) push(reg_oi);
 
     prepare_output(ur_w);
@@ -1656,7 +1668,7 @@ inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
 
     if (generate_ocb_loop) {
         add(reg_dst, jcp.oc_block * typesize);
-        const int ker_shift = jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw
+        const dim_t ker_shift = jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw
                 * jcp.ic_block * jcp.oc_block * typesize;
         add(reg_ker, ker_shift);
         sub(reg_channel, jcp.oc_block);
@@ -1673,20 +1685,20 @@ inline void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int kw = jcp.kw;
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
     int ur_w = jcp.ur_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int nb_iw = jcp.nb_iw;
-    int iw_block = jcp.iw_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_iw = jcp.nb_iw;
+    const dim_t iw_block = jcp.iw_block;
     int ur_w_tail = jcp.ur_w_tail;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    int dilate_w = static_cast<int>(jcp.dilate_w) + 1;
+    int stride_w = static_cast<int>(jcp.stride_w);
 
-    int dst_shift = jcp.typesize_in * (ur_w / stride_w)
+    dim_t dst_shift = jcp.typesize_in * (ur_w / stride_w)
             * (is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block);
-    int src_shift = jcp.typesize_out * ur_w
+    dim_t src_shift = jcp.typesize_out * ur_w
             * (is_dsrc_layout_nxc() ? jcp.ngroups * jcp.ic : ic_block);
 
     preamble();
@@ -1711,15 +1723,16 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
         L(masking_done);
     }
 
-    int l_overflow = nstl::max(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
-    int r_overflow = nstl::max(
-            0, ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad)) / stride_w);
-    int r_overflow_no_tail = nstl::max(0,
-            ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad + ur_w_tail))
-                    / stride_w);
+    int l_overflow = static_cast<int>(
+            nstl::max<dim_t>(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w));
+    int r_overflow = static_cast<int>(nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad)) / stride_w));
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad + ur_w_tail))
+                    / stride_w));
 
     int body_l_overflow = 0, body_r_overflow = 0;
-    int n_oi = iw / ur_w;
+    int n_oi = static_cast<int>(iw / ur_w);
     int head_n_oi = 0, body_n_oi = 0, pretail_n_oi = 0, tail_n_oi = 0;
     int head_thread = 0, pretail_thread = 0, tail_thread = 0;
     bool threaded = is_iw_threading_on(jcp);
@@ -1747,12 +1760,12 @@ void jit_avx512_common_conv_bwd_data_kernel_f32_vmm_t<Vmm>::generate() {
         // Setup for threaded code generation, and jump into the correct
         // portion of code for execution.
         head_thread = 0;
-        tail_thread = nb_iw - 1;
+        tail_thread = static_cast<int>(nb_iw - 1);
         pretail_thread = tail_thread;
 
-        int base_n_oi = iw_block / ur_w;
+        int base_n_oi = static_cast<int>(iw_block / ur_w);
         head_n_oi = l_overflow > 0 ? base_n_oi - 1 : base_n_oi;
-        tail_n_oi = (iw - iw_block * (nb_iw - 1)) / ur_w;
+        tail_n_oi = static_cast<int>((iw - iw_block * (nb_iw - 1)) / ur_w);
         pretail_n_oi = tail_n_oi;
         if (r_overflow_no_tail > 0) {
             if (tail_n_oi > 0) {
@@ -1921,9 +1934,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -2034,11 +2047,11 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     jcp.nb_ic = div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ur_w = jcp.stride_w;
+    jcp.ur_w = static_cast<int>(jcp.stride_w);
 
     int regs = 28;
     if (jcp.iw <= regs)
-        jcp.ur_w = jcp.iw;
+        jcp.ur_w = static_cast<int>(jcp.iw);
     else {
         for (int ur_w = regs; ur_w > 0; --ur_w)
             if (ur_w % jcp.stride_w == 0) {
@@ -2046,13 +2059,13 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 break;
             }
     }
-    int l_overflow = nstl::max(
-            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
-    int r_overflow_no_tail = nstl::max(0,
+    int l_overflow = static_cast<int>(nstl::max<dim_t>(
+            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w));
+    int r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.iw % jcp.ur_w))
-                    / jcp.stride_w);
-    int n_oi = jcp.iw / jcp.ur_w;
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.iw % jcp.ur_w))
+                    / jcp.stride_w));
+    dim_t n_oi = jcp.iw / jcp.ur_w;
     if (r_overflow_no_tail > 0) n_oi--;
 
     jcp.typesize_in = typesize;
@@ -2066,12 +2079,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             && (r_overflow_no_tail > 0) && (l_overflow > 0);
     if (large_code_size) {
         const int max_code_size = 24 * 1024;
-        const int num_ops_per_reg = 6 + jcp.oc_block * jcp.kw;
+        const dim_t num_ops_per_reg = 6 + jcp.oc_block * jcp.kw;
         int mult = 1;
         if (l_overflow > 0) mult += 1;
         if (r_overflow_no_tail > 0) mult += 1;
         for (int ur_w = jcp.ur_w; ur_w > regs / 2; --ur_w) {
-            if ((ur_w / jcp.stride_w) * mult * num_ops_per_reg * 9.2
+            if ((double)((ur_w / jcp.stride_w) * mult * num_ops_per_reg) * 9.2
                     < max_code_size) {
                 if (ur_w % jcp.stride_w == 0) {
                     jcp.ur_w = ur_w;
@@ -2099,13 +2112,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
     if (mayiuse(avx512_core)) {
         int try_nb_ic_blocking = 2;
-        unsigned int ker_inp_size = typesize * jcp.iw * jcp.ic_block
+        const size_t ker_inp_size = typesize * jcp.iw * jcp.ic_block
                 * try_nb_ic_blocking * jcp.kh;
-        unsigned int ker_out_size = typesize * jcp.ow * jcp.oc_block;
-        unsigned int ker_wei_size = typesize * jcp.kh * jcp.kw * jcp.ic_block
+        const size_t ker_out_size = typesize * jcp.ow * jcp.oc_block;
+        const size_t ker_wei_size = typesize * jcp.kh * jcp.kw * jcp.ic_block
                 * jcp.oc_block * try_nb_ic_blocking;
-        unsigned int ker_total_size
-                = ker_inp_size + ker_out_size + ker_wei_size;
+        size_t ker_total_size = ker_inp_size + ker_out_size + ker_wei_size;
         bool use_expl_bcast
                 = !(jcp.kw == 1 || (jcp.kw == 5 && jcp.iw < 8)
                           || (jcp.kw < 5
@@ -2115,7 +2127,7 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 || jcp.stride_h > 1 || jcp.stride_d > 1;
         if (use_expl_bcast && !jcp.large_w_filter) {
             jcp.kernel_kind = embd_bcast;
-            jcp.ur_w = nstl::min(jcp.iw, regs);
+            jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.iw, regs));
             jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
             if (!(jcp.kw > 3
                         || (jcp.kw == 3 && ker_total_size < L1_cache_size
@@ -2124,13 +2136,14 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 if (jcp.nb_ic % try_nb_ic_blocking == 0) {
                     jcp.nb_ic_blocking = try_nb_ic_blocking;
                     jcp.ur_w = 31 / (jcp.nb_ic_blocking + 1);
-                    if (jcp.iw < jcp.ur_w) jcp.ur_w = jcp.iw;
+                    if (jcp.iw < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.iw);
                 }
         } else {
             jcp.kernel_kind = expl_bcast;
             jcp.nb_oc_blocking = 1;
             jcp.nb_ic_blocking = jcp.large_w_filter ? 2 : 4;
-            if (jcp.nb_ic < jcp.nb_ic_blocking) jcp.nb_ic_blocking = jcp.nb_ic;
+            if (jcp.nb_ic < jcp.nb_ic_blocking)
+                jcp.nb_ic_blocking = static_cast<int>(jcp.nb_ic);
             if (jcp.nb_ic % jcp.nb_ic_blocking != 0)
                 for (int i = jcp.nb_ic_blocking; i > 0; i--)
                     if (jcp.nb_ic % i == 0) {
@@ -2138,34 +2151,35 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                         break;
                     }
             jcp.ur_w = 31 / (jcp.nb_ic_blocking + 1);
-            if (jcp.iw < jcp.ur_w) jcp.ur_w = jcp.iw;
+            if (jcp.iw < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.iw);
         }
     }
     jcp.ur_w_tail = jcp.iw % jcp.ur_w;
 
     auto is_iw_threading_applicable = [&]() { return one_of(jcp.ndims, 3, 4); };
 
-    auto get_thr_eff = [&](int nb_ic_blocking, int iw_block, int nthr) {
+    auto get_thr_eff = [&](int nb_ic_blocking, dim_t iw_block, int nthr) {
         // Cost heuristic for threading overhead. Determined using OMP.
         const float iw_block_cost = 32.0;
 
-        int nb_iw = div_up(jcp.iw, iw_block);
-        int nb_ic_chunks = div_up(jcp.nb_ic, nb_ic_blocking);
-        int work_amount = jcp.mb * jcp.ih * nb_ic_chunks * nb_iw;
-        float disbalance = (float)jcp.iw / rnd_up(jcp.iw, iw_block);
-        float block_overhead = nstl::max(0.0f, 1.0f - iw_block_cost / iw_block);
+        const dim_t nb_iw = div_up(jcp.iw, iw_block);
+        const dim_t nb_ic_chunks = div_up(jcp.nb_ic, nb_ic_blocking);
+        const dim_t work_amount = jcp.mb * jcp.ih * nb_ic_chunks * nb_iw;
+        float disbalance = (float)jcp.iw / (float)rnd_up(jcp.iw, iw_block);
+        float block_overhead
+                = nstl::max(0.0f, 1.0f - iw_block_cost / (float)iw_block);
         float thr_eff = block_overhead * disbalance
-                * ((float)work_amount / rnd_up(work_amount, nthr));
+                * ((float)work_amount / (float)rnd_up(work_amount, nthr));
         return thr_eff;
     };
 
     auto get_iw_block
             = [&](int nb_ic_blocking, int ur_w, float &eff, int nthr) {
-        int res_iw_block = jcp.iw;
+        int res_iw_block = static_cast<int>(jcp.iw);
         if (!is_iw_threading_applicable()) return res_iw_block;
 
-        int max_nb_iw = div_up(jcp.iw, 2 * ur_w);
-        int iw_block_thr;
+        const dim_t max_nb_iw = div_up(jcp.iw, 2 * ur_w);
+        dim_t iw_block_thr;
 
         if (jcp.ndims == 3) {
             // Blocking optimization to prevent data from leaving cache This
@@ -2175,14 +2189,15 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             // the height dimension.
             int L2_part
                     = (platform::get_per_core_cache_size(2) * 7 / 8) / typesize;
-            int size_diff_src_chunk = jcp.ic_block * nb_ic_blocking * ur_w;
-            int size_diff_dst_chunk = jcp.oc_block * ur_w;
-            int size_wei_chunk
+            const dim_t size_diff_src_chunk
+                    = jcp.ic_block * nb_ic_blocking * ur_w;
+            const dim_t size_diff_dst_chunk = jcp.oc_block * ur_w;
+            const dim_t size_wei_chunk
                     = jcp.ic_block * nb_ic_blocking * jcp.oc_block * jcp.kw;
-            int nurw_cache = (L2_part - 2 * size_wei_chunk)
+            const dim_t nurw_cache = (L2_part - 2 * size_wei_chunk)
                     / (2 * size_diff_dst_chunk + 2 * size_diff_src_chunk);
             // current design of generate() requires iw_block >= 2 * ur_w
-            int iw_block_cache = ur_w * nstl::max(2, nurw_cache);
+            const dim_t iw_block_cache = ur_w * nstl::max<dim_t>(2, nurw_cache);
 
             iw_block_thr = iw_block_cache;
         } else
@@ -2190,12 +2205,12 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         eff = get_thr_eff(nb_ic_blocking, iw_block_thr, nthr);
 
         // Search for most efficient threading over iw_blocks.
-        int start_nb_iw = div_up(jcp.iw, iw_block_thr);
-        for (int nb_iw = start_nb_iw; nb_iw <= max_nb_iw; nb_iw++) {
+        const dim_t start_nb_iw = div_up(jcp.iw, iw_block_thr);
+        for (dim_t nb_iw = start_nb_iw; nb_iw <= max_nb_iw; nb_iw++) {
             float eff_threshold = 0.98f;
             if (eff > eff_threshold) break;
-            int iw_block
-                    = nstl::min(rnd_up(div_up(jcp.iw, nb_iw), ur_w), jcp.iw);
+            const dim_t iw_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.iw, nb_iw), ur_w), jcp.iw);
             if (div_up(jcp.iw, iw_block) != nb_iw) continue;
             float thr_eff = get_thr_eff(nb_ic_blocking, iw_block, nthr);
             if (iw_block >= 2 * ur_w && thr_eff > eff) {
@@ -2203,7 +2218,8 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
                 eff = thr_eff;
             }
         }
-        res_iw_block = nstl::min(jcp.iw, nstl::max(2 * ur_w, iw_block_thr));
+        res_iw_block = static_cast<int>(nstl::min<dim_t>(
+                jcp.iw, nstl::max<dim_t>(2 * ur_w, iw_block_thr)));
         return res_iw_block;
     };
 
@@ -2224,8 +2240,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
     size_t total_size = jcp.ngroups * (wei_size + out_size + inp_size);
 
     if (jcp.ngroups < jcp.nthr && (total_size < L1_cache_size)) {
-        int iw_block = jcp.iw_block;
-        int end_nthr = with_groups ? jcp.ngroups : ndims - 2;
+        int iw_block = static_cast<int>(jcp.iw_block);
+        const int end_nthr
+                = with_groups ? static_cast<int>(jcp.ngroups) : ndims - 2;
         float eff = -1.0f;
         float best_thr_eff = -1.0f;
         // When thr_eff equals zero (cannot get the proper effciency)
@@ -2253,10 +2270,10 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
             !(l_overflow * jcp.stride_w > jcp.ur_w && !jcp.large_w_filter),
             VERBOSE_BAD_PARAM, "stride, unroll width");
 
-    r_overflow_no_tail = nstl::max(0,
+    r_overflow_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.ur_w_tail))
-                    / jcp.stride_w);
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.ur_w_tail))
+                    / jcp.stride_w));
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
             || r_overflow_no_tail * jcp.stride_w > jcp.ur_w
@@ -2276,7 +2293,7 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         if (jcp.nb_oc > nb_oc_theshold_L2 && jcp.nb_oc < 2 * nb_oc_theshold_L2)
             jcp.nb_oc_L2 = div_up(jcp.nb_oc, 2);
         else
-            jcp.nb_oc_L2 = nstl::min(nb_oc_theshold_L2, jcp.nb_oc);
+            jcp.nb_oc_L2 = nstl::min<dim_t>(nb_oc_theshold_L2, jcp.nb_oc);
     }
 
     bool args_ok = true && jcp.ic <= diff_src_d.padded_dims()[1]
@@ -2292,9 +2309,9 @@ status_t jit_avx512_common_conv_bwd_data_kernel_f32_t::init_conf(
         const int max_code_size = 256 * 1024; // default size of jit generator
         int mult = 1 + (l_overflow > 0) + (r_overflow_no_tail > 0);
         const float max_instruction_size = 15;
-        float ur_fac
-                = (float)jcp.kw * jcp.oc_block * jcp.nb_ic_blocking * jcp.ur_w;
-        float code_size = mult * ur_fac * max_instruction_size;
+        float ur_fac = (float)jcp.kw * (float)jcp.oc_block
+                * (float)jcp.nb_ic_blocking * (float)jcp.ur_w;
+        float code_size = (float)mult * ur_fac * max_instruction_size;
         VDISPATCH_CONV_IC(!(code_size > max_code_size && !jcp.large_w_filter),
                 "code size limit exceeded");
     }
@@ -2320,10 +2337,10 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     mov(kj, reg_kd_count);
     L(kd_comeback_label);
     {
-        int inp_mult = is_src_layout_nxc()
+        const dim_t inp_mult = is_src_layout_nxc()
                 ? jcp.ngroups * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
-        int iw = jcp.iw;
+        const dim_t iw = jcp.iw;
         sub(reg_input,
                 jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * iw * inp_mult);
         sub(reg_kernel,
@@ -2341,11 +2358,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     mov(kj, reg_kh);
     L(kh_comeback_label);
     {
-        int kw = jcp.is_hw_transp ? 1 : jcp.kw;
-        int inp_mult = is_src_layout_nxc()
+        const dim_t kw = jcp.is_hw_transp ? 1 : jcp.kw;
+        const dim_t inp_mult = is_src_layout_nxc()
                 ? jcp.ngroups * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
-        int iw = jcp.is_hw_transp ? 1 : jcp.iw;
+        const dim_t iw = jcp.is_hw_transp ? 1 : jcp.iw;
         sub(reg_input, jcp.typesize_in * (jcp.dilate_h + 1) * iw * inp_mult);
         sub(reg_kernel, jcp.typesize_out * kw * jcp.ic_block * jcp.oc_block);
         dec(kj);
@@ -2355,15 +2372,16 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset, bool input_wraparound) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset,
+        bool input_wraparound) {
 
-    int kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
-    int iw = jcp.is_hw_transp ? jcp.tr_iw : jcp.iw;
-    int kw_tr_mult = jcp.is_hw_transp ? jcp.kw : 1;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    auto get_ker_offt = [&](int i_kw, int i_ic) {
+    const dim_t kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
+    const dim_t iw = jcp.is_hw_transp ? jcp.tr_iw : jcp.iw;
+    const dim_t kw_tr_mult = jcp.is_hw_transp ? jcp.kw : 1;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    auto get_ker_offt = [&](dim_t i_kw, dim_t i_ic) {
         return typesize * (i_kw * kw_tr_mult * ic_block + i_ic) * jcp.oc_block
                 + kernel_offset;
     };
@@ -2371,11 +2389,13 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
         for (int i_ic = 0; i_ic < ic_block_step; i_ic++)
             vmovups(Zmm(i_kw * ic_block_step + i_ic),
                     EVEX_compress_addr(reg_kernel, get_ker_offt(i_kw, i_ic)));
-    const int out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
+    const dim_t out_mult
+            = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
     const int oc_tail = jcp.oc_tail;
 
     for (int i_ur = 0; i_ur < ur_w; i_ur++) {
-        const int ddst_pipeline_start_idx = ic_block_step * kw;
+        const int ddst_pipeline_start_idx
+                = static_cast<int>(ic_block_step * kw);
         static constexpr int ddst_pipeline_len = 4;
         auto get_ddst_reg_idx = [ddst_pipeline_start_idx](int ur_idx) {
             return ddst_pipeline_start_idx + (ur_idx) % ddst_pipeline_len;
@@ -2403,7 +2423,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
         }
 
         for (int i_kw = 0; i_kw < kw; i_kw++) {
-            int i_iw = get_iw_idx(i_ur, i_kw, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, i_kw, pad_l);
             if (i_iw < 0 || i_iw > get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r
                     || get_iw_idx(i_ur, i_kw, jcp.l_pad) >= iw)
                 continue;
@@ -2424,29 +2444,30 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step_fma(
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_fma_expl(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int input_offset, int kernel_offset,
-                int output_offset, bool input_wraparound) {
-    int kw = jcp.kw;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+        compute_ic_block_step_fma_expl(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+                dim_t output_offset, bool input_wraparound) {
+    dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
     const int oc_tail = jcp.oc_tail;
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const int max_regs = 32;
-    const int ddst_pipeline_start_idx = 2 * ic_block_step * kw;
+    const int ddst_pipeline_start_idx
+            = static_cast<int>(2 * ic_block_step * kw);
     const int ddst_pipeline_len
             = ddst_layout_nxc ? 1 : max_regs - ddst_pipeline_start_idx;
-    const int iw_last_value = get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r;
+    const dim_t iw_last_value = get_iw_idx(ur_w - 1, kw - 1, pad_l) - pad_r;
     assert(jcp.stride_w == 1 && jcp.dilate_w == 0 && ddst_pipeline_len > 0
             && jcp.kernel_kind == expl_bcast);
 
-    const int out_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
+    const dim_t out_mult = ddst_layout_nxc ? jcp.ngroups * jcp.oc : oc_block;
     auto get_diff_wei_reg_idx = [ic_block_step](int i_kw, int i_ic) {
         return i_kw * ic_block_step + i_ic;
     };
-    auto get_src_reg_idx = [&](int i_iw, int i_ic) {
-        return kw * ic_block_step + ((i_iw + pad_l) % kw) * ic_block_step
-                + i_ic;
+    auto get_src_reg_idx = [&](dim_t i_iw, int i_ic) {
+        return static_cast<int>(kw * ic_block_step
+                + ((i_iw + pad_l) % kw) * ic_block_step + i_ic);
     };
     auto get_diff_dst_reg_idx
             = [ddst_pipeline_start_idx, ddst_pipeline_len](int i_ur) {
@@ -2470,7 +2491,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
             }
 
             for (int i_kw = 0; i_kw < kw; i_kw++) {
-                int i_iw = get_iw_idx(0, i_kw, pad_l);
+                dim_t i_iw = get_iw_idx(0, i_kw, pad_l);
                 if (i_iw < 0 || i_iw > iw_last_value) continue;
 
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
@@ -2491,7 +2512,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
                 vmovups(zmm_ddst, addr_out);
             }
 
-            int i_iw = get_iw_idx(i_ur, kw - 1, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, kw - 1, pad_l);
             if (i_iw >= 0 && i_iw <= iw_last_value) {
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
                     auto addr_inp = EVEX_compress_addr_safe(reg_input,
@@ -2502,7 +2523,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
             }
         }
         for (int i_kw = 0; i_kw < kw; i_kw++) {
-            int i_iw = get_iw_idx(i_ur, i_kw, pad_l);
+            dim_t i_iw = get_iw_idx(i_ur, i_kw, pad_l);
             if (i_iw < 0 || i_iw > iw_last_value) continue;
             for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
                 vfmadd231ps(Zmm(get_diff_wei_reg_idx(i_kw, i_ic)),
@@ -2530,8 +2551,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int input_offset,
-        int kernel_offset, int output_offset, bool input_wraparound) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step,
+        dim_t input_offset, dim_t kernel_offset, dim_t output_offset,
+        bool input_wraparound) {
     if (jcp.kernel_kind == expl_bcast)
         compute_ic_block_step_fma_expl(ur_w, pad_l, pad_r, ic_block_step,
                 input_offset, kernel_offset, output_offset, input_wraparound);
@@ -2546,15 +2568,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
 
     Label kh_label, kd_label;
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
     const bool src_layout_nxc = is_src_layout_nxc();
-    int inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
-                                 : (!jcp.is_1stconv ? ic_block : 1);
-    int iw = jcp.iw;
+    dim_t inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
+                                   : (!jcp.is_1stconv ? ic_block : 1);
+    dim_t iw = jcp.iw;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    dim_t l_pad = jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2595,7 +2617,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
         L(icb_block_label_end);
 
-        const int input_icb_shift = jcp.typesize_in * ic_block;
+        const dim_t input_icb_shift = jcp.typesize_in * ic_block;
         const size_t kernel_icb_shift = (size_t)jcp.typesize_out * jcp.kd
                 * jcp.kh * jcp.kw * ic_block * oc_block;
 
@@ -2663,19 +2685,19 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w) {
     Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
     const bool src_layout_nxc = is_src_layout_nxc();
-    int inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
-                                 : (!jcp.is_1stconv ? jcp.ic_block : 1);
+    dim_t inp_mul = src_layout_nxc ? jcp.ngroups * jcp.ic
+                                   : (!jcp.is_1stconv ? jcp.ic_block : 1);
     const int ic_tail = jcp.ic_tail;
     UNUSED(max_ur_w);
 
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
 
-    int inp_icb_sp_stride = jcp.is_hw_transp ? 1 : jcp.iw;
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t inp_icb_sp_stride = jcp.is_hw_transp ? 1 : jcp.iw;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    dim_t l_pad = jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2704,7 +2726,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         mov(b_ic, ic_block);
         L(ic_block_label);
         {
-            compute_ic_block_step(ow, l_pad, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(
+                    static_cast<int>(ow), l_pad, r_pad, ic_block_step, 0, 0, 0);
             size_t inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
                     ? (size_t)jcp.ih * jcp.iw * jcp.id
                     : 1;
@@ -2719,7 +2742,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
         L(icb_block_label_end);
 
-        const int input_shift = jcp.typesize_in * (jcp.dilate_h + 1)
+        const dim_t input_shift = jcp.typesize_in * (jcp.dilate_h + 1)
                 * inp_icb_sp_stride * inp_mul;
 
         if (generate_icb_loop || ic_tail) {
@@ -2762,8 +2785,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
                 if (ic_tail % ic_block_step) {
                     cmp(reg_icb, 0);
                     jle(skip_ic_tail, T_NEAR);
-                    compute_ic_block_step(
-                            ow, l_pad, r_pad, ic_tail % ic_block_step, 0, 0, 0);
+                    compute_ic_block_step(static_cast<int>(ow), l_pad, r_pad,
+                            ic_tail % ic_block_step, 0, 0, 0);
                 }
                 L(skip_ic_tail);
             }
@@ -2808,16 +2831,16 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
     Label kh_label, ic_block_label, ic_tail_loop_label, ic_tail_label, kd_label;
 
     const bool src_layout_nxc = is_src_layout_nxc();
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    int r_pad = max(0, jcp.r_pad);
-    int l_pad = jcp.l_pad;
+    int ow = static_cast<int>(jcp.is_hw_transp ? jcp.oh : jcp.ow);
+    int r_pad = static_cast<int>(max<dim_t>(0, jcp.r_pad));
+    int l_pad = static_cast<int>(jcp.l_pad);
 
-    int ur_w = min(ow, max_ur_w);
-    int ur_w_trips = ow / ur_w;
-    int ur_w_tail = ow % ur_w;
+    int ur_w = static_cast<int>(min<dim_t>(ow, max_ur_w));
+    dim_t ur_w_trips = ow / ur_w;
+    dim_t ur_w_tail = ow % ur_w;
     if ((ur_w_tail == 0 && r_pad != 0) || (r_pad > 0 && r_pad >= ur_w_tail)) {
         if (ur_w_trips > 1) {
             ur_w_tail += ur_w;
@@ -2829,26 +2852,27 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
     }
 
     assert(l_pad <= max_ur_w);
-    int inp_mult = src_layout_nxc
+    dim_t inp_mult = src_layout_nxc
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : ic_block * (jcp.is_hw_transp ? jcp.iw : 1));
-    int out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
-    int input_comeback
-            = max((ur_w_trips * ur_w * jcp.stride_w - l_pad), 0) * inp_mult;
-    int output_comeback = ur_w_trips * ur_w * out_mult;
+    dim_t out_mult = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : oc_block;
+    dim_t input_comeback
+            = max<dim_t>(ur_w_trips * ur_w * jcp.stride_w - l_pad, 0)
+            * inp_mult;
+    dim_t output_comeback = ur_w_trips * ur_w * out_mult;
     const int ic_tail = jcp.ic_tail;
     const bool generate_icb_loop = jcp.nb_ic_blocking_max > 1;
 
     auto ic_loop = [&](int ic_block_step) {
         Label ow_block_label, ic_block_inner_label;
-        int ur_w_blocks = ur_w_trips;
+        int ur_w_blocks = static_cast<int>(ur_w_trips);
 
-        int l_pad_tail = max(l_pad - ur_w, 0);
+        dim_t l_pad_tail = max<dim_t>(l_pad - ur_w, 0);
         L(ic_block_inner_label);
         if (l_pad != 0) {
             ur_w_blocks--;
             compute_ic_block_step(ur_w, l_pad, 0, ic_block_step, 0, 0, 0);
-            int iw_offset = ur_w * jcp.stride_w - l_pad;
+            dim_t iw_offset = ur_w * jcp.stride_w - l_pad;
             if (iw_offset > 0)
                 add(reg_input, jcp.typesize_in * iw_offset * inp_mult);
             add(reg_output, jcp.typesize_in * ur_w * out_mult);
@@ -2869,13 +2893,13 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
                 inc(reg_ur_w_trips);
                 cmp(reg_ur_w_trips, ur_w_blocks);
                 jl(ow_block_label, T_NEAR);
-                l_pad_tail = max(l_pad_tail - ur_w, 0);
+                l_pad_tail = max<dim_t>(l_pad_tail - ur_w, 0);
             }
         }
 
         if (ur_w_tail > 0)
-            compute_ic_block_step(
-                    ur_w_tail, l_pad_tail, r_pad, ic_block_step, 0, 0, 0);
+            compute_ic_block_step(static_cast<int>(ur_w_tail), l_pad_tail,
+                    r_pad, ic_block_step, 0, 0, 0);
 
         sub(reg_output, jcp.typesize_in * output_comeback);
     };
@@ -2909,7 +2933,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
         {
             ic_loop(ic_block_step);
             sub(reg_input, jcp.typesize_in * input_comeback);
-            int inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
+            dim_t inp_icblk_stride = jcp.is_1stconv && !src_layout_nxc
                     ? jcp.ih * jcp.iw * jcp.id
                     : 1;
             size_t input_offset
@@ -2923,7 +2947,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_common(
         }
         L(ic_block_label_end);
 
-        const int input_shift
+        const dim_t input_shift
                 = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw * inp_mult;
 
         if (generate_icb_loop || ic_tail) {
@@ -3013,14 +3037,14 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::compute_oh_step_disp() {
     if (jcp.is_1stconv) {
         bool large_code = jcp.kw >= 7 && (jcp.l_pad > 0 || jcp.t_pad > 0);
         ic_block_step = (jcp.kw * jcp.ic_block <= 28 && !large_code)
-                ? jcp.ic_block
+                ? static_cast<int>(jcp.ic_block)
                 : 1;
     }
 
     bool too_large_to_unroll = (jcp.kw > 1 || jcp.kh > 1 || jcp.kd > 1)
             && (jcp.stride_w > 1 || jcp.stride_h > 1 || jcp.stride_d > 1);
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
     if (jcp.ndims == 5) {
         /* NOTE: reg_kd_count = aux_reg_input = r12. The following order of
          * 'movs' must be guaranteed. */
@@ -3112,7 +3136,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_2d() {
         if (oc_tail) zmm_out = zmm_out | k_oc_mask | T_z;
         vmovups(zmm_out, ptr[reg_output + reg_tmp]);
         vaddps(Zmm(0), Zmm(0), Zmm(1));
-        const int oc_stride
+        const dim_t oc_stride
                 = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
         add(reg_tmp, jcp.typesize_out * oc_stride);
         dec(reg_oi);
@@ -3172,27 +3196,27 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_3d() {
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         compute_oh_loop_common() {
     assert(one_of(jcp.harness, harness_mb_reduction, harness_3d_reduction));
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    dim_t b_pad = jcp.b_pad;
+    dim_t t_pad = jcp.t_pad;
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
-    const int inp_mult = is_src_layout_nxc()
+    dim_t dilate_h = jcp.dilate_h + 1;
+    dim_t stride_h = jcp.stride_h;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
-    int iw = jcp.is_hw_transp ? 1 : jcp.iw;
+    dim_t iw = jcp.is_hw_transp ? 1 : jcp.iw;
     Label oh_label, oh_label_end, oh_tpad_label, oh_tpad_tail_label,
             oh_bpad_label, oh_bpad_label_end, oh_dilate_label_shift,
             oh_dilate_label_noshift, oh_dilate_label_end;
 
-    int ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    int oh = jcp.is_hw_transp ? jcp.ow : jcp.oh;
-    int kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
-    int kh = jcp.is_hw_transp ? jcp.tr_kh : jcp.kh;
-    int ih = jcp.is_hw_transp ? jcp.tr_ih : jcp.ih;
-    int ihp = jcp.is_hw_transp ? jcp.tr_ih : jcp.ihp;
+    dim_t ow = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    dim_t oh = jcp.is_hw_transp ? jcp.ow : jcp.oh;
+    dim_t kw = jcp.is_hw_transp ? jcp.tr_kw : jcp.kw;
+    dim_t kh = jcp.is_hw_transp ? jcp.tr_kh : jcp.kh;
+    dim_t ih = jcp.is_hw_transp ? jcp.tr_ih : jcp.ih;
+    dim_t ihp = jcp.is_hw_transp ? jcp.tr_ih : jcp.ihp;
 
     assert(IMPLICATION(jcp.is_hw_transp,
             everyone_is(1, oh, stride_h, dilate_h)
@@ -3202,10 +3226,11 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
     xor_(reg_oj, reg_oj);
     /* Compute 'top' edge */
     if (t_pad > 0) {
-        const int kh_range = 1 + (kh - 1) * dilate_h;
-        const int overflow = nstl::max(0, kh - div_up(t_pad + ih, dilate_h));
-        const int underflow = div_up(t_pad, dilate_h);
-        const int initial_inp_ker_overlap = kh - overflow - underflow;
+        const dim_t kh_range = 1 + (kh - 1) * dilate_h;
+        const dim_t overflow
+                = nstl::max<dim_t>(0, kh - div_up(t_pad + ih, dilate_h));
+        const dim_t underflow = div_up(t_pad, dilate_h);
+        const dim_t initial_inp_ker_overlap = kh - overflow - underflow;
         mov(reg_kh, initial_inp_ker_overlap);
         add(reg_kernel,
                 jcp.typesize_out * underflow * kw * jcp.ic_block
@@ -3213,8 +3238,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         // generate loop to process kernel while it remains within t_pad + ih
         if (kh_range < t_pad + ih) {
             if (is_dilated) {
-                const int tail = t_pad % dilate_h;
-                const int shift = tail == 0 ? 0 : dilate_h - tail;
+                const int tail = static_cast<int>(t_pad % dilate_h);
+                const int shift
+                        = tail == 0 ? 0 : static_cast<int>(dilate_h - tail);
                 mov(reg_tmp, shift);
                 if (tail != 0)
                     add(reg_input, jcp.typesize_in * shift * iw * inp_mult);
@@ -3250,8 +3276,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
                 inc(reg_oj);
 
                 // final number of kernel elements that overlap with input
-                const int final_inp_ker_overlap
-                        = nstl::min(kh, div_up(ih, dilate_h));
+                const int final_inp_ker_overlap = static_cast<int>(
+                        nstl::min<dim_t>(kh, div_up(ih, dilate_h)));
                 cmp(reg_kh, final_inp_ker_overlap);
                 jl(oh_tpad_label, T_NEAR);
             }
@@ -3285,7 +3311,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
             // kernel has moved beyond padding (adjust for stride effects)
             if (t_pad % stride_h != 0) {
                 assert(!is_dilated);
-                int inp_corr = stride_h - t_pad % stride_h;
+                const dim_t inp_corr = stride_h - t_pad % stride_h;
                 add(reg_kernel,
                         jcp.typesize_out * inp_corr * kw * jcp.ic_block
                                 * jcp.oc_block);
@@ -3300,9 +3326,10 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
         }
     }
 
-    const int oj_end_value = nstl::min(oh,
+    const int oj_end_value = static_cast<int>(nstl::min<dim_t>(oh,
             utils::div_up(
-                    nstl::max(0, ihp - b_pad - (kh - 1) * dilate_h), stride_h));
+                    nstl::max<dim_t>(0, ihp - b_pad - (kh - 1) * dilate_h),
+                    stride_h)));
     cmp(reg_oj, oj_end_value);
     jge(oh_label_end, T_NEAR);
 
@@ -3360,16 +3387,17 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t ::
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         compute_oh_loop_partial() {
     assert(jcp.harness == harness_2d_reduction);
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    const int inp_mult = is_src_layout_nxc()
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
-    const int input_bottom_padding_overlap = div_up(
-            nstl::max(0, jcp.ih + jcp.t_pad - (jcp.kh - 1)), jcp.stride_h);
-    const int bottom_pad_input_correction
+    const dim_t input_bottom_padding_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.ih + jcp.t_pad - (jcp.kh - 1)),
+                    jcp.stride_h);
+    const dim_t bottom_pad_input_correction
             = jcp.ih + jcp.t_pad - input_bottom_padding_overlap * jcp.stride_h;
 
     const size_t filter_shift = jcp.typesize_out * jcp.kw * ic_block * oc_block;
@@ -3422,7 +3450,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3430,7 +3458,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
                 add(reg_kernel, filter_shift * inp_corr);
                 add(reg_input, input_shift * inp_corr);
             }
@@ -3489,19 +3517,20 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
 void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         compute_od_loop_partial() {
     assert(jcp.harness == harness_3d_reduction);
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    const int inp_mult = is_src_layout_nxc()
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t inp_mult = is_src_layout_nxc()
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int out_mult
+    const dim_t out_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    const int input_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
-    const int back_pad_input_correction
+    dim_t iw = jcp.iw;
+    dim_t ow = jcp.ow;
+    const dim_t input_backpad_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d);
+    const dim_t back_pad_input_correction
             = jcp.id + jcp.f_pad - input_backpad_overlap * jcp.stride_d;
 
     const size_t filter_shift
@@ -3554,7 +3583,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const int inp_ker_overlap
+                = static_cast<int>(nstl::min<dim_t>(jcp.kd, jcp.id));
         cmp(reg_kd_count, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3562,7 +3592,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int inp_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                const dim_t inp_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
                 add(reg_kernel, filter_shift * inp_corr);
                 add(reg_input_d, input_shift * inp_corr);
             }
@@ -3668,33 +3698,33 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
     MAYBE_UNUSED(ddst_reg_count);
     assert(ker_reg_count + src_reg_count + ddst_reg_count <= 32);
 
-    auto dwei_offset = [&](int i_kw, int i_ic) {
-        const int oc_block_size = sizeof(float);
-        const int ic_block_size = jcp.oc_block * oc_block_size;
-        const int kw_block_size = jcp.ic_block * ic_block_size;
-        const int kh_block_size = jcp.kw * kw_block_size;
-        const int kd_block_size = jcp.kh * kh_block_size;
-        const int icb_block_size = jcp.kd * kd_block_size;
+    auto dwei_offset = [&](dim_t i_kw, dim_t i_ic) {
+        const dim_t oc_block_size = sizeof(float);
+        const dim_t ic_block_size = jcp.oc_block * oc_block_size;
+        const dim_t kw_block_size = jcp.ic_block * ic_block_size;
+        const dim_t kh_block_size = jcp.kw * kw_block_size;
+        const dim_t kd_block_size = jcp.kh * kh_block_size;
+        const dim_t icb_block_size = jcp.kd * kd_block_size;
 
-        int icb = i_ic / jcp.ic_block;
+        const dim_t icb = i_ic / jcp.ic_block;
         i_ic = i_ic % jcp.ic_block;
 
         return icb * icb_block_size + i_kw * kw_block_size
                 + i_ic * ic_block_size;
     };
 
-    auto src_offset = [&](int i_ic, int i_iw) {
+    auto src_offset = [&](int i_ic, dim_t i_iw) -> dim_t {
         const int ic_block_size = sizeof(float);
-        const int g_block_size = jcp.ic * ic_block_size;
-        const int iw_block_size = jcp.ngroups * g_block_size;
+        const dim_t g_block_size = jcp.ic * ic_block_size;
+        const dim_t iw_block_size = jcp.ngroups * g_block_size;
 
         return i_iw * iw_block_size + i_ic * ic_block_size;
     };
 
     auto ddst_offset = [&](int i_ow) {
         const int oc_block_size = sizeof(float);
-        const int g_block_size = jcp.oc * oc_block_size;
-        const int ow_block_size = jcp.ngroups * g_block_size;
+        const dim_t g_block_size = jcp.oc * oc_block_size;
+        const dim_t ow_block_size = jcp.ngroups * g_block_size;
 
         return i_ow * ow_block_size;
     };
@@ -3763,7 +3793,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
                 }
             }
             for (int i_ic = 0; i_ic < ur_ic; i_ic++) {
-                int ker_offset = dwei_offset(i_kw, i_ic);
+                const dim_t ker_offset = dwei_offset(i_kw, i_ic);
                 vaddps(get_ker_zmm(i_ic), zword[reg_dwei + ker_offset]);
                 vmovups(zword[reg_dwei + ker_offset], get_ker_zmm(i_ic));
             }
@@ -3774,8 +3804,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
 
     auto kw_loop = [&](int ur_ow, int ur_ic, int is_iw_edge) {
         Label kwb_loop_begin, kwb_loop_end;
-        int kw_tail = jcp.kw % kw_unroll;
-        int kw_iter = jcp.kw / kw_unroll;
+        const int kw_tail = jcp.kw % kw_unroll;
+        const int kw_iter = static_cast<int>(jcp.kw / kw_unroll);
 
         if (kw_iter > 0) {
             if (kw_iter > 1) {
@@ -3803,8 +3833,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
 
     auto ic_loop = [&](int ur_ow, int is_iw_edge) {
         Label icb_loop_begin, icb_loop_end;
-        int ic_tail = jcp.ic % ic_unroll;
-        int ic_iter = jcp.ic / ic_unroll;
+        const int ic_tail = jcp.ic % ic_unroll;
+        const int ic_iter = static_cast<int>(jcp.ic / ic_unroll);
 
         if (ic_iter > 0) {
             if (ic_iter > 1 || ic_tail) {
@@ -3859,7 +3889,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::generate_microkernel() {
     auto ic_loop_dispatch = [&](int ur_ow) {
         Label iw_edge_case, ic_end;
 
-        const int iw_overflow_bound = jcp.iw - (ur_ow - 1) * jcp.stride_w
+        const dim_t iw_overflow_bound = jcp.iw - (ur_ow - 1) * jcp.stride_w
                 - (jcp.kw - 1) * (jcp.dilate_w + 1);
         cmp(reg_iw_base, iw_overflow_bound);
         jge(iw_edge_case, T_NEAR);
@@ -3984,9 +4014,9 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -3998,13 +4028,13 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     VDISPATCH_CONV_IC(ok, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -4092,7 +4122,7 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd
@@ -4105,8 +4135,9 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     if (!jcp.is_hw_transp && jcp.kw > 14) return status::unimplemented;
 
     /* setting register strategy */
-    const int unroll_dim = jcp.is_hw_transp ? jcp.oh : jcp.ow;
-    for (int ur_w = nstl::min(max_ur_w, unroll_dim); ur_w > 0; --ur_w) {
+    const dim_t unroll_dim = jcp.is_hw_transp ? jcp.oh : jcp.ow;
+    for (int ur_w = static_cast<int>(nstl::min<dim_t>(max_ur_w, unroll_dim));
+            ur_w > 0; --ur_w) {
         if (unroll_dim % ur_w == 0) {
             jcp.ur_w = ur_w;
             break;
@@ -4235,7 +4266,7 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
         jcp.ur_ic = 2 - jcp.ic % 2;
         jcp.ur_kw = 1;
         if (jcp.stride_w == jcp.dilate_w + 1) {
-            jcp.ur_kw = jcp.kw;
+            jcp.ur_kw = static_cast<int>(jcp.kw);
             if (jcp.kw > 7) {
                 // Blocking by kw is more effective than by ic in the compute
                 // kernel since neighbor kw operations share src data
@@ -4247,11 +4278,11 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
 
         // Unroll by ow to decrease updates to diff_weights. In practice, this
         // should be approximately 1/4 - 1/2 of the zmm registers
-        jcp.ur_ow = nstl::min(
-                (zmm_regs - jcp.ur_kw * jcp.ur_ic) / (jcp.ur_ic + 1), jcp.ow);
+        jcp.ur_ow = static_cast<int>(nstl::min<dim_t>(
+                (zmm_regs - jcp.ur_kw * jcp.ur_ic) / (jcp.ur_ic + 1), jcp.ow));
 
-        int work_amount_base = jcp.mb * jcp.od * jcp.oh;
-        int ow_iter = div_up(jcp.ow, jcp.ur_ow);
+        int work_amount_base = static_cast<int>(jcp.mb * jcp.od * jcp.oh);
+        int ow_iter = static_cast<int>(div_up(jcp.ow, jcp.ur_ow));
         int nthr_ow = nstl::min(
                 jcp.nthr / math::gcd(work_amount_base, jcp.nthr), ow_iter);
         int ow_block = div_up(ow_iter, nthr_ow) * jcp.ur_ow;
@@ -4261,8 +4292,8 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
 
         // Choose a simple parallelization method. A more advance may need made
         // later
-        int work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow;
-        nthr_mb = nstl::min(jcp.nthr, work_amount);
+        const dim_t work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow;
+        nthr_mb = nstl::min(jcp.nthr, static_cast<int>(work_amount));
         nthr_g = 1;
         nthr_oc_b = 1;
         nthr_ic_b = 1;
@@ -4286,7 +4317,8 @@ status_t jit_avx512_common_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.nb_ic_blocking_max = 1;
     if (is_data_layout_nxc && (jcp.ow > max_ur_w || jcp.ndims == 5)) {
         assert(!jcp.is_hw_transp);
-        jcp.nb_ic_blocking_max = nstl::min(8, div_up(jcp.nb_ic, jcp.nthr_ic_b));
+        jcp.nb_ic_blocking_max = static_cast<int>(
+                nstl::min<dim_t>(8, div_up(jcp.nb_ic, jcp.nthr_ic_b)));
     }
 
     return status::success;
@@ -4326,17 +4358,18 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = nthreads / nthr_g_;
 
-    const int ih = j.is_hw_transp ? j.tr_ih : j.ih;
-    const int oh = j.is_hw_transp ? j.ow : j.oh;
+    const dim_t ih = j.is_hw_transp ? j.tr_ih : j.ih;
+    const dim_t oh = j.is_hw_transp ? j.ow : j.oh;
 
-    int ih_reduce = j.harness == harness_2d_reduction ? ih : 1;
-    int oh_reduce = j.harness == harness_2d_reduction ? oh : 1;
-    int ih_no_reduce = j.harness == harness_2d_reduction ? 1 : ih;
-    int oh_no_reduce = j.harness == harness_2d_reduction ? 1 : oh;
-    int nthr_oh_reduce = nstl::max(1, oh_reduce / min_oh_reduce);
+    const dim_t ih_reduce = j.harness == harness_2d_reduction ? ih : 1;
+    const dim_t oh_reduce = j.harness == harness_2d_reduction ? oh : 1;
+    const dim_t ih_no_reduce = j.harness == harness_2d_reduction ? 1 : ih;
+    const dim_t oh_no_reduce = j.harness == harness_2d_reduction ? 1 : oh;
+    const int nthr_oh_reduce
+            = static_cast<int>(nstl::max<dim_t>(1, oh_reduce / min_oh_reduce));
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
         /* calculate per thread memory cost (read/write). high level optimizer
@@ -4371,12 +4404,15 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     dim_t best_mem_cost = calc_mem_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, j.mb * j.od * nthr_oh_reduce);
+    const int nthr_mb_max = static_cast<int>(
+            nstl::min<dim_t>(nthr, j.mb * j.od * nthr_oh_reduce));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
 
             dim_t mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -4403,15 +4439,17 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     dim_t best_comp_cost = calc_comp_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
             dim_t mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             dim_t comp_cost = calc_comp_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
             const bool opt1 = comp_cost <= best_comp_cost
-                    && IMPLICATION(
-                            !j.is_hw_transp, mem_cost < 1.1 * best_mem_cost);
+                    && IMPLICATION(!j.is_hw_transp,
+                            (double)mem_cost < 1.1 * (double)best_mem_cost);
             const bool opt2 = 4 * comp_cost <= 3 * best_comp_cost;
 
             if (opt1 || opt2) {
@@ -4424,7 +4462,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::balance(
     }
 
     if (nthr_mb_ > nthreads / 2 && nthr_mb_ < nthreads)
-        nthr_mb_ = nstl::min(j.mb * j.od * nthr_oh_reduce, nthreads);
+        nthr_mb_ = static_cast<int>(
+                nstl::min<dim_t>(j.mb * j.od * nthr_oh_reduce, nthreads));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= nthreads);

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.hpp
@@ -102,7 +102,7 @@ private:
     }
 
     inline Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+        const int idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
         return Vmm(idx);
     }
@@ -116,13 +116,13 @@ private:
     inline void prepare_output(int ur_w);
     inline void apply_postops(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop_fma(int ur_w, int pad_l, int pad_r);
-    inline void compute_loop_fma_core(int ur_w, int pad_l, int pad_r);
-    inline void compute_loop(int ur_w, int pad_l, int pad_r);
+    inline void compute_loop_fma(int ur_w, dim_t pad_l, dim_t pad_r);
+    inline void compute_loop_fma_core(int ur_w, dim_t pad_l, dim_t pad_r);
+    inline void compute_loop(int ur_w, dim_t pad_l, dim_t pad_r);
 
     void generate() override;
 
-    inline size_t get_output_offset(int oi, int n_oc_block) {
+    inline size_t get_output_offset(dim_t oi, dim_t n_oc_block) {
         const bool is_nxc_layout = is_dst_layout_nxc();
         size_t ow_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
         size_t ocb_str = is_nxc_layout
@@ -132,37 +132,38 @@ private:
         return jcp.typesize_out * (n_oc_block * ocb_str + oi * ow_str);
     }
 
-    inline size_t get_input_offset(int ki, int ic, int oi, int pad_l) {
+    inline dim_t get_input_offset(dim_t ki, dim_t ic, dim_t oi, dim_t pad_l) {
         const bool is_nxc_layout = is_src_layout_nxc();
-        size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic
-                                      : (!jcp.is_1stconv ? jcp.ic_block : 1);
-        size_t ic_str = !jcp.is_1stconv || is_nxc_layout
+        dim_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic
+                                     : (!jcp.is_1stconv ? jcp.ic_block : 1);
+        dim_t ic_str = !jcp.is_1stconv || is_nxc_layout
                 ? 1
-                : (size_t)jcp.iw * jcp.ih * jcp.id;
-        size_t iw_idx = ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
+                : jcp.iw * jcp.ih * jcp.id;
+        dim_t iw_idx = ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
 
         return jcp.typesize_in * (iw_idx * iw_str + ic * ic_str);
     }
 
-    inline int get_kernel_offset(
-            int ki, int ic, int n_oc_block, int ker_number) {
+    inline dim_t get_kernel_offset(
+            dim_t ki, dim_t ic, dim_t n_oc_block, dim_t ker_number) {
         return jcp.typesize_in * jcp.oc_block
                 * (n_oc_block * jcp.nb_ic * jcp.ic_block * jcp.kh * jcp.kw
                                 * jcp.kd
                         + (ic + ker_number) + ki * jcp.ic_block);
     }
 
-    inline int get_ow_start(int ki, int pad_l) {
-        return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+    inline int get_ow_start(dim_t ki, dim_t pad_l) {
+        return static_cast<int>(utils::div_up(
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w));
     }
 
-    inline int get_ow_end(int ur_w, int ki, int pad_r) {
-        return ur_w
+    inline int get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
+        return static_cast<int>(ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
-                        jcp.stride_w);
+                        jcp.stride_w));
     }
     inline bool is_src_layout_nxc() {
         return utils::one_of(jcp.src_tag, format_tag::ndhwc, format_tag::nhwc,
@@ -276,12 +277,12 @@ private:
         return Vmm(ker_reg_base_idx + i_ic);
     }
     inline Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+        const int idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
         return Vmm(idx);
     }
     inline Vmm vmm_out(int i_ur, int i_oc) {
-        int idx = i_ur + i_oc * jcp.ur_w;
+        const int idx = i_ur + i_oc * jcp.ur_w;
         assert(idx < ker_reg_base_idx);
         return Vmm(idx);
     }
@@ -290,35 +291,35 @@ private:
 
     inline void prepare_output(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop_fma(int ur_w, int l_overflow, int r_overflow);
+    inline void compute_loop_fma(int ur_w, dim_t l_overflow, dim_t r_overflow);
     inline void compute_loop_fma_core(
-            int ur_w, int l_overflow, int r_overflow, int k_offset);
+            int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset);
     inline void compute_loop(
-            int ur_w, int l_overflow, int r_overflow, int k_offset = 0);
+            int ur_w, dim_t l_overflow, dim_t r_overflow, int k_offset = 0);
     void generate() override;
 
-    inline int get_iw_start(int ki, int l_overflow) {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    inline int get_iw_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
 
-        return res;
+        return static_cast<int>(res);
     }
 
-    inline int get_iw_end(int ur_w, int ki, int r_overflow) {
+    inline int get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
 
-        return ur_w - res;
+        return static_cast<int>(ur_w - res);
     }
 
-    inline size_t get_diff_src_offset(int iw, int icb) {
+    inline size_t get_diff_src_offset(dim_t iw, dim_t icb) {
         const bool is_nxc_layout = is_dsrc_layout_nxc();
         size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
         size_t icb_str = is_nxc_layout
@@ -328,7 +329,7 @@ private:
         return typesize * (icb * icb_str + iw * iw_str);
     }
 
-    inline ptrdiff_t get_dst_offset(int iw, int oc, int kw) {
+    inline ptrdiff_t get_dst_offset(dim_t iw, dim_t oc, dim_t kw) {
         ptrdiff_t ow
                 = (iw + jcp.l_pad - kw * (jcp.dilate_w + 1)) / jcp.stride_w;
         ptrdiff_t ow_str = is_ddst_layout_nxc()
@@ -460,15 +461,15 @@ private:
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
     inline void compute_oh_step_unroll_ow(int ic_block_step, int max_ur_w);
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound = false);
-    inline void compute_ic_block_step_fma(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound);
-    inline void compute_ic_block_step_fma_expl(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int input_offset, int kernel_offset,
-            int output_offset, bool input_wraparound);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset, bool input_wraparound = false);
+    inline void compute_ic_block_step_fma(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t input_offset, dim_t kernel_offset,
+            dim_t output_offset, bool input_wraparound);
+    inline void compute_ic_block_step_fma_expl(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t input_offset,
+            dim_t kernel_offset, dim_t output_offset, bool input_wraparound);
     inline void compute_oh_step_common(int ic_block_step, int max_ur_w);
     inline void compute_oh_step_disp();
     inline void compute_oh_loop_common();
@@ -486,7 +487,7 @@ private:
     }
 
     inline ptrdiff_t get_full_src_offset(
-            int i_iw, int i_ic, ptrdiff_t input_offset) {
+            dim_t i_iw, int i_ic, ptrdiff_t input_offset) {
         const bool is_nxc_layout = is_src_layout_nxc();
         const size_t w_shift_st = (jcp.is_hw_transp ? jcp.iw : 1)
                 * (jcp.is_1stconv ? 1 : jcp.ic_block);
@@ -499,7 +500,7 @@ private:
         return input_offset + typesize * local_input_offset;
     }
 
-    inline int get_iw_idx(int ow, int kw, int l_pad) const {
+    inline dim_t get_iw_idx(dim_t ow, dim_t kw, dim_t l_pad) const {
         return ow * jcp.stride_w + kw * (jcp.dilate_w + 1) - l_pad;
     }
 

--- a/src/cpu/x64/jit_avx512_common_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.cpp
@@ -118,7 +118,7 @@ inline void jit_conv_ker_pipeline_bwd_w(const jit_conv_ker_t ker,
         const void *bias, int channel, int kh_padding, size_t reduce_work,
         size_t load_work) {
     jit_conv_ker_pipeline(ker, p, src, dst, filt, bias, channel, kh_padding,
-            reduce_work, load_work);
+            static_cast<int>(reduce_work), static_cast<int>(load_work));
 }
 
 void jit_conv_2d_ker_bwd_w_pipeline(const jit_conv_ker_t ker,
@@ -203,14 +203,14 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
     int nthr = jcp.aligned_threads;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -221,9 +221,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t src_c_stride = src_d.blk_off<false, true>(0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn) {
                 int dummy {0};
@@ -241,20 +241,20 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
             }
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
                 const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-                const int oc_off_idx = is_dst_layout_nxc
+                const dim_t oc_off_idx = is_dst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g_ocb;
                 auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, ow_s);
                 const bool is_src_layout_nxc = jcp.src_tag == format_tag::nwc;
-                const int ic_off_idx = is_src_layout_nxc
+                const dim_t ic_off_idx = is_src_layout_nxc
                         ? g * jcp.ic + icb_l2 * jcp.ic_block
                         : g_icb + icb_l2;
                 auto src_w = src + src_d.blk_off(n, ic_off_idx, iw_s);
@@ -264,16 +264,18 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                         * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                    : nullptr;
 
-                int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
-                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                dim_t icb_end
+                        = nstl::min<dim_t>(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const dim_t oc_work = utils::this_block_size(ocb * jcp.oc_block,
                         jcp.oc_without_padding,
                         jcp.nb_oc_blocking * jcp.oc_block);
 
-                int ic_work = icb_step * jcp.ic_block;
+                dim_t ic_work = icb_step * jcp.ic_block;
 
-                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = static_cast<int>(
+                            nstl::min<dim_t>(icb_step, icb_end - icb));
                     int flags = 0;
                     if (icb == 0) flags |= FLAG_IC_FIRST;
                     if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -282,7 +284,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                 jcp.ic, icb_step * jcp.ic_block);
                     }
                     jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv, src_w,
-                            dst_w, wht_w, bias_w, icb, 1, owb, ic_work, oc_work,
+                            dst_w, wht_w, bias_w, static_cast<int>(icb), 1,
+                            static_cast<int>(owb), static_cast<int>(ic_work),
+                            static_cast<int>(oc_work),
                             post_ops_binary_rhs_arg_vec.data(), dst, flags);
 
                     src_w += src_c_stride;
@@ -329,14 +333,14 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
     int nthr = jcp.aligned_threads;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -350,9 +354,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn)
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -367,49 +371,52 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int work_rem = end - start;
+                dim_t work_rem = end - start;
 
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; //step instead
 
-                for (int oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
-                    int ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
+                for (dim_t oh_b = oh_s; oh_b < oh_e; oh_b += jcp.h_blocking) {
+                    dim_t ih_b = -jcp.t_pad + oh_b * jcp.stride_h;
                     const bool is_dst_layout_nxc
                             = jcp.dst_tag == format_tag::nhwc;
-                    const int oc_off_idx = is_dst_layout_nxc
+                    const dim_t oc_off_idx = is_dst_layout_nxc
                             ? g * jcp.oc + ocb * jcp.oc_block
                             : g_ocb;
                     auto dst_w = dst + dst_d.blk_off(n, oc_off_idx, oh_b, ow_s);
                     const bool is_src_layout_nxc
                             = jcp.src_tag == format_tag::nhwc;
-                    const int ic_off_idx = is_src_layout_nxc
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g * jcp.ic + icb_l2 * jcp.ic_block
                             : g_icb + icb_l2;
                     auto src_w = src + src_d.blk_off(n, ic_off_idx, ih_b, iw_s);
                     auto wht_w
                             = weights + wht_blk_off(weights_d, g, ocb, icb_l2);
 
-                    int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                    int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                    dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                    dim_t icb_end = nstl::min<dim_t>(
+                            jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
                     auto bias_w = bias ? bias
                                     + oc_off_idx
                                             * (is_dst_layout_nxc ? 1
                                                                  : jcp.oc_block)
                                        : nullptr;
-                    const int oc_work = utils::this_block_size(
+                    const dim_t oc_work = utils::this_block_size(
                             ocb * jcp.oc_block, jcp.oc_without_padding,
                             jcp.nb_oc_blocking * jcp.oc_block);
-                    int ic_work = icb_step * jcp.ic_block;
-                    for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                        int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                    dim_t ic_work = icb_step * jcp.ic_block;
+                    for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                        int curr_nb_ic = static_cast<int>(
+                                nstl::min<dim_t>(icb_step, icb_end - icb));
                         int flags = 0;
                         if (icb == 0) flags |= FLAG_IC_FIRST;
                         if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -419,18 +426,19 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                         }
                         auto src_c = src_w;
                         auto dst_c = dst_w;
-                        for (int oj = oh_b, ij = ih_b;
-                                oj < min(oh_e, oh_b + jcp.h_blocking);
+                        for (dim_t oj = oh_b, ij = ih_b; oj
+                                < nstl::min<dim_t>(oh_e, oh_b + jcp.h_blocking);
                                 ++oj, ij += jcp.stride_h) {
-                            int dilate_h = jcp.dilate_h + 1;
-                            int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t dilate_h = jcp.dilate_h + 1;
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0, -ij), dilate_h);
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             ij - jcp.ih
                                                     + (jcp.kh - 1) * dilate_h
                                                     + 1),
                                     dilate_h);
-                            int kh_padding = nstl::max(
+                            dim_t kh_padding = nstl::max<dim_t>(
                                     0, jcp.kh - i_t_overflow - i_b_overflow);
 
                             auto aux_src = src_c
@@ -438,8 +446,12 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                             auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
                             jit_conv_ker_pipeline_ow_thr(jit_ker, par_conv,
-                                    aux_src, dst_c, aux_wht, bias_w, icb,
-                                    kh_padding, owb, ic_work, oc_work,
+                                    aux_src, dst_c, aux_wht, bias_w,
+                                    static_cast<int>(icb),
+                                    static_cast<int>(kh_padding),
+                                    static_cast<int>(owb),
+                                    static_cast<int>(ic_work),
+                                    static_cast<int>(oc_work),
                                     post_ops_binary_rhs_arg_vec.data(), dst,
                                     flags);
 
@@ -488,15 +500,15 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -512,9 +524,9 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
         size_t wht_ic_stride = wht_blk_off(weights_d, 0, 0, 1);
 
-        for (int icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
+        for (dim_t icb_l2 = 0; icb_l2 < jcp.nb_ic; icb_l2 += jcp.nb_ic_L2) {
             start = start_copy;
-            int n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
+            dim_t n {0}, gg {0}, occ {0}, oh_s {0}, od_s {0}, owb {0};
 
             if (jcp.loop_order == loop_cwgn)
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -529,36 +541,38 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int ocb = occ * jcp.nb_oc_blocking;
-                int g = gg * g_blocking;
-                int g_ocb = g * jcp.nb_oc + ocb;
-                int g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
+                dim_t ocb = occ * jcp.nb_oc_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_ocb = g * jcp.nb_oc + ocb;
+                dim_t g_icb = g * jcp.nb_ic * jcp.nonblk_group_off;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; //step instead
 
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
 
-                int dilate_d = jcp.dilate_d + 1;
-                int d_t_overflow = div_up(max(0, -id_s), dilate_d);
-                int d_b_overflow = div_up(
-                        max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+                dim_t dilate_d = jcp.dilate_d + 1;
+                dim_t d_t_overflow = div_up(max<dim_t>(0, -id_s), dilate_d);
+                dim_t d_b_overflow = div_up(
+                        max<dim_t>(
+                                0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
                         dilate_d);
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_t_overflow - d_b_overflow);
+                dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_t_overflow - d_b_overflow);
                 const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-                const int oc_off_idx = is_dst_layout_nxc
+                const dim_t oc_off_idx = is_dst_layout_nxc
                         ? g * jcp.oc + ocb * jcp.oc_block
                         : g_ocb;
                 auto dst_w
                         = dst + dst_d.blk_off(n, oc_off_idx, od_s, oh_s, ow_s);
                 const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-                const int ic_off_idx = is_src_layout_nxc
+                const dim_t ic_off_idx = is_src_layout_nxc
                         ? g * jcp.ic + icb_l2 * jcp.ic_block
                         : g_icb + icb_l2;
                 auto src_w = src
@@ -571,15 +585,17 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                                         * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                    : nullptr;
 
-                const int icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
-                int icb_end = min(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
-                const int oc_work = utils::this_block_size(ocb * jcp.oc_block,
+                const dim_t icb_step = is_src_layout_nxc ? jcp.nb_ic_L2 : 1;
+                dim_t icb_end
+                        = nstl::min<dim_t>(jcp.nb_ic, icb_l2 + jcp.nb_ic_L2);
+                const dim_t oc_work = utils::this_block_size(ocb * jcp.oc_block,
                         jcp.oc_without_padding,
                         jcp.nb_oc_blocking * jcp.oc_block);
 
-                int ic_work = icb_step * jcp.ic_block;
-                for (int icb = icb_l2; icb < icb_end; icb += icb_step) {
-                    int curr_nb_ic = nstl::min(icb_step, icb_end - icb);
+                dim_t ic_work = icb_step * jcp.ic_block;
+                for (dim_t icb = icb_l2; icb < icb_end; icb += icb_step) {
+                    int curr_nb_ic = static_cast<int>(
+                            nstl::min<dim_t>(icb_step, icb_end - icb));
                     int flags = 0;
                     if (icb == 0) flags |= FLAG_IC_FIRST;
                     if (icb + curr_nb_ic >= jcp.nb_ic) {
@@ -589,22 +605,27 @@ void jit_avx512_common_convolution_fwd_t<src_type, wei_type,
                     }
                     auto src_c = src_w;
                     auto dst_c = dst_w;
-                    for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                    for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                             ++oj, ij += jcp.stride_h) {
-                        int dilate_h = jcp.dilate_h + 1;
-                        int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                        int i_b_overflow = div_up(
-                                max(0,
+                        dim_t dilate_h = jcp.dilate_h + 1;
+                        dim_t i_t_overflow
+                                = div_up(max<dim_t>(0, -ij), dilate_h);
+                        dim_t i_b_overflow = div_up(
+                                max<dim_t>(0,
                                         ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                 + 1),
                                 dilate_h);
-                        int kh_padding = nstl::max(
+                        dim_t kh_padding = nstl::max<dim_t>(
                                 0, jcp.kh - i_t_overflow - i_b_overflow);
                         jit_conv_3d_ker_pipeline_ow_thr(jit_ker, par_conv,
                                 src_c + i_t_overflow * dilate_h * src_h_stride,
                                 dst_c, wht_w + i_t_overflow * wht_h_stride,
-                                bias_w, icb, kh_padding, kd_padding, owb,
-                                ic_work, oc_work,
+                                bias_w, static_cast<int>(icb),
+                                static_cast<int>(kh_padding),
+                                static_cast<int>(kd_padding),
+                                static_cast<int>(owb),
+                                static_cast<int>(ic_work),
+                                static_cast<int>(oc_work),
                                 post_ops_binary_rhs_arg_vec.data(), dst, flags);
 
                         src_c += src_h_stride * jcp.stride_h;
@@ -650,14 +671,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.nb_iw;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -668,9 +689,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         size_t diff_dst_c_stride = diff_dst_d.blk_off<false, true>(0, 1);
         size_t wht_oc_stride = wht_blk_off(weights_d, 0, 1);
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, iwb {0};
+            dim_t n {0}, gg {0}, icc {0}, iwb {0};
             if (jcp.loop_order == loop_cwgn) {
                 int dummy {0};
                 nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
@@ -687,42 +708,47 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
             }
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
-                int iw_s = iwb * jcp.iw_block;
-                int ow_s = iw_s / jcp.stride_w;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
+                dim_t iw_s = iwb * jcp.iw_block;
+                dim_t ow_s = iw_s / jcp.stride_w;
 
                 const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w
                         = diff_src + diff_src_d.blk_off(n, ic_off_idx, iw_s);
                 const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w
                         = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, ow_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc
+                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
 
                     jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv, diff_src_w,
-                            diff_dst_w, wht_w, nullptr, ocb, 1, iwb,
-                            reduce_work, load_work);
+                            diff_dst_w, wht_w, nullptr, static_cast<int>(ocb),
+                            1, static_cast<int>(iwb),
+                            static_cast<int>(reduce_work),
+                            static_cast<int>(load_work));
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
                 }
@@ -762,14 +788,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -785,9 +811,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
 
         bool is_fast_path = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
+            dim_t n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
 
             if (jcp.loop_order == loop_cwgn) {
                 nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
@@ -802,62 +828,66 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
 
-                int work_rem = end - start;
-                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_e
+                        = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     ih_e = ih_s + 1; //step instead
-                int iw_s = iwb * jcp.iw_block;
-                int ow_s = iw_s / jcp.stride_w;
+                dim_t iw_s = iwb * jcp.iw_block;
+                dim_t ow_s = iw_s / jcp.stride_w;
                 const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::nhwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w
                         = diff_src + diff_src_d.blk_off(n, ic_off_idx, 0, iw_s);
                 const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w
                         = diff_dst + diff_dst_d.blk_off(n, oc_off_idx, 0, ow_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb);
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc
+                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
-                    for (int ij = ih_s; ij < ih_e; ++ij) {
-                        int oj, k_len, k_lo;
+                    for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                        dim_t oj, k_len, k_lo;
                         if (is_fast_path) { // dilate == 0 && stride == 1
-                            int i_t_overflow
-                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                            int i_b_overflow
-                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            dim_t i_t_overflow = max<dim_t>(
+                                    0, jcp.kh - 1 - ij - jcp.t_pad);
+                            dim_t i_b_overflow = max<dim_t>(
+                                    0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                             k_len = jcp.kh - i_t_overflow - i_b_overflow;
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow;
                         } else if (jcp.dilate_h != 0) { // stride == 1
-                            int dilate_h = jcp.dilate_h + 1;
+                            dim_t dilate_h = jcp.dilate_h + 1;
                             // Note: use div_up to account for "holes" in filter
-                            int i_t_overflow
-                                    = div_up(max(0,
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0,
                                                      (jcp.kh - 1) * dilate_h
                                                              - ij - jcp.t_pad),
                                             dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             (jcp.kh - 1) * dilate_h + 1 - jcp.ih
                                                     + ij - jcp.b_pad),
                                     dilate_h);
@@ -865,16 +895,16 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                         } else { // dilate == 0
-                            int i_t_overflow = max(0,
+                            dim_t i_t_overflow = max<dim_t>(0,
                                     (jcp.kh - 1 - ij - jcp.t_pad)
                                             / jcp.stride_h);
-                            int i_b_overflow = max(0,
+                            dim_t i_b_overflow = max<dim_t>(0,
                                     (jcp.kh - jcp.ih + ij - jcp.b_pad)
                                             / jcp.stride_h);
-                            int overflow_kh_hi = jcp.kh - 1
+                            dim_t overflow_kh_hi = jcp.kh - 1
                                     - modulo(jcp.ih - 1 + jcp.b_pad - ij,
                                             jcp.stride_h);
-                            int overflow_kh_lo
+                            dim_t overflow_kh_lo
                                     = (ij + jcp.t_pad) % jcp.stride_h;
 
                             k_len = (overflow_kh_hi - overflow_kh_lo)
@@ -887,8 +917,11 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                         jit_conv_ker_pipeline_iw_thr(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
-                                k_len, iwb, reduce_work, load_work);
+                                wht_w + k_lo * wht_h_stride, nullptr,
+                                static_cast<int>(ocb), static_cast<int>(k_len),
+                                static_cast<int>(iwb),
+                                static_cast<int>(reduce_work),
+                                static_cast<int>(load_work));
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -926,14 +959,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
     const auto &jcp = pd()->jcp_;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
 
-    int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
     int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
-    int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
+    dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
     int nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0}, start_copy;
+        dim_t start {0}, end {0}, start_copy;
         balance211(work_amount, nthr, ithr, start, end);
         start_copy = start;
 
@@ -953,9 +986,9 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
         bool is_fast_path_d = jcp.dilate_d == 0 && jcp.stride_d == 1;
         bool is_fast_path_h = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        for (int ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
+        for (dim_t ocb_l2 = 0; ocb_l2 < jcp.nb_oc; ocb_l2 += jcp.nb_oc_L2) {
             start = start_copy;
-            int n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
+            dim_t n {0}, gg {0}, icc {0}, ih_s {0}, id_s {0};
             // Input width threading is not currently implemented for 3d, so it
             // is not included in the iterator.
             if (jcp.loop_order == loop_cwgn)
@@ -971,31 +1004,35 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 assert(!"unsupported loop order");
 
             while (start < end) {
-                int icb = icc * jcp.nb_ic_blocking;
-                int g = gg * g_blocking;
-                int g_icb = g * jcp.nb_ic + icb;
-                int g_ocb = g * jcp.nb_oc;
+                dim_t icb = icc * jcp.nb_ic_blocking;
+                dim_t g = gg * g_blocking;
+                dim_t g_icb = g * jcp.nb_ic + icb;
+                dim_t g_ocb = g * jcp.nb_oc;
 
-                int work_rem = end - start;
-                int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_e
+                        = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     ih_e = ih_s + 1; //step instead
-                int d_len = 0, d_lo = 0, d_oj = 0;
+                dim_t d_len = 0;
+                dim_t d_lo = 0, d_oj = 0;
                 if (is_fast_path_d) { // dilate == 0 && stride == 1
-                    int d_t_overflow = max(0, jcp.kd - 1 - id_s - jcp.f_pad);
-                    int d_b_overflow
-                            = max(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
+                    dim_t d_t_overflow
+                            = max<dim_t>(0, jcp.kd - 1 - id_s - jcp.f_pad);
+                    dim_t d_b_overflow = max<dim_t>(
+                            0, jcp.kd - jcp.id + id_s - jcp.back_pad);
                     d_len = jcp.kd - d_t_overflow - d_b_overflow;
                     d_lo = d_b_overflow;
                     d_oj = id_s + jcp.f_pad - d_b_overflow;
                 } else if (jcp.dilate_d != 0) { // stride == 1
-                    int dilate_d = jcp.dilate_d + 1;
+                    dim_t dilate_d = jcp.dilate_d + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int d_t_overflow = div_up(
-                            max(0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
+                    dim_t d_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
                             dilate_d);
-                    int d_b_overflow = div_up(
-                            max(0,
+                    dim_t d_b_overflow = div_up(
+                            max<dim_t>(0,
                                     (jcp.kd - 1) * dilate_d + 1 - jcp.id + id_s
                                             - jcp.back_pad),
                             dilate_d);
@@ -1003,15 +1040,15 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                     d_lo = d_b_overflow;
                     d_oj = id_s + jcp.f_pad - d_b_overflow * dilate_d;
                 } else { // dilate == 0
-                    int d_t_overflow = max(
+                    dim_t d_t_overflow = max<dim_t>(
                             0, (jcp.kd - 1 - id_s - jcp.f_pad) / jcp.stride_d);
-                    int d_b_overflow = max(0,
+                    dim_t d_b_overflow = max<dim_t>(0,
                             (jcp.kd - jcp.id + id_s - jcp.back_pad)
                                     / jcp.stride_d);
-                    int overflow_kd_hi = jcp.kd - 1
+                    dim_t overflow_kd_hi = jcp.kd - 1
                             - modulo(jcp.id - 1 + jcp.back_pad - id_s,
                                     jcp.stride_d);
-                    int overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
+                    dim_t overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
 
                     d_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                             - d_t_overflow - d_b_overflow;
@@ -1021,14 +1058,14 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
 
                 const bool is_dsrc_layout_nxc
                         = jcp.src_tag == format_tag::ndhwc;
-                const int ic_off_idx = is_dsrc_layout_nxc
+                const dim_t ic_off_idx = is_dsrc_layout_nxc
                         ? g * jcp.ic + icb * jcp.ic_block
                         : g_icb;
                 auto diff_src_w = diff_src + diff_src_d.blk_off(n, ic_off_idx)
                         + id_s * diff_src_d_stride;
                 const bool is_ddst_layout_nxc
                         = jcp.dst_tag == format_tag::ndhwc;
-                const int oc_off_idx = is_ddst_layout_nxc
+                const dim_t oc_off_idx = is_ddst_layout_nxc
                         ? g * jcp.oc + ocb_l2 * jcp.oc_block
                         : g_ocb + ocb_l2;
                 auto diff_dst_w = diff_dst + diff_dst_d.blk_off(n, oc_off_idx)
@@ -1036,37 +1073,41 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb_l2, icb)
                         + d_lo * wht_d_stride;
 
-                int ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
-                int ocb_end = min(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
-                const int load_work = utils::this_block_size(icb * jcp.ic_block,
-                        jcp.ic, jcp.nb_ic_blocking * jcp.ic_block);
-                int reduce_work = ocb_step * jcp.oc_block;
-                for (int ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
-                    int curr_nb_oc = nstl::min(ocb_step, ocb_end - ocb);
+                dim_t ocb_step = is_ddst_layout_nxc ? jcp.nb_oc_L2 : 1;
+                dim_t ocb_end
+                        = nstl::min<dim_t>(jcp.nb_oc, ocb_l2 + jcp.nb_oc_L2);
+                const dim_t load_work
+                        = utils::this_block_size(icb * jcp.ic_block, jcp.ic,
+                                jcp.nb_ic_blocking * jcp.ic_block);
+                dim_t reduce_work = ocb_step * jcp.oc_block;
+                for (dim_t ocb = ocb_l2; ocb < ocb_end; ocb += ocb_step) {
+                    dim_t curr_nb_oc
+                            = nstl::min<dim_t>(ocb_step, ocb_end - ocb);
                     if (ocb + curr_nb_oc >= jcp.nb_oc) {
                         reduce_work = utils::this_block_size(ocb * jcp.oc_block,
                                 jcp.oc, ocb_step * jcp.oc_block);
                     }
-                    for (int ij = ih_s; ij < ih_e; ++ij) {
-                        int oj, k_len, k_lo;
+                    for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                        dim_t oj, k_lo;
+                        dim_t k_len;
                         if (is_fast_path_h) { // dilate == 0 && stride == 1
-                            int i_t_overflow
-                                    = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                            int i_b_overflow
-                                    = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                            dim_t i_t_overflow = max<dim_t>(
+                                    0, jcp.kh - 1 - ij - jcp.t_pad);
+                            dim_t i_b_overflow = max<dim_t>(
+                                    0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                             k_len = jcp.kh - i_t_overflow - i_b_overflow;
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow;
                         } else if (jcp.dilate_h != 0) { // stride == 1
-                            int dilate_h = jcp.dilate_h + 1;
+                            dim_t dilate_h = jcp.dilate_h + 1;
                             // Note: use div_up to account for "holes" in filter
-                            int i_t_overflow
-                                    = div_up(max(0,
+                            dim_t i_t_overflow
+                                    = div_up(max<dim_t>(0,
                                                      (jcp.kh - 1) * dilate_h
                                                              - ij - jcp.t_pad),
                                             dilate_h);
-                            int i_b_overflow = div_up(
-                                    max(0,
+                            dim_t i_b_overflow = div_up(
+                                    max<dim_t>(0,
                                             (jcp.kh - 1) * dilate_h + 1 - jcp.ih
                                                     + ij - jcp.b_pad),
                                     dilate_h);
@@ -1074,16 +1115,16 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                             k_lo = i_b_overflow;
                             oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                         } else { // dilate == 0
-                            int i_t_overflow = max(0,
+                            dim_t i_t_overflow = max<dim_t>(0,
                                     (jcp.kh - 1 - ij - jcp.t_pad)
                                             / jcp.stride_h);
-                            int i_b_overflow = max(0,
+                            dim_t i_b_overflow = max<dim_t>(0,
                                     (jcp.kh - jcp.ih + ij - jcp.b_pad)
                                             / jcp.stride_h);
-                            int overflow_kh_hi = jcp.kh - 1
+                            dim_t overflow_kh_hi = jcp.kh - 1
                                     - modulo(jcp.ih - 1 + jcp.b_pad - ij,
                                             jcp.stride_h);
-                            int overflow_kh_lo
+                            dim_t overflow_kh_lo
                                     = (ij + jcp.t_pad) % jcp.stride_h;
 
                             k_len = (overflow_kh_hi - overflow_kh_lo)
@@ -1097,8 +1138,11 @@ void jit_avx512_common_convolution_bwd_data_t<diff_dst_type, wei_type,
                         jit_conv_3d_ker_pipeline(jit_ker, par_conv,
                                 diff_src_w + ij * diff_src_h_stride,
                                 diff_dst_w + oj * diff_dst_h_stride,
-                                wht_w + k_lo * wht_h_stride, nullptr, ocb,
-                                k_len, d_len, reduce_work, load_work);
+                                wht_w + k_lo * wht_h_stride, nullptr,
+                                static_cast<int>(ocb), static_cast<int>(k_len),
+                                static_cast<int>(d_len),
+                                static_cast<int>(reduce_work),
+                                static_cast<int>(load_work));
                     }
                     diff_dst_w += diff_dst_c_stride;
                     wht_w += wht_oc_stride;
@@ -1173,10 +1217,10 @@ struct jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     int ithr_but_oc;
     int ithr_but_ic;
 
-    int img_work, img_start = 0, img_end = 0;
-    int g_work, g_start = 0, g_end = 0;
-    int oc_b_work, oc_b_start = 0, oc_b_end = 0;
-    int ic_b_work, ic_b_start = 0, ic_b_end = 0;
+    dim_t img_work, img_start = 0, img_end = 0;
+    dim_t g_work, g_start = 0, g_end = 0;
+    dim_t oc_b_work, oc_b_start = 0, oc_b_end = 0;
+    dim_t ic_b_work, ic_b_start = 0, ic_b_end = 0;
 
     thread_info_t(const jit_avx512_common_convolution_bwd_weights_t *self,
             const exec_ctx_t &ctx, int ithr)
@@ -1212,7 +1256,8 @@ struct jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 key_conv_wei_bia_reduction_bctx);
 
         /* reduction dimension */
-        int oh_reduce = jcp.harness == harness_2d_reduction ? jcp.oh : 1;
+        int oh_reduce = static_cast<int>(
+                jcp.harness == harness_2d_reduction ? jcp.oh : 1);
         balance211(jcp.mb * jcp.od * oh_reduce, self->nthr_mb_, ithr_mb,
                 img_start, img_end);
         img_work = img_end - img_start;
@@ -1238,25 +1283,25 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
         const {
     const auto &jcp = kernel_->jcp;
 
-    const int wei_size
+    const dim_t wei_size
             = jcp.ngroups * jcp.oc * jcp.ic * jcp.kh * jcp.kw * jcp.kd;
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
             : ti->wei_bia_reduction + (ti->ithr_mb - 1) * wei_size;
 
-    auto diff_weights_offset
-            = [&](int g, int i_kd, int i_kh, int i_kw, int i_ic, int i_oc) {
-        const int oc_block_size = 1;
-        const int ic_block_size = jcp.oc_block * oc_block_size;
-        const int kw_block_size = jcp.ic_block * ic_block_size;
-        const int kh_block_size = jcp.kw * kw_block_size;
-        const int kd_block_size = jcp.kh * kh_block_size;
-        const int icb_block_size = jcp.kd * kd_block_size;
-        const int ocb_block_size = jcp.nb_ic * icb_block_size;
-        const int g_block_size = jcp.nb_oc * ocb_block_size;
+    auto diff_weights_offset = [&](dim_t g, dim_t i_kd, dim_t i_kh, dim_t i_kw,
+                                       dim_t i_ic, dim_t i_oc) {
+        const dim_t oc_block_size = 1;
+        const dim_t ic_block_size = jcp.oc_block * oc_block_size;
+        const dim_t kw_block_size = jcp.ic_block * ic_block_size;
+        const dim_t kh_block_size = jcp.kw * kw_block_size;
+        const dim_t kd_block_size = jcp.kh * kh_block_size;
+        const dim_t icb_block_size = jcp.kd * kd_block_size;
+        const dim_t ocb_block_size = jcp.nb_ic * icb_block_size;
+        const dim_t g_block_size = jcp.nb_oc * ocb_block_size;
 
-        int icb = i_ic / jcp.ic_block;
-        int ocb = i_oc / jcp.oc_block;
+        dim_t icb = i_ic / jcp.ic_block;
+        dim_t ocb = i_oc / jcp.oc_block;
         i_ic = i_ic % jcp.ic_block;
         i_oc = i_oc % jcp.oc_block;
 
@@ -1265,27 +1310,27 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                 + i_kw * kw_block_size + i_ic * ic_block_size
                 + i_oc * oc_block_size;
     };
-    auto src_offset
-            = [&](int g, int i_mb, int i_id, int i_ih, int i_ic, int i_iw) {
-        const int ic_block_size = 1;
-        const int g_block_size = jcp.ic * ic_block_size;
-        const int iw_block_size = jcp.ngroups * g_block_size;
-        const int ih_block_size = jcp.iw * iw_block_size;
-        const int id_block_size = jcp.ih * ih_block_size;
-        const int mb_block_size = jcp.id * id_block_size;
+    auto src_offset = [&](dim_t g, dim_t i_mb, dim_t i_id, dim_t i_ih,
+                              dim_t i_ic, dim_t i_iw) {
+        const dim_t ic_block_size = 1;
+        const dim_t g_block_size = jcp.ic * ic_block_size;
+        const dim_t iw_block_size = jcp.ngroups * g_block_size;
+        const dim_t ih_block_size = jcp.iw * iw_block_size;
+        const dim_t id_block_size = jcp.ih * ih_block_size;
+        const dim_t mb_block_size = jcp.id * id_block_size;
 
         return g * g_block_size + i_mb * mb_block_size + i_id * id_block_size
                 + i_ih * ih_block_size + i_iw * iw_block_size
                 + i_ic * ic_block_size;
     };
-    auto diff_dst_offset
-            = [&](int g, int i_mb, int i_od, int i_oh, int i_ow, int i_oc) {
-        const int oc_block_size = 1;
-        const int g_block_size = jcp.oc * oc_block_size;
-        const int ow_block_size = jcp.ngroups * g_block_size;
-        const int oh_block_size = jcp.ow * ow_block_size;
-        const int od_block_size = jcp.oh * oh_block_size;
-        const int mb_block_size = jcp.od * od_block_size;
+    auto diff_dst_offset = [&](dim_t g, dim_t i_mb, dim_t i_od, dim_t i_oh,
+                                   dim_t i_ow, dim_t i_oc) {
+        const dim_t oc_block_size = 1;
+        const dim_t g_block_size = jcp.oc * oc_block_size;
+        const dim_t ow_block_size = jcp.ngroups * g_block_size;
+        const dim_t oh_block_size = jcp.ow * ow_block_size;
+        const dim_t od_block_size = jcp.oh * oh_block_size;
+        const dim_t mb_block_size = jcp.od * od_block_size;
 
         return g * g_block_size + i_mb * mb_block_size + i_od * od_block_size
                 + i_oh * oh_block_size + i_ow * ow_block_size
@@ -1297,47 +1342,47 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             diff_wei[i] = 0;
     };
 
-    int kd_step = jcp.dilate_d + 1;
-    int kh_step = jcp.dilate_h + 1;
-    int stride_d = jcp.stride_d;
-    int stride_h = jcp.stride_h;
-    int f_pad = jcp.f_pad;
-    int t_pad = jcp.t_pad;
+    dim_t kd_step = jcp.dilate_d + 1;
+    dim_t kh_step = jcp.dilate_h + 1;
+    dim_t stride_d = jcp.stride_d;
+    dim_t stride_h = jcp.stride_h;
+    dim_t f_pad = jcp.f_pad;
+    dim_t t_pad = jcp.t_pad;
 
     dim_t work_amount
             = static_cast<dim_t>(jcp.mb) * jcp.od * jcp.oh * jcp.nb_ow;
     dim_t i_work {0}, i_work_end {0};
     balance211(work_amount, jcp.nthr_mb, ti->ithr_mb, i_work, i_work_end);
 
-    int i_mb {0}, i_od {0}, i_oh {0}, i_owb {0};
+    dim_t i_mb {0}, i_od {0}, i_oh {0}, i_owb {0};
     nd_iterator_init(
             i_work, i_mb, jcp.mb, i_od, jcp.od, i_oh, jcp.oh, i_owb, jcp.nb_ow);
 
     zero_diff_weights();
     while (i_work < i_work_end) {
-        int kd_start = div_up(
-                nstl::max(0, jcp.f_pad - jcp.stride_d * i_od), kd_step);
-        int kd_end = nstl::min(
+        dim_t kd_start = div_up(
+                nstl::max<dim_t>(0, jcp.f_pad - jcp.stride_d * i_od), kd_step);
+        dim_t kd_end = nstl::min<dim_t>(
                 jcp.kd - 1, (jcp.id - 1 + f_pad - stride_d * i_od) / kd_step);
-        int i_id_base = stride_d * i_od - f_pad;
-        int kh_start = div_up(
-                nstl::max(0, jcp.t_pad - jcp.stride_h * i_oh), +kh_step);
-        int kh_end = nstl::min(
+        dim_t i_id_base = stride_d * i_od - f_pad;
+        dim_t kh_start = div_up(
+                nstl::max<dim_t>(0, jcp.t_pad - jcp.stride_h * i_oh), kh_step);
+        dim_t kh_end = nstl::min<dim_t>(
                 jcp.kh - 1, (jcp.ih - 1 + t_pad - stride_h * i_oh) / kh_step);
-        int i_ih_base = jcp.stride_h * i_oh + -jcp.t_pad;
-        int i_ow_base = i_owb * jcp.ow_block;
-        int i_ow_end = nstl::min(jcp.ow, i_ow_base + jcp.ow_block);
+        dim_t i_ih_base = jcp.stride_h * i_oh + -jcp.t_pad;
+        dim_t i_ow_base = i_owb * jcp.ow_block;
+        dim_t i_ow_end = nstl::min<dim_t>(jcp.ow, i_ow_base + jcp.ow_block);
 
         // The kernel is small so these loops produce measurable overhead. Since
         // these are simple loops, the compiler will likely make the loops just
         // as well as we can with the jitted assembly, so there is not
         // necessarily a reason to move these loops into assembly. Avoid placing
         // computationally heavy operations within the loops.
-        for_(int i_ow = i_ow_base; i_ow < i_ow_end; i_ow += jcp.ur_ow)
-        for_(int i_oc = 0; i_oc < jcp.oc; i_oc += jcp.oc_block)
-        for_(int g = 0; g < jcp.ngroups; g++)
-        for_(int i_kd = kd_start; i_kd <= kd_end; i_kd++)
-        for (int i_kh = kh_start; i_kh <= kh_end; i_kh++) {
+        for_(dim_t i_ow = i_ow_base; i_ow < i_ow_end; i_ow += jcp.ur_ow)
+        for_(dim_t i_oc = 0; i_oc < jcp.oc; i_oc += jcp.oc_block)
+        for_(dim_t g = 0; g < jcp.ngroups; g++)
+        for_(dim_t i_kd = kd_start; i_kd <= kd_end; i_kd++)
+        for (dim_t i_kh = kh_start; i_kh <= kh_end; i_kh++) {
             // Some Optimization Observations: It may be
             // worthwhile to move the kd and kh loops below the
             // icb loop in the kernel to further amortize the
@@ -1349,16 +1394,18 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             // The compiler seems to do a good job at optimizing these
             // computations. The offset functions likely need to be located
             // so that they will be inlined.
-            int i_iw = i_ow * jcp.stride_w - jcp.l_pad;
-            int i_id = i_id_base + i_kd * kd_step;
-            int i_ih = i_ih_base + i_kh * kh_step;
-            int ddst_offset = diff_dst_offset(g, i_mb, i_od, i_oh, i_ow, i_oc);
-            int s_off_base = src_offset(g, i_mb, i_id, i_ih, 0, i_iw);
-            int dwei_off_base = diff_weights_offset(g, i_kd, i_kh, 0, 0, i_oc);
+            dim_t i_iw = i_ow * jcp.stride_w - jcp.l_pad;
+            dim_t i_id = i_id_base + i_kd * kd_step;
+            dim_t i_ih = i_ih_base + i_kh * kh_step;
+            dim_t ddst_offset
+                    = diff_dst_offset(g, i_mb, i_od, i_oh, i_ow, i_oc);
+            dim_t s_off_base = src_offset(g, i_mb, i_id, i_ih, 0, i_iw);
+            dim_t dwei_off_base
+                    = diff_weights_offset(g, i_kd, i_kh, 0, 0, i_oc);
             // ensure all parameters are 64bit, to comply with windows kernel
             // param access where the params from 5th are passed using stack.
             (*kernel_)(&diff_wei[dwei_off_base], &ti->src[s_off_base],
-                    &ti->diff_dst[ddst_offset], (dim_t)i_iw, (dim_t)i_ow);
+                    &ti->diff_dst[ddst_offset], i_iw, i_ow);
         }
         nd_iterator_step(
                 i_mb, jcp.mb, i_od, jcp.od, i_oh, jcp.oh, i_owb, jcp.nb_ow);
@@ -1377,9 +1424,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw * jcp.kd;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1388,33 +1435,35 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const bool is_src_layout_nxc = utils::one_of(
             jcp.src_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
-    int ic_b_step = jcp.nb_ic_blocking_max;
-    int icb_work = ti->ic_b_end - ti->ic_b_start;
+    dim_t ic_b_step = jcp.nb_ic_blocking_max;
+    dim_t icb_work = ti->ic_b_end - ti->ic_b_start;
     if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
         ic_b_step = utils::div_up(icb_work, 2);
 
-    for (int img = ti->img_start; img < ti->img_end; ++img) {
+    for (dim_t img = ti->img_start; img < ti->img_end; ++img) {
         auto p = jit_conv_args_t();
 
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
         const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
 
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
 
@@ -1439,9 +1488,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1451,47 +1500,50 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             : ti->wei_bia_reduction + (nthr_mb_ - 1) * wei_size
                     + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
 
-    int img {0}, oh_s {0};
-    int img_start = ti->img_start, img_end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t img_start = ti->img_start, img_end = ti->img_end;
     nd_iterator_init(img_start, img, jcp.mb, oh_s, jcp.oh);
-    const int img_first = img;
+    const dim_t img_first = img;
 
-    int ic_b_step = jcp.nb_ic_blocking_max;
-    int icb_work = ti->ic_b_end - ti->ic_b_start;
+    dim_t ic_b_step = jcp.nb_ic_blocking_max;
+    dim_t icb_work = ti->ic_b_end - ti->ic_b_start;
     if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
         ic_b_step = utils::div_up(icb_work, 2);
     while (img_start < img_end) {
         auto p = jit_conv_args_t();
 
-        int work_rem = img_end - img_start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        const int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        const int kh_top_overflow = nstl::max(0, -ih_s);
-        const int kh_bottom_overflow = nstl::max(0, ih_s - jcp.ih + jcp.kh);
-        int kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
-        int kh_padding_offset = nstl::min(jcp.kh - 1, kh_top_overflow) * jcp.kw
-                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        dim_t work_rem = img_end - img_start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        const dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        const dim_t kh_top_overflow = nstl::max<dim_t>(0, -ih_s);
+        const dim_t kh_bottom_overflow
+                = nstl::max<dim_t>(0, ih_s - jcp.ih + jcp.kh);
+        dim_t kh_padding = jcp.kh - kh_top_overflow - kh_bottom_overflow;
+        dim_t kh_padding_offset = nstl::min<dim_t>(jcp.kh - 1, kh_top_overflow)
+                * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
         auto src_h = ti->src + src_d.blk_off(img, 0, ih_s + kh_top_overflow);
         auto diff_dst_h = ti->diff_dst + diff_dst_d.blk_off(img, 0, oh_s);
 
         const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
         const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
             auto src = src_h + src_d.blk_off(0, ic_off_idx);
@@ -1499,9 +1551,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             p.flags = ic_b == 0 ? 0 : 1;
             jit_conv_2d_ker_bwd_w_pipeline(jit_ker, p, src, diff_dst,
                     diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
-                    diff_bia + _oc * jcp.oc_block, (img == img_first), oh_s,
-                    oh_e, kh_padding, kh_padding_offset, ic_to_compute,
-                    oc_to_compute);
+                    diff_bia + _oc * jcp.oc_block, (img == img_first),
+                    static_cast<int>(oh_s), static_cast<int>(oh_e),
+                    static_cast<int>(kh_padding), kh_padding_offset,
+                    ic_to_compute, oc_to_compute);
         }
         nd_iterator_jump(img_start, img_end, img, jcp.mb, oh_s, jcp.oh);
     }
@@ -1518,9 +1571,9 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const auto &jcp = kernel_->jcp;
     const jit_conv_ker_t jit_ker = (decltype(jit_ker))kernel_->jit_ker();
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw * jcp.kd;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     diff_weights_data_t *diff_wei = ti->ithr_mb == 0
             ? (diff_weights_data_t *)ti->diff_weights
@@ -1531,55 +1584,57 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     + (ti->ithr_mb - 1) * jcp.ngroups * padded_oc;
 
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-    const int inp_mult = is_src_layout_nxc
+    const dim_t inp_mult = is_src_layout_nxc
             ? jcp.ngroups * jcp.ic
             : (jcp.is_1stconv ? 1 : jcp.ic_block);
-    const int input_step = jcp.ih * jcp.iw * inp_mult;
+    const dim_t input_step = jcp.ih * jcp.iw * inp_mult;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-    const int output_step = jcp.ow * jcp.oh
+    const dim_t output_step = jcp.ow * jcp.oh
             * (is_ddst_layout_nxc ? jcp.ngroups * jcp.oc : jcp.oc_block);
-    int img {0}, od_s {0};
-    int img_start = ti->img_start, img_end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t img_start = ti->img_start, img_end = ti->img_end;
     nd_iterator_init(img_start, img, jcp.mb, od_s, jcp.od);
-    const int img_first = img;
+    const dim_t img_first = img;
 
-    int ic_b_step = jcp.nb_ic_blocking_max;
-    int icb_work = ti->ic_b_end - ti->ic_b_start;
+    dim_t ic_b_step = jcp.nb_ic_blocking_max;
+    dim_t icb_work = ti->ic_b_end - ti->ic_b_start;
     if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
         ic_b_step = utils::div_up(icb_work, 2);
 
     while (img_start < img_end) {
         auto p = jit_conv_args_t();
 
-        int work_rem = img_end - img_start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        const int id_s = od_s * jcp.stride_d;
-        const int ik_overlap = nstl::max(0, id_s - jcp.f_pad);
-        const int kd_front_pad = nstl::max(0, jcp.f_pad - id_s);
-        const int kd_back_pad
-                = nstl::max(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
-        int kd_pad_off = nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw
-                * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
+        dim_t work_rem = img_end - img_start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        const dim_t id_s = od_s * jcp.stride_d;
+        const dim_t ik_overlap = nstl::max<dim_t>(0, id_s - jcp.f_pad);
+        const dim_t kd_front_pad = nstl::max<dim_t>(0, jcp.f_pad - id_s);
+        const dim_t kd_back_pad
+                = nstl::max<dim_t>(0, id_s - jcp.f_pad - jcp.id + jcp.kd);
+        dim_t kd_pad_off = nstl::min<dim_t>(jcp.kd - 1, kd_front_pad) * jcp.kh
+                * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
-        const int max_oc = nstl::min(ti->oc_b_end * jcp.oc_block, jcp.oc);
-        const int max_ic = nstl::min(ti->ic_b_end * jcp.ic_block, jcp.ic);
+        const dim_t max_oc
+                = nstl::min<dim_t>(ti->oc_b_end * jcp.oc_block, jcp.oc);
+        const dim_t max_ic
+                = nstl::min<dim_t>(ti->ic_b_end * jcp.ic_block, jcp.ic);
 
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int _oc = g * jcp.nb_oc + oc_b;
-            const int _ic = g * jcp.nb_ic + ic_b;
+            const dim_t _oc = g * jcp.nb_oc + oc_b;
+            const dim_t _ic = g * jcp.nb_ic + ic_b;
 
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, max_ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, max_oc, jcp.oc_block);
 
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : _ic;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : _oc;
             auto src = &ti->src[src_d.blk_off(img, ic_off_idx)
@@ -1590,9 +1645,10 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
             p.flags = ic_b == 0 ? 0 : 1;
             jit_conv_3d_ker_bwd_w_pipeline(jit_ker, p, src, dst,
                     diff_wei + wht_blk_off(diff_weights_d, g, oc_b, ic_b),
-                    diff_bia_ptr, (img == img_first), od_s, od_e,
-                    jcp.kd - kd_front_pad - kd_back_pad, kd_pad_off,
-                    ic_to_compute, oc_to_compute);
+                    diff_bia_ptr, (img == img_first), static_cast<int>(od_s),
+                    static_cast<int>(od_e),
+                    static_cast<int>(jcp.kd - kd_front_pad - kd_back_pad),
+                    kd_pad_off, ic_to_compute, oc_to_compute);
         }
         nd_iterator_jump(img_start, img_end, img, jcp.mb, od_s, jcp.od);
     }
@@ -1605,34 +1661,35 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int padded_oc = rnd_up(jcp.oc, jcp.oc_block);
-    const int wei_size = jcp.ngroups * padded_oc * rnd_up(jcp.ic, jcp.ic_block)
-            * jcp.kh * jcp.kw;
+    const dim_t padded_oc = rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t wei_size = jcp.ngroups * padded_oc
+            * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw;
 
     /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
     if (dnnl_thr_syncable())
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work = ti->ic_b_work * jcp.kh;
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t ic_b_kh_work = ti->ic_b_work * jcp.kh;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
-    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
-    if (start == end) return;
+    int bal_start {0}, bal_end {0};
+    balance211(
+            static_cast<int>(work), nthr_mb_, ti->ithr_mb, bal_start, bal_end);
+    if (bal_start == bal_end) return;
 
     for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = bal_start, end = bal_end;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
-            const int kh = sub_ic_b_kh_start % jcp.kh;
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kh;
+            const dim_t kh = sub_ic_b_kh_start % jcp.kh;
 
-            const int acc_size
-                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
+            const dim_t acc_size = nstl::min<dim_t>(end - w,
+                                           ic_b_kh_work - sub_ic_b_kh_start)
                     * jcp.kw * jcp.ic_block * jcp.oc_block;
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kh);
@@ -1658,33 +1715,34 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
 
     /* diff_weights[:] += sum(wei_reduction_[thr_mb][:]) */
     if (dnnl_thr_syncable())
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work = ti->ic_b_work * jcp.kd;
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t ic_b_kh_work = ti->ic_b_work * jcp.kd;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
-    balance211(work, nthr_mb_, ti->ithr_mb, start, end);
-    if (start == end) return;
+    int bal_start {0}, bal_end {0};
+    balance211(
+            static_cast<int>(work), nthr_mb_, ti->ithr_mb, bal_start, bal_end);
+    if (bal_start == bal_end) return;
 
     for (int thr_mb = 1; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = bal_start, end = bal_end;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
-            const int kd = sub_ic_b_kh_start % jcp.kd;
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start + sub_ic_b_kh_start / jcp.kd;
+            const dim_t kd = sub_ic_b_kh_start % jcp.kd;
 
-            const int acc_size
-                    = nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start)
+            const dim_t acc_size = nstl::min<dim_t>(end - w,
+                                           ic_b_kh_work - sub_ic_b_kh_start)
                     * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.kh;
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kd);
@@ -1720,23 +1778,23 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
     if (b_njobs == 0) return;
 
     /* reduction dimension */
-    int img_start {0}, img_end {0};
+    dim_t img_start {0}, img_end {0};
     balance211(jcp.mb, rb->balancer().nthr_per_group_,
             rb->balancer().id_in_group(ti->ithr), img_start, img_end);
 
     /* jobs */
     int g_start {0}, ocb_start {0};
     nd_iterator_init(b_job_start, g_start, jcp.ngroups, ocb_start, jcp.nb_oc);
-    for (int img = img_start; img < img_end; ++img) {
+    for (dim_t img = img_start; img < img_end; ++img) {
         int g = g_start, ocb = ocb_start;
         for (int b_job_loc = 0; b_job_loc < b_njobs; ++b_job_loc) {
-            const size_t _oc = g * jcp.nb_oc + ocb;
-            const int max_oc
+            const dim_t _oc = g * jcp.nb_oc + ocb;
+            const dim_t max_oc
                     = this_block_size(ocb * jcp.oc_block, jcp.oc, jcp.oc_block);
 
             const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                     format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : _oc;
             const diff_dst_data_t *d_dst
@@ -1751,7 +1809,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                     d_bias[o] = 0;
             for (int hw = 0; hw < jcp.oh * jcp.ow * jcp.od; ++hw) {
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < max_oc; ++o)
+                for (dim_t o = 0; o < max_oc; ++o)
                     d_bias[o] += d_dst[o];
                 d_dst += is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
                                             : jcp.oc_block;
@@ -1773,7 +1831,7 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     const size_t wei_size = (size_t)jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block) * jcp.kh * jcp.kw * jcp.kd;
-    const int bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
+    const dim_t bia_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
     const diff_weights_data_t *diff_bias_ws
             = ti->wei_bia_reduction + (size_t)(nthr_mb_ - 1) * wei_size;
 
@@ -1910,8 +1968,8 @@ void jit_avx512_common_convolution_bwd_weights_t<src_type, diff_dst_type,
                                              key_conv_padded_bias);
             auto diff_bias_in
                     = CTX_OUT_MEM(diff_weights_data_t *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
             for (int g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);

--- a/src/cpu/x64/jit_avx512_common_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_common_convolution.hpp
@@ -232,8 +232,9 @@ struct jit_avx512_common_convolution_bwd_weights_t : public primitive_t {
             const size_t max_buffer_size = jcp_.nthr * 3 * 5 * 5 * 16 * 16;
             if (with_bias()) {
                 reducer_bia_conf_.init(reduce_balancer_t(jcp_.nthr,
-                        jcp_.oc_block, jcp_.ngroups * jcp_.nb_oc, jcp_.mb,
-                        max_buffer_size, true));
+                        static_cast<int>(jcp_.oc_block),
+                        static_cast<int>(jcp_.ngroups * jcp_.nb_oc),
+                        static_cast<int>(jcp_.mb), max_buffer_size, true));
             }
         }
     };

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.cpp
@@ -91,25 +91,25 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::init_runtime_counters() {
     is_buffer_empty_ = true;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_h_shift() const {
-    return (size_t)jcp.ow * jcp.ngroups * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_h_shift() const {
+    return jcp.ow * jcp.ngroups * jcp.oc_without_padding;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_w_shift() const {
-    return (size_t)jcp.ngroups * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_w_shift() const {
+    return jcp.ngroups * jcp.oc_without_padding;
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::inp_offset(
-        int h, int w, int icb) const {
-    return (size_t)jcp.typesize_in
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::inp_offset(
+        dim_t h, dim_t w, dim_t icb) const {
+    return jcp.typesize_in
             * (h * jcp.iw * jcp.ngroups * jcp.ic_without_padding
                     + w * jcp.ngroups * jcp.ic_without_padding
                     + icb * jcp.ic_block_int_np);
 }
 
-size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
-        int h, int w, int ocb) const {
-    return (size_t)jcp.typesize_out
+dim_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
+        dim_t h, dim_t w, dim_t ocb) const {
+    return jcp.typesize_out
             * (h * jcp.ow * jcp.ngroups * jcp.oc_without_padding
                     + w * jcp.ngroups * jcp.oc_without_padding
                     + ocb * jcp.oc_block);
@@ -118,9 +118,9 @@ size_t jit_avx512_core_amx_1x1_fwd_kernel_t::out_row_offset(
 void jit_avx512_core_amx_1x1_fwd_kernel_t::update_buffer_pointers() {
     auto buffer_offset
             = [this](bool shift) { return ((buf_count_ + shift) % 2); };
-    int wsp_shift = jcp.typesize_acc * (jcp.wsp_buffer_size / 2);
+    dim_t wsp_shift = jcp.typesize_acc * (jcp.wsp_buffer_size / 2);
 
-    int postop_shift = wsp_shift * buffer_offset(true);
+    dim_t postop_shift = wsp_shift * buffer_offset(true);
 
     mov(reg_postop, wsp_ptr);
     add(reg_postop, postop_shift);
@@ -150,7 +150,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::interleave_store() {
                             {bin_injector_helper_reg_1,
                                     bin_injector_helper_reg_2,
                                     bin_injector_helper_reg_3});
-            const int wsp_row_offset = jcp.typesize_acc
+            const dim_t wsp_row_offset = jcp.typesize_acc
                     * (osb * jcp.nb_oc_blocking * jcp.max_width * jcp.oc_block
                             + ocb * jcp.max_width * jcp.oc_block
                             + row * jcp.oc_block);
@@ -165,7 +165,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::interleave_store() {
         if (row_count_ == exp_row_count) {
             int oh = ((jcp.nb_os_blocking * jcp.tile_width) / jcp.ow);
             int ow = ((jcp.nb_os_blocking * jcp.tile_width) % jcp.ow);
-            size_t out_offset = jcp.typesize_out
+            dim_t out_offset = jcp.typesize_out
                     * (oh * out_h_shift() + ow * out_w_shift());
             add(out_ptr, out_offset);
             row_count_ = 0;
@@ -267,7 +267,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
     }
 
     if (jcp.src_zero_point) {
-        const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
         const Zmm zmm_zp_m = zmm_mask(zmm_zp, mask_flag);
         vpmulld(zmm_zp_m, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -296,7 +296,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
         for (int j = 0; j < jcp.tile_width; j++) {
-            const int scale_offset
+            const dim_t scale_offset
                     = jcp.is_oc_scale * (sizeof(float) * ocb * jcp.oc_block);
             const Zmm zmm_r = zmm_out(j);
             const Zmm zmm_r_msk = zmm_mask(zmm_r, mask_flag);
@@ -308,7 +308,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_int8(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
         for (int j = 0; j < jcp.tile_width; j++) {
@@ -405,12 +405,12 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
     if (jcp.src_zero_point) {
-        const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
         const Zmm zmm_zp_m = zmm_mask(zmm_zp, mask_flag);
         vpmulld(zmm_zp_m, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -427,7 +427,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        int scale_offset
+        const dim_t scale_offset
                 = jcp.is_oc_scale * (sizeof(float) * ocb * jcp.oc_block);
         const Zmm zmm_out_msk = zmm_mask(zmm_out, mask_flag);
         vmulps(zmm_out_msk, zmm_out,
@@ -476,7 +476,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vectors_bf16(
 
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
-        const int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         const auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
         for (int j = 0; j < jcp.tile_width; j++) {
@@ -542,7 +542,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output_vector_bf16(
         }
     }
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         if (jcp.bia_dt == data_type::bf16) {
             vpmovzxwd(zmm_mask(zmm_bias, mask_flag), bias_addr);
@@ -591,7 +591,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::store_output(
         bool do_store, bool has_tail) {
 
     auto store_output_subblock = [&](int ocb, int osb) {
-        const int wsp_offset = jcp.typesize_acc
+        const dim_t wsp_offset = jcp.typesize_acc
                 * (osb * jcp.nb_oc_blocking * jcp.max_width * jcp.oc_block
                         + ocb * jcp.max_width * jcp.oc_block);
         tilestored(ptr[wsp_ptr + stride_seq + wsp_offset],
@@ -670,12 +670,13 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
         }
     };
 
-    auto tileloadd_nt = [this](const Tmm &t1, int offset) {
-        int ab_size = jcp.nb_os2_blocking * jcp.nb_os_blocking * jcp.tile_width
+    auto tileloadd_nt = [this](const Tmm &t1, dim_t offset) {
+        const dim_t ab_size = jcp.nb_os2_blocking * jcp.nb_os_blocking
+                * jcp.tile_width
                 * (jcp.nb_ic_int * jcp.ic_block_int_np
                         + jcp.nb_oc_blocking * jcp.oc_block);
-        int c_size = (jcp.nb_ic_int * jcp.ic_block_int_np * jcp.nb_oc_blocking
-                * jcp.oc_block);
+        const dim_t c_size = (jcp.nb_ic_int * jcp.ic_block_int_np
+                * jcp.nb_oc_blocking * jcp.oc_block);
         // If the size of  src + wei used in the kernel cannot fit into L1 cache,
         // use non-temporal load of weights to help keep src in L1 cache
         if (static_cast<size_t>(jcp.typesize_in * (ab_size + c_size))
@@ -687,13 +688,13 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     auto compute_block = [&](int icb, int os_b) {
         for (int osb = 0; osb < os_b; osb++) {
-            int ih = ((osb * jcp.tile_width) / jcp.ow) * jcp.stride_h;
-            int iw = ((osb * jcp.tile_width) % jcp.ow) * jcp.stride_w;
+            dim_t ih = ((osb * jcp.tile_width) / jcp.ow) * jcp.stride_h;
+            dim_t iw = ((osb * jcp.tile_width) % jcp.ow) * jcp.stride_w;
             tileloadd(Tmm(get_inp_tensor(osb)),
                     ptr[inp_ptr + stride_nhwc + inp_offset(ih, iw, icb)]);
         }
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-            const int wei_offset = jcp.typesize_in
+            const dim_t wei_offset = jcp.typesize_in
                     * (ocb
                                     * utils::rnd_up(jcp.ic_without_padding,
                                             jcp.ic_block_int)
@@ -722,7 +723,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
         mov(reg_tilebuff, ptr[param1 + GET_OFF(src_prf)]);
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++)
             for (int osb = 0; osb < os_b; osb++) {
-                const int wsp_offset = jcp.typesize_acc
+                const dim_t wsp_offset = jcp.typesize_acc
                         * (osb * jcp.nb_oc_blocking * jcp.max_width
                                         * jcp.oc_block
                                 + ocb * jcp.max_width * jcp.oc_block);
@@ -745,7 +746,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     auto compute_icb_loop = [&](int os_b = 1) {
         int shift = (get_ic_tail() && os_b == 1) ? 1 : 0;
-        int nb_ic_int = jcp.nb_ic_int - shift;
+        const int nb_ic_int = static_cast<int>(jcp.nb_ic_int - shift);
 
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
@@ -771,7 +772,7 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::icb_loop(bool do_store) {
 
     Label label_last_os, label_compute_done, label_tail, label_done;
 
-    int stride_nhwc_ = jcp.typesize_in * jcp.ngroups * jcp.ic_without_padding
+    dim_t stride_nhwc_ = jcp.typesize_in * jcp.ngroups * jcp.ic_without_padding
             * jcp.stride_w;
     mov(stride_nhwc, stride_nhwc_);
 
@@ -808,19 +809,19 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::osb_loop(int nb_os) {
         int oh = (((osi + 1) * jcp.nb_os_blocking * jcp.tile_width) / jcp.ow);
         int ow = (((osi + 1) * jcp.nb_os_blocking * jcp.tile_width) % jcp.ow);
         if (do_store) {
-            size_t out_offset = jcp.typesize_out
+            dim_t out_offset = jcp.typesize_out
                     * (oh * out_h_shift() + ow * out_w_shift());
             add(out_ptr, out_offset);
         }
 
-        int ih = oh * jcp.stride_h;
-        int iw = ow * jcp.stride_w;
+        dim_t ih = oh * jcp.stride_h;
+        dim_t iw = ow * jcp.stride_w;
         add(inp_ptr, inp_offset(ih, iw, 0));
     }
 }
 
 int jit_avx512_core_amx_1x1_fwd_kernel_t::get_ic_tail() const {
-    return (jcp.ic_without_padding % jcp.ic_block_int_np);
+    return static_cast<int>(jcp.ic_without_padding % jcp.ic_block_int_np);
 }
 
 void jit_avx512_core_amx_1x1_fwd_kernel_t::generate() {
@@ -909,12 +910,12 @@ void jit_avx512_core_amx_1x1_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                 tc_configure_tile(buff, get_out_tensor(s, i), Cr, Cc);
             }
 
-        buff->palette_id = amx::get_target_palette();
+        buff->palette_id = static_cast<uint8_t>(amx::get_target_palette());
     };
 
-    int Ac = jcp.typesize_in
+    int Ac = static_cast<int>(jcp.typesize_in
             * ((jcp.nb_ic_int == 1 && get_ic_tail()) ? get_ic_tail()
-                                                     : jcp.ic_block_int_np);
+                                                     : jcp.ic_block_int_np));
 
     cfg_tiles((palette_config_t *)tcfg_buff, Ac);
     if (jcp.nb_ic_int > 1 && get_ic_tail()) {
@@ -1150,10 +1151,13 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                     p, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -1166,8 +1170,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const int size_treshold = 32;
     const int min_width
             = 1; // TODO: Possible optimizations: do not use small values
-    const int spatial = jcp.od * jcp.oh;
-    const int os = jcp.od * jcp.oh * jcp.ow;
+    const dim_t spatial = jcp.od * jcp.oh;
+    const dim_t os = jcp.od * jcp.oh * jcp.ow;
 
     jcp.tile_width = 1;
     for (int s_size = jcp.max_width; s_size >= min_width; s_size--) {
@@ -1178,7 +1182,7 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
         }
     }
     if (jcp.tile_width == 1) {
-        jcp.tile_width = nstl::min(jcp.max_width, os);
+        jcp.tile_width = static_cast<int>(nstl::min<dim_t>(jcp.max_width, os));
         jcp.tile_tail = os % jcp.max_width;
         for (int i = jcp.max_width; i >= min_width; i--) {
             int i_tail = os % i;
@@ -1222,7 +1226,8 @@ status_t jit_avx512_core_amx_1x1_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     int ops_tile_store
             = jcp.nb_oc_blocking * jcp.nb_os_blocking * jcp.tile_width;
-    int avaliable_ops = jcp.nb_ic_int * jcp.nb_oc_blocking * jcp.nb_os_blocking;
+    const dim_t avaliable_ops
+            = jcp.nb_ic_int * jcp.nb_oc_blocking * jcp.nb_os_blocking;
     jcp.per_one_pstore
             = (avaliable_ops) ? ops_tile_store / avaliable_ops + 1 : 0;
     if (jcp.per_one_pstore > 12) jcp.per_one_pstore = 0;

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_conv_kernel.hpp
@@ -122,10 +122,10 @@ private:
     int get_wei_tensor(int i) const;
     int get_ic_tail() const;
 
-    size_t out_h_shift() const;
-    size_t out_w_shift() const;
-    size_t inp_offset(int ih, int iw, int icb) const;
-    size_t out_row_offset(int h, int w, int ocb) const;
+    dim_t out_h_shift() const;
+    dim_t out_w_shift() const;
+    dim_t inp_offset(dim_t ih, dim_t iw, dim_t icb) const;
+    dim_t out_row_offset(dim_t h, dim_t w, dim_t ocb) const;
 
     void prepare_output();
 

--- a/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_1x1_convolution.cpp
@@ -121,17 +121,16 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             utils::rnd_up(jcp.ic_without_padding, jcp.ic_block_int)
             * jcp.oc_block * jcp.nb_oc_blocking);
 
-    int nb_os = (jcp.tile_tail) ? jcp.nb_os + 1 : jcp.nb_os;
-    int os_step = jcp.nb_os2_blocking * jcp.nb_os_blocking;
-    int os_chunks = div_up(nb_os, os_step);
+    const dim_t nb_os = (jcp.tile_tail) ? jcp.nb_os + 1 : jcp.nb_os;
+    const dim_t os_step = jcp.nb_os2_blocking * jcp.nb_os_blocking;
+    const dim_t os_chunks = div_up(nb_os, os_step);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
 
-    const size_t work_amount
-            = (size_t)jcp.mb * jcp.ngroups * os_chunks * oc_chunks;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * os_chunks * oc_chunks;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -153,19 +152,19 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, _osb {0}, _ocb {0};
+        dim_t mb {0}, g {0}, _osb {0}, _ocb {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, _osb, os_chunks,
                 _ocb, oc_chunks);
 
         while (start < end) {
-            int osb = _osb * os_step;
-            int ocb = _ocb * jcp.nb_oc_blocking;
+            const dim_t osb = _osb * os_step;
+            const dim_t ocb = _ocb * jcp.nb_oc_blocking;
             auto bias_w = bias
                     ? bias + (bias_d.blk_off(ocb * jcp.oc_block) * bia_dt_size)
                     : nullptr;
 
-            int oc = g * jcp.oc_without_padding + ocb * jcp.oc_block;
-            int ic = g * jcp.ic_without_padding;
+            const dim_t oc = g * jcp.oc_without_padding + ocb * jcp.oc_block;
+            const dim_t ic = g * jcp.ic_without_padding;
 
             p.acc_s32 = wsp + ithr * jcp.wsp_buffer_size;
             p.src_prf = wsp_tile + ithr * (jcp.wsp_buffer_size / 2);
@@ -191,18 +190,18 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
             const bool is_overflow = (osb + os_step >= nb_os);
             if (is_overflow
                     && (os_chunks > 1 || (os_chunks == 1 && is_ic_tail))) {
-                int step = (check_last_sp) ? 1 : jcp.nb_os_blocking;
-                for (int osi = 0; osi < nb_os - osb; osi += step) {
-                    int osb_i = osi + osb;
-                    int od {0}, oh {0}, ow {0};
+                const dim_t step = (check_last_sp) ? 1 : jcp.nb_os_blocking;
+                for (dim_t osi = 0; osi < nb_os - osb; osi += step) {
+                    const dim_t osb_i = osi + osb;
+                    dim_t od {0}, oh {0}, ow {0};
                     nd_iterator_init(osb_i * jcp.tile_width, od, jcp.od, oh,
                             jcp.oh, ow, jcp.ow);
                     size_t dst_offset = md_blk_off(dst_d, mb, oc, od, oh, ow);
                     p.dst = dst + dst_dt_size * dst_offset;
 
-                    int id = od * jcp.stride_d;
-                    int ih = oh * jcp.stride_h;
-                    int iw = ow * jcp.stride_w;
+                    const dim_t id = od * jcp.stride_d;
+                    const dim_t ih = oh * jcp.stride_h;
+                    const dim_t iw = ow * jcp.stride_w;
                     size_t inp_offset = md_blk_off(src_d, mb, ic, id, ih, iw);
                     p.src = src + src_dt_size * inp_offset;
 
@@ -213,15 +212,15 @@ status_t jit_avx512_core_amx_1x1_convolution_fwd_t::execute_forward(
                     (*kernel_)(&p);
                 }
             } else {
-                int od {0}, oh {0}, ow {0};
+                dim_t od {0}, oh {0}, ow {0};
                 nd_iterator_init(osb * jcp.tile_width, od, jcp.od, oh, jcp.oh,
                         ow, jcp.ow);
                 size_t dst_offset = md_blk_off(dst_d, mb, oc, od, oh, ow);
                 p.dst = dst + dst_dt_size * dst_offset;
 
-                int id = od * jcp.stride_d;
-                int ih = oh * jcp.stride_h;
-                int iw = ow * jcp.stride_w;
+                const dim_t id = od * jcp.stride_d;
+                const dim_t ih = oh * jcp.stride_h;
+                const dim_t iw = ow * jcp.stride_w;
                 size_t inp_offset = md_blk_off(src_d, mb, ic, id, ih, iw);
                 p.src = src + src_dt_size * inp_offset;
 

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -42,7 +42,7 @@ using namespace dnnl::impl::data_type;
 using namespace dnnl::impl::utils;
 using namespace Xbyak;
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(int ur_w) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(dim_t ur_w) {
     for (int oc = 0; oc < jcp.nb_oc_blocking; oc++)
         for (int ur = 0; ur < ur_w; ur++) {
             const Zmm zmm = zmm_out(ur, oc);
@@ -51,22 +51,22 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::prepare_output(int ur_w) {
 }
 
 void jit_avx512_core_amx_compute_zp_pbuff_t::store_output(
-        int ur_w, bool last_oc_block_flag) {
+        dim_t ur_w, bool last_oc_block_flag) {
     assert(jcp.is_nspc);
 
-    const int nb_oc_block = jcp.nb_oc_blocking;
-    const int oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t oc_block = jcp.oc_block;
 
     const auto src_zp_addr = EVEX_compress_addr(reg_src_zero_point, 0, true);
 
     /* write out register to output_addr */
     for (int oc = 0; oc < nb_oc_block; oc++) {
         const bool mask_flag = last_oc_block_flag && oc == nb_oc_block - 1;
-        for (int ur = 0; ur < ur_w; ur++) {
-            const int output_offset = sizeof(int32_t)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
+            const dim_t output_offset = sizeof(int32_t)
                     * (oc * oc_block
                             + ur * jcp.oc_without_padding * jcp.ngroups);
-            const Zmm zmm_dst = zmm_out(ur, oc);
+            const Zmm zmm_dst = zmm_out(static_cast<int>(ur), oc);
             const Zmm m_zmm_dst = mask_flag ? zmm_dst | ktail_mask : zmm_dst;
             // multiply dst by src_zero_point
             vpmulld(m_zmm_dst, zmm_dst, src_zp_addr);
@@ -75,13 +75,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::store_output(
     }
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool padded) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag, bool padded) {
 
-    const int kw = jcp.kw;
-    const int ic_block = jcp.ic_block_int_np;
-    const int oc_block = jcp.oc_block;
-    const int nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t kw = jcp.kw;
+    const dim_t ic_block = jcp.ic_block_int_np;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
 
     const bool ic_tail
             = (jcp.ic_without_padding % (jcp.ic_block / ic_inner_block)) > 0;
@@ -90,24 +90,23 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
 
     /* Skip the last loads of input
             if (ic%16)/ic_sub_step < ic_block/ic_sub_step */
-    const int icb = (last_ic_block_flag == ic_block_t::last_ic_block)
+    const dim_t icb = (last_ic_block_flag == ic_block_t::last_ic_block)
             ? div_up((jcp.ic_without_padding % jcp.ic_block_int),
                       ic_inner_block)
             : ic_block / ic_inner_block;
 
-    auto get_filter_offset = [this, oc_block](int ocb, int ic, int ki) {
-        size_t w_step = jcp.is_relo ? jcp.kh : 1;
-        size_t kw_offset = static_cast<size_t>(ki) * w_step
-                * jcp.ic_block_int_np * jcp.oc_block;
-        size_t oc_subblock_step = static_cast<size_t>(jcp.kd) * jcp.kh * jcp.kw
-                * jcp.ic_block_int_np * jcp.oc_block;
-        size_t offset = kw_offset
-                + static_cast<size_t>(ocb) * jcp.nb_ic_int * oc_subblock_step
-                + static_cast<size_t>(ic) * oc_block * ic_inner_block;
-        return sizeof(char) * offset;
+    auto get_filter_offset = [this, oc_block](dim_t ocb, dim_t ic, dim_t ki) {
+        const dim_t w_step = jcp.is_relo ? jcp.kh : 1;
+        const dim_t kw_offset
+                = ki * w_step * jcp.ic_block_int_np * jcp.oc_block;
+        const dim_t oc_subblock_step
+                = jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
+        return static_cast<dim_t>(sizeof(char))
+                * (kw_offset + ocb * jcp.nb_ic_int * oc_subblock_step
+                        + ic * oc_block * ic_inner_block);
     };
     auto compute_fma = [this, masked_write, icb](const Zmm zmm_accum,
-                               const int ic, const Address addr) {
+                               const dim_t ic, const Address addr) {
         if (jcp.is_relo) {
             vmovups(zmm_permb, ptr[reg_scratch]); // get permute index table
             const Zmm r_zmm = masked_write && ic == icb - 1
@@ -130,18 +129,19 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
     }
     if (jcp.is_relo) mov(reg_scratch, permb_idx_label);
 
-    for (int ki = 0; ki < kw; ki++) {
-        const int ur_start = get_ow_start(ki, pad_l);
-        const int ur_end = get_ow_end(ur_w, ki, pad_r);
-        for (int ur = 0; ur < ur_w; ur++) {
+    for (dim_t ki = 0; ki < kw; ki++) {
+        const dim_t ur_start = get_ow_start(ki, pad_l);
+        const dim_t ur_end = get_ow_end(ur_w, ki, pad_r);
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             // Calculate zero_point padding as:
             // accum = is_padding ? src_zero_point_s32 * conv(1, wei_s8) : 0)
             if (ur < ur_start || ur >= ur_end || padded) {
                 for (int oc = 0; oc < nb_oc_block; oc++) {
-                    const Zmm zmm_accum = zmm_out(ur, oc);
-                    for (int ic = 0; ic < icb; ic++) {
-                        const auto addr_filt = EVEX_compress_addr(
-                                aux_reg_filt, get_filter_offset(oc, ic, ki));
+                    const Zmm zmm_accum = zmm_out(static_cast<int>(ur), oc);
+                    for (dim_t ic = 0; ic < icb; ic++) {
+                        const auto addr_filt = EVEX_compress_addr(aux_reg_filt,
+
+                                get_filter_offset(oc, ic, ki));
                         compute_fma(zmm_accum, ic, addr_filt);
                     }
                 }
@@ -150,14 +150,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::compute_ker(int ur_w, int pad_l,
     }
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(dim_t ur_w, dim_t pad_l,
+        dim_t pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
 
     Label kh_label, skip_kh_loop;
-    const size_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
-    const size_t shift_wei_h_step = sizeof(char)
-            * static_cast<size_t>(wei_h_step) * jcp.ic_block_int_np
-            * jcp.oc_block;
+    const dim_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
+    const dim_t shift_wei_h_step
+            = sizeof(char) * wei_h_step * jcp.ic_block_int_np * jcp.oc_block;
 
     // Compute zero_point compensation for the padded region. Total compute
     // area is 'overflow * kw' where 'overflow' indicates the overlap
@@ -201,14 +200,13 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kh_loop(int ur_w, int pad_l,
     if (handle_h_pad && jcp.ndims > 3) compute_kh_loop(GET_OFF(b_overflow));
 }
 
-void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(int ur_w, int pad_l,
-        int pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
+void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(dim_t ur_w, dim_t pad_l,
+        dim_t pad_r, ic_block_t last_ic_block_flag, bool handle_h_pad) {
 
     Label kd_label, skip_kd_loop;
-    const size_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
-    const size_t shift_wei_h_step = sizeof(char)
-            * static_cast<size_t>(wei_h_step) * jcp.ic_block_int_np
-            * jcp.oc_block;
+    const dim_t wei_h_step = jcp.is_relo ? 1 : jcp.kw;
+    const dim_t shift_wei_h_step
+            = sizeof(char) * wei_h_step * jcp.ic_block_int_np * jcp.oc_block;
 
     // Compute zero_point compensation for the padded region. Total compute
     // area is 'overflow * kh * kw' where 'overflow' indicates the overlap
@@ -270,7 +268,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::kd_loop(int ur_w, int pad_l,
 }
 
 void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool handle_h_pad) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, bool handle_h_pad) {
 
     Label icb_label;
     const size_t nb_ic = jcp.nb_ic_int;
@@ -308,8 +306,8 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        const size_t shift_wei_icb_step = static_cast<size_t>(jcp.kd) * jcp.kh
-                * jcp.kw * jcp.oc_block * jcp.ic_block_int_np;
+        const dim_t shift_wei_icb_step
+                = jcp.kd * jcp.kh * jcp.kw * jcp.oc_block * jcp.ic_block_int_np;
         add(reg_filt, sizeof(char) * shift_wei_icb_step);
 
         dec(reg_icb);
@@ -340,36 +338,41 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
 void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
         const bool h_padding) {
 
-    auto ur_w_shift = [&](const int ur_w) {
-        return sizeof(int32_t) * (ur_w * jcp.oc_without_padding * jcp.ngroups);
+    auto ur_w_shift = [&](const dim_t ur_w) {
+        return static_cast<dim_t>(sizeof(int32_t))
+                * (ur_w * jcp.oc_without_padding * jcp.ngroups);
     };
 
     const int max_ur_w = jit_avx512_core_amx_compute_zp_pbuff_t::max_regs_ur
             / (jcp.nb_oc_blocking);
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int l_pad = jcp.l_pad;
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t l_pad = jcp.l_pad;
 
-    const int l_pad_output = jcp.l_pad_output;
-    const int r_pad_output = jcp.r_pad_output;
+    const dim_t l_pad_output = jcp.l_pad_output;
+    const dim_t r_pad_output = jcp.r_pad_output;
 
     // a single middle element (if required) containing only height padding
-    const int no_pad = nstl::max(0, jcp.ow - l_pad_output - r_pad_output);
+    const dim_t no_pad
+            = nstl::max<dim_t>(0, jcp.ow - l_pad_output - r_pad_output);
 
-    const int ow_start = nstl::max(jcp.ow - r_pad_output, l_pad_output);
-    const int r_pad_start = nstl::min(jcp.ow_pad - l_pad_output, r_pad_output);
+    const dim_t ow_start
+            = nstl::max<dim_t>(jcp.ow - r_pad_output, l_pad_output);
+    const dim_t r_pad_start
+            = nstl::min(jcp.ow_pad - l_pad_output, r_pad_output);
 
-    int ow = 0;
-    int cur_l_pad_output = l_pad_output;
+    dim_t ow = 0;
+    dim_t cur_l_pad_output = l_pad_output;
     while (cur_l_pad_output > 0) {
-        const int ur_w = nstl::min(cur_l_pad_output, max_ur_w);
+        const dim_t ur_w
+                = nstl::min(cur_l_pad_output, static_cast<dim_t>(max_ur_w));
         ow += ur_w;
-        const int cur_r_pad = calculate_end_padding(
+        const dim_t cur_r_pad = calculate_end_padding(
                 jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, l_pad, cur_r_pad, h_padding);
         add(reg_zp_pbuff, ur_w_shift(ur_w));
 
-        l_pad = nstl::max(l_pad - ur_w * jcp.stride_w, 0);
-        cur_l_pad_output = nstl::max(cur_l_pad_output - ur_w, 0);
+        l_pad = nstl::max<dim_t>(l_pad - ur_w * jcp.stride_w, 0);
+        cur_l_pad_output = nstl::max<dim_t>(cur_l_pad_output - ur_w, 0);
     }
 
     if (no_pad > 0) {
@@ -380,16 +383,17 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::unroll_width(
     assert(ow + no_pad == ow_start);
 
     ow = ow_start;
-    int cur_r_pad_output = r_pad_start;
+    dim_t cur_r_pad_output = r_pad_start;
     while (cur_r_pad_output > 0 && ow < jcp.ow) {
-        const int ur_w = nstl::min(cur_r_pad_output, max_ur_w);
+        const dim_t ur_w
+                = nstl::min(cur_r_pad_output, static_cast<dim_t>(max_ur_w));
         ow += ur_w;
-        const int cur_r_pad = calculate_end_padding(
+        const dim_t cur_r_pad = calculate_end_padding(
                 jcp.l_pad, ow, jcp.iw, jcp.stride_w, ext_kw);
         icb_loop(ur_w, 0, cur_r_pad, h_padding);
         add(reg_zp_pbuff, ur_w_shift(ur_w));
 
-        cur_r_pad_output = nstl::max(cur_r_pad_output - ur_w, 0);
+        cur_r_pad_output = nstl::max<dim_t>(cur_r_pad_output - ur_w, 0);
     }
 }
 
@@ -407,7 +411,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::generate() {
 
     if (jcp.oc_without_padding != jcp.oc) {
         const Reg32 reg_tmp = reg_scratch.cvt32();
-        const int tail_size = jcp.oc_without_padding % jcp.oc_block;
+        const dim_t tail_size = jcp.oc_without_padding % jcp.oc_block;
         const int mask = (1 << tail_size) - 1;
         mov(reg_tmp, mask);
         kmovw(ktail_mask, reg_tmp);
@@ -455,7 +459,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::generate() {
             db(select_src2_bit | permb_idx_table[i]);
 
         // write zero-mask (permb) for ic_tail in VNNI format '..16o4i'
-        const int ic_tail_size
+        const dim_t ic_tail_size
                 = jcp.ic_without_padding % (jcp.ic_block / ic_inner_block);
         if (jcp.ic_without_padding != jcp.ic && ic_tail_size > 0) {
             align(64);
@@ -493,26 +497,26 @@ void jit_avx512_core_amx_copy_to_wbuffer_t::generate() {
         vmovdqu8(zmm_idx, ptr[reg_tmp]);
 
     const int vnni_width = is_bf16 ? 2 : 4;
-    const int r = jcp.kh * jcp.kw * jcp.ic_without_padding;
-    const int nb_r = div_up(r, vnni_width);
-    const int rtail = (r % vnni_width) * jcp.oc_block;
+    const dim_t r = jcp.kh * jcp.kw * jcp.ic_without_padding;
+    const dim_t nb_r = div_up(r, vnni_width);
+    const dim_t rtail = (r % vnni_width) * jcp.oc_block;
     if (rtail > 0) {
         uint64_t mask = (UINT64_C(1) << rtail) - 1;
         mov(reg_tmp, mask);
         kmovq(kmask_load, reg_tmp);
     }
-    const int nb_z = rnd_up(nb_r, jcp.ic_block);
+    const dim_t nb_z = rnd_up(nb_r, jcp.ic_block);
     if (nb_r < nb_z) vpxord(zmm_zero, zmm_zero, zmm_zero);
 
-    const int tile_size = jcp.ic_block_int * jcp.oc_block * jcp.typesize_in;
-    const int ocb_src_step = r * jcp.oc_block * jcp.typesize_in;
-    const int ocb_dst_step = rnd_up(ocb_src_step, tile_size);
+    const dim_t tile_size = jcp.ic_block_int * jcp.oc_block * jcp.typesize_in;
+    const dim_t ocb_src_step = r * jcp.oc_block * jcp.typesize_in;
+    const dim_t ocb_dst_step = rnd_up(ocb_src_step, tile_size);
 
     // reorder from ~Owhi16o -> ~OR16oVr with r := whi and V := vnni_width
-    for (int g = 0; g < jcp.ngroups; g++) {
-        for (int ocb = 0; ocb < jcp.nb_oc; ocb++) {
-            int offset = 0;
-            int rb = 0;
+    for (dim_t g = 0; g < jcp.ngroups; g++) {
+        for (dim_t ocb = 0; ocb < jcp.nb_oc; ocb++) {
+            dim_t offset = 0;
+            dim_t rb = 0;
             for (; rb < nb_r; offset += 64, rb++) {
                 auto zmm_src_tmp = (rtail > 0 && rb == nb_r - 1)
                         ? zmm_src | kmask_load | T_z
@@ -556,37 +560,37 @@ void jit_avx512_core_amx_copy_to_wbuffer_t::generate() {
 }
 
 void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_body(
-        int lpad, int iw_len, int icb) {
+        dim_t lpad, dim_t iw_len, dim_t icb) {
 
     const bool is_bf16 = jcp.src_dt == data_type::bf16;
-    int iwp_idx = 0;
+    dim_t iwp_idx = 0;
     // there are min(gen_kw, jcp.stride_w) continuous sets of input
     // data (for each stride idx), they are placed one by one
     // without additional padding
     const bool are_sets_interleaved
             = IMPLICATION(jcp.dilate_w != 0, jcp.stride_w == 1);
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
-    const int num_sets = are_sets_interleaved ? jcp.n_stride_sets : jcp.kw;
-    for (int set_idx = 0; set_idx < num_sets; set_idx++) {
-        int set_width_padded = !jcp.is_pbuffer_strided
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t num_sets = are_sets_interleaved ? jcp.n_stride_sets : jcp.kw;
+    for (dim_t set_idx = 0; set_idx < num_sets; set_idx++) {
+        dim_t set_width_padded = !jcp.is_pbuffer_strided
                 ? (jcp.ow_block - 1) * jcp.stride_w + gen_kw
                 : are_sets_interleaved ? jcp.ow_block - 1 + gen_kw / num_sets
                         + (set_idx < gen_kw % num_sets ? 1 : 0)
                                        : jcp.ow_block;
-        for (int set_shift = 0; set_shift < set_width_padded;
+        for (dim_t set_shift = 0; set_shift < set_width_padded;
                 set_shift++, iwp_idx++) {
-            int iw_idx = set_idx * (jcp.dilate_w + 1)
+            dim_t iw_idx = set_idx * (jcp.dilate_w + 1)
                     + set_shift * (jcp.is_pbuffer_strided ? jcp.stride_w : 1)
                     - lpad;
-            size_t out_base_offset
-                    = (size_t)jcp.typesize_in * iwp_idx * jcp.ic_block_int_np;
+            const dim_t out_base_offset
+                    = jcp.typesize_in * iwp_idx * jcp.ic_block_int_np;
             if (iw_idx < 0 || iw_idx >= iw_len) {
                 // left or right padding
                 vmovups(ptr[reg_aux_out_ptr + out_base_offset], zmm_zero);
             } else if (jcp.is_nspc) {
-                size_t inp_w_offset = (size_t)jcp.typesize_in * iw_idx
+                const dim_t inp_w_offset = jcp.typesize_in * iw_idx
                         * jcp.ngroups * jcp.ic_without_padding;
-                int ic = icb * jcp.ic_block_int_np;
+                const dim_t ic = icb * jcp.ic_block_int_np;
                 // TODO: use Xmm or Ymm moves for better small ic efficiency
                 auto zmm_tmp_mask
                         = ic + jcp.ic_block_int <= jcp.ic_without_padding
@@ -602,11 +606,12 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_body(
                 }
             } else {
                 assert(is_bf16);
-                size_t inp_w_offset
-                        = (size_t)jcp.typesize_in * iw_idx * jcp.ic_block;
-                for (int j = 0; j < jcp.ic_block_int_np / jcp.ic_block; j++) {
-                    int ic = icb * jcp.ic_block_int_np + j * jcp.ic_block;
-                    size_t inp_c_w_offset = (size_t)jcp.typesize_in * j * jcp.ih
+                const dim_t inp_w_offset
+                        = jcp.typesize_in * iw_idx * jcp.ic_block;
+                for (dim_t j = 0; j < jcp.ic_block_int_np / jcp.ic_block; j++) {
+                    const dim_t ic
+                            = icb * jcp.ic_block_int_np + j * jcp.ic_block;
+                    const dim_t inp_c_w_offset = jcp.typesize_in * j * jcp.ih
                                     * jcp.iw * jcp.ic_block
                             + inp_w_offset;
                     if (ic + jcp.ic_block <= jcp.ic) {
@@ -615,8 +620,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_body(
                     } else {
                         vpxord(ymm_tmp, ymm_tmp, ymm_tmp);
                     }
-                    size_t out_offset = out_base_offset
-                            + (size_t)jcp.typesize_in * j * jcp.ic_block;
+                    const dim_t out_offset = out_base_offset
+                            + jcp.typesize_in * j * jcp.ic_block;
                     vmovdqu16(ptr[reg_aux_out_ptr + out_offset], ymm_tmp);
                 }
             }
@@ -624,24 +629,26 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_body(
     }
 }
 
-void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(int icb) {
+void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(dim_t icb) {
     if (jcp.nb_ow == 1) {
         copy_row_body(jcp.l_pad, jcp.iw, icb);
     } else {
-        auto get_iw_len_required = [&](int cur_ow_block, int cur_lpad) {
+        auto get_iw_len_required
+                = [&](dim_t cur_ow_block, dim_t cur_lpad) -> dim_t {
             return (cur_ow_block - 1) * jcp.stride_w
                     + (jcp.kw - 1) * (jcp.dilate_w + 1) + 1 - cur_lpad;
         };
 
-        auto get_iw_len_limited = [&](int owb, int cur_ow_block, int cur_lpad) {
+        auto get_iw_len_limited
+                = [&](dim_t owb, dim_t cur_ow_block, dim_t cur_lpad) -> dim_t {
             auto len_req = get_iw_len_required(cur_ow_block, cur_lpad);
             if (owb < 0) return len_req;
-            int ow_block_start = nstl::max(
+            const dim_t ow_block_start = nstl::max<dim_t>(
                     0, owb * jcp.ow_block * jcp.stride_w - jcp.l_pad);
-            return nstl::min(jcp.iw - ow_block_start, len_req);
+            return nstl::min<dim_t>(jcp.iw - ow_block_start, len_req);
         };
 
-        int general_owb_cases = jcp.nb_ow;
+        dim_t general_owb_cases = jcp.nb_ow;
         Xbyak::Label copy_row_done_label;
         bool special_first_block_case = jcp.l_pad > 0;
         if (special_first_block_case) {
@@ -665,8 +672,9 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row(int icb) {
             Xbyak::Label skip_last_block_case_label;
             cmp(reg_owb, jcp.nb_ow - 1);
             jne(skip_last_block_case_label, T_NEAR);
-            int ow_block_tail = jcp.ow % jcp.ow_block;
-            int cur_ow_block = ow_block_tail > 0 ? ow_block_tail : jcp.ow_block;
+            dim_t ow_block_tail = jcp.ow % jcp.ow_block;
+            dim_t cur_ow_block
+                    = ow_block_tail > 0 ? ow_block_tail : jcp.ow_block;
             copy_row_body(
                     0, get_iw_len_limited(jcp.nb_ow - 1, cur_ow_block, 0), icb);
             jmp(copy_row_done_label, T_NEAR);
@@ -704,7 +712,7 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
             == 64);
     assert(jcp.is_nspc);
 
-    auto load_mask = [this](int tail, Opmask kmask) {
+    auto load_mask = [this](dim_t tail, Opmask kmask) {
         uint64_t mask = (UINT64_C(1) << tail) - 1;
         mov(reg_tmp, mask);
         kmovq(kmask, reg_tmp);
@@ -713,17 +721,18 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::copy_row_reduced_lowering() {
     const bool is_f32 = jcp.src_dt == data_type::f32;
     const bool is_xf16 = one_of(jcp.src_dt, data_type::bf16, data_type::f16);
 
-    const int inp_w_step
+    const dim_t inp_w_step
             = jcp.ngroups * jcp.ic_without_padding * jcp.typesize_in;
-    const int inp_h_step = jcp.iw * inp_w_step;
-    const int out_h_step = jcp.ic_without_padding * jcp.typesize_in;
-    const int out_w_step = jcp.kh * out_h_step;
-    const int tail_size = jcp.ic_without_padding % jcp.ic_block_int;
+    const dim_t inp_h_step = jcp.iw * inp_w_step;
+    const dim_t out_h_step = jcp.ic_without_padding * jcp.typesize_in;
+    const dim_t out_w_step = jcp.kh * out_h_step;
+    const dim_t tail_size = jcp.ic_without_padding % jcp.ic_block_int;
     if (tail_size > 0) load_mask(tail_size, ktail_mask);
 
     auto zero_it = [this, is_f32, is_xf16](reg64_t tmp_out_ptr) {
-        for (int ic = 0; ic < jcp.ic_without_padding; ic += jcp.ic_block_int) {
-            const int offset = ic * jcp.typesize_in;
+        for (dim_t ic = 0; ic < jcp.ic_without_padding;
+                ic += jcp.ic_block_int) {
+            const dim_t offset = ic * jcp.typesize_in;
             const bool masked = ic + jcp.ic_block_int > jcp.ic_without_padding;
             Zmm zmm = masked ? zmm_zero | ktail_mask : zmm_zero;
             if (is_f32)
@@ -956,7 +965,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
     vpxord(zmm_zero, zmm_zero, zmm_zero);
 
     if (jcp.is_nspc && jcp.ic_without_padding % jcp.ic_block_int) {
-        int tail_size = jcp.ic_without_padding % jcp.ic_block_int;
+        int tail_size
+                = static_cast<int>(jcp.ic_without_padding % jcp.ic_block_int);
         uint64_t mask = (UINT64_C(1) << tail_size) - 1;
         mov(reg_tmp, mask);
         kmovq(ktail_mask, reg_tmp);
@@ -993,7 +1003,8 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
                 vmovups(ptr[reg_aux_out_ptr
                                 + jcp.typesize_in * iw * jcp.ic_block_int_np],
                         zmm_zero);
-            int out_h_offset = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
             add(reg_aux_out_ptr, out_h_offset);
 
             dec(reg_kh_over);
@@ -1008,12 +1019,12 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
         L(kh_label);
         {
             copy_row(icb);
-            size_t inp_h_offset = !jcp.is_nspc
-                    ? (size_t)jcp.typesize_in * jcp.iw * jcp.ic_block
-                    : (size_t)jcp.typesize_in * jcp.iw * jcp.ngroups
+            const dim_t inp_h_offset = !jcp.is_nspc
+                    ? jcp.typesize_in * jcp.iw * jcp.ic_block
+                    : jcp.typesize_in * jcp.iw * jcp.ngroups
                             * jcp.ic_without_padding;
-            size_t out_h_offset
-                    = (size_t)jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
 
             add(reg_aux_inp_ptr, inp_h_offset);
             add(reg_aux_out_ptr, out_h_offset);
@@ -1034,20 +1045,21 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
                 vmovups(ptr[reg_aux_out_ptr
                                 + jcp.typesize_in * iw * jcp.ic_block_int_np],
                         zmm_zero);
-            int out_h_offset = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
+            const dim_t out_h_offset
+                    = jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np;
             add(reg_aux_out_ptr, out_h_offset);
 
             dec(reg_khc);
             jnz(kh_bover_label, T_NEAR);
         }
-        size_t out_d_offset = (size_t)jcp.typesize_in
+        const dim_t out_d_offset = jcp.typesize_in
                 * (jcp.ihp * jcp.iwp * jcp.ic_block_int_np + jcp.ic_block_int);
         L(no_kh_bover_label);
         if (is_3d) {
-            size_t inp_d_offset = !jcp.is_nspc
-                    ? (size_t)jcp.typesize_in * jcp.ih * jcp.iw * jcp.ic_block
+            const dim_t inp_d_offset = !jcp.is_nspc
+                    ? jcp.typesize_in * jcp.ih * jcp.iw * jcp.ic_block
                             * (jcp.dilate_d + 1)
-                    : (size_t)jcp.typesize_in * jcp.ih * jcp.iw * jcp.ngroups
+                    : jcp.typesize_in * jcp.ih * jcp.iw * jcp.ngroups
                             * jcp.ic_without_padding * (jcp.dilate_d + 1);
             pop(reg_aux_out_ptr);
             pop(reg_aux_inp_ptr);
@@ -1058,11 +1070,11 @@ void jit_avx512_core_amx_copy_to_pbuffer_t::generate() {
             L(no_kd_label);
         }
         // End IC Loop
-        size_t inp_cb_offset = !jcp.is_nspc
-                ? (size_t)jcp.typesize_in * (jcp.ic_block_int_np / jcp.ic_block)
+        const dim_t inp_cb_offset = !jcp.is_nspc
+                ? jcp.typesize_in * (jcp.ic_block_int_np / jcp.ic_block)
                         * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
-                : (size_t)jcp.typesize_in * jcp.ic_block_int_np;
-        size_t out_cb_offset = (size_t)jcp.kd * out_d_offset;
+                : jcp.typesize_in * jcp.ic_block_int_np;
+        const dim_t out_cb_offset = jcp.kd * out_d_offset;
 
         add(reg_inp_ptr, inp_cb_offset);
         add(reg_out_ptr, out_cb_offset);
@@ -1136,10 +1148,10 @@ int jit_avx512_core_amx_fwd_kernel_t::get_out_tensor(
     const int C_LAST = 4;
     assert(0 <= C_BASE && C_BASE < C_LAST && C_LAST <= jcp.max_tiles);
     MAYBE_UNUSED(C_LAST);
-    const int tile = C_BASE
+    const int tile = static_cast<int>(C_BASE
             + (jcp.nb_oh_blocking > 1
                             ? h * jcp.nb_oh_blocking + i
-                            : (int)is_h_tail * jcp.nb_oc_blocking + i);
+                            : (int)is_h_tail * jcp.nb_oc_blocking + i));
     assert(C_BASE <= tile && tile < C_LAST);
     return tile;
 }
@@ -1164,99 +1176,95 @@ int jit_avx512_core_amx_fwd_kernel_t::get_wei_tensor(int i) const {
 }
 
 // Shifts and offsets
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_icb_step() const {
-    return (size_t)jcp.kd * get_inp_d_step();
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_icb_step() const {
+    return jcp.kd * get_inp_d_step();
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_icb_step() const {
-    return (size_t)jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw
-            * jcp.ic_block_int_np * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_icb_step() const {
+    return jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np
+            * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_d_step() const {
-    return (size_t)jcp.typesize_in
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_d_step() const {
+    return jcp.typesize_in
             * (jcp.ihp * jcp.iwp * jcp.ic_block_int_np + jcp.ic_block_int);
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_h_step() const {
-    return (size_t)jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np
-            * (jcp.dilate_h + 1);
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_h_step() const {
+    return jcp.typesize_in * jcp.iwp * jcp.ic_block_int_np * (jcp.dilate_h + 1);
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_d_step() const {
-    return (size_t)jcp.typesize_in * jcp.kh * jcp.kw * jcp.ic_block_int_np
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_d_step() const {
+    return jcp.typesize_in * jcp.kh * jcp.kw * jcp.ic_block_int_np
             * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_h_step() const {
-    return (size_t)jcp.typesize_in * jcp.kw * jcp.ic_block_int_np
-            * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_h_step() const {
+    return jcp.typesize_in * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_ocb_offset(
-        int ohb, int ocb, size_t typesize) const {
-    size_t el_offset = jcp.is_nspc
-            ? (size_t)ocb * jcp.oc_block
-                    + (size_t)ohb * jcp.ow * jcp.ngroups
-                            * jcp.oc_without_padding
-            : (size_t)ocb * jcp.oh * jcp.ow * jcp.oc_block
-                    + (size_t)ohb * jcp.ow * jcp.oc_block;
-    return (size_t)typesize * el_offset;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_ocb_offset(
+        dim_t ohb, dim_t ocb, dim_t typesize) const {
+    dim_t el_offset = jcp.is_nspc ? ocb * jcp.oc_block
+                    + ohb * jcp.ow * jcp.ngroups * jcp.oc_without_padding
+                                  : ocb * jcp.oh * jcp.ow * jcp.oc_block
+                    + ohb * jcp.ow * jcp.oc_block;
+    return typesize * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_row_offset(
-        int ohb, int ocb, int j, size_t typesize) const {
-    size_t offset_w = jcp.is_nspc
-            ? (size_t)typesize * j * jcp.ngroups * jcp.oc_without_padding
-            : (size_t)typesize * j * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_row_offset(
+        dim_t ohb, dim_t ocb, dim_t j, dim_t typesize) const {
+    const dim_t offset_w = jcp.is_nspc
+            ? typesize * j * jcp.ngroups * jcp.oc_without_padding
+            : typesize * j * jcp.oc_block;
     return get_out_ocb_offset(ohb, ocb, typesize) + offset_w;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_out_shift(
-        int width, size_t typesize) const {
-    return jcp.is_nspc
-            ? (size_t)typesize * width * jcp.ngroups * jcp.oc_without_padding
-            : (size_t)typesize * width * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_out_shift(
+        dim_t width, dim_t typesize) const {
+    return jcp.is_nspc ? typesize * width * jcp.ngroups * jcp.oc_without_padding
+                       : typesize * width * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_ocb_offset(
-        int ohb, int ocb) const {
-    size_t el_offset = (size_t)ocb * prv_width_ * jcp.oc_block
-            + (size_t)ohb * jcp.nb_oc_blocking * jcp.full_tile_width
-                    * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_ocb_offset(
+        dim_t ohb, dim_t ocb) const {
+    dim_t el_offset = ocb * prv_width_ * jcp.oc_block
+            + ohb * jcp.nb_oc_blocking * jcp.full_tile_width * jcp.oc_block;
     return jcp.typesize_acc * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_row_offset(
-        int ohb, int ocb, int j) const {
-    return get_wsp_ocb_offset(ohb, ocb)
-            + (size_t)jcp.typesize_acc * j * jcp.oc_block;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_row_offset(
+        dim_t ohb, dim_t ocb, dim_t j) const {
+    return get_wsp_ocb_offset(ohb, ocb) + jcp.typesize_acc * j * jcp.oc_block;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_shift() const {
-    return (size_t)jcp.typesize_acc * jcp.nb_oh_blocking * jcp.full_tile_width
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wsp_shift() const {
+    return jcp.typesize_acc * jcp.nb_oh_blocking * jcp.full_tile_width
             * jcp.oc_block * jcp.nb_oc_blocking;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_wei_offset(int ocb, int kw) const {
-    size_t el_offset = (size_t)kw * jcp.ic_block_int_np * jcp.oc_block;
-    size_t raw_oc_subblock_step
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_wei_offset(
+        dim_t ocb, dim_t kw) const {
+    dim_t el_offset = kw * jcp.ic_block_int_np * jcp.oc_block;
+    dim_t raw_oc_subblock_step
             = jcp.kd * jcp.kh * jcp.kw * jcp.ic_block_int_np * jcp.oc_block;
-    size_t oc_subblock_step = jcp.is_relo
+    dim_t oc_subblock_step = jcp.is_relo
             ? rnd_up(raw_oc_subblock_step, jcp.ic_block_int * jcp.oc_block)
             : raw_oc_subblock_step;
-    el_offset += (size_t)ocb * jcp.nb_ic_int * oc_subblock_step;
+    el_offset += ocb * jcp.nb_ic_int * oc_subblock_step;
     return jcp.typesize_in * el_offset;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_shift() const {
-    size_t w_step = (jcp.is_relo ? jcp.stride_w * jcp.kh
-                                    : jcp.is_pbuffer_strided ? 1
-                                                             : jcp.stride_w)
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_shift() const {
+    const dim_t w_step
+            = (jcp.is_relo                             ? jcp.stride_w * jcp.kh
+                              : jcp.is_pbuffer_strided ? 1
+                                                       : jcp.stride_w)
             * jcp.ic_block_int_np;
-    return (size_t)jcp.typesize_in * jcp.tile_width * w_step;
+    return jcp.typesize_in * jcp.tile_width * w_step;
 }
-size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(int ohb, int kw) const {
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(
+        dim_t ohb, dim_t kw) const {
     if (jcp.is_relo)
         return ohb * jcp.iwp * jcp.kh * jcp.ic_block_int_np * jcp.typesize_in;
     // calculate offset by height dimension
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_stride_h = nstl::min(jcp.stride_h, gen_kh);
-    size_t el_offset = (size_t)ohb * jcp.oh_per_tile * gen_stride_h * jcp.iwp
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_stride_h = nstl::min<dim_t>(jcp.stride_h, gen_kh);
+    dim_t el_offset = ohb * jcp.oh_per_tile * gen_stride_h * jcp.iwp
             * jcp.ic_block_int_np;
 
     // add offset by width dimension
     if (IMPLICATION(jcp.is_pbuffer_strided, jcp.stride_w == 1)) {
-        el_offset += (size_t)kw * (jcp.dilate_w + 1) * jcp.ic_block_int_np;
+        el_offset += kw * (jcp.dilate_w + 1) * jcp.ic_block_int_np;
     } else if (jcp.dilate_w > 0) {
-        el_offset += (size_t)kw * jcp.ow_block * jcp.ic_block_int_np;
+        el_offset += kw * jcp.ow_block * jcp.ic_block_int_np;
     } else {
         // dilate_w == 0 && stride_w > 1
         // there are min(jcp.kw, jcp.stride_w) continuous sets of input data
@@ -1264,35 +1272,36 @@ size_t jit_avx512_core_amx_fwd_kernel_t::get_inp_offset(int ohb, int kw) const {
         // padding
 
         // calculate set idx for current kw value
-        int set_idx = kw % jcp.stride_w;
+        const dim_t set_idx = kw % jcp.stride_w;
         // calculate shift within set for current kw value
-        int set_shift = kw / jcp.stride_w;
+        const dim_t set_shift = kw / jcp.stride_w;
 
         // calculate the beginning of the current set along width, each set
         // with index set_i contains number of elements along width equal to
         // jcp.ow - 1 + jcp.kw / jcp.stride_w
         //     + (set_i < jcp.kw % jcp.stride_w)
-        size_t set_start = (jcp.ow_block - 1 + jcp.kw / jcp.stride_w) * set_idx
-                + nstl::min(set_idx, jcp.kw % jcp.stride_w);
+        const dim_t set_start
+                = (jcp.ow_block - 1 + jcp.kw / jcp.stride_w) * set_idx
+                + nstl::min<dim_t>(set_idx, jcp.kw % jcp.stride_w);
         el_offset += (set_start + set_shift) * jcp.ic_block_int_np;
     }
     return jcp.typesize_in * el_offset;
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::get_zp_comp_offset(
-        int ocb, int zp_h, int zp_w) const {
-    const size_t ocb_offset = (size_t)ocb * jcp.oc_block;
-    const size_t sp_offset = (size_t)(zp_h * jcp.ow_pad + zp_w) * jcp.ngroups
-            * jcp.oc_without_padding;
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_zp_comp_offset(
+        dim_t ocb, dim_t zp_h, dim_t zp_w) const {
+    const dim_t ocb_offset = ocb * jcp.oc_block;
+    const dim_t sp_offset
+            = (zp_h * jcp.ow_pad + zp_w) * jcp.ngroups * jcp.oc_without_padding;
     return (ocb_offset + sp_offset) * sizeof(int32_t);
 }
 
-int jit_avx512_core_amx_fwd_kernel_t::get_zp_index_offset(
-        int index, int mid, int s_pad_output, int e_pad_output) {
+dim_t jit_avx512_core_amx_fwd_kernel_t::get_zp_index_offset(
+        dim_t index, dim_t mid, dim_t s_pad_output, dim_t e_pad_output) {
     using namespace nstl;
-    const int mid_end = e_pad_output - 1;
-    int zp_mid = nstl::min(mid, nstl::max(0, index - mid_end));
-    int zp_pad_offset
+    const dim_t mid_end = e_pad_output - 1;
+    const dim_t zp_mid = nstl::min(mid, nstl::max<dim_t>(0, index - mid_end));
+    const dim_t zp_pad_offset
             = accum_with_upper_bound(index, s_pad_output, e_pad_output);
     return zp_pad_offset + zp_mid;
 }
@@ -1315,41 +1324,41 @@ void jit_avx512_core_amx_fwd_kernel_t::init_runtime_counters(
     is_buffer_empty_ = true;
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_block(
-        const int block_size, const int pad_output) {
-    return (size_t)(pad_output >= block_size ? block_size : 0)
+dim_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_block(
+        const dim_t block_size, const dim_t pad_output) {
+    return (pad_output >= block_size ? block_size : 0)
             + (pad_output % block_size);
 }
 
-size_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_blocked_dims(
-        const int dim_size, const int block_size, const int s_pad_output,
-        const int e_pad_output) {
+dim_t jit_avx512_core_amx_fwd_kernel_t::reduce_to_blocked_dims(
+        const dim_t dim_size, const dim_t block_size, const dim_t s_pad_output,
+        const dim_t e_pad_output) {
     using namespace nstl;
 
     // start padding (s_pad)
-    int s_pad_limit = reduce_to_block(block_size, s_pad_output);
-    int s_pad_area_blk = rnd_up(s_pad_limit, block_size);
+    const dim_t s_pad_limit = reduce_to_block(block_size, s_pad_output);
+    const dim_t s_pad_area_blk = rnd_up(s_pad_limit, block_size);
 
     // middle (no padding)
-    int no_pad_area = nstl::max(
+    const dim_t no_pad_area = nstl::max<dim_t>(
             0, dim_size - rnd_up(s_pad_output, block_size) - e_pad_output);
-    int no_pad_limit = (no_pad_area >= block_size ? block_size : 0);
+    const dim_t no_pad_limit = (no_pad_area >= block_size ? block_size : 0);
 
     // end padding (e_pad)
-    int no_pad_area_shift = no_pad_area % block_size;
-    int e_pad_area_overlap
+    const dim_t no_pad_area_shift = no_pad_area % block_size;
+    const dim_t e_pad_area_overlap
             = no_pad_area_shift == 0 ? 0 : block_size - no_pad_area_shift;
     // middle and end padding shift
-    int e_pad_shift_limit
+    const dim_t e_pad_shift_limit
             = no_pad_area_shift + min(e_pad_output, e_pad_area_overlap);
-    int e_pad_area_blk = nstl::max(0, e_pad_output - e_pad_area_overlap);
+    const dim_t e_pad_area_blk
+            = nstl::max<dim_t>(0, e_pad_output - e_pad_area_overlap);
     // full end padding block
-    int e_pad_limit = reduce_to_block(block_size, e_pad_area_blk);
+    const dim_t e_pad_limit = reduce_to_block(block_size, e_pad_area_blk);
 
     // calculate reduced size of s_pad, middle and e_pad blocks.
-    return min((size_t)dim_size,
-            (size_t)s_pad_area_blk + no_pad_limit + e_pad_shift_limit
-                    + e_pad_limit);
+    return min(dim_size,
+            s_pad_area_blk + no_pad_limit + e_pad_shift_limit + e_pad_limit);
 }
 
 Ymm jit_avx512_core_amx_fwd_kernel_t::ymm_mask(
@@ -1408,7 +1417,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_ymm_bf16(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
-        const Zmm &zmm_out, int ocb, int h, int w) {
+        const Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w) {
     const bool mask_flag = jcp.is_nspc && jcp.oc_without_padding != jcp.oc
             && ocb == (jcp.nb_oc_blocking - 1);
 
@@ -1429,7 +1438,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
         }
     }
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         if (jcp.bia_dt == data_type::bf16) {
             vpmovzxwd(zmm_mask(zmm_bias, mask_flag), bias_addr);
@@ -1449,10 +1458,10 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_bf16(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
-        const Zmm &zmm_out, int ocb, int h, int w, const bool compute_zp,
-        const int zp_h, const int zp_w) {
-    const int nb_oc_block = jcp.nb_oc_blocking;
-    const int oc_block = jcp.oc_block;
+        const Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w, const bool compute_zp,
+        const dim_t zp_h, const dim_t zp_w) {
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t oc_block = jcp.oc_block;
     const bool mask_flag = true && jcp.oc_without_padding != jcp.oc
             && ocb == (nb_oc_block - 1);
 
@@ -1460,7 +1469,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
     auto addr = EVEX_compress_addr(reg_out_ptr, off);
 
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * ocb * oc_block;
+        const dim_t bias_offset = jcp.typesize_bia * ocb * oc_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
@@ -1476,7 +1485,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
     }
     if (jcp.src_zero_point) {
         // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-        int zp_offset = sizeof(int32_t) * ocb * oc_block;
+        const dim_t zp_offset = sizeof(int32_t) * ocb * oc_block;
         const Zmm m_zmm_zp = zmm_mask(zmm_zp, mask_flag);
         vpmulld(m_zmm_zp, zmm_src_zp,
                 EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -1496,7 +1505,7 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        const int scale_offset
+        const dim_t scale_offset
                 = jcp.is_oc_scale * (sizeof(float) * ocb * oc_block);
         vmulps(zmm_out_msk, zmm_out,
                 EVEX_compress_addr(reg_ptr_wei_scales, scale_offset,
@@ -1537,8 +1546,8 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector_int8(
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::store_output_vector(const Zmm &zmm_out,
-        int ocb, int h, int w, const bool compute_zp, const int zp_h,
-        const int zp_w) {
+        dim_t ocb, dim_t h, dim_t w, const bool compute_zp, const dim_t zp_h,
+        const dim_t zp_w) {
     /*
     Output:
               jcp.is_nspc              !jcp.is_nspc
@@ -1553,23 +1562,25 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output_vector(const Zmm &zmm_out,
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
-        bool do_store, const bool handle_h_blk, const int t_pad_output,
-        const int b_pad_output, const int l_pad_output, const int r_pad_output,
-        const bool is_last_oh_block, const bool zp_3d_pad) {
-    auto store_output_block
-            = [&](int width, int tail, bool do_store, bool is_last_h = false) {
+void jit_avx512_core_amx_fwd_kernel_t::store_output(dim_t width, int tail,
+        bool do_store, const bool handle_h_blk, const dim_t t_pad_output,
+        const dim_t b_pad_output, const dim_t l_pad_output,
+        const dim_t r_pad_output, const bool is_last_oh_block,
+        const bool zp_3d_pad) {
+    auto store_output_block = [&](dim_t width, int tail, bool do_store,
+                                      bool is_last_h = false) {
         // Calculate the number of oh blocks; it may differ on last call
-        const int last_h_blks
-                = div_up(jcp.oh, jcp.oh_per_tile) % jcp.nb_oh_blocking;
-        const int h_blks = is_last_h && last_h_blks != 0 ? last_h_blks
-                                                         : jcp.nb_oh_blocking;
+        const int last_h_blks = static_cast<int>(
+                div_up(jcp.oh, jcp.oh_per_tile) % jcp.nb_oh_blocking);
+        const int h_blks = is_last_h && last_h_blks != 0
+                ? last_h_blks
+                : static_cast<int>(jcp.nb_oh_blocking);
         // Calculate the number of oh rows per tile; it may differ on last call
         const int h_tail = is_last_h && jcp.oh % jcp.oh_per_tile != 0
                 ? (h_blks - 1) * jcp.oh_per_tile + jcp.oh % jcp.oh_per_tile
                 : h_blks * jcp.oh_per_tile;
-        const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
-        const int owp = gen_kw + jcp.ow - 1;
+        const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+        const dim_t owp = gen_kw + jcp.ow - 1;
 
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[param1 + GET_OFF(zp_compensation)]);
@@ -1600,17 +1611,17 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
 
             for (int tw = 0; tw < width && do_store; tw++) {
                 // height
-                const int oh_index = ohb * jcp.oh_per_tile + tw / owp;
+                const dim_t oh_index = ohb * jcp.oh_per_tile + tw / owp;
                 const bool zp_h_pad
                         = oh_index < t_pad_output || oh_index >= b_pad_output;
-                const int zp_h = get_zp_index_offset(
-                        oh_index, (int)jcp.oh_mid, t_pad_output, b_pad_output);
+                const dim_t zp_h = get_zp_index_offset(
+                        oh_index, jcp.oh_mid, t_pad_output, b_pad_output);
                 // width
-                const int ow_index = tw % owp;
+                const dim_t ow_index = tw % owp;
                 const bool zp_w_pad
                         = ow_index < l_pad_output || ow_index >= r_pad_output;
-                const int zp_w = get_zp_index_offset(
-                        ow_index, (int)jcp.ow_mid, l_pad_output, r_pad_output);
+                const dim_t zp_w = get_zp_index_offset(
+                        ow_index, jcp.ow_mid, l_pad_output, r_pad_output);
 
                 const bool compute_zp = jcp.req_zero_point_buffer
                         && (zp_3d_pad || zp_w_pad || zp_h_pad);
@@ -1652,15 +1663,16 @@ void jit_avx512_core_amx_fwd_kernel_t::store_output(int width, int tail,
     if (do_store) {
         add(reg_out_ptr, get_out_shift(width, jcp.typesize_out));
         if (jcp.req_zero_point_buffer) {
-            const size_t sp_shift
+            const dim_t sp_shift
                     = accum_with_upper_bound(width, l_pad_output, r_pad_output);
             add(reg_zero_point_pbuff, get_out_shift(sp_shift, sizeof(int32_t)));
         }
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
-        int const t_pad_output, int const b_pad_output, const bool zp_3d_pad) {
+void jit_avx512_core_amx_fwd_kernel_t::interleave_store(dim_t width,
+        dim_t const t_pad_output, dim_t const b_pad_output,
+        const bool zp_3d_pad) {
     for (int c = 0;
             c < jcp.per_one_pstore && !is_store_done_ && !is_buffer_empty_;
             c++) {
@@ -1675,20 +1687,20 @@ void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
                         {bin_injector_helper_reg_1, bin_injector_helper_reg_2});
 
         // height
-        const int oh_index = ohb;
+        const dim_t oh_index = ohb;
         const bool zp_h_pad
                 = oh_index < t_pad_output || oh_index >= b_pad_output;
-        const int zp_h = get_zp_index_offset(
-                oh_index, (int)jcp.oh_mid, t_pad_output, b_pad_output);
+        const dim_t zp_h = get_zp_index_offset(
+                oh_index, jcp.oh_mid, t_pad_output, b_pad_output);
         // width
-        const int l_pad_output
+        const dim_t l_pad_output
                 = w_padding.empty() ? 0 : w_padding.front().l_pad_output;
-        const int r_pad_output
+        const dim_t r_pad_output
                 = w_padding.empty() ? jcp.ow : w_padding.front().r_pad_output;
 
         const bool zp_w_pad = tw < l_pad_output || tw >= r_pad_output;
-        const int zp_w = get_zp_index_offset(
-                tw, (int)jcp.ow_mid, l_pad_output, r_pad_output);
+        const dim_t zp_w = get_zp_index_offset(
+                tw, jcp.ow_mid, l_pad_output, r_pad_output);
 
         const bool compute_zp = jcp.req_zero_point_buffer
                 && (zp_3d_pad || zp_w_pad || zp_h_pad);
@@ -1700,9 +1712,11 @@ void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
 
         if (row_count_
                 == prv_width_ * jcp.nb_oc_blocking * jcp.nb_oh_blocking) {
-            add(reg_out_ptr, get_out_shift(prv_width_, jcp.typesize_out));
+            add(reg_out_ptr,
+
+                    get_out_shift(prv_width_, jcp.typesize_out));
             if (jcp.req_zero_point_buffer) {
-                const size_t sp_shift = accum_with_upper_bound(
+                const dim_t sp_shift = accum_with_upper_bound(
                         prv_width_, l_pad_output, r_pad_output);
                 add(reg_zero_point_pbuff,
                         get_out_shift(sp_shift, sizeof(int32_t)));
@@ -1710,15 +1724,16 @@ void jit_avx512_core_amx_fwd_kernel_t::interleave_store(int width,
             }
             row_count_ = 0;
             is_store_done_ = true;
-            prv_width_ = width;
+            prv_width_ = static_cast<int>(width);
         }
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
-        bool do_store, const bool handle_h_blk, const int t_pad_output,
-        const int b_pad_output, const int l_pad_output, const int r_pad_output,
-        const bool zp_3d_pad, const bool is_last_oh_block) {
+void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(dim_t width,
+        bool do_store, const bool handle_h_blk, const dim_t t_pad_output,
+        const dim_t b_pad_output, const dim_t l_pad_output,
+        const dim_t r_pad_output, const bool zp_3d_pad,
+        const bool is_last_oh_block) {
     const bool tail = width == jcp.tile_tail;
 
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
@@ -1752,13 +1767,14 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
 
     // reduced lowering path
     if (jcp.is_relo) {
-        const int nreduce = jcp.nreduce;
-        const int stride = jcp.ic_block_int; // ie 64 (32) for int8 (bf16)
+        const dim_t nreduce = jcp.nreduce;
+        const int stride = static_cast<int>(
+                jcp.ic_block_int); // ie 64 (32) for int8 (bf16)
 
         push(reg_inp_ptr);
         push(reg_wei_ptr);
 
-        for (int ireduce = 0; ireduce < nreduce; ireduce += stride) {
+        for (dim_t ireduce = 0; ireduce < nreduce; ireduce += stride) {
             for (int ohb = 0; ohb < jcp.nb_oh_blocking; ohb++) {
                 tileloadd(Tmm(get_inp_tensor(ohb, tail)),
                         ptr[reg_inp_ptr + get_inp_offset(ohb, 0)
@@ -1791,18 +1807,18 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
         return;
     }
 
-    auto wei_offset = [&](int icb, int ocb, int kd, int kh, int kw) {
-        return (size_t)icb * get_wei_icb_step() + kd * get_wei_d_step()
+    auto wei_offset = [&](dim_t icb, dim_t ocb, dim_t kd, dim_t kh, dim_t kw) {
+        return icb * get_wei_icb_step() + kd * get_wei_d_step()
                 + kh * get_wei_h_step() + get_wei_offset(ocb, kw);
     };
 
-    auto inp_offset = [&](int icb, int ohb, int kd, int kh, int kw) {
-        return (size_t)icb * get_inp_icb_step() + kd * get_inp_d_step()
+    auto inp_offset = [&](dim_t icb, dim_t ohb, dim_t kd, dim_t kh, dim_t kw) {
+        return icb * get_inp_icb_step() + kd * get_inp_d_step()
                 + kh * get_inp_h_step() + get_inp_offset(ohb, kw);
     };
 
     auto safe_tileloadd
-            = [this](const Tmm &t1, const Xbyak::Reg64 &reg_ptr, size_t offset,
+            = [this](const Tmm &t1, const Xbyak::Reg64 &reg_ptr, dim_t offset,
                       const Xbyak::Reg64 &reg_stride) {
         if (offset <= INT32_MAX) {
             tileloadd(t1, ptr[reg_ptr + offset + reg_stride]);
@@ -1820,24 +1836,24 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
         Label kd_skip_compute;
         if (check_kd_padding) mov(reg_kd, ptr[param1 + GET_OFF(kd_padding)]);
 
-        for (int kd = 0; kd < jcp.kd; kd++) {
+        for (dim_t kd = 0; kd < jcp.kd; kd++) {
             if (check_kd_padding) {
                 dec(reg_kd);
                 jl(kd_skip_compute, T_NEAR);
                 push(reg_kd);
             }
-            for (int kh = 0; kh < jcp.kh; kh++) {
-                for (int set_idx = 0; set_idx < jcp.n_stride_sets;
+            for (dim_t kh = 0; kh < jcp.kh; kh++) {
+                for (dim_t set_idx = 0; set_idx < jcp.n_stride_sets;
                         set_idx++) { // used to optimize input memory reuse in L1$
-                    for (int kw = set_idx; kw < jcp.kw; kw += jcp.kw_step) {
+                    for (dim_t kw = set_idx; kw < jcp.kw; kw += jcp.kw_step) {
                         for (int ohb = 0; ohb < jcp.nb_oh_blocking; ohb++) {
-                            const size_t inp_off
+                            const dim_t inp_off
                                     = inp_offset(icb, ohb, kd, kh, kw);
                             safe_tileloadd(Tmm(get_inp_tensor(ohb, tail)),
                                     reg_inp_ptr, inp_off, reg_inp_stride);
                         }
                         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-                            const size_t wei_off
+                            const dim_t wei_off
                                     = wei_offset(icb, ocb, kd, kh, kw);
                             safe_tileloadd(Tmm(get_wei_tensor(ocb)),
                                     reg_wei_ptr, wei_off, reg_wei_stride);
@@ -1864,15 +1880,15 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_icb_loop(int width,
     add(reg_inp_ptr, get_inp_shift());
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
-        bool do_store, const int l_pad_output, const int r_pad_output,
+void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(dim_t width,
+        bool do_store, const dim_t l_pad_output, const dim_t r_pad_output,
         const bool zp_3d_pad) {
     if (jcp.req_zero_point_buffer
             && (jcp.t_pad_output > 0 || jcp.b_pad_output > 0)) {
-        const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
-        const size_t height_limit = reduce_to_blocked_dims(
+        const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+        const dim_t height_limit = reduce_to_blocked_dims(
                 jcp.oh, oh_step_size, jcp.t_pad_output, jcp.b_pad_output);
-        const int ur_h = div_up(height_limit, oh_step_size);
+        const int ur_h = static_cast<int>(div_up(height_limit, oh_step_size));
         assert(6 >= ur_h);
 
         // Use a jump-table to execute the corresponding block
@@ -1895,8 +1911,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
         const bool local_is_buffer_empty = is_buffer_empty_;
 
         // Unroll ow_block with regards to l_pad_output and r_pad_output
-        int cur_t_pad = reduce_to_block(oh_step_size, jcp.t_pad_output);
-        int cur_b_pad = height_limit
+        dim_t cur_t_pad = reduce_to_block(oh_step_size, jcp.t_pad_output);
+        dim_t cur_b_pad = height_limit
                 - reduce_to_block(oh_step_size, jcp.b_pad_output);
         for (int u = 0; u < ur_h; u++) {
             bool last = u == ur_h - 1;
@@ -1909,8 +1925,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
             is_buffer_empty_ = local_is_buffer_empty;
             compute_icb_loop(width, do_store, false, cur_t_pad, cur_b_pad,
                     l_pad_output, r_pad_output, zp_3d_pad, last);
-            cur_t_pad = nstl::max(0, cur_t_pad - oh_step_size);
-            cur_b_pad = nstl::max(0, cur_b_pad - oh_step_size);
+            cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step_size);
+            cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step_size);
             if (!last) jmp(h_blk_end_label, T_NEAR);
         }
         L(h_blk_end_label);
@@ -1920,8 +1936,8 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_icb_loop(int width,
     }
 }
 
-void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(int width,
-        bool do_store, const int l_pad_output, const int r_pad_output) {
+void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(dim_t width,
+        bool do_store, const dim_t l_pad_output, const dim_t r_pad_output) {
     if (jcp.req_zero_point_buffer && (jcp.f_pad > 0 || jcp.back_pad > 0)) {
         Label compute_3d_zp_label, zp_d_end_label;
         mov(reg_kd, ptr[param1 + GET_OFF(kd_padding)]);
@@ -1951,18 +1967,21 @@ void jit_avx512_core_amx_fwd_kernel_t::dispatch_zp_3d_compute(int width,
 
 void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
     auto compute_ow_loop_body
-            = [this](bool last_owb, int num_tile_blocks, const int l_pad_output,
-                      const int r_pad_output) {
-        int cur_l_pad_output = l_pad_output;
-        int cur_r_pad_output = r_pad_output;
-        int gen_tile_tail = last_owb && jcp.tile_tail > 0 ? jcp.tile_tail
-                                                          : jcp.tile_width;
+            = [this](bool last_owb, int num_tile_blocks,
+                      const dim_t l_pad_output, const dim_t r_pad_output) {
+        dim_t cur_l_pad_output = l_pad_output;
+        dim_t cur_r_pad_output = r_pad_output;
+        const dim_t gen_tile_tail = last_owb && jcp.tile_tail > 0
+                ? jcp.tile_tail
+                : jcp.tile_width;
         init_runtime_counters(last_owb && num_tile_blocks == 1);
         for (int owb = 0; owb < num_tile_blocks - 1; owb++) {
             dispatch_zp_3d_compute(
                     jcp.tile_width, false, cur_l_pad_output, cur_r_pad_output);
-            cur_l_pad_output = nstl::max(0, cur_l_pad_output - jcp.tile_width);
-            cur_r_pad_output = nstl::max(0, cur_r_pad_output - jcp.tile_width);
+            cur_l_pad_output
+                    = nstl::max<dim_t>(0, cur_l_pad_output - jcp.tile_width);
+            cur_r_pad_output
+                    = nstl::max<dim_t>(0, cur_r_pad_output - jcp.tile_width);
         }
         dispatch_zp_3d_compute(
                 gen_tile_tail, true, cur_l_pad_output, cur_r_pad_output);
@@ -1970,23 +1989,23 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
 
     assert(jcp.nb_ow > 0);
     if (jcp.nb_ow == 1) {
-        const int ow_r_pad_start
-                = nstl::max(jcp.ow - jcp.r_pad_output, jcp.l_pad_output);
-        compute_ow_loop_body(
-                true, jcp.ow_blocks, jcp.l_pad_output, ow_r_pad_start);
+        const dim_t ow_r_pad_start
+                = nstl::max<dim_t>(jcp.ow - jcp.r_pad_output, jcp.l_pad_output);
+        compute_ow_loop_body(true, static_cast<int>(jcp.ow_blocks),
+                jcp.l_pad_output, ow_r_pad_start);
     } else if (jcp.req_zero_point_buffer
             && (jcp.l_pad_output > 0 || jcp.r_pad_output > 0)) {
 
-        const size_t zp_addr_shift
+        const dim_t zp_addr_shift
                 = jcp.ngroups * jcp.oc_without_padding * sizeof(int32_t);
-        const int ow_step_size = jcp.ow_block;
+        const int ow_step_size = static_cast<int>(jcp.ow_block);
         const int ow_blocks_per_call = div_up(ow_step_size, jcp.tile_width);
         const int last_owb_tile_blocks = jcp.ow_blocks % ow_blocks_per_call == 0
                 ? ow_blocks_per_call
                 : jcp.ow_blocks % ow_blocks_per_call;
-        const int width_limit = reduce_to_blocked_dims(
+        const dim_t width_limit = reduce_to_blocked_dims(
                 jcp.ow, ow_step_size, jcp.l_pad_output, jcp.r_pad_output);
-        const int ur_w = div_up(width_limit, ow_step_size);
+        const int ur_w = static_cast<int>(div_up(width_limit, ow_step_size));
         assert(6 >= ur_w);
         // Use a jump-table to execute the corresponding block
         Label w_blk_label[6], w_blk_end_label, jmp_table_label;
@@ -2002,10 +2021,10 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
         }
 
         // Unroll ow_block with regards to l_pad_output and r_pad_output
-        int cur_l_pad = reduce_to_block(ow_step_size, jcp.l_pad_output);
-        int cur_r_pad
+        dim_t cur_l_pad = reduce_to_block(ow_step_size, jcp.l_pad_output);
+        dim_t cur_r_pad
                 = width_limit - reduce_to_block(ow_step_size, jcp.r_pad_output);
-        int zp_offset = 0;
+        dim_t zp_offset = 0;
         for (int u = 0; u < ur_w; u++) {
             const bool last = u == ur_w - 1;
             L(w_blk_label[u]);
@@ -2015,8 +2034,8 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
                     cur_r_pad);
             zp_offset += accum_with_upper_bound(
                     ow_step_size, cur_l_pad, cur_r_pad);
-            cur_l_pad = nstl::max(0, cur_l_pad - ow_step_size);
-            cur_r_pad = nstl::max(0, cur_r_pad - ow_step_size);
+            cur_l_pad = nstl::max<dim_t>(0, cur_l_pad - ow_step_size);
+            cur_r_pad = nstl::max<dim_t>(0, cur_r_pad - ow_step_size);
             if (!last) jmp(w_blk_end_label, T_NEAR);
         }
         L(w_blk_end_label);
@@ -2024,7 +2043,8 @@ void jit_avx512_core_amx_fwd_kernel_t::compute_ow_loop() {
     } else {
         assert(jcp.oh_per_tile == 1);
         Label label_done;
-        int ow_blocks_per_call = utils::div_up(jcp.ow_block, jcp.tile_width);
+        int ow_blocks_per_call
+                = static_cast<int>(utils::div_up(jcp.ow_block, jcp.tile_width));
         int last_owb_tile_blocks = jcp.ow_blocks % ow_blocks_per_call;
         if (last_owb_tile_blocks == 0 && jcp.tile_tail > 0)
             last_owb_tile_blocks = ow_blocks_per_call;
@@ -2058,11 +2078,11 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
 
-    const int fac = jcp.is_relo      ? jcp.stride_w * jcp.kh
+    const dim_t fac = jcp.is_relo    ? jcp.stride_w * jcp.kh
             : jcp.is_pbuffer_strided ? 1
                                      : jcp.stride_w;
-    const int inp_stride = fac * jcp.ic_block_int_np * jcp.typesize_in;
-    const int wei_stride = jcp.oc_block * jcp.typesize_acc;
+    const dim_t inp_stride = fac * jcp.ic_block_int_np * jcp.typesize_in;
+    const dim_t wei_stride = jcp.oc_block * jcp.typesize_acc;
     mov(reg_inp_stride, inp_stride);
     mov(reg_wei_stride, wei_stride);
 
@@ -2071,7 +2091,7 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
         // loads / stores with block index
         // ocb = occ * jcp.nb_oc_blocking + (jcp.nb_oc_blocking - 1)
         // TODO: use masked loads / stores for the last occ only
-        int current_block_size = jcp.oc_block;
+        dim_t current_block_size = jcp.oc_block;
         int mask = (1 << current_block_size) - 1;
         Xbyak::Reg32 regw_tmp = reg_tmp.cvt32();
         mov(regw_tmp, mask);
@@ -2099,10 +2119,11 @@ void jit_avx512_core_amx_fwd_kernel_t::generate() {
 void jit_avx512_core_amx_fwd_kernel_t::tile_configure(char *tcfg_buff) {
     const int vnni_width = jcp.src_dt == data_type::bf16 ? 2 : 4;
     // Input tile dimensions
-    const int a_col = jcp.is_relo ? jcp.ic_block_int
-                                  : jcp.ic_block_int_np * jcp.kw_per_tile;
+    const int a_col = static_cast<int>(jcp.is_relo
+                    ? jcp.ic_block_int
+                    : jcp.ic_block_int_np * jcp.kw_per_tile);
     // Weights tile dimensions
-    const int b_col = jcp.oc_block * vnni_width;
+    const int b_col = static_cast<int>(jcp.oc_block) * vnni_width;
     const int b_row = a_col / vnni_width;
     // Accumulator tile dimensions
     const int c_col = 16;
@@ -2137,7 +2158,8 @@ void jit_avx512_core_amx_fwd_kernel_t::tile_configure(char *tcfg_buff) {
                     c_col * jcp.typesize_acc);
     }
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 void jit_avx512_core_amx_fwd_kernel_t::set_oh_blk_limits(jit_conv_conf_t &jcp) {
@@ -2152,31 +2174,33 @@ void jit_avx512_core_amx_fwd_kernel_t::set_oh_blk_limits(jit_conv_conf_t &jcp) {
     if (jcp.req_zero_point_buffer && calculate_oh_limits) {
 
         int limit_idx = 0;
-        const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+        const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
 
         // full t_pad output block
-        const int t_pad_blk_end = rnd_dn(jcp.t_pad_output, oh_step_size);
+        const dim_t t_pad_blk_end = rnd_dn(jcp.t_pad_output, oh_step_size);
         if (jcp.t_pad_output >= oh_step_size) {
             jcp.h_blk_limits[limit_idx++] = t_pad_blk_end;
         }
         // t_pad output overlap with no padding
-        const int t_pad_shift = jcp.t_pad_output % oh_step_size;
+        const dim_t t_pad_shift = jcp.t_pad_output % oh_step_size;
         if (t_pad_shift != 0) {
             jcp.h_blk_limits[limit_idx++] = t_pad_blk_end + t_pad_shift;
         }
-        const int t_pad_next_blk = rnd_up(jcp.t_pad_output, oh_step_size);
-        const int oh_blk_tail = jcp.oh % oh_step_size;
-        const int b_pad_no_tail = nstl::max(0, jcp.b_pad_output - oh_blk_tail);
-        const int b_pad_start
-                = nstl::max(jcp.t_pad_output, jcp.oh - jcp.b_pad_output);
-        const int b_pad_blk_start = rnd_dn(b_pad_start, oh_step_size);
+        const dim_t t_pad_next_blk = rnd_up(jcp.t_pad_output, oh_step_size);
+        const dim_t oh_blk_tail = jcp.oh % oh_step_size;
+        const dim_t b_pad_no_tail
+                = nstl::max<dim_t>(0, jcp.b_pad_output - oh_blk_tail);
+        const dim_t b_pad_start
+                = nstl::max<dim_t>(jcp.t_pad_output, jcp.oh - jcp.b_pad_output);
+        const dim_t b_pad_blk_start = rnd_dn(b_pad_start, oh_step_size);
         // middle block without padding
-        const int mid_blk = nstl::max(0, b_pad_blk_start - t_pad_next_blk);
+        const dim_t mid_blk
+                = nstl::max<dim_t>(0, b_pad_blk_start - t_pad_next_blk);
         if (mid_blk >= oh_step_size) {
             jcp.h_blk_limits[limit_idx++] = b_pad_blk_start;
         }
         // no padding with b_pad overlap
-        const int b_pad_shift = b_pad_no_tail % oh_step_size;
+        const dim_t b_pad_shift = b_pad_no_tail % oh_step_size;
         if (b_pad_shift != 0) {
             jcp.h_blk_limits[limit_idx++] = rnd_up(b_pad_start, oh_step_size);
         }
@@ -2197,7 +2221,7 @@ void jit_avx512_core_amx_fwd_kernel_t::set_ow_blk_limits(jit_conv_conf_t &jcp) {
     const bool calculate_ow_limits
             = jcp.nb_ow > 1 && (jcp.l_pad_output > 0 || jcp.r_pad_output > 0);
     if (jcp.req_zero_point_buffer && calculate_ow_limits) {
-        const int ow_step_size = jcp.ow_block;
+        const int ow_step_size = static_cast<int>(jcp.ow_block);
 
         // l_pad
         const int l_pad_limit
@@ -2207,16 +2231,16 @@ void jit_avx512_core_amx_fwd_kernel_t::set_ow_blk_limits(jit_conv_conf_t &jcp) {
         jcp.l_pad_blk = div_up(l_pad_limit, ow_step_size);
 
         // middle (area without padding)
-        const int no_pad_area
-                = nstl::max(0, jcp.ow - l_pad_area_blk - jcp.r_pad_output);
+        const int no_pad_area = static_cast<int>(nstl::max<dim_t>(
+                0, jcp.ow - l_pad_area_blk - jcp.r_pad_output));
         jcp.no_pad_w_blk = no_pad_area >= ow_step_size ? 1 : 0;
 
         // r_pad
         const int no_pad_area_shift = no_pad_area % ow_step_size;
         const int r_pad_area_overlap
                 = no_pad_area_shift == 0 ? 0 : ow_step_size - no_pad_area_shift;
-        const int r_pad_area
-                = nstl::max(0, jcp.r_pad_output - r_pad_area_overlap);
+        const int r_pad_area = static_cast<int>(
+                nstl::max<dim_t>(0, jcp.r_pad_output - r_pad_area_overlap));
         const int r_pad_limit = (r_pad_area >= ow_step_size ? ow_step_size : 0)
                 + (r_pad_area % ow_step_size);
         jcp.r_pad_blk = (r_pad_area_overlap > 0 ? 1 : 0)
@@ -2292,9 +2316,9 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = !is_1d ? cd.dilates[ndims - 4] : 0;
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, gen_kd);
     jcp.b_pad = calculate_end_padding(
@@ -2426,7 +2450,7 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // small-ic parameters
     jcp.ic_block_int_np = jcp.is_nspc
-            ? nstl::min(jcp.ic_block_int, jcp.ic_without_padding)
+            ? nstl::min<dim_t>(jcp.ic_block_int, jcp.ic_without_padding)
             : jcp.ic_block_int;
     bool is_small_ic = jcp.ic_block_int_np < jcp.ic_block_int;
 
@@ -2541,10 +2565,13 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -2568,19 +2595,20 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const bool ok_to_pack_tile = !jcp.is_relo
             && (utils::everyone_is(1, jcp.kh, jcp.kw)
                     || utils::everyone_is(1, jcp.stride_h, jcp.stride_w));
-    const int max_oh_per_tile
-            = 1 + (jcp.full_tile_width - jcp.ow) / (jcp.ow + gen_kw - 1);
+    const int max_oh_per_tile = static_cast<int>(
+            1 + (jcp.full_tile_width - jcp.ow) / (jcp.ow + gen_kw - 1));
     jcp.oh_per_tile = ok_to_pack_tile
-            ? nstl::min(jcp.oh, nstl::max(1, max_oh_per_tile))
+            ? static_cast<int>(
+                      nstl::min<dim_t>(jcp.oh, nstl::max(1, max_oh_per_tile)))
             : 1;
-    jcp.tile_width = nstl::min<int>(
-            jcp.full_tile_width, calculate_tile_width(jcp.oh_per_tile));
+    jcp.tile_width = static_cast<int>(nstl::min<dim_t>(
+            jcp.full_tile_width, calculate_tile_width(jcp.oh_per_tile)));
     jcp.ow_blocks = utils::div_up(jcp.ow, jcp.tile_width);
 
     // Prefer to use a single tile width when possible
     // (eg ow28 => 2 tiles of 14 vs 1 of 16 and 1 of 12)
     if (jcp.oh_per_tile == 1 && jcp.ow % jcp.ow_blocks == 0)
-        jcp.tile_width = jcp.ow / jcp.ow_blocks;
+        jcp.tile_width = static_cast<int>(jcp.ow / jcp.ow_blocks);
     jcp.tile_tail = jcp.oh_per_tile == 1 ? jcp.ow % jcp.tile_width : 0;
 
     jcp.nb_oc_blocking = (jcp.nb_oc % 2 == 0) ? 2 : 1;
@@ -2598,20 +2626,23 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // TODO: tune oh blocking
     const int oh_blk_size_param = jcp.is_relo ? 1 : 10;
-    const int oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
+    const dim_t oh_step_size = jcp.nb_oh_blocking * jcp.oh_per_tile;
     const int oh_blk_size = rnd_up(oh_blk_size_param, oh_step_size);
-    jcp.oh_blk_size = rnd_up(nstl::min(jcp.oh, oh_blk_size), oh_step_size);
+    jcp.oh_blk_size
+            = rnd_up(nstl::min<dim_t>(jcp.oh, oh_blk_size), oh_step_size);
     // Here ihp means the input buffer height including padding (ie the number
     // of input rows required for computation of jcp.oh_blk_size output rows.
     // If an input row doesn't participate in the computation of any output row,
     // it isn't copied to the buffer at all (eg jcp.stride_h > gen_kh).
     jcp.ihp = jcp.is_relo
             ? jcp.oh_blk_size
-            : (jcp.oh_blk_size - 1) * nstl::min(jcp.stride_h, gen_kh) + gen_kh;
+            : (jcp.oh_blk_size - 1) * nstl::min<dim_t>(jcp.stride_h, gen_kh)
+                    + gen_kh;
 
     // TODO: tune ow blocking
     const int ow_blocks_per_call = jcp.is_relo ? 10 : 2;
-    jcp.ow_block = nstl::min(jcp.ow, jcp.tile_width * ow_blocks_per_call);
+    jcp.ow_block
+            = nstl::min<dim_t>(jcp.ow, jcp.tile_width * ow_blocks_per_call);
     jcp.nb_ow = utils::div_up(jcp.ow, jcp.ow_block);
     // iwp includes all width elements that are really used in calculation
     // including left and right zero padding
@@ -2624,9 +2655,9 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // Number of ops per tile store
     int ops_tile_store = jcp.tile_width;
     // Number of ops per accumulation tile
-    int avaliable_ops = jcp.is_relo
-            ? utils::div_up(jcp.nreduce, jcp.ic_block_int)
-            : jcp.nb_ic_int * jcp.kh * (jcp.kw / jcp.kw_per_tile);
+    const int avaliable_ops = static_cast<int>(jcp.is_relo
+                    ? utils::div_up(jcp.nreduce, jcp.ic_block_int)
+                    : jcp.nb_ic_int * jcp.kh * (jcp.kw / jcp.kw_per_tile));
     // Number of vectors to store per tile operation
     // NOTE: set to zero to turn off interleave store (mostly for debugging)
     jcp.per_one_pstore = utils::div_up(ops_tile_store, avaliable_ops);
@@ -2656,24 +2687,25 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.with_dst_scales = !attr.scales_.get(DNNL_ARG_DST).has_default_values();
 
     // Note: currently unsupported, results in seg-fault
-    const int l_pad_output
-            = nstl::min(jcp.ow, div_up(nstl::max(0, jcp.l_pad), jcp.stride_w));
+    const dim_t l_pad_output = nstl::min<dim_t>(
+            jcp.ow, div_up(nstl::max<dim_t>(0, jcp.l_pad), jcp.stride_w));
     VDISPATCH_CONV_IC(!(!jcp.is_relo && (l_pad_output > jcp.ow_block)),
             VERBOSE_BLOCKING_FAIL, "bad padding dimensions for blocking");
 
     // Relevant to 'zero_point padding buffer' (pbuff) jit kernel
     if (jcp.req_zero_point_buffer) {
         auto calculate_output_padding_dims
-                = [](int o_dim, int s_pad, int e_pad, int &s_pad_output,
-                          int &e_pad_output, bool &o_mid, int &o_pad,
-                          int stride, bool req_mid_area) {
-            s_pad_output
-                    = nstl::min(o_dim, div_up(nstl::max(0, s_pad), stride));
-            e_pad_output
-                    = nstl::min(o_dim, div_up(nstl::max(0, e_pad), stride));
+                = [](dim_t o_dim, dim_t s_pad, dim_t e_pad, dim_t &s_pad_output,
+                          dim_t &e_pad_output, bool &o_mid, dim_t &o_pad,
+                          dim_t stride, bool req_mid_area) {
+            s_pad_output = nstl::min<dim_t>(
+                    o_dim, div_up(nstl::max<dim_t>(0, s_pad), stride));
+            e_pad_output = nstl::min<dim_t>(
+                    o_dim, div_up(nstl::max<dim_t>(0, e_pad), stride));
             o_mid = (o_dim - s_pad_output - e_pad_output > 0) && req_mid_area;
-            o_pad = nstl::min(o_dim,
-                    nstl::max(1, s_pad_output + e_pad_output + (int)o_mid));
+            o_pad = nstl::min<dim_t>(o_dim,
+                    nstl::max<dim_t>(
+                            1, s_pad_output + e_pad_output + (dim_t)o_mid));
         };
 
         const bool mid_w_area = (jcp.l_pad > 0 || jcp.r_pad > 0)
@@ -2741,7 +2773,7 @@ status_t jit_avx512_core_amx_fwd_kernel_t::init_scratchpad(
         scratchpad.book(key_conv_zero_point_pad,
                 (size_t)nthr * jcp.zp_pbuff_size, sizeof(int32_t));
         if (!jcp.zp_pbuff_outer_compute) {
-            const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+            const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
             scratchpad.book<bool>(key_conv_zero_point_flag,
                     (size_t)jcp.nthr * oc_chunks * jcp.ngroups);
         }
@@ -2770,13 +2802,13 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
 
     const bool is_xf16
             = utils::one_of(jcp.ddst_dt, data_type::bf16, data_type::f16);
-    const int inp_w_step
+    const dim_t inp_w_step
             = jcp.ngroups * jcp.oc_without_padding * jcp.typesize_in;
-    const int inp_h_step = jcp.ow * inp_w_step;
-    const int out_w_step = jcp.oc_block_int * jcp.typesize_in;
-    const int out_h_step = jcp.owp * out_w_step;
+    const dim_t inp_h_step = jcp.ow * inp_w_step;
+    const dim_t out_w_step = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t out_h_step = jcp.owp * out_w_step;
 
-    auto zero_it = [this, is_xf16](reg64_t tmp_out_ptr, int offset) {
+    auto zero_it = [this, is_xf16](reg64_t tmp_out_ptr, dim_t offset) {
         // no mask as output is a padded buffer
         if (is_xf16)
             vmovdqu16(ptr[tmp_out_ptr + offset], zmm_zero);
@@ -2784,8 +2816,8 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
             vmovdqu8(ptr[tmp_out_ptr + offset], zmm_zero);
     };
 
-    auto copy_it = [this, is_masked, is_xf16](reg64_t tmp_inp_ptr, int inp_off,
-                           reg64_t tmp_out_ptr, int out_off) {
+    auto copy_it = [this, is_masked, is_xf16](reg64_t tmp_inp_ptr,
+                           dim_t inp_off, reg64_t tmp_out_ptr, dim_t out_off) {
         Zmm zmm_load = is_masked ? zmm_tmp | ktail_mask | T_z : zmm_tmp;
         Zmm zmm_stor = zmm_tmp; // no mask as output is padded buffer
         if (is_xf16) {
@@ -2806,7 +2838,7 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
         L(label_tov_loop);
         {
             for (int ow = 0; ow < jcp.owp; ow++) {
-                const int offset = ow * out_w_step;
+                const dim_t offset = ow * out_w_step;
                 zero_it(reg_ptr_aux_out, offset);
             }
             add(reg_ptr_aux_out, out_h_step);
@@ -2867,7 +2899,7 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
                     jz(label_kwp_skip, T_NEAR);
                     // Handle Dilation-by-Stride
                     for (int sw = 0; sw < jcp.stride_w - 1; sw++) {
-                        const int offset = sw * out_w_step;
+                        const dim_t offset = sw * out_w_step;
                         zero_it(reg_ptr_aux_out, offset);
                     }
                     add(reg_ptr_aux_out, (jcp.stride_w - 1) * out_w_step);
@@ -2907,7 +2939,7 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
             // Handle Dilation-by-Stride
             for (int sh = 0; sh < jcp.stride_h - 1; sh++) {
                 for (int ow = 0; ow < jcp.owp; ow++) {
-                    const int offset = sh * out_h_step + ow * out_w_step;
+                    const dim_t offset = sh * out_h_step + ow * out_w_step;
                     zero_it(reg_ptr_aux_out, offset);
                 }
             }
@@ -2933,7 +2965,7 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::copy_row(
         L(label_bov_loop);
         {
             for (int ow = 0; ow < jcp.owp; ow++) {
-                const int offset = ow * out_w_step;
+                const dim_t offset = ow * out_w_step;
                 zero_it(reg_ptr_aux_out, offset);
             }
             add(reg_ptr_aux_out, out_h_step);
@@ -2965,11 +2997,10 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::kd_loop(bool is_masked) {
     copy_row(is_masked);
 
     if (is_3d) {
-        const size_t inp_d_offset = static_cast<size_t>(jcp.typesize_in)
-                * (jcp.dilate_d + 1) * jcp.oh * jcp.ow * jcp.ngroups
-                * jcp.oc_without_padding;
-        const size_t out_d_offset = static_cast<size_t>(jcp.typesize_in)
-                * jcp.ohp * jcp.owp * jcp.oc_block_int;
+        const dim_t inp_d_offset = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.oh
+                * jcp.ow * jcp.ngroups * jcp.oc_without_padding;
+        const dim_t out_d_offset
+                = jcp.typesize_in * jcp.ohp * jcp.owp * jcp.oc_block_int;
         pop(reg_ptr_aux_inp_h);
         pop(reg_ptr_aux_out);
         sub(reg_ptr_aux_inp_h, inp_d_offset);
@@ -2983,10 +3014,10 @@ void jit_avx512_core_amx_bwd_data_copy_kernel_t::kd_loop(bool is_masked) {
 
 void jit_avx512_core_amx_bwd_data_copy_kernel_t::generate() {
 
-    const int inp_c_step = jcp.oc_block_int * jcp.typesize_in;
-    const int out_c_step = jcp.kd * jcp.ohp * jcp.owp * inp_c_step;
-    const int nb_oc_int_no_tail = jcp.oc_without_padding / jcp.oc_block_int;
-    const int oc_block_int_tail = jcp.oc_without_padding % jcp.oc_block_int;
+    const dim_t inp_c_step = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t out_c_step = jcp.kd * jcp.ohp * jcp.owp * inp_c_step;
+    const dim_t nb_oc_int_no_tail = jcp.oc_without_padding / jcp.oc_block_int;
+    const dim_t oc_block_int_tail = jcp.oc_without_padding % jcp.oc_block_int;
 
     preamble();
 
@@ -3046,7 +3077,7 @@ int jit_avx512_core_amx_bwd_data_kernel_t::get_out_tensor(int h, int i) const {
     const int C_LAST = 4;
     assert(0 <= C_BASE && C_BASE < C_LAST && C_LAST <= jcp.max_tiles);
     MAYBE_UNUSED(C_LAST);
-    const int tile = C_BASE + h * jcp.nb_ih_blocking + i;
+    const int tile = static_cast<int>(C_BASE + h * jcp.nb_ih_blocking + i);
     assert(C_BASE <= tile && tile < C_LAST);
     return tile;
 }
@@ -3073,85 +3104,80 @@ int jit_avx512_core_amx_bwd_data_kernel_t::get_wei_tensor(int i) const {
 // - inp is a padded buffer ~ [nb_oc_int][kd][ohp][owp]{32c,64c}
 // - weights is user buffer ~ OIdhw16o16i{2o,4o}
 // - output is tiled buffer ~ [NBIH][NBIC][tile_width][16c]
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_ocb_step() const {
-    return (size_t)jcp.typesize_in * jcp.kd * jcp.ohp * jcp.owp
-            * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_ocb_step() const {
+    return jcp.typesize_in * jcp.kd * jcp.ohp * jcp.owp * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_shift() const {
-    return (size_t)jcp.typesize_in * jcp.tile_width * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_shift() const {
+    return jcp.typesize_in * jcp.tile_width * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_d_step() const {
-    return static_cast<size_t>(jcp.typesize_in) * jcp.ohp * jcp.owp
-            * jcp.oc_block_int;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_d_step() const {
+    return jcp.typesize_in * jcp.ohp * jcp.owp * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_offset(
-        int ihb, int kh, int kw) const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_inp_offset(
+        dim_t ihb, dim_t kh, dim_t kw) const {
     // calculate offset by src height dimension
-    size_t sp_offset = (size_t)ihb * jcp.owp;
+    dim_t sp_offset = ihb * jcp.owp;
     // add offset by kernel height dimension
-    sp_offset += (size_t)(jcp.kh - 1 - kh) * (jcp.dilate_h + 1) * jcp.owp;
+    sp_offset += (jcp.kh - 1 - kh) * (jcp.dilate_h + 1) * jcp.owp;
     // add offset by kernel width dimension
-    sp_offset += (size_t)(jcp.kw - 1 - kw) * (jcp.dilate_w + 1);
+    sp_offset += (jcp.kw - 1 - kw) * (jcp.dilate_w + 1);
     return jcp.typesize_in * sp_offset * jcp.oc_block_int;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_kh_step() const {
-    return (size_t)jcp.typesize_in * jcp.kw * jcp.oc_block_int * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_kh_step() const {
+    return jcp.typesize_in * jcp.kw * jcp.oc_block_int * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_ocb_step() const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_ocb_step() const {
     const bool is_deconv = jcp.prop_kind != prop_kind::backward_data;
-    return (size_t)jcp.typesize_in * (is_deconv ? 1 : jcp.nb_ic) * jcp.kd
-            * jcp.kh * jcp.kw * jcp.oc_block_int * jcp.ic_block;
+    return jcp.typesize_in * (is_deconv ? 1 : jcp.nb_ic) * jcp.kd * jcp.kh
+            * jcp.kw * jcp.oc_block_int * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_offset(
-        int icb, int kh, int kw) const {
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_offset(
+        dim_t icb, dim_t kh, dim_t kw) const {
     const bool is_deconv = jcp.prop_kind != prop_kind::backward_data;
-    const size_t wei_kw_stride = jcp.oc_block_int * jcp.ic_block;
-    const size_t wei_kh_stride = jcp.kw * wei_kw_stride;
-    const size_t wei_kd_stride = jcp.kh * wei_kh_stride;
-    const size_t wei_icb_stride
+    const dim_t wei_kw_stride = jcp.oc_block_int * jcp.ic_block;
+    const dim_t wei_kh_stride = jcp.kw * wei_kw_stride;
+    const dim_t wei_kd_stride = jcp.kh * wei_kh_stride;
+    const dim_t wei_icb_stride
             = (is_deconv ? jcp.nb_oc_int : 1) * jcp.kd * wei_kd_stride;
     return jcp.typesize_in
             * (icb * wei_icb_stride + kh * wei_kh_stride + kw * wei_kw_stride);
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_d_step() const {
-    const size_t wei_kd_stride
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wei_d_step() const {
+    const dim_t wei_kd_stride
             = jcp.kh * jcp.kw * jcp.oc_block_int * jcp.ic_block;
     // step through 'kd' weight elements by `stride_d`
-    return static_cast<size_t>(jcp.typesize_in) * jcp.stride_d * wei_kd_stride;
+    return jcp.typesize_in * jcp.stride_d * wei_kd_stride;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_icb_offset(
-        int ihb, int icb) const {
-    size_t el_offset = jcp.is_nspc
-            ? (size_t)icb * jcp.ic_block
-                    + (size_t)ihb * jcp.iw * jcp.ngroups
-                            * jcp.ic_without_padding
-            : (size_t)icb * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
-                    + (size_t)ihb * jcp.iw * jcp.ic_block;
-    return (size_t)jcp.typesize_out * el_offset;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_icb_offset(
+        dim_t ihb, dim_t icb) const {
+    dim_t el_offset = jcp.is_nspc
+            ? icb * jcp.ic_block
+                    + ihb * jcp.iw * jcp.ngroups * jcp.ic_without_padding
+            : icb * jcp.id * jcp.ih * jcp.iw * jcp.ic_block
+                    + ihb * jcp.iw * jcp.ic_block;
+    return jcp.typesize_out * el_offset;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_row_offset(
-        int ihb, int icb, int j) const {
-    size_t offset_w = jcp.is_nspc ? (size_t)jcp.typesize_out * j * jcp.ngroups
-                    * jcp.ic_without_padding
-                                  : (size_t)jcp.typesize_out * j * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_row_offset(
+        dim_t ihb, dim_t icb, dim_t j) const {
+    const dim_t offset_w = jcp.is_nspc
+            ? jcp.typesize_out * j * jcp.ngroups * jcp.ic_without_padding
+            : jcp.typesize_out * j * jcp.ic_block;
     return get_out_icb_offset(ihb, icb) + offset_w;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_shift(int width) const {
-    return jcp.is_nspc ? (size_t)jcp.typesize_out * width * jcp.ngroups
-                    * jcp.ic_without_padding
-                       : (size_t)jcp.typesize_out * width * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_out_shift(dim_t width) const {
+    return jcp.is_nspc
+            ? jcp.typesize_out * width * jcp.ngroups * jcp.ic_without_padding
+            : jcp.typesize_out * width * jcp.ic_block;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_icb_offset(
-        int ihb, int icb) const {
-    size_t el_offset = (size_t)icb * prv_width_ * jcp.ic_block
-            + (size_t)ihb * jcp.nb_ic_blocking * jcp.full_tile_width
-                    * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_icb_offset(
+        dim_t ihb, dim_t icb) const {
+    dim_t el_offset = icb * prv_width_ * jcp.ic_block
+            + ihb * jcp.nb_ic_blocking * jcp.full_tile_width * jcp.ic_block;
     return jcp.typesize_acc * el_offset;
 }
-size_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_row_offset(
-        int ihb, int icb, int j) const {
-    return get_wsp_icb_offset(ihb, icb)
-            + (size_t)jcp.typesize_acc * j * jcp.ic_block;
+dim_t jit_avx512_core_amx_bwd_data_kernel_t::get_wsp_row_offset(
+        dim_t ihb, dim_t icb, dim_t j) const {
+    return get_wsp_icb_offset(ihb, icb) + jcp.typesize_acc * j * jcp.ic_block;
 }
 
 // Code generation
@@ -3213,7 +3239,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::cvt2ps(data_type_t type_in,
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
-        const Zmm &zmm_out, int icb, int h, int w) {
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
     const bool mask_flag = jcp.is_nspc && jcp.ic_without_padding != jcp.ic
             && icb == (jcp.nb_ic_blocking - 1);
 
@@ -3239,7 +3265,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
     const int sum_idx = p.find(primitive_kind::sum);
     if (sum_idx != -1) load_and_add(jcp.dsrc_dt, zmm_prev_dst, zmm_out, addr);
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * icb * jcp.ic_block;
+        const dim_t bias_offset = jcp.typesize_bia * icb * jcp.ic_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         load_and_add(jcp.bia_dt, zmm_bias, zmm_out, bias_addr);
     }
@@ -3265,9 +3291,9 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_xf16(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
-        const Zmm &zmm_out, int icb, int h, int w) {
-    const int nb_ic_block = jcp.nb_ic_blocking;
-    const int ic_block = jcp.ic_block;
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
+    const dim_t nb_ic_block = jcp.nb_ic_blocking;
+    const dim_t ic_block = jcp.ic_block;
     const bool mask_flag = true && jcp.ic_without_padding != jcp.ic
             && icb == (nb_ic_block - 1);
 
@@ -3291,7 +3317,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
     }
 
     if (jcp.with_bias) {
-        int bias_offset = jcp.typesize_bia * icb * ic_block;
+        const dim_t bias_offset = jcp.typesize_bia * icb * ic_block;
         auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
         cvt2ps(jcp.bia_dt, zmm_bias, bias_addr, mask_flag);
     }
@@ -3308,7 +3334,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
 
     if (jcp.with_wei_scales) {
         mov(reg_ptr_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
-        const int scale_offset
+        const dim_t scale_offset
                 = jcp.is_ic_scale * (sizeof(float) * icb * ic_block);
         vmulps(zmm_out_msk, zmm_out,
                 EVEX_compress_addr(reg_ptr_wei_scales, scale_offset,
@@ -3357,7 +3383,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector_int8(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector(
-        const Zmm &zmm_out, int icb, int h, int w) {
+        const Zmm &zmm_out, dim_t icb, dim_t h, dim_t w) {
     /*
     Output:
               jcp.is_nspc                 !jcp.is_nspc
@@ -3373,22 +3399,24 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output_vector(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::store_output(
-        int width, bool do_store) {
+        dim_t width, bool do_store) {
     auto store_output_block
-            = [this](int width, bool do_store, bool is_last_ih_blks) {
+            = [this](dim_t width, bool do_store, bool is_last_ih_blks) {
         // Calculate the number of ih blocks; it may differ on last call
-        const int n_ih_blks = is_last_ih_blks ? jcp.ih % jcp.nb_ih_blocking
-                                              : jcp.nb_ih_blocking;
-        for (int icb = 0; icb < jcp.nb_ic_blocking; icb++) {
-            for (int ihb = 0; ihb < n_ih_blks; ihb++) {
+        const int n_ih_blks = is_last_ih_blks
+                ? static_cast<int>(jcp.ih % jcp.nb_ih_blocking)
+                : static_cast<int>(jcp.nb_ih_blocking);
+        for (dim_t icb = 0; icb < jcp.nb_ic_blocking; icb++) {
+            for (dim_t ihb = 0; ihb < n_ih_blks; ihb++) {
                 /* Formats: Workspace: [NBIH][NBIC][W][16OC] */
                 tilestored(ptr[reg_wsp_ptr + reg_wei_stride
                                    + get_wsp_icb_offset(ihb, icb)],
-                        Tmm(get_out_tensor(ihb, icb)));
+                        Tmm(get_out_tensor(
+                                static_cast<int>(ihb), static_cast<int>(icb))));
                 is_buffer_empty_ = false;
                 is_store_done_ = false;
-                for (int tw = 0; tw < width && do_store; tw++) {
-                    Zmm zmm_out = Zmm(tw);
+                for (dim_t tw = 0; tw < width && do_store; tw++) {
+                    Zmm zmm_out = Zmm(static_cast<int>(tw));
                     vmovups(zmm_out,
                             ptr[reg_wsp_ptr
                                     + get_wsp_row_offset(ihb, icb, tw)]);
@@ -3415,7 +3443,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::store_output(
     if (do_store) add(reg_out_ptr, get_out_shift(width));
 }
 
-void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(int width) {
+void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(dim_t width) {
     for (int c = 0;
             c < jcp.per_one_pstore && !is_store_done_ && !is_buffer_empty_;
             c++) {
@@ -3438,7 +3466,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::interleave_store(int width) {
 
             row_count_ = 0;
             is_store_done_ = true;
-            prv_width_ = width;
+            prv_width_ = static_cast<int>(width);
         }
     }
 }
@@ -3447,8 +3475,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::skipped_interleave_store() {
 
     if (is_store_done_save_ || is_buffer_empty_) return;
 
-    const int store_count
-            = prv_width_save_ * jcp.nb_ic_blocking * jcp.nb_ih_blocking;
+    const int store_count = static_cast<int>(
+            prv_width_save_ * jcp.nb_ic_blocking * jcp.nb_ih_blocking);
     for (int row_count = 0; row_count < store_count; row_count++) {
         // row_count = ihb * ICB * TW + icb * TW + tw
         int tw = row_count % prv_width_save_;
@@ -3464,7 +3492,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::skipped_interleave_store() {
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
-        int width, bool do_interleave_store) {
+        dim_t width, bool do_interleave_store) {
 
     auto tdpbxxd = [this](const Tmm &x1, const Tmm &x2, const Tmm &x3) {
         switch (jcp.ddst_dt) {
@@ -3477,11 +3505,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
         }
     };
 
-    for (int ocb = 0; ocb < jcp.nb_oc_int; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp.nb_oc_int; ocb++) {
         // reverse order through spatial components of weights so that
         // input buffer is accessed in a monotonically increasing fashion
-        for (int kh = jcp.kh - 1; kh >= 0; kh--) {
-            for (int kw = jcp.kw - 1; kw >= 0; kw--) {
+        for (dim_t kh = jcp.kh - 1; kh >= 0; kh--) {
+            for (dim_t kw = jcp.kw - 1; kw >= 0; kw--) {
                 for (int ihb = 0; ihb < jcp.nb_ih_blocking; ihb++) {
                     tileloadd(Tmm(get_inp_tensor(ihb)),
                             ptr[reg_inp_ptr + get_inp_offset(ihb, kh, kw)
@@ -3508,7 +3536,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_ocb_loop(
 }
 
 void jit_avx512_core_amx_bwd_data_kernel_t::compute_kd_loop(
-        int width, bool do_store, bool handle_skipped_stores) {
+        dim_t width, bool do_store, bool handle_skipped_stores) {
 
     Label skip_compute_kd_label, kd_loop_label, end_kd_compute_label;
 
@@ -3590,10 +3618,11 @@ void jit_avx512_core_amx_bwd_data_kernel_t::compute_iw_loop() {
     };
 
     if (jcp.nb_iw == 1) {
-        compute_iw_loop_body(true, jcp.iw_blocks);
+        compute_iw_loop_body(true, static_cast<int>(jcp.iw_blocks));
     } else {
         Label label_done;
-        int iw_blocks_per_call = div_up(jcp.iw_block, jcp.tile_width);
+        int iw_blocks_per_call
+                = static_cast<int>(div_up(jcp.iw_block, jcp.tile_width));
         int last_iwb_tile_blocks = jcp.iw_blocks % iw_blocks_per_call;
         if (last_iwb_tile_blocks == 0 && jcp.tile_tail > 0)
             last_iwb_tile_blocks = iw_blocks_per_call;
@@ -3627,8 +3656,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
 
     mov(reg_last_h, ptr[param1 + GET_OFF(last_h)]);
 
-    const int inp_stride = jcp.oc_block_int * jcp.typesize_in;
-    const int wei_stride = jcp.ic_block * jcp.typesize_acc;
+    const dim_t inp_stride = jcp.oc_block_int * jcp.typesize_in;
+    const dim_t wei_stride = jcp.ic_block * jcp.typesize_acc;
     mov(reg_inp_stride, inp_stride);
     mov(reg_wei_stride, wei_stride);
 
@@ -3637,7 +3666,7 @@ void jit_avx512_core_amx_bwd_data_kernel_t::generate() {
         // loads / stores with block index
         // icb = icc * jcp.nb_ic_blocking + (jcp.nb_ic_blocking - 1)
         // TODO: use masked loads / stores for the last icc only
-        int current_block_size = jcp.ic_block;
+        dim_t current_block_size = jcp.ic_block;
         int mask = (1 << current_block_size) - 1;
         Xbyak::Reg32 regw_tmp = reg_tmp.cvt32();
         mov(regw_tmp, mask);
@@ -3694,13 +3723,13 @@ void jit_avx512_core_amx_bwd_data_kernel_t::tile_configure(char *tcfg_buff) {
             = utils::one_of(jcp.ddst_dt, data_type::bf16, data_type::f16) ? 2
                                                                           : 4;
     // Input tile dimensions
-    const int a_col = jcp.oc_block_int;
+    const int a_col = static_cast<int>(jcp.oc_block_int);
     const int a_row = jcp.tile_width;
     // Weights tile dimensions
-    const int b_col = jcp.ic_block * vnni_width;
-    const int b_row = a_col / vnni_width;
+    const dim_t b_col = jcp.ic_block * vnni_width;
+    const dim_t b_row = a_col / vnni_width;
     // Accumulator tile dimensions
-    const int c_col = jcp.ic_block;
+    const dim_t c_col = jcp.ic_block;
     const int c_row = a_row;
 
     for (size_t i = 0; i < 64; i++)
@@ -3720,7 +3749,8 @@ void jit_avx512_core_amx_bwd_data_kernel_t::tile_configure(char *tcfg_buff) {
                     get_out_tensor(h, i), c_row, c_col * jcp.typesize_acc);
     }
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
@@ -3802,9 +3832,9 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!(jcp.dilate_d != 0 && jcp.stride_d != 1),
             "unsupported stride/dilation values");
 
-    const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
-    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+    const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
     jcp.back_pad = calculate_end_padding(
             jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, gen_kd);
     jcp.b_pad = calculate_end_padding(
@@ -3927,10 +3957,13 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(
             set_or_check_wei_format(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
 
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
     jcp.typesize_acc = sizeof(int32_t);
 
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -3943,12 +3976,14 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(!(jcp.max_tiles != 8 || jcp.full_tile_width != 16),
             VERBOSE_BLOCKING_FAIL, "bad blocking parameters");
 
-    jcp.tile_width = nstl::min(jcp.full_tile_width, jcp.iw);
+    jcp.tile_width
+            = static_cast<int>(nstl::min<dim_t>(jcp.full_tile_width, jcp.iw));
     jcp.iw_blocks = div_up(jcp.iw, jcp.tile_width);
 
     // Prefer to use a single tile width when possible
     // (eg iw28 => 2 tiles of 14 vs 1 of 16 and 1 of 12)
-    if (jcp.iw % jcp.iw_blocks == 0) jcp.tile_width = jcp.iw / jcp.iw_blocks;
+    if (jcp.iw % jcp.iw_blocks == 0)
+        jcp.tile_width = static_cast<int>(jcp.iw / jcp.iw_blocks);
     jcp.tile_tail = jcp.iw % jcp.tile_width;
 
     jcp.nb_ic_blocking = (jcp.nb_ic % 2 == 0) ? 2 : 1;
@@ -3961,8 +3996,9 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     // TODO: tune ih blocking
     const int ih_blk_size_tmp = 10;
-    const int ih_step = jcp.nb_ih_blocking;
-    jcp.ih_blk_size = rnd_up(nstl::min(jcp.ih, ih_blk_size_tmp), ih_step);
+    const dim_t ih_step = jcp.nb_ih_blocking;
+    jcp.ih_blk_size
+            = rnd_up(nstl::min<dim_t>(jcp.ih, ih_blk_size_tmp), ih_step);
     // ohp includes all elements that are really used in calculation,
     // including zero-padded "dilate-by-strides" and top and bottom overflow
     jcp.ohp = jcp.ih_blk_size + gen_kh - 1;
@@ -3978,7 +4014,7 @@ status_t jit_avx512_core_amx_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // Number of ops per tile store
     int ops_tile_store = jcp.tile_width;
     // Number of ops per accumulation tile
-    int avaliable_ops = jcp.nb_oc_int * jcp.kh * jcp.kw;
+    const int avaliable_ops = static_cast<int>(jcp.nb_oc_int * jcp.kh * jcp.kw);
     // Number of vectors to store per tile operation
     // NOTE: set to zero to turn off interleave store (mostly for debugging)
     jcp.per_one_pstore = div_up(ops_tile_store, avaliable_ops);
@@ -4055,14 +4091,14 @@ int jit_avx512_core_amx_bwd_weights_kernel_t::get_ddst_tensor(int ocb) const {
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::tile_configure(char *tcfg_buff) {
     // Input tile dimensions
-    const int a_col = jcp.ur_w;
-    const int a_row = jcp.ic_block;
+    const dim_t a_col = jcp.ur_w;
+    const dim_t a_row = jcp.ic_block;
     // Weights tile dimensions
-    const int b_col = jcp.oc_block * 2;
-    const int b_row = a_col / 2;
+    const dim_t b_col = jcp.oc_block * 2;
+    const dim_t b_row = a_col / 2;
     // Accumulator tile dimensions
-    const int c_col = jcp.oc_block;
-    const int c_row = a_row;
+    const dim_t c_col = jcp.oc_block;
+    const dim_t c_row = a_row;
 
     for (size_t i = 0; i < 64; i++)
         tcfg_buff[i] = 0;
@@ -4080,7 +4116,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::tile_configure(char *tcfg_buff) {
             tc_configure_tile((palette_config_t *)tcfg_buff,
                     get_wei_tensor(ocb, icb), c_row, c_col * jcp.typesize_out);
 
-    ((palette_config_t *)tcfg_buff)->palette_id = amx::get_target_palette();
+    ((palette_config_t *)tcfg_buff)->palette_id
+            = static_cast<uint8_t>(amx::get_target_palette());
 }
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::od_step_comeback_pointers() {
@@ -4124,9 +4161,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
     auto ddst_row_size = get_ddst_offset(0, 1);
     auto row_size = src_row_size + ddst_row_size;
 
-    int h_block_size = jcp.oh;
+    int h_block_size = static_cast<int>(jcp.oh);
     int h_last_block_size = h_block_size;
-    int min_h_block_size = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+    int min_h_block_size = static_cast<int>(
+            nstl::max<dim_t>(1, nstl::max(jcp.b_pad, jcp.t_pad)));
     auto working_set_size = row_size * h_block_size;
 
     if (working_set_size > full_spat_max_working_set_size) {
@@ -4218,7 +4256,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
         int oh_block_size = (is_last_block) ? h_last_block_size : h_block_size;
         // NB: this is correct because we only support t_pad = kh / 2 and thus
         // ih == oh
-        int ih_block_size = oh_block_size
+        const dim_t ih_block_size = oh_block_size
                 + (!is_first_block + !is_last_block) * jcp.t_pad;
 
         L(kh_loop);
@@ -4287,8 +4325,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
 
             L(kh_loop_work);
 
-            mul_by_const(reg_ihs, reg_tmp, get_src_offset(0, 0, 1));
-            mul_by_const(reg_ohs, reg_tmp, get_ddst_offset(0, 1));
+            mul_by_const(reg_ihs, reg_tmp,
+                    static_cast<int>(get_src_offset(0, 0, 1)));
+            mul_by_const(
+                    reg_ohs, reg_tmp, static_cast<int>(get_ddst_offset(0, 1)));
 
             add(reg_src, reg_ihs);
             add(reg_ddst, reg_ohs);
@@ -4377,7 +4417,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
         add(reg_src, first_src_block_step);
         add(reg_ddst, ddst_block_step);
 
-        int num_innermost_iters
+        const dim_t num_innermost_iters
                 = (jcp.oh - h_last_block_size) / h_block_size - 1;
         if (num_innermost_iters > 0) {
             Label h_block_loop;
@@ -4405,9 +4445,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_full_spat_loop(
 void jit_avx512_core_amx_bwd_weights_kernel_t::compute_ic_loop(
         int ic_block, int nb_ic_blocking, int nb_oc_blocking) {
     assert(jcp.ur_w % 2 == 0);
-    const int str_w = jcp.stride_w;
+    const dim_t str_w = jcp.stride_w;
     assert(jcp.tr_iw % str_w == 0);
-    const int src_stride_w_shift = jcp.tr_iw / str_w;
+    const dim_t src_stride_w_shift = jcp.tr_iw / str_w;
 
     mov(reg_b_stride, 64);
     mov(reg_a_stride, jcp.tr_iw * jcp.typesize_in);
@@ -4422,7 +4462,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_ic_loop(
                                     + get_full_kernel_offset(
                                             ocb, icb, 0, i_kw)]);
 
-            int src_offset_l = (i_kw * (jcp.dilate_w + 1)) / str_w
+            const dim_t src_offset_l = (i_kw * (jcp.dilate_w + 1)) / str_w
                     + s * src_stride_w_shift;
 
             for (int ur_w_b = 0; ur_w_b < jcp.ur_w_blocks; ur_w_b++) {
@@ -4486,7 +4526,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_diff_bias_row(
     };
 
     Label ow_loop, ow_tail;
-    int niters = jcp.tr_ow / 2;
+    int niters = static_cast<int>(jcp.tr_ow / 2);
     if (niters > 0) {
         mov(reg_tmp, jcp.tr_ow / 2);
         L(ow_loop);
@@ -4524,7 +4564,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::maybe_compute_diff_bias(
         Label bias_loop, skip_label_local;
 
         mov(reg_ddst, ptr[param + GET_OFF(dst)]);
-        add(reg_ddst, jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
+        add(reg_ddst,
+
+                jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
 
         switch (jcp.harness) {
             case harness_2d_reduction:
@@ -4566,7 +4608,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_step_common(
         int nb_ic_blocking, int nb_oc_blocking) {
     Label kh_label, ic_block_label, ow_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    const int ic_block = static_cast<int>(jcp.ic_block);
     int ic_tail = jcp.ic_tail;
 
     auto ic_loop = [&](int nb_ic_blocking, int nb_oc_blocking) {
@@ -4695,12 +4737,12 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::maybe_zero_kernel(
 
 void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
         int nb_ic_blocking, int nb_oc_blocking, bool is_partial) {
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    int b_pad = static_cast<int>(jcp.b_pad);
+    int t_pad = static_cast<int>(jcp.t_pad);
 
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t stride_h = jcp.stride_h;
     auto filter_step_size = get_kernel_offset(0, jcp.kw);
     auto src_step_size = get_src_offset(0, 0, 1);
     auto ddst_step_size = get_ddst_offset(0, 1);
@@ -4710,17 +4752,19 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             oh_dilate_label_end, oh_dilate_setup_label_shift,
             oh_dilate_setup_label_noshift, oh_dilate_setup_label_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int oh_body_end
-            = div_up(nstl::max(0, t_pad + jcp.ih - ext_kh + 1), stride_h);
+    int ext_kh = static_cast<int>(
+            calculate_extended_filter_size(jcp.kh, jcp.dilate_h));
+    int oh_body_end = static_cast<int>(
+            div_up(nstl::max<dim_t>(0, t_pad + jcp.ih - ext_kh + 1), stride_h));
     int oh_head_end
             = nstl::min(div_up(nstl::max(0, t_pad), stride_h), oh_body_end);
     int oh_head_overflow_end = div_up(nstl::max(0, t_pad), stride_h);
-    int oh_tail_end = jcp.oh;
+    int oh_tail_end = static_cast<int>(jcp.oh);
 
-    int body_src_start_offset = (stride_h - (t_pad % stride_h)) % stride_h;
-    int ih_body_end
-            = nstl::max(-t_pad + oh_body_end * stride_h, body_src_start_offset);
+    const dim_t body_src_start_offset
+            = (stride_h - (t_pad % stride_h)) % stride_h;
+    const dim_t ih_body_end = nstl::max<dim_t>(
+            -t_pad + oh_body_end * stride_h, body_src_start_offset);
 
     if (is_partial)
         mov(reg_oj, ptr[param + GET_OFF(os_index_begin)]);
@@ -4733,17 +4777,20 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_oh_loop_common(
             cmp(reg_oj, oh_head_overflow_end);
             jge(oh_tpad_tail_label_end, T_NEAR);
         }
-        const int overflow = nstl::max(
-                0, jcp.kh - div_up(nstl::max(0, t_pad + jcp.ih), dilate_h));
-        const int underflow = div_up(nstl::max(0, t_pad), dilate_h);
-        const int initial_kh = jcp.kh - overflow - underflow;
+        const int overflow = static_cast<int>(nstl::max<dim_t>(0,
+                jcp.kh
+                        - div_up(nstl::max<dim_t>(0, t_pad + jcp.ih),
+                                dilate_h)));
+        const int underflow = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, t_pad), dilate_h));
+        const dim_t initial_kh = jcp.kh - overflow - underflow;
 
         // Setup reg_kh, reg_kernel, and reg_src
         mov(reg_kh, initial_kh);
         add(reg_kernel, filter_step_size * underflow);
         if (is_dilated) {
-            const int tail = t_pad % dilate_h;
-            const int shift = tail == 0 ? 0 : dilate_h - tail;
+            const dim_t tail = t_pad % dilate_h;
+            const dim_t shift = tail == 0 ? 0 : dilate_h - tail;
             mov(reg_ih_shift, shift);
             if (!is_partial) mov(ptr[rsp + ih_dilate_offset], reg_ih_shift);
             add(reg_src, src_step_size * shift);
@@ -4957,15 +5004,17 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         int nb_ic_blocking, int nb_oc_blocking, bool is_partial) {
     assert(jcp.harness == harness_3d_reduction);
 
-    const int src_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
+    const int src_backpad_overlap = static_cast<int>(
+            div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d));
 
     const auto filter_shift = get_kernel_offset(0, jcp.kh * jcp.kw);
     const auto src_shift = get_src_offset(0, 0, jcp.ih);
     const auto ddst_shift = get_ddst_offset(0, jcp.oh);
 
-    const int kd_front_pad = nstl::max(0, jcp.f_pad);
-    const int kd_back_pad = nstl::max(0, jcp.kd - jcp.f_pad - jcp.id);
+    const int kd_front_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.f_pad));
+    const int kd_back_pad = static_cast<int>(
+            nstl::max<dim_t>(0, jcp.kd - jcp.f_pad - jcp.id));
 
     Label d_loop_label, loop_end_label, common_block_label, fpad_end_label,
             backpad_end_label, backpad_label;
@@ -4979,9 +5028,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         mov(reg_d_index, ptr[param + GET_OFF(os_index_begin)]);
         mov(reg_kd_count, ptr[param + GET_OFF(kd_padding)]);
     } else {
-        const int kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
-        const int kd_offset = get_kernel_offset(
-                0, nstl::min(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw);
+        const dim_t kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
+        const dim_t kd_offset = get_kernel_offset(0,
+                nstl::min<dim_t>(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw);
         add(reg_kernel, kd_offset);
         xor_(reg_d_index, reg_d_index);
         mov(reg_kd_count, kd_padding);
@@ -5013,7 +5062,9 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
     /* Compute 'front' edge */
     if (jcp.f_pad > 0) {
         /* Check if within fpad region */
-        cmp(reg_d_index, div_up(nstl::max(0, jcp.f_pad), jcp.stride_d));
+        cmp(reg_d_index,
+
+                div_up(nstl::max<dim_t>(0, jcp.f_pad), jcp.stride_d));
         jge(fpad_end_label, T_NEAR);
 
         /* Fpad steps */
@@ -5021,7 +5072,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with src */
-        const int src_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const dim_t src_ker_overlap = nstl::min<dim_t>(jcp.kd, jcp.id);
         cmp(reg_kd_count, src_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -5029,7 +5080,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::compute_od_loop_common(
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                const dim_t src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
                 add(reg_kernel, filter_shift * src_corr);
                 add(reg_src_d, src_shift * src_corr);
             }
@@ -5227,9 +5278,9 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -5249,13 +5300,13 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
 
     jcp.transform_to_vnni = diff_weights_d.data_type() == data_type::bf16;
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -5327,12 +5378,14 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
             CHECK(memory_desc_init_by_tag(diff_bias_md, format_tag::x));
     }
     jcp.bia_dt = jcp.with_bias ? diff_bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd;
@@ -5344,8 +5397,8 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ic_tail = jcp.ic % jcp.ic_block;
-    jcp.oc_tail = jcp.oc % jcp.oc_block;
+    jcp.ic_tail = static_cast<int>(jcp.ic % jcp.ic_block);
+    jcp.oc_tail = static_cast<int>(jcp.oc % jcp.oc_block);
 
     jcp.nb_oc_blocking = (jcp.nb_oc > 1) ? 2 : 1;
     jcp.nb_ic_blocking = (jcp.nb_ic > 1) ? 2 : 1;
@@ -5365,21 +5418,22 @@ status_t jit_avx512_core_amx_bwd_weights_kernel_t::init_conf(
     // TODO: Find more shapes (especially 3D with large spatials) for which
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
-    int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    const dim_t optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
 
     jcp.global_transpose = dnnl_thr_syncable();
     jcp.spatial_blk_size = optimal_blk_size;
 
     const int tr_round = 32; // To load full tile register
-    int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
-    jcp.tr_iw = rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
-            * jcp.stride_w;
+    const dim_t tr_pad
+            = rnd_up(nstl::max<dim_t>(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    jcp.tr_iw = (rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
+            * jcp.stride_w);
 
     jcp.tr_src_num_guard_elems = tr_pad; // upper bound
     jcp.tr_ow = rnd_up(jcp.ow, 2);
 
     if (jcp.tr_ow <= max_ur_w) {
-        jcp.ur_w = jcp.tr_ow;
+        jcp.ur_w = static_cast<int>(jcp.tr_ow);
         jcp.ur_w_blocks = 1;
     } else {
         jcp.ur_w = 1;
@@ -5543,7 +5597,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = max_threads / nthr_g_;
 
     auto calc_mem_cost
@@ -5570,9 +5624,10 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         dim_t wei_size
                 = (dim_t)j.oc * j.ic * j.kd * j.kh * j.kw * wei_type_size;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
+        float wei_compensation_scale
+                = 0.5f * (float)(dst_size + src_size) / (float)wei_size;
         float oi_channels_ratio = (float)(j.nb_oc / j.nb_oc_blocking)
-                / (j.nb_ic / j.nb_ic_blocking);
+                / (float)(j.nb_ic / j.nb_ic_blocking);
         auto get_src_coef = [oi_channels_ratio, wei_compensation_scale]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
             if (wei_compensation_scale < 1.0f) src_coef *= 4.0f;
@@ -5592,23 +5647,29 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
         const float dst_coef = get_dst_coef();
         const float wei_coef = get_wei_coef();
 
-        float src_v = src_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.mb
-                * (j.ic_block * j.nb_ic_blocking) * j.id * j.ih * j.tr_iw
-                / j.nthr_mb_work / j.stride_d / j.stride_h / j.stride_w;
-        float wei_v = wei_coef * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_oc / j.nb_oc_blocking),
-                        (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
-                * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.kh * j.kw
-                * j.kd * (j.ic_block * j.nb_ic_blocking)
-                * (j.oc_block * j.nb_oc_blocking);
-        float dst_v = dst_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_)
-                * div_up((j.nb_oc / j.nb_oc_blocking),
-                        (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
-                * j.mb * (j.oc_block * j.nb_oc_blocking) * j.od * j.oh * j.tr_ow
-                / j.nthr_mb_work;
+        float src_v = src_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.mb
+                        * (j.ic_block * j.nb_ic_blocking) * j.id * j.ih
+                        * j.tr_iw)
+                / (float)(j.nthr_mb_work * j.stride_d * j.stride_h
+                        * j.stride_w);
+        float wei_v = wei_coef
+                * (float)(div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_oc / j.nb_oc_blocking),
+                                (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
+                        * div_up((j.nb_ic / j.nb_ic_blocking), nthr_ic_b) * j.kh
+                        * j.kw * j.kd * (j.ic_block * j.nb_ic_blocking)
+                        * (j.oc_block * j.nb_oc_blocking));
+        float dst_v = dst_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up((j.nb_oc / j.nb_oc_blocking),
+                                (j.oc_block * j.nb_oc_blocking) * nthr_oc_b)
+                        * j.mb * (j.oc_block * j.nb_oc_blocking) * j.od * j.oh
+                        * j.tr_ow)
+                / (float)j.nthr_mb_work;
 
         return src_v + dst_v + wei_v;
     };
@@ -5617,14 +5678,15 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
 
     /* find the best thread distribution with lowest memory cost */
 
-    const int nthr_mb_max = nstl::min(nthr, j.nthr_mb_work);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, j.nthr_mb_work));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par,
-                (j.nb_oc / j.nb_oc_blocking)); // Amount of nb_oc_blocks
+        const int nthr_oc_b_max = static_cast<int>(nstl::min<dim_t>(nthr_par,
+                (j.nb_oc / j.nb_oc_blocking))); // Amount of nb_oc_blocks
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(
-                    nthr_par / nthr_oc_b, (j.nb_ic / j.nb_ic_blocking));
+            int nthr_ic_b = static_cast<int>(nstl::min<dim_t>(
+                    nthr_par / nthr_oc_b, (j.nb_ic / j.nb_ic_blocking)));
 
             float mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -5637,7 +5699,7 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
     }
 
     if (nthr_mb_ > nthr / 2 && nthr_mb_ < nthr)
-        nthr_mb_ = nstl::min(j.nthr_mb_work, nthr);
+        nthr_mb_ = static_cast<int>(nstl::min<dim_t>(j.nthr_mb_work, nthr));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= max_threads);
@@ -5646,7 +5708,8 @@ void jit_avx512_core_amx_bwd_weights_kernel_t::balance(const jit_conv_conf_t &j,
 // start of diff_bias kernel
 dim_t jit_avx512_core_amx_bwd_bias_kernel_t::get_ddst_offset(
         dim_t w_idx, dim_t hd_idx) const {
-    int ow_per_oc = data_type_vnni_granularity(jcp.ddst_dt);
+    const int ow_per_oc
+            = static_cast<int>(data_type_vnni_granularity(jcp.ddst_dt));
     if (ow_per_oc == 0) {
         assert(!"Invalid vnni granularity.");
         return 0;
@@ -5761,7 +5824,9 @@ void jit_avx512_core_amx_bwd_bias_kernel_t::compute_diff_bias(
 
         // pointer to diff_dst
         mov(reg_ddst, ptr[param + GET_OFF(dst)]);
-        add(reg_ddst, jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
+        add(reg_ddst,
+
+                jcp.typesize_in * ocb * jcp.tr_diff_dst_buf_size);
 
         // number of rows
         mov(reg_oj, reg_nrows);

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.hpp
@@ -80,31 +80,35 @@ private:
     const Xbyak::Opmask kmask_ic_block = Xbyak::Opmask(1);
     const Xbyak::Opmask ktail_mask = Xbyak::Opmask(2);
 
-    void prepare_output(int ur_w);
-    void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void prepare_output(dim_t ur_w);
+    void store_output(dim_t ur_w, bool last_oc_block_flag);
+    void compute_ker(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool padded);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag,
-            bool handle_h_pad);
-    void kd_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag,
-            bool handle_h_pad);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool handle_h_pad);
+    void kh_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag, bool handle_h_pad);
+    void kd_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag, bool handle_h_pad);
+    void icb_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r, bool handle_h_pad);
     void unroll_width(const bool h_padding);
 
     void generate() override;
 
     Xbyak::Zmm zmm_out(int i_ur, int i_oc) const {
-        int idx = i_ur * jcp.nb_oc_blocking + i_oc;
+        const int idx = i_ur * jcp.nb_oc_blocking + i_oc;
         assert(idx < max_regs_ur);
         return Xbyak::Zmm(idx);
     }
-    int get_ow_start(int ki, int pad_l) const {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) const {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) const {
-        int filter_overlap = pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
-        return ur_w - utils::div_up(nstl::max(0, filter_overlap), jcp.stride_w);
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) const {
+        const dim_t filter_overlap
+                = pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
+        return ur_w
+                - utils::div_up(
+                        nstl::max<dim_t>(0, filter_overlap), jcp.stride_w);
     }
 };
 
@@ -184,8 +188,8 @@ private:
     const Xbyak::Zmm &zmm_zero = zmm1;
 
     void generate() override;
-    void copy_row(int icb);
-    void copy_row_body(int lpad, int iw_len, int icb);
+    void copy_row(dim_t icb);
+    void copy_row_body(dim_t lpad, dim_t iw_len, dim_t icb);
     void copy_row_reduced_lowering();
 };
 
@@ -204,11 +208,11 @@ struct jit_avx512_core_amx_fwd_kernel_t : public jit_generator_t {
     static status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
             const jit_conv_conf_t &jcp, const primitive_attr_t &attr);
 
-    inline int accum_with_upper_bound(
-            int upper_bound, int lower_value, int upper_value) {
-        return nstl::min(upper_bound,
-                nstl::min(upper_bound, lower_value)
-                        + nstl::max(0, upper_bound - upper_value));
+    inline dim_t accum_with_upper_bound(
+            dim_t upper_bound, dim_t lower_value, dim_t upper_value) {
+        return nstl::min<dim_t>(upper_bound,
+                nstl::min<dim_t>(upper_bound, lower_value)
+                        + nstl::max<dim_t>(0, upper_bound - upper_value));
     }
 
     /*  Calculate and store the limits relevant to 'ow_block'. These limits
@@ -291,9 +295,10 @@ private:
     bool is_buffer_empty_ = true;
 
     struct w_pad_output_t {
-        int l_pad_output;
-        int r_pad_output;
-        w_pad_output_t(int l_, int r_) : l_pad_output(l_), r_pad_output(r_) {}
+        dim_t l_pad_output;
+        dim_t r_pad_output;
+        w_pad_output_t(dim_t l_, dim_t r_)
+            : l_pad_output(l_), r_pad_output(r_) {}
     };
     std::queue<w_pad_output_t> w_padding;
 
@@ -343,24 +348,25 @@ private:
     const Xbyak::Reg64 bin_injector_helper_reg_3 = r11;
 
     // AUX: Steps, shifts and offsets
-    size_t get_inp_icb_step() const;
-    size_t get_wei_icb_step() const;
-    size_t get_inp_d_step() const;
-    size_t get_inp_h_step() const;
-    size_t get_wei_d_step() const;
-    size_t get_wei_h_step() const;
-    size_t get_out_ocb_offset(int ohb, int ocb, size_t typesize) const;
-    size_t get_out_row_offset(int ohb, int ocb, int j, size_t typesize) const;
-    size_t get_out_shift(int width, size_t typesize) const;
-    size_t get_wsp_ocb_offset(int ohb, int ocb) const;
-    size_t get_wsp_row_offset(int ohb, int ocb, int j) const;
-    size_t get_wsp_shift() const;
-    size_t get_wei_offset(int ocb, int kw) const;
-    size_t get_inp_shift() const;
-    size_t get_inp_offset(int ohb, int kw) const;
-    size_t get_zp_comp_offset(int ocb, int zp_h, int zp_w) const;
-    int get_zp_index_offset(
-            int index, int mid, int s_pad_output, int e_pad_output);
+    dim_t get_inp_icb_step() const;
+    dim_t get_wei_icb_step() const;
+    dim_t get_inp_d_step() const;
+    dim_t get_inp_h_step() const;
+    dim_t get_wei_d_step() const;
+    dim_t get_wei_h_step() const;
+    dim_t get_out_ocb_offset(dim_t ohb, dim_t ocb, dim_t typesize) const;
+    dim_t get_out_row_offset(
+            dim_t ohb, dim_t ocb, dim_t j, dim_t typesize) const;
+    dim_t get_out_shift(dim_t width, dim_t typesize) const;
+    dim_t get_wsp_ocb_offset(dim_t ohb, dim_t ocb) const;
+    dim_t get_wsp_row_offset(dim_t ohb, dim_t ocb, dim_t j) const;
+    dim_t get_wsp_shift() const;
+    dim_t get_wei_offset(dim_t ocb, dim_t kw) const;
+    dim_t get_inp_shift() const;
+    dim_t get_inp_offset(dim_t ohb, dim_t kw) const;
+    dim_t get_zp_comp_offset(dim_t ocb, dim_t zp_h, dim_t zp_w) const;
+    dim_t get_zp_index_offset(
+            dim_t index, dim_t mid, dim_t s_pad_output, dim_t e_pad_output);
 
     int get_out_tensor(int h, int i, bool is_h_tail = false) const;
     int get_inp_tensor(int h, bool is_h_tail = false) const;
@@ -368,9 +374,9 @@ private:
 
     void prepare_output(int tail);
     void init_runtime_counters(bool start_with_last_tile_block);
-    size_t reduce_to_block(const int block_size, const int pad_output);
-    size_t reduce_to_blocked_dims(const int dim_size, const int block_size,
-            const int s_pad_output, const int e_pad_output);
+    dim_t reduce_to_block(const dim_t block_size, const dim_t pad_output);
+    dim_t reduce_to_blocked_dims(const dim_t dim_size, const dim_t block_size,
+            const dim_t s_pad_output, const dim_t e_pad_output);
     void cvt2ps(data_type_t type_in, const Xbyak::Zmm &ymm_in,
             const Xbyak::Operand &op, bool mask_flag = false);
     Xbyak::Zmm zmm_out(const int idx) const {
@@ -396,27 +402,27 @@ private:
     inline void store_output_ymm_bf16(
             const int idx, const Xbyak::Address &addr, const bool mask_flag);
     void store_output_vector_bf16(
-            const Xbyak::Zmm &zmm_out, int ocb, int h, int w);
-    void store_output_vector_int8(const Xbyak::Zmm &zmm_out, int ocb, int h,
-            int w, const bool compute_zp, const int zp_h, const int zp_w);
-    void store_output_vector(const Xbyak::Zmm &zmm_out, int ocb, int h, int w,
-            const bool compute_zp = false, const int zp_h = 0,
-            const int zp_w = 0);
-    void store_output(int width, int tail, bool do_store,
-            const bool handle_h_block, const int t_pad_output,
-            const int b_pad_output, const int l_pad_output,
-            const int r_pad_output, const bool is_last_oh_block,
+            const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h, dim_t w);
+    void store_output_vector_int8(const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h,
+            dim_t w, const bool compute_zp, const dim_t zp_h, const dim_t zp_w);
+    void store_output_vector(const Xbyak::Zmm &zmm_out, dim_t ocb, dim_t h,
+            dim_t w, const bool compute_zp = false, const dim_t zp_h = 0,
+            const dim_t zp_w = 0);
+    void store_output(dim_t width, int tail, bool do_store,
+            const bool handle_h_block, const dim_t t_pad_output,
+            const dim_t b_pad_output, const dim_t l_pad_output,
+            const dim_t r_pad_output, const bool is_last_oh_block,
             const bool zp_3d_pad = false);
-    void interleave_store(int width, int const t_pad_output,
-            int const b_pad_output, const bool zp_3d_pad = false);
-    void compute_icb_loop(int width, bool do_store, const bool handle_h_block,
-            const int t_pad_output, const int b_pad_output,
-            const int l_pad_output, const int r_pad_output,
+    void interleave_store(dim_t width, dim_t const t_pad_output,
+            dim_t const b_pad_output, const bool zp_3d_pad = false);
+    void compute_icb_loop(dim_t width, bool do_store, const bool handle_h_block,
+            const dim_t t_pad_output, const dim_t b_pad_output,
+            const dim_t l_pad_output, const dim_t r_pad_output,
             const bool zp_3d_pad, const bool is_last_oh_block = false);
-    void dispatch_icb_loop(int width, bool do_store, const int l_pad_output,
-            const int r_pad_output, const bool zp_3d_pad);
-    void dispatch_zp_3d_compute(int width, bool do_store,
-            const int l_pad_output, const int r_pad_output);
+    void dispatch_icb_loop(dim_t width, bool do_store, const dim_t l_pad_output,
+            const dim_t r_pad_output, const bool zp_3d_pad);
+    void dispatch_zp_3d_compute(dim_t width, bool do_store,
+            const dim_t l_pad_output, const dim_t r_pad_output);
     void compute_ow_loop();
 
     void generate() override;
@@ -559,27 +565,27 @@ private:
     const Xbyak::Zmm zmm_sum_zp = zmm28;
 
     // AUX: Steps, shifts and offsets
-    size_t get_inp_ocb_step() const;
-    size_t get_inp_offset(int ihb, int kh, int kw) const;
-    size_t get_inp_shift() const;
-    size_t get_inp_d_step() const;
-    size_t get_out_icb_offset(int ihb, int icb) const;
-    size_t get_out_row_offset(int ihb, int icb, int j) const;
-    size_t get_out_shift(int width) const;
-    size_t get_wei_kh_step() const;
-    size_t get_wei_ocb_step() const;
-    size_t get_wei_offset(int icb, int kh, int kw) const;
-    size_t get_wei_d_step() const;
-    size_t get_wsp_icb_offset(int ihb, int icb) const;
-    size_t get_wsp_row_offset(int ihb, int icb, int j) const;
-    size_t get_wsp_shift() const;
+    dim_t get_inp_ocb_step() const;
+    dim_t get_inp_offset(dim_t ihb, dim_t kh, dim_t kw) const;
+    dim_t get_inp_shift() const;
+    dim_t get_inp_d_step() const;
+    dim_t get_out_icb_offset(dim_t ihb, dim_t icb) const;
+    dim_t get_out_row_offset(dim_t ihb, dim_t icb, dim_t j) const;
+    dim_t get_out_shift(dim_t width) const;
+    dim_t get_wei_kh_step() const;
+    dim_t get_wei_ocb_step() const;
+    dim_t get_wei_offset(dim_t icb, dim_t kh, dim_t kw) const;
+    dim_t get_wei_d_step() const;
+    dim_t get_wsp_icb_offset(dim_t ihb, dim_t icb) const;
+    dim_t get_wsp_row_offset(dim_t ihb, dim_t icb, dim_t j) const;
+    dim_t get_wsp_shift() const;
 
     int get_out_tensor(int h, int i) const;
     int get_inp_tensor(int h) const;
     int get_wei_tensor(int i) const;
 
     inline bool gaps_in_store() const {
-        const int gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
+        const dim_t gen_kd = (jcp.kd - 1) * (jcp.dilate_d + 1) + 1;
         return gen_kd < jcp.stride_d || jcp.dilate_d > 0;
     }
 
@@ -595,16 +601,17 @@ private:
             const Xbyak::Zmm &zmm_in, bool mask_flag, bool store = false);
 
     void store_output_vector_xf16(
-            const Xbyak::Zmm &zmm_out, int icb, int ihb, int iw);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ihb, dim_t iw);
     void store_output_vector_int8(
-            const Xbyak::Zmm &zmm_out, int icb, int ihb, int iw);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ihb, dim_t iw);
     void store_output_vector(
-            const Xbyak::Zmm &zmm_out, int icb, int ih, int iw);
-    void store_output(int width, bool do_store);
+            const Xbyak::Zmm &zmm_out, dim_t icb, dim_t ih, dim_t iw);
+    void store_output(dim_t width, bool do_store);
     void skipped_interleave_store();
-    void interleave_store(int width);
-    void compute_ocb_loop(int width, bool do_interleave_store);
-    void compute_kd_loop(int width, bool do_store, bool handle_skipped_stores);
+    void interleave_store(dim_t width);
+    void compute_ocb_loop(dim_t width, bool do_interleave_store);
+    void compute_kd_loop(
+            dim_t width, bool do_store, bool handle_skipped_stores);
     void compute_iw_loop();
 
     void generate() override;
@@ -721,7 +728,7 @@ private:
         return jcp.typesize_in * (w_off + jcp.tr_ow * jcp.oc_block * hd_idx);
     }
 
-    inline dim_t get_kernel_offset(int ic_idx, dim_t ksp_idx) const {
+    inline dim_t get_kernel_offset(dim_t ic_idx, dim_t ksp_idx) const {
         return jcp.typesize_out * jcp.oc_block
                 * (ksp_idx * jcp.ic_block + ic_idx);
     }

--- a/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_utils.hpp
@@ -47,40 +47,43 @@ struct spatial_features_3d_t {
         , init_overflow_(0)
         , end_overflow_(0) {}
 
-    inline int get_init_overflow(const int in) const {
+    inline dim_t get_init_overflow(const dim_t in) const {
         if (is_fast_path_)
-            return nstl::max(0, filter_size_ - 1 - in - init_pad_);
+            return nstl::max<dim_t>(0, filter_size_ - 1 - in - init_pad_);
         if (dilate_ != 1)
             return div_up(
-                    nstl::max(0, (filter_size_ - 1) * dilate_ - in - init_pad_),
+                    nstl::max<dim_t>(
+                            0, (filter_size_ - 1) * dilate_ - in - init_pad_),
                     dilate_);
-        return nstl::max(0, (filter_size_ - 1 - in - init_pad_) / stride_);
+        return nstl::max<dim_t>(
+                0, (filter_size_ - 1 - in - init_pad_) / stride_);
     }
 
-    inline int get_end_overflow(const int in) const {
+    inline dim_t get_end_overflow(const dim_t in) const {
         if (is_fast_path_)
-            return nstl::max(0, filter_size_ - input_size_ + in - end_pad_);
+            return nstl::max<dim_t>(
+                    0, filter_size_ - input_size_ + in - end_pad_);
         if (dilate_ != 1)
-            return div_up(nstl::max(0,
+            return div_up(nstl::max<dim_t>(0,
                                   (filter_size_ - 1) * dilate_ + 1 - input_size_
                                           + in - end_pad_),
                     dilate_);
-        return nstl::max(
+        return nstl::max<dim_t>(
                 0, (filter_size_ - input_size_ + in - end_pad_) / stride_);
     }
 
-    void update_params(const int in) {
+    void update_params(const dim_t in) {
 
         init_overflow_ = get_init_overflow(in);
         end_overflow_ = get_end_overflow(in);
 
         // overflow_kd_hi
-        const int overflow_filter_hi_ = compute_extended_features_
+        const dim_t overflow_filter_hi_ = compute_extended_features_
                 ? filter_size_ - 1
                         - nstl::modulo(input_size_ - 1 + end_pad_ - in, stride_)
                 : 0;
         // overflow_kd_lo
-        const int overflow_filter_lo_
+        const dim_t overflow_filter_lo_
                 = compute_extended_features_ ? (in + init_pad_) % stride_ : 0;
 
         filter_ = compute_extended_features_
@@ -96,30 +99,30 @@ struct spatial_features_3d_t {
                 : in + init_pad_ - end_overflow_ * dilate_;
     }
 
-    inline int get_filter_padding() const {
+    inline dim_t get_filter_padding() const {
         return filter_ - init_overflow_ - end_overflow_;
     }
 
-    inline int get_lower_offset() const { return lower_offset_; }
+    inline dim_t get_lower_offset() const { return lower_offset_; }
 
-    inline int get_output_offset() const { return output_offset_; }
+    inline dim_t get_output_offset() const { return output_offset_; }
 
 private:
-    int input_size_;
-    int filter_size_;
-    int dilate_;
-    int stride_;
-    int init_pad_; // f_pad
-    int end_pad_; // back_pad
+    dim_t input_size_;
+    dim_t filter_size_;
+    dim_t dilate_;
+    dim_t stride_;
+    dim_t init_pad_; // f_pad
+    dim_t end_pad_; // back_pad
     bool is_fast_path_; // 'dilate_ == 1 && stride_ == 1'
     bool compute_extended_features_; // eq. '(!is_fast_path_) && dilate_ == 1'
 
-    int filter_;
-    int lower_offset_; // d_lo
-    int output_offset_; // d_oj
+    dim_t filter_;
+    dim_t lower_offset_; // d_lo
+    dim_t output_offset_; // d_oj
 
-    int init_overflow_; // d_t_overflow
-    int end_overflow_; // d_b_overflow
+    dim_t init_overflow_; // d_t_overflow
+    dim_t end_overflow_; // d_b_overflow
 };
 
 } // namespace amx_utils

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -48,7 +48,7 @@ using namespace nstl;
 
 template <typename T>
 static inline T accum_with_upper_bound(T ub, T lv, T uv) {
-    return nstl::min(ub, nstl::min(ub, lv) + nstl::max(0, ub - uv));
+    return nstl::min<T>(ub, nstl::min<T>(ub, lv) + nstl::max<T>(0, ub - uv));
 }
 
 void jit_avx512_core_amx_convolution_fwd_t::prepare_padded_bias(
@@ -123,18 +123,19 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             ? reinterpret_cast<int32_t *>(w + offset)
             : nullptr;
 
-    const int t_pad_output = jcp.t_pad_output;
-    const int b_pad_output = jcp.b_pad_output;
-    const int b_pad_start = nstl::max(jcp.oh - b_pad_output, t_pad_output);
-    const int zp_buff_b_pad_start
-            = nstl::max(jcp.oh_pad - b_pad_output, t_pad_output);
+    const dim_t t_pad_output = jcp.t_pad_output;
+    const dim_t b_pad_output = jcp.b_pad_output;
+    const int b_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.oh - b_pad_output, t_pad_output));
+    const dim_t zp_buff_b_pad_start
+            = nstl::max<dim_t>(jcp.oh_pad - b_pad_output, t_pad_output);
 
-    const int ngroups = jcp.ngroups;
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
-    const int work_amount
+    const dim_t ngroups = jcp.ngroups;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * oh_chunks * jcp.nb_ow * oc_chunks;
-    const int zp_pbuff_size = jcp.zp_pbuff_size;
+    const dim_t zp_pbuff_size = jcp.zp_pbuff_size;
 
     // reorder weights from (g)Owhi16o to (g)OR16r16o4r, where r := whi
     auto p = jit_conv_args_t();
@@ -156,27 +157,29 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
     if (req_zero_point_buffer && zp_pbuff_outer_compute) {
         const size_t wei_oc_step = (size_t)jcp.kh * jcp.kw * jcp.ic_block_int_np
                 * jcp.nb_oc_blocking * jcp.oc_block;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
-        const int oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
         parallel_nd(ngroups, oc_chunks, oh_work,
                 [= COMPAT_THIS_CAPTURE](dim_t g, dim_t occ, dim_t oh) {
             auto p = jit_conv_args_t();
 
-            const int oh_ = oh >= zp_buff_b_pad_start
+            const dim_t oh_ = oh >= zp_buff_b_pad_start
                     ? b_pad_start + oh - zp_buff_b_pad_start
                     : oh;
-            const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-            const int t_overflow
-                    = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-            const int b_overflow = nstl::min(jcp.kh,
-                    div_up(nstl::max(0, ih + gen_kh - jcp.ih), dilate_h));
+            const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+            const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+            const int b_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kh,
+                    div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                            dilate_h)));
             p.t_overflow = t_overflow;
             p.b_overflow = b_overflow;
-            p.kh_padding = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+            p.kh_padding
+                    = nstl::max<dim_t>(0, jcp.kh - t_overflow - b_overflow);
 
-            const int ocb
+            const dim_t ocb
                     = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
             const size_t ch_offset = dst_d.blk_off(0, ocb);
             const size_t sp_offset = oh * jcp.ow_pad * sp_stride;
@@ -193,7 +196,7 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
     // TODO: implement 2D parallelization driver (g * spatial x oc) to increase
     // input data reuse and parallelize input data reorders
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
         int32_t *local_zp_pbuff = req_zero_point_buffer
                 ? (zp_pbuff_outer_compute
@@ -205,7 +208,7 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 : nullptr;
         if (zp_pbuff_parallel_block) {
             PRAGMA_OMP_SIMD()
-            for (int oc = 0; oc < oc_chunks * ngroups; oc++)
+            for (dim_t oc = 0; oc < oc_chunks * ngroups; oc++)
                 zp_flags[oc] = true;
         }
 
@@ -225,31 +228,31 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        const int oh_work = jcp.oh_pad;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
         const size_t wei_oc_step = (size_t)jcp.kh * jcp.kw * jcp.ic_block_int_np
                 * jcp.nb_oc_blocking * jcp.oc_block;
         size_t oc_stride = dst_d.blk_off(0, 1);
-        const int owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
+        const dim_t owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
 
-        int mb {0}, g {0}, ohc {0}, owb {0}, occ {0};
+        dim_t mb {0}, g {0}, ohc {0}, owb {0}, occ {0};
         // need "inner" oh blocks w.r.t. ow blocks to allow pbuffer reuse
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, owb, jcp.nb_ow, ohc,
                 oh_chunks, occ, oc_chunks);
-        int last_copied_mb = -1;
-        int last_copied_ohc = -1;
-        int last_copied_owb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_ohc = -1;
+        dim_t last_copied_owb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + src_dt_size * ithr * jcp.inp_buffer_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            int oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
-            int ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
+            dim_t oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
+            dim_t ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
             const char *bias_w = bias
                     ? bias + (bias_d.blk_off(oc) * bia_dt_size)
                     : nullptr;
@@ -258,8 +261,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
             p.src_zero_point = src_zero_points;
             p.dst_zero_point = dst_zero_points;
 
-            int oh_s = ohc * jcp.oh_blk_size;
-            int oh_e = nstl::min(jcp.oh, oh_s + jcp.oh_blk_size);
+            dim_t oh_s = ohc * jcp.oh_blk_size;
+            dim_t oh_e = nstl::min<dim_t>(jcp.oh, oh_s + jcp.oh_blk_size);
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_ohc == ohc && last_copied_owb == owb
                     && last_copied_g == g;
@@ -270,11 +273,12 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                     ? zp_flags[g * oc_chunks + occ] // already computed?
                     : false;
 
-            int cur_t_pad = nstl::max(0, t_pad_output - oh_s);
-            int cur_b_pad = nstl::max(
-                    nstl::max(0, jcp.oh - b_pad_output - oh_s), cur_t_pad);
-            size_t zp_oh
-                    = accum_with_upper_bound(oh_s, t_pad_output, b_pad_start);
+            dim_t cur_t_pad = nstl::max<dim_t>(0, t_pad_output - oh_s);
+            dim_t cur_b_pad = nstl::max<dim_t>(
+                    nstl::max<dim_t>(0, jcp.oh - b_pad_output - oh_s),
+                    cur_t_pad);
+            size_t zp_oh = accum_with_upper_bound<dim_t>(
+                    oh_s, t_pad_output, b_pad_start);
 
             int limit_idx = 0;
             constexpr int limit_size = 5;
@@ -288,19 +292,20 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 assert(!zp_pbuff_outer_compute);
                 zp_flags[g * oc_chunks + occ] = false;
                 for (int oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
-                    const int oh_ = oh_pad >= zp_buff_b_pad_start
+                    const dim_t oh_ = oh_pad >= zp_buff_b_pad_start
                             ? b_pad_start + oh_pad - zp_buff_b_pad_start
                             : oh_pad;
-                    const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-                    const int t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-                    const int b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0, ih + gen_kh - jcp.ih),
-                                    dilate_h));
+                    const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+                    const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+                    const int b_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh,
+                            div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                                    dilate_h)));
                     p.t_overflow = t_overflow;
                     p.b_overflow = b_overflow;
-                    p.kh_padding
-                            = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+                    p.kh_padding = nstl::max<dim_t>(
+                            0, jcp.kh - t_overflow - b_overflow);
 
                     const size_t ch_offset = dst_d.blk_off(0, oc);
                     const size_t sp_offset = oh_pad * jcp.ow_pad * sp_stride;
@@ -314,49 +319,50 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 }
             }
 
-            int oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
-            for (int oh = oh_s; oh < oh_e; oh += oh_step) {
-                const int inp_buffer_h_step
+            dim_t oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
+            for (dim_t oh = oh_s; oh < oh_e; oh += oh_step) {
+                const dim_t inp_buffer_h_step
                         = jcp.stride_h * jcp.ic_without_padding;
                 assert(jcp.is_nspc);
                 assert(jcp.stride_h <= jcp.kh);
 
-                int ow = owb * jcp.ow_block;
+                dim_t ow = owb * jcp.ow_block;
 
                 char *inp_buffer_oh
                         = inp_buffer + src_dt_size * oh * inp_buffer_h_step;
 
                 if (!is_inp_buffer_relevant) {
                     // prepare padded input buffer
-                    const int icb = g * jcp.ic;
+                    const dim_t icb = g * jcp.ic;
                     size_t inp_offset = src_d.blk_off(mb, icb);
-                    const int iw_step = jcp.ngroups * jcp.ic_without_padding;
+                    const dim_t iw_step = jcp.ngroups * jcp.ic_without_padding;
                     const char *psrc = src + src_dt_size * inp_offset;
                     // calculate overlap...
-                    const int ih_overlap = has_inp_buffer_overlap
-                            * nstl::max(0, jcp.kh - oh_step * jcp.stride_h);
-                    const int kh_eff = jcp.kh - ih_overlap;
+                    const dim_t ih_overlap = has_inp_buffer_overlap
+                            * nstl::max<dim_t>(
+                                    0, jcp.kh - oh_step * jcp.stride_h);
+                    const dim_t kh_eff = jcp.kh - ih_overlap;
                     // prepare padded input buffer
                     char *pdst = inp_buffer_oh
                             + src_dt_size * ih_overlap * jcp.ic_without_padding;
                     for (int doh = 0; doh < oh_step; doh++) {
-                        const int ih_s = (doh + oh) * jcp.stride_h - jcp.t_pad
+                        const dim_t ih_s = (doh + oh) * jcp.stride_h - jcp.t_pad
                                 + ih_overlap;
-                        const int ih_e = ih_s + kh_eff;
-                        const int ih = nstl::max(0, ih_s);
-                        p.t_overflow = nstl::max(0, -ih_s);
-                        p.b_overflow = nstl::min<int>(
-                                kh_eff, nstl::max(0, ih_e - jcp.ih));
-                        p.kh_padding = nstl::max<int>(
-                                0, (kh_eff - p.t_overflow - p.b_overflow));
+                        const dim_t ih_e = ih_s + kh_eff;
+                        const dim_t ih = nstl::max<dim_t>(0, ih_s);
+                        p.t_overflow = nstl::max<dim_t>(0, -ih_s);
+                        p.b_overflow = nstl::min<dim_t>(
+                                kh_eff, nstl::max<dim_t>(0, ih_e - jcp.ih));
+                        p.kh_padding = nstl::max<dim_t>(
+                                0, kh_eff - p.t_overflow - p.b_overflow);
                         p.kh_offset = kh_eff;
 
-                        const int iw_s = ow * jcp.stride_w - jcp.l_pad;
-                        const int iw_e = iw_s + jcp.iwp;
-                        const int iw = nstl::max(0, iw_s);
-                        p.f_overflow = nstl::max(0, -iw_s);
-                        p.back_overflow = nstl::max(0, iw_e - jcp.iw);
-                        p.kw_padding = nstl::max<int>(
+                        const dim_t iw_s = ow * jcp.stride_w - jcp.l_pad;
+                        const dim_t iw_e = iw_s + jcp.iwp;
+                        const dim_t iw = nstl::max<dim_t>(0, iw_s);
+                        p.f_overflow = nstl::max<dim_t>(0, -iw_s);
+                        p.back_overflow = nstl::max<dim_t>(0, iw_e - jcp.iw);
+                        p.kw_padding = nstl::max<dim_t>(
                                 0, jcp.iwp - p.f_overflow - p.back_overflow);
 
                         p.src = psrc
@@ -395,8 +401,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                     limit_idx++;
                 p.ohb = limit_idx;
                 p.last_h = (oh + oh_step <= oh_e);
-                const int zp_owb = nstl::min(jcp.l_pad_blk, owb)
-                        + nstl::max(0, owb - owb_limit);
+                const dim_t zp_owb = nstl::min<dim_t>(jcp.l_pad_blk, owb)
+                        + nstl::max<dim_t>(0, owb - owb_limit);
                 p.owb = req_zero_point_buffer ? zp_owb : owb;
 
                 p.oc_blocks = occ * jcp.nb_oc_blocking;
@@ -410,8 +416,8 @@ jit_avx512_core_amx_convolution_fwd_t::execute_forward_reduced_lowering(
                 if (req_zero_point_buffer) {
                     zp_oh += accum_with_upper_bound(
                             oh_step, cur_t_pad, cur_b_pad);
-                    cur_t_pad = nstl::max(0, cur_t_pad - oh_step);
-                    cur_b_pad = nstl::max(0, cur_b_pad - oh_step);
+                    cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step);
+                    cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step);
                 }
             }
             last_copied_mb = mb;
@@ -494,24 +500,25 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             ? reinterpret_cast<int32_t *>(&w[offset])
             : nullptr;
 
-    const int f_pad_output = jcp.f_pad_output;
-    const int back_pad_output = jcp.back_pad_output;
-    const int back_pad_start
-            = nstl::max(jcp.od - back_pad_output, f_pad_output);
-    const int zp_buff_back_pad_start
-            = nstl::max(jcp.od_pad - back_pad_output, f_pad_output);
-    const int t_pad_output = jcp.t_pad_output;
-    const int b_pad_output = jcp.b_pad_output;
-    const int b_pad_start = nstl::max(jcp.oh - b_pad_output, t_pad_output);
-    const int zp_buff_b_pad_start
-            = nstl::max(jcp.oh_pad - b_pad_output, t_pad_output);
+    const dim_t f_pad_output = jcp.f_pad_output;
+    const dim_t back_pad_output = jcp.back_pad_output;
+    const int back_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.od - back_pad_output, f_pad_output));
+    const dim_t zp_buff_back_pad_start
+            = nstl::max<dim_t>(jcp.od_pad - back_pad_output, f_pad_output);
+    const dim_t t_pad_output = jcp.t_pad_output;
+    const dim_t b_pad_output = jcp.b_pad_output;
+    const int b_pad_start = static_cast<int>(
+            nstl::max<dim_t>(jcp.oh - b_pad_output, t_pad_output));
+    const dim_t zp_buff_b_pad_start
+            = nstl::max<dim_t>(jcp.oh_pad - b_pad_output, t_pad_output);
 
-    const int ngroups = jcp.ngroups;
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
-    const size_t work_amount = (size_t)jcp.mb * jcp.ngroups * jcp.od * oh_chunks
-            * jcp.nb_ow * oc_chunks;
-    const int zp_pbuff_size = jcp.zp_pbuff_size;
+    const dim_t ngroups = jcp.ngroups;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t oh_chunks = utils::div_up(jcp.oh, jcp.oh_blk_size);
+    const dim_t work_amount
+            = jcp.mb * jcp.ngroups * jcp.od * oh_chunks * jcp.nb_ow * oc_chunks;
+    const dim_t zp_pbuff_size = jcp.zp_pbuff_size;
 
     // init zero_point padding buffer
     const bool req_zero_point_buffer = jcp.req_zero_point_buffer;
@@ -519,42 +526,46 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
     const bool zp_pbuff_parallel_block
             = req_zero_point_buffer && !zp_pbuff_outer_compute;
     if (req_zero_point_buffer && zp_pbuff_outer_compute) {
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_d = jcp.dilate_d + 1;
-        const int gen_kd = (jcp.kd - 1) * dilate_d + 1;
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
-        const int od_work = jcp.od_pad;
-        const int oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_d = jcp.dilate_d + 1;
+        const dim_t gen_kd = (jcp.kd - 1) * dilate_d + 1;
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t od_work = jcp.od_pad;
+        const dim_t oh_work = jcp.oh_pad;
         parallel_nd(ngroups, oc_chunks, od_work, oh_work,
                 [= COMPAT_THIS_CAPTURE](
                         dim_t g, dim_t occ, dim_t od, dim_t oh) {
             auto p = jit_conv_args_t();
 
-            const int od_ = od >= zp_buff_back_pad_start
+            const dim_t od_ = od >= zp_buff_back_pad_start
                     ? back_pad_start + od - zp_buff_back_pad_start
                     : od;
-            const int id = od_ * jcp.stride_d - jcp.f_pad;
-            const int f_overflow
-                    = nstl::min(jcp.kd, div_up(max(0, -id), dilate_d));
-            const int back_overflow = nstl::min(jcp.kd,
-                    div_up(nstl::max(0, id + gen_kd - jcp.id), dilate_d));
+            const dim_t id = od_ * jcp.stride_d - jcp.f_pad;
+            const int f_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd, div_up(max<dim_t>(0, -id), dilate_d)));
+            const int back_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kd,
+                    div_up(nstl::max<dim_t>(0, id + gen_kd - jcp.id),
+                            dilate_d)));
             p.f_overflow = f_overflow;
             p.back_overflow = back_overflow;
-            p.kd_padding = nstl::max(0, jcp.kd - f_overflow - back_overflow);
-            const int oh_ = oh >= zp_buff_b_pad_start
+            p.kd_padding
+                    = nstl::max<dim_t>(0, jcp.kd - f_overflow - back_overflow);
+            const dim_t oh_ = oh >= zp_buff_b_pad_start
                     ? b_pad_start + oh - zp_buff_b_pad_start
                     : oh;
-            const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-            const int t_overflow
-                    = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-            const int b_overflow = nstl::min(jcp.kh,
-                    div_up(nstl::max(0, ih + gen_kh - jcp.ih), dilate_h));
+            const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+            const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+            const int b_overflow = static_cast<int>(nstl::min<dim_t>(jcp.kh,
+                    div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                            dilate_h)));
             p.t_overflow = t_overflow;
             p.b_overflow = b_overflow;
-            p.kh_padding = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+            p.kh_padding
+                    = nstl::max<dim_t>(0, jcp.kh - t_overflow - b_overflow);
 
-            const int ocb
+            const dim_t ocb
                     = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
             const size_t ch_offset = dst_d.blk_off(0, ocb);
             auto sp_offset = (od * jcp.oh_pad + oh) * jcp.ow_pad * sp_stride;
@@ -571,7 +582,7 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
     // TODO: implement 2D parallelization driver (g * spatial x oc) to increase
     // input data reuse and parallelize input data reorders
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        size_t start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
         int32_t *local_zp_pbuff = req_zero_point_buffer
                 ? (zp_pbuff_outer_compute
@@ -583,7 +594,7 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 : nullptr;
         if (zp_pbuff_parallel_block) {
             PRAGMA_OMP_SIMD()
-            for (int oc = 0; oc < oc_chunks * ngroups; oc++)
+            for (dim_t oc = 0; oc < oc_chunks * ngroups; oc++)
                 zp_flags[oc] = true;
         }
 
@@ -604,30 +615,30 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        const int oh_work = jcp.oh_pad;
-        const int sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
-        const int dilate_d = jcp.dilate_d + 1;
-        const int dilate_h = jcp.dilate_h + 1;
-        const int gen_kh = (jcp.kh - 1) * dilate_h + 1;
+        const dim_t oh_work = jcp.oh_pad;
+        const size_t sp_stride = mem_blk_off(dst_d, 0, 0, 0, 0, 1);
+        const dim_t dilate_d = jcp.dilate_d + 1;
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t gen_kh = (jcp.kh - 1) * dilate_h + 1;
         size_t oc_stride = dst_d.blk_off(0, 1);
-        const int owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
+        const dim_t owb_limit = jcp.nb_ow - jcp.r_pad_blk - jcp.no_pad_w_blk;
 
-        int mb {0}, g {0}, odc {0}, ohc {0}, owb {0}, occ {0};
+        dim_t mb {0}, g {0}, odc {0}, ohc {0}, owb {0}, occ {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, odc, jcp.od, ohc,
                 oh_chunks, owb, jcp.nb_ow, occ, oc_chunks);
-        int last_copied_mb = -1;
-        int last_copied_odc = -1;
-        int last_copied_ohc = -1;
-        int last_copied_owb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_odc = -1;
+        dim_t last_copied_ohc = -1;
+        dim_t last_copied_owb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + src_dt_size * ithr * jcp.inp_buffer_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            int oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
-            int ocb = jcp.is_nspc ? oc : oc / jcp.oc_block;
+            dim_t oc = g * jcp.oc + occ * jcp.nb_oc_blocking * jcp.oc_block;
+            int ocb = static_cast<int>(jcp.is_nspc ? oc : oc / jcp.oc_block);
             const char *bias_w = bias
                     ? bias + (bias_d.blk_off(oc) * bia_dt_size)
                     : nullptr;
@@ -637,8 +648,8 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
             p.dst_zero_point = dst_zero_points;
 
             const size_t inp_src_d_stride = mem_blk_off(src_d, 0, 0, 1, 0, 0);
-            int oh_s = ohc * jcp.oh_blk_size;
-            int oh_e = nstl::min(jcp.oh, oh_s + jcp.oh_blk_size);
+            dim_t oh_s = ohc * jcp.oh_blk_size;
+            dim_t oh_e = nstl::min<dim_t>(jcp.oh, oh_s + jcp.oh_blk_size);
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_odc == odc && last_copied_ohc == ohc
                     && last_copied_owb == owb && last_copied_g == g;
@@ -646,14 +657,15 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                     ? zp_flags[g * oc_chunks + occ] // already computed?
                     : false;
 
-            int cur_t_pad = nstl::max(0, t_pad_output - oh_s);
-            int cur_b_pad = nstl::max(
-                    nstl::max(0, jcp.oh - b_pad_output - oh_s), cur_t_pad);
+            dim_t cur_t_pad = nstl::max<dim_t>(0, t_pad_output - oh_s);
+            dim_t cur_b_pad = nstl::max<dim_t>(
+                    nstl::max<dim_t>(0, jcp.oh - b_pad_output - oh_s),
+                    cur_t_pad);
             const size_t zp_od = odc >= back_pad_start
                     ? odc - back_pad_start + zp_buff_back_pad_start
-                    : nstl::min(f_pad_output, odc);
-            size_t zp_oh
-                    = accum_with_upper_bound(oh_s, t_pad_output, b_pad_start);
+                    : nstl::min<dim_t>(f_pad_output, odc);
+            size_t zp_oh = accum_with_upper_bound<dim_t>(
+                    oh_s, t_pad_output, b_pad_start);
 
             int limit_idx = 0;
             constexpr int limit_size = 5;
@@ -667,20 +679,21 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 assert(pd()->ndims() != 5);
                 assert(!zp_pbuff_outer_compute);
                 zp_flags[g * oc_chunks + occ] = false;
-                for (int oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
-                    const int oh_ = oh_pad >= zp_buff_b_pad_start
+                for (dim_t oh_pad = 0; oh_pad < oh_work; ++oh_pad) {
+                    const dim_t oh_ = oh_pad >= zp_buff_b_pad_start
                             ? b_pad_start + oh_pad - zp_buff_b_pad_start
                             : oh_pad;
-                    const int ih = oh_ * jcp.stride_h - jcp.t_pad;
-                    const int t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ih), dilate_h));
-                    const int b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0, ih + gen_kh - jcp.ih),
-                                    dilate_h));
+                    const dim_t ih = oh_ * jcp.stride_h - jcp.t_pad;
+                    const int t_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ih), dilate_h)));
+                    const int b_overflow = static_cast<int>(nstl::min<dim_t>(
+                            jcp.kh,
+                            div_up(nstl::max<dim_t>(0, ih + gen_kh - jcp.ih),
+                                    dilate_h)));
                     p.t_overflow = t_overflow;
                     p.b_overflow = b_overflow;
-                    p.kh_padding
-                            = nstl::max(0, jcp.kh - t_overflow - b_overflow);
+                    p.kh_padding = nstl::max<dim_t>(
+                            0, jcp.kh - t_overflow - b_overflow);
 
                     const size_t ch_offset = dst_d.blk_off(0, oc);
                     const size_t sp_offset = oh_pad * jcp.ow_pad * sp_stride;
@@ -695,38 +708,43 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 }
             }
 
-            const int id_s = odc * jcp.stride_d - jcp.f_pad;
-            const int d_f_overflow
-                    = nstl::min(jcp.kd, div_up(max(0, -id_s), dilate_d));
-            const int d_back_overflow = nstl::min(jcp.kd,
-                    div_up(max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
-                            dilate_d));
-            p.kd_padding
-                    = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+            const dim_t id_s = odc * jcp.stride_d - jcp.f_pad;
+            const int d_f_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd, div_up(max<dim_t>(0, -id_s), dilate_d)));
+            const int d_back_overflow = static_cast<int>(nstl::min<dim_t>(
+                    jcp.kd,
+                    div_up(max<dim_t>(0,
+                                   id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+                            dilate_d)));
+            p.kd_padding = nstl::max<dim_t>(
+                    0, jcp.kd - d_f_overflow - d_back_overflow);
 
-            int oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
-            for (int oh = oh_s; oh < oh_e; oh += oh_step) {
-                const int gen_kh = ((jcp.kh - 1) * (jcp.dilate_h + 1) + 1);
-                const int gen_stride_h = nstl::min(jcp.stride_h, gen_kh);
+            dim_t oh_step = jcp.nb_oh_blocking * jcp.oh_per_tile;
+            for (dim_t oh = oh_s; oh < oh_e; oh += oh_step) {
+                const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                const int gen_stride_h = static_cast<int>(
+                        nstl::min<dim_t>(jcp.stride_h, gen_kh));
                 if (!is_inp_buffer_relevant) {
-                    const int iw = nstl::max(
+                    const dim_t iw = nstl::max<dim_t>(
                             0, owb * jcp.ow_block * jcp.stride_w - jcp.l_pad);
 
                     assert(IMPLICATION(
                             jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-                    const int icb = g * (jcp.is_nspc ? jcp.ic : jcp.nb_ic);
+                    const dim_t icb = g * (jcp.is_nspc ? jcp.ic : jcp.nb_ic);
 
                     // generalized kh including dilation
                     // the current implementation of copy routine is not
                     // optimal for small jcp.oh_blk_size as it copies
                     // dilation rows to buffer
                     const bool continuous_copy = gen_kh >= jcp.stride_h;
-                    int current_oh_block = nstl::min(oh_e - oh, oh_step);
-                    int num_copy_calls = continuous_copy ? 1 : current_oh_block;
+                    dim_t current_oh_block
+                            = nstl::min<dim_t>(oh_e - oh, oh_step);
+                    dim_t num_copy_calls
+                            = continuous_copy ? 1 : current_oh_block;
                     for (int ohi = 0; ohi < num_copy_calls; ohi++) {
-                        int ih_copy_start
+                        dim_t ih_copy_start
                                 = (oh + ohi) * jcp.stride_h - jcp.t_pad;
-                        int ih_copy_end = ih_copy_start + gen_kh;
+                        dim_t ih_copy_end = ih_copy_start + gen_kh;
                         if (continuous_copy) {
                             ih_copy_end
                                     += jcp.stride_h * (current_oh_block - 1);
@@ -737,21 +755,22 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                                 //     (oh - 1) * str_h - t_pad + kh
                                 ih_copy_start += gen_kh - jcp.stride_h;
                         }
-                        int ih_zero_top = nstl::max(0, -ih_copy_start);
-                        int ih_zero_bottom = nstl::max(0, ih_copy_end - jcp.ih);
+                        dim_t ih_zero_top = nstl::max<dim_t>(0, -ih_copy_start);
+                        dim_t ih_zero_bottom
+                                = nstl::max<dim_t>(0, ih_copy_end - jcp.ih);
                         // how many real data rows to copy (including padding)
-                        int rows_to_copy = ih_copy_end - ih_copy_start;
-                        p.kh_padding = max(0, rows_to_copy);
+                        dim_t rows_to_copy = ih_copy_end - ih_copy_start;
+                        p.kh_padding = nstl::max<dim_t>(0, rows_to_copy);
                         p.t_overflow = ih_zero_top;
                         p.b_overflow = ih_zero_bottom;
                         p.owb = owb;
-                        int ih = nstl::max(ih_copy_start, 0);
+                        dim_t ih = nstl::max<dim_t>(ih_copy_start, 0);
                         size_t inp_offset
                                 = mem_blk_off(src_d, mb, icb, id_s, ih, iw)
                                 + d_f_overflow * dilate_d * inp_src_d_stride;
                         p.src = src + src_dt_size * inp_offset;
                         // inp_buffer has physical padding
-                        int ih_buf = continuous_copy
+                        dim_t ih_buf = continuous_copy
                                 ? ih_copy_start + jcp.t_pad
                                         - oh_s * jcp.stride_h
                                 : gen_stride_h * (oh + ohi - oh_s);
@@ -762,8 +781,8 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                         kernel_->copy_to_pbuffer()(&p);
                     }
                 }
-                int ih_buf = gen_stride_h * (oh - oh_s);
-                int ow = owb * jcp.ow_block;
+                dim_t ih_buf = gen_stride_h * (oh - oh_s);
+                dim_t ow = owb * jcp.ow_block;
                 p.src = inp_buffer
                         + src_dt_size * ih_buf * jcp.iwp * jcp.ic_block_int_np;
 
@@ -795,8 +814,8 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 assert(limit_idx < 6);
                 p.ohb = limit_idx;
                 p.last_h = (oh + oh_step <= oh_e);
-                const int zp_owb = nstl::min(jcp.l_pad_blk, owb)
-                        + nstl::max(0, owb - owb_limit);
+                const dim_t zp_owb = nstl::min<dim_t>(jcp.l_pad_blk, owb)
+                        + nstl::max<dim_t>(0, owb - owb_limit);
                 p.owb = req_zero_point_buffer ? zp_owb : owb;
 
                 p.oc_blocks = occ * jcp.nb_oc_blocking;
@@ -808,10 +827,10 @@ status_t jit_avx512_core_amx_convolution_fwd_t::execute_forward(
                 (*kernel_)(&p);
 
                 if (req_zero_point_buffer) {
-                    zp_oh += accum_with_upper_bound(
+                    zp_oh += accum_with_upper_bound<dim_t>(
                             oh_step, cur_t_pad, cur_b_pad);
-                    cur_t_pad = nstl::max(0, cur_t_pad - oh_step);
-                    cur_b_pad = nstl::max(0, cur_b_pad - oh_step);
+                    cur_t_pad = nstl::max<dim_t>(0, cur_t_pad - oh_step);
+                    cur_b_pad = nstl::max<dim_t>(0, cur_b_pad - oh_step);
                 }
             }
             last_copied_mb = mb;
@@ -864,16 +883,16 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
     auto global_tcfg = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_tilecfg);
 
-    const int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-    const int ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
-    const int work_amount
+    const dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    const dim_t ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * jcp.id * ih_chunks * jcp.nb_iw * ic_chunks;
 
     const bool is_1d = jcp.ndims == 3;
     const bool is_3d = jcp.ndims == 5;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -895,83 +914,93 @@ status_t jit_avx512_core_amx_convolution_bwd_data_t::execute_backward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
+        dim_t mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, id_s, jcp.id, ihc,
                 ih_chunks, iwb, jcp.nb_iw, icc, ic_chunks);
-        int last_copied_mb = -1;
-        int last_copied_id = -1;
-        int last_copied_ihc = -1;
-        int last_copied_iwb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_id = -1;
+        dim_t last_copied_ihc = -1;
+        dim_t last_copied_iwb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer = inp_p_buffer
                     + ithr * jcp.inp_buffer_size * diff_dst_dt_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-            int ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
-            int icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
+            dim_t ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
+            dim_t icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            const int ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
+            const dim_t ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
 
-            const int ih_b = ihc * jcp.ih_blk_size;
-            const int ih_e = nstl::min(jcp.ih, ih_b + jcp.ih_blk_size);
-            const int iw = iwb * jcp.iw_block;
+            const dim_t ih_b = ihc * jcp.ih_blk_size;
+            const dim_t ih_e = nstl::min<dim_t>(jcp.ih, ih_b + jcp.ih_blk_size);
+            const dim_t iw = iwb * jcp.iw_block;
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_id == id_s && last_copied_ihc == ihc
                     && last_copied_iwb == iwb && last_copied_g == g;
 
             sfd.update_params(id_s);
             p.kd_padding = sfd.get_filter_padding();
-            const int d_lo = sfd.get_lower_offset();
-            const int d_oj = sfd.get_output_offset();
+            const dim_t d_lo = sfd.get_lower_offset();
+            const dim_t d_oj = sfd.get_output_offset();
 
-            int ih_step = jcp.nb_ih_blocking;
-            for (int ih = ih_b; ih < ih_e; ih += ih_step) {
+            dim_t ih_step = jcp.nb_ih_blocking;
+            for (dim_t ih = ih_b; ih < ih_e; ih += ih_step) {
                 if (!is_inp_buffer_relevant) {
-                    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-                    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+                    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
                     // dox: x-index dilated by strides (dox = ox * stride_x)
-                    const int doh = ih + jcp.t_pad - (gen_kh - 1);
-                    const int dow = iw + jcp.l_pad - (gen_kw - 1);
-                    const int doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
-                    const int doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
-                    const int dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
+                    const dim_t doh = ih + jcp.t_pad - (gen_kh - 1);
+                    const dim_t dow = iw + jcp.l_pad - (gen_kw - 1);
+                    const dim_t doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
+                    const dim_t doh_l = (jcp.oh - 1) * jcp.stride_h;
+                    const dim_t dow_l = (jcp.ow - 1) * jcp.stride_w;
 
                     // dox_{s,f}: start and finish indices for copy kernel
-                    const int doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
-                    const int doh_f = doh + (ih_step - 1) + (gen_kh - 1);
-                    const int delta_h = doh_f - doh_s + 1;
-                    const int doh_t_overflow = 0 < doh_s && doh_s < doh_l
-                            ? nstl::additive_inverse_modulo(doh_s, jcp.stride_h)
-                            : nstl::max(0, -doh_s);
-                    const int doh_b_overflow = 0 < doh_f && doh_f < doh_l
-                            ? nstl::modulo(doh_f, jcp.stride_h)
-                            : nstl::max(0, nstl::min(delta_h, doh_f - doh_l));
-                    int dow_s = dow;
-                    int dow_f = dow + jcp.owp - 1;
-                    const int delta_w = dow_f - dow_s + 1;
-                    const int dow_l_overflow = 0 < dow_s && dow_s < dow_l
-                            ? nstl::additive_inverse_modulo(dow_s, jcp.stride_w)
-                            : nstl::max(0, -dow_s);
-                    const int dow_r_overflow = 0 < dow_f && dow_f < dow_l
-                            ? nstl::modulo(dow_f, jcp.stride_w)
-                            : nstl::max(0, nstl::min(delta_w, dow_f - dow_l));
-                    const int oh_s
-                            = utils::div_up(nstl::max(0, doh_s), jcp.stride_h);
-                    const int ow_s
-                            = utils::div_up(nstl::max(0, dow_s), jcp.stride_w);
+                    const dim_t doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
+                    const dim_t doh_f = doh + (ih_step - 1) + (gen_kh - 1);
+                    const dim_t delta_h = doh_f - doh_s + 1;
+                    const int doh_t_overflow
+                            = static_cast<int>(0 < doh_s && doh_s < doh_l
+                                            ? nstl::additive_inverse_modulo(
+                                                      doh_s, jcp.stride_h)
+                                            : nstl::max<dim_t>(0, -doh_s));
+                    const int doh_b_overflow
+                            = static_cast<int>(0 < doh_f && doh_f < doh_l
+                                            ? nstl::modulo(doh_f, jcp.stride_h)
+                                            : nstl::max<dim_t>(0,
+                                                      nstl::min<dim_t>(delta_h,
+                                                              doh_f - doh_l)));
+                    dim_t dow_s = dow;
+                    dim_t dow_f = dow + jcp.owp - 1;
+                    const dim_t delta_w = dow_f - dow_s + 1;
+                    const int dow_l_overflow
+                            = static_cast<int>(0 < dow_s && dow_s < dow_l
+                                            ? nstl::additive_inverse_modulo(
+                                                      dow_s, jcp.stride_w)
+                                            : nstl::max<dim_t>(0, -dow_s));
+                    const int dow_r_overflow
+                            = static_cast<int>(0 < dow_f && dow_f < dow_l
+                                            ? nstl::modulo(dow_f, jcp.stride_w)
+                                            : nstl::max<dim_t>(0,
+                                                      nstl::min<dim_t>(delta_w,
+                                                              dow_f - dow_l)));
+                    const dim_t oh_s = utils::div_up(
+                            nstl::max<dim_t>(0, doh_s), jcp.stride_h);
+                    const dim_t ow_s = utils::div_up(
+                            nstl::max<dim_t>(0, dow_s), jcp.stride_w);
                     // how many real data rows to copy (including padding)
-                    p.t_overflow = nstl::min(delta_h, doh_t_overflow);
-                    p.b_overflow = nstl::min<size_t>(
+                    p.t_overflow = nstl::min<dim_t>(delta_h, doh_t_overflow);
+                    p.b_overflow = nstl::min<dim_t>(
                             delta_h - p.t_overflow, doh_b_overflow);
-                    p.kh_padding = nstl::max<size_t>(
+                    p.kh_padding = nstl::max<dim_t>(
                             0, delta_h - p.t_overflow - p.b_overflow);
-                    p.l_overflow = nstl::min(delta_w, dow_l_overflow);
-                    p.kw_padding = nstl::max<size_t>(
+                    p.l_overflow = nstl::min<dim_t>(delta_w, dow_l_overflow);
+                    p.kw_padding = nstl::max<dim_t>(
                             0, delta_w - dow_l_overflow - dow_r_overflow);
-                    p.r_overflow = nstl::min<size_t>(
+                    p.r_overflow = nstl::min<dim_t>(
                             delta_w - dow_l_overflow, dow_r_overflow);
                     size_t inp_offset = is_1d
                             ? diff_dst_d.blk_off(mb, ocb, ow_s)
@@ -1049,8 +1078,11 @@ status_t jit_avx512_core_amx_convolution_bwd_weights_t::init(engine_t *engine) {
     }
     if (j.transform_to_vnni) {
         CHECK(safe_ptr_assign(diff_wei_trans_kernel_,
-                new jit_diff_wei_trans_to_vnni_t(j.wei_dt, j.kd, j.kh, j.kw,
-                        j.ic_block, j.oc_block, j.nb_ic)));
+                new jit_diff_wei_trans_to_vnni_t(j.wei_dt,
+                        static_cast<int>(j.kd), static_cast<int>(j.kh),
+                        static_cast<int>(j.kw), static_cast<int>(j.ic_block),
+                        static_cast<int>(j.oc_block),
+                        static_cast<int>(j.nb_ic))));
         CHECK(diff_wei_trans_kernel_->create_kernel());
     }
     return status::success;
@@ -1078,10 +1110,10 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
     int ithr_but_oc = 0;
     int ithr_but_ic = 0;
 
-    int img_start = 0, img_end = 0, img_work = 0;
-    int g_start = 0, g_end = 0, g_work = 0;
-    int oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
-    int ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
+    dim_t img_start = 0, img_end = 0, img_work = 0;
+    dim_t g_start = 0, g_end = 0, g_work = 0;
+    dim_t oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
+    dim_t ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
 
     thread_info_t(const jit_avx512_core_amx_convolution_bwd_weights_t *self,
             const exec_ctx_t &ctx, int ithr)
@@ -1134,7 +1166,7 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
         ithr_but_ic = (ithr_mb * self->nthr_g_ + ithr_g) * self->nthr_oc_b_
                 + ithr_oc_b;
 
-        int work_amount = jcp.nthr_mb_work;
+        const dim_t work_amount = jcp.nthr_mb_work;
         /* reduction dimension */
         balance211(work_amount, self->nthr_mb_, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
@@ -1158,7 +1190,7 @@ struct jit_avx512_core_amx_convolution_bwd_weights_t::thread_info_t {
 };
 
 size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_src_buf_number(
-        const thread_info_t *ti, int g, int ic) const {
+        const thread_info_t *ti, dim_t g, dim_t ic) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_ic * jcp.ngroups + g * jcp.nb_ic + ic
@@ -1166,7 +1198,7 @@ size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_src_buf_number(
 }
 
 size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_diff_dst_buf_number(
-        const thread_info_t *ti, int g, int oc) const {
+        const thread_info_t *ti, dim_t g, dim_t oc) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_oc * jcp.ngroups + g * jcp.nb_oc + oc
@@ -1174,27 +1206,29 @@ size_t jit_avx512_core_amx_convolution_bwd_weights_t::tr_diff_dst_buf_number(
 }
 
 void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
-        src_data_t *tr_src, const src_data_t *src_base, int spatial_start,
-        dim_t spatial_start_offset, int icb_start, dim_t chb_stride,
-        int row_count) const {
+        src_data_t *tr_src, const src_data_t *src_base, dim_t spatial_start,
+        dim_t spatial_start_offset, dim_t icb_start, dim_t chb_stride,
+        dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int src_stride = jcp.iw * jcp.ngroups * jcp.ic;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
-    int work_rest = row_count;
-    int max_spatial_work = jcp.id * jcp.ih;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    dim_t work_rest = row_count;
+    const dim_t max_spatial_work = jcp.id * jcp.ih;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *src = src_base + spatial_start_offset;
-    int icb = 0;
-    const int ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
+    dim_t icb = 0;
+    const dim_t ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = src;
             ctx.tr_src = tr_src;
             assert(icb_start + icb < jcp.nb_ic);
-            ctx.ch_work = (icb_start + icb + 1) == jcp.nb_ic ? ic_tail_work
-                                                             : jcp.ic_block;
+            ctx.ch_work = static_cast<int>((icb_start + icb + 1) == jcp.nb_ic
+                            ? ic_tail_work
+                            : jcp.ic_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_kernel_)(&ctx);
@@ -1202,7 +1236,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
             tr_src += tr_src_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         icb++;
         src = src_base + icb * chb_stride;
     }
@@ -1210,25 +1244,27 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_src_nxc(
 
 void jit_avx512_core_amx_convolution_bwd_weights_t::trans_dst_nxc(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst_base,
-        int spatial_start, dim_t spatial_start_offset, int ocb_start,
-        dim_t chb_stride, int row_count) const {
+        dim_t spatial_start, dim_t spatial_start_offset, dim_t ocb_start,
+        dim_t chb_stride, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
-    int work_rest = row_count;
-    int max_spatial_work = jcp.od * jcp.oh;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    const dim_t diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    dim_t work_rest = row_count;
+    const dim_t max_spatial_work = jcp.od * jcp.oh;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *diff_dst = diff_dst_base + spatial_start_offset;
-    int ocb = 0;
-    const int oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
+    dim_t ocb = 0;
+    const dim_t oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = diff_dst;
             ctx.tr_src = tr_diff_dst;
             assert(ocb_start + ocb < jcp.nb_oc);
-            ctx.ch_work = (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
-                                                             : jcp.oc_block;
+            ctx.ch_work = static_cast<int>((ocb_start + ocb + 1) == jcp.nb_oc
+                            ? oc_tail_work
+                            : jcp.oc_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_dst_kernel_)(&ctx);
@@ -1236,7 +1272,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::trans_dst_nxc(
             tr_diff_dst += tr_diff_dst_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         ocb++;
         diff_dst = diff_dst_base + ocb * chb_stride;
     }
@@ -1249,10 +1285,10 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_hblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_hblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1272,7 +1308,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * adj
@@ -1280,23 +1316,23 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                 + oj * tr_row_size;
     };
 
-    int img {0}, oh_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     nd_iterator_init(start, img, jcp.mb, oh_s, jcp.oh);
 
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        int ih_s = nstl::max(0, -jcp.t_pad + oh_s * jcp.stride_h);
-        const int ih_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        dim_t ih_s = nstl::max<dim_t>(0, -jcp.t_pad + oh_s * jcp.stride_h);
+        const dim_t ih_e = nstl::min<dim_t>(
                 jcp.ih, -jcp.t_pad + (oh_e - 1) * jcp.stride_h + ext_kh);
 
-        auto tr_src_off = [&](int g, int ic, int ih_end, int ij) {
+        auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ih_end, dim_t ij) {
             const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
             // Aligned to buffer end to use guard elements
@@ -1308,24 +1344,25 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             using simple_barrier::barrier;
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][ih][16][~iw~] <- src[nb_ic][ih][iw][16] */
-            int j {0};
-            int work_amount = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
-            int tr_start {0}, tr_end {0};
+            dim_t j {0};
+            dim_t work_amount = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
+            dim_t tr_start {0}, tr_end {0};
             balance211(
                     work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start, tr_end);
 
-            int g {0}, ic_b {0};
+            dim_t g {0}, ic_b {0};
             nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work, j,
                     ih_e - ih_s);
 
             if (nthr_oc_b_ > 1)
                 barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int ic_b_ = ic_b + ti->ic_b_start;
-                int j_s = j + ih_s;
-                int j_e = j_s + nstl::min(tr_end - tr_start, ih_e - j_s);
-                const int ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t ic_b_ = ic_b + ti->ic_b_start;
+                dim_t j_s = j + ih_s;
+                dim_t j_e
+                        = j_s + nstl::min<dim_t>(tr_end - tr_start, ih_e - j_s);
+                const dim_t ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
                 const src_data_t *src
                         = &ti->src[src_d.blk_off(img, ic_off_idx, j_s)];
                 src_data_t *tr_src
@@ -1345,18 +1382,19 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                     work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start, tr_end);
 
             g = 0;
-            int oc_b = 0;
+            dim_t oc_b = 0;
             nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work, j,
                     oh_e - oh_s);
 
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int oc_b_ = oc_b + ti->oc_b_start;
-                int j_s = j + oh_s;
-                int j_e = j_s + nstl::min(tr_end - tr_start, oh_e - j_s);
-                const int oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t oc_b_ = oc_b + ti->oc_b_start;
+                dim_t j_s = j + oh_s;
+                dim_t j_e
+                        = j_s + nstl::min<dim_t>(tr_end - tr_start, oh_e - j_s);
+                const dim_t oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
                 const diff_dst_data_t *diff_dst
                         = &ti->diff_dst[diff_dst_d.blk_off(
                                 img, oc_off_idx, j_s)];
@@ -1371,31 +1409,35 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
         }
-        int height_block = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
+        dim_t height_block
+                = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
 
-        for_(int ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+        for_(dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                 oc_b += jcp.nb_oc_blocking)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int ohb_e = nstl::min(ohb_s + height_block, oh_e);
-            const int ihb_s = nstl::max(0, -jcp.t_pad + ohb_s * jcp.stride_h);
-            const int ihb_e = nstl::min(
+            const dim_t ohb_e = nstl::min<dim_t>(ohb_s + height_block, oh_e);
+            const dim_t ihb_s
+                    = nstl::max<dim_t>(0, -jcp.t_pad + ohb_s * jcp.stride_h);
+            const dim_t ihb_e = nstl::min<dim_t>(
                     jcp.ih, -jcp.t_pad + (ohb_e - 1) * jcp.stride_h + ext_kh);
             assert(IMPLICATION(jcp.global_transpose,
                     oh_s == ohb_s && oh_e == ohb_e && ih_s == ihb_s
                             && ih_e == ihb_e));
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
@@ -1403,8 +1445,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
                 src_data_t *tr_src
                         = &ti->tr_src[tr_src_off(0, 0, ihb_e, ihb_s)];
 
-                for (int icb = 0; icb < nb_ic_blocks; icb++) {
-                    const int ic_off_idx
+                for (dim_t icb = 0; icb < nb_ic_blocks; icb++) {
+                    const dim_t ic_off_idx
                             = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
                     const src_data_t *src
                             = (src_data_t *)&ti->src[src_d.blk_off(
@@ -1422,8 +1464,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_2d(
             if (!jcp.global_transpose) {
                 diff_dst_data_t *tr_diff_dst
                         = &ti->tr_diff_dst[tr_diff_dst_off(0, 0, 0)];
-                for (int ocb = 0; ocb < nb_oc_blocks; ocb++) {
-                    const int oc_off_idx
+                for (dim_t ocb = 0; ocb < nb_oc_blocks; ocb++) {
+                    const dim_t oc_off_idx
                             = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
                     const diff_dst_data_t *diff_dst
                             = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1466,10 +1508,10 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_dblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_dblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1489,7 +1531,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od) {
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         const size_t tr_3d_size = tr_row_size * jcp.oh;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
@@ -1497,22 +1539,22 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size;
     };
-    int img {0}, od_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     nd_iterator_init(start, img, jcp.mb, od_s, jcp.od);
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        int id_s = nstl::max(0, -jcp.f_pad + od_s * jcp.stride_d);
-        const int id_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        dim_t id_s = nstl::max<dim_t>(0, -jcp.f_pad + od_s * jcp.stride_d);
+        const dim_t id_e = nstl::min<dim_t>(
                 jcp.id, -jcp.f_pad + (od_e - 1) * jcp.stride_d + ext_kd);
 
-        auto tr_src_off_3d = [&](int g, int ic, int id_end, int id) {
+        auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id_end, dim_t id) {
             const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             const size_t tr_3d_size = tr_row_size * jcp.ih;
             int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
@@ -1525,15 +1567,15 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             using simple_barrier::barrier;
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][id][16][~iw~] <- src[nb_ic][id][iw][16] */
-            int d {0};
+            dim_t d {0};
 
-            int work_amount = ti->g_work * ti->ic_b_work * (id_e - id_s);
+            dim_t work_amount = ti->g_work * ti->ic_b_work * (id_e - id_s);
 
-            int tr_start {0}, tr_end {0};
+            dim_t tr_start {0}, tr_end {0};
             balance211(
                     work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start, tr_end);
 
-            int g {0}, ic_b {0};
+            dim_t g {0}, ic_b {0};
 
             nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work, d,
                     id_e - id_s);
@@ -1541,12 +1583,13 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (nthr_oc_b_ > 1)
                 barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int ic_b_ = ic_b + ti->ic_b_start;
-                int d_s = d + id_s;
-                int d_e = d_s + nstl::min(tr_end - tr_start, id_e - d_s);
+                dim_t g_ = g + ti->g_start;
+                dim_t ic_b_ = ic_b + ti->ic_b_start;
+                dim_t d_s = d + id_s;
+                dim_t d_e
+                        = d_s + nstl::min<dim_t>(tr_end - tr_start, id_e - d_s);
 
-                const int ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
+                const dim_t ic_off_idx = g_ * jcp.ic + ic_b_ * jcp.ic_block;
                 const src_data_t *src
                         = &ti->src[src_d.blk_off(img, ic_off_idx, d_s)];
                 src_data_t *tr_src
@@ -1568,7 +1611,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                     work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start, tr_end);
 
             g = 0;
-            int oc_b = 0;
+            dim_t oc_b = 0;
 
             nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work, d,
                     od_e - od_s);
@@ -1576,11 +1619,12 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (nthr_ic_b_ > 1)
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             while (tr_start < tr_end) {
-                int g_ = g + ti->g_start;
-                int oc_b_ = oc_b + ti->oc_b_start;
-                int d_s = d + od_s;
-                int d_e = d_s + nstl::min(tr_end - tr_start, od_e - d_s);
-                const int oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
+                dim_t g_ = g + ti->g_start;
+                dim_t oc_b_ = oc_b + ti->oc_b_start;
+                dim_t d_s = d + od_s;
+                dim_t d_e
+                        = d_s + nstl::min<dim_t>(tr_end - tr_start, od_e - d_s);
+                const dim_t oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
 
                 const diff_dst_data_t *diff_dst
                         = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1598,40 +1642,43 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
         }
 
-        int depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
+        dim_t depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
 
-        for_(int odb_s = od_s; odb_s < od_e; odb_s += depth_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+        for_(dim_t odb_s = od_s; odb_s < od_e; odb_s += depth_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                 oc_b += jcp.nb_oc_blocking)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int odb_e = nstl::min(odb_s + depth_block, od_e);
-            const int idb_s = nstl::max(0, -jcp.f_pad + odb_s * jcp.stride_d);
-            const int idb_e = nstl::min(
+            const dim_t odb_e = nstl::min<dim_t>(odb_s + depth_block, od_e);
+            const dim_t idb_s
+                    = nstl::max<dim_t>(0, -jcp.f_pad + odb_s * jcp.stride_d);
+            const dim_t idb_e = nstl::min<dim_t>(
                     jcp.id, -jcp.f_pad + (odb_e - 1) * jcp.stride_d + ext_kd);
-            const int kdb_front_pad
-                    = nstl::max(0, jcp.f_pad - odb_s * jcp.stride_d);
+            const dim_t kdb_front_pad
+                    = nstl::max<dim_t>(0, jcp.f_pad - odb_s * jcp.stride_d);
             // Assumes kd_back_pad = 0 when kernel is dilated
-            const int kdb_back_pad = nstl::max(
+            const dim_t kdb_back_pad = nstl::max<dim_t>(
                     0, odb_s * jcp.stride_d + jcp.kd - jcp.f_pad - jcp.id);
-            const int kdb_pad_off = nstl::min(jcp.kd - 1, kdb_front_pad)
-                    * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
-                    * jcp.typesize_out;
+            const dim_t kdb_pad_off
+                    = nstl::min<dim_t>(jcp.kd - 1, kdb_front_pad) * jcp.kh
+                    * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
             assert(IMPLICATION(jcp.global_transpose,
                     od_s == odb_s && od_e == odb_e && id_s == idb_s
                             && id_e == idb_e));
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
@@ -1639,8 +1686,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
                 src_data_t *tr_src
                         = &ti->tr_src[tr_src_off_3d(0, 0, idb_e, idb_s)];
 
-                for (int icb = 0; icb < nb_ic_blocks; icb++) {
-                    const int ic_off_idx
+                for (dim_t icb = 0; icb < nb_ic_blocks; icb++) {
+                    const dim_t ic_off_idx
                             = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
                     const src_data_t *src
                             = (src_data_t *)&ti->src[src_d.blk_off(
@@ -1658,8 +1705,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights_3d(
             if (!jcp.global_transpose) {
                 diff_dst_data_t *tr_diff_dst
                         = &ti->tr_diff_dst[tr_diff_dst_off_3d(0, 0, 0)];
-                for (int ocb = 0; ocb < nb_oc_blocks; ocb++) {
-                    const int oc_off_idx
+                for (dim_t ocb = 0; ocb < nb_oc_blocks; ocb++) {
+                    const dim_t oc_off_idx
                             = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
                     const diff_dst_data_t *diff_dst
                             = &ti->diff_dst[diff_dst_d.blk_off(
@@ -1704,9 +1751,9 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1726,23 +1773,24 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_src_off = [&](int g, int ic, int nb_ic_block, int ij) {
+    auto tr_src_off = [&](dim_t g, dim_t ic, dim_t nb_ic_block, dim_t ij) {
         const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size * adj
                 + ij * tr_row_size + nb_ic_block * jcp.tr_src_buf_size;
     };
 
-    auto tr_src_off_3d = [&](int g, int ic, int nb_ic_block, int id, int ij) {
+    auto tr_src_off_3d
+            = [&](dim_t g, dim_t ic, dim_t nb_ic_block, dim_t id, dim_t ij) {
         const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         const size_t tr_3d_size = tr_row_size * jcp.ih;
-        int adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
+        dim_t adj = (jcp.global_transpose) ? 1 : jcp.nb_ic_blocking;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size * adj
                 + id * tr_3d_size + ij * tr_row_size
                 + nb_ic_block * jcp.tr_src_buf_size;
     };
 
-    auto tr_diff_dst_off = [&](int g, int oc, int nb_oc_block, int oj) {
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t nb_oc_block, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
@@ -1751,26 +1799,26 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
     };
 
     auto tr_diff_dst_off_3d
-            = [&](int g, int oc, int nb_oc_block, int od, int oj) {
+            = [&](dim_t g, dim_t oc, dim_t nb_oc_block, dim_t od, dim_t oj) {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         const size_t tr_3d_size = tr_row_size * jcp.oh;
-        int adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
+        dim_t adj = (jcp.global_transpose) ? 1 : jcp.nb_oc_blocking;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 * adj
                 + od * tr_3d_size + oj * tr_row_size
                 + nb_oc_block * jcp.tr_src_buf_size;
     };
 
-    auto uker_trans
-            = [&](int img, int g = 0, int ic_b = 0, int nb_ic_block = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.ih * jcp.id;
-        int ic;
-        int icb_start = ic_b;
+    auto uker_trans = [&](dim_t img, dim_t g = 0, dim_t ic_b = 0,
+                              dim_t nb_ic_block = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.ih * jcp.id;
+        dim_t ic;
+        dim_t icb_start = ic_b;
         if (jcp.global_transpose) {
-            const int work_amount = ti->ic_b_work * jcp.ih * jcp.id;
+            const dim_t work_amount = ti->ic_b_work * jcp.ih * jcp.id;
 
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, start, end);
             my_work = end - start;
 
@@ -1792,7 +1840,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
         const bool need_local_gwork = jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) ic = gg * jcp.ic + ic_b * jcp.ic_block;
             src_data_t *tr_src = (jcp.ndims == 5)
                     ? &ti->tr_src[tr_src_off_3d(gg, ic_b, nb_ic_block, d, j)]
@@ -1803,23 +1851,23 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
             dim_t sp_start_offset = (jcp.ndims == 5) ? src_d.blk_off(0, 0, d, j)
                                                      : src_d.blk_off(0, 0, j);
             dim_t ch_shift = src_d.blk_off(0, jcp.ic_block);
-            int sp_start_idx = d * jcp.ih + j;
+            dim_t sp_start_idx = d * jcp.ih + j;
             trans_src_nxc(tr_src, src, sp_start_idx, sp_start_offset, icb_start,
                     ch_shift, my_work);
         }
     };
 
-    auto diff_dst_trans
-            = [&](int img, int g = 0, int oc_b = 0, int nb_oc_block = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.oh * jcp.od;
-        int oc;
-        int ocb_start = oc_b;
+    auto diff_dst_trans = [&](dim_t img, dim_t g = 0, dim_t oc_b = 0,
+                                  dim_t nb_oc_block = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.oh * jcp.od;
+        dim_t oc;
+        dim_t ocb_start = oc_b;
 
         if (jcp.global_transpose) {
-            const size_t work_amount = ti->oc_b_work * jcp.oh * jcp.od;
+            const dim_t work_amount = ti->oc_b_work * jcp.oh * jcp.od;
 
-            size_t start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, start, end);
             my_work = end - start;
 
@@ -1841,7 +1889,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
         const bool need_local_gwork = jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) oc = gg * jcp.oc + oc_b * jcp.oc_block;
             diff_dst_data_t *tr_diff_dst = (jcp.ndims == 5)
                     ? &ti->tr_diff_dst[tr_diff_dst_off_3d(
@@ -1855,13 +1903,13 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                     ? diff_dst_d.blk_off(0, 0, d, j)
                     : diff_dst_d.blk_off(0, 0, j);
             dim_t ch_shift = diff_dst_d.blk_off(0, jcp.oc_block);
-            int sp_start_idx = d * jcp.oh + j;
+            dim_t sp_start_idx = d * jcp.oh + j;
             trans_dst_nxc(tr_diff_dst, diff_dst, sp_start_idx, sp_start_offset,
                     ocb_start, ch_shift, my_work);
         }
     };
 
-    for (int img = ti->img_start; img < ti->img_end; ++img) {
+    for (dim_t img = ti->img_start; img < ti->img_end; ++img) {
         auto p = jit_conv_args_t();
         if (jcp.global_transpose) {
             using simple_barrier::barrier;
@@ -1879,27 +1927,29 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::compute_diff_weights(
                 barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
         }
 
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                 oc_b += jcp.nb_oc_blocking)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += jcp.nb_ic_blocking) {
-            const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
+            const dim_t nb_ic_blocks
+                    = (ic_b + jcp.nb_ic_blocking > ti->ic_b_end)
                     ? 1
                     : jcp.nb_ic_blocking;
-            const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
+            const dim_t nb_oc_blocks
+                    = (oc_b + jcp.nb_oc_blocking > ti->oc_b_end)
                     ? 1
                     : jcp.nb_oc_blocking;
 
-            const int ic_to_compute
+            const dim_t ic_to_compute
                     = this_block_size((ic_b + nb_ic_blocks - 1) * jcp.ic_block,
                             jcp.ic, jcp.ic_block);
-            const int oc_to_compute
+            const dim_t oc_to_compute
                     = this_block_size((oc_b + nb_oc_blocks - 1) * jcp.oc_block,
                             jcp.oc, jcp.oc_block);
 
             if (!jcp.global_transpose) {
-                for (int nib = 0; nib < nb_ic_blocks; nib++)
+                for (dim_t nib = 0; nib < nb_ic_blocks; nib++)
                     uker_trans(img, g, ic_b + nib, nib);
             }
             if (jcp.ndims == 5) {
@@ -1951,15 +2001,15 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::store_in_vnni_format(
     const auto icb2_work = div_up(ti->ic_b_work, 2);
     const auto work = ti->g_work * ti->oc_b_work * icb2_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, jcp.nthr_mb, ti->ithr_mb, start, end);
-    int sub_g_start {0}, sub_oc_b_start {0}, sub_icb2_start {0};
+    dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_icb2_start {0};
     nd_iterator_init(start, sub_g_start, ti->g_work, sub_oc_b_start,
             ti->oc_b_work, sub_icb2_start, icb2_work);
-    for (int w = start; w < end; w++) {
-        const int g = ti->g_start + sub_g_start;
-        const int oc_b = ti->oc_b_start + sub_oc_b_start;
-        const int ic_b = ti->ic_b_start + 2 * sub_icb2_start;
+    for (dim_t w = start; w < end; w++) {
+        const dim_t g = ti->g_start + sub_g_start;
+        const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+        const dim_t ic_b = ti->ic_b_start + 2 * sub_icb2_start;
         jit_conv_args_t p = jit_conv_args_t();
 
         bfloat16_t *output = (bfloat16_t *)ti->diff_weights
@@ -1981,7 +2031,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = kernel_->jcp;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1);
 
     const bool is_bf16_out = diff_weights_d.data_type() == data_type::bf16;
@@ -1993,8 +2043,8 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
             if (jcp.transform_to_vnni) {
                 store_in_vnni_format(ti);
             } else {
-                for_(int g = ti->g_start; g < ti->g_end; g++)
-                for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
+                for_(dim_t g = ti->g_start; g < ti->g_end; g++)
+                for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
                     const size_t acc_size = (size_t)ti->ic_b_work * jcp.kh
                             * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1)
                             * jcp.ic_block * jcp.oc_block;
@@ -2007,12 +2057,12 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
             }
         }
         if (is_bf16_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
-                int result_start_idx = g * jcp.oc_without_padding
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
+                dim_t result_start_idx = g * jcp.oc_without_padding
                         + ti->oc_b_start * jcp.oc_block;
-                int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
                 bfloat16_t *diff_bias
@@ -2028,26 +2078,26 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
     if (jcp.global_transpose)
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work
+    const dim_t ic_b_kh_work
             = ti->ic_b_work * ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, nthr_mb_, ti->ithr_mb, start, end);
     if (!jcp.transform_to_vnni && start == end) return;
 
     const int _start_nthr_mb = 1;
     for (int thr_mb = _start_nthr_mb; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = start;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start
                     + sub_ic_b_kh_start / ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-            const int kX
+            const dim_t kX
                     = sub_ic_b_kh_start % ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
 
             const size_t acc_size = (size_t)jcp.kw * jcp.ic_block * jcp.oc_block
@@ -2082,22 +2132,22 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::
         }
         if (jcp.with_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0
                 && ti->ithr_mb == 0 && ti->img_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
                 float *bias_reduced = is_bf16_bias ? ti->bia_reduction
                                                    : (float *)(ti->diff_bias);
                 int thr_mb_buffer_idx = is_bf16_bias ? thr_mb : thr_mb - 1;
-                int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+                dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
                 float *bias_to_reduce
                         = ti->bia_reduction + thr_mb_buffer_idx * bias_buf_size;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
-                int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 if (is_bf16_bias && thr_mb == nthr_mb_ - 1) {
                     // the last iteration for bfloat16 requires conversion and
                     // store to diff_weights array
-                    int diff_bias_idx = g * jcp.oc_without_padding
+                    dim_t diff_bias_idx = g * jcp.oc_without_padding
                             + ti->oc_b_start * jcp.oc_block;
                     add_floats_and_cvt_to_bfloat16(
                             (bfloat16_t *)(ti->diff_bias) + diff_bias_idx,
@@ -2132,7 +2182,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::prepare_scratchpad_data(
     for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
         src_data_t *ts
                 = &tr_src[ithr * jcp.tr_src_buf_size * jcp.nb_ic_blocking];
-        for (int i = 0; i < jcp.tr_src_num_guard_elems; ++i)
+        for (dim_t i = 0; i < jcp.tr_src_num_guard_elems; ++i)
             ts[i] = 0;
     }
 
@@ -2228,9 +2278,9 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::execute_backward_weights(
                     = ctx.get_scratchpad_grantor().template get<const float>(
                             key_conv_padded_bias);
             auto diff_bias_in = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.hpp
@@ -260,15 +260,16 @@ private:
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    size_t tr_src_buf_number(const thread_info_t *ti, int g, int ic) const;
-    size_t tr_diff_dst_buf_number(const thread_info_t *ti, int g, int oc) const;
+    size_t tr_src_buf_number(const thread_info_t *ti, dim_t g, dim_t ic) const;
+    size_t tr_diff_dst_buf_number(
+            const thread_info_t *ti, dim_t g, dim_t oc) const;
     void trans_src_nxc(src_data_t *tr_src, const src_data_t *src_base,
-            int spatial_start, dim_t spatial_start_offset, int icb_start,
-            dim_t chb_stride, int my_work) const;
+            dim_t spatial_start, dim_t spatial_start_offset, dim_t icb_start,
+            dim_t chb_stride, dim_t my_work) const;
     void trans_dst_nxc(diff_dst_data_t *tr_diff_dst,
-            const diff_dst_data_t *diff_dst_base, int spatial_start,
-            dim_t spatial_start_offset, int ocb_start, dim_t chb_stride,
-            int my_work) const;
+            const diff_dst_data_t *diff_dst_base, dim_t spatial_start,
+            dim_t spatial_start_offset, dim_t ocb_start, dim_t chb_stride,
+            dim_t my_work) const;
 
     int nthr_ = 0, nthr_mb_ = 0, nthr_g_ = 0, nthr_oc_b_ = 0, nthr_ic_b_ = 0;
 
@@ -280,7 +281,8 @@ private:
     std::unique_ptr<jit_trans_src_t> trans_kernel_;
     std::unique_ptr<jit_trans_dst_t> trans_dst_kernel_;
 
-    inline dim_t wei_offset_int(int g, int oc_b, int ic_b, int kX) const {
+    inline dim_t wei_offset_int(
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kX) const {
         const auto &jcp = kernel_->jcp;
         const dim_t const_extra_offset = jcp.kw * jcp.ic_block * jcp.oc_block;
         dim_t extra_offset = (jcp.ndims == 5) ? kX * jcp.kh * const_extra_offset
@@ -289,9 +291,10 @@ private:
                 * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
                 + extra_offset;
     }
-    inline dim_t wei_offset_ext(int g, int oc_b, int ic_b, int kX) const {
+    inline dim_t wei_offset_ext(
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kX) const {
         const auto &jcp = kernel_->jcp;
-        const int nb_ic = utils::div_up(jcp.ic, 2 * jcp.ic_block);
+        const dim_t nb_ic = utils::div_up(jcp.ic, 2 * jcp.ic_block);
         const dim_t const_extra_offset
                 = static_cast<dim_t>(jcp.kw) * jcp.ic_block * jcp.oc_block * 2;
         dim_t extra_offset = (jcp.ndims == 5) ? kX * jcp.kh * const_extra_offset

--- a/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_deconvolution.cpp
@@ -75,7 +75,7 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
 
     const dim_t wei_g_shift = wht_blk_off(weights_d, 1, 0);
     const dim_t wei_ic_shift = wht_blk_off(weights_d, 0, jcp.nb_ic_blocking);
-    const size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
+    const dim_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
     auto inp_p_buffer = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_inp_buffer);
@@ -84,9 +84,9 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
     auto global_tcfg = ctx.get_scratchpad_grantor().template get<char>(
             key_conv_amx_tilecfg);
 
-    const int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-    const int ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
-    const int work_amount
+    const dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+    const dim_t ih_chunks = utils::div_up(jcp.ih, jcp.ih_blk_size);
+    const dim_t work_amount
             = jcp.mb * jcp.ngroups * jcp.id * ih_chunks * jcp.nb_iw * ic_chunks;
 
     const bool is_1d = jcp.ndims == 3;
@@ -108,7 +108,7 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
     });
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -130,88 +130,90 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
+        dim_t mb {0}, g {0}, id_s {0}, ihc {0}, iwb {0}, icc {0};
         nd_iterator_init(start, mb, jcp.mb, g, jcp.ngroups, id_s, jcp.id, ihc,
                 ih_chunks, iwb, jcp.nb_iw, icc, ic_chunks);
-        int last_copied_mb = -1;
-        int last_copied_id = -1;
-        int last_copied_ihc = -1;
-        int last_copied_iwb = -1;
-        int last_copied_g = -1;
+        dim_t last_copied_mb = -1;
+        dim_t last_copied_id = -1;
+        dim_t last_copied_ihc = -1;
+        dim_t last_copied_iwb = -1;
+        dim_t last_copied_g = -1;
         while (start < end) {
             char *inp_buffer
                     = inp_p_buffer + ithr * jcp.inp_buffer_size * src_dt_size;
 
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.ic == jcp.ic_without_padding));
-            int ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
-            int icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
+            dim_t ic = g * jcp.ic + icc * jcp.nb_ic_blocking * jcp.ic_block;
+            dim_t icb = jcp.is_nspc ? ic : ic / jcp.ic_block;
             assert(IMPLICATION(
                     jcp.ngroups > 1, jcp.oc == jcp.oc_without_padding));
-            const int ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
+            const dim_t ocb = g * (jcp.is_nspc ? jcp.oc : jcp.nb_oc);
             auto bias_w = bias_ptr
                     ? bias_ptr + (bias_d.blk_off(ic) * bia_dt_size)
                     : nullptr;
 
-            const int ih_b = ihc * jcp.ih_blk_size;
-            const int ih_e = nstl::min(jcp.ih, ih_b + jcp.ih_blk_size);
-            const int iw = iwb * jcp.iw_block;
+            const dim_t ih_b = ihc * jcp.ih_blk_size;
+            const dim_t ih_e = nstl::min<dim_t>(jcp.ih, ih_b + jcp.ih_blk_size);
+            const dim_t iw = iwb * jcp.iw_block;
             bool is_inp_buffer_relevant = true && last_copied_mb == mb
                     && last_copied_id == id_s && last_copied_ihc == ihc
                     && last_copied_iwb == iwb && last_copied_g == g;
 
             sfd.update_params(id_s);
             p.kd_padding = sfd.get_filter_padding();
-            const int d_lo = sfd.get_lower_offset();
-            const int d_oj = sfd.get_output_offset();
+            const dim_t d_lo = sfd.get_lower_offset();
+            const dim_t d_oj = sfd.get_output_offset();
 
-            int ih_step = jcp.nb_ih_blocking;
-            for (int ih = ih_b; ih < ih_e; ih += ih_step) {
+            const dim_t ih_step = jcp.nb_ih_blocking;
+            for (dim_t ih = ih_b; ih < ih_e; ih += ih_step) {
                 if (!is_inp_buffer_relevant) {
-                    const int gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
-                    const int gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
+                    const dim_t gen_kh = (jcp.kh - 1) * (jcp.dilate_h + 1) + 1;
+                    const dim_t gen_kw = (jcp.kw - 1) * (jcp.dilate_w + 1) + 1;
                     // dox: x-index dilated by strides (dox = ox * stride_x)
-                    const int doh = ih + jcp.t_pad - (gen_kh - 1);
-                    const int dow = iw + jcp.l_pad - (gen_kw - 1);
-                    const int doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
-                    const int doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
-                    const int dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
+                    const dim_t doh = ih + jcp.t_pad - (gen_kh - 1);
+                    const dim_t dow = iw + jcp.l_pad - (gen_kw - 1);
+                    const dim_t doh_b = ih_b + jcp.t_pad - (gen_kh - 1);
+                    const dim_t doh_l = (jcp.oh - 1) * jcp.stride_h; // last oh
+                    const dim_t dow_l = (jcp.ow - 1) * jcp.stride_w; // last ow
 
                     // dox_{s,f}: start and finish indices for copy kernel
-                    const int doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
-                    const int doh_f = doh + (ih_step - 1) + (gen_kh - 1);
-                    const int delta_h = doh_f - doh_s + 1;
-                    const int doh_t_overflow = 0 < doh_s && doh_s < doh_l
+                    const dim_t doh_s = doh + (ih == ih_b ? 0 : gen_kh - 1);
+                    const dim_t doh_f = doh + (ih_step - 1) + (gen_kh - 1);
+                    const dim_t delta_h = doh_f - doh_s + 1;
+                    const dim_t doh_t_overflow = 0 < doh_s && doh_s < doh_l
                             ? nstl::additive_inverse_modulo(doh_s, jcp.stride_h)
-                            : nstl::max(0, -doh_s);
-                    const int doh_b_overflow = 0 < doh_f && doh_f < doh_l
+                            : nstl::max<dim_t>(0, -doh_s);
+                    const dim_t doh_b_overflow = 0 < doh_f && doh_f < doh_l
                             ? nstl::modulo(doh_f, jcp.stride_h)
-                            : nstl::max(0, nstl::min(delta_h, doh_f - doh_l));
-                    int dow_s = dow;
-                    int dow_f = dow + jcp.owp - 1;
-                    const int delta_w = dow_f - dow_s + 1;
-                    const int dow_l_overflow = 0 < dow_s && dow_s < dow_l
+                            : nstl::max<dim_t>(0,
+                                      nstl::min<dim_t>(delta_h, doh_f - doh_l));
+                    dim_t dow_s = dow;
+                    dim_t dow_f = dow + jcp.owp - 1;
+                    const dim_t delta_w = dow_f - dow_s + 1;
+                    const dim_t dow_l_overflow = 0 < dow_s && dow_s < dow_l
                             ? nstl::additive_inverse_modulo(dow_s, jcp.stride_w)
-                            : nstl::max(0, -dow_s);
-                    const int dow_r_overflow = 0 < dow_f && dow_f < dow_l
+                            : nstl::max<dim_t>(0, -dow_s);
+                    const dim_t dow_r_overflow = 0 < dow_f && dow_f < dow_l
                             ? nstl::modulo(dow_f, jcp.stride_w)
-                            : nstl::max(0, nstl::min(delta_w, dow_f - dow_l));
-                    const int oh_s
-                            = utils::div_up(nstl::max(0, doh_s), jcp.stride_h);
-                    const int ow_s
-                            = utils::div_up(nstl::max(0, dow_s), jcp.stride_w);
+                            : nstl::max<dim_t>(0,
+                                      nstl::min<dim_t>(delta_w, dow_f - dow_l));
+                    const dim_t oh_s = utils::div_up(
+                            nstl::max<dim_t>(0, doh_s), jcp.stride_h);
+                    const dim_t ow_s = utils::div_up(
+                            nstl::max<dim_t>(0, dow_s), jcp.stride_w);
                     // how many real data rows to copy (including padding)
-                    p.t_overflow = nstl::min(delta_h, doh_t_overflow);
-                    p.b_overflow = nstl::min<size_t>(
+                    p.t_overflow = nstl::min<dim_t>(delta_h, doh_t_overflow);
+                    p.b_overflow = nstl::min<dim_t>(
                             delta_h - p.t_overflow, doh_b_overflow);
-                    p.kh_padding = nstl::max<size_t>(
+                    p.kh_padding = nstl::max<dim_t>(
                             0, delta_h - p.t_overflow - p.b_overflow);
-                    p.l_overflow = nstl::min(delta_w, dow_l_overflow);
-                    p.kw_padding = nstl::max<size_t>(
+                    p.l_overflow = nstl::min<dim_t>(delta_w, dow_l_overflow);
+                    p.kw_padding = nstl::max<dim_t>(
                             0, delta_w - dow_l_overflow - dow_r_overflow);
-                    p.r_overflow = nstl::min<size_t>(
+                    p.r_overflow = nstl::min<dim_t>(
                             delta_w - dow_l_overflow, dow_r_overflow);
-                    size_t inp_offset = is_1d ? src_d.blk_off(mb, ocb, ow_s)
+                    dim_t inp_offset = is_1d ? src_d.blk_off(mb, ocb, ow_s)
                             : is_3d ? src_d.blk_off(mb, ocb, d_oj, oh_s, ow_s)
                                     : src_d.blk_off(mb, ocb, oh_s, ow_s);
                     p.src = src + src_dt_size * inp_offset;
@@ -222,9 +224,9 @@ status_t jit_avx512_core_amx_deconvolution_fwd_t::execute_forward(
                     kernel_->bwd_data_copy_kernel()(&p);
                 }
 
-                size_t dst_offset = is_1d ? dst_d.blk_off(mb, icb, iw)
-                        : is_3d           ? dst_d.blk_off(mb, icb, id_s, ih, iw)
-                                          : dst_d.blk_off(mb, icb, ih, iw);
+                dim_t dst_offset = is_1d ? dst_d.blk_off(mb, icb, iw)
+                        : is_3d          ? dst_d.blk_off(mb, icb, id_s, ih, iw)
+                                         : dst_d.blk_off(mb, icb, ih, iw);
                 p.dst = inp_buffer
                         + (size_t)(ih - ih_b) * jcp.owp * jcp.oc_block_int
                                 * src_dt_size;

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -93,7 +93,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const int num_substeps = static_cast<int>(jcp.bcast_block / jcp.ur);
         assert(num_substeps > 0 && num_substeps < 10);
         for (int i = 0; i < num_substeps; i++) {
             if (i + 1 == num_substeps) L(long_tail);
@@ -152,11 +152,11 @@ Address jit_avx512_core_bf16_1x1_conv_kernel_t::output_ptr(
     if (one_of(jcp.prop_kind, forward_training, forward_inference,
                 backward_data)) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        int i_load_shift = is_output_layout_nxc
+        dim_t i_load_shift = is_output_layout_nxc
                 ? jcp.load_block
                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim) * jcp.load_block;
-        int i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offset = (i_load * i_load_shift + i_ur * i_ur_shift)
+        dim_t i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_out;
         return EVEX_compress_addr(aux_reg_output_data, offset);
     } else
@@ -195,7 +195,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::apply_postops(
             iterate(load_loop_blk, ur, mask_tail,
                     [&](const bool mask_flag, const int i_load,
                             const int i_ur) {
-                const int aux_output_l_off
+                const dim_t aux_output_l_off
                         = get_output_offset(i_load, i_ur, true);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -255,8 +255,9 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
         int load_loop_blk, int ur, int substep, bool wraparound) {
     const bool load_layout_nxc = is_load_layout_nxc();
     const bool bcast_layout_nxc = is_bcast_layout_nxc();
-    const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const int reduce_dim_tail
+            = static_cast<int>(jcp.reduce_dim % jcp.reduce_block);
+    const int load_dim_tail = static_cast<int>(jcp.load_dim % jcp.load_block);
 
     auto vreg_load = [ur, load_loop_blk](int i_load) {
         int idx = ur * load_loop_blk + i_load;
@@ -276,22 +277,22 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto bcast_ptr
-            = [this, bcast_layout_nxc](int i_reduce, int i_ur, bool bcast) {
+            = [this, bcast_layout_nxc](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
-        int offt;
+        dim_t offt;
         if (one_of(jcp.prop_kind, forward_training, forward_inference,
                     backward_data)) {
             assert(jcp.reduce_loop_unroll == jcp.reduce_block);
-            const int reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
-                                                    : jcp.reduce_loop_unroll;
+            const dim_t reduce_mul = bcast_layout_nxc ? jcp.reduce_dim
+                                                      : jcp.reduce_loop_unroll;
             offt = (i_reduce == jcp.reduce_loop_unroll)
                     ? (jcp.bcast_dim + i_ur) * reduce_mul
                     : i_ur * reduce_mul + i_reduce;
         } else {
             if (jcp.uses_permw_transposition) {
-                int rmul = bcast_layout_nxc ? jcp.ngroups * jcp.ic
-                                            : jcp.ic_block;
+                dim_t rmul = bcast_layout_nxc ? jcp.ngroups * jcp.ic
+                                              : jcp.ic_block;
                 offt = i_reduce * rmul + i_ur;
             } else {
                 offt = (i_reduce / 2) * 2 * jcp.ic_block + 2 * i_ur;
@@ -304,22 +305,22 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     auto load_ptr = [this, load_layout_nxc](int i_reduce, int i_load) {
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
-        int lmul = jcp.load_block
+        dim_t lmul = jcp.load_block
                 * (load_layout_nxc ? 1
                                    : utils::rnd_up(
                                              jcp.reduce_dim, jcp.reduce_block));
-        int rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offt = i_load * lmul + u0 * rmul;
+        dim_t rmul = load_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offt = i_load * lmul + u0 * rmul;
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
     };
 
     auto store_buffer_ptr = [this](int i_load, int i_ur) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        int i_load_shift
+        dim_t i_load_shift
                 = jcp.load_block * (is_output_layout_nxc ? 1 : jcp.bcast_dim);
-        int i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
-        int offset = (i_load * i_load_shift + i_ur * i_ur_shift)
+        dim_t i_ur_shift = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
+        dim_t offset = (i_load * i_load_shift + i_ur * i_ur_shift)
                 * jcp.typesize_acc;
         return EVEX_compress_addr(aux_reg_store_buf, offset);
     };
@@ -541,11 +542,12 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block_bwd_w = [&](bool is_tail) {
-        int n_reduce_tail = jcp.reduce_dim % jcp.reduce_loop_unroll;
-        int n_reduce
+        const int n_reduce_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_loop_unroll);
+        const int n_reduce
                 = is_tail && n_reduce_tail > 0 && !jcp.uses_permw_transposition
                 ? n_reduce_tail
-                : jcp.reduce_loop_unroll;
+                : static_cast<int>(jcp.reduce_loop_unroll);
         int bcast_count = 0;
         int pipeline_length_max = 1;
         if (isa_has_bf16(jcp.isa)) {
@@ -744,9 +746,11 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::reduce_loop(
     };
 
     auto fma_block_fwd_bwd_d = [&](bool is_tail) {
-        int n_reduce_tail = jcp.reduce_dim % jcp.reduce_loop_unroll;
-        int n_reduce = is_tail && n_reduce_tail > 0 ? n_reduce_tail
-                                                    : jcp.reduce_loop_unroll;
+        const int n_reduce_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_loop_unroll);
+        const int n_reduce = is_tail && n_reduce_tail > 0
+                ? n_reduce_tail
+                : static_cast<int>(jcp.reduce_loop_unroll);
         const int reduce_step = 2;
         for (int i_reduce = 0; i_reduce < n_reduce; i_reduce += 2) {
             if (isa_has_bf16(jcp.isa)) {
@@ -973,7 +977,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::compute_diff_bias(
     test(reg_reduce_pos_flag, FLAG_REDUCE_FIRST); // If FLAG_REDUCE_FIRST
     jnz(skip_reading, T_NEAR);
 
-    const int load_dim_tail = jcp.load_dim % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(jcp.load_dim % jcp.load_block);
     for (int i_load = 0; i_load < load_loop_blk; i_load++) {
         bool mask_flag = load_dim_tail && i_load + 1 == load_loop_blk;
         auto vacc = vreg_acc(i_load);
@@ -1014,11 +1018,11 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::generate() {
     mov(reg_trans_tmp.cvt32(), 0xffff0000);
     kmovd(half_mask_hi, reg_trans_tmp.cvt32());
 
-    const int load_dim_tail
-            = (one_of(jcp.prop_kind, forward_training, forward_inference)
-                              ? jcp.oc_without_padding
-                              : jcp.load_dim)
-            % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(
+            (one_of(jcp.prop_kind, forward_training, forward_inference)
+                            ? jcp.oc_without_padding
+                            : jcp.load_dim)
+            % jcp.load_block);
     if (load_dim_tail) {
         mov(reg_trans_tmp.cvt32(), (1 << load_dim_tail) - 1);
         kmovw(k_load_dim_tail_mask, reg_trans_tmp.cvt32());
@@ -1077,12 +1081,12 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::generate() {
         mov(reg_load_loop_work, ptr[rsp + reg_load_loop_work_off]);
 
         add(reg_load_data, load_loop_blk * jcp.load_loop_load_step);
-        const size_t off_with_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t off_with_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out
                 * (is_out_layout_nxc()
                                 ? 1
                                 : (jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim));
-        const size_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
+        const dim_t offst_wo_dw_conv = load_loop_blk * jcp.load_block
                 * jcp.typesize_out * (is_out_layout_nxc() ? 1 : jcp.bcast_dim);
         switch (jcp.prop_kind) {
             case forward_training:
@@ -1246,7 +1250,9 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             ? pick_by_prop_kind(jcp.prop_kind, cd.bias_desc.data_type,
                       data_type::undef, cd.diff_bias_desc.data_type)
             : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     jcp.os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
     jcp.is = static_cast<dim_t>(jcp.id) * jcp.ih * jcp.iw;
@@ -1344,15 +1350,20 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
     jcp.typesize_acc = sizeof(float);
     if (one_of(jcp.prop_kind, forward_training, forward_inference)) {
-        jcp.typesize_in = types::data_type_size(src_d.data_type());
-        jcp.typesize_out = types::data_type_size(dst_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
+        jcp.typesize_out
+                = static_cast<int>(types::data_type_size(dst_d.data_type()));
         jcp.dst_dt = dst_d.data_type();
     } else if (jcp.prop_kind == backward_data) {
-        jcp.typesize_in = types::data_type_size(dst_d.data_type());
-        jcp.typesize_out = types::data_type_size(src_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(dst_d.data_type()));
+        jcp.typesize_out
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
         jcp.dst_dt = src_d.data_type();
     } else if (jcp.prop_kind == backward_weights) {
-        jcp.typesize_in = types::data_type_size(src_d.data_type());
+        jcp.typesize_in
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
         jcp.typesize_out = sizeof(prec_traits_t<data_type::f32>::type);
         jcp.dst_dt = weights_d.data_type();
     }
@@ -1389,7 +1400,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 backward_data)) {
         jcp.nthr = nthreads;
         if (one_of(jcp.prop_kind, forward_inference, forward_training)) {
-            if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+            if (jcp.with_dw_conv)
+                jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
             jcp.reduce_dim = jcp.ic;
             jcp.reduce_block = jcp.ic_block;
 
@@ -1417,11 +1429,12 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
 
         // adjusting registry blocking
         int max_regs, min_regs, size_treshold, ur_step;
-        const int spatial
+        const dim_t spatial
                 = (one_of(jcp.prop_kind, forward_training, forward_inference))
                 ? jcp.od * jcp.oh
                 : jcp.id * jcp.ih;
-        const int reduce_dim_tail = jcp.reduce_dim % jcp.reduce_block;
+        const int reduce_dim_tail
+                = static_cast<int>(jcp.reduce_dim % jcp.reduce_block);
         if (reduce_dim_tail % 2 == 0 // cannot expl_bcast odd tail
                 && (8 * jcp.mb) / jcp.nthr >= 1) {
             max_regs = 9;
@@ -1455,7 +1468,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i -= ur_step) {
                 int i_tail = jcp.os % i;
@@ -1484,22 +1497,26 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         else
             jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-        int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-        int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
-        int nb_load = div_up(jcp.load_dim, jcp.load_block);
+        int nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+        int nb_reduce
+                = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
+        int nb_load = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
 
         if (is_data_layout_nxc
                 || (jcp.prop_kind == backward_data && reduce_src)) {
-            reduce_blocking = jcp.reduce_dim;
+            reduce_blocking = static_cast<int>(jcp.reduce_dim);
         } else {
             if (jcp.expl_bcast) {
                 if (jcp.load_dim <= BIG_LOAD_DIM && spatial > SMALL_SPATIAL
                         && spatial < BIG_SPATIAL)
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 160);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 160));
                 else if (spatial > SMALL_SPATIAL)
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 1024);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 1024));
                 else
-                    reduce_blocking = nstl::min<dim_t>(jcp.reduce_dim, 512);
+                    reduce_blocking = static_cast<int>(
+                            nstl::min<dim_t>(jcp.reduce_dim, 512));
             } else {
                 reduce_blocking = nb_reduce;
                 if (spatial <= SMALL_SPATIAL
@@ -1521,14 +1538,15 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             int max_hits = 7;
             if (jcp.bcast_dim * reduce_blocking > way_size * max_hits) {
                 int nrb = reduce_blocking / simd_w;
-                int sp = jcp.bcast_dim;
-                int wl = way_size / simd_w;
+                dim_t sp = jcp.bcast_dim;
+                dim_t wl = way_size / simd_w;
                 for (int start_off = 0; start_off < jcp.ur; start_off++) {
-                    for (int off = start_off, hits = 0; off < sp * nrb;
+                    for (dim_t off = start_off, hits = 0; off < sp * nrb;
                             off += wl) {
                         if (off % sp >= jcp.ur || ++hits < max_hits) continue;
-                        int max_r_blocking
-                                = simd_w * nstl::max(1, (off + wl) / sp);
+                        int max_r_blocking = simd_w
+                                * static_cast<int>(
+                                        nstl::max<dim_t>(1, (off + wl) / sp));
                         reduce_blocking
                                 = nstl::min(reduce_blocking, max_r_blocking);
                         break;
@@ -1536,10 +1554,10 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 }
             }
         }
-        load_blocking = jcp.load_dim;
+        load_blocking = static_cast<int>(jcp.load_dim);
 
-        int load_size = jcp.load_dim * jcp.reduce_dim;
-        auto bcast_size
+        dim_t load_size = jcp.load_dim * jcp.reduce_dim;
+        const dim_t bcast_size
                 = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
 
         if (jcp.nthr <= 28 && jcp.mb < jcp.nthr
@@ -1550,11 +1568,11 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             float ratio = (float)load_size / (float)bcast_size;
             int best_lgc = ratio > 1 ? n_lgc : 1;
             auto calc_job_cost = [&](int lb, int tg, float mem_k) {
-                int bb_size = jcp.mb * div_up(nb_bcast, tg);
+                dim_t bb_size = jcp.mb * div_up(nb_bcast, tg);
                 float calc_size = (float)(bb_size * jcp.ur)
-                        * (lb * jcp.load_block) * jcp.reduce_dim;
+                        * (float)(lb * jcp.load_block) * (float)jcp.reduce_dim;
                 float mem_size = (float)(bb_size * jcp.ur + lb * jcp.load_block)
-                        * jcp.reduce_dim;
+                        * (float)jcp.reduce_dim;
                 return calc_koef * calc_size + mem_k * mem_size;
             };
             for (int lgc, ilgc = 0; ilgc < n_lgc; ilgc++) {
@@ -1580,8 +1598,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 }
             }
             jcp.load_grp_count = best_lgc;
-            load_blocking
-                    = div_up(nb_load, jcp.load_grp_count) * jcp.load_block;
+            load_blocking = static_cast<int>(
+                    div_up(nb_load, jcp.load_grp_count) * jcp.load_block);
         } else {
             jcp.load_grp_count
                     = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
@@ -1594,24 +1612,26 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         } else if (jcp.bcast_dim <= 49 && jcp.mb <= jcp.nthr
                 && jcp.load_dim > 512 && jcp.load_dim / jcp.reduce_dim >= 4) {
             jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2);
-            load_blocking = jcp.load_block;
+            load_blocking = static_cast<int>(jcp.load_block);
         }
 
-        bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                                 div_up(jcp.nthr, jcp.load_grp_count))
-                * jcp.bcast_block;
-        bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                           div_up(jcp.nthr, jcp.load_grp_count))
+                        * jcp.bcast_block);
+        bcast_blocking = static_cast<int>(
+                nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
         bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
-        int space_for_bcast = (L2_capacity - /* kernel_size - */
+        dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
                 2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
                 - 3 * 1024);
         if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
 
-        int bcast_in_cache
-                = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-        bcast_blocking = nstl::min(
-                bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+        const dim_t bcast_in_cache = nstl::max<dim_t>(
+                jcp.bcast_block, space_for_bcast / reduce_blocking);
+        bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+                bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
         load_blocking_max = load_blocking;
         bcast_blocking_max = bcast_blocking * 3 / 2;
@@ -1630,7 +1650,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
                 && IMPLICATION(ndims == 5, jcp.oc <= 64);
 
         if (jcp.uses_permw_transposition) {
-            int rdim = nstl::min<dim_t>(256, jcp.reduce_dim);
+            int rdim = static_cast<int>(nstl::min<dim_t>(256, jcp.reduce_dim));
             jcp.reduce_block = best_divider(jcp.reduce_dim, 7, rdim, true, 2);
         } else
             jcp.reduce_block = best_divider(jcp.reduce_dim, 8, 16, true, 2);
@@ -1649,8 +1669,8 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.bcast_dim = jcp.ic;
         jcp.bcast_block = jcp.ic_block;
 
-        jcp.ur = jcp.bcast_block;
-        jcp.ur_tail = jcp.bcast_dim % jcp.bcast_block;
+        jcp.ur = static_cast<int>(jcp.bcast_block);
+        jcp.ur_tail = static_cast<int>(jcp.bcast_dim % jcp.bcast_block);
         // TODO: try to enable jcp.expl_bcast version
         jcp.expl_bcast = false;
 
@@ -1682,16 +1702,18 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         /* --- */
         balance(jcp, jcp.nthr);
 
-        load_blocking = div_up(jcp.load_dim, jcp.load_block);
+        load_blocking = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
         load_blocking = best_divider(load_blocking, 16, load_blocking, false);
         load_blocking *= jcp.load_block;
 
         load_blocking_max = load_blocking;
 
-        int max_bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        int max_bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         int min_bcast_blocking = 5;
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         bcast_blocking = best_divider(
                 bcast_blocking, min_bcast_blocking, max_bcast_blocking, false);
         bcast_blocking *= jcp.bcast_block;
@@ -1702,14 +1724,14 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         }
 
         // for reduction balance
-        int max_reduce_blocking
-                = nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim);
-        int min_reduce_blocking
-                = nstl::min(L1_capacity / jcp.ur, nstl::max(jcp.iw, jcp.ih));
+        int max_reduce_blocking = static_cast<int>(
+                nstl::min<dim_t>(L1_capacity / jcp.ur, jcp.reduce_dim));
+        int min_reduce_blocking = static_cast<int>(nstl::min<dim_t>(
+                L1_capacity / jcp.ur, nstl::max<dim_t>(jcp.iw, jcp.ih)));
         reduce_blocking = best_divider(
                 jcp.reduce_dim, min_reduce_blocking, max_reduce_blocking, true);
-        reduce_blocking = nstl::max(
-                rnd_dn(reduce_blocking, jcp.reduce_block), jcp.reduce_block);
+        reduce_blocking = static_cast<int>(nstl::max<dim_t>(
+                rnd_dn(reduce_blocking, jcp.reduce_block), jcp.reduce_block));
 
         reduce_blocking_max = rnd_dn(reduce_blocking * 3 / 2, jcp.reduce_block);
     } else
@@ -1759,7 +1781,7 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
             && jcp.typesize_in * bcast_size < 8192 && jcp.ngroups < jcp.nthr
             && jcp.nb_bcast * jcp.nb_load < jcp.nthr;
     if (is_adjust_thread) {
-        int nthr = nstl::max(jcp.nb_bcast, jcp.nb_load);
+        int nthr = static_cast<int>(nstl::max(jcp.nb_bcast, jcp.nb_load));
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 
@@ -1856,11 +1878,13 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
         /* simplification... fortunately it doesn't hurt much */
         return;
     }
-    const int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    const int nb_load = div_up(jcp.load_dim, jcp.load_block);
-    const int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const int nb_bcast
+            = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    const int nb_load = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
+    const int nb_reduce
+            = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
-    jcp.nthr_g = jcp.ngroups;
+    jcp.nthr_g = static_cast<int>(jcp.ngroups);
     const int nthr = nthreads / jcp.nthr_g;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -1878,7 +1902,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
 
         if (jcp.prop_kind == backward_weights) {
             int mult = (jcp.stride_h == 1 && jcp.stride_w == 1)
-                    ? nstl::max(1, (jcp.oc / jcp.ic))
+                    ? static_cast<int>(nstl::max<dim_t>(1, (jcp.oc / jcp.ic)))
                     : 1;
             output_koeff = 4 * mult;
         }
@@ -1900,7 +1924,8 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
     auto best_mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
 
     /* step 1: find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, jcp.mb * nb_reduce);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, jcp.mb * nb_reduce));
     for (nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
         const int nthr_oc_b_max = nstl::min(nthr_par, nb_load);
@@ -1916,7 +1941,7 @@ void jit_avx512_core_bf16_1x1_conv_kernel_t::balance(
         }
     }
     if (jcp.nthr_mb > nthreads / 2 && jcp.nthr_mb < nthreads)
-        jcp.nthr_mb = nstl::min(jcp.mb, nthreads);
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(jcp.mb, nthreads));
 
     jcp.nthr = jcp.nthr_mb * jcp.nthr_g * jcp.nthr_oc_b * jcp.nthr_ic_b;
     assert(jcp.nthr <= nthreads);

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.hpp
@@ -182,14 +182,14 @@ private:
         return ymm;
     }
 
-    inline size_t get_output_offset(
+    inline dim_t get_output_offset(
             const int i_load, const int i_ur, bool ignore_dw_conv) {
         const bool is_output_layout_nxc = is_out_layout_nxc();
-        const size_t i_load_shift = is_output_layout_nxc
+        const dim_t i_load_shift = is_output_layout_nxc
                 ? jcp.load_block
                 : (!ignore_dw_conv && jcp.with_dw_conv ? jcp.ow : jcp.bcast_dim)
                         * jcp.load_block;
-        const size_t i_ur_shift
+        const dim_t i_ur_shift
                 = is_output_layout_nxc ? jcp.load_dim : jcp.load_block;
         return jcp.typesize_out * (i_load * i_load_shift + i_ur * i_ur_shift);
     }

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.cpp
@@ -44,7 +44,7 @@ namespace {
  * not used here ?*/
 template <typename T, typename U>
 void balance2D(U nthr, U ithr, T ny, T &ny_start, T &ny_end, T nx, T &nx_start,
-        T &nx_end, T nx_divider) {
+        T &nx_end, U nx_divider) {
     const T grp_size = utils::div_up(nthr, nx_divider);
     const T grp_count = utils::div_up(nthr, grp_size);
 
@@ -77,7 +77,8 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_ != nullptr
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -145,26 +146,27 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     float *store_buffer = scratchpad.template get<float>(key_conv_store_wsp);
 
     const int ndims = src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -172,7 +174,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     dst_data_t *pbuf; //bf16->bf16 fusion
     size_t row_offset;
     const auto jcp_dw = pd()->jcp_dw_;
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<decltype(pbuf)> addrs;
     const bool is_dst_layout_nxc = utils::one_of(
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
@@ -181,23 +183,23 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
     auto start_off = dst_d.off_l(0);
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -210,16 +212,16 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
-        const auto max_oc
-                = nstl::min(ocb_end * jcp.oc_block, jcp.oc_without_padding);
+        const auto max_oc = nstl::min<dim_t>(
+                ocb_end * jcp.oc_block, jcp.oc_without_padding);
         p.load_dim = this_block_size(
                 ocb * jcp.oc_block, max_oc, load_step * jcp.oc_block);
     };
 
-    auto init_reduce = [&](int icb) {
-        const int nb_ic_blocking_step
+    auto init_reduce = [&](dim_t icb) {
+        const dim_t nb_ic_blocking_step
                 = nstl::min(icb + nb_ic_blocking, nb_ic) - icb;
         p.first_last_flag = 0 | (icb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (icb + nb_ic_blocking_step >= nb_ic ? FLAG_REDUCE_LAST : 0);
@@ -229,12 +231,13 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int icb, int n, int g, int od,
-                           int oh, int ow, int id, int ih, int iw) {
-        const int oc_off_idx = is_dst_layout_nxc
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t icb, dim_t n, dim_t g,
+                           dim_t od, dim_t oh, dim_t ow, dim_t id, dim_t ih,
+                           dim_t iw) {
+        const dim_t oc_off_idx = is_dst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, od, oh, ow);
 
         void *output_data = jcp.with_dw_conv
                 ? (void *)(pbuf + (oh % jcp_dw->kh) * row_offset)
@@ -247,7 +250,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 = &weights[pd()->with_groups() ? weights_d.blk_off(g, ocb, icb)
                                                : weights_d.blk_off(ocb, icb)];
 
-        const int ic_off_idx = is_src_layout_nxc
+        const dim_t ic_off_idx = is_src_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
         if (pd()->rtus_.reduce_src_) {
@@ -278,21 +281,22 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                            id {0}, ih {0}, iw {0};
+                    dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                            iw {0};
+                    dim_t bcast_step {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -302,17 +306,18 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
-                        id {0}, ih {0}, iw {0};
+                dim_t n {0}, g {0}, od {0}, oh {0}, ow {0}, id {0}, ih {0},
+                        iw {0};
+                dim_t bcast_step {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
-                    for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                    for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                         init_reduce(icb);
                         ker_1x1(ocb, ocb_start, icb, n, g, od, oh, ow, id, ih,
                                 iw);
@@ -326,8 +331,9 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw->stride_h - jcp_dw->t_pad, 0);
 
         for (int i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw->kh) * row_offset;
@@ -336,22 +342,22 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw->iw)
                 * jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
 
-        const int dil_h = jcp_dw->dilate_h + 1;
-        const int str_h = jcp_dw->stride_h;
-        const int ch_num = jcp_dw->nb_ch_blocking;
+        const dim_t dil_h = jcp_dw->dilate_h + 1;
+        const dim_t str_h = jcp_dw->stride_h;
+        const dim_t ch_num = jcp_dw->nb_ch_blocking;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw->nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw->t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw->ih,
-                              (int)(dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
-                                      - jcp_dw->t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw->t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw->ih,
+                              dw_oh * str_h + (jcp_dw->kh - 1) * dil_h
+                                      - jcp_dw->t_pad + 1)
                     - jcp_dw->ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
+            const int kh = static_cast<int>(div_up(i_t_overflow, dil_h));
+            const dim_t kh_padding = jcp_dw->kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
             const int ow = 0;
@@ -360,7 +366,7 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw->ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -373,9 +379,10 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw->ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw->nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw->nb_ch) - ch)
                     * jcp_dw->ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -402,33 +409,34 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
                 bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -444,8 +452,8 @@ void jit_avx512_core_bf16_1x1_convolution_fwd_t<dst_type>::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
                 ocb_start, ocb_end, jcp.load_grp_count);
 
@@ -491,13 +499,13 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
             : nullptr;
     float *store_buffer = scratchpad.template get<float>(key_conv_store_wsp);
     const int ndims = diff_src_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -505,26 +513,27 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const int nb_ic = jcp.nb_load;
-    const int nb_oc = jcp.nb_reduce;
-    const int os_block = jcp.bcast_block;
-    const int nb_oc_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_ic = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_reduce;
+    const dim_t os_block = jcp.bcast_block;
+    const dim_t nb_oc_blocking = jcp.nb_reduce_blocking;
 
-    int bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
+    dim_t bcast_start {0}, bcast_end {0}, icb_start {0}, icb_end {0};
     balance2D(nthr, ithr, work_amount, bcast_start, bcast_end, jcp.nb_load,
             icb_start, icb_end, jcp.load_grp_count);
 
-    auto init_bcast = [&](int iwork, int &n, int &g, int &bcast_step, int &od,
-                              int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast
+            = [&](dim_t iwork, dim_t &n, dim_t &g, dim_t &bcast_step, dim_t &od,
+                      dim_t &oh, dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, jcp.nb_bcast);
         bcast_step = step(jcp.nb_bcast_blocking, jcp.nb_bcast - osb,
                 jcp.nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
         id = od * stride_d;
@@ -536,17 +545,17 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int icb, int &load_step) {
+    auto init_load = [&](dim_t icb, dim_t &load_step) {
         load_step = step(
                 jcp.nb_load_blocking, icb_end - icb, jcp.nb_load_blocking_max);
-        const int max_ic = nstl::min(icb_end * jcp.ic_block, jcp.ic);
+        const dim_t max_ic = nstl::min<dim_t>(icb_end * jcp.ic_block, jcp.ic);
         p.load_dim = this_block_size(
                 icb * jcp.ic_block, max_ic, load_step * jcp.ic_block);
         rp.icb = p.load_dim;
     };
 
-    auto init_reduce = [&](int ocb) {
-        const int nb_oc_blocking_step
+    auto init_reduce = [&](dim_t ocb) {
+        const dim_t nb_oc_blocking_step
                 = nstl::min(ocb + nb_oc_blocking, nb_oc) - ocb;
         p.first_last_flag = 0 | (ocb == 0 ? FLAG_REDUCE_FIRST : 0)
                 | (ocb + nb_oc_blocking_step >= nb_oc ? FLAG_REDUCE_LAST : 0);
@@ -555,14 +564,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
                 ocb * jcp.oc_block, jcp.oc, nb_oc_blocking_step * jcp.oc_block);
     };
 
-    auto inner_ker = [&](int icb, int ocb, int n, int g, int od, int oh, int ow,
-                             int id, int ih, int iw) {
+    auto inner_ker = [&](dim_t icb, dim_t ocb, dim_t n, dim_t g, dim_t od,
+                             dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
         const bool is_dsrc_layout_nxc = utils::one_of(jcp.src_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-        const int ic_off_idx = is_dsrc_layout_nxc
+        const dim_t ic_off_idx = is_dsrc_layout_nxc
                 ? g * jcp.ic + icb * jcp.ic_block
                 : g * nb_ic + icb;
-        const size_t diff_src_off
+        const dim_t diff_src_off
                 = data_blk_off(diff_src_d, n, ic_off_idx, id, ih, iw);
 
         rp.src = diff_src + diff_src_off;
@@ -577,7 +586,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
 
         const bool is_ddst_layout_nxc = utils::one_of(jcp.dst_tag,
                 format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
-        const int oc_off_idx = is_ddst_layout_nxc
+        const dim_t oc_off_idx = is_ddst_layout_nxc
                 ? g * jcp.oc + ocb * jcp.oc_block
                 : g * nb_oc + ocb;
         p.bcast_data = diff_dst
@@ -596,15 +605,16 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_data_t<
     };
 
     if (jcp.loop_order == loop_lbr) {
-        int icb = icb_start;
+        dim_t icb = icb_start;
         while (icb < icb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(icb, load_step);
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, n, g, bcast_step, od, oh, ow, id, ih, iw);
-                for (int ocb = 0; ocb < nb_oc; ocb += nb_oc_blocking) {
+                for (dim_t ocb = 0; ocb < nb_oc; ocb += nb_oc_blocking) {
                     init_reduce(ocb);
                     inner_ker(icb, ocb, n, g, od, oh, ow, id, ih, iw);
                 }
@@ -652,13 +662,13 @@ jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::init(
             CHECK(tr_reorder_->create_kernel());
         }
         if (is_src_layout_nxc) {
-            int ic = pd()->jcp_.ic * pd()->jcp_.ngroups;
+            int ic = static_cast<int>(pd()->jcp_.ic * pd()->jcp_.ngroups);
             CHECK(safe_ptr_assign(tr_reorder_nhwc_src_,
                     new jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t(ic)));
             CHECK(tr_reorder_nhwc_src_->create_kernel());
         }
         if (is_ddst_layout_nxc) {
-            int oc = pd()->jcp_.oc * pd()->jcp_.ngroups;
+            int oc = static_cast<int>(pd()->jcp_.oc * pd()->jcp_.ngroups);
             CHECK(safe_ptr_assign(tr_reorder_nhwc_ddst_,
                     new jit_avx512_core_bf16_reorder_s16c_to_S16c2s_t(oc)));
             CHECK(tr_reorder_nhwc_ddst_->create_kernel());
@@ -700,7 +710,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             : nullptr;
 
     const int ndims = src_d.ndims();
-    const int wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
+    const dim_t wei_size = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block)
             * rnd_up(jcp.ic, jcp.ic_block);
     const int n_wei_buffers
             = jcp.dst_dt == data_type::bf16 ? jcp.nthr_mb : jcp.nthr_mb - 1;
@@ -715,18 +725,18 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
     // TODO (Roma): remove this restriction
     assert(jcp.stride_w == 1 && jcp.stride_h == 1);
 
-    const int nb_ic_blocking = jcp.nb_bcast_blocking;
+    const dim_t nb_ic_blocking = jcp.nb_bcast_blocking;
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_oc_blocking = jcp.nb_load_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_oc_blocking = jcp.nb_load_blocking;
 
-    const int sp_nb = jcp.nb_reduce;
-    const int mb_sp_work = jcp.mb * sp_nb;
+    const dim_t sp_nb = jcp.nb_reduce;
+    const dim_t mb_sp_work = jcp.mb * sp_nb;
 
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[0];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
@@ -735,22 +745,22 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             jcp.dst_tag, format_tag::nwc, format_tag::nhwc, format_tag::ndhwc);
 
     auto maybe_zero_icpad
-            = [= COMPAT_THIS_CAPTURE](const int g_start, const int g_end,
-                      const int ocb_start, const int ocb_end) {
+            = [= COMPAT_THIS_CAPTURE](const dim_t g_start, const dim_t g_end,
+                      const dim_t ocb_start, const dim_t ocb_end) {
         // write zeros to IC padded region.
-        const int ic_tail = jcp.ic_without_padding % jcp.ic_block;
+        const dim_t ic_tail = jcp.ic_without_padding % jcp.ic_block;
         if (ic_tail != 0) {
-            for_(int g = g_start; g < g_end; ++g)
-            for (int z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
-                const int z_icb = jcp.nb_bcast - 1;
-                const size_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t z_ocb = ocb_start; z_ocb < ocb_end; ++z_ocb) {
+                const dim_t z_icb = jcp.nb_bcast - 1;
+                const dim_t off = wht_blk_off(diff_weights_d, g, z_ocb, z_icb)
                         + ic_tail * jcp.oc_block;
                 diff_wei_data_t *z_wei = diff_weights + off;
-                const int zero_work
+                const dim_t zero_work
                         = (jcp.nb_bcast * jcp.ic_block - jcp.ic_without_padding)
                         * jcp.oc_block;
                 PRAGMA_OMP_SIMD()
-                for (int o = 0; o < zero_work; ++o) {
+                for (dim_t o = 0; o < zero_work; ++o) {
                     z_wei[o] = 0;
                 }
             }
@@ -766,13 +776,15 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* reduction dimension */
-        int mb_sp_b_start {0}, mb_sp_b_end {0};
+        dim_t mb_sp_b_start {0}, mb_sp_b_end {0};
         balance211(
                 mb_sp_work, jcp.nthr_mb, ithr_mb, mb_sp_b_start, mb_sp_b_end);
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0};
+        dim_t oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0};
+        dim_t oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
@@ -790,7 +802,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
         float *diff_bia = nullptr;
         if (jcp.with_bias) {
-            const int bias_size = jcp.ngroups * jcp.nb_load * jcp.oc_block;
+            const dim_t bias_size = jcp.ngroups * jcp.nb_load * jcp.oc_block;
             if (jcp.bia_dt == data_type::bf16) {
                 diff_bia = bia_reduction + (ithr_mb)*bias_size;
             } else {
@@ -800,42 +812,42 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
         }
 
-        int sp_b_step = 0;
-        for (int mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
+        dim_t sp_b_step = 0;
+        for (dim_t mb_sp_b = mb_sp_b_start; mb_sp_b < mb_sp_b_end;
                 mb_sp_b += sp_b_step) {
-            int img {0}, sp_b {0};
+            dim_t img {0}, sp_b {0};
             nd_iterator_init(mb_sp_b, img, jcp.mb, sp_b, sp_nb);
             sp_b_step = step(jcp.nb_reduce_blocking,
                     nstl::min(sp_nb - sp_b, mb_sp_b_end - mb_sp_b),
                     jcp.nb_reduce_blocking_max);
 
-            for (int g = g_start; g < g_end; ++g) {
-                int load_step = 0;
-                int bcast_step = 0;
-                for (int ic_b = ic_b_start; ic_b < ic_b_end;
+            for (dim_t g = g_start; g < g_end; ++g) {
+                dim_t load_step = 0;
+                dim_t bcast_step = 0;
+                for (dim_t ic_b = ic_b_start; ic_b < ic_b_end;
                         ic_b += bcast_step) {
                     bcast_step = step(nb_ic_blocking, ic_b_end - ic_b,
                             jcp.nb_bcast_blocking_max);
-                    for (int oc_b = oc_b_start; oc_b < oc_b_end;
+                    for (dim_t oc_b = oc_b_start; oc_b < oc_b_end;
                             oc_b += load_step) {
                         load_step = step(nb_oc_blocking, oc_b_end - oc_b,
                                 jcp.nb_load_blocking_max);
 
                         float *store_to;
 
-                        const size_t off
+                        const dim_t off
                                 = wht_blk_off(diff_weights_d, g, oc_b, ic_b);
                         store_to = diff_wei + off;
 
                         const bool is_src_layout_nxc
                                 = utils::one_of(jcp.src_tag, format_tag::nwc,
                                         format_tag::nhwc, format_tag::ndhwc);
-                        const int ic_off_idx = is_src_layout_nxc
+                        const dim_t ic_off_idx = is_src_layout_nxc
                                 ? g * jcp.ic + ic_b * jcp.ic_block
                                 : g * nb_oc + ic_b;
                         const src_data_t *diff_src
                                 = &src[src_d.blk_off(img, ic_off_idx)];
-                        const int oc_off_idx = is_ddst_layout_nxc
+                        const dim_t oc_off_idx = is_ddst_layout_nxc
                                 ? g * jcp.oc + oc_b * jcp.oc_block
                                 : g * nb_oc + oc_b;
                         const diff_dst_data_t *pdiff_dst
@@ -859,9 +871,8 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
                         p.reduce_dim = sp_b_step * jcp.reduce_block;
                         if (!jcp.uses_permw_transposition)
-                            p.reduce_dim = nstl::min(p.reduce_dim,
-                                    (size_t)jcp.reduce_dim
-                                            - sp_b * jcp.reduce_block);
+                            p.reduce_dim = nstl::min<size_t>(p.reduce_dim,
+                                    jcp.reduce_dim - sp_b * jcp.reduce_block);
 
                         rp.os = p.reduce_dim;
 
@@ -870,17 +881,18 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                                             : 0)
                                 | (ic_b == 0 ? FLAG_COMPUTE_BIAS : 0);
 
-                        int sp = sp_b * jcp.reduce_block;
-                        int oc_mult = is_ddst_layout_nxc ? jcp.ngroups * jcp.oc
-                                                         : jcp.oc_block;
+                        dim_t sp = sp_b * jcp.reduce_block;
+                        dim_t oc_mult = is_ddst_layout_nxc
+                                ? jcp.ngroups * jcp.oc
+                                : jcp.oc_block;
                         p.load_data = pdiff_dst + sp * oc_mult;
 
                         if (pd()->rtus_.reduce_src_) {
-                            const int oh = sp / jcp.ow;
-                            const int ow = sp % jcp.ow;
+                            const dim_t oh = sp / jcp.ow;
+                            const dim_t ow = sp % jcp.ow;
 
-                            const int ih = oh * stride_h;
-                            const int iw = ow * stride_w;
+                            const dim_t ih = oh * stride_h;
+                            const dim_t iw = ow * stride_w;
                             rp.iw_start = iw;
 
                             rp.ws = rtus_space
@@ -898,7 +910,7 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
                             p.bcast_data = rp.ws;
                         } else {
-                            int ic_mult = is_src_layout_nxc
+                            dim_t ic_mult = is_src_layout_nxc
                                     ? jcp.ngroups * jcp.ic
                                     : jcp.ic_block;
                             p.bcast_data = local_src + sp * ic_mult;
@@ -906,22 +918,23 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                         if (!jcp.uses_permw_transposition) {
                             bf16_support::jit_call_t ptr;
                             ptr.nelems = p.reduce_dim;
-                            int thr_src_block_size = rnd_up(jcp.reduce_dim, 2)
+                            dim_t thr_src_block_size = rnd_up(jcp.reduce_dim, 2)
                                     * jcp.ic_block * jcp.nb_bcast_blocking_max;
                             src_data_t *tr_src
                                     = &tr_src_buffer[ithr * thr_src_block_size];
-                            for (int bs = 0; bs < bcast_step; bs++) {
-                                size_t src_off = bs * jcp.ic_block
+                            for (dim_t bs = 0; bs < bcast_step; bs++) {
+                                dim_t src_off = bs * jcp.ic_block
                                         * (is_src_layout_nxc ? 1
                                                              : jcp.reduce_dim);
-                                size_t src_tr_off = bs
+                                dim_t src_tr_off = bs
                                         * rnd_up(jcp.reduce_dim, 2)
                                         * jcp.ic_block;
                                 src_data_t *curr_inp = &(
                                         (src_data_t *)p.bcast_data)[src_off];
                                 src_data_t *curr_out = &tr_src[src_tr_off];
-                                int ch_work = nstl::min<int>(
-                                        p.bcast_dim - bs * jcp.bcast_block, 16);
+                                int ch_work = static_cast<int>(nstl::min<dim_t>(
+                                        p.bcast_dim - bs * jcp.bcast_block,
+                                        16));
                                 assert(ch_work <= 16);
                                 ptr.mask = (1 << ch_work) - 1;
                                 ptr.inp = (void *)curr_inp;
@@ -933,14 +946,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                             }
 
                             p.bcast_data = (void *)tr_src;
-                            int thr_dst_block_size = rnd_up(jcp.reduce_dim, 2)
+                            dim_t thr_dst_block_size = rnd_up(jcp.reduce_dim, 2)
                                     * jcp.oc_block * jcp.nb_load_blocking_max;
                             diff_dst_data_t *tr_diff_dst = &tr_diff_buffer[ithr
                                     * thr_dst_block_size];
-                            for (int ls = 0; ls < load_step; ls++) {
-                                size_t ddst_off = ls * jcp.oc_block
+                            for (dim_t ls = 0; ls < load_step; ls++) {
+                                dim_t ddst_off = ls * jcp.oc_block
                                         * (is_ddst_layout_nxc ? 1 : jcp.os);
-                                size_t ddst_tr_off = ls
+                                dim_t ddst_tr_off = ls
                                         * rnd_up(jcp.reduce_dim, 2)
                                         * jcp.oc_block;
                                 diff_dst_data_t *curr_inp
@@ -948,8 +961,8 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                                         p.load_data)[ddst_off];
                                 diff_dst_data_t *curr_out
                                         = &tr_diff_dst[ddst_tr_off];
-                                int ch_work = nstl::min<int>(
-                                        p.load_dim - ls * jcp.load_block, 16);
+                                int ch_work = static_cast<int>(nstl::min<dim_t>(
+                                        p.load_dim - ls * jcp.load_block, 16));
                                 ptr.mask = (1 << ch_work) - 1;
                                 ptr.inp = (void *)curr_inp;
                                 ptr.out = (void *)curr_out;
@@ -983,17 +996,17 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         const int ithr_mb = ithr / jcp.nthr_ic_b / jcp.nthr_oc_b / jcp.nthr_g;
 
         /* independent dimensions */
-        int g_start {0}, oc_b_start {0}, ic_b_start {0};
-        int g_end {0}, oc_b_end {0}, ic_b_end {0};
+        dim_t g_start {0}, oc_b_start {0}, ic_b_start {0};
+        dim_t g_end {0}, oc_b_end {0}, ic_b_end {0};
 
         balance211(jcp.ngroups, jcp.nthr_g, ithr_g, g_start, g_end);
         balance211(jcp.nb_load, jcp.nthr_oc_b, ithr_oc_b, oc_b_start, oc_b_end);
         balance211(
                 jcp.nb_bcast, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
 
-        const int g_work = g_end - g_start;
-        const int oc_b_work = oc_b_end - oc_b_start;
-        const int ic_b_work = ic_b_end - ic_b_start;
+        const dim_t g_work = g_end - g_start;
+        const dim_t oc_b_work = oc_b_end - oc_b_start;
+        const dim_t ic_b_work = ic_b_end - ic_b_start;
 
         const int _start_nthr_mb = 1;
         const bool is_bf16_out = diff_weights_type == data_type::bf16;
@@ -1003,24 +1016,25 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
         if (jcp.nthr_mb > _start_nthr_mb) {
             if (dnnl_thr_syncable())
                 simple_barrier::barrier(reduction_barrier, jcp.nthr);
-            const int work = g_work * oc_b_work * ic_b_work;
-            int start {0}, end {0};
+            const dim_t work = g_work * oc_b_work * ic_b_work;
+            dim_t start {0}, end {0};
             balance211(work, jcp.nthr_mb, ithr_mb, start, end);
             if (start == end) return;
 
             for (int thr_mb = _start_nthr_mb; thr_mb < jcp.nthr_mb; ++thr_mb) {
-                int w = start;
-                int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
+                dim_t w = start;
+                dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_start {0};
                 nd_iterator_init(w, sub_g_start, g_work, sub_oc_b_start,
                         oc_b_work, sub_ic_b_start, ic_b_work);
                 while (w < end) {
-                    const int g = g_start + sub_g_start;
-                    const int oc_b = oc_b_start + sub_oc_b_start;
-                    const int ic_b = ic_b_start + sub_ic_b_start;
-                    const int ic_to_accumulate
-                            = nstl::min(end - w, ic_b_work - sub_ic_b_start)
+                    const dim_t g = g_start + sub_g_start;
+                    const dim_t oc_b = oc_b_start + sub_oc_b_start;
+                    const dim_t ic_b = ic_b_start + sub_ic_b_start;
+                    const dim_t ic_to_accumulate
+                            = nstl::min<dim_t>(
+                                      end - w, ic_b_work - sub_ic_b_start)
                             * jcp.ic_block;
-                    const int acc_size
+                    const size_t acc_size
                             = this_block_size(ic_b * jcp.ic_block,
                                       jcp.ic_without_padding, ic_to_accumulate)
                             * jcp.oc_block;
@@ -1051,12 +1065,12 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
 
                 if (jcp.with_bias && ithr_ic_b == 0 && ic_b_work > 0
                         && ithr_mb == 0) {
-                    for (int g = g_start; g < g_end; g++) {
+                    for (dim_t g = g_start; g < g_end; g++) {
                         float *bias_reduced
                                 = is_bf16_bias ? bia_reduction : diff_bias;
                         int thr_mb_buffer_idx
                                 = is_bf16_bias ? thr_mb : thr_mb - 1;
-                        int bias_buf_size
+                        dim_t bias_buf_size
                                 = jcp.ngroups * rnd_up(jcp.oc, jcp.oc_block);
                         float *bias_to_reduce = bia_reduction
                                 + thr_mb_buffer_idx * bias_buf_size;
@@ -1064,12 +1078,12 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
                                 = this_block_size(oc_b_start * jcp.oc_block,
                                         jcp.oc_without_padding,
                                         (oc_b_end - oc_b_start) * jcp.oc_block);
-                        int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                        dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                                 + oc_b_start * jcp.oc_block;
                         if (is_bf16_bias && thr_mb == jcp.nthr_mb - 1) {
                             // the last iteration for bfloat16 requires conversion and
                             // store to diff_weights array
-                            int diff_bias_idx = g * jcp.oc_without_padding
+                            dim_t diff_bias_idx = g * jcp.oc_without_padding
                                     + oc_b_start * jcp.oc_block;
                             bfloat16_t *diff_bias_result
                                     = CTX_OUT_MEM(
@@ -1087,10 +1101,11 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
         } else {
             if (is_bf16_out) {
-                const auto ic_work = nstl::min(jcp.ic, ic_b_end * jcp.ic_block)
+                const dim_t ic_work
+                        = nstl::min<dim_t>(jcp.ic, ic_b_end * jcp.ic_block)
                         - ic_b_start * jcp.ic_block;
-                for_(int g = g_start; g < g_end; g++)
-                for (int oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
+                for_(dim_t g = g_start; g < g_end; g++)
+                for (dim_t oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
                     const size_t acc_size = (size_t)ic_work * jcp.oc_block;
                     const size_t off
                             = wht_blk_off(diff_weights_d, g, oc_b, ic_b_start);
@@ -1101,13 +1116,14 @@ void jit_avx512_core_bf16_1x1_convolution_bwd_weights_t<diff_weights_type>::
             }
 
             if (is_bf16_bias && ithr_ic_b == 0 && ic_b_work > 0) {
-                for (int g = g_start; g < g_end; g++) {
-                    int result_start_idx = g * jcp.oc_without_padding
+                for (dim_t g = g_start; g < g_end; g++) {
+                    dim_t result_start_idx = g * jcp.oc_without_padding
                             + oc_b_start * jcp.oc_block;
-                    int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                    dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                             + oc_b_start * jcp.oc_block;
-                    const size_t acc_size = nstl::min(jcp.oc_without_padding,
-                                                    oc_b_end * jcp.oc_block)
+                    const size_t acc_size
+                            = nstl::min<dim_t>(jcp.oc_without_padding,
+                                      oc_b_end * jcp.oc_block)
                             - oc_b_start * jcp.oc_block;
                     bfloat16_t *diff_bias_result
                             = CTX_OUT_MEM(bfloat16_t *, DNNL_ARG_DIFF_BIAS)

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_convolution.hpp
@@ -300,8 +300,8 @@ struct jit_avx512_core_bf16_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw->nb_ch_blocking != 0)
                 --jcp_dw->nb_ch_blocking;
 
-            jcp_dw->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
 
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -89,8 +89,8 @@ inline bool is_iw_threading_on(const jit_conv_conf_t &jcp) {
 }
 inline bool is_1stconv(const jit_conv_conf_t &jcp) {
     const bool no_big_offt = nstl::max<size_t>(jcp.ic, jcp.oc)
-                    * nstl::max(jcp.typesize_in, jcp.typesize_out) * jcp.id
-                    * jcp.ih * jcp.iw
+                    * nstl::max<dim_t>(jcp.typesize_in, jcp.typesize_out)
+                    * jcp.id * jcp.ih * jcp.iw
             < INT_MAX;
     return jcp.ic < 16 && jcp.ngroups == 1 && no_big_offt;
 }
@@ -201,7 +201,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w) {
             if (mask_tail || oc_blk_is_smaller_than_vmm) {
                 Label postops_no_tail;
                 if (mask_tail) {
-                    test(byte[param1 + GET_OFF(load_work)], jcp.oc_block - 1);
+                    test(byte[param1 + GET_OFF(load_work)],
+                            static_cast<uint32_t>(jcp.oc_block - 1));
                     jz(postops_no_tail, T_NEAR);
                 }
                 postops_injector_->compute_vector_range(
@@ -253,7 +254,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::store_dst(int ur_w) {
     if (jcp.with_bias) {
         mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
         for (int k = 0; k < jcp.nb_oc_blocking; k++) {
-            int bias_offset = jcp.typesize_bia * k * jcp.oc_block;
+            dim_t bias_offset = jcp.typesize_bia * k * jcp.oc_block;
             for (int j = 0; j < ur_w; j++) {
                 // mask only needed for last oc_block
                 bool mask_flag = oc_tail && k + 1 == jcp.nb_oc_blocking;
@@ -361,7 +362,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::store_dst(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int pad_l, int pad_r) {
+        int ur_w, dim_t pad_l, dim_t pad_r) {
     Label kh_label, kd_label;
     const int ic_tail = jcp.ic_tail;
     const int ic_step = 2;
@@ -378,12 +379,12 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     dim_t max_src_offset = 0;
     if (jcp.is_1stconv || ic_tail) {
         for (int ki = 0; ki < jcp.kw; ki++) {
-            int ow_fst = get_ow_start(ki, pad_l);
-            int ow_last = get_ow_end(ur_w, ki, pad_r) - 1;
+            dim_t ow_fst = get_ow_start(ki, pad_l);
+            dim_t ow_last = get_ow_end(ur_w, ki, pad_r) - 1;
             if (ow_fst > ow_last) continue;
-            int ic_last = rnd_up(nstl::min(jcp.ic_block,
-                                         nstl::max(jcp.ic, ic_tail)),
-                                  ic_step)
+            dim_t ic_last = rnd_up(nstl::min<dim_t>(jcp.ic_block,
+                                           nstl::max<dim_t>(jcp.ic, ic_tail)),
+                                    ic_step)
                     - ic_step;
 
             dim_t src_offset = get_src_offset(
@@ -399,7 +400,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
         mov(reg_kj, ptr[param1 + GET_OFF(kd_padding)]);
         if ((jcp.dilate_d >= jcp.id)
                 || (jcp.kd - 1) * (jcp.dilate_d + 1)
-                        < nstl::max(jcp.f_pad, jcp.back_pad)) {
+                        < nstl::max<dim_t>(jcp.f_pad, jcp.back_pad)) {
             cmp(reg_kj, 0);
             je(skip_compute_loop, T_NEAR);
         }
@@ -407,7 +408,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     mov(reg_kj, reg_kh);
     if ((jcp.dilate_h >= jcp.ih)
             || (jcp.kh - 1) * (jcp.dilate_h + 1)
-                    < nstl::max(jcp.t_pad, jcp.b_pad)) {
+                    < nstl::max<dim_t>(jcp.t_pad, jcp.b_pad)) {
         cmp(reg_kj, 0);
         je(skip_compute_loop, T_NEAR);
     }
@@ -434,20 +435,21 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
     L(kh_label);
     {
         for (int ki = 0; ki < jcp.kw; ki++) {
-            int ow_start = get_ow_start(ki, pad_l);
-            int ow_end = get_ow_end(ur_w, ki, pad_r);
-            for (int ic = 0;
-                    ic < rnd_up(nstl::min(jcp.ic_block, jcp.ic), ic_step);
+            dim_t ow_start = get_ow_start(ki, pad_l);
+            dim_t ow_end = get_ow_end(ur_w, ki, pad_r);
+            for (int ic = 0; ic
+                    < rnd_up(nstl::min<dim_t>(jcp.ic_block, jcp.ic), ic_step);
                     ic += ic_step) {
                 if (ic_tail && ic == rnd_up(ic_tail, ic_step)) {
                     // insert this check at most once per icb, no more.
                     cmp(reg_ic, ic_tail);
                     je(ic_tail_jmp[ki], T_NEAR);
                 }
-                for (int oi = ow_start; oi < ow_end; oi++) {
+                for (dim_t oi = ow_start; oi < ow_end; oi++) {
                     dim_t src_offset = get_src_offset(
                             ic, filter_w_to_src(ki, oi, pad_l));
-                    auto vmm_in = vmm_src(oi, jcp.nb_oc_blocking);
+                    auto vmm_in
+                            = vmm_src(static_cast<int>(oi), jcp.nb_oc_blocking);
                     const auto addr_base = EVEX_compress_addr_safe(
                             aux_reg_src, src_offset, reg_long_offt);
                     const bool tail_load
@@ -522,9 +524,10 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
                     vmovups(vmm_wei,
                             EVEX_compress_addr_safe(
                                     aux_reg_ker, wei_off, reg_long_offt));
-                    for (int oi = ow_start; oi < ow_end; oi++) {
-                        auto acc = vmm_dst(oi, kk);
-                        auto src = vmm_src(oi, jcp.nb_oc_blocking);
+                    for (dim_t oi = ow_start; oi < ow_end; oi++) {
+                        auto acc = vmm_dst(static_cast<int>(oi), kk);
+                        auto src = vmm_src(
+                                static_cast<int>(oi), jcp.nb_oc_blocking);
                         if (isa_has_bf16(jcp.isa)) {
                             vdpbf16ps(acc, vmm_wei, src);
                         } else
@@ -557,7 +560,7 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
     // End of IC Loop
     dim_t src_step = get_src_offset(jcp.ic_block, 0);
-    const size_t ker_step = get_kernel_offset(0, jcp.ic_block, 0);
+    const dim_t ker_step = get_kernel_offset(0, jcp.ic_block, 0);
     safe_add(reg_src, src_step, reg_long_offt);
     safe_add(reg_ker, ker_step, reg_long_offt);
 
@@ -574,15 +577,15 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int ow_block = jcp.ow_block;
-    int nb_ow = jcp.nb_ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    dim_t iw = jcp.iw;
+    dim_t ow = jcp.ow;
+    int ow_block = static_cast<int>(jcp.ow_block);
+    dim_t nb_ow = jcp.nb_ow;
+    dim_t kw = jcp.kw;
+    dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    dim_t stride_w = jcp.stride_w;
 
     auto src_shift = get_src_offset(0, filter_w_to_src(0, ur_w));
     auto dst_shift = get_dst_offset(ur_w, 0);
@@ -624,7 +627,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
             kxnord(k_oc_tail_mask_extended, k_oc_tail_mask_extended,
                     k_oc_tail_mask_extended);
 
-        test(byte[param1 + GET_OFF(load_work)], jcp.oc_block - 1);
+        test(byte[param1 + GET_OFF(load_work)],
+                static_cast<uint32_t>(jcp.oc_block - 1));
         jz(done, T_NEAR);
         auto reg_tail_32 = reg_oc.cvt32();
         mov(reg_tail_32, (1 << jcp.oc_tail) - 1);
@@ -654,9 +658,9 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
     mov(reg_ker, ptr[param1 + GET_OFF(filt)]);
     mov(reg_kh, ptr[param1 + GET_OFF(kh_padding)]);
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
+    dim_t r_pad = nstl::max<dim_t>(0, jcp.r_pad);
+    dim_t n_oi = ow / ur_w;
+    dim_t r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
             calculate_extended_filter_size(kw, jcp.dilate_w));
 
     if (!is_ow_threading_on(jcp)) {
@@ -716,7 +720,8 @@ void jit_avx512_core_bf16_fwd_kernel_vmm_t<Vmm>::generate() {
         int n_oi_next_last_ow_block = n_oi_not_last_ow_block;
         int n_oi_first_ow_block = n_oi_not_last_ow_block;
 
-        int n_oi_last_ow_block = (ow - ow_block * (nb_ow - 1)) / ur_w;
+        int n_oi_last_ow_block
+                = static_cast<int>((ow - ow_block * (nb_ow - 1)) / ur_w);
 
         // prepare right padding
         bool next_last_ow_block_padded = r_pad1 > 0 && n_oi_last_ow_block == 0;
@@ -881,15 +886,19 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.with_bias = cd.bias_desc.format_kind != format_kind::undef;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1056,7 +1065,7 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_ic_blocking = jcp.nb_oc_blocking = 1;
 
     jcp.kernel_kind = expl_bcast;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--) {
         int ur_w = regs / (jcp.nb_oc_blocking + 1);
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
@@ -1066,27 +1075,27 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     }
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     jcp.ow_block = jcp.ow;
     if (is_ow_threading_available(jcp)) {
         const int L1_part = platform::get_per_core_cache_size(1) * 5 / 8;
-        int size_src_chunk = jcp.typesize_in * jcp.ic_block * jcp.ur_w;
-        int size_dst_chunk = jcp.typesize_out * jcp.oc_block
+        dim_t size_src_chunk = jcp.typesize_in * jcp.ic_block * jcp.ur_w;
+        dim_t size_dst_chunk = jcp.typesize_out * jcp.oc_block
                 * jcp.nb_oc_blocking * jcp.ur_w;
-        int size_wei_chunk = jcp.typesize_in * jcp.oc_block * jcp.ic_block
+        dim_t size_wei_chunk = jcp.typesize_in * jcp.oc_block * jcp.ic_block
                 * jcp.nb_oc_blocking * jcp.kw;
-        int nurw = (L1_part - size_wei_chunk)
+        dim_t nurw = (L1_part - size_wei_chunk)
                 / (size_dst_chunk + size_src_chunk);
         // current design of generate() requires ow_block >= 2 * ur_w
-        jcp.ow_block = jcp.ur_w * nstl::max(2, nurw);
+        jcp.ow_block = jcp.ur_w * nstl::max<dim_t>(2, nurw);
     }
     jcp.nb_ow = div_up(jcp.ow, jcp.ow_block);
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(!(jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w),
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -1106,10 +1115,11 @@ status_t jit_avx512_core_bf16_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     size_t total_size = jcp.ngroups * (wei_size + inp_size + out_size);
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
-    // The factor for 1d=1, 2d=2, 3d=4;
+    // The factor for 1d=1, 2d=2, 3d=4; a small fixed code-generation
+    // constant, not a tensor-scale value.
     int factor = nstl::max(1, (2 * (ndims - 3)));
     if (jcp.ngroups < jcp.nthr && total_size < L1_cache_size / factor) {
-        jcp.nthr = nstl::min(jcp.nthr, 4);
+        jcp.nthr = static_cast<int>(nstl::min<dim_t>(jcp.nthr, 4));
     }
 
     pick_loop_order(jcp);
@@ -1235,11 +1245,11 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::store_output(int ur_w) {
 
 template <typename Vmm>
 void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
-        int ur_w, int l_overflow, int r_overflow) {
-    int kw = jcp.kw;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
-    int stride_h = jcp.stride_h;
+        int ur_w, dim_t l_overflow, dim_t r_overflow) {
+    dim_t kw = jcp.kw;
+    dim_t dilate_w = jcp.dilate_w + 1;
+    dim_t stride_w = jcp.stride_w;
+    dim_t stride_h = jcp.stride_h;
     const int oc_tail = jcp.oc_tail;
     Label kh_label, skip_compute_label;
 
@@ -1279,29 +1289,29 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
     L(kh_label);
     {
         for (int ki = 0; ki < kw; ki++) {
-            int jj_start = get_iw_start(ki, l_overflow);
-            int jj_end = get_iw_end(ur_w, ki, r_overflow);
-            const int ref_jj_start
-                    = nstl::max(0, l_overflow - (kw - 1 - ki) * dilate_w);
-            const int ref_jj_end
-                    = ur_w - nstl::max(0, r_overflow - ki * dilate_w);
+            dim_t jj_start = get_iw_start(ki, l_overflow);
+            dim_t jj_end = get_iw_end(ur_w, ki, r_overflow);
+            const dim_t ref_jj_start = nstl::max<dim_t>(
+                    0, l_overflow - (kw - 1 - ki) * dilate_w);
+            const dim_t ref_jj_end
+                    = ur_w - nstl::max<dim_t>(0, r_overflow - ki * dilate_w);
             assert(IMPLICATION(stride_w == 1,
                     jj_start == ref_jj_start && jj_end == ref_jj_end));
             UNUSED(ref_jj_start);
             UNUSED(ref_jj_end);
             const int oc_step = 2;
-            for (int oc = 0;
-                    oc < rnd_up(nstl::min(jcp.oc_block, jcp.oc), oc_step);
+            for (int oc = 0; oc
+                    < rnd_up(nstl::min<dim_t>(jcp.oc_block, jcp.oc), oc_step);
                     oc += oc_step) {
                 if (oc_tail && oc == rnd_up(oc_tail, oc_step)) {
                     cmp(reg_oc, oc_tail);
                     je(oc_tail_jmp[ki], T_NEAR);
                 }
-                for (int jj = jj_start; jj < jj_end; jj += stride_w) {
+                for (dim_t jj = jj_start; jj < jj_end; jj += stride_w) {
                     assert((jj + jcp.l_pad - ki * dilate_w) % stride_w == 0);
-                    int ow_idx = (jj + jcp.l_pad - ki * dilate_w) / stride_w;
+                    dim_t ow_idx = (jj + jcp.l_pad - ki * dilate_w) / stride_w;
                     auto aux_ddst_offset = get_diff_dst_offset(ow_idx, oc);
-                    auto ddst = vmm_ddst(jj / stride_w);
+                    auto ddst = vmm_ddst(static_cast<int>(jj / stride_w));
                     const bool tail_load = oc_tail && oc == rnd_dn(oc_tail, 2);
                     const bool need_single_load = oc + 1 == oc_tail;
 
@@ -1325,9 +1335,9 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
                     vmovups(vmm_wei,
                             EVEX_compress_addr(aux_reg_ker, aux_kernel_offset));
 
-                    for (int jj = jj_start; jj < jj_end; jj += stride_w) {
-                        auto ddst = vmm_ddst(jj / stride_w);
-                        auto acc = vmm_dsrc(jj, kk);
+                    for (dim_t jj = jj_start; jj < jj_end; jj += stride_w) {
+                        auto ddst = vmm_ddst(static_cast<int>(jj / stride_w));
+                        auto acc = vmm_dsrc(static_cast<int>(jj), kk);
 
                         if (isa_has_bf16(jcp.isa)) {
                             vdpbf16ps(acc, vmm_wei, ddst);
@@ -1376,14 +1386,14 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::compute_loop(
 
 template <typename Vmm>
 void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
-    int iw = jcp.iw;
-    int kw = jcp.kw;
+    const dim_t iw = jcp.iw;
+    const int kw = static_cast<int>(jcp.kw);
     int ur_w = jcp.ur_w;
-    int nb_iw = jcp.nb_iw;
-    int iw_block = jcp.iw_block;
+    dim_t nb_iw = jcp.nb_iw;
+    int iw_block = static_cast<int>(jcp.iw_block);
     int ur_w_tail = jcp.ur_w_tail;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dst_shift = get_diff_dst_offset(ur_w / stride_w, 0);
     const auto src_shift = get_diff_src_offset(ur_w, 0);
@@ -1409,7 +1419,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
             kxnord(k_ic_tail_mask_extended, k_ic_tail_mask_extended,
                     k_ic_tail_mask_extended);
 
-        test(byte[param1 + GET_OFF(load_work)], jcp.ic_block - 1);
+        test(byte[param1 + GET_OFF(load_work)],
+                static_cast<uint32_t>(jcp.ic_block - 1));
         jz(done, T_NEAR);
         Reg32 reg_tail_32 = reg_ic.cvt32();
         mov(reg_tail_32, (1 << jcp.ic_tail) - 1);
@@ -1427,15 +1438,16 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
 
     mov(reg_kh, ptr[param + GET_OFF(kh_padding)]);
 
-    int l_overflow = nstl::max(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
-    int r_overflow = nstl::max(
-            0, ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad)) / stride_w);
-    int r_overflow1 = nstl::max(0,
-            ((kw - 1) * dilate_w - nstl::max(0, jcp.r_pad + ur_w_tail))
+    dim_t l_overflow
+            = nstl::max<dim_t>(0, ((kw - 1) * dilate_w - jcp.l_pad) / stride_w);
+    dim_t r_overflow = nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad)) / stride_w);
+    dim_t r_overflow1 = nstl::max<dim_t>(0,
+            ((kw - 1) * dilate_w - nstl::max<dim_t>(0, jcp.r_pad + ur_w_tail))
                     / stride_w);
 
     int body_l_overflow = 0, body_r_overflow = 0;
-    int n_oi = iw / ur_w;
+    int n_oi = static_cast<int>(iw / ur_w);
     int head_n_oi = 0, body_n_oi = 0, pretail_n_oi = 0, tail_n_oi = 0;
     int head_thread = 0, pretail_thread = 0, tail_thread = 0;
     bool threaded = is_iw_threading_on(jcp);
@@ -1447,8 +1459,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
     if (n_oi < 0) {
         // l_overflow and r_overflow1 are handled in the same compute_loop.
         // Perform one iteration of body handling l_overflow and r_overflow1.
-        body_l_overflow = l_overflow;
-        body_r_overflow = r_overflow1;
+        body_l_overflow = static_cast<int>(l_overflow);
+        body_r_overflow = static_cast<int>(r_overflow1);
         n_oi = 1;
         l_overflow = 0;
         r_overflow1 = 0;
@@ -1460,12 +1472,12 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
         // Setup for threaded code generation, and jump into the correct
         // portion of code for execution.
         head_thread = 0;
-        tail_thread = nb_iw - 1;
+        tail_thread = static_cast<int>(nb_iw - 1);
         pretail_thread = tail_thread;
 
         int base_n_oi = iw_block / ur_w;
         head_n_oi = l_overflow > 0 ? base_n_oi - 1 : base_n_oi;
-        tail_n_oi = (iw - iw_block * (nb_iw - 1)) / ur_w;
+        tail_n_oi = static_cast<int>((iw - iw_block * (nb_iw - 1)) / ur_w);
         pretail_n_oi = tail_n_oi;
         if (r_overflow1 > 0) {
             if (tail_n_oi > 0) {
@@ -1487,8 +1499,8 @@ void jit_avx512_core_bf16_bwd_data_kernel_vmm_t<Vmm>::generate() {
         // n_oi is used to determine how much control flow in the body portion
         // of the code needs generated. As such, n_oi needs to be set to the
         // maximum number of iterations it will be used the body code section.
-        n_oi = nstl::max(body_n_oi, head_n_oi);
-        n_oi = nstl::max(n_oi, pretail_n_oi);
+        n_oi = static_cast<int>(nstl::max<dim_t>(body_n_oi, head_n_oi));
+        n_oi = static_cast<int>(nstl::max<dim_t>(n_oi, pretail_n_oi));
 
         assert(iw_block % ur_w == 0);
         mov(reg_iwb, ptr[param1 + GET_OFF(iwb)]);
@@ -1625,9 +1637,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(dilate_ok, VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride > 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1740,7 +1752,7 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ur_w = jcp.stride_w;
+    jcp.ur_w = static_cast<int>(jcp.stride_w);
 
     /* Maximum number of registers available for result accumulation and delta
        dst data. One additional register is reserved for weights data. */
@@ -1748,11 +1760,13 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
             = isa_has_bf16(jcp.isa) ? 31 : 26; /* In case of cpx emulation
                                                   additional 5 registers are
                                                   reserved */
-    int l_overflow = nstl::max(
+    const dim_t l_overflow = nstl::max<dim_t>(
             0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
 
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
 
     /* Find the best blocking with maximum number of compute instructions
        per ur_w * nb_ic_blocking compute loops. Number of required registers
@@ -1769,10 +1783,10 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
         for (int b = 1; b <= max_ic_blocks; b++) {
             if (jcp.nb_ic % b != 0) continue;
 
-            for (int u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
+            for (dim_t u = jcp.stride_w; u * b + u / jcp.stride_w <= max_regs
                     && u < jcp.iw + jcp.stride_w;
                     u += jcp.stride_w) {
-                int ur_w = nstl::min(u, jcp.iw);
+                const int ur_w = static_cast<int>(nstl::min<dim_t>(u, jcp.iw));
                 /* maximum 1 step with l_overflow so far */
                 if (l_overflow * jcp.stride_w > ur_w && ur_w != jcp.iw)
                     continue;
@@ -1792,23 +1806,24 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.ur_w_tail = jcp.iw % jcp.ur_w;
 
     if (is_iw_threading_available(jcp)) {
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
-        int work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih;
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih;
 
         auto efficiency = [](dim_t size, dim_t block) {
             // avoid msvc warning 'potential divide by zero'
             if (size <= 0 || block == 0) return 0.f;
-            return (float)size / rnd_up(size, block);
+            return (float)size / (float)rnd_up(size, block);
         };
 
         float no_iw_block_eff = efficiency(work_units, jcp.nthr);
 
         // current design of generate() requires iw_block >= 2 * ur_w
         const int min_iw_block = jcp.ur_w * 2;
-        int iw_threads = jcp.nthr / math::gcd(work_units, jcp.nthr);
-        int iw_block = nstl::max(min_iw_block,
-                rnd_up(jcp.iw, jcp.ur_w * iw_threads) / iw_threads);
-        int nb_iw = div_up(jcp.iw, iw_block);
+        int iw_threads
+                = jcp.nthr / math::gcd(static_cast<int>(work_units), jcp.nthr);
+        int iw_block = static_cast<int>(nstl::max<dim_t>(min_iw_block,
+                rnd_up(jcp.iw, jcp.ur_w * iw_threads) / iw_threads));
+        const int nb_iw = static_cast<int>(div_up(jcp.iw, iw_block));
 
         float block_eff = efficiency(jcp.iw, iw_block);
         work_units = jcp.ngroups * jcp.mb * ic_chunks * jcp.ih * nb_iw;
@@ -1817,7 +1832,8 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
         const int iw_thread_min_size = 16 * 128;
         const float iw_block_cost = 20.0;
-        float block_overhead = nstl::max(0.0f, 1.0f - iw_block_cost / iw_block);
+        float block_overhead
+                = nstl::max(0.0f, 1.0f - iw_block_cost / (float)iw_block);
 
         bool iw_thread_useful = no_iw_block_eff < block_overhead * iw_block_eff
                 && jcp.ic_block * jcp.iw > iw_thread_min_size;
@@ -1831,9 +1847,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     VDISPATCH_CONV_IC(l_overflow * jcp.stride_w <= jcp.ur_w,
             VERBOSE_BLOCKING_FAIL, "failing boundary conditions");
 
-    int r_overflow_no_tail = nstl::max(0,
+    const dim_t r_overflow_no_tail = nstl::max<dim_t>(0,
             ((jcp.kw - 1) * (jcp.dilate_w + 1)
-                    - nstl::max(0, jcp.r_pad + jcp.ur_w_tail))
+                    - nstl::max<dim_t>(0, jcp.r_pad + jcp.ur_w_tail))
                     / jcp.stride_w);
     bool tails_not_ok = false
             /* maximum 1 ur_w block with r_overflow so far */
@@ -1860,9 +1876,9 @@ status_t jit_avx512_core_bf16_bwd_data_kernel_t::init_conf(jit_conv_conf_t &jcp,
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
     //The factor for 1d: 1, 2d: 2, 3d: 4;
-    int factor = nstl::max(1, (2 * (ndims - 3)));
+    const int factor = static_cast<int>(nstl::max<dim_t>(1, 2 * (ndims - 3)));
     if (jcp.ngroups < jcp.nthr && total_size < L1_cache_size / factor) {
-        jcp.nthr = nstl::min(jcp.nthr, 4);
+        jcp.nthr = static_cast<int>(nstl::min<dim_t>(jcp.nthr, 4));
     }
 
     pick_loop_order(jcp);
@@ -1901,18 +1917,18 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_extern(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_extern(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!is_src_layout_nxc() && !is_ddst_layout_nxc());
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     bool no_src_pad = jcp.is_1stconv && !jcp.transpose_src;
     static constexpr int ddst_zmm_base_idx = 24;
     const int num_ddst_zmm_regs = !isa_has_bf16(jcp.isa) ? 2 : 4;
     const int zmm_src_reg = ddst_zmm_base_idx + num_ddst_zmm_regs;
 
-    auto zmm_ker = [ic_block_step](int i_kw, int i_ic) {
-        return Zmm(i_kw * ic_block_step + i_ic);
+    auto zmm_ker = [ic_block_step](dim_t i_kw, dim_t i_ic) {
+        return Zmm(static_cast<int>(i_kw * ic_block_step + i_ic));
     };
     auto zmm_ddst = [num_ddst_zmm_regs](int i_iw) {
         // TODO: move reg calc to global member funcs
@@ -1924,8 +1940,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         return EVEX_compress_addr(reg_kernel, local_offset + kernel_offset);
     };
     auto src_addr
-            = [this, src_offset](int i_iw, int i_ic, ptrdiff_t extra_offset = 0,
-                      bool vnni_bcast = false) {
+            = [this, src_offset](dim_t i_iw, int i_ic,
+                      ptrdiff_t extra_offset = 0, bool vnni_bcast = false) {
         auto local_offset = get_src_offset(i_ic, i_iw);
         return EVEX_compress_addr(
                 reg_src, local_offset + src_offset + extra_offset, vnni_bcast);
@@ -1944,22 +1960,23 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     assert(ur_w % 2 == 0);
     auto steps = ur_w / 2;
 
-    const int str_w = jcp.stride_w;
+    const dim_t str_w = jcp.stride_w;
     const int underflow_boundary = -1;
-    int i_iw_shift = jcp.tr_ow - ur_w - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
-    const int overflow_boundary = jcp.iw - 1 - i_iw_shift;
+    const dim_t i_iw_shift
+            = jcp.tr_ow - ur_w - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
+    const dim_t overflow_boundary = jcp.iw - 1 - i_iw_shift;
 
     for (int s = 0; s < str_w; s++) {
         const int kw_start = s;
         assert(jcp.tr_iw % str_w == 0);
-        const int src_stride_w_shift = jcp.tr_iw / str_w;
+        const int src_stride_w_shift = static_cast<int>(jcp.tr_iw / str_w);
         for (int i_ur = 0; i_ur < steps; i_ur++) {
             auto zmm = zmm_ddst(i_ur);
             vmovdqu16(zmm, ddst_addr(i_ur));
 
             for (int i_kw = kw_start; i_kw < kw; i_kw += str_w) {
                 for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
-                    int i_iw = 2 * i_ur + (i_kw * (jcp.dilate_w + 1)) / str_w
+                    dim_t i_iw = 2 * i_ur + (i_kw * (jcp.dilate_w + 1)) / str_w
                             + s * src_stride_w_shift;
                     bool underflow = false;
                     bool overflow = false;
@@ -2013,7 +2030,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         interleave_w_reorder_size(int ur_w) const {
     const int reorder_block = 16;
-    return rnd_up(jcp.stride_w * (ur_w - 1) + jcp.kw, reorder_block);
+    return static_cast<int>(
+            rnd_up(jcp.stride_w * (ur_w - 1) + jcp.kw, reorder_block));
 }
 int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         interleave_w_reorder_bytes(int ur_w) {
@@ -2024,12 +2042,12 @@ int jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::interleave_stack_size(
     return ic_block_step * interleave_w_reorder_bytes(ur_w);
 }
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_interleave(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_interleave(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     // Only supports nchw format src
     assert(jcp.is_1stconv && !jcp.transpose_src);
-    int kw = jcp.kw;
+    const dim_t kw = jcp.kw;
     static constexpr int ddst_zmm_base_idx = 24;
     static constexpr int in_zmm_base_idx = 24;
     const int num_ddst_zmm_regs = !isa_has_bf16(jcp.isa) ? 2 : 4;
@@ -2062,9 +2080,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         return EVEX_compress_addr(reg_kernel, local_offset + kernel_offset);
     };
     auto src_addr
-            = [this, reorder_bytes](int i_iw, int i_ic,
+            = [this, reorder_bytes](dim_t i_iw, int i_ic,
                       ptrdiff_t extra_offset = 0, bool vnni_bcast = false) {
-        int local_offset = i_ic * reorder_bytes + 2 * jcp.typesize_in * i_iw;
+        const dim_t local_offset
+                = i_ic * reorder_bytes + 2 * jcp.typesize_in * i_iw;
         return EVEX_compress_addr(rsp, local_offset, vnni_bcast);
     };
     auto ddst_addr = [this, ddst_offset](int i_ur) {
@@ -2073,14 +2092,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
                 reg_ddst, get_ddst_offset(ow_scale * i_ur) + ddst_offset);
     };
     auto load_src_to_stack
-            = [&](int i_iw, int i_ic, Opmask mask, bool mask_empty,
+            = [&](dim_t i_iw, int i_ic, Opmask mask, bool mask_empty,
                       Opmask stride_mask, bool stride_mask_empty) {
         auto local_offset = get_src_offset(i_ic, i_iw);
-        int stack_offset
+        const dim_t stack_offset
                 = i_ic * reorder_bytes + 2 * jcp.typesize_in * (i_iw + pad_l);
 
-        auto zmm = zmm_in(i_iw, i_ic, false);
-        auto zmm_stride = zmm_in(i_iw, i_ic, true);
+        auto zmm = zmm_in(static_cast<int>(i_iw), i_ic, false);
+        auto zmm_stride = zmm_in(static_cast<int>(i_iw), i_ic, true);
         auto base_addr
                 = EVEX_compress_addr(reg_src, local_offset + src_offset, false);
         auto stride_addr = EVEX_compress_addr(reg_src,
@@ -2103,18 +2122,18 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     assert(ur_w % 2 == 0);
     auto steps = ur_w / 2;
 
-    const int str_w = jcp.stride_w;
-    int i_iw_shift = str_w * (jcp.tr_ow - ur_w)
+    const dim_t str_w = jcp.stride_w;
+    const dim_t i_iw_shift = str_w * (jcp.tr_ow - ur_w)
             - ((jcp.l_pad != pad_l) ? jcp.l_pad : 0);
-    const int overflow_boundary
+    const dim_t overflow_boundary
             = is_tail ? jcp.iw - i_iw_shift : str_w * (ur_w - 1) + kw - pad_l;
 
     // Calculate padding required by the data reorder using 32 byte loads
-    int reorder_overflow = reorder_size - pad_l - overflow_boundary;
-    int reorder_stride_overflow = reorder_overflow + str_w;
-    reorder_overflow = nstl::max(0, reorder_overflow);
-    reorder_stride_overflow = nstl::max(0, reorder_stride_overflow);
-    int reorder_pad_r = reorder_overflow % reorder_block;
+    dim_t reorder_overflow = reorder_size - pad_l - overflow_boundary;
+    dim_t reorder_stride_overflow = reorder_overflow + str_w;
+    reorder_overflow = nstl::max<dim_t>(0, reorder_overflow);
+    reorder_stride_overflow = nstl::max<dim_t>(0, reorder_stride_overflow);
+    const int reorder_pad_r = reorder_overflow % reorder_block;
     int reorder_stride_pad_r = reorder_stride_overflow % reorder_block;
     if (reorder_stride_overflow >= reorder_size && reorder_stride_pad_r == 0) {
         assert(reorder_stride_overflow == reorder_size);
@@ -2135,18 +2154,21 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         // Overflow and underflow happen in different data reorder rounds
         kxnorw(overflow_stride_mask, overflow_stride_mask,
                 overflow_stride_mask);
-        kshiftlw(underflow_mask, overflow_stride_mask, pad_l);
+        kshiftlw(underflow_mask, overflow_stride_mask,
+                static_cast<uint8_t>(pad_l));
         kshiftlw(underflow_stride_mask, overflow_stride_mask,
-                pad_l >= str_w ? pad_l - str_w : 0);
-        kshiftrw(overflow_mask, overflow_stride_mask, reorder_pad_r);
+                static_cast<uint8_t>(pad_l >= str_w ? pad_l - str_w : 0));
+        kshiftrw(overflow_mask, overflow_stride_mask,
+                static_cast<uint8_t>(reorder_pad_r));
         kshiftrw(overflow_stride_mask, overflow_stride_mask,
-                reorder_stride_pad_r);
+                static_cast<uint8_t>(reorder_stride_pad_r));
     } else if (reorder_size - reorder_overflow > reorder_block) {
         // Overflow and underflow happen in the same round for loading the data
         // at the stride offset.
         kxnorw(overflow_mask, overflow_mask, overflow_mask);
-        kshiftlw(underflow_mask, overflow_mask, pad_l);
-        kshiftrw(overflow_mask, overflow_mask, reorder_pad_r);
+        kshiftlw(underflow_mask, overflow_mask, static_cast<uint8_t>(pad_l));
+        kshiftrw(overflow_mask, overflow_mask,
+                static_cast<uint8_t>(reorder_pad_r));
         mov(reg_tmp.cvt32(), pad_l_mask_strided & pad_r_mask_strided);
         kmovw(underflow_stride_mask, reg_tmp.cvt32());
     } else {
@@ -2158,9 +2180,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     }
 
     // Load and reorder data to the stack
-    int reorder_start = -pad_l;
-    int reorder_end = reorder_size - pad_l;
-    for (int i_iw = reorder_start; i_iw < reorder_end; i_iw += reorder_block) {
+    const dim_t reorder_start = -pad_l;
+    const dim_t reorder_end = reorder_size - pad_l;
+    for (dim_t i_iw = reorder_start; i_iw < reorder_end;
+            i_iw += reorder_block) {
         for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
             Opmask mask, stride_mask;
             bool mask_empty, stride_mask_empty;
@@ -2224,7 +2247,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
         for (int i_kw = 0; i_kw < kw; i_kw++) {
             for (int i_ic = 0; i_ic < ic_block_step; i_ic++) {
-                int i_iw = 2 * i_ur * str_w + i_kw;
+                const dim_t i_iw = 2 * i_ur * str_w + i_kw;
                 auto acc = zmm_ker(i_kw, i_ic);
                 auto ddst = zmm_ddst(i_ur);
 
@@ -2262,7 +2285,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         convert_src_to_vnni_format(
-                int ur_w, int pad_l, int pad_r, int src_offset) {
+                int ur_w, dim_t pad_l, dim_t pad_r, dim_t src_offset) {
     Reg64 reg_trans_tmp = r11;
     const int ic_tail = jcp.ic_tail;
     mov(EVEX_compress_addr(rsp, trans_tmp_offset), reg_trans_tmp);
@@ -2283,7 +2306,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     for (int src_count = 0;
             sizeof_cacheline * src_count < permw_stack_size(ur_w);
             src_count++) {
-        int i_ur = nstl::min(src_count, ur_w - 2);
+        const int i_ur
+                = static_cast<int>(nstl::min<dim_t>(src_count, ur_w - 2));
         int i_kw = src_count - i_ur;
         int buffer_offset = permw_buffer_start + src_count * 64;
         auto bcast_values = Zmm(src_count % max_regs);
@@ -2352,15 +2376,16 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_vpermw_expl(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_vpermw_expl(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!jcp.is_1stconv); // This method does not support nchw data
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
     int src_count = 0;
-    int ic_block_step_idx = src_offset / (jcp.typesize_in * ic_block_step);
+    const int ic_block_step_idx
+            = static_cast<int>(src_offset / (jcp.typesize_in * ic_block_step));
     const int max_regs = (!isa_has_bf16(jcp.isa)) ? 26 : 31;
-    int src_pl_len = kw;
+    const int src_pl_len = kw;
     const int diff_dst_pl_start_reg_idx = ic_block_step * (kw + src_pl_len);
     const int diff_dst_pl_len = max_regs - diff_dst_pl_start_reg_idx;
 
@@ -2410,8 +2435,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     int src_count_last = 0;
     for (int i_ur = 0; i_ur < ur_w; i_ur += 2) {
         if (i_ur == 0) {
-            for (int dst_count = 0;
-                    dst_count < nstl::min(diff_dst_pl_len, div_up(ur_w, 2));
+            for (int dst_count = 0; dst_count
+                    < nstl::min<dim_t>(diff_dst_pl_len, div_up(ur_w, 2));
                     dst_count++) {
                 load_dst(dst_count);
             }
@@ -2478,18 +2503,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
-        compute_ic_block_step_vpermw(int ur_w, int pad_l, int pad_r,
-                int ic_block_step, int src_offset, int kernel_offset,
-                int ddst_offset, bool is_tail) {
+        compute_ic_block_step_vpermw(int ur_w, dim_t pad_l, dim_t pad_r,
+                int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+                dim_t ddst_offset, bool is_tail) {
     assert(!jcp.is_1stconv); // This method does not support nchw data
-    int kw = jcp.kw;
+    const int kw = static_cast<int>(jcp.kw);
 
     int dst_count = 0;
 
-    int ic_block_step_idx = src_offset / (jcp.typesize_in * ic_block_step);
+    const int ic_block_step_idx
+            = static_cast<int>(src_offset / (jcp.typesize_in * ic_block_step));
 
-    int pipeline_length = (isa_has_bf16(jcp.isa))
-            ? nstl::max(1, nstl::min(4, ur_w / 2))
+    const int pipeline_length = isa_has_bf16(jcp.isa)
+            ? static_cast<int>(
+                      nstl::max<dim_t>(1, nstl::min<dim_t>(4, ur_w / 2)))
             : 1;
     may_be_set_oc_tail_mask();
 
@@ -2612,7 +2639,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_diff_bias_row(
     };
 
     Label ow_loop, ow_tail;
-    int niters = jcp.tr_ow / 2;
+    int niters = static_cast<int>(jcp.tr_ow / 2);
     if (niters > 0) {
         mov(reg_tmp, jcp.tr_ow / 2);
         L(ow_loop);
@@ -2681,8 +2708,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 }
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
-        int ur_w, int pad_l, int pad_r, int ic_block_step, int src_offset,
-        int kernel_offset, int ddst_offset, bool is_tail) {
+        int ur_w, dim_t pad_l, dim_t pad_r, int ic_block_step, dim_t src_offset,
+        dim_t kernel_offset, dim_t ddst_offset, bool is_tail) {
 
     if (jcp.uses_permw_transposition)
         if (jcp.kernel_kind == expl_bcast)
@@ -2702,7 +2729,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_ic_block_step(
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
         int &ur_w, int &ur_w_tail, int &ur_w_trips) const {
     if (jcp.tr_ow <= max_ur_w) {
-        ur_w = jcp.tr_ow;
+        ur_w = static_cast<int>(jcp.tr_ow);
         ur_w_tail = 0;
         ur_w_trips = 1;
         return;
@@ -2711,14 +2738,15 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
     int r_pad = 0;
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        r_pad = nstl::max(0,
-                calculate_end_padding(
-                        jcp.l_pad, jcp.tr_ow, jcp.tr_iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(jcp.l_pad, jcp.tr_ow, jcp.tr_iw,
+                        jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
     ur_w = max_ur_w;
-    ur_w_trips = jcp.tr_ow / ur_w;
+    ur_w_trips = static_cast<int>(jcp.tr_ow / ur_w);
     ur_w_tail = jcp.tr_ow % ur_w;
     if ((ur_w_tail == 0 && jcp.r_pad != 0) || r_pad >= ur_w_tail) {
         if (ur_w_trips > 1) {
@@ -2730,7 +2758,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::get_ur_w(
                                               : ur_w_tail / 2 + 1;
             ur_w_tail = ur_w_tail_total - ur_w;
             if (l_pad > ur_w / 2) {
-                ur_w = (l_pad % 2 == 0) ? l_pad : l_pad + 1;
+                ur_w = static_cast<int>((l_pad % 2 == 0) ? l_pad : l_pad + 1);
                 ur_w_tail = ur_w_tail_total - ur_w;
             } else if (r_pad > ur_w_tail) {
                 ur_w_tail = (r_pad % 2 == 0) ? r_pad : r_pad + 1;
@@ -2744,9 +2772,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow_icblock(int ic_block_step) {
     Label kh_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     int r_pad = 0;
     int ur_w, ur_w_tail, ur_w_trips;
     get_ur_w(ur_w, ur_w_tail, ur_w_trips);
@@ -2754,12 +2782,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2789,7 +2819,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         const int ic_tail_loop_work = rnd_up(ic_tail, ic_block_step);
         for (int i_b_ic = 0; i_b_ic < jcp.ic_block; i_b_ic += ic_block_step) {
-            const int src_offset = get_src_offset(i_b_ic, 0);
+            const dim_t src_offset = get_src_offset(i_b_ic, 0);
             compute_ic_block_step(ur_w, l_pad, r_pad, ic_block_step, src_offset,
                     get_kernel_offset(i_b_ic, 0), 0, true);
             if (generate_icb_loop || ic_tail) sub(reg_icb, ic_block_step);
@@ -2845,9 +2875,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_step_unroll_ow(int ic_block_step) {
     Label kh_label, ic_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     const int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
 
     int r_pad = 0;
     int ur_w, ur_w_tail, ur_w_trips;
@@ -2856,12 +2886,14 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     if (jcp.ndims == 5) {
         L(kd_label);
@@ -2888,7 +2920,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
 
         xor_(b_ic, b_ic);
         if (jcp.uses_permw_transposition) {
-            convert_src_to_vnni_format(ow, l_pad, r_pad, 0);
+            convert_src_to_vnni_format(static_cast<int>(ow), l_pad, r_pad, 0);
             xor_(b_ic, b_ic);
         }
 
@@ -2977,18 +3009,20 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         int ic_block_step) {
     Label kh_label, ic_block_label, ow_block_label, kd_label;
 
-    int ic_block = jcp.ic_block;
+    dim_t ic_block = jcp.ic_block;
     int ic_tail = jcp.ic_tail;
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     int r_pad = 0;
     if (!jcp.transpose_src) {
         // If jcp.transpose_src, the buffer has physical padding
-        int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-        int iw = jcp.tr_iw;
-        r_pad = nstl::max(0,
-                calculate_end_padding(jcp.l_pad, ow, iw, jcp.stride_w, ext_kw));
+        const dim_t ext_kw
+                = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+        dim_t iw = jcp.tr_iw;
+        r_pad = static_cast<int>(nstl::max<dim_t>(0,
+                calculate_end_padding(
+                        jcp.l_pad, ow, iw, jcp.stride_w, ext_kw)));
     }
-    int l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
+    dim_t l_pad = (jcp.transpose_src) ? 0 : jcp.l_pad;
 
     int ur_w, ur_w_trips, ur_w_tail;
     get_ur_w(ur_w, ur_w_tail, ur_w_trips);
@@ -3115,7 +3149,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
         auto src_icbstep_shift = get_src_offset(1, 0);
 
         auto ic_loop = [&](int ic_block_step) {
-            int ic_work = ic_block;
+            dim_t ic_work = ic_block;
             Label ow_block_label, ic_block_label_padl, ic_block_label_general,
                     ic_block_label_tail;
             int ur_w_blocks = ur_w_trips;
@@ -3256,12 +3290,12 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::compute_oh_step_common(
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         compute_oh_step_disp() {
-    int ic_block_step = jcp.ic_block_step;
+    const int ic_block_step = static_cast<int>(jcp.ic_block_step);
 
     bool too_large_to_unroll = (jcp.kw > 1 || jcp.kh > 1 || jcp.kd > 1)
             && (jcp.stride_w > 1 || jcp.stride_h > 1 || jcp.stride_d > 1);
 
-    int ow = jcp.tr_ow;
+    dim_t ow = jcp.tr_ow;
     if (jcp.ndims == 5) {
         /* NOTE: reg_kd_count = aux_reg_src = r12. The following order of
          * 'movs' must be guaranteed. */
@@ -3356,11 +3390,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
 
 void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_oh_loop_common(bool is_partial) {
-    int b_pad = jcp.b_pad;
-    int t_pad = jcp.t_pad;
+    dim_t b_pad = jcp.b_pad;
+    dim_t t_pad = jcp.t_pad;
     bool is_dilated = jcp.dilate_h != 0;
-    int dilate_h = jcp.dilate_h + 1;
-    int stride_h = jcp.stride_h;
+    dim_t dilate_h = jcp.dilate_h + 1;
+    dim_t stride_h = jcp.stride_h;
     auto filter_step_size = get_kernel_offset(0, jcp.kw);
     auto src_step_size = get_src_offset(0, 0, 1);
     auto ddst_step_size = get_ddst_offset(0, 1);
@@ -3370,15 +3404,17 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             oh_dilate_label_end, oh_dilate_setup_label_shift,
             oh_dilate_setup_label_noshift, oh_dilate_setup_label_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int oh_body_end = div_up(t_pad + jcp.ih - ext_kh + 1, stride_h);
-    int oh_head_end = nstl::min(div_up(t_pad, stride_h), oh_body_end);
-    int oh_head_overflow_end = div_up(t_pad, stride_h);
-    int oh_tail_end = jcp.oh;
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t oh_body_end = div_up(t_pad + jcp.ih - ext_kh + 1, stride_h);
+    const dim_t oh_head_end
+            = nstl::min<dim_t>(div_up(t_pad, stride_h), oh_body_end);
+    const dim_t oh_head_overflow_end = div_up(t_pad, stride_h);
+    const dim_t oh_tail_end = jcp.oh;
 
-    int body_src_start_offset = (stride_h - (t_pad % stride_h)) % stride_h;
-    int ih_body_end
-            = nstl::max(-t_pad + oh_body_end * stride_h, body_src_start_offset);
+    const dim_t body_src_start_offset
+            = (stride_h - (t_pad % stride_h)) % stride_h;
+    const dim_t ih_body_end = nstl::max<dim_t>(
+            -t_pad + oh_body_end * stride_h, body_src_start_offset);
 
     if (is_partial)
         mov(reg_oj, ptr[param + GET_OFF(os_index_begin)]);
@@ -3391,17 +3427,17 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
             cmp(reg_oj, oh_head_overflow_end);
             jge(oh_tpad_tail_label_end, T_NEAR);
         }
-        const int overflow
-                = nstl::max(0, jcp.kh - div_up(t_pad + jcp.ih, dilate_h));
-        const int underflow = div_up(t_pad, dilate_h);
-        const int initial_kh = jcp.kh - overflow - underflow;
+        const dim_t overflow = nstl::max<dim_t>(
+                0, jcp.kh - div_up(t_pad + jcp.ih, dilate_h));
+        const dim_t underflow = div_up(t_pad, dilate_h);
+        const dim_t initial_kh = jcp.kh - overflow - underflow;
 
         // Setup reg_kh, reg_kernel, and reg_src
         mov(reg_kh, initial_kh);
         add(reg_kernel, filter_step_size * underflow);
         if (is_dilated) {
-            const int tail = t_pad % dilate_h;
-            const int shift = tail == 0 ? 0 : dilate_h - tail;
+            const int tail = static_cast<int>(t_pad % dilate_h);
+            const int shift = tail == 0 ? 0 : static_cast<int>(dilate_h - tail);
             mov(reg_ih_shift, shift);
             if (!is_partial) mov(ptr[rsp + ih_dilate_shift], reg_ih_shift);
             add(reg_src, src_step_size * shift);
@@ -3558,7 +3594,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         }
         if (is_partial) {
             lea(reg_oj_setup,
-                    ptr[reg_oj - nstl::max(oh_body_end, oh_head_overflow_end)]);
+                    ptr[reg_oj
+                            - nstl::max<dim_t>(
+                                    oh_body_end, oh_head_overflow_end)]);
             if (stride_h == 1 && !is_dilated) {
                 sub(reg_kh, reg_oj_setup);
             } else {
@@ -3615,8 +3653,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         compute_od_loop_common(bool is_partial) {
     assert(jcp.harness == harness_3d_reduction);
 
-    const int src_backpad_overlap = div_up(
-            nstl::max(0, jcp.id + jcp.f_pad - (jcp.kd - 1)), jcp.stride_d);
+    const dim_t src_backpad_overlap
+            = div_up(nstl::max<dim_t>(0, jcp.id + jcp.f_pad - (jcp.kd - 1)),
+                    jcp.stride_d);
 
     const auto filter_shift
             = get_kernel_offset(0, static_cast<dim_t>(jcp.kh) * jcp.kw);
@@ -3624,8 +3663,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
     const auto ddst_shift = get_ddst_offset(0, jcp.oh);
     const dim_t src_common_shift = src_shift * jcp.stride_d;
 
-    const int kd_front_pad = nstl::max(0, jcp.f_pad);
-    const int kd_back_pad = nstl::max(0, jcp.kd - jcp.f_pad - jcp.id);
+    const dim_t kd_front_pad = nstl::max<dim_t>(0, jcp.f_pad);
+    const dim_t kd_back_pad = nstl::max<dim_t>(0, jcp.kd - jcp.f_pad - jcp.id);
 
     Label d_loop_label, loop_end_label, common_block_label, fpad_end_label,
             backpad_end_label, backpad_label;
@@ -3639,10 +3678,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         mov(reg_d_index, ptr[param + GET_OFF(os_index_begin)]);
         mov(reg_kd_count, ptr[param + GET_OFF(kd_padding)]);
     } else {
-        const int kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
-        const int kd_offset = get_kernel_offset(0,
-                nstl::min(jcp.kd - 1, kd_front_pad) * static_cast<dim_t>(jcp.kh)
-                        * jcp.kw);
+        const dim_t kd_padding = jcp.kd - kd_front_pad - kd_back_pad;
+        const dim_t kd_offset = get_kernel_offset(0,
+                nstl::min<dim_t>(jcp.kd - 1, kd_front_pad) * jcp.kh * jcp.kw);
         add(reg_kernel, kd_offset);
         xor_(reg_d_index, reg_d_index);
         mov(reg_kd_count, kd_padding);
@@ -3682,7 +3720,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         add(reg_kd_count, jcp.stride_d);
 
         /* Final number of kernel elements that overlap with src */
-        const int src_ker_overlap = nstl::min(jcp.kd, jcp.id);
+        const dim_t src_ker_overlap = nstl::min<dim_t>(jcp.kd, jcp.id);
         cmp(reg_kd_count, src_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -3690,7 +3728,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t ::
         if (jcp.f_pad <= jcp.od * jcp.stride_d) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.f_pad % jcp.stride_d != 0) {
-                int src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
+                const dim_t src_corr = jcp.stride_d - jcp.f_pad % jcp.stride_d;
                 add(reg_kernel, filter_shift * src_corr);
                 // for src, subtract src_common_shift that gets added later.
                 add(reg_src_d, src_shift * src_corr - src_common_shift);
@@ -3761,9 +3799,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
     auto ddst_row_size = get_ddst_offset(0, 1);
     auto row_size = src_row_size + ddst_row_size;
 
-    int h_block_size = jcp.oh;
-    int h_last_block_size = h_block_size;
-    int min_h_block_size = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+    dim_t h_block_size = jcp.oh;
+    dim_t h_last_block_size = h_block_size;
+    const dim_t min_h_block_size
+            = nstl::max<dim_t>(1, nstl::max<dim_t>(jcp.b_pad, jcp.t_pad));
     auto working_set_size = row_size * h_block_size;
 
     if (working_set_size > full_spat_max_working_set_size) {
@@ -3771,7 +3810,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
         while (working_set_size > full_spat_opt_working_set_size
                 && h_block_size >= min_h_block_size) {
-            for (int i = 2; i <= h_block_size; i++)
+            for (dim_t i = 2; i <= h_block_size; i++)
                 if (i == h_block_size)
                     h_block_size = h_block_size / 2;
                 else if (h_block_size % i == 0) {
@@ -3780,7 +3819,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
                 }
             working_set_size = row_size * h_block_size;
         }
-        h_block_size = nstl::max(min_h_block_size, h_block_size);
+        h_block_size = nstl::max<dim_t>(min_h_block_size, h_block_size);
         h_last_block_size = jcp.oh % h_block_size;
         if (h_last_block_size < jcp.b_pad) h_last_block_size += h_block_size;
     }
@@ -3848,10 +3887,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         };
 
         if (full_w_unroll) {
-            emit_step(pad_ow, true);
+            emit_step(static_cast<int>(pad_ow), true);
         } else {
             Label w_loop;
-            int num_w_iters = pad_ow / def_step_size;
+            int num_w_iters = static_cast<int>(pad_ow / def_step_size);
             mov(reg_i, num_w_iters);
             L(w_loop);
             {
@@ -3894,10 +3933,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         xor_(reg_kh, reg_kh);
         Label kh_loop, kh_loop_end;
 
-        int oh_block_size = (is_last_block) ? h_last_block_size : h_block_size;
+        const dim_t oh_block_size
+                = (is_last_block) ? h_last_block_size : h_block_size;
         // NB: this is correct because we only support t_pad = kh / 2 and thus
         // ih == oh
-        int ih_block_size = oh_block_size
+        const dim_t ih_block_size = oh_block_size
                 + (!is_first_block + !is_last_block) * jcp.t_pad;
 
         L(kh_loop);
@@ -3964,8 +4004,10 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
 
             L(kh_loop_work);
 
-            mul_by_const(reg_ihs, reg_tmp, get_src_offset(0, 0, 1));
-            mul_by_const(reg_ohs, reg_tmp, get_ddst_offset(0, 1));
+            mul_by_const(reg_ihs, reg_tmp,
+                    static_cast<int>(get_src_offset(0, 0, 1)));
+            mul_by_const(
+                    reg_ohs, reg_tmp, static_cast<int>(get_ddst_offset(0, 1)));
 
             add(reg_src, reg_ihs);
             add(reg_ddst, reg_ohs);
@@ -4048,8 +4090,8 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::
         add(reg_src, first_src_block_step);
         add(reg_ddst, ddst_block_step);
 
-        int num_innermost_iters
-                = (jcp.oh - h_last_block_size) / h_block_size - 1;
+        const int num_innermost_iters = static_cast<int>(
+                (jcp.oh - h_last_block_size) / h_block_size - 1);
         if (num_innermost_iters > 0) {
             Label h_block_loop;
 
@@ -4131,10 +4173,11 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::setup_stack_space() {
             || jcp.uses_permw_transposition) {
         int ur_w, ur_w_tail, ur_w_trips;
         get_ur_w(ur_w, ur_w_tail, ur_w_trips);
-        ur_w = nstl::max(ur_w, ur_w_tail);
+        ur_w = static_cast<int>(nstl::max<dim_t>(ur_w, ur_w_tail));
         ic_block_step_stack_size = jcp.uses_permw_transposition
-                ? permw_stack_size(ur_w)
-                : interleave_stack_size(ur_w, jcp.ic_block_step);
+                ? static_cast<int>(permw_stack_size(ur_w))
+                : interleave_stack_size(
+                          ur_w, static_cast<int>(jcp.ic_block_step));
     } else
         ic_block_step_stack_size = extern_ic_block_step_stack_size;
 
@@ -4232,9 +4275,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     bool ok = true
             // general condition to simplify dilations
@@ -4245,13 +4288,13 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             && IMPLICATION(jcp.dilate_h != 0, ext_kh <= jcp.ih);
     VDISPATCH_CONV_IC(ok, "dilation / stride values do not match");
 
-    jcp.r_pad = nstl::max(0,
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
-    jcp.back_pad = nstl::max(0,
+    jcp.back_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.f_pad, jcp.od, jcp.id, jcp.stride_d, ext_kd));
 
@@ -4331,14 +4374,16 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             CHECK(memory_desc_init_by_tag(diff_bias_md, x));
     }
     jcp.bia_dt = jcp.with_bias ? diff_bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(jcp.bia_dt))
+            : 0;
 
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = ext_kh / 2;
+    const dim_t max_pad_h = ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < ext_kw && jcp.r_pad < ext_kw
             && jcp.t_pad <= max_pad_h && jcp.b_pad <= max_pad_h
             && jcp.f_pad < ext_kd && jcp.back_pad < ext_kd
@@ -4362,8 +4407,10 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
                     data_type::bf16);
     VDISPATCH_CONV_IC(ok, VERBOSE_UNSUPPORTED_DT_CFG);
 
-    jcp.ic_tail = is_data_layout_nxc ? jcp.ic % jcp.ic_block : 0;
-    jcp.oc_tail = is_data_layout_nxc ? jcp.oc % jcp.oc_block : 0;
+    jcp.ic_tail
+            = is_data_layout_nxc ? static_cast<int>(jcp.ic % jcp.ic_block) : 0;
+    jcp.oc_tail
+            = is_data_layout_nxc ? static_cast<int>(jcp.oc % jcp.oc_block) : 0;
 
     if (jcp.is_1stconv) {
         jcp.ic_block_step = 24 / jcp.kw;
@@ -4383,7 +4430,7 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
             && jcp.kw == 1 && jcp.ic_block_step > 4;
     // Threshold is based on performance measurements
     const bool apply_permw_nxc = is_data_layout_nxc && ndims == 3
-            && nstl::max(jcp.ic, jcp.oc) <= 32;
+            && nstl::max<dim_t>(jcp.ic, jcp.oc) <= 32;
     jcp.uses_permw_transposition
             = is_permw_applicable && (apply_permw_blocked || apply_permw_nxc);
 
@@ -4439,7 +4486,9 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
     bool use_spatial_blocking = jcp.is_1stconv && !nt_stores_ok && blocking_ok;
-    int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    int optimal_blk_size = static_cast<int>(is_3d ? jcp.od
+                    : is_2d                       ? jcp.oh
+                                                  : jcp.ow);
     if (use_spatial_blocking) {
         // Default value, works best most of the times
         // TODO: For 3D shapes with intermediate sizes especially the ones not
@@ -4493,7 +4542,8 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     // padding. Because elements are read two at a time, we may need r_pad + 1
     // padding on the right. As such, the shared padding is the max of l_pad and
     // r_pad + 1, rounded as necessary for the transpose data format.
-    int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    const dim_t tr_pad
+            = rnd_up(nstl::max<dim_t>(jcp.l_pad, jcp.r_pad + 1), tr_round);
     jcp.tr_iw = jcp.transpose_src
             ? rnd_up(div_up(jcp.iw, jcp.stride_w) + tr_pad, tr_round)
                     * jcp.stride_w
@@ -4519,7 +4569,7 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     const auto out_row_size
             = static_cast<size_t>(jcp.oc_block) * jcp.tr_ow * jcp.typesize_in;
     const auto full_spat_min_h_block_size
-            = nstl::max(1, nstl::max(jcp.b_pad, jcp.t_pad));
+            = nstl::max<dim_t>(1, nstl::max<dim_t>(jcp.b_pad, jcp.t_pad));
     const auto full_spat_working_set_size
             = (inp_row_size + out_row_size) * full_spat_min_h_block_size;
     bool use_full_spat_loop = isa_has_bf16(jcp.isa) && jcp.ndims < 5
@@ -4574,7 +4624,8 @@ status_t jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::init_conf(
     jcp.nb_ic_blocking_max = 1;
     if (is_data_layout_nxc && jcp.uses_permw_transposition
             && (jcp.ow > max_ur_w || jcp.ndims == 5))
-        jcp.nb_ic_blocking_max = nstl::min(8, div_up(jcp.nb_ic, jcp.nthr_ic_b));
+        jcp.nb_ic_blocking_max = static_cast<int>(
+                nstl::min<dim_t>(8, div_up(jcp.nb_ic, jcp.nthr_ic_b)));
     return status::success;
 }
 
@@ -4658,7 +4709,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         return;
     }
 
-    nthr_g_ = j.ngroups;
+    nthr_g_ = static_cast<int>(j.ngroups);
     const int nthr = max_threads / nthr_g_;
 
     auto calc_mem_cost = [&](int nthr_mb, int nthr_oc_b, int nthr_ic_b) {
@@ -4684,8 +4735,9 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         dim_t wei_size
                 = (dim_t)j.oc * j.ic * j.kd * j.kh * j.kw * wei_type_size;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
-        float oi_channels_ratio = (float)j.nb_oc / j.nb_ic;
+        float wei_compensation_scale
+                = 0.5f * (float)(dst_size + src_size) / (float)wei_size;
+        float oi_channels_ratio = (float)j.nb_oc / (float)j.nb_ic;
         auto get_src_coef = [oi_channels_ratio, wei_compensation_scale]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
             if (wei_compensation_scale < 1.0f) src_coef *= 4.0f;
@@ -4705,16 +4757,24 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
         const float dst_coef = get_dst_coef();
         const float wei_coef = get_wei_coef();
 
-        float src_v = src_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_ic, nthr_ic_b) * j.mb
-                * j.ic_block * j.id * j.ih * j.tr_iw / j.nthr_mb_work
-                / j.stride_d / j.stride_h / j.stride_w;
-        float wei_v = wei_coef * div_up(j.ngroups, nthr_g_)
-                * div_up(j.nb_oc, nthr_oc_b) * div_up(j.nb_ic, nthr_ic_b) * j.kh
-                * j.kw * j.kd * j.ic_block * j.oc_block;
-        float dst_v = dst_coef * div_up(j.nthr_mb_work, nthr_mb)
-                * div_up(j.ngroups, nthr_g_) * div_up(j.nb_oc, nthr_oc_b) * j.mb
-                * j.oc_block * j.od * j.oh * j.tr_ow / j.nthr_mb_work;
+        float src_v = src_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_ic, nthr_ic_b) * j.mb * j.ic_block * j.id
+                        * j.ih * j.tr_iw)
+                / (float)(j.nthr_mb_work * j.stride_d * j.stride_h
+                        * j.stride_w);
+        float wei_v = wei_coef
+                * (float)(div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_oc, nthr_oc_b)
+                        * div_up(j.nb_ic, nthr_ic_b) * j.kh * j.kw * j.kd
+                        * j.ic_block * j.oc_block);
+        float dst_v = dst_coef
+                * (float)(div_up(j.nthr_mb_work, nthr_mb)
+                        * div_up(j.ngroups, nthr_g_)
+                        * div_up(j.nb_oc, nthr_oc_b) * j.mb * j.oc_block * j.od
+                        * j.oh * j.tr_ow)
+                / (float)j.nthr_mb_work;
 
         return src_v + dst_v + wei_v;
     };
@@ -4722,12 +4782,15 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
     float best_mem_cost = calc_mem_cost(nthr_mb_, nthr_oc_b_, nthr_ic_b_);
 
     /* find the best thread distribution with lowest memory cost */
-    const int nthr_mb_max = nstl::min(nthr, j.nthr_mb_work);
+    const int nthr_mb_max
+            = static_cast<int>(nstl::min<dim_t>(nthr, j.nthr_mb_work));
     for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
         const int nthr_par = nthr / nthr_mb;
-        const int nthr_oc_b_max = nstl::min(nthr_par, j.nb_oc);
+        const int nthr_oc_b_max
+                = static_cast<int>(nstl::min<dim_t>(nthr_par, j.nb_oc));
         for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-            int nthr_ic_b = nstl::min(nthr_par / nthr_oc_b, j.nb_ic);
+            int nthr_ic_b = static_cast<int>(
+                    nstl::min<dim_t>(nthr_par / nthr_oc_b, j.nb_ic));
 
             float mem_cost = calc_mem_cost(nthr_mb, nthr_oc_b, nthr_ic_b);
             if (mem_cost <= best_mem_cost) {
@@ -4740,7 +4803,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::balance(
     }
 
     if (nthr_mb_ > nthr / 2 && nthr_mb_ < nthr)
-        nthr_mb_ = nstl::min(j.nthr_mb_work, nthr);
+        nthr_mb_ = static_cast<int>(nstl::min<dim_t>(j.nthr_mb_work, nthr));
     nthr_ = nthr_mb_ * nthr_g_ * nthr_oc_b_ * nthr_ic_b_;
 
     assert(nthr_ <= max_threads);

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.hpp
@@ -134,11 +134,11 @@ private:
     inline void prepare_dst(int ur_w);
     void apply_postops(int ur_w);
     inline void store_dst(int ur_w);
-    inline void compute_loop(int ur_w, int pad_l, int pad_r);
+    inline void compute_loop(int ur_w, dim_t pad_l, dim_t pad_r);
 
     void generate() override;
 
-    inline dim_t get_dst_offset(dim_t sp_idx, int ocb) {
+    inline dim_t get_dst_offset(dim_t sp_idx, dim_t ocb) {
         const bool is_layout_nxc = is_dst_layout_nxc();
         dim_t sp_str = is_layout_nxc ? static_cast<dim_t>(jcp.ngroups) * jcp.oc
                                      : jcp.oc_block;
@@ -147,20 +147,19 @@ private:
         return jcp.typesize_out * (ocb_str * ocb + sp_str * sp_idx);
     }
 
-    inline dim_t filter_w_to_src(int kw, int ow = 0, int pad_l = 0) {
-        return static_cast<dim_t>(kw) * (jcp.dilate_w + 1) + ow * jcp.stride_w
-                - pad_l;
+    inline dim_t filter_w_to_src(dim_t kw, dim_t ow = 0, dim_t pad_l = 0) {
+        return kw * (jcp.dilate_w + 1) + ow * jcp.stride_w - pad_l;
     }
-    inline dim_t filter_h_to_src(int kh) {
-        return static_cast<dim_t>(kh) * (jcp.dilate_h + 1) * jcp.iw;
+    inline dim_t filter_h_to_src(dim_t kh) {
+        return kh * (jcp.dilate_h + 1) * jcp.iw;
     }
-    inline dim_t filter_d_to_src(int kd) {
-        return static_cast<dim_t>(kd) * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
+    inline dim_t filter_d_to_src(dim_t kd) {
+        return kd * (jcp.dilate_d + 1) * jcp.iw * jcp.ih;
     }
 
     inline dim_t get_src_offset(dim_t ic_idx, dim_t isp) {
-        int icb = ic_idx / jcp.ic_block;
-        int ic = ic_idx % jcp.ic_block;
+        dim_t icb = ic_idx / jcp.ic_block;
+        dim_t ic = ic_idx % jcp.ic_block;
         dim_t isp_str = is_src_layout_nxc()
                 ? static_cast<dim_t>(jcp.ngroups) * jcp.ic
                 : (jcp.is_1stconv ? 1 : jcp.ic_block);
@@ -174,12 +173,12 @@ private:
     }
 
     inline dim_t get_kernel_offset(
-            int ocb, int ic_idx, int kw, int kh = 0, int kd = 0) {
-        int scale = 2; //bf16 vnni is used
-        int rnd_ic_block = utils::rnd_up(jcp.ic_block, scale);
-        int icb = ic_idx / jcp.ic_block;
-        int ic = ic_idx % jcp.ic_block;
-        dim_t ksp_str = static_cast<dim_t>(rnd_ic_block) * jcp.oc_block;
+            dim_t ocb, dim_t ic_idx, dim_t kw, dim_t kh = 0, dim_t kd = 0) {
+        const dim_t scale = 2; //bf16 vnni is used
+        dim_t rnd_ic_block = utils::rnd_up(jcp.ic_block, scale);
+        dim_t icb = ic_idx / jcp.ic_block;
+        dim_t ic = ic_idx % jcp.ic_block;
+        dim_t ksp_str = rnd_ic_block * jcp.oc_block;
         dim_t ksp_idx
                 = static_cast<dim_t>(kd) * jcp.kh * jcp.kw + kh * jcp.kw + kw;
 
@@ -191,15 +190,16 @@ private:
                 * (ocb * ocb_str + icb * icb_str + ksp_idx * ksp_str + ic_off);
     }
 
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
 
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
@@ -352,11 +352,11 @@ private:
 
     inline void prepare_output(int ur_w);
     inline void store_output(int ur_w);
-    inline void compute_loop(int ur_w, int l_overflow, int r_overflow);
+    inline void compute_loop(int ur_w, dim_t l_overflow, dim_t r_overflow);
     void generate() override;
 
-    int get_iw_start(int ki, int l_overflow) {
-        int res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
+    dim_t get_iw_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.iw - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -365,10 +365,10 @@ private:
         return res;
     }
 
-    int get_iw_end(int ur_w, int ki, int r_overflow) {
+    dim_t get_iw_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.iw, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
@@ -376,39 +376,39 @@ private:
         return ur_w - res;
     }
 
-    inline int filter_h_to_dst(int kh) {
+    inline dim_t filter_h_to_dst(dim_t kh) {
         return kh * (jcp.dilate_h + 1) * jcp.ow;
     }
-    inline int filter_d_to_dst(int kd) {
+    inline dim_t filter_d_to_dst(dim_t kd) {
         return kd * (jcp.dilate_d + 1) * jcp.ow * jcp.oh;
     }
 
-    inline size_t get_diff_src_offset(int iw_idx, int n_ic_block) {
+    inline dim_t get_diff_src_offset(dim_t iw_idx, dim_t n_ic_block) {
         const bool is_nxc_layout = is_dsrc_layout_nxc();
-        size_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
-        size_t icb_str = jcp.ic_block
-                * (is_nxc_layout ? 1 : (size_t)jcp.id * jcp.ih * jcp.iw);
+        dim_t iw_str = is_nxc_layout ? jcp.ngroups * jcp.ic : jcp.ic_block;
+        dim_t icb_str
+                = jcp.ic_block * (is_nxc_layout ? 1 : jcp.id * jcp.ih * jcp.iw);
         return jcp.typesize_out * (iw_str * iw_idx + icb_str * n_ic_block);
     }
 
-    inline size_t get_diff_dst_offset(
-            int osp_idx, int oc_within_block_idx, int oc_block_idx = 0) {
+    inline dim_t get_diff_dst_offset(
+            dim_t osp_idx, dim_t oc_within_block_idx, dim_t oc_block_idx = 0) {
         const bool is_nxc_layout = is_ddst_layout_nxc();
-        size_t osp_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
-        size_t ocb_str = jcp.oc_block
-                * (is_nxc_layout ? 1 : (size_t)jcp.od * jcp.oh * jcp.ow);
+        dim_t osp_str = is_nxc_layout ? jcp.ngroups * jcp.oc : jcp.oc_block;
+        dim_t ocb_str
+                = jcp.oc_block * (is_nxc_layout ? 1 : jcp.od * jcp.oh * jcp.ow);
         return jcp.typesize_in
                 * (osp_str * osp_idx + ocb_str * oc_block_idx
                         + oc_within_block_idx);
     }
 
-    inline size_t get_kernel_offset(
-            int icb, int oc_idx, int kw, int kh = 0, int kd = 0) {
+    inline dim_t get_kernel_offset(
+            dim_t icb, dim_t oc_idx, dim_t kw, dim_t kh = 0, dim_t kd = 0) {
         int scale = 2; //bf16 vnni is used
-        int ocb = oc_idx / jcp.oc_block;
-        int oc = oc_idx % jcp.oc_block;
-        size_t ksp_str = jcp.ic_block * jcp.oc_block;
-        size_t ksp_idx = kd * jcp.kh * jcp.kw + kh * jcp.kw + kw;
+        dim_t ocb = oc_idx / jcp.oc_block;
+        dim_t oc = oc_idx % jcp.oc_block;
+        dim_t ksp_str = jcp.ic_block * jcp.oc_block;
+        dim_t ksp_idx = kd * jcp.kh * jcp.kw + kh * jcp.kw + kw;
 
         size_t icb_str = jcp.kd * jcp.kh * jcp.kw * ksp_str;
         size_t ocb_str = jcp.nb_ic * icb_str;
@@ -565,18 +565,18 @@ private:
     inline void od_step_comeback_pointers();
     inline void oh_step_comeback_pointers();
     inline void compute_oh_step_unroll_ow(int ic_block_step);
-    inline void compute_ic_block_step(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_extern(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_interleave(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
-    inline void compute_ic_block_step_vpermw(int ur_w, int pad_l, int pad_r,
-            int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_extern(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_interleave(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t src_offset,
+            dim_t kernel_offset, dim_t ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_vpermw(int ur_w, dim_t pad_l, dim_t pad_r,
+            int ic_block_step, dim_t src_offset, dim_t kernel_offset,
+            dim_t ddst_offset, bool is_tail = false);
     inline void compute_oh_step_common(int ic_block_step);
     inline void compute_oh_step_disp();
     inline void compute_loop();
@@ -587,12 +587,12 @@ private:
     void compute_diff_bias_row(bool is_partial = true);
     void maybe_compute_diff_bias();
     void convert_src_to_vnni_format(
-            int ur_w, int pad_l, int pad_r, int src_offset);
+            int ur_w, dim_t pad_l, dim_t pad_r, dim_t src_offset);
     void may_be_set_oc_tail_mask();
     void may_be_reset_oc_tail_mask();
-    inline void compute_ic_block_step_vpermw_expl(int ur_w, int pad_l,
-            int pad_r, int ic_block_step, int src_offset, int kernel_offset,
-            int ddst_offset, bool is_tail = false);
+    inline void compute_ic_block_step_vpermw_expl(int ur_w, dim_t pad_l,
+            dim_t pad_r, int ic_block_step, dim_t src_offset,
+            dim_t kernel_offset, dim_t ddst_offset, bool is_tail = false);
     inline bool is_src_layout_nxc() const {
         return jcp.uses_permw_transposition
                 && utils::one_of(jcp.src_tag, format_tag::ndhwc,
@@ -609,26 +609,26 @@ private:
     static void balance(const jit_conv_conf_t &j, int &nthr, int &nthr_mb,
             int &nthr_g, int &nthr_oc_b, int &nthr_ic_b);
 
-    void get_w_positions(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw,
+    void get_w_positions(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw,
             int &iw_0, int &iw_1) const {
         auto get_w_position = [&](int idx) {
-            int iw = i_ur + idx;
+            dim_t iw = i_ur + idx;
             if (iw >= ur_w) return -1;
             iw += i_kw;
             if (iw - pad_l < 0 || iw > (ur_w - 1) + (jcp.kw - 1) - pad_r)
                 return -1;
-            return iw - pad_l;
+            return static_cast<int>(iw - pad_l);
         };
         iw_0 = get_w_position(0);
         iw_1 = get_w_position(1);
     }
-    bool check_borders(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw) {
+    bool check_borders(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw) {
         int iw_1, iw_2;
         get_w_positions(ur_w, pad_l, pad_r, i_ur, i_kw, iw_1, iw_2);
 
         return (iw_1 == -1 && iw_2 == -1) ? false : true;
     }
-    bool get_load_mask(int ur_w, int pad_l, int pad_r, int i_ur, int i_kw,
+    bool get_load_mask(int ur_w, dim_t pad_l, dim_t pad_r, int i_ur, int i_kw,
             Xbyak::Opmask &load_mask) {
         int iw_1, iw_2;
         get_w_positions(ur_w, pad_l, pad_r, i_ur, i_kw, iw_1, iw_2);
@@ -646,10 +646,10 @@ private:
         return rt;
     }
 
-    inline dim_t filter_w_to_src(int kw, int ow = 0, int pad_l = 0) const {
-        int stride_w = jcp.transpose_src ? 1 : jcp.stride_w;
-        return static_cast<dim_t>(kw) * (jcp.dilate_w + 1) + ow * stride_w
-                - pad_l;
+    inline dim_t filter_w_to_src(
+            dim_t kw, dim_t ow = 0, dim_t pad_l = 0) const {
+        const dim_t stride_w = jcp.transpose_src ? 1 : jcp.stride_w;
+        return kw * (jcp.dilate_w + 1) + ow * stride_w - pad_l;
     }
     inline dim_t filter_h_to_src(int kh) const {
         return static_cast<dim_t>(kh) * (jcp.dilate_h + 1);
@@ -686,8 +686,8 @@ private:
     }
 
     inline dim_t get_ddst_offset(dim_t w_idx, dim_t hd_idx = 0) {
-        int ow_per_oc = jcp.transpose_dst ? 2 : 1;
-        int ch_mult
+        const dim_t ow_per_oc = jcp.transpose_dst ? 2 : 1;
+        dim_t ch_mult
                 = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
         dim_t hd_off = jcp.tr_ow * ch_mult * hd_idx;
         dim_t w_off
@@ -695,7 +695,7 @@ private:
         return jcp.typesize_in * (w_off + hd_off);
     }
 
-    inline dim_t get_kernel_offset(int ic_idx, dim_t ksp_idx) const {
+    inline dim_t get_kernel_offset(dim_t ic_idx, dim_t ksp_idx) const {
         // Only the ic_idx index inside the block is supported,
         // ic_idx == jcp.ic_block is considered as a shift inside one block
         // and not as moving to the next ic block.
@@ -717,7 +717,7 @@ private:
     inline int interleave_w_reorder_size(int ur_w) const;
     inline int interleave_w_reorder_bytes(int ur_w);
     inline int interleave_stack_size(int ur_w, int ic_block_step);
-    inline int permw_stack_size(int ur_w) const {
+    inline dim_t permw_stack_size(dim_t ur_w) const {
         return (ur_w + jcp.kw - 1) * sizeof_cacheline;
     }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -71,10 +71,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount
             = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks * jcp.nb_ow;
 
@@ -84,14 +84,14 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
         balance211(work_amount, nthr, ithr, start, end);
         auto par_conv = jit_conv_args_t();
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn) {
-            int dummy {0};
+            dim_t dummy {0};
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
                     nb_groups, n, jcp.mb, dummy, 1);
         } else if (jcp.loop_order == loop_gncw) {
-            int dummy {0};
+            dim_t dummy {0};
             nd_iterator_init(start, gg, nb_groups, n, jcp.mb, occ, oc_chunks,
                     owb, jcp.nb_ow, dummy, 1);
         } else if (jcp.loop_order == loop_nhwcg) {
@@ -101,13 +101,13 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w
@@ -117,7 +117,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::nwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, iw_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb);
 
@@ -135,11 +135,11 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_1d(
             (*kernel_)(&par_conv);
 
             if (jcp.loop_order == loop_cwgn) {
-                int dummy {0};
+                dim_t dummy {0};
                 nd_iterator_jump(start, end, occ, oc_chunks, owb, jcp.nb_ow, gg,
                         nb_groups, n, jcp.mb, dummy, 1);
             } else if (jcp.loop_order == loop_gncw) {
-                int dummy {0};
+                dim_t dummy {0};
                 nd_iterator_jump(start, end, gg, nb_groups, n, jcp.mb, occ,
                         oc_chunks, owb, jcp.nb_ow, dummy, 1);
             } else if (jcp.loop_order == loop_nhwcg) {
@@ -172,10 +172,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks
             * jcp.oh * jcp.nb_ow;
 
@@ -191,7 +191,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
         size_t dst_h_stride = dst_d.blk_off<false, true>(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, oh_s {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -207,18 +207,18 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
 
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) oh_e = oh_s + 1; //step instead
 
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w = dst
@@ -228,19 +228,20 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_2d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, ih_s, iw_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-            for (int oj = oh_s, ij = ih_s; oj < oh_e;
+            for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                     ++oj, ij += jcp.stride_h) {
-                int dilate_h = jcp.dilate_h + 1;
-                int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                int i_b_overflow = div_up(
-                        max(0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+                dim_t dilate_h = jcp.dilate_h + 1;
+                dim_t i_t_overflow = div_up(max<dim_t>(0, -ij), dilate_h);
+                dim_t i_b_overflow = div_up(
+                        max<dim_t>(
+                                0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h);
-                int kh_padding
-                        = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+                dim_t kh_padding = nstl::max<dim_t>(
+                        0, jcp.kh - i_t_overflow - i_b_overflow);
                 auto aux_src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
@@ -298,10 +299,10 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
 
     assert(jcp.nb_oc % jcp.nb_oc_blocking == 0);
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
     // TODO: experiment with g_blocking for perf fine tuning
-    int g_blocking = 1;
-    int nb_groups = jcp.ngroups / g_blocking;
+    dim_t g_blocking = 1;
+    dim_t nb_groups = jcp.ngroups / g_blocking;
     dim_t work_amount = static_cast<dim_t>(jcp.mb) * nb_groups * oc_chunks
             * jcp.od * jcp.oh * jcp.nb_ow;
 
@@ -319,7 +320,7 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, gg {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
 
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -335,25 +336,26 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
 
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) oh_e = oh_s + 1; //step instead
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
-            int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-            int dilate_d = jcp.dilate_d + 1;
-            int d_t_overflow = div_up(max(0, -id_s), dilate_d);
-            int d_b_overflow = div_up(
-                    max(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
+            dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+            dim_t dilate_d = jcp.dilate_d + 1;
+            dim_t d_t_overflow = div_up(max<dim_t>(0, -id_s), dilate_d);
+            dim_t d_b_overflow = div_up(
+                    max<dim_t>(0, id_s - jcp.id + (jcp.kd - 1) * dilate_d + 1),
                     dilate_d);
-            int kd_padding = nstl::max(0, jcp.kd - d_t_overflow - d_b_overflow);
+            dim_t kd_padding
+                    = nstl::max<dim_t>(0, jcp.kd - d_t_overflow - d_b_overflow);
 
             const bool is_dst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-            const int oc_idx = is_dst_layout_nxc
+            const dim_t oc_idx = is_dst_layout_nxc
                     ? g * jcp.oc + ocb * jcp.oc_block
                     : g * jcp.nb_oc + ocb;
             auto dst_w = dst
@@ -364,21 +366,22 @@ void jit_avx512_core_bf16_convolution_fwd_t::execute_forward_3d(
                                     * (is_dst_layout_nxc ? 1 : jcp.oc_block)
                                : nullptr;
             const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-            const int ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
+            const dim_t ic_idx = is_src_layout_nxc ? g * jcp.ic : g * jcp.nb_ic;
             auto src_w = src + src_d.blk_off(n, ic_idx, id_s, ih_s, iw_s)
                     + d_t_overflow * dilate_d * src_d_stride;
             auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0)
                     + d_t_overflow * wht_d_stride;
 
-            for (int oj = oh_s, ij = ih_s; oj < oh_e;
+            for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                     ++oj, ij += jcp.stride_h) {
-                int dilate_h = jcp.dilate_h + 1;
-                int i_t_overflow = div_up(max(0, -ij), dilate_h);
-                int i_b_overflow = div_up(
-                        max(0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+                dim_t dilate_h = jcp.dilate_h + 1;
+                dim_t i_t_overflow = div_up(max<dim_t>(0, -ij), dilate_h);
+                dim_t i_b_overflow = div_up(
+                        max<dim_t>(
+                                0, ij - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h);
-                int kh_padding
-                        = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+                dim_t kh_padding = nstl::max<dim_t>(
+                        0, jcp.kh - i_t_overflow - i_b_overflow);
                 auto aux_src = src_w + i_t_overflow * dilate_h * src_h_stride;
                 auto aux_wht = wht_w + i_t_overflow * wht_h_stride;
 
@@ -430,12 +433,12 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
     const auto &jcp = pd()->jcp_;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t start {0}, end {0};
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
         // TODO: experiment with g_blocking for perf fine tuning
-        int g_blocking = 1;
-        int nb_groups = jcp.ngroups / g_blocking;
-        int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
+        dim_t g_blocking = 1;
+        dim_t nb_groups = jcp.ngroups / g_blocking;
+        dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.id * jcp.ih;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto par_conv = jit_conv_args_t();
@@ -449,7 +452,7 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
         bool is_fast_path_d = jcp.dilate_d == 0 && jcp.stride_d == 1;
         bool is_fast_path_h = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        int n {0}, gg {0}, icc {0}, id_s {0}, ih_s {0};
+        dim_t n {0}, gg {0}, icc {0}, id_s {0}, ih_s {0};
         if (jcp.loop_order == loop_cgn)
             nd_iterator_init(start, icc, ic_chunks, gg, nb_groups, n, jcp.mb,
                     id_s, jcp.id, ih_s, jcp.ih);
@@ -463,28 +466,30 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int icb = icc * jcp.nb_ic_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+            dim_t icb = icc * jcp.nb_ic_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) ih_e = ih_s + 1; //step instead
 
-            int od_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t od_s = 0, kd_len = 0, kd_lo = 0;
             if (is_fast_path_d) {
-                int d_t_overflow = max(0, jcp.kd - 1 - id_s - jcp.f_pad);
-                int d_b_overflow
-                        = max(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
+                dim_t d_t_overflow
+                        = max<dim_t>(0, jcp.kd - 1 - id_s - jcp.f_pad);
+                dim_t d_b_overflow
+                        = max<dim_t>(0, jcp.kd - jcp.id + id_s - jcp.back_pad);
                 kd_len = jcp.kd - d_t_overflow - d_b_overflow;
                 kd_lo = d_b_overflow;
                 od_s = id_s + jcp.f_pad - d_b_overflow;
             } else if (jcp.dilate_d != 0) { // stride == 1
-                int dilate_d = jcp.dilate_d + 1;
+                dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
-                int d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
+                dim_t d_t_overflow = div_up(
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - id_s - jcp.f_pad),
                         dilate_d);
-                int d_b_overflow
-                        = div_up(max(0,
+                dim_t d_b_overflow
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.id
                                                  + id_s - jcp.back_pad),
                                 dilate_d);
@@ -492,14 +497,14 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
                 kd_lo = d_b_overflow;
                 od_s = id_s + jcp.f_pad - d_b_overflow * dilate_d;
             } else { // dilate == 0
-                int d_t_overflow = max(
+                dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - 1 - id_s - jcp.f_pad) / jcp.stride_d);
-                int d_b_overflow = max(0,
+                dim_t d_b_overflow = max<dim_t>(0,
                         (jcp.kd - jcp.id + id_s - jcp.back_pad) / jcp.stride_d);
-                int overflow_kd_hi = jcp.kd - 1
+                dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(
                                 jcp.id - 1 + jcp.back_pad - id_s, jcp.stride_d);
-                int overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
+                dim_t overflow_kd_lo = (id_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_b_overflow;
@@ -509,32 +514,36 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
             assert(kd_len >= 0);
 
             const bool is_dsrc_layout_nxc = jcp.src_tag == format_tag::ndhwc;
-            const int ic_idx = is_dsrc_layout_nxc
+            const dim_t ic_idx = is_dsrc_layout_nxc
                     ? g * jcp.ic + icb * jcp.ic_block
                     : g * jcp.nb_ic + icb;
             auto diff_src_w = diff_src
                     + jcp.typesize_out * diff_src_d.blk_off(n, ic_idx, id_s);
             const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-            const int oc_idx = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
+            const dim_t oc_idx
+                    = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
             auto diff_dst_w = diff_dst + diff_dst_d.blk_off(n, oc_idx, od_s);
             auto wht_w = weights + wht_blk_off(weights_d, g, 0, icb, kd_lo);
 
-            for (int ij = ih_s; ij < ih_e; ++ij) {
-                int oj, kh_len, kh_lo;
+            for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                dim_t oj, kh_len, kh_lo;
                 if (is_fast_path_h) { // dilate == 0 && stride == 1
-                    int i_t_overflow = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                    int i_b_overflow = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                    dim_t i_t_overflow
+                            = max<dim_t>(0, jcp.kh - 1 - ij - jcp.t_pad);
+                    dim_t i_b_overflow
+                            = max<dim_t>(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                     kh_len = jcp.kh - i_t_overflow - i_b_overflow;
                     kh_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow;
                 } else if (jcp.dilate_h != 0) { // stride == 1
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int i_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
+                    dim_t i_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
                             dilate_h);
-                    int i_b_overflow
-                            = div_up(max(0,
+                    dim_t i_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.ih + ij - jcp.b_pad),
                                     dilate_h);
@@ -542,13 +551,13 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data_3d(
                     kh_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                 } else { // dilate == 0
-                    int i_t_overflow = max(
+                    dim_t i_t_overflow = max<dim_t>(
                             0, (jcp.kh - 1 - ij - jcp.t_pad) / jcp.stride_h);
-                    int i_b_overflow = max(0,
+                    dim_t i_b_overflow = max<dim_t>(0,
                             (jcp.kh - jcp.ih + ij - jcp.b_pad) / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.ih - 1 + jcp.b_pad - ij, jcp.stride_h);
-                    int overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - i_t_overflow - i_b_overflow;
@@ -598,12 +607,12 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
     const auto &jcp = pd()->jcp_;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
+        dim_t start {0}, end {0};
+        dim_t ic_chunks = jcp.nb_ic / jcp.nb_ic_blocking;
         // TODO: experiment with g_blocking for perf fine tuning
-        int g_blocking = 1;
-        int nb_groups = jcp.ngroups / g_blocking;
-        int work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
+        dim_t g_blocking = 1;
+        dim_t nb_groups = jcp.ngroups / g_blocking;
+        dim_t work_amount = nb_groups * jcp.mb * ic_chunks * jcp.ih * jcp.nb_iw;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto par_conv = jit_conv_args_t();
@@ -616,7 +625,7 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
 
         bool is_fast_path = jcp.dilate_h == 0 && jcp.stride_h == 1;
 
-        int n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
+        dim_t n {0}, gg {0}, icc {0}, ih_s {0}, iwb {0};
         if (jcp.loop_order == loop_cwgn)
             nd_iterator_init(start, icc, ic_chunks, iwb, jcp.nb_iw, gg,
                     nb_groups, n, jcp.mb, ih_s, jcp.ih);
@@ -630,22 +639,23 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
             assert(!"unsupported loop order");
 
         while (start < end) {
-            int icb = icc * jcp.nb_ic_blocking;
-            int g = gg * g_blocking;
-            int work_rem = end - start;
-            int ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
+            dim_t icb = icc * jcp.nb_ic_blocking;
+            dim_t g = gg * g_blocking;
+            dim_t work_rem = end - start;
+            dim_t ih_e = ih_s + work_rem > jcp.ih ? jcp.ih : ih_s + work_rem;
             if (jcp.loop_order == loop_nhwcg) ih_e = ih_s + 1; //step instead
-            int iw_s = iwb * jcp.iw_block;
-            int ow_s = iw_s / jcp.stride_w;
+            dim_t iw_s = iwb * jcp.iw_block;
+            dim_t ow_s = iw_s / jcp.stride_w;
 
             auto diff_src_w = diff_src;
             auto diff_dst_w = diff_dst;
             const bool is_ddst_layout_nxc = utils::one_of(
                     jcp.dst_tag, format_tag::nwc, format_tag::nhwc);
-            const int oc_idx = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
+            const dim_t oc_idx
+                    = is_ddst_layout_nxc ? g * jcp.oc : g * jcp.nb_oc;
             const bool is_dsrc_layout_nxc = utils::one_of(
                     jcp.src_tag, format_tag::nwc, format_tag::nhwc);
-            const int ic_idx = is_dsrc_layout_nxc
+            const dim_t ic_idx = is_dsrc_layout_nxc
                     ? g * jcp.ic + icb * jcp.ic_block
                     : g * jcp.nb_ic + icb;
             if (jcp.ndims == 3) {
@@ -659,22 +669,25 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
             }
             auto wht_w = weights + wht_blk_off(weights_d, g, 0, icb);
 
-            for (int ij = ih_s; ij < ih_e; ++ij) {
-                int oj, k_len, k_lo;
+            for (dim_t ij = ih_s; ij < ih_e; ++ij) {
+                dim_t oj, k_len, k_lo;
                 if (is_fast_path) { // dilate == 0 && stride == 1
-                    int i_t_overflow = max(0, jcp.kh - 1 - ij - jcp.t_pad);
-                    int i_b_overflow = max(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
+                    dim_t i_t_overflow
+                            = max<dim_t>(0, jcp.kh - 1 - ij - jcp.t_pad);
+                    dim_t i_b_overflow
+                            = max<dim_t>(0, jcp.kh - jcp.ih + ij - jcp.b_pad);
                     k_len = jcp.kh - i_t_overflow - i_b_overflow;
                     k_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow;
                 } else if (jcp.dilate_h != 0) { // stride == 1
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int i_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
+                    dim_t i_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - ij - jcp.t_pad),
                             dilate_h);
-                    int i_b_overflow
-                            = div_up(max(0,
+                    dim_t i_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.ih + ij - jcp.b_pad),
                                     dilate_h);
@@ -682,13 +695,13 @@ void jit_avx512_core_bf16_convolution_bwd_data_t ::execute_backward_data(
                     k_lo = i_b_overflow;
                     oj = ij + jcp.t_pad - i_b_overflow * dilate_h;
                 } else { // dilate == 0
-                    int i_t_overflow = max(
+                    dim_t i_t_overflow = max<dim_t>(
                             0, (jcp.kh - 1 - ij - jcp.t_pad) / jcp.stride_h);
-                    int i_b_overflow = max(0,
+                    dim_t i_b_overflow = max<dim_t>(0,
                             (jcp.kh - jcp.ih + ij - jcp.b_pad) / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.ih - 1 + jcp.b_pad - ij, jcp.stride_h);
-                    int overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (ij + jcp.t_pad) % jcp.stride_h;
 
                     k_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h + 1
                             - i_t_overflow - i_b_overflow;
@@ -778,10 +791,10 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t ::thread_info_t {
     int ithr_but_oc = 0;
     int ithr_but_ic = 0;
 
-    int img_start = 0, img_end = 0, img_work = 0;
-    int g_start = 0, g_end = 0, g_work = 0;
-    int oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
-    int ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
+    dim_t img_start = 0, img_end = 0, img_work = 0;
+    dim_t g_start = 0, g_end = 0, g_work = 0;
+    dim_t oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
+    dim_t ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
 
     thread_info_t(const jit_avx512_core_bf16_convolution_bwd_weights_t *self,
             const exec_ctx_t &ctx, int ithr)
@@ -842,7 +855,7 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t ::thread_info_t {
         ithr_but_ic = (ithr_mb * self->nthr_g_ + ithr_g) * self->nthr_oc_b_
                 + ithr_oc_b;
 
-        int work_amount = jcp.nthr_mb_work;
+        const dim_t work_amount = jcp.nthr_mb_work;
         /* reduction dimension */
         balance211(work_amount, self->nthr_mb_, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
@@ -862,14 +875,14 @@ struct jit_avx512_core_bf16_convolution_bwd_weights_t ::thread_info_t {
 };
 
 size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_src_buf_number(
-        const thread_info_t *ti, int g, int ic) const {
+        const thread_info_t *ti, dim_t g, dim_t ic) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_ic * jcp.ngroups + g * jcp.nb_ic + ic
             : ti->ithr;
 }
 size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_diff_dst_buf_number(
-        const thread_info_t *ti, int g, int oc) const {
+        const thread_info_t *ti, dim_t g, dim_t oc) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     return jcp.global_transpose
             ? ti->ithr_mb * jcp.nb_oc * jcp.ngroups + g * jcp.nb_oc + oc
@@ -877,7 +890,7 @@ size_t jit_avx512_core_bf16_convolution_bwd_weights_t::tr_diff_dst_buf_number(
 }
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
-        src_data_t *tr_src, const src_data_t *src, int row_count) const {
+        src_data_t *tr_src, const src_data_t *src, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     const int pf_depth = 2;
     struct {
@@ -886,14 +899,14 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
     } pf_circ_buf_src[pf_depth];
 
     assert(jcp.ic_block == 16 || jcp.is_1stconv);
-    const int src_stride = jcp.iw * jcp.ic_block;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ic_block;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
     for (int iwork = 0; iwork < row_count + pf_depth - 1; iwork++) {
         pf_circ_buf_src[iwork % pf_depth] = {src, tr_src};
 
         if (iwork >= pf_depth - 1) {
-            int old_idx = (iwork - pf_depth + 1) % pf_depth;
+            dim_t old_idx = (iwork - pf_depth + 1) % pf_depth;
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = pf_circ_buf_src[old_idx].src;
             ctx.tr_src = pf_circ_buf_src[old_idx].tr_src;
@@ -907,27 +920,29 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_src(
 }
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
-        src_data_t *tr_src, const src_data_t *src_base, int spatial_start,
-        dim_t spatial_start_offset, int icb_start, dim_t chb_stride,
-        int row_count) const {
+        src_data_t *tr_src, const src_data_t *src_base, dim_t spatial_start,
+        dim_t spatial_start_offset, dim_t icb_start, dim_t chb_stride,
+        dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int src_stride = jcp.iw * jcp.ngroups * jcp.ic;
-    const int tr_src_stride = jcp.tr_iw * jcp.ic_block;
+    const dim_t src_stride = jcp.iw * jcp.ngroups * jcp.ic;
+    const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block;
 
-    int work_rest = row_count;
-    int max_spatial_work = jcp.id * jcp.ih;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    dim_t work_rest = row_count;
+    dim_t max_spatial_work = jcp.id * jcp.ih;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *src = src_base + spatial_start_offset;
-    int icb = 0;
-    const int ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
+    dim_t icb = 0;
+    const dim_t ic_tail_work = jcp.ic_tail ? jcp.ic_tail : jcp.ic_block;
     while (work_rest > 0) {
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_src_t::ctx_t();
             ctx.src = src;
             ctx.tr_src = tr_src;
             assert(icb_start + icb < jcp.nb_ic);
-            ctx.ch_work = (icb_start + icb + 1) == jcp.nb_ic ? ic_tail_work
-                                                             : jcp.ic_block;
+            ctx.ch_work = static_cast<int>((icb_start + icb + 1) == jcp.nb_ic
+                            ? ic_tail_work
+                            : jcp.ic_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_kernel_)(&ctx);
@@ -935,7 +950,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
             tr_src += tr_src_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         icb++;
         src = src_base + icb * chb_stride;
     }
@@ -943,7 +958,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_src_nxc(
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst,
-        int row_count) const {
+        dim_t row_count) const {
 
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
     const int pf_depth = 2;
@@ -953,15 +968,15 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
     } pf_circ_buf_dst[pf_depth];
 
     assert(jcp.ic_block == 16 || jcp.is_1stconv);
-    const int diff_dst_stride = jcp.ow * jcp.oc_block;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    const dim_t diff_dst_stride = jcp.ow * jcp.oc_block;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
 
     for (int iwork = 0; iwork < row_count + pf_depth - 1; iwork++) {
         pf_circ_buf_dst[iwork % pf_depth]
                 = {(diff_dst_data_t *)diff_dst, tr_diff_dst};
 
         if (iwork >= pf_depth - 1) {
-            int old_idx = (iwork - pf_depth + 1) % pf_depth;
+            dim_t old_idx = (iwork - pf_depth + 1) % pf_depth;
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = pf_circ_buf_dst[old_idx].diff_dst;
             ctx.tr_src = pf_circ_buf_dst[old_idx].tr_diff_dst;
@@ -976,25 +991,27 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::trans_dst(
 
 void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_dst_nxc(
         diff_dst_data_t *tr_diff_dst, const diff_dst_data_t *diff_dst_base,
-        int spatial_start, dim_t spatial_start_offset, int ocb_start,
-        dim_t chb_stride, int row_count) const {
+        dim_t spatial_start, dim_t spatial_start_offset, dim_t ocb_start,
+        dim_t chb_stride, dim_t row_count) const {
     const jit_conv_conf_t &jcp = this->kernel_->jcp;
-    const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
-    const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
-    int work_rest = row_count;
-    int max_spatial_work = jcp.od * jcp.oh;
-    int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+    const dim_t diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc;
+    const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block;
+    dim_t work_rest = row_count;
+    dim_t max_spatial_work = jcp.od * jcp.oh;
+    dim_t sp_work
+            = nstl::min<dim_t>(work_rest, max_spatial_work - spatial_start);
     const src_data_t *diff_dst = diff_dst_base + spatial_start_offset;
-    int ocb = 0;
-    const int oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
+    dim_t ocb = 0;
+    const dim_t oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
     while (work_rest > 0) {
         for (int iwork = 0; iwork < sp_work; iwork++) {
             auto ctx = jit_trans_dst_t::ctx_t();
             ctx.src = diff_dst;
             ctx.tr_src = tr_diff_dst;
             assert(ocb_start + ocb < jcp.nb_oc);
-            ctx.ch_work = (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
-                                                             : jcp.oc_block;
+            ctx.ch_work = static_cast<int>((ocb_start + ocb + 1) == jcp.nb_oc
+                            ? oc_tail_work
+                            : jcp.oc_block);
             ctx.src_prf = nullptr;
             ctx.tr_src_prf = nullptr;
             (*trans_dst_kernel_)(&ctx);
@@ -1002,7 +1019,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::trans_dst_nxc(
             tr_diff_dst += tr_diff_dst_stride;
         }
         work_rest -= sp_work;
-        sp_work = nstl::min(work_rest, max_spatial_work);
+        sp_work = nstl::min<dim_t>(work_rest, max_spatial_work);
         ocb++;
         diff_dst = diff_dst_base + ocb * chb_stride;
     }
@@ -1017,10 +1034,10 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_hblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_hblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1040,30 +1057,30 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + oj * tr_row_size;
     };
 
-    int img {0}, oh_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
 
     nd_iterator_init(start, img, jcp.mb, oh_s, jcp.oh);
 
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-        int ih_s = nstl::max(0, -jcp.t_pad + oh_s * jcp.stride_h);
-        const int ih_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+        dim_t ih_s = nstl::max<dim_t>(0, -jcp.t_pad + oh_s * jcp.stride_h);
+        const dim_t ih_e = nstl::min<dim_t>(
                 jcp.ih, -jcp.t_pad + (oh_e - 1) * jcp.stride_h + ext_kh);
 
-        auto tr_src_off = [&](int g, int ic, int ih_end, int ij) {
-            const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ih_end, dim_t ij) {
+            const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
             // Aligned to buffer end to use guard elements
             return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                     + (jcp.ih - ih_end + ij) * tr_row_size;
@@ -1074,25 +1091,26 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][ih][16][~iw~] <- src[nb_ic][ih][iw][16] */
             if (jcp.transpose_src) {
-                int j {0};
-                const int work_amount
+                dim_t j {0};
+                const dim_t work_amount
                         = ti->g_work * ti->ic_b_work * (ih_e - ih_s);
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start,
                         tr_end);
 
-                int g {0}, ic_b {0};
+                dim_t g {0}, ic_b {0};
                 nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work,
                         j, ih_e - ih_s);
 
                 if (nthr_oc_b_ > 1)
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int ic_b_ = ic_b + ti->ic_b_start;
-                    int j_s = j + ih_s;
-                    int j_e = j_s + nstl::min(tr_end - tr_start, ih_e - j_s);
-                    const int ic_off_idx = is_src_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t ic_b_ = ic_b + ti->ic_b_start;
+                    dim_t j_s = j + ih_s;
+                    dim_t j_e = j_s
+                            + nstl::min<dim_t>(tr_end - tr_start, ih_e - j_s);
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g_ * jcp.ic + ic_b_ * jcp.ic_block
                             : g_ * jcp.nb_ic + ic_b_;
                     const src_data_t *src
@@ -1112,25 +1130,26 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             }
             if (jcp.transpose_dst) {
-                int j {0};
-                const int work_amount
+                dim_t j {0};
+                const dim_t work_amount
                         = ti->g_work * ti->oc_b_work * (oh_e - oh_s);
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start,
                         tr_end);
 
-                int g {0}, oc_b {0};
+                dim_t g {0}, oc_b {0};
                 nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work,
                         j, oh_e - oh_s);
 
                 if (nthr_ic_b_ > 1)
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int oc_b_ = oc_b + ti->oc_b_start;
-                    int j_s = j + oh_s;
-                    int j_e = j_s + nstl::min(tr_end - tr_start, oh_e - j_s);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t oc_b_ = oc_b + ti->oc_b_start;
+                    dim_t j_s = j + oh_s;
+                    dim_t j_e = j_s
+                            + nstl::min<dim_t>(tr_end - tr_start, oh_e - j_s);
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g_ * jcp.oc + oc_b_ * jcp.oc_block
                             : g_ * jcp.nb_oc + oc_b_;
                     const diff_dst_data_t *diff_dst
@@ -1152,34 +1171,36 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_2d(
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             }
         }
-        int height_block = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
-        int ic_b_step
+        dim_t height_block
+                = jcp.global_transpose ? oh_e - oh_s : optimal_hblock;
+        dim_t ic_b_step
                 = jcp.uses_permw_transposition ? jcp.nb_ic_blocking_max : 1;
-        int icb_work = ti->ic_b_end - ti->ic_b_start;
+        dim_t icb_work = ti->ic_b_end - ti->ic_b_start;
         if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
             ic_b_step = utils::div_up(icb_work, 2);
 
-        for_(int ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for_(dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int ohb_e = nstl::min(ohb_s + height_block, oh_e);
-            const int ihb_s = nstl::max(0, -jcp.t_pad + ohb_s * jcp.stride_h);
-            const int ihb_e = nstl::min(
+            const dim_t ohb_e = nstl::min<dim_t>(ohb_s + height_block, oh_e);
+            const dim_t ihb_s
+                    = nstl::max<dim_t>(0, -jcp.t_pad + ohb_s * jcp.stride_h);
+            const dim_t ihb_e = nstl::min<dim_t>(
                     jcp.ih, -jcp.t_pad + (ohb_e - 1) * jcp.stride_h + ext_kh);
             assert(IMPLICATION(jcp.global_transpose,
                     oh_s == ohb_s && oh_e == ohb_e && ih_s == ihb_s
                             && ih_e == ihb_e));
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
 
             if (jcp.transpose_src) {
@@ -1249,10 +1270,10 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
     const auto &jcp = kernel_->jcp;
     const bool is_src_layout_nxc = jcp.src_tag == format_tag::ndhwc;
     const bool is_ddst_layout_nxc = jcp.dst_tag == format_tag::ndhwc;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_dblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_dblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1272,31 +1293,31 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od) {
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od) {
         assert(IMPLICATION(is_ddst_layout_nxc, jcp.transpose_dst));
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
-        const size_t tr_3d_size = tr_row_size * jcp.oh;
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.oh;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size;
     };
-    int img {0}, od_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
 
     nd_iterator_init(start, img, jcp.mb, od_s, jcp.od);
     while (start < end) {
         auto p = jit_conv_args_t();
-        int work_rem = end - start;
-        const int od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
-        int id_s = nstl::max(0, -jcp.f_pad + od_s * jcp.stride_d);
-        const int id_e = nstl::min(
+        dim_t work_rem = end - start;
+        const dim_t od_e = od_s + work_rem > jcp.od ? jcp.od : od_s + work_rem;
+        dim_t id_s = nstl::max<dim_t>(0, -jcp.f_pad + od_s * jcp.stride_d);
+        const dim_t id_e = nstl::min<dim_t>(
                 jcp.id, -jcp.f_pad + (od_e - 1) * jcp.stride_d + ext_kd);
 
-        auto tr_src_off_3d = [&](int g, int ic, int id_end, int id) {
-            const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
-            const size_t tr_3d_size = tr_row_size * jcp.ih;
+        auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id_end, dim_t id) {
+            const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+            const dim_t tr_3d_size = tr_row_size * jcp.ih;
             // Aligned to buffer end to use guard elements
             return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                     + (jcp.id - id_end + id) * tr_3d_size;
@@ -1307,16 +1328,16 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
             // TODO: try to call local transpositions just before jit kernel
             /* tr_src[nb_ic][id][16][~iw~] <- src[nb_ic][id][iw][16] */
             if (jcp.transpose_src) {
-                int d {0};
+                dim_t d {0};
 
-                const int work_amount
+                const dim_t work_amount
                         = ti->g_work * ti->ic_b_work * (id_e - id_s);
 
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, tr_start,
                         tr_end);
 
-                int g {0}, ic_b {0};
+                dim_t g {0}, ic_b {0};
 
                 nd_iterator_init(tr_start, g, ti->g_work, ic_b, ti->ic_b_work,
                         d, id_e - id_s);
@@ -1324,12 +1345,13 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                 if (nthr_oc_b_ > 1)
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int ic_b_ = ic_b + ti->ic_b_start;
-                    int d_s = d + id_s;
-                    int d_e = d_s + nstl::min(tr_end - tr_start, id_e - d_s);
+                    dim_t g_ = g + ti->g_start;
+                    dim_t ic_b_ = ic_b + ti->ic_b_start;
+                    dim_t d_s = d + id_s;
+                    dim_t d_e = d_s
+                            + nstl::min<dim_t>(tr_end - tr_start, id_e - d_s);
 
-                    const int ic_off_idx = is_src_layout_nxc
+                    const dim_t ic_off_idx = is_src_layout_nxc
                             ? g_ * jcp.ic + ic_b_ * jcp.ic_block
                             : g_ * jcp.nb_ic + ic_b_;
                     const src_data_t *src
@@ -1350,16 +1372,16 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                     barrier(&ti->tr_src_bctx[ti->ithr_but_oc], nthr_oc_b_);
             }
             if (jcp.transpose_dst) {
-                int d {0};
+                dim_t d {0};
 
-                const int work_amount
+                const dim_t work_amount
                         = ti->g_work * ti->oc_b_work * (od_e - od_s);
 
-                int tr_start {0}, tr_end {0};
+                dim_t tr_start {0}, tr_end {0};
                 balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, tr_start,
                         tr_end);
 
-                int g {0}, oc_b {0};
+                dim_t g {0}, oc_b {0};
 
                 nd_iterator_init(tr_start, g, ti->g_work, oc_b, ti->oc_b_work,
                         d, od_e - od_s);
@@ -1367,11 +1389,12 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
                 if (nthr_ic_b_ > 1)
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
                 while (tr_start < tr_end) {
-                    int g_ = g + ti->g_start;
-                    int oc_b_ = oc_b + ti->oc_b_start;
-                    int d_s = d + od_s;
-                    int d_e = d_s + nstl::min(tr_end - tr_start, od_e - d_s);
-                    const int oc_off_idx = is_ddst_layout_nxc
+                    dim_t g_ = g + ti->g_start;
+                    dim_t oc_b_ = oc_b + ti->oc_b_start;
+                    dim_t d_s = d + od_s;
+                    dim_t d_e = d_s
+                            + nstl::min<dim_t>(tr_end - tr_start, od_e - d_s);
+                    const dim_t oc_off_idx = is_ddst_layout_nxc
                             ? g_ * jcp.oc + oc_b_ * jcp.oc_block
                             : g_ * jcp.nb_oc + oc_b_;
 
@@ -1396,37 +1419,38 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights_3d(
             }
         }
 
-        int depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
+        dim_t depth_block = jcp.global_transpose ? od_e - od_s : optimal_dblock;
 
-        for_(int odb_s = od_s; odb_s < od_e; odb_s += depth_block)
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end; ++ic_b) {
-            const int odb_e = nstl::min(odb_s + depth_block, od_e);
-            const int idb_s = nstl::max(0, -jcp.f_pad + odb_s * jcp.stride_d);
-            const int idb_e = nstl::min(
+        for_(dim_t odb_s = od_s; odb_s < od_e; odb_s += depth_block)
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end; ++ic_b) {
+            const dim_t odb_e = nstl::min<dim_t>(odb_s + depth_block, od_e);
+            const dim_t idb_s
+                    = nstl::max<dim_t>(0, -jcp.f_pad + odb_s * jcp.stride_d);
+            const dim_t idb_e = nstl::min<dim_t>(
                     jcp.id, -jcp.f_pad + (odb_e - 1) * jcp.stride_d + ext_kd);
-            const int kdb_front_pad
-                    = nstl::max(0, jcp.f_pad - odb_s * jcp.stride_d);
+            const dim_t kdb_front_pad
+                    = nstl::max<dim_t>(0, jcp.f_pad - odb_s * jcp.stride_d);
             // Assumes kd_back_pad = 0 when kernel is dilated
-            const int kdb_back_pad = nstl::max(
+            const dim_t kdb_back_pad = nstl::max<dim_t>(
                     0, odb_s * jcp.stride_d + jcp.kd - jcp.f_pad - jcp.id);
-            const int kdb_pad_off = nstl::min(jcp.kd - 1, kdb_front_pad)
-                    * jcp.kh * jcp.kw * jcp.ic_block * jcp.oc_block
-                    * jcp.typesize_out;
+            const dim_t kdb_pad_off
+                    = nstl::min<dim_t>(jcp.kd - 1, kdb_front_pad) * jcp.kh
+                    * jcp.kw * jcp.ic_block * jcp.oc_block * jcp.typesize_out;
 
             assert(IMPLICATION(jcp.global_transpose,
                     od_s == odb_s && od_e == odb_e && id_s == idb_s
                             && id_e == idb_e));
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
             if (jcp.transpose_src) {
                 if (!jcp.global_transpose) {
@@ -1504,7 +1528,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
     const size_t wei_size = static_cast<size_t>(jcp.ngroups) * jcp.nb_oc
             * jcp.oc_block * jcp.nb_ic * jcp.ic_block * jcp.kh * jcp.kw
             * jcp.kd;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
 
     float *diff_wei;
     if (diff_weights_d.data_type() == data_type::bf16)
@@ -1524,45 +1548,45 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    auto tr_src_off = [&](int g, int ic, int ij) {
+    auto tr_src_off = [&](dim_t g, dim_t ic, dim_t ij) {
         assert(IMPLICATION(is_src_layout_nxc, jcp.transpose_src));
-        const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                 + ij * tr_row_size;
     };
 
-    auto tr_src_off_3d = [&](int g, int ic, int id, int ij) {
+    auto tr_src_off_3d = [&](dim_t g, dim_t ic, dim_t id, dim_t ij) {
         assert(IMPLICATION(is_ddst_layout_nxc, jcp.transpose_dst));
-        const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
-        const size_t tr_3d_size = tr_row_size * jcp.ih;
+        const dim_t tr_row_size = jcp.tr_iw * jcp.ic_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.ih;
         return tr_src_buf_number(ti, g, ic) * jcp.tr_src_buf_size
                 + id * tr_3d_size + ij * tr_row_size;
     };
 
-    auto tr_diff_dst_off = [&](int g, int oc, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+    auto tr_diff_dst_off = [&](dim_t g, dim_t oc, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + oj * tr_row_size;
     };
 
-    auto tr_diff_dst_off_3d = [&](int g, int oc, int od, int oj) {
-        const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
-        const size_t tr_3d_size = tr_row_size * jcp.oh;
+    auto tr_diff_dst_off_3d = [&](dim_t g, dim_t oc, dim_t od, dim_t oj) {
+        const dim_t tr_row_size = jcp.tr_ow * jcp.oc_block;
+        const dim_t tr_3d_size = tr_row_size * jcp.oh;
         return tr_diff_dst_buf_number(ti, g, oc) * jcp.tr_diff_dst_buf_size
                 + od * tr_3d_size + oj * tr_row_size;
     };
 
-    auto uker_trans = [&](int img, int g = 0, int ic_b = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.ih * jcp.id;
+    auto uker_trans = [&](dim_t img, dim_t g = 0, dim_t ic_b = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.ih * jcp.id;
         dim_t ic;
-        int icb_start = ic_b;
+        dim_t icb_start = ic_b;
         if (jcp.global_transpose) {
-            const int work_amount = is_src_layout_nxc
+            const dim_t work_amount = is_src_layout_nxc
                     ? ti->ic_b_work * jcp.ih * jcp.id
                     : ti->g_work * ti->ic_b_work * jcp.ih * jcp.id;
 
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_oc_b_, ti->ithr_oc_b, start, end);
             my_work = end - start;
 
@@ -1596,7 +1620,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         const bool need_local_gwork = is_src_layout_nxc && jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork)
                 ic = static_cast<dim_t>(gg) * jcp.ic
                         + static_cast<dim_t>(ic_b) * jcp.ic_block;
@@ -1614,7 +1638,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                         ? src_d.blk_off(0, 0, d, j)
                         : src_d.blk_off(0, 0, j);
                 dim_t ch_shift = src_d.blk_off(0, jcp.ic_block);
-                int sp_start_idx = d * jcp.ih + j;
+                dim_t sp_start_idx = d * jcp.ih + j;
                 trans_src_nxc(tr_src, src, sp_start_idx, sp_start_offset,
                         icb_start, ch_shift, my_work);
             } else
@@ -1622,18 +1646,18 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         }
     };
 
-    auto diff_dst_trans = [&](int img, int g = 0, int oc_b = 0) {
-        int j {0}, d {0};
-        int my_work = jcp.oh * jcp.od;
-        int oc;
-        int ocb_start = oc_b;
+    auto diff_dst_trans = [&](dim_t img, dim_t g = 0, dim_t oc_b = 0) {
+        dim_t j {0}, d {0};
+        dim_t my_work = jcp.oh * jcp.od;
+        dim_t oc;
+        dim_t ocb_start = oc_b;
 
         if (jcp.global_transpose) {
-            const size_t work_amount = is_ddst_layout_nxc
+            const dim_t work_amount = is_ddst_layout_nxc
                     ? ti->oc_b_work * jcp.oh * jcp.od
                     : ti->g_work * ti->oc_b_work * jcp.oh * jcp.od;
 
-            size_t start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr_ic_b_, ti->ithr_ic_b, start, end);
             my_work = end - start;
 
@@ -1666,7 +1690,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                 = is_ddst_layout_nxc && jcp.global_transpose;
         const auto local_gwork = need_local_gwork ? ti->g_work : 1;
 
-        for (int gg = g; gg < g + local_gwork; ++gg) {
+        for (dim_t gg = g; gg < g + local_gwork; ++gg) {
             if (need_local_gwork) oc = gg * jcp.oc + oc_b * jcp.oc_block;
             diff_dst_data_t *tr_diff_dst = (jcp.ndims == 5)
                     ? &ti->tr_diff_dst[tr_diff_dst_off_3d(gg, oc_b, d, j)]
@@ -1682,7 +1706,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                         ? diff_dst_d.blk_off(0, 0, d, j)
                         : diff_dst_d.blk_off(0, 0, j);
                 dim_t ch_shift = diff_dst_d.blk_off(0, jcp.oc_block);
-                int sp_start_idx = d * jcp.oh + j;
+                dim_t sp_start_idx = d * jcp.oh + j;
                 trans_dst_nxc(tr_diff_dst, diff_dst, sp_start_idx,
                         sp_start_offset, ocb_start, ch_shift, my_work);
             } else
@@ -1690,7 +1714,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
         }
     };
 
-    for (int img = ti->img_start; img < ti->img_end; ++img) {
+    for (dim_t img = ti->img_start; img < ti->img_end; ++img) {
         auto p = jit_conv_args_t();
         if (jcp.global_transpose) {
             using simple_barrier::barrier;
@@ -1711,24 +1735,24 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::compute_diff_weights(
                     barrier(&ti->tr_diff_dst_bctx[ti->ithr_but_ic], nthr_ic_b_);
             }
         }
-        int ic_b_step
+        dim_t ic_b_step
                 = jcp.uses_permw_transposition ? jcp.nb_ic_blocking_max : 1;
-        int icb_work = ti->ic_b_end - ti->ic_b_start;
+        dim_t icb_work = ti->ic_b_end - ti->ic_b_start;
         if (ic_b_step > 1 && icb_work > ic_b_step && icb_work < 2 * ic_b_step)
             ic_b_step = utils::div_up(icb_work, 2);
-        for_(int g = ti->g_start; g < ti->g_end; ++g)
-        for_(int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
-        for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+        for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+        for_(dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; ++oc_b)
+        for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                 ic_b += ic_b_step) {
-            const int ic_off_idx = is_src_layout_nxc
+            const dim_t ic_off_idx = is_src_layout_nxc
                     ? g * jcp.ic + ic_b * jcp.ic_block
                     : g * jcp.nb_ic + ic_b;
-            const int oc_off_idx = is_ddst_layout_nxc
+            const dim_t oc_off_idx = is_ddst_layout_nxc
                     ? g * jcp.oc + oc_b * jcp.oc_block
                     : g * jcp.nb_oc + oc_b;
-            const int ic_to_compute = this_block_size(
+            const dim_t ic_to_compute = this_block_size(
                     ic_b * jcp.ic_block, jcp.ic, ic_b_step * jcp.ic_block);
-            const int oc_to_compute = this_block_size(
+            const dim_t oc_to_compute = this_block_size(
                     oc_b * jcp.oc_block, jcp.oc, jcp.oc_block);
             if (jcp.transpose_src) {
                 if (!jcp.global_transpose) {
@@ -1798,8 +1822,8 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
     if (nthr_mb_ == 1) {
         if (is_bf16_out) {
             // reduction is not required, only conversion
-            for_(int g = ti->g_start; g < ti->g_end; g++)
-            for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
+            for_(dim_t g = ti->g_start; g < ti->g_end; g++)
+            for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
                 const size_t acc_size = (size_t)ti->ic_b_work * jcp.kh * jcp.kw
                         * ((jcp.ndims == 5) ? jcp.kd : 1) * jcp.ic_block
                         * jcp.oc_block;
@@ -1811,12 +1835,12 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
         }
 
         if (is_bf16_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
-                int result_start_idx = g * jcp.oc_without_padding
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
+                dim_t result_start_idx = g * jcp.oc_without_padding
                         + ti->oc_b_start * jcp.oc_block;
-                int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
                 bfloat16_t *diff_bias
@@ -1832,31 +1856,32 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
     if (jcp.global_transpose)
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, nthr_);
 
-    const int ic_b_kh_work
+    const dim_t ic_b_kh_work
             = ti->ic_b_work * ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, nthr_mb_, ti->ithr_mb, start, end);
     if (start == end) return;
 
     const int _start_nthr_mb = 1;
     for (int thr_mb = _start_nthr_mb; thr_mb < nthr_mb_; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = start;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start
                     + sub_ic_b_kh_start / ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-            const int kX
+            const dim_t kX
                     = sub_ic_b_kh_start % ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
 
             const size_t acc_size = (size_t)jcp.kw * jcp.ic_block * jcp.oc_block
                     * ((jcp.ndims == 5) ? jcp.kh : 1)
-                    * nstl::min(end - w, ic_b_kh_work - sub_ic_b_kh_start);
+                    * nstl::min<dim_t>(
+                            end - w, ic_b_kh_work - sub_ic_b_kh_start);
 
             const size_t off = wht_blk_off(diff_weights_d, g, oc_b, ic_b, kX);
 
@@ -1882,22 +1907,22 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::
         }
         if (jcp.with_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0
                 && ti->ithr_mb == 0 && ti->img_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
                 float *bias_reduced = is_bf16_bias ? ti->bia_reduction
                                                    : (float *)(ti->diff_bias);
                 int thr_mb_buffer_idx = is_bf16_bias ? thr_mb : thr_mb - 1;
-                int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+                dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
                 float *bias_to_reduce
                         = ti->bia_reduction + thr_mb_buffer_idx * bias_buf_size;
-                const size_t acc_size = nstl::min(jcp.oc_without_padding,
+                const size_t acc_size = nstl::min<dim_t>(jcp.oc_without_padding,
                                                 ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
-                int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 if (is_bf16_bias && thr_mb == nthr_mb_ - 1) {
                     // the last iteration for bfloat16 requires conversion and
                     // store to diff_weights array
-                    int diff_bias_idx = g * jcp.oc_without_padding
+                    dim_t diff_bias_idx = g * jcp.oc_without_padding
                             + ti->oc_b_start * jcp.oc_block;
                     add_floats_and_cvt_to_bfloat16(
                             (bfloat16_t *)(ti->diff_bias) + diff_bias_idx,
@@ -1926,7 +1951,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::prepare_scratchpad_data(
         // buffers sharing padding
         for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
             src_data_t *ts = &tr_src[ithr * jcp.tr_src_buf_size];
-            for (int i = 0; i < jcp.tr_src_num_guard_elems; ++i)
+            for (dim_t i = 0; i < jcp.tr_src_num_guard_elems; ++i)
                 ts[i] = 0;
         }
 
@@ -2007,9 +2032,9 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t ::execute_backward_weights(
                     = ctx.get_scratchpad_grantor().template get<const float>(
                             key_conv_padded_bias);
             auto diff_bias_in = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc_without_padding;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc_without_padding;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.hpp
@@ -254,19 +254,20 @@ private:
 
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
-    size_t tr_src_buf_number(const thread_info_t *ti, int g, int ic) const;
-    size_t tr_diff_dst_buf_number(const thread_info_t *ti, int g, int oc) const;
+    size_t tr_src_buf_number(const thread_info_t *ti, dim_t g, dim_t ic) const;
+    size_t tr_diff_dst_buf_number(
+            const thread_info_t *ti, dim_t g, dim_t oc) const;
     void trans_src(
-            src_data_t *tr_src1, const src_data_t *src1, int my_work) const;
+            src_data_t *tr_src1, const src_data_t *src1, dim_t my_work) const;
     void trans_dst(diff_dst_data_t *tr_diff_dst1,
-            const diff_dst_data_t *diff_dst1, int my_work) const;
+            const diff_dst_data_t *diff_dst1, dim_t my_work) const;
     void trans_src_nxc(src_data_t *tr_src, const src_data_t *src_base,
-            int spatial_start, dim_t spatial_start_offset, int icb_start,
-            dim_t chb_stride, int my_work) const;
+            dim_t spatial_start, dim_t spatial_start_offset, dim_t icb_start,
+            dim_t chb_stride, dim_t my_work) const;
     void trans_dst_nxc(diff_dst_data_t *tr_diff_dst,
-            const diff_dst_data_t *diff_dst_base, int spatial_start,
-            dim_t spatial_start_offset, int ocb_start, dim_t chb_stride,
-            int my_work) const;
+            const diff_dst_data_t *diff_dst_base, dim_t spatial_start,
+            dim_t spatial_start_offset, dim_t ocb_start, dim_t chb_stride,
+            dim_t my_work) const;
 
     int nthr_ = 0, nthr_mb_ = 0, nthr_g_ = 0, nthr_oc_b_ = 0, nthr_ic_b_ = 0;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -89,14 +89,14 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::load_src(
                     = mask_flag ? zmm_acc | ktail_mask | T_z : zmm_acc;
 
             if (this->jcp.with_bias) {
-                int b_off = ch * ch_blk;
+                const dim_t b_off = ch * ch_blk;
                 uni_vmovups(
                         zmm_acc_msk, vmmword[reg_bias + b_off * sizeof(float)]);
             } else {
                 uni_vpxor(zmm_acc, zmm_acc, zmm_acc);
             }
             if (this->jcp.with_sum) {
-                int o_off = ch * ocb_stride + ow * ow_stride;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                 if (jcp.dst_dt == data_type::bf16) {
                     const Zmm zmm_prev_dst_msk = mask_flag
                             ? zmm_prev_dst | ktail_mask | T_z
@@ -117,10 +117,10 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::load_src(
 void jit_avx512_dw_conv_fwd_kernel_bf16_t::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r,
         bool last_ch_block_flag) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -145,20 +145,21 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::apply_filter_unrolled(
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
             const bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
             for (int kw = 0; kw < jcp.kw; kw++) {
-                int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
+                const dim_t ker_off
+                        = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
                 const Zmm zmm_ker_reg_msk = mask_flag
                         ? zmm_ker_reg | ktail_mask | T_z
                         : zmm_ker_reg;
                 vpmovzxwd(zmm_ker_reg_msk,
                         ptr[aux_reg_kernel + ker_off * jcp.typesize_in]);
-                int ow_start = get_ow_start(kw, pad_l);
-                int ow_end = get_ow_end(ur_w, kw, pad_r);
-                for (int ow = ow_start; ow < ow_end; ow++) {
+                const dim_t ow_start = get_ow_start(kw, pad_l);
+                const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                for (dim_t ow = ow_start; ow < ow_end; ow++) {
                     const Zmm zmm_src_reg_msk = mask_flag
                             ? zmm_src_reg | ktail_mask | T_z
                             : zmm_src_reg;
-                    Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
-                    int inp_off = ch * icb_stride
+                    Zmm zmm_acc = get_acc_reg(static_cast<int>(ch * ur_w + ow));
+                    const dim_t inp_off = ch * icb_stride
                             + (ow * stride_w - pad_l) * iw_stride
                             + kw * dilate_w * iw_stride;
                     /* zero-extend bf16 to packed 32-bit int */
@@ -313,7 +314,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::store_dst(
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 bool mask_flag = last_ch_block_flag && ch == ur_ch_blocks - 1;
                 for (int ow = 0; ow < ur_w; ow++) {
-                    int o_off = ch * ocb_stride + ow * ow_stride;
+                    const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                     Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
                     Zmm zmm_dst_msk
                             = mask_flag ? zmm_dst | ktail_mask : zmm_dst;
@@ -354,7 +355,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::store_dst(
                     bool mask_flag
                             = last_ch_block_flag && ch == ur_ch_blocks - 1;
                     for (int ow = 0; ow < ur_w; ow++) {
-                        int o_off = ch * ocb_stride + ow * ow_stride;
+                        const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                         Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
 
                         /* down-convert f32 output to bf16 */
@@ -409,10 +410,10 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
 
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_ch = jcp.oc / jcp.ch_block;
-        const int nb_ch_blocking_tail
-                = jcp.nb_ch - utils::rnd_dn(nb_ch, jcp.nb_ch_blocking);
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int nb_ch = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int nb_ch_blocking_tail = static_cast<int>(
+                jcp.nb_ch - utils::rnd_dn(nb_ch, jcp.nb_ch_blocking));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         push(reg_kernel);
         push(reg_input);
@@ -459,36 +460,36 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
 
 void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int n_oi = static_cast<int>(ow / ur_w);
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
     if (r_pad1 > 0) n_oi--;
     xor_(reg_oi, reg_oi);
     if (ow == ur_w) {
-        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
+        compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad);
     } else {
         if (n_oi == 0) {
-            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
+            compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad1);
             add(reg_input, inp_shift_pad);
             add(reg_output, out_shift);
             if (ur_w_tail != 0) {
@@ -496,7 +497,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
             }
         } else {
             if (l_pad > 0) {
-                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
+                compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), 0);
                 add(reg_input, inp_shift_pad);
                 add(reg_output, out_shift);
                 inc(reg_oi);
@@ -564,7 +565,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::generate() {
     if (oc_tail != 0) {
         // Note: is_src_layout_nxc() == true, otherwise channels are padded
         // Prepare masks for tailing
-        const int oc_tail_shift
+        const dim_t oc_tail_shift
                 = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
         static constexpr auto zmm_16b_mask = ((1 << 16) - 1);
 
@@ -598,7 +599,7 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        loop_ow(jcp.nb_ch);
+        loop_ow(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
@@ -633,14 +634,14 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::load_ddst(
 
 inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
         int ur_ch_blocks, int ur_str_w, bool last_ch_block_flag) {
-    int kw = jcp.kw;
-    int kh = jcp.kh;
-    int ow = jcp.ow;
-    int oh = jcp.oh;
+    const dim_t kw = jcp.kw;
+    const dim_t kh = jcp.kh;
+    const dim_t ow = jcp.ow;
+    const dim_t oh = jcp.oh;
 
-    int ch_blk = jcp.ch_block;
-    int stride_h = jcp.stride_h;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const size_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
@@ -668,7 +669,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
                 const bool mask_flag
                         = last_ch_block_flag && ch == ur_ch_blocks - 1;
-                int ker_off = ch * kh * kw * ch_blk;
+                const dim_t ker_off = ch * kh * kw * ch_blk;
                 Zmm mm_zmm_ker // mm: maybe masked
                         = mask_flag ? zmm_ker_reg | k_ch_tail_mask | T_z
                                     : zmm_ker_reg;
@@ -714,10 +715,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
 
 inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::store_dsrc(
         int ur_ch_blocks, int ur_str_w, bool last_ch_block_flag) {
-    int ch_blk = jcp.ch_block;
-    int iw = jcp.iw;
-    int ih = jcp.ih;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t iw = jcp.iw;
+    const dim_t ih = jcp.ih;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dsrc_layout_nxc = is_dsrc_layout_nxc();
     const size_t ch_block_step = ch_blk * (dsrc_layout_nxc ? 1 : ih * iw);
@@ -731,7 +732,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::store_dsrc(
         for (int w = 0; w < ur_str_w; w++) {
             size_t sp_offset = w * stride_w * sp_step;
             size_t ch_offset = ch * ch_block_step;
-            int dsrc_off = sp_offset + ch_offset;
+            const dim_t dsrc_off = sp_offset + ch_offset;
             auto zmm_dsrc = get_acc_reg(ch * ur_str_w + w);
             Zmm mm_zmm_dsrc // mm: maybe masked
                     = mask_flag ? zmm_dsrc | k_ch_tail_mask : zmm_dsrc;
@@ -777,10 +778,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
         assert(is_ddst_layout_nxc() && is_dsrc_layout_nxc());
 
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_oc = jcp.oc / jcp.ch_block;
-        const int ch_block_tail
-                = jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int nb_oc = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int ch_block_tail = static_cast<int>(
+                jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking)));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         const size_t wei_ch_stride
                 = (size_t)jcp.nb_ch_blocking * jcp.kh * jcp.kw * jcp.ch_block;
@@ -802,8 +803,12 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
                 call_compute_body(jcp.nb_ch_blocking, unroll_w);
 
                 add(reg_kernel, wei_ch_stride * jcp.typesize_in);
-                add(reg_dsrc, data_ch_stride * jcp.typesize_out);
-                add(reg_ddst, data_ch_stride * jcp.typesize_in);
+                add(reg_dsrc,
+
+                        data_ch_stride * jcp.typesize_out);
+                add(reg_ddst,
+
+                        data_ch_stride * jcp.typesize_in);
 
                 sub(aux_reg_ch_blocks, ch_step);
                 cmp(aux_reg_ch_blocks, ch_step);
@@ -843,7 +848,9 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::unroll_width_body(
 
             ch_loop_body(ur_ch_blocks, unroll_w);
 
-            add(reg_dsrc, jcp.typesize_out * jcp.stride_w * ch_step);
+            add(reg_dsrc,
+
+                    jcp.typesize_out * jcp.stride_w * ch_step);
             add(reg_ddst, jcp.typesize_in * ch_step);
 
             sub(reg_ur_str_w, unroll_w);
@@ -884,7 +891,7 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
             L(masking_done);
         }
 
-        unroll_width_body(jcp.nb_ch);
+        unroll_width_body(static_cast<int>(jcp.nb_ch));
     } else {
         auto ch_blocks_loop = [&](int ch_blocks) {
             Label skip_loop_label;
@@ -914,7 +921,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter() {
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::load_filter(
         bool is_last_ch) {
     for (int i = 0; i < jcp.kw; ++i) {
-        int off_filter = i * jcp.ch_block;
+        const dim_t off_filter = i * jcp.ch_block;
         Zmm zmm_acc = get_acc_reg(i);
         Zmm m_zmm_acc = is_last_ch ? zmm_acc | k_ch_tail_mask | T_z : zmm_acc;
         vmovups(m_zmm_acc,
@@ -937,14 +944,15 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
         bool is_last_ch) {
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const int right_border = static_cast<int>(jcp.iw - iw_block);
+    const int r_pad = static_cast<int>(jcp.r_pad);
 
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const int cascade_input = static_cast<int>(nstl::min(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const int input_overlap
+            = static_cast<int>(nstl::max<dim_t>(jcp.kw - l_pad, 0));
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
 
     /* LOAD initial input registers, then cascade LOADs and FMAs*/
@@ -972,8 +980,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
             }
         } else {
             for (int c = 0; c < cascade_input; ++c) {
-                int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                int input_sp = overlap + c - pad_offset;
+                const dim_t overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
+                const dim_t input_sp = overlap + c - pad_offset;
                 if (input_sp < 0 || overlap + c + l_pad > right_border)
                     continue;
 
@@ -983,7 +991,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
 
                 size_t input_offset = static_cast<size_t>(
                         input_sp * ch_step * jcp.typesize_in);
-                Zmm zmm_input = get_input_reg(overlap + c);
+                Zmm zmm_input = get_input_reg(static_cast<int>(overlap + c));
                 Zmm m_zmm_input = is_last_ch ? zmm_input | k_ch_tail_mask | T_z
                                              : zmm_input;
                 vpmovzxwd(m_zmm_input, ptr[reg_tmp_input + input_offset]);
@@ -991,7 +999,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
         }
 
         for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-            int io_overlap = i_kw + (i_ur * jcp.stride_w);
+            const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
             /* Don't apply FMAs that fall into the padded region */
             if (io_overlap - l_pad < 0
@@ -1002,7 +1010,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
                     && (io_overlap - jcp.l_pad + jcp.r_pad > right_border);
             if (over_steps_bdry) continue;
 
-            Zmm zmm_input = get_input_reg(io_overlap - l_pad);
+            Zmm zmm_input = get_input_reg(static_cast<int>(io_overlap - l_pad));
             Zmm zmm_acc = get_acc_reg(i_kw);
             if (isa_has_bf16(jcp.isa))
                 vdpbf16ps(zmm_acc, zmm_input, zmm_out_reg);
@@ -1015,7 +1023,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_step_unroll(
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_bias_step_unroll(
         const int unroll_w, bool is_last_ch) {
 
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t ch_step = is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block;
     for (int i = 0; i < unroll_w; ++i) {
         size_t off_output = static_cast<size_t>(i * ch_step * jcp.typesize_in);
         /* bf16 output data requires conversion to f32 */
@@ -1033,7 +1041,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::store_filter(
     /* bf16: all data is stored as f32. Down-convert to bf16 happens at the
      * reduction phase. */
     for (int i = 0; i < jcp.kw; ++i) {
-        int off_filter = i * jcp.ch_block;
+        const dim_t off_filter = i * jcp.ch_block;
         Zmm zmm_acc = get_acc_reg(i);
         Zmm m_zmm_acc = is_last_ch ? zmm_acc | k_ch_tail_mask : zmm_acc;
         vmovups(vmmword[reg_tmp_filter + off_filter * jcp.typesize_out],
@@ -1052,8 +1060,9 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
     Label oh_label;
     Label ow_blk_label;
 
-    const int unroll_w = nstl::min(max_unroll_w_, jcp.ow);
-    const int unroll_w_trips = jcp.ow / unroll_w;
+    const int unroll_w
+            = static_cast<int>(nstl::min<dim_t>(max_unroll_w_, jcp.ow));
+    const int unroll_w_trips = static_cast<int>(jcp.ow / unroll_w);
     const int tail_w = jcp.ow > max_unroll_w_ ? jcp.ow % max_unroll_w_ : 0;
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1314,7 +1323,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
     mov(reg_tmp_input, reg_input_baddr);
     mov(reg_tmp_filter, reg_filter_baddr);
 
-    const int input_bottom_padding_overlap
+    const dim_t input_bottom_padding_overlap
             = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1353,7 +1362,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -1361,7 +1370,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                const dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
                 add(reg_tmp_filter, filter_shift * inp_corr);
                 add(reg_tmp_input, input_shift * inp_corr);
             }
@@ -1416,12 +1425,12 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
 }
 
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::calculate_w_unrolling(
-        int &unroll_trips, int &unroll_w, int &unroll_w_tail) {
+        int &unroll_trips, int &unroll_w, int &unroll_w_tail) const {
 
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (do_unroll_w) {
-        unroll_w = nstl::min(block_size_, jcp.ow);
-        unroll_trips = jcp.ow / unroll_w;
+        unroll_w = static_cast<int>(nstl::min<dim_t>(block_size_, jcp.ow));
+        unroll_trips = static_cast<int>(jcp.ow / unroll_w);
         /* calculate tail */
         unroll_w_tail = jcp.ow % unroll_w;
         /* Perform some rebalancing if tail too small*/
@@ -1437,7 +1446,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::calculate_w_unrolling(
             }
         }
     } else {
-        unroll_w_tail = jcp.ow;
+        unroll_w_tail = static_cast<int>(jcp.ow);
     }
 }
 
@@ -1445,7 +1454,7 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
 
     Label ow_blk_label; // for compute middle block
     int pad_offset = 0;
-    int l_pad = jcp.l_pad;
+    int l_pad = static_cast<int>(jcp.l_pad);
     int unroll_w_tail = 0;
     int unroll_w = 0;
     int unroll_trips = 0;
@@ -1493,8 +1502,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
 
     /* compute right padded block */
     if (unroll_w_tail) {
-        compute_h_loop(
-                unroll_w_tail, l_pad, pad_offset, jcp.ow - unroll_w_tail);
+        compute_h_loop(unroll_w_tail, l_pad, pad_offset,
+                static_cast<int>(jcp.ow - unroll_w_tail));
     }
 }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.hpp
@@ -88,16 +88,17 @@ private:
     Xbyak::Zmm get_acc_reg(int idx);
 
     int get_ow_start(int ki, int pad_l) const {
-        return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+        return static_cast<int>(utils::div_up(
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w));
     }
 
     int get_ow_end(int ur_w, int ki, int pad_r) const {
         return ur_w
-                - utils::div_up(
-                        nstl::max(0,
+                - static_cast<int>(utils::div_up(
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
-                        jcp.stride_w);
+                        jcp.stride_w));
     }
 
     inline bool is_src_layout_nxc() const {
@@ -242,7 +243,7 @@ private:
         return Xbyak::Zmm(idx + idx_start);
     }
     inline Xbyak::Zmm get_input_reg(int idx) const {
-        const int i_idx = idx_start + jcp.kw + idx % jcp.kw;
+        const int i_idx = static_cast<int>(idx_start + jcp.kw + idx % jcp.kw);
         assert(i_idx <= get_max_regs());
         return Xbyak::Zmm(i_idx);
     }
@@ -313,7 +314,7 @@ private:
     void store_bias(bool is_last_ch);
     void compute_bias();
     void calculate_w_unrolling(
-            int &unroll_trips, int &unroll_w, int &unroll_w_tail);
+            int &unroll_trips, int &unroll_w, int &unroll_w_tail) const;
 
     void generate() override;
 

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -79,7 +79,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const int c_tail = jcp.oc % jcp.ch_block;
+    const dim_t c_tail = jcp.oc % jcp.ch_block;
 
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
         const bool is_tail_load
@@ -92,14 +92,14 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
                 const Zmm zmm_acc_msk = is_tail_load
                         ? zmm_acc | k_oc_tail_mask | T_z
                         : zmm_acc;
-                const int b_off = ch * ch_blk;
+                const dim_t b_off = ch * ch_blk;
                 uni_vmovups(zmm_acc_msk, ptr[reg_bias + b_off * sizeof(float)]);
             } else {
                 uni_vpxor(zmm_acc, zmm_acc, zmm_acc);
             }
 
             if (jcp.with_sum) {
-                const int o_off = ch * ocb_stride + ow * ow_stride;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride;
                 // using ker_zmm as zmm_tmp as it is safe to do so.
                 auto zmm_tmp = get_ker_reg(0);
                 io_->at(jcp.src_dt)
@@ -113,10 +113,10 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::load_src(
 
 void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r, bool is_ch_tail) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -126,16 +126,16 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             : (jcp.is_fused_conv ? 1 : jcp.ih) * jcp.iw * ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
 
-    auto get_input_spatial_index = [=](int oi, int ki) {
+    auto get_input_spatial_index = [=](dim_t oi, dim_t ki) -> dim_t {
         return (ki * dilate_w + oi * stride_w - pad_l);
     };
 
-    auto get_input_offset = [&](int ii, int ci) {
+    auto get_input_offset = [&](dim_t ii, dim_t ci) -> dim_t {
         return (ci * icb_stride + ii * iw_stride) * jcp.typesize_in;
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise) {
         // find bounds of input spatial indices
         bool first = true;
@@ -143,7 +143,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             int oi_start = get_ow_start(ki, pad_l);
             int oi_end = get_ow_end(ur_w, ki, pad_r);
             for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = get_input_spatial_index(oi, ki);
+                const dim_t ii = get_input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -164,42 +164,44 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_filter_unrolled(
             mov(aux_reg_input, ptr[aux_reg_input_buffer_ptr]);
             add(aux_reg_input, reg_iw_offset);
         }
-        const int c_tail = jcp.oc % jcp.ch_block;
+        const dim_t c_tail = jcp.oc % jcp.ch_block;
         for (int ch = 0; ch < ur_ch_blocks; ch++) {
             const bool is_tail_load = check_if_tail(
                     is_ch_tail, c_tail, ch, ur_ch_blocks, simd_w);
             if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= 0) continue;
             if (jcp.is_resrc_depthwise) {
                 // now we can load input once and reuse up to jcp.kw times
-                for (int ii = ii_start; ii <= ii_end; ii++) {
-                    Zmm zmm_src = get_src_reg(ii);
-                    const int inp_off = get_input_offset(ii, ch);
+                for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                    Zmm zmm_src = get_src_reg(static_cast<int>(ii));
+                    const dim_t inp_off = get_input_offset(ii, ch);
                     io_->at(jcp.src_dt)
                             ->load(ptr[aux_reg_input + inp_off], zmm_src,
                                     is_tail_load);
                 }
             }
             for (int kw = 0; kw < jcp.kw; kw++) {
-                const int ker_off = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
+                const dim_t ker_off
+                        = ch * jcp.kh * jcp.kw * ch_blk + kw * ch_blk;
 
                 Zmm zmm_ker = get_ker_reg(0);
                 io_->at(jcp.src_dt)
                         ->load(ptr[aux_reg_kernel + ker_off * jcp.typesize_in],
                                 zmm_ker, is_tail_load);
-                int ow_start = get_ow_start(kw, pad_l);
-                int ow_end = get_ow_end(ur_w, kw, pad_r);
-                for (int ow = ow_start; ow < ow_end; ow++) {
+                const dim_t ow_start = get_ow_start(kw, pad_l);
+                const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                for (dim_t ow = ow_start; ow < ow_end; ow++) {
 
-                    const int ii = get_input_spatial_index(ow, kw);
-                    Zmm zmm_src = jcp.is_resrc_depthwise ? get_src_reg(ii)
-                                                         : get_src_reg(0);
+                    const dim_t ii = get_input_spatial_index(ow, kw);
+                    Zmm zmm_src = jcp.is_resrc_depthwise
+                            ? get_src_reg(static_cast<int>(ii))
+                            : get_src_reg(0);
                     if (!jcp.is_resrc_depthwise) {
-                        const int inp_off = get_input_offset(ii, ch);
+                        const dim_t inp_off = get_input_offset(ii, ch);
                         io_->at(jcp.src_dt)
                                 ->load(ptr[aux_reg_input + inp_off], zmm_src,
                                         is_tail_load);
                     }
-                    Zmm zmm_acc = get_acc_reg(ch * ur_w + ow);
+                    Zmm zmm_acc = get_acc_reg(static_cast<int>(ch * ur_w + ow));
                     const Zmm zmm_ker_msk = is_tail_load
                             ? zmm_ker | k_oc_tail_mask | T_z
                             : zmm_ker;
@@ -253,7 +255,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::apply_postops(
             const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
             const auto mask_tail_blocked_layout
                     = jcp.oc_without_padding % jcp.ch_block && !dst_layout_nxc;
-            const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+            const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
             iterate(ur_ch_blocks, ur_w, mask_tail_blocked_layout,
                     [&](const int ch, const int ow,
                             const bool mask_flag_blocked_layout) {
@@ -317,14 +319,14 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::store_dst(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int simd_w = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
-    const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+    const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
 
     for (int ch = 0; ch < ur_ch_blocks; ch++) {
         const bool is_tail_load
                 = check_if_tail(is_ch_tail, c_tail, ch, ur_ch_blocks, simd_w);
         if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= 0) continue;
         for (int ow = 0; ow < ur_w; ow++) {
-            const int o_off = ch * ocb_stride + ow * ow_stride;
+            const dim_t o_off = ch * ocb_stride + ow * ow_stride;
             Zmm zmm_dst = get_acc_reg(ch * ur_w + ow);
             io_->at(jcp.dst_dt)
                     ->store(zmm_dst, ptr[reg_output + o_off * jcp.typesize_out],
@@ -365,9 +367,9 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
     mov(aux_reg_ch_blocks, reg_ch_blocks);
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int ch_block_tail = jcp.nb_ch
-                - (utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
-        const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
+        const int ch_block_tail = static_cast<int>(jcp.nb_ch
+                - utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
+        const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
         push(reg_kernel);
         push(reg_input);
@@ -414,36 +416,36 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
 
 void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    const dim_t iw = jcp.iw;
+    const dim_t ow = jcp.ow;
+    const dim_t kw = jcp.kw;
+    const dim_t l_pad = jcp.l_pad;
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int n_oi = static_cast<int>(ow / ur_w);
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
     if (r_pad1 > 0) n_oi--;
     xor_(reg_oi, reg_oi);
     if (ow == ur_w) {
-        compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad);
+        compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad);
     } else {
         if (n_oi == 0) {
-            compute_loop(ur_w, ur_ch_blocks, l_pad, r_pad1);
+            compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), r_pad1);
             add(reg_input, inp_shift_pad);
             add(reg_output, out_shift);
             if (ur_w_tail != 0) {
@@ -451,7 +453,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
             }
         } else {
             if (l_pad > 0) {
-                compute_loop(ur_w, ur_ch_blocks, l_pad, 0);
+                compute_loop(ur_w, ur_ch_blocks, static_cast<int>(l_pad), 0);
                 add(reg_input, inp_shift_pad);
                 add(reg_output, out_shift);
                 inc(reg_oi);
@@ -519,7 +521,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::generate() {
     if (oc_tail != 0) {
         // Prepare masks for tailing
         // Not using io_->prepare_tail_mask() since mask needs shifting
-        const int oc_tail_shift
+        const dim_t oc_tail_shift
                 = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
         static constexpr auto zmm_full_mask = ((1 << 16) - 1);
         Reg32 reg_tail_32 = reg_tail.cvt32();
@@ -528,7 +530,7 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        ow_loop(jcp.nb_ch);
+        ow_loop(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.hpp
@@ -85,16 +85,17 @@ private:
     }
 
     int get_ow_start(int ki, int pad_l) const {
-        return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+        return static_cast<int>(utils::div_up(
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w));
     }
 
     int get_ow_end(int ur_w, int ki, int pad_r) const {
         return ur_w
-                - utils::div_up(
-                        nstl::max(0,
+                - static_cast<int>(utils::div_up(
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
-                        jcp.stride_w);
+                        jcp.stride_w));
     }
 
     inline bool is_src_layout_nxc() const {

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -85,7 +85,7 @@ jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
-        int load_loop_blk) {
+        dim_t load_loop_blk) {
     mov(aux1_reg_bcast_data, reg_bcast_data);
     mov(aux_reg_bcast_data, reg_bcast_data);
 
@@ -101,9 +101,9 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const dim_t num_substeps = jcp.bcast_block / jcp.ur;
         assert(num_substeps > 0 && num_substeps < 10);
-        for (int i = 0; i < num_substeps; i++) {
+        for (dim_t i = 0; i < num_substeps; i++) {
             reduce_loop(load_loop_blk, jcp.ur, false);
             if (i < num_substeps - 1) {
                 add(aux1_reg_bcast_data, jcp.bcast_loop_bcast_substep);
@@ -113,7 +113,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::bcast_loop(
                         jcp.bcast_loop_bcast_step
                                 - (num_substeps - 1)
                                         * jcp.bcast_loop_bcast_substep);
-                int output_offset = jcp.bcast_loop_output_step
+                dim_t output_offset = jcp.bcast_loop_output_step
                         - (num_substeps - 1) * jcp.bcast_loop_output_substep;
 
                 add(aux_reg_output_data, output_offset);
@@ -155,24 +155,24 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::cvt2ps(
 }
 
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur,
+static void iterate(const dim_t load_loop_blk, const dim_t ur,
         const bool last_oc_block_flag, const bool force_masking, const F &f) {
-    for (int i_load = 0; i_load < load_loop_blk; i_load++) {
+    for (dim_t i_load = 0; i_load < load_loop_blk; i_load++) {
         const bool mask_flag = force_masking
                 || (last_oc_block_flag && i_load + 1 == load_loop_blk);
-        for (int i_ur = 0; i_ur < ur; i_ur++)
+        for (dim_t i_ur = 0; i_ur < ur; i_ur++)
             f(mask_flag, i_load, i_ur);
     }
 }
 template <typename F>
-static void iterate(const int load_loop_blk, const int ur, const F &f) {
+static void iterate(const dim_t load_loop_blk, const dim_t ur, const F &f) {
     iterate(load_loop_blk, ur, false, false, f);
 }
 
 template <typename Vmm>
 Address jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::output_ptr(
-        const int i_load, const int i_ur) {
-    const size_t ur_stride = jcp.with_dw_conv
+        dim_t i_load, dim_t i_ur) {
+    const dim_t ur_stride = jcp.with_dw_conv
             ? jcp.nb_load_blocking * jcp.oc_block * i_ur
             : jcp.oc_without_padding * jcp.ngroups * i_ur;
 
@@ -182,19 +182,19 @@ Address jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::output_ptr(
 
 template <typename Vmm>
 int jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::vreg_accum_idx(
-        const int load_loop_blk, int i_load, int i_ur) const {
-    return (i_ur * load_loop_blk + i_load);
+        dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const {
+    return static_cast<int>(i_ur * load_loop_blk + i_load);
 }
 
 template <typename Vmm>
 Vmm jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::vreg_accum(
-        const int load_loop_blk, int i_load, int i_ur) const {
+        dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const {
     return Vmm(vreg_accum_idx(load_loop_blk, i_load, i_ur));
 }
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
-        const int load_loop_blk, const int ur) {
+        dim_t load_loop_blk, dim_t ur) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         injector_utils::vmm_index_set_t vmm_idxs;
         // Sum post-op requires binary parameters to be set.
@@ -205,11 +205,11 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
             const bool oc_blk_is_smaller_than_vmm
                     = jcp.oc_block < isa_simd_width_;
             iterate(load_loop_blk, ur, mask_tail, oc_blk_is_smaller_than_vmm,
-                    [&](const bool mask_flag, const int i_load,
-                            const int i_ur) {
-                const int ur_stride
+                    [&](const bool mask_flag, const dim_t i_load,
+                            const dim_t i_ur) {
+                const dim_t ur_stride
                         = jcp.oc_without_padding * jcp.ngroups * i_ur;
-                const size_t aux_output_l_off = jcp.typesize_out
+                const dim_t aux_output_l_off = jcp.typesize_out
                         * (ur_stride + i_load * jcp.load_block);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -249,7 +249,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
 
         } else {
             iterate(load_loop_blk, ur,
-                    [&](const bool, const int i_load, const int i_ur) {
+                    [&](const bool, const dim_t i_load, const dim_t i_ur) {
                 vmm_idxs.emplace(vreg_accum_idx(load_loop_blk, i_load, i_ur));
             });
             postops_injector_->compute_vector_range(vmm_idxs);
@@ -259,45 +259,45 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::apply_postops(
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
-        int load_loop_blk, int ur, bool wraparound) {
-    auto vreg_load = [ur, load_loop_blk](int i_load) {
-        return Vmm(ur * load_loop_blk + i_load);
+        dim_t load_loop_blk, dim_t ur, bool wraparound) {
+    auto vreg_load = [ur, load_loop_blk](dim_t i_load) {
+        return Vmm(static_cast<int>(ur * load_loop_blk + i_load));
     };
 
-    auto bias_ptr = [this](int i_load) {
+    auto bias_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_bias_data, jcp.typesize_bia * jcp.oc_block * i_load);
     };
 
-    auto comp_ptr = [this](int i_load) {
+    auto comp_ptr = [this](dim_t i_load) {
         return EVEX_compress_addr(
                 reg_comp_data, sizeof(int32_t) * jcp.oc_block * i_load);
     };
 
-    auto bcast_ptr = [this](int i_reduce, int i_ur, bool bcast) {
+    auto bcast_ptr = [this](dim_t i_reduce, dim_t i_ur, bool bcast) {
         assert(i_ur < jcp.ur);
         assert(i_reduce <= jcp.reduce_loop_unroll);
         assert(jcp.reduce_loop_unroll == jcp.reduce_block);
 
-        int offt = (jcp.ic_without_padding * i_ur * jcp.ngroups + i_reduce);
+        dim_t offt = jcp.ic_without_padding * i_ur * jcp.ngroups + i_reduce;
 
         return EVEX_compress_addr(
                 aux_reg_bcast_data, jcp.typesize_in * offt, bcast);
     };
 
-    auto load_ptr = [this](int i_reduce, int i_load) {
-        int u0 = i_reduce % jcp.reduce_loop_unroll;
-        int u1 = i_reduce / jcp.reduce_loop_unroll;
+    auto load_ptr = [this](dim_t i_reduce, dim_t i_load) {
+        const dim_t u0 = i_reduce % jcp.reduce_loop_unroll;
+        const dim_t u1 = i_reduce / jcp.reduce_loop_unroll;
 
-        int offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
+        dim_t offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
 
         return EVEX_compress_addr(aux_reg_load_data,
                 u1 * jcp.reduce_loop_load_step + jcp.typesize_in * offt);
     };
 
     auto init = [this, load_loop_blk, ur]() {
-        for (int i_load = 0; i_load < load_loop_blk; ++i_load)
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+        for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load)
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                 vpxord(r, r, r);
             }
@@ -318,7 +318,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             mov(reg_src_zero_point,
                     EVEX_compress_addr(rsp, reg_src_zero_point_off));
         }
-        for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+        for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
             const bool mask_flag = mask_flag_in && i_load == load_loop_blk - 1;
             auto vmm_bias = vmm_tmp;
             auto vmm_comp = vmm_bcast;
@@ -334,7 +334,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             }
             if (jcp.src_zero_point) {
                 // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-                const int zp_offset = sizeof(int32_t) * i_load * jcp.load_block;
+                const dim_t zp_offset
+                        = sizeof(int32_t) * i_load * jcp.load_block;
                 vmovups(vmm_zp,
                         EVEX_compress_addr(reg_zp_compensation, zp_offset));
                 vpmulld(vmm_zp, vmm_zp,
@@ -345,7 +346,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                         = mask_flag ? vmm_zp | k_load_dim_mask | T_z : vmm_zp;
                 vcvtdq2ps(vmm_, vmm_);
             }
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 auto vmm = vreg_accum(load_loop_blk, i_load, i_ur);
                 vcvtdq2ps(vmm, vmm);
                 if (jcp.signed_input) vaddps(vmm, vmm, vmm_comp);
@@ -380,7 +381,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                     mov(reg_wei_scales,
                             EVEX_compress_addr(rsp, reg_wei_scales_off));
 
-                    int scale_offset = jcp.is_oc_scale
+                    const dim_t scale_offset = jcp.is_oc_scale
                             * (sizeof(float) * jcp.oc_block * i_load);
                     vmulps(vmm_k, vmm,
                             EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -405,10 +406,10 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             mov(reg_dst_scales, EVEX_compress_addr(rsp, reg_dst_scales_off));
 
             /* Apply dst scale to accumulator */
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 const bool mask_flag
                         = mask_flag_in && i_load == load_loop_blk - 1;
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     const auto vmm = vreg_accum(load_loop_blk, i_load, i_ur);
                     const Vmm vmm_k
                             = mask_flag ? vmm | k_load_dim_mask | T_z : vmm;
@@ -425,8 +426,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
             vcvtdq2ps(vmm_zp, EVEX_compress_addr(reg_dst_zero_point, 0, true));
 
             /* Add dst zero_point to accumulator */
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     const auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     vaddps(r, r, vmm_zp);
                 }
@@ -437,8 +438,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
         if (one_of(jcp.dst_dt, u8, s8, s32)) {
             init_saturate_f32(vmm_zero, vmm_saturation,
                     reg_ptr_saturation_ubound, f32, jcp.dst_dt);
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     saturate_cvt_f32(r, vmm_zero, vmm_saturation, jcp.dst_dt);
                 }
@@ -452,8 +453,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
         if (jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa)) {
             // Optimization: use single store instruction for pair
             // of the nearest vectors along LOAD dimension
-            for (int i_ur = 0; i_ur < ur; i_ur++) {
-                int i_load = 0;
+            for (dim_t i_ur = 0; i_ur < ur; i_ur++) {
+                dim_t i_load = 0;
                 for (; i_load < rnd_dn(load_loop_blk, 2); i_load += 2) {
                     auto vmm_dst = vreg_accum(load_loop_blk, i_load, i_ur);
                     auto vmm_dst_next
@@ -474,10 +475,10 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
                 }
             }
         } else {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                 const bool mask_flag
                         = mask_flag_in && i_load == load_loop_blk - 1;
-                for (int i_ur = 0; i_ur < ur; ++i_ur) {
+                for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                     auto r = vreg_accum(load_loop_blk, i_load, i_ur);
                     const Vmm r_vmm = mask_flag ? r | k_load_dim_mask : r;
 
@@ -518,28 +519,28 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::reduce_loop(
     };
 
     auto fma_block = [&](bool last_block) {
-        int reduce_step = 4;
-        int ic_tail_size = jcp.ic_without_padding % reduce_step;
-        int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
+        const dim_t reduce_step = 4;
+        const dim_t ic_tail_size = jcp.ic_without_padding % reduce_step;
+        const dim_t loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
                 ? rnd_up(jcp.ic_without_padding % jcp.ic_block, reduce_step)
                 : jcp.reduce_loop_unroll;
-        for (int i_reduce = 0; i_reduce < loop_unroll;
+        for (dim_t i_reduce = 0; i_reduce < loop_unroll;
                 i_reduce += reduce_step) {
-            for (int i_load = 0; i_load < load_loop_blk; ++i_load)
+            for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load)
                 vmovups(vreg_load(i_load), load_ptr(i_reduce, i_load));
-            for (int i_ur = 0; i_ur < ur; ++i_ur) {
+            for (dim_t i_ur = 0; i_ur < ur; ++i_ur) {
                 if (last_block && ic_tail_size != 0
                         && i_reduce == loop_unroll - reduce_step) {
                     Xmm xmm_bcast = Xmm(vmm_bcast.getIdx());
                     load_bytes(xmm_bcast, aux_reg_bcast_data,
                             jcp.ic_without_padding * i_ur + i_reduce,
-                            ic_tail_size);
+                            static_cast<int>(ic_tail_size));
                     vpbroadcastd(vmm_bcast, xmm_bcast);
                 } else {
                     vpbroadcastd(vmm_bcast, bcast_ptr(i_reduce, i_ur, false));
                 }
                 if (jcp.signed_input) vpsubb(vmm_bcast, vmm_bcast, vmm_shift);
-                for (int i_load = 0; i_load < load_loop_blk; ++i_load) {
+                for (dim_t i_load = 0; i_load < load_loop_blk; ++i_load) {
                     compute(vreg_accum(load_loop_blk, i_load, i_ur),
                             vreg_load(i_load), vmm_bcast);
                 }
@@ -607,7 +608,7 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
 
     preamble();
 
-    const int simd_w = jcp.ic_block;
+    const int simd_w = static_cast<int>(jcp.ic_block);
     xor_(reg_scratch, reg_scratch);
     Reg16 _t = reg_scratch.cvt16();
     mov(_t, 0x1);
@@ -666,11 +667,11 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         kmovb(k_load_dim_tail_mask, reg_tail_32);
     }
 
-    const int load_dim_tail
-            = (one_of(jcp.prop_kind, forward_training, forward_inference)
-                              ? jcp.oc_without_padding
-                              : jcp.load_dim)
-            % jcp.load_block;
+    const int load_dim_tail = static_cast<int>(
+            (one_of(jcp.prop_kind, forward_training, forward_inference)
+                            ? jcp.oc_without_padding
+                            : jcp.load_dim)
+            % jcp.load_block);
     const bool use_extended_mask
             = jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa);
     if (load_dim_tail) {
@@ -1011,10 +1012,13 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     const int SMALL_SPATIAL = 7 * 7;
     const int BIG_REDUCE_DIM = 1024;
@@ -1050,9 +1054,9 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             && (jcp.oh <= size_treshold && jcp.ow <= size_treshold)) {
         if (jcp.os <= SMALL_SPATIAL && jcp.oc * jcp.ic < L2_size)
             max_regs = min_regs; // mobilenet_v2 performance improvement
-        jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
     } else {
-        const int spatial = jcp.od * jcp.oh;
+        const dim_t spatial = jcp.od * jcp.oh;
         jcp.ur = 1;
         for (int ur_w = max_regs; ur_w >= min_regs; ur_w--) {
             if ((spatial >= size_treshold && spatial % ur_w == 0)
@@ -1062,7 +1066,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
                 int i_tail = jcp.os % i;
@@ -1074,7 +1078,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             }
         }
     }
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
     jcp.reduce_dim = jcp.ic;
     jcp.reduce_block = jcp.ic_block;
@@ -1105,8 +1110,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-    int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    int nb_bcast = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    int nb_reduce = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     reduce_blocking = nb_reduce;
     if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -1118,7 +1123,7 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
 
     bool cmp_reduce = reduce_blocking <= jcp.reduce_dim;
     if (cmp_reduce) jcp.loop_order = reduce_src ? loop_rbl : loop_rlb;
-    load_blocking = jcp.load_dim;
+    load_blocking = static_cast<int>(jcp.load_dim);
 
     jcp.load_grp_count = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
     jcp.load_grp_count = best_divider(
@@ -1129,25 +1134,30 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
         jcp.load_grp_count = nstl::max(jcp.load_grp_count, 4);
     } else if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.mb <= jcp.nthr
             && jcp.load_dim > 512 && jcp.load_dim / jcp.reduce_dim >= 4) {
-        jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2); //
-        load_blocking = jcp.load_block;
+        jcp.load_grp_count
+                = static_cast<int>(nstl::max<dim_t>(jcp.load_grp_count, 2)); //
+        load_blocking = static_cast<int>(jcp.load_block);
     }
 
-    bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                             div_up(jcp.nthr, jcp.load_grp_count))
-            * jcp.bcast_block;
-    bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+    bcast_blocking
+            = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                       div_up(jcp.nthr, jcp.load_grp_count))
+                    * jcp.bcast_block);
+    bcast_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
     bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
-    int space_for_bcast = (L2_capacity - /* kernel_size - */
+    const dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
             2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
             - 3 * 1024);
-    if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
+    dim_t space_for_bcast_adjusted = space_for_bcast;
+    if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity)
+        space_for_bcast_adjusted /= 2;
 
-    int bcast_in_cache
-            = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-    bcast_blocking = nstl::min(
-            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+    const dim_t bcast_in_cache = nstl::max<dim_t>(
+            jcp.bcast_block, space_for_bcast_adjusted / reduce_blocking);
+    bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
     load_blocking_max = load_blocking;
     bcast_blocking_max = bcast_blocking * 3 / 2;
@@ -1192,7 +1202,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
     if (jcp.mb == 1 && jcp.nb_load % 4 == 0 && jcp.ic / jcp.oc >= 4
             && jcp.ic * jcp.oc <= L2_size && jcp.nthr <= ncores_per_socket) {
         jcp.nb_load_chunk = 4;
-        jcp.load_grp_count = nstl::max(jcp.nb_load / 4, jcp.load_grp_count);
+        jcp.load_grp_count = static_cast<int>(
+                nstl::max<dim_t>(jcp.nb_load / 4, jcp.load_grp_count));
     }
 
     /* adjust the thread decomposition
@@ -1205,7 +1216,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             = (dim_t)jcp.mb * jcp.ngroups * jcp.bcast_dim * jcp.reduce_dim;
     if (jcp.typesize_in * bcast_size < 8192 && jcp.ngroups < jcp.nthr
             && jcp.nb_bcast * jcp.nb_load < jcp.nthr) {
-        int nthr = nstl::max(jcp.nb_load, jcp.nb_bcast);
+        const int nthr
+                = static_cast<int>(nstl::max<dim_t>(jcp.nb_load, jcp.nb_bcast));
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.hpp
@@ -130,13 +130,13 @@ private:
     }
     inline Vmm_down_t vmm_store() { return Vmm_down_t(ymm_store.getIdx()); }
 
-    void bcast_loop(int load_loop_blk);
-    void reduce_loop(int load_loop_blk, int ur, bool wraparound);
+    void bcast_loop(dim_t load_loop_blk);
+    void reduce_loop(dim_t load_loop_blk, dim_t ur, bool wraparound);
 
-    Xbyak::Address output_ptr(const int i_load, const int i_ur);
-    int vreg_accum_idx(const int load_loop_blk, int i_load, int i_ur) const;
-    Vmm vreg_accum(const int load_loop_blk, int i_load, int i_ur) const;
-    void apply_postops(const int load_loop_blk, const int ur);
+    Xbyak::Address output_ptr(dim_t i_load, dim_t i_ur);
+    int vreg_accum_idx(dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const;
+    Vmm vreg_accum(dim_t load_loop_blk, dim_t i_load, dim_t i_ur) const;
+    void apply_postops(dim_t load_loop_blk, dim_t ur);
     void generate() override;
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Xbyak::Operand &op,
             bool mask_flag);
@@ -146,7 +146,7 @@ struct jit_avx512_core_x8s8s32x_1x1_conv_kernel_t {
     jit_avx512_core_x8s8s32x_1x1_conv_kernel_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.ic_block;
+        const dim_t ch_block = ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.cpp
@@ -49,7 +49,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const void *src_scales
@@ -110,14 +111,14 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
             ? scratchpad.get<char>(key_conv_rtus_space)
             : nullptr;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     const bool is_2d = pd()->ndims() == 4;
     const bool is_3d = pd()->ndims() == 5;
 
-    const int stride_d = pd()->KSD();
-    const int stride_h = pd()->KSH();
-    const int stride_w = pd()->KSW();
+    const dim_t stride_d = pd()->KSD();
+    const dim_t stride_h = pd()->KSH();
+    const dim_t stride_w = pd()->KSW();
 
     auto offset = weights_d.size() - weights_d.additional_buffer_size();
     char *w = const_cast<char *>(weights);
@@ -139,16 +140,17 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = rtus_driver_t<avx512_core>::call_params_t();
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -183,26 +185,26 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
     char *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<char *> addrs;
     // End
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
-        bcast_step = nstl::min(bcast_step, bcast_end - iwork);
+        bcast_step = nstl::min<dim_t>(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
-        const int depth_orthogonal_area = jcp.ow * jcp.oh;
+        const dim_t os = osb * os_block;
+        const dim_t depth_orthogonal_area = jcp.ow * jcp.oh;
         od = os / depth_orthogonal_area;
         oh = (os % depth_orthogonal_area) / jcp.ow;
         ow = (os % depth_orthogonal_area) % jcp.ow;
@@ -216,7 +218,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         p.load_dim = this_block_size(ocb * jcp.oc_block, ocb_end * jcp.oc_block,
                 load_step * jcp.oc_block);
@@ -229,17 +231,17 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
     auto init_reduce = [&]() {
         p.reduce_dim = this_block_size(
-                0, jcp.ic_without_padding, jcp.ic_without_padding);
+                dim_t {0}, jcp.ic_without_padding, jcp.ic_without_padding);
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int n, int g, int od, int oh,
-                           int ow, int id, int ih, int iw) {
-        const int icb = 0; // Start from the first IC block
-        const int _ocb = g * nb_oc + ocb;
-        const int _icb = g * nb_ic + icb;
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t n, dim_t g, dim_t od,
+                           dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
+        constexpr dim_t icb = 0; // Start from the first IC block
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g * nb_ic + icb;
 
-        const size_t dst_off = is_3d
+        const dim_t dst_off = is_3d
                 ? dst_d.blk_off(n, _ocb * jcp.oc_block, od, oh, ow)
                 : is_2d ? dst_d.blk_off(n, _ocb * jcp.oc_block, oh, ow)
                         : dst_d.blk_off(n, _ocb * jcp.oc_block, ow);
@@ -288,18 +290,19 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_rlb) {
             init_reduce();
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                    dim_t n, g, od, oh, ow, id, ih, iw;
+                    dim_t bcast_step;
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -308,13 +311,14 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                    dim_t n, g, od, oh, ow, id, ih, iw;
+                    dim_t bcast_step;
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
                     init_reduce();
@@ -325,14 +329,15 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
             }
         } else if (jcp.loop_order == loop_rbl) {
             init_reduce();
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                     ocb += load_step;
@@ -340,14 +345,15 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                 iwork += bcast_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n, g, bcast_step, od, oh, ow, id, ih, iw;
+                dim_t n, g, od, oh, ow, id, ih, iw;
+                dim_t bcast_step;
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     init_reduce();
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -360,30 +366,31 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
-        int oh_1x1_begin = nstl::max(oh_1x1, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
+        dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1_begin++) % jcp_dw->kh) * row_offset;
 
         const auto ocb_end = ocb_start + load_step;
-        const size_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
+        const dim_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         auto par_conv_dw = jit_conv_args_t();
 
-        par_conv_dw.t_overflow = nstl::min(jcp_dw->kh, nstl::max(0, -oh_1x1));
-        par_conv_dw.b_overflow = nstl::min(
-                jcp_dw->kh, nstl::max(0, oh_1x1 - jcp.oh + jcp_dw->kh));
-        par_conv_dw.kh_padding = nstl::max<int>(0,
+        par_conv_dw.t_overflow
+                = nstl::max<dim_t>(0, nstl::min<dim_t>(jcp_dw->kh, -oh_1x1));
+        par_conv_dw.b_overflow = nstl::max<dim_t>(
+                0, nstl::min<dim_t>(jcp_dw->kh, oh_1x1 - jcp.oh + jcp_dw->kh));
+        par_conv_dw.kh_padding = nstl::max<dim_t>(0,
                 jcp_dw->kh - par_conv_dw.t_overflow - par_conv_dw.b_overflow);
 
-        const size_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
+        const dim_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
                 + dw_oh * jcp_dw->ow * jcp_dw->ngroups;
 
         const auto wht_h_stride = dw_weights_d.blk_off(0, 0, 0, 1);
         const auto wei_stride = (!jcp_dw->signed_input) * par_conv_dw.t_overflow
                 * wht_h_stride;
-        for (int ocb = ocb_start; ocb < ocb_end;
+        for (dim_t ocb = ocb_start; ocb < ocb_end;
                 ocb += jcp_dw->nb_ch_blocking) {
 
             par_conv_dw.src = addrs.data();
@@ -395,7 +402,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
                     = weights_dw + dw_weights_d.blk_off(ocb, 0) + wei_stride;
             par_conv_dw.bias
                     = &bias_dw[ocb * jcp_dw->ch_block * dw_bia_dt_size];
-            par_conv_dw.ur_w = (size_t)(jcp_dw->ow);
+            par_conv_dw.ur_w = jcp_dw->ow;
             par_conv_dw.owb = jcp_dw->ow;
             par_conv_dw.oc_blocks = ocb;
             par_conv_dw.compensation = compensation_dw
@@ -414,7 +421,7 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
 
             (*kernel_dw_)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += src_ch_stride;
         }
     };
@@ -423,39 +430,41 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
         auto jcp_dw = pd()->jcp_dw_;
         auto dw_conv_buffer = dw_scratchpad.get<char>(key_fusion_inout_buffer);
 
-        const auto dw_conv_buffer_size_
-                = (size_t)jcp_dw->kh * jcp.ow * nb_buffer * jcp.oc_block;
+        const dim_t dw_conv_buffer_size_
+                = jcp_dw->kh * jcp.ow * nb_buffer * jcp.oc_block;
         pbuf = dw_conv_buffer + ithr * dw_conv_buffer_size_;
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+                bcast_end, nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -471,10 +480,10 @@ void jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
                 jcp.nb_load / jcp.nb_load_chunk, ocb_start, ocb_end,
-                jcp.load_grp_count);
+                static_cast<dim_t>(jcp.load_grp_count));
         if (jcp.nb_load_chunk > 1) {
             ocb_start *= jcp.nb_load_chunk;
             ocb_end *= jcp.nb_load_chunk;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_convolution.hpp
@@ -265,8 +265,8 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw_->nb_ch_blocking != 0)
                 --jcp_dw_->nb_ch_blocking;
 
-            jcp_dw_->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw_->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
             jcp_1x1.bcast_loop_output_step = jcp_1x1.ur
                     * (jcp_1x1.nb_load_blocking * jcp_1x1.oc_block)
                     * jcp_1x1.typesize_out;
@@ -274,7 +274,7 @@ struct jit_avx512_core_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             registrar_t scratchpad(scratchpad_registry_);
             registrar_t dw_scratchpad(scratchpad, names::prefix_fusion);
 
-            size_t dw_conv_buffer_size_ = (size_t)nthr * jcp_dw_->kh
+            dim_t dw_conv_buffer_size_ = static_cast<dim_t>(nthr) * jcp_dw_->kh
                     * jcp_dw_->iw * jcp_dw_->dw_conv_buffer_oc;
             assert(dw_conv_buffer_size_);
             dw_scratchpad.book(memory_tracking::names::key_fusion_inout_buffer,

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.cpp
@@ -94,8 +94,9 @@ jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::prepare_output(int ur_w) {
-    int nb_oc_block
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::prepare_output(
+        dim_t ur_w) {
+    const dim_t nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
     for (int k = 0; k < nb_oc_block; k++)
         for (int j = 0; j < ur_w; j++) {
@@ -144,23 +145,24 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::cvt2ps(data_type_t type_in,
 }
 
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w,
+static void iterate(const dim_t nb_oc_block, const dim_t ur_w,
         const bool last_oc_block_flag, const bool force_masking, const F &f) {
-    for (int k = 0; k < nb_oc_block; k++) {
+    for (dim_t k = 0; k < nb_oc_block; k++) {
         const bool mask_flag
                 = force_masking || (last_oc_block_flag && k + 1 == nb_oc_block);
-        for (int j = 0; j < ur_w; j++)
+        for (dim_t j = 0; j < ur_w; j++)
             f(mask_flag, k, j);
     }
 }
 template <typename F>
-static void iterate(const int nb_oc_block, const int ur_w, const F &f) {
+static void iterate(const dim_t nb_oc_block, const dim_t ur_w, const F &f) {
     iterate(nb_oc_block, ur_w, false, false, f);
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
-        bool last_oc_block_flag, const int nb_oc_block, const int oc_block) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(dim_t ur_w,
+        bool last_oc_block_flag, const dim_t nb_oc_block,
+        const dim_t oc_block) {
     if (jcp.with_eltwise || jcp.with_binary || jcp.with_sum) {
         injector_utils::vmm_index_set_t vmm_idxs;
         // Sum post-op requires binary parameters to be set.
@@ -169,8 +171,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
             const bool oc_blk_is_smaller_than_vmm = oc_block < isa_simd_width_;
             iterate(nb_oc_block, ur_w, last_oc_block_flag,
                     oc_blk_is_smaller_than_vmm,
-                    [&](const bool mask_flag, const int k, const int j) {
-                const size_t aux_output_l_off = jcp.typesize_out
+                    [&](const bool mask_flag, const dim_t k, const dim_t j) {
+                const dim_t aux_output_l_off = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 const auto vmm_idx = vmm_out_idx(j, k);
@@ -185,7 +187,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
             postops_injector_->compute_vector_range(vmm_idxs, rhs_arg_params);
         } else {
             iterate(nb_oc_block, ur_w,
-                    [&](const bool, const int k, const int j) {
+                    [&](const bool, const dim_t k, const dim_t j) {
                 vmm_idxs.emplace(vmm_out_idx(j, k));
             });
             postops_injector_->compute_vector_range(vmm_idxs);
@@ -195,10 +197,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::apply_postops(int ur_w,
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
-        int ur_w, bool last_oc_block_flag) {
-    int nb_oc_block
+        dim_t ur_w, bool last_oc_block_flag) {
+    const dim_t nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-    int oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
+    const dim_t oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
     if (jcp.signed_input)
@@ -212,20 +214,20 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
     for (int k = 0; k < nb_oc_block; k++) {
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * k * oc_block;
+            const dim_t bias_offset = jcp.typesize_bia * k * oc_block;
             auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
 
             cvt2ps(jcp.bia_dt, vmm_bias, bias_addr, mask_flag);
         }
         if (jcp.signed_input) {
-            int comp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * k * oc_block;
             Vmm vmm_comp_ = vmm_mask(vmm_comp, mask_flag);
             vmovups(vmm_comp_,
                     EVEX_compress_addr(reg_compensation, comp_offset));
         }
         if (jcp.src_zero_point) {
             // zero_point: conv(src_x8, wei_s8) - src_shift_s32 * compensation_s32
-            int zp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * k * oc_block;
             Vmm vmm_zp_ = vmm_mask(vmm_zp, mask_flag);
             vmovups(vmm_zp_,
                     EVEX_compress_addr(reg_zp_compensation, zp_offset));
@@ -234,7 +236,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
                             reg_src_zero_point, 0, jcp.zp_src_is_common));
         }
         /* add to zmm_accum: compensation, zero_point, bias and permute */
-        for (int j = 0; j < ur_w; j++) {
+        for (dim_t j = 0; j < ur_w; j++) {
             Vmm vmm = vmm_out(j, k);
             if (jcp.is_fast_depthwise)
                 vpermd(zmm_out(j, k), zmm_permute, zmm_out(j, k));
@@ -270,7 +272,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             if (jcp.with_wei_scales) {
                 mov(reg_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
 
-                int scale_offset
+                const dim_t scale_offset
                         = jcp.is_oc_scale * (sizeof(float) * k * oc_block);
                 vmulps(vmm_k, vmm,
                         EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -295,9 +297,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         mov(reg_dst_scales, ptr[param1 + GET_OFF(dst_scales)]);
 
         /* Apply dst scale to accumulator */
-        for (int k = 0; k < nb_oc_block; k++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
             const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-            for (int j = 0; j < ur_w; j++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 const Vmm vmm_k = vmm_mask(vmm, mask_flag);
                 vmulps(vmm_k, vmm,
@@ -312,8 +314,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
         vcvtdq2ps(vmm_zp, EVEX_compress_addr(reg_dst_zero_point, 0, true));
 
         /* Add dst zero_point to accumulator */
-        for (int k = 0; k < nb_oc_block; k++) {
-            for (int j = 0; j < ur_w; j++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 vaddps(vmm, vmm, vmm_zp);
             }
@@ -324,8 +326,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
     if (one_of(jcp.dst_dt, u8, s8, s32)) {
         init_saturate_f32(
                 vmm_zero, vmm_saturation, aux_reg_saturation, f32, jcp.dst_dt);
-        for (int k = 0; k < nb_oc_block; k++) {
-            for (int j = 0; j < ur_w; j++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
+            for (dim_t j = 0; j < ur_w; j++) {
                 Vmm vmm = vmm_out(j, k);
                 saturate_cvt_f32(vmm, vmm_zero, vmm_saturation, jcp.dst_dt);
             }
@@ -339,13 +341,13 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
     if (jcp.dst_dt == data_type::bf16 && isa_has_bf16(jcp.isa)) {
         // Optimization: use single store instruction for pair of the
         // nearest vectors along OC dimension
-        for (int j = 0; j < ur_w; j++) {
-            int k = 0;
+        for (dim_t j = 0; j < ur_w; j++) {
+            dim_t k = 0;
             for (; k < rnd_dn(nb_oc_block, 2); k += 2) {
                 Vmm vmm = vmm_out(j, k);
                 Vmm vmm_next = vmm_out(j, k + 1);
 
-                int aux_output_offset = jcp.typesize_out
+                dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -360,7 +362,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             if (nb_oc_block % 2 != 0) {
                 Vmm vmm = vmm_out(j, k);
                 auto vmm_down = Vmm_down_t(vmm.getIdx());
-                int aux_output_offset = jcp.typesize_out
+                dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -372,10 +374,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
             }
         }
     } else {
-        for (int k = 0; k < nb_oc_block; k++) {
+        for (dim_t k = 0; k < nb_oc_block; k++) {
             const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-            for (int j = 0; j < ur_w; j++) {
-                int aux_output_offset = jcp.typesize_out
+            for (dim_t j = 0; j < ur_w; j++) {
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 auto addr = EVEX_compress_addr(reg_out, aux_output_offset);
@@ -400,14 +402,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::store_output(
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker_dw(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     assert(!"invalid group blocking for depthwise convolution");
 }
 
 template <>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
 
     const bool compute_kernel = IMPLICATION(h_padded, jcp.signed_input);
 
@@ -416,11 +420,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    auto input_spatial_index = [this, pad_l](int oi, int ki) {
+    auto input_spatial_index = [this, pad_l](dim_t oi, dim_t ki) -> dim_t {
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
 
-    auto input_offset2 = [this](int ii, int ci) {
+    auto input_offset2 = [this](dim_t ii, dim_t ci) -> dim_t {
         if (jcp.is_fused_conv)
             return jcp.typesize_in
                     * (ii * jcp.dw_conv_buffer_oc + ci * jcp.ch_block);
@@ -429,11 +433,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
     };
 
     auto input_offset3 = [this, input_offset2, input_spatial_index](
-                                 int oi, int ci, int ki) {
+                                 dim_t oi, dim_t ci, dim_t ki) {
         return jcp.typesize_in * input_offset2(input_spatial_index(oi, ki), ci);
     };
 
-    auto kernel_offset = [this](int ci, int ki) {
+    auto kernel_offset = [this](dim_t ci, dim_t ki) -> dim_t {
         return jcp.typesize_in * ((ci * jcp.kh * jcp.kw + ki) * jcp.ch_block);
     };
 
@@ -447,16 +451,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
         }
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise && !h_padded) {
         // find bounds of input spatial indices
         bool first = true;
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = input_spatial_index(oi, ki);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; oi++) {
+                const dim_t ii = input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -466,13 +470,13 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 
     if (jcp.signed_input) vmovups(zmm_shifted_zero, vmm_shift);
 
-    for (int ci = 0; ci < jcp.nb_ch_blocking; ci++) {
+    for (dim_t ci = 0; ci < jcp.nb_ch_blocking; ci++) {
         const bool mask_flag = last_ic_block_flag != ic_block_t::no_last_block
                 && ci == jcp.nb_ch_blocking - 1;
         if (jcp.is_resrc_depthwise && !h_padded) {
             // now we can load input once and reuse up to jcp.kw times
-            for (int ii = ii_start; ii <= ii_end; ii++) {
-                int aux_input_offset = input_offset2(ii, ci);
+            for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                dim_t aux_input_offset = input_offset2(ii, ci);
                 const Zmm zmm_inp_tmp = zmm_inp(ii, jcp.nb_ch_blocking);
                 const Zmm zmm_inp_msk = mask_flag
                         ? zmm_inp_tmp | ktail_mask | T_z
@@ -489,10 +493,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
                     vpaddb(zmm_inp_tmp, zmm_inp_tmp, vmm_shift);
             }
         }
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int aux_kernel_offset = kernel_offset(ci, ki);
-            const int oi_start = get_ow_start(ki, pad_l);
-            const int oi_end = get_ow_end(ur_w, ki, pad_r);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            dim_t aux_kernel_offset = kernel_offset(ci, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
             if (compute_kernel) {
                 if (jcp.is_fast_depthwise) {
                     vbroadcasti32x4(zmm_wei,
@@ -505,20 +509,20 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 
                 if (h_padded) {
                     assert(jcp.signed_input);
-                    for (int oi = 0; oi < ur_w; oi++)
+                    for (dim_t oi = 0; oi < ur_w; oi++)
                         compute(zmm_out(oi, ci), zmm_wei, zmm_shifted_zero);
                 } else {
                     const Zmm r_zmm_src
                             = mask_flag ? zmm_src | ktail_mask : zmm_src;
-                    int start_ = jcp.signed_input ? 0 : oi_start;
-                    int end_ = jcp.signed_input ? ur_w : oi_end;
-                    for (int oi = start_; oi < end_; oi++) {
+                    const dim_t start_ = jcp.signed_input ? 0 : oi_start;
+                    const dim_t end_ = jcp.signed_input ? ur_w : oi_end;
+                    for (dim_t oi = start_; oi < end_; oi++) {
                         if (oi >= oi_start && oi < oi_end) {
                             if (jcp.is_resrc_depthwise) {
-                                int ii = input_spatial_index(oi, ki);
+                                const dim_t ii = input_spatial_index(oi, ki);
                                 zmm_src = zmm_inp(ii, jcp.nb_ch_blocking);
                             } else {
-                                int aux_input_offset
+                                dim_t aux_input_offset
                                         = input_offset3(oi, ci, ki);
                                 if (jcp.is_fast_depthwise) {
                                     assert(!mask_flag);
@@ -551,8 +555,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
                     if (jcp.is_fast_depthwise)
                         vpermd(zmm_wei, zmm_permute, zmm_wei);
                 } // else: already loaded weights from previous block
-                int zp_offset = 0;
-                for (int oi = 0; oi < ur_w; oi++) {
+                dim_t zp_offset = 0;
+                for (dim_t oi = 0; oi < ur_w; oi++) {
                     if (oi < oi_start || oi >= oi_end || h_padded) {
                         vpmulld(vmm_zp_tmp, zmm_wei,
                                 EVEX_compress_addr(reg_src_zero_point,
@@ -567,8 +571,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Zmm>::compute_ker_dw(int ur_w,
 }
 
 template <typename Vmm>
-void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(dim_t ur_w,
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
 
@@ -581,22 +586,23 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int ch_block_all = jcp.ch_block * ic_block * oc_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t ic_block = jcp.ic_block;
+    const dim_t oc_block = jcp.oc_block;
+    const dim_t ch_block_all = jcp.ch_block * ic_block * oc_block;
 
-    int nb_oc_block = jcp.nb_oc_blocking;
+    const dim_t nb_oc_block = jcp.nb_oc_blocking;
 
-    auto input_offset = [this, stride_w, pad_l](int oi, int ic, int ki) {
+    auto input_offset
+            = [this, stride_w, pad_l](dim_t oi, dim_t ic, dim_t ki) -> dim_t {
         return jcp.typesize_in
                 * ((ki * (jcp.dilate_w + 1) + oi * stride_w - pad_l)
                                 * jcp.ic_without_padding * jcp.ngroups
                         + ic_sub_step * ic);
     };
-    auto kernel_offset
-            = [this, ch_block_all, oc_block](int ii, int ic, int ki) {
+    auto kernel_offset = [this, ch_block_all, oc_block](
+                                 dim_t ii, dim_t ic, dim_t ki) -> dim_t {
         return jcp.typesize_in
                 * ((ii * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
@@ -612,19 +618,19 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
         }
     };
 
-    for (int ki = 0; ki < kw; ki++) {
-        int jj_start = get_ow_start(ki, pad_l);
-        int jj_end = get_ow_end(ur_w, ki, pad_r);
-        int ic_tail_size = jcp.ic_without_padding % ic_sub_step;
-        int _start = jcp.signed_input ? 0 : jj_start;
-        int _end = jcp.signed_input ? ur_w : jj_end;
+    for (dim_t ki = 0; ki < kw; ki++) {
+        const dim_t jj_start = get_ow_start(ki, pad_l);
+        const dim_t jj_end = get_ow_end(ur_w, ki, pad_r);
+        const dim_t ic_tail_size = jcp.ic_without_padding % ic_sub_step;
+        const dim_t _start = jcp.signed_input ? 0 : jj_start;
+        const dim_t _end = jcp.signed_input ? ur_w : jj_end;
         /* Skip the last loads of input
             if (ic%16)/ic_sub_step < ic_block/ic_sub_step */
-        int icb = (last_ic_block_flag != ic_block_t::no_last_block)
-                ? div_up((jcp.ic_without_padding % ic_block), ic_sub_step)
+        const dim_t icb = (last_ic_block_flag != ic_block_t::no_last_block)
+                ? div_up(jcp.ic_without_padding % ic_block, ic_sub_step)
                 : ic_block / ic_sub_step;
         if (compute_kernel) {
-            for (int ic = 0; ic < icb; ic++) {
+            for (dim_t ic = 0; ic < icb; ic++) {
                 if (h_padded) {
                     // fill padded area with shifted value in first iteration
                     if (ic == 0) {
@@ -632,15 +638,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                         vmovups(inp, vmm_shift); // bcast(128)
                     }
                 } else {
-                    for (int jj = _start; jj < _end; jj++) {
-                        int aux_input_offset = input_offset(jj, ic, ki);
+                    for (dim_t jj = _start; jj < _end; jj++) {
+                        dim_t aux_input_offset = input_offset(jj, ic, ki);
                         if (jj >= jj_start && jj < jj_end) {
                             if (last_ic_block_flag == ic_block_t::last_sp_block
                                     && ic_tail_size != 0 && ic == icb - 1) {
                                 Xmm xmm_tmp = Xmm(
                                         vmm_inp(jj, nb_oc_block).getIdx());
                                 load_bytes(xmm_tmp, aux_reg_inp,
-                                        aux_input_offset, ic_tail_size);
+                                        aux_input_offset,
+                                        static_cast<int>(ic_tail_size));
                                 vpbroadcastd(vmm_inp(jj, nb_oc_block), xmm_tmp);
                             } else {
                                 vpbroadcastd(vmm_inp(jj, nb_oc_block),
@@ -660,11 +667,11 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                         }
                     }
                 }
-                for (int ii = 0; ii < nb_oc_block; ii++) {
-                    int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                for (dim_t ii = 0; ii < nb_oc_block; ii++) {
+                    dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                     vmovups(vmm_wei,
                             EVEX_compress_addr(aux_reg_ker, aux_kernel_offset));
-                    for (int jj = _start; jj < _end; jj++) {
+                    for (dim_t jj = _start; jj < _end; jj++) {
                         Vmm inp = h_padded ? vmm_inp(0, nb_oc_block)
                                            : vmm_inp(jj, nb_oc_block);
                         compute(vmm_out(jj, ii), vmm_wei, inp);
@@ -676,12 +683,12 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
             /* calculate src_zero_point padding as:
              *      (is_padding ? src_zero_point_s32 * conv(1, wei_s8) : 0) */
             Vmm vmm_tmp = vmm_inp(0, nb_oc_block);
-            for (int jj = 0; jj < ur_w; jj++) {
+            for (dim_t jj = 0; jj < ur_w; jj++) {
                 if (jj < jj_start || jj >= jj_end || h_padded) {
-                    for (int ii = 0; ii < nb_oc_block; ii++) {
+                    for (dim_t ii = 0; ii < nb_oc_block; ii++) {
                         vpxord(vmm_zp_tmp, vmm_zp_tmp, vmm_zp_tmp);
-                        for (int ic = 0; ic < icb; ic++) {
-                            int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                        for (dim_t ic = 0; ic < icb; ic++) {
+                            dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                             if (jcp.has_vnni) {
                                 vpdpbusd(vmm_zp_tmp, vmm_zp_one,
                                         EVEX_compress_addr(aux_reg_ker,
@@ -694,7 +701,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
                                 vpaddd(vmm_zp_tmp, vmm_zp_tmp, vmm_tmp);
                             }
                         }
-                        int zp_offset = 0;
+                        const dim_t zp_offset = 0;
                         vpmulld(vmm_zp_tmp, vmm_zp_tmp,
                                 EVEX_compress_addr(reg_src_zero_point,
                                         zp_offset, jcp.zp_src_is_common));
@@ -710,16 +717,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::compute_ker(int ur_w,
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::kh_loop(
-        int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag) {
     Label kd_label, kh_label, skip_kd_loop, skip_kh_loop;
     Label f_overflow_label, no_f_overflow_label, d_h_f_overflow_label,
             t_overflow_label, no_t_overflow_label, b_overflow_label,
             no_b_overflow_label, back_overflow_label, no_back_overflow_label,
             d_h_back_overflow_label;
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
-    int shift_input_ptr
+    dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    dim_t shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
+    dim_t shift_input_ptr
             = jcp.typesize_in * jcp.iw * jcp.ic_without_padding * jcp.ngroups;
 
     if (jcp.ndims == 5) {
@@ -860,7 +867,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::kh_loop(
 
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
+        dim_t ur_w, dim_t pad_l, dim_t pad_r, bool is_last_sp_block) {
 
     if (jcp.src_zero_point && !jcp.is_depthwise) {
         xor_(reg_scratch, reg_scratch);
@@ -902,9 +909,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        int inp_step = jcp.ic_block;
-        const size_t ker_step = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.oc_block
-                * jcp.ic_block;
+        const dim_t inp_step = jcp.ic_block;
+        const dim_t ker_step
+                = jcp.kd * jcp.kh * jcp.kw * jcp.oc_block * jcp.ic_block;
         add(reg_inp, jcp.typesize_in * inp_step);
         safe_add(reg_ker, jcp.typesize_in * ker_step, reg_ker_long_offt);
 
@@ -942,16 +949,19 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::icb_loop(
 template <typename Vmm>
 void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
     Label permute_index_table;
-    int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
-                                        : jcp.ic_without_padding * jcp.ngroups;
-    const int urw_inp_stride = jcp.ur_w * jcp.stride_w;
-    const int n_urw_l_pad = nstl::min(
-            div_up(nstl::max(0, jcp.l_pad), urw_inp_stride), jcp.ow / jcp.ur_w);
-    const int inp_shift_pad = nstl::max(0,
+    const dim_t in_ic_shift = jcp.is_fused_conv
+            ? jcp.dw_conv_buffer_oc
+            : jcp.ic_without_padding * jcp.ngroups;
+    const dim_t urw_inp_stride = jcp.ur_w * jcp.stride_w;
+    const dim_t n_urw_l_pad = nstl::min<dim_t>(
+            div_up(nstl::max<dim_t>(0, jcp.l_pad), urw_inp_stride),
+            jcp.ow / jcp.ur_w);
+    const dim_t inp_shift_pad = nstl::max<dim_t>(0,
             jcp.typesize_in * (n_urw_l_pad * urw_inp_stride - jcp.l_pad)
                     * in_ic_shift);
-    int inp_shift = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
-    int out_shift = jcp.typesize_out
+    const dim_t inp_shift
+            = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
+    const dim_t out_shift = jcp.typesize_out
             * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups);
     preamble();
 
@@ -1004,10 +1014,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         kmovb(ktail_mask, reg_tail_32);
     }
     if (jcp.ngroups % jcp.ch_block != 0 || jcp.oc_without_padding != jcp.oc) {
-        int tail_size = jcp.is_depthwise
+        const dim_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
-        int mask = (1 << tail_size) - 1;
+        const int mask = (1 << tail_size) - 1;
         mov(reg_oc_blocks, ptr[param1 + GET_OFF(oc_blocks)]);
         Reg32 regw_tmp = reg_oi.cvt32();
         mov(regw_tmp, mask);
@@ -1042,19 +1052,21 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         mov(reg_scratch, permute_index_table);
         vmovdqu32(zmm_permute, ptr[reg_scratch]);
     }
-    const int extended_filter_size
-            = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int r_pad = nstl::max(0, jcp.r_pad);
+    const int extended_filter_size = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
+    const int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     const int ow_with_no_rpad = 1
-            + (jcp.iw + jcp.l_pad + nstl::min(0, jcp.r_pad)
-                      - extended_filter_size)
-                    / jcp.stride_w;
-    const int n_urw_per_ow_block = jcp.ow_block / jcp.ur_w;
-    const int max_safe_iw = nstl::max(
-            0, jcp.iw - div_up(ic_sub_step, jcp.ic_without_padding));
+            + static_cast<int>(
+                    (jcp.iw + jcp.l_pad + nstl::min<dim_t>(0, jcp.r_pad)
+                            - extended_filter_size)
+                    / jcp.stride_w);
+    const int n_urw_per_ow_block = static_cast<int>(jcp.ow_block / jcp.ur_w);
+    const int max_safe_iw = static_cast<int>(nstl::max<dim_t>(
+            0, jcp.iw - div_up(ic_sub_step, jcp.ic_without_padding)));
     const int max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
-            ? jcp.ow
-            : (max_safe_iw + jcp.l_pad - extended_filter_size) / jcp.stride_w;
+            ? static_cast<int>(jcp.ow)
+            : static_cast<int>((max_safe_iw + jcp.l_pad - extended_filter_size)
+                      / jcp.stride_w);
     Label middle_block_label, done_compute;
     std::vector<Label> ow_block_jmp_table;
 
@@ -1107,15 +1119,16 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         int cur_ow = 0;
 
         // l_pad region:
-        n_l_pad_labels = div_up(n_urw_l_pad, n_urw_per_ow_block);
+        n_l_pad_labels
+                = static_cast<int>(div_up(n_urw_l_pad, n_urw_per_ow_block));
         n_labels = n_l_pad_labels;
         cur_ow += n_urw_l_pad * jcp.ur_w;
 
         // middle_region:
         int n_urw_middle_block_loop = 0;
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
             n_urw_middle_block_loop
                     = nstl::max(0,
@@ -1129,8 +1142,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
         // r_pad or ic_block_t::last_sp_block
         if (cur_ow + jcp.ur_w <= jcp.ow) {
             if (r_pad_fall_through_n_urw == 0) ++n_labels;
-            const int n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
-            n_labels += nstl::max(0,
+            const int n_urw_r_pad_region
+                    = static_cast<int>((jcp.ow - cur_ow) / jcp.ur_w);
+            n_labels += nstl::max<dim_t>(0,
                     div_up(r_pad_fall_through_n_urw + n_urw_r_pad_region,
                             n_urw_per_ow_block)
                             - 1);
@@ -1157,9 +1171,10 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
             L(middle_or_rpad_check);
             // harness passes shifted src pointer that does not take
             // left-padding into account. So, we must re-shift here.
-            const int inp_shift_pad_middle_block = -1 * jcp.typesize_in
-                    * nstl::min(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
-                    * in_ic_shift;
+            const int inp_shift_pad_middle_block = static_cast<int>(-1
+                    * jcp.typesize_in
+                    * nstl::min<dim_t>(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
+                    * in_ic_shift);
             add(reg_inp, inp_shift_pad_middle_block);
         }
         if (r_pad_fall_through_n_urw != 0) {
@@ -1202,7 +1217,7 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
     int label_cntr = 0;
     int cur_l_pad = 0;
     if (jcp.l_pad > 0) {
-        for (cur_l_pad = jcp.l_pad;
+        for (cur_l_pad = static_cast<int>(jcp.l_pad);
                 cur_l_pad > 0 && cur_ow + jcp.ur_w <= jcp.ow;
                 cur_l_pad -= urw_inp_stride) {
             if (jcp.nb_ow > 1 && cur_n_oi == 0) {
@@ -1218,9 +1233,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
             }
 
             cur_ow += jcp.ur_w;
-            int cur_r_pad = nstl::max(0,
+            int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                     calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                            jcp.stride_w, extended_filter_size));
+                            jcp.stride_w, extended_filter_size)));
             icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_out, out_shift);
             dec(reg_oi);
@@ -1240,9 +1255,9 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
 
     // middle_block
     {
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
             int n_oi_middle_block_loop
                     = nstl::max(0,
@@ -1283,8 +1298,8 @@ void jit_avx512_core_x8s8s32x_fwd_kernel_vmm_t<Vmm>::generate() {
                 L(ow_block_jmp_table[label_cntr++]);
             }
             cur_ow += jcp.ur_w;
-            int cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                    jcp.stride_w, extended_filter_size);
+            int cur_r_pad = static_cast<int>(calculate_end_padding(jcp.l_pad,
+                    cur_ow, jcp.iw, jcp.stride_w, extended_filter_size));
             assert(cur_r_pad > 0 || cur_ow > max_safe_ow); // else, why be here?
             icb_loop(jcp.ur_w, 0, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_inp, inp_shift);
@@ -1400,9 +1415,9 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1459,7 +1474,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                 VERBOSE_BLOCKING_FAIL, "bad blocking dimensions");
     }
 
-    jcp.simd_w = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+    jcp.simd_w
+            = static_cast<int>(jcp.is_depthwise ? jcp.ch_block : jcp.ic_block);
 
     const auto &zp = attr.zero_points_;
     jcp.dst_zero_point = !zp.has_default_values(DNNL_ARG_DST);
@@ -1611,10 +1627,13 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
                                     post_ops, dst_d));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -1631,7 +1650,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     // factor smaller than the left padding (special requirement for SSD:fc6),
     // then search for a smaller OC blocking that satisfies both constraints.
     auto is_oc_blocking_ok = [&](int block) {
-        int ur_w = nstl::min(jcp.ow, jcp.max_regs_ur / (block + 1));
+        int ur_w = static_cast<int>(
+                nstl::min<dim_t>(jcp.ow, jcp.max_regs_ur / (block + 1)));
         return jcp.nb_oc % block == 0 && jcp.l_pad <= ur_w
                 && jcp.ow % ur_w != 1;
     };
@@ -1646,8 +1666,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && jcp.stride_w == 1 && jcp.ic % 64 == 0
             && jcp.nthr <= ncores_per_socket)
         max_threading_nb_oc_chunk = 2;
-    jcp.nb_oc_blocking_thr_chunk
-            = nstl::min(max_threading_nb_oc_chunk, jcp.nb_oc);
+    jcp.nb_oc_blocking_thr_chunk = static_cast<int>(
+            nstl::min<dim_t>(max_threading_nb_oc_chunk, jcp.nb_oc));
     for (; jcp.nb_oc_blocking_thr_chunk > 1; jcp.nb_oc_blocking_thr_chunk--) {
         if (is_oc_blocking_ok(jcp.nb_oc_blocking_thr_chunk)) break;
     }
@@ -1663,7 +1683,8 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
             && !(jcp.kh == 1 && jcp.kw == 3)
             && !(jcp.kh >= 7 && jcp.oc % 64 == 0)) {
         const int max_nb_oc_blocking = 2;
-        jcp.nb_oc_blocking = nstl::min(max_nb_oc_blocking, jcp.nb_oc);
+        jcp.nb_oc_blocking = static_cast<int>(
+                nstl::min<dim_t>(max_nb_oc_blocking, jcp.nb_oc));
         for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
             if (jcp.nb_oc_blocking_thr_chunk % jcp.nb_oc_blocking == 0
                     && is_oc_blocking_ok(jcp.nb_oc_blocking))
@@ -1671,30 +1692,30 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
     }
 
     if (jcp.is_resrc_depthwise)
-        jcp.ur_w = (jcp.max_regs_ur - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        jcp.ur_w = static_cast<int>((jcp.max_regs_ur - jcp.kw + jcp.stride_w)
+                / (jcp.nb_ch_blocking + jcp.stride_w));
     else
         jcp.ur_w = jcp.max_regs_ur
                 / (jcp.is_depthwise ? jcp.nb_ch_blocking
                                     : jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
-    auto get_thr_eff = [&](int nb_ow, int nthr) {
-        int base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
+    auto get_thr_eff = [&](dim_t nb_ow, int nthr) {
+        const dim_t base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
                 * (jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk);
-        auto work_amount = base_work_amount * nb_ow;
-        return float(work_amount) / rnd_up(work_amount, nthr);
+        const dim_t work_amount = base_work_amount * nb_ow;
+        return float(work_amount) / (float)rnd_up(work_amount, nthr);
     };
 
-    auto get_ow_block = [&](int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+    auto get_ow_block = [&](dim_t ur_w, int nthr) {
+        dim_t res_ow_block = jcp.ow;
         float best_thr_eff = get_thr_eff(1, nthr);
         float thr_eff;
-        int max_nb_ow = div_up(jcp.ow, ur_w);
-        for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, ur_w);
+        for (dim_t nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
                     && best_thr_eff > 0.8f)
                 break;
@@ -1727,12 +1748,12 @@ status_t jit_avx512_core_x8s8s32x_fwd_kernel_t::init_conf(jit_conv_conf_t &jcp,
 
     if (thr_eff < 0.9f && jcp.ngroups < jcp.nthr
             && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        int ow_block = static_cast<int>(jcp.ow_block);
         float best_thr_eff = -1.0f;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr > end_nthr; nthr--) {
-            ow_block = get_ow_block(jcp.ur_w, nthr);
+            ow_block = static_cast<int>(get_ow_block(jcp.ur_w, nthr));
             eff = get_thr_eff(div_up(jcp.ow, ow_block), nthr);
             if (eff > 1.1f * best_thr_eff) {
                 best_thr_eff = eff;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_conv_kernel.hpp
@@ -146,54 +146,55 @@ private:
     Xbyak::Zmm zmm_shifted_zero;
     Xbyak::Zmm zmm_permute;
 
-    int vmm_out_idx(int i_ur, int i_oc) {
-        const int nb_x_blocking
+    int vmm_out_idx(dim_t i_ur, dim_t i_oc) {
+        const dim_t nb_x_blocking
                 = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-        const int idx = i_ur * nb_x_blocking + i_oc;
+        const dim_t idx = i_ur * nb_x_blocking + i_oc;
         assert(idx < (jcp.is_depthwise              ? ker_dw_reg_base_idx
                                : jcp.src_zero_point ? ker_zp_reg_base_idx
                                                     : ker_reg_base_idx));
-        return idx;
+        return static_cast<int>(idx);
     }
 
-    Vmm vmm_out(int i_ur, int i_oc) { return Vmm(vmm_out_idx(i_ur, i_oc)); }
-    Xbyak::Zmm zmm_out(int i_ur, int i_oc) {
-        int idx = vmm_out(i_ur, i_oc).getIdx();
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) { return Vmm(vmm_out_idx(i_ur, i_oc)); }
+    Xbyak::Zmm zmm_out(dim_t i_ur, dim_t i_oc) {
+        const int idx = vmm_out(i_ur, i_oc).getIdx();
         assert(idx
                 < (jcp.is_depthwise ? ker_dw_reg_base_idx : ker_reg_base_idx));
         return Xbyak::Zmm(idx);
     }
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
-    Xbyak::Zmm zmm_inp(int i_ic, int nb_x_blocking) {
-        const int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Xbyak::Zmm zmm_inp(dim_t i_ic, dim_t nb_x_blocking) {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         const int max_idx = jcp.src_zero_point ? ker_zp_reg_base_idx
                                                : ker_dw_reg_base_idx;
         assert(idx < max_idx);
         MAYBE_UNUSED(max_idx);
 
-        return Xbyak::Zmm(idx);
+        return Xbyak::Zmm(static_cast<int>(idx));
     }
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
 
     // bf16 utils
-    int get_src_down_idx(int nb_x_blocking) {
-        int idx = nb_x_blocking * jcp.ur_w;
+    int get_src_down_idx(dim_t nb_x_blocking) {
+        const dim_t idx = nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return idx;
+        return static_cast<int>(idx);
     }
     inline Vmm maybe_mask_vmm(Vmm vmm, bool mask_flag) {
         return mask_flag ? vmm | ktail_mask_extended : vmm;
@@ -213,16 +214,18 @@ private:
                 maybe_mask_vmm_down(vmm_down, mask_flag || jcp.simd_w == 4));
     }
 
-    void prepare_output(int ur_w);
-    void apply_postops(int ur_w, bool last_oc_block_flag, const int nb_oc_block,
-            const int oc_block);
-    void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker_dw(int ur_w, int pad_l, int pad_r,
+    void prepare_output(dim_t ur_w);
+    void apply_postops(dim_t ur_w, bool last_oc_block_flag,
+            const dim_t nb_oc_block, const dim_t oc_block);
+    void store_output(dim_t ur_w, bool last_oc_block_flag);
+    void compute_ker_dw(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void compute_ker(dim_t ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded = false);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool is_last_spatial_block);
+    void kh_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r,
+            ic_block_t last_ic_block_flag);
+    void icb_loop(
+            dim_t ur_w, dim_t pad_l, dim_t pad_r, bool is_last_spatial_block);
     void generate() override;
     void cvt2ps(data_type_t type_in, Vmm ymm_in, const Xbyak::Operand &op,
             bool mask_flag);
@@ -234,7 +237,8 @@ struct jit_avx512_core_x8s8s32x_fwd_kernel_t {
     jit_avx512_core_x8s8s32x_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_convolution.cpp
@@ -75,8 +75,8 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
 
     size_t extra_data_offset
             = weights_d.size() - weights_d.additional_buffer_size();
-    size_t ch_offset = jcp.is_depthwise ? jcp.nb_ch * jcp.ch_block
-                                        : jcp.ngroups * jcp.oc;
+    const dim_t ch_offset = jcp.is_depthwise ? jcp.nb_ch * jcp.ch_block
+                                             : jcp.ngroups * jcp.oc;
     auto w = const_cast<char *>(weights);
     int32_t *compensation = (jcp.signed_input)
             ? reinterpret_cast<int32_t *>(&w[extra_data_offset])
@@ -86,13 +86,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
                     + (jcp.signed_input ? ch_offset : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
+    const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -108,7 +108,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -129,13 +129,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_1d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int gb = gg * jcp.nb_ch_blocking;
-            int g = gb * group_block;
-            int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.nb_ic * jcp.ic_block;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t gb = gg * jcp.nb_ch_blocking;
+            dim_t g = gb * group_block;
+            dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
+            dim_t ow_s = owb * jcp.ow_block;
+            dim_t iw_s = ow_s * jcp.stride_w;
 
             p.bias = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                           : nullptr;
@@ -234,12 +234,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
+            = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -259,7 +260,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
         size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -276,20 +277,21 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
+            for (dim_t occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -301,17 +303,17 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d(
                 auto src_w = src + src_d.blk_off(n, g_ic, ih_s, iw_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(max(0,
+                    dim_t dilate_h = jcp.dilate_h + 1;
+                    dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ij), dilate_h));
+                    dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
@@ -416,8 +418,8 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.nb_ch * jcp.ch_block : 0)
             : nullptr;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [= COMPAT_THIS_CAPTURE](dim_t n, dim_t oh_s, dim_t owb, dim_t gg) {
@@ -426,12 +428,12 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int gb = gg * jcp.nb_ch_blocking;
-        int g = gb * group_block;
+        dim_t gb = gg * jcp.nb_ch_blocking;
+        dim_t g = gb * group_block;
 
-        int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        int ow_s = owb * jcp.ow_block;
-        int iw_s = ow_s * jcp.stride_w;
+        dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        dim_t ow_s = owb * jcp.ow_block;
+        dim_t iw_s = ow_s * jcp.stride_w;
 
         auto bias_w = bias ? bias + (bias_d.blk_off(g) * bia_dt_size) : nullptr;
         int32_t *compensation_w = jcp.signed_input ? compensation + g : nullptr;
@@ -455,12 +457,15 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_2d_dw(
                 ? static_cast<const float *>(wei_scales) + jcp.is_oc_scale * g
                 : nullptr;
 
-        int dilate_h = jcp.dilate_h + 1;
-        int i_t_overflow = nstl::min(jcp.kh, div_up(max(0, -ih_s), dilate_h));
-        int i_b_overflow = nstl::min(jcp.kh,
-                div_up(max(0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
+        dim_t dilate_h = jcp.dilate_h + 1;
+        dim_t i_t_overflow = nstl::min<dim_t>(
+                jcp.kh, div_up(max<dim_t>(0, -ih_s), dilate_h));
+        dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                div_up(max<dim_t>(
+                               0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h));
-        int kh_padding = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+        dim_t kh_padding
+                = nstl::max<dim_t>(0, jcp.kh - i_t_overflow - i_b_overflow);
 
         size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
                 ? 0
@@ -535,13 +540,13 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -563,7 +568,7 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -580,32 +585,33 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
+            for (dim_t occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-                int dilate_d = jcp.dilate_d + 1;
-                int d_f_overflow
-                        = nstl::min(jcp.kd, div_up(max(0, -id_s), dilate_d));
-                int d_back_overflow = nstl::min(jcp.kd,
-                        div_up(max(0,
+                dim_t ow_s = owb * jcp.ow_block;
+                dim_t iw_s = ow_s * jcp.stride_w;
+                dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                dim_t dilate_d = jcp.dilate_d + 1;
+                dim_t d_f_overflow = nstl::min<dim_t>(
+                        jcp.kd, div_up(max<dim_t>(0, -id_s), dilate_d));
+                dim_t d_back_overflow = nstl::min<dim_t>(jcp.kd,
+                        div_up(max<dim_t>(0,
                                        id_s - jcp.id + (jcp.kd - 1) * dilate_d
                                                + 1),
                                 dilate_d));
 
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+                dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_f_overflow - d_back_overflow);
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -623,17 +629,17 @@ status_t jit_avx512_core_x8s8s32x_convolution_fwd_t::execute_forward_3d(
                                           : d_f_overflow)
                                 * wht_d_stride;
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow
-                            = nstl::min(jcp.kh, div_up(max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(max(0,
+                    dim_t dilate_h = jcp.dilate_h + 1;
+                    dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(max<dim_t>(0, -ij), dilate_h));
+                    dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.cpp
@@ -259,9 +259,9 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride = 1' when 'dilate > 0'");
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.iw, jcp.ow, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -303,10 +303,13 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_oc = jcp.oc / jcp.oc_block;
@@ -315,18 +318,18 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
     /* kernel blocking params */
     const int regs = jcp.has_vnni ? 30 : 28;
     jcp.nb_ch_blocking = 1;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
                 && jcp.l_pad <= regs / (jcp.nb_oc_blocking + 1))
             break;
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    int l_overflow = max(
-            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
+    int l_overflow = static_cast<int>(max<dim_t>(
+            0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w));
 
     if (jcp.ow < jcp.ur_w) {
-        jcp.ur_w = jcp.ow;
+        jcp.ur_w = static_cast<int>(jcp.ow);
         jcp.ur_w_tail = 0;
     } else {
         for (; jcp.ur_w >= 1; jcp.ur_w--) {
@@ -339,10 +342,10 @@ status_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t::init_conf(
                are computed in a single call of compute loop */
             bool left_boundary_covered = jcp.ur_w >= l_overflow * jcp.stride_w;
             jcp.ur_w_tail = jcp.ow % jcp.ur_w;
-            int r_overflow_no_tail = max(0,
-                    ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad)
-                            - jcp.ur_w_tail)
-                            / jcp.stride_w);
+            int r_overflow_no_tail = static_cast<int>(max<dim_t>(0,
+                    ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                            - max<dim_t>(0, jcp.r_pad) - jcp.ur_w_tail)
+                            / jcp.stride_w));
             bool right_boundary_covered
                     = jcp.ur_w >= r_overflow_no_tail * jcp.stride_w;
 
@@ -496,7 +499,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
 
     const auto load_zp_src_pad_comp
             = [&](const Vmm &zp_pad_comp_vmm, const Xbyak::Address &comp_addr,
-                      const int ocb) {
+                      const dim_t ocb) {
         const bool is_last_ocb = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
         const bool is_tail = is_last_ocb && get_tail_size() > 0;
         if (is_tail)
@@ -505,16 +508,16 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
             vmovups(zp_pad_comp_vmm, comp_addr);
     };
 
-    const auto get_zp_src_comp_pad_off = [&](int it_kw, int ocb) {
+    const auto get_zp_src_comp_pad_off = [&](dim_t it_kw, dim_t ocb) {
         const auto kw_offset = it_kw * jcp.oc_without_padding * jcp.ngroups;
         const auto oc_offset = ocb * jcp.oc_block;
 
         return (kw_offset + oc_offset) * sizeof(int32_t);
     };
 
-    for (int it_kw = 0; it_kw < jcp.kw; ++it_kw) {
-        const int ow_start = get_ow_start(it_kw, l_overflow);
-        const int ow_end = get_ow_end(ur_w, it_kw, r_overflow);
+    for (dim_t it_kw = 0; it_kw < jcp.kw; ++it_kw) {
+        const dim_t ow_start = get_ow_start(it_kw, l_overflow);
+        const dim_t ow_end = get_ow_end(ur_w, it_kw, r_overflow);
 
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
             Vmm zp_src_comp_pad_vmm; // will be assigned later
@@ -523,7 +526,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
             const auto zp_src_comp_pad_off
                     = get_zp_src_comp_pad_off(it_kw, ocb);
 
-            for (int it_ow = 0; it_ow < ur_w; ++it_ow) {
+            for (dim_t it_ow = 0; it_ow < ur_w; ++it_ow) {
 
                 const bool inside_padded_area = h_padded
                         || !(it_ow >= ow_start && it_ow < ow_end
@@ -552,7 +555,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<
     if (jcp.ndims > 3) {
         if (!base_comp_addr_loaded) load_base_zp_src_pad_comp_addr();
 
-        const auto kh_offset = jcp.kw * jcp.oc_without_padding * jcp.ngroups
+        const dim_t kh_offset = jcp.kw * jcp.oc_without_padding * jcp.ngroups
                 * sizeof(int32_t);
 
         add(reg_zp_src_pad_comp, kh_offset);
@@ -571,33 +574,34 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
     const bool signed_input_or_src_zp
             = (jcp.signed_input || jcp.src_zero_point);
 
-    const int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    const int ur_w_stride = signed_input_or_src_zp ? 1 : jcp.stride_w;
+    const dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    const int ur_w_stride
+            = signed_input_or_src_zp ? 1 : static_cast<int>(jcp.stride_w);
 
-    auto src_offset = [this](int oj, int icb, int ki) {
+    auto src_offset = [this](dim_t oj, dim_t icb, dim_t ki) {
         return jcp.typesize_in
                 * (((oj + jcp.l_pad - ki * (jcp.dilate_w + 1)) / jcp.stride_w)
                                 * jcp.ngroups * jcp.ic_without_padding
                         + icb * 4);
     };
 
-    auto kernel_offset = [this, ch_block_all](int ocb, int icb, int ki) {
+    auto kernel_offset = [this, ch_block_all](dim_t ocb, dim_t icb, dim_t ki) {
         return jcp.typesize_in
                 * ((ocb * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
                         + icb * jcp.oc_block * ic_sub_step);
     };
 
-    for (int ki = 0; ki < jcp.kw; ki++) {
-        int jj_start = get_ow_start(ki, l_overflow);
-        int jj_end = get_ow_end(ur_w, ki, r_overflow);
+    for (dim_t ki = 0; ki < jcp.kw; ki++) {
+        dim_t jj_start = get_ow_start(ki, l_overflow);
+        dim_t jj_end = get_ow_end(ur_w, ki, r_overflow);
 
-        int _start = (signed_input_or_src_zp) ? 0 : jj_start;
-        int _end = (signed_input_or_src_zp) ? ur_w : jj_end;
+        dim_t _start = (signed_input_or_src_zp) ? 0 : jj_start;
+        dim_t _end = (signed_input_or_src_zp) ? ur_w : jj_end;
 
-        int tail_size = jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
-                                         : jcp.ic_without_padding % 4;
-        int n_ic_blocks = jcp.is_depthwise
+        dim_t tail_size = jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
+                                           : jcp.ic_without_padding % 4;
+        dim_t n_ic_blocks = jcp.is_depthwise
                 ? 1
                 : (last_ic_block_flag & ~ker_block_t::no_last_block
                                   ? div_up(jcp.ic_without_padding
@@ -605,7 +609,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                                             4)
                                   : jcp.ic_block / 4);
 
-        for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
+        for (dim_t icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded == true) {
                 if (jcp.signed_input) {
                     /* fill padded area with shifted values */
@@ -615,9 +619,9 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                 }
             } else {
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
-                    int aux_src_off = src_offset(jj, icb1, ki);
+                    dim_t aux_src_off = src_offset(jj, icb1, ki);
 
                     if (jj >= jj_start && jj < jj_end
                             && ((jj + jcp.l_pad - ki) % jcp.stride_w == 0)) {
@@ -635,9 +639,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                                 && tail_size != 0 && icb1 == n_ic_blocks - 1) {
                             const Xmm xmm_tmp = Xmm(
                                     vmm_inp(jj, jcp.nb_oc_blocking).getIdx());
-                            for (int r = 0; r < tail_size; ++r)
+                            for (dim_t r = 0; r < tail_size; ++r)
                                 vpinsrb(xmm_tmp, xmm_tmp,
-                                        ptr[aux_reg_src + aux_src_off + r], r);
+                                        ptr[aux_reg_src + aux_src_off + r],
+                                        static_cast<uint8_t>(r));
                             vpbroadcastd(
                                     vmm_inp(jj, jcp.nb_oc_blocking), xmm_tmp);
                         } else {
@@ -659,7 +664,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                 }
             }
             for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-                int aux_filt_off = kernel_offset(ocb, icb1, ki);
+                dim_t aux_filt_off = kernel_offset(ocb, icb1, ki);
 
                 if (_end - _start > 0) {
                     if (jcp.is_depthwise)
@@ -669,7 +674,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::compute_ker(int ur_w,
                         vmovups(vmm_wei,
                                 EVEX_compress_addr(aux_reg_filt, aux_filt_off));
                 }
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
                     const bool jj_between_start_end
                             = jj >= jj_start && jj < jj_end;
                     const bool ki_applies_to_stride
@@ -698,15 +703,15 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     const bool signed_input_or_src_zp
             = (jcp.signed_input || jcp.src_zero_point);
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_src_ih = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw
+    dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    dim_t shift_src_ih = jcp.typesize_in * (jcp.dilate_h + 1) * jcp.iw
             * jcp.ngroups * jcp.ic_without_padding;
-    int shift_src_id = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * jcp.iw
+    dim_t shift_src_id = jcp.typesize_in * (jcp.dilate_d + 1) * jcp.ih * jcp.iw
             * jcp.ngroups * jcp.ic_without_padding;
-    const int stride_h = signed_input_or_src_zp ? 1 : jcp.stride_h;
-    int shift_filt_kh = jcp.typesize_in * jcp.kw * ch_block_all * stride_h;
-    const int stride_d = signed_input_or_src_zp ? 1 : jcp.stride_d;
-    int shift_filt_kd
+    const dim_t stride_h = signed_input_or_src_zp ? 1 : jcp.stride_h;
+    dim_t shift_filt_kh = jcp.typesize_in * jcp.kw * ch_block_all * stride_h;
+    const dim_t stride_d = signed_input_or_src_zp ? 1 : jcp.stride_d;
+    dim_t shift_filt_kd
             = jcp.typesize_in * jcp.kw * ch_block_all * jcp.kh * stride_d;
 
     Label kd_loop_label, kh_loop_label, skip_kh_loop, skip_kd_loop;
@@ -746,9 +751,9 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
         if ((signed_input_or_src_zp) || (jcp.dilate_d >= jcp.id)
                 || (jcp.kd < jcp.stride_d)
                 || ((!signed_input_or_src_zp)
-                        && ((min(jcp.f_pad, jcp.back_pad) < 0)
+                        && ((min<dim_t>(jcp.f_pad, jcp.back_pad) < 0)
                                 || ((jcp.kd - 1) * (jcp.dilate_d + 1)
-                                        < nstl::max(
+                                        < nstl::max<dim_t>(
                                                 jcp.f_pad, jcp.back_pad))))) {
             cmp(reg_ki, 0);
             je(skip_kd_loop, T_NEAR);
@@ -784,9 +789,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     if ((signed_input_or_src_zp) || (jcp.dilate_h >= jcp.ih)
             || (jcp.kh < jcp.stride_h)
             || ((!signed_input_or_src_zp)
-                    && ((min(jcp.t_pad, jcp.b_pad) < 0)
+                    && ((min<dim_t>(jcp.t_pad, jcp.b_pad) < 0)
                             || ((jcp.kh - 1) * (jcp.dilate_h + 1)
-                                    < nstl::max(jcp.t_pad, jcp.b_pad))))) {
+                                    < nstl::max<dim_t>(
+                                            jcp.t_pad, jcp.b_pad))))) {
         cmp(reg_kh, 0);
         je(skip_kh_loop, T_NEAR);
     }
@@ -887,14 +893,14 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::kh_loop(int ur_w,
     }
 }
 template <typename Vmm>
-int jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_tail_size()
+dim_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_tail_size()
         const noexcept {
     return jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
                             : jcp.oc_without_padding % jcp.oc_block;
 }
 
 template <typename Vmm>
-int jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_blocking_size()
+dim_t jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_blocking_size()
         const noexcept {
     return jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
 }
@@ -950,7 +956,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
 
         const bool is_tail = get_tail_size() > 0;
         for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
-            const int zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
             const bool is_last_ocb
                     = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
             const auto vmm = is_last_ocb && is_tail
@@ -972,12 +978,12 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
 
         const Vmm vmm_bias = vmm_tmp;
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
+            const dim_t bias_offset = jcp.typesize_bia * ocb * jcp.oc_block;
             auto bias_addr = EVEX_compress_addr(reg_bias, bias_offset);
             cvt2ps(jcp.bia_dt, vmm_bias, bias_addr, mask_flag);
         }
         if (jcp.signed_input) {
-            int comp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * ocb * jcp.oc_block;
             auto comp_addr = EVEX_compress_addr(reg_compensation, comp_offset);
             cvt2ps(data_type::s32, vmm_comp, comp_addr, mask_flag);
         }
@@ -1012,7 +1018,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
             if (jcp.with_wei_scales) {
                 mov(reg_wei_scales, ptr[param1 + GET_OFF(wei_scales)]);
 
-                int scale_offset = jcp.is_oc_scale
+                const dim_t scale_offset = jcp.is_oc_scale
                         * (sizeof(float) * ocb * jcp.oc_block);
                 vmulps(mask_vmm, vmm,
                         EVEX_compress_addr(reg_wei_scales, scale_offset,
@@ -1040,7 +1046,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
                         = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
                 for (int ur = 0; ur < ur_w; ur++) {
                     const int vmm_idx = vmm_out(ur, ocb).getIdx();
-                    const size_t aux_output_offset = jcp.typesize_out
+                    const dim_t aux_output_offset = jcp.typesize_out
                             * (ocb * jcp.oc_block
                                     + ur * jcp.oc_without_padding
                                             * jcp.ngroups);
@@ -1131,7 +1137,7 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::store_output(
     for (int ocb = 0; ocb < jcp.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp.nb_oc_blocking - 1;
         for (int ur = 0; ur < ur_w; ur++) {
-            int aux_dst_off = jcp.typesize_out
+            dim_t aux_dst_off = jcp.typesize_out
                     * (ur * jcp.ngroups * jcp.oc_without_padding
                             + ocb * jcp.oc_block);
             auto addr = EVEX_compress_addr(reg_dst, aux_dst_off);
@@ -1153,9 +1159,9 @@ template <typename Vmm>
 void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::icb_loop(
         int ur_w, int l_overflow, int r_overflow, bool is_last_sp_block) {
 
-    int shift_src_icb = jcp.typesize_in * jcp.ic_block;
-    const size_t shift_filt_icb = (size_t)jcp.typesize_in * jcp.kd * jcp.kh
-            * jcp.kw * jcp.ic_block * jcp.oc_block;
+    dim_t shift_src_icb = jcp.typesize_in * jcp.ic_block;
+    const dim_t shift_filt_icb = jcp.typesize_in * jcp.kd * jcp.kh * jcp.kw
+            * jcp.ic_block * jcp.oc_block;
 
     prepare_output(ur_w);
 
@@ -1230,20 +1236,20 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::icb_loop(
 template <typename Vmm>
 ur_w_blks_params_t
 jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
-    const int n_ur_blocks = jcp.ow / jcp.ur_w;
+    const dim_t n_ur_blocks = jcp.ow / jcp.ur_w;
 
     ur_w_blks_params_t ur_w_blks_params;
-    int num_blks_to_process_sp_carefully = 0;
-    int idx_last_non_zero_l_overflow_blk = -1;
-    int idx_first_non_zero_r_overflow_blk = n_ur_blocks;
+    dim_t num_blks_to_process_sp_carefully = 0;
+    dim_t idx_last_non_zero_l_overflow_blk = -1;
+    dim_t idx_first_non_zero_r_overflow_blk = n_ur_blocks;
 
     static constexpr int src_pixels_loaded_for_bcast = 4;
     const auto ic_mod = jcp.ic_without_padding % src_pixels_loaded_for_bcast;
-    for (int blk_idx = 0; blk_idx < n_ur_blocks; blk_idx++) {
-        const int first_blk_dst_elem = blk_idx * jcp.ur_w;
-        const int last_dst_blk_elem = first_blk_dst_elem + jcp.ur_w - 1;
+    for (dim_t blk_idx = 0; blk_idx < n_ur_blocks; blk_idx++) {
+        const dim_t first_blk_dst_elem = blk_idx * jcp.ur_w;
+        const dim_t last_dst_blk_elem = first_blk_dst_elem + jcp.ur_w - 1;
 
-        const int last_blk_src_idx = nstl::min(
+        const dim_t last_blk_src_idx = nstl::min<dim_t>(
                 jcp.iw - 1, (last_dst_blk_elem + jcp.l_pad) / jcp.stride_w);
         const bool is_out_of_src_pixels_scope
                 = ((jcp.iw - 1 - last_blk_src_idx) * jcp.ic_without_padding
@@ -1252,30 +1258,29 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
 
         const bool process_sp_carefully
                 = (ic_mod != 0) && is_out_of_src_pixels_scope;
-        const int curr_l_overflow = nstl::max(0,
+        const dim_t curr_l_overflow = nstl::max<dim_t>(0,
                 ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad
                         - first_blk_dst_elem)
                         / jcp.stride_w);
-        const int curr_r_overflow = nstl::max(0,
+        const dim_t curr_r_overflow = nstl::max<dim_t>(0,
                 (last_dst_blk_elem + jcp.l_pad) / jcp.stride_w - (jcp.iw - 1));
 
         ur_w_blks_params.blks_params.emplace_back(
                 curr_l_overflow, curr_r_overflow, process_sp_carefully);
 
-        num_blks_to_process_sp_carefully
-                += static_cast<int>(process_sp_carefully);
+        num_blks_to_process_sp_carefully += process_sp_carefully;
         if (curr_l_overflow > 0) idx_last_non_zero_l_overflow_blk = blk_idx;
         if (curr_r_overflow > 0 && idx_first_non_zero_r_overflow_blk > blk_idx)
             idx_first_non_zero_r_overflow_blk = blk_idx;
     }
     idx_first_non_zero_r_overflow_blk
-            = nstl::max(idx_first_non_zero_r_overflow_blk,
+            = nstl::max<dim_t>(idx_first_non_zero_r_overflow_blk,
                     idx_last_non_zero_l_overflow_blk + 1);
     // limit num_r_overflow_blks and num_blks_to_process_last_sp_carefully so that:
-    // n_ur_blocks >= num_l_overflow_blks + max(num_r_overflow_blks, num_blks_to_process_last_sp_carefully)
+    // n_ur_blocks >= num_l_overflow_blks + max<dim_t>(num_r_overflow_blks, num_blks_to_process_last_sp_carefully)
     ur_w_blks_params.num_pre_blks
-            = nstl::max(0, idx_last_non_zero_l_overflow_blk + 1);
-    const int num_r_overflow_blks = idx_first_non_zero_r_overflow_blk
+            = nstl::max<dim_t>(0, idx_last_non_zero_l_overflow_blk + 1);
+    const dim_t num_r_overflow_blks = idx_first_non_zero_r_overflow_blk
                     <= idx_last_non_zero_l_overflow_blk
             ? n_ur_blocks - ur_w_blks_params.num_pre_blks
             : n_ur_blocks - idx_first_non_zero_r_overflow_blk;
@@ -1284,8 +1289,8 @@ jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::get_ur_w_blks_params() {
                     < n_ur_blocks
             ? num_blks_to_process_sp_carefully
             : n_ur_blocks - ur_w_blks_params.num_pre_blks;
-    ur_w_blks_params.num_post_blks
-            = nstl::max(num_r_overflow_blks, num_blks_to_process_sp_carefully);
+    ur_w_blks_params.num_post_blks = nstl::max<dim_t>(
+            num_r_overflow_blks, num_blks_to_process_sp_carefully);
 
     return ur_w_blks_params;
 }
@@ -1303,10 +1308,10 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
     vpbroadcastw(vmm_one, _t);
 
     if (jcp.ngroups % jcp.ch_block != 0 || jcp.oc_without_padding != jcp.oc) {
-        int tail_size = jcp.is_depthwise
+        const dim_t tail_size = jcp.is_depthwise
                 ? jcp.ngroups % jcp.ch_block
                 : jcp.oc_without_padding % jcp.oc_block;
-        int mask = (1 << tail_size) - 1;
+        const uint32_t mask = (uint32_t(1) << tail_size) - 1;
         Reg32 regw_tmp = reg_nur_w.cvt32();
         Label skip_tail_mask;
         if (jcp.is_depthwise) {
@@ -1323,26 +1328,26 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
     mov(reg_filt, ptr[param1 + GET_OFF(filt)]);
     mov(reg_dst, ptr[param1 + GET_OFF(dst)]);
 
-    int dst_shift = jcp.typesize_out * jcp.ur_w * jcp.ngroups
+    dim_t dst_shift = jcp.typesize_out * jcp.ur_w * jcp.ngroups
             * jcp.oc_without_padding;
-    int src_shift = jcp.typesize_in * (jcp.ur_w / jcp.stride_w) * jcp.ngroups
+    dim_t src_shift = jcp.typesize_in * (jcp.ur_w / jcp.stride_w) * jcp.ngroups
             * jcp.ic_without_padding;
 
     const auto ur_w_blks_params = get_ur_w_blks_params();
-    const int nur_w = jcp.ow / jcp.ur_w - ur_w_blks_params.num_pre_blks
-            - ur_w_blks_params.num_post_blks;
+    const int nur_w = static_cast<int>(jcp.ow / jcp.ur_w
+            - ur_w_blks_params.num_pre_blks - ur_w_blks_params.num_post_blks);
 
     const auto &blks_params = ur_w_blks_params.blks_params;
     const auto num_pre_blks = ur_w_blks_params.num_pre_blks;
     const auto num_post_blks = ur_w_blks_params.num_post_blks;
 
-    for (int i = 0; i < num_pre_blks; i++) {
+    for (dim_t i = 0; i < num_pre_blks; i++) {
         const bool blk_process_carefully = blks_params[i].process_sp_carefully;
-        const int blk_l_overflow = blks_params[i].l_overflow;
-        const int blk_r_overflow = blks_params[i].r_overflow;
+        const dim_t blk_l_overflow = blks_params[i].l_overflow;
+        const dim_t blk_r_overflow = blks_params[i].r_overflow;
 
-        icb_loop(jcp.ur_w, blk_l_overflow, blk_r_overflow,
-                blk_process_carefully);
+        icb_loop(jcp.ur_w, static_cast<int>(blk_l_overflow),
+                static_cast<int>(blk_r_overflow), blk_process_carefully);
         add(reg_src, src_shift);
         add(reg_dst, dst_shift);
     }
@@ -1367,11 +1372,11 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
         for (size_t i = start_blk_idx; i < blks_params_size; i++) {
             const bool blk_process_carefully
                     = blks_params[i].process_sp_carefully;
-            const int blk_l_overflow = blks_params[i].l_overflow;
-            const int blk_r_overflow = blks_params[i].r_overflow;
+            const dim_t blk_l_overflow = blks_params[i].l_overflow;
+            const dim_t blk_r_overflow = blks_params[i].r_overflow;
 
-            icb_loop(jcp.ur_w, blk_l_overflow, blk_r_overflow,
-                    blk_process_carefully);
+            icb_loop(jcp.ur_w, static_cast<int>(blk_l_overflow),
+                    static_cast<int>(blk_r_overflow), blk_process_carefully);
             add(reg_src, src_shift);
             add(reg_dst, dst_shift);
         }
@@ -1382,14 +1387,14 @@ void jit_avx512_core_x8s8s32x_deconv_fwd_kernel_t<Vmm>::generate() {
         //              when computing the left-most (in w dim) output pixel
         int l_overflow = 0;
         if (jcp.ur_w == jcp.ow)
-            l_overflow = max(0,
+            l_overflow = static_cast<int>(max<dim_t>(0,
                     ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad)
-                            / jcp.stride_w);
+                            / jcp.stride_w));
         // r_overflow - no/ of spatial elements of weights standing out of src spatial
         //              when computing the right-most (in w dim) output pixel
-        const int r_overflow = max(0,
-                ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad))
-                        / jcp.stride_w);
+        const int r_overflow = static_cast<int>(max<dim_t>(0,
+                ((jcp.kw - 1) * (jcp.dilate_w + 1) - max<dim_t>(0, jcp.r_pad))
+                        / jcp.stride_w));
 
         icb_loop(jcp.ur_w_tail, l_overflow, r_overflow, true);
     }
@@ -1434,8 +1439,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
     const auto post_ops_binary_rhs_arg_vec
             = binary_injector::prepare_binary_args(jcp.post_ops, ctx);
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const void *src_scales
             = CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
@@ -1455,8 +1460,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1472,7 +1477,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0};
+        dim_t n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks);
         else if (jcp.loop_order == loop_cgn)
@@ -1481,9 +1486,9 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_1d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
 
             p.dst = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             p.src = src + src_d.blk_off(n, g_ic);
@@ -1555,8 +1560,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     size_t src_h_stride = src_d.blk_off(0, 0, 1);
     size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -1580,8 +1585,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1598,7 +1603,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     oh_s, jcp.oh);
@@ -1609,11 +1614,11 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
-            int work_rem = end - start;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            dim_t work_rem = end - start;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
 
             auto dst_w = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             auto src_w = src + src_d.blk_off(n, g_ic);
@@ -1624,17 +1629,18 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
             int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    int o_b_overflow
-                            = div_up(max(0,
+                    dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1642,15 +1648,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    int o_t_overflow = max(
+                    dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    int o_b_overflow = max(0,
+                    dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1658,7 +1664,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                int wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
+                dim_t wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
                 p.src = src_w + ih_max * src_h_stride;
@@ -1668,10 +1674,10 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_2d(
                 p.compensation = compensation_w;
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
@@ -1740,8 +1746,8 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     size_t src_d_stride = src_d.blk_off(0, 0, 1);
     size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);
@@ -1768,8 +1774,9 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
+        dim_t start {0}, end {0};
+        const dim_t work_amount
+                = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1786,7 +1793,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     od_s, jcp.od, oh_s, jcp.oh);
@@ -1797,23 +1804,24 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            int ocb = occ * jcp.nb_oc_blocking;
-            int g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.ch_block * jcp.ic;
-            int work_rem = end - start;
-            int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-            int input_d_s = 0, kd_len = 0, kd_lo = 0;
-            int d_t_overflow, d_back_overflow;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            dim_t g_oc = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
+            dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            dim_t work_rem = end - start;
+            dim_t oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+            dim_t input_d_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t d_t_overflow, d_back_overflow;
 
             if (jcp.dilate_d != 0 && jcp.stride_d == 1) {
                 /* dilation */
-                int dilate_d = jcp.dilate_d + 1;
+                dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
                 d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
                         dilate_d);
                 d_back_overflow
-                        = div_up(max(0,
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.od
                                                  + od_s - jcp.back_pad),
                                 dilate_d);
@@ -1821,15 +1829,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 kd_lo = d_back_overflow;
                 input_d_s = od_s + jcp.f_pad - d_back_overflow * dilate_d;
             } else {
-                int d_t_overflow = max(
+                dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - (od_s + 1 + jcp.f_pad)) / jcp.stride_d);
-                int d_back_overflow = max(0,
+                dim_t d_back_overflow = max<dim_t>(0,
                         ((od_s + jcp.kd) - (jcp.od + jcp.back_pad))
                                 / jcp.stride_d);
-                int overflow_kd_hi = jcp.kd - 1
+                dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(jcp.od + jcp.back_pad - (od_s + 1),
                                 jcp.stride_d);
-                int overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
+                dim_t overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_back_overflow;
@@ -1851,17 +1859,18 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
             int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    int dilate_h = jcp.dilate_h + 1;
+                    dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    int o_b_overflow
-                            = div_up(max(0,
+                    dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1869,15 +1878,15 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    int o_t_overflow = max(
+                    dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    int o_b_overflow = max(0,
+                    dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    int overflow_kh_hi = jcp.kh - 1
+                    dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    dim_t overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1885,7 +1894,7 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                int wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
+                dim_t wei_stride = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
                 p.src = src_w + ih_max * src_h_stride;
@@ -1897,19 +1906,19 @@ status_t jit_avx512_core_x8s8s32x_deconvolution_fwd_t::execute_forward_3d(
                 strides together */
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kd
                                           - (kd_lo
-                                                  + max(0, kd_len - 1)
+                                                  + max<dim_t>(0, kd_len - 1)
                                                           * jcp.stride_d
                                                   + 1));
                 p.back_overflow = kd_lo;

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_deconvolution.hpp
@@ -49,25 +49,25 @@ enum ker_block_t {
 struct ur_w_blks_params_t {
     struct single_ur_w_blk_params_t {
         single_ur_w_blk_params_t(
-                int l_overflow, int r_overflow, bool process_sp_carefully)
+                dim_t l_overflow, dim_t r_overflow, bool process_sp_carefully)
             : l_overflow(l_overflow)
             , r_overflow(r_overflow)
             , process_sp_carefully(process_sp_carefully) {}
 
         // l_overflow - no. of spatial elements of weights standing out of
         // src spatial when computing the 1st output pixel in the current blk
-        int l_overflow;
+        dim_t l_overflow;
         // r_overflow - no. of spatial elements of weights standing out of
         // src spatial when computing the lst output pixel in the current blk
-        int r_overflow;
+        dim_t r_overflow;
         // process_sp_carefully - indicates if loading the last src sp
         // for computation of the last dst sp of the block can't be done
         // by fetching 4 src sp at once
         bool process_sp_carefully;
     };
     std::vector<single_ur_w_blk_params_t> blks_params;
-    int num_pre_blks; // num of blocks with l_overflow>0
-    int num_post_blks; // num of blocks with r_overflow>0 or that need to be
+    dim_t num_pre_blks; // num of blocks with l_overflow>0
+    dim_t num_post_blks; // num of blocks with r_overflow>0 or that need to be
             // processed carefully
 };
 
@@ -139,19 +139,19 @@ private:
     const Vmm vmm_bias = Vmm(31);
     const Vmm vmm_scale_adjust = Vmm(31);
 
-    Vmm vmm_out(int i_ur, int i_oc) {
-        int idx = i_ur * jcp.nb_oc_blocking + i_oc;
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) {
+        const dim_t idx = i_ur * jcp.nb_oc_blocking + i_oc;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) const {
-        int idx = i_ic + nb_x_blocking * jcp.ur_w;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) const {
+        const dim_t idx = i_ic + nb_x_blocking * jcp.ur_w;
         assert(idx < 31);
-        return Vmm(idx);
+        return Vmm(static_cast<int>(idx));
     }
 
-    int get_ow_start(int ki, int l_overflow) {
-        int res = (jcp.ow - 1 + jcp.r_pad) % jcp.stride_w
+    dim_t get_ow_start(dim_t ki, dim_t l_overflow) {
+        dim_t res = (jcp.ow - 1 + jcp.r_pad) % jcp.stride_w
                 + l_overflow * jcp.stride_w
                 - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1);
         while (res < 0)
@@ -159,18 +159,18 @@ private:
         return res;
     }
 
-    int get_ow_end(int ur_w, int ki, int r_overflow) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t r_overflow) {
         if (utils::one_of(ur_w, jcp.ow, jcp.ur_w_tail))
-            ur_w += nstl::min(0, jcp.r_pad); // remove negative padding
-        int res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
+            ur_w += nstl::min<dim_t>(0, jcp.r_pad); // remove negative padding
+        dim_t res = (ur_w - 1 + jcp.l_pad) % jcp.stride_w
                 + r_overflow * jcp.stride_w - ki * (jcp.dilate_w + 1);
         while (res < 0)
             res += jcp.stride_w;
         return ur_w - res;
     }
 
-    int get_blocking_size() const noexcept;
-    int get_tail_size() const noexcept;
+    dim_t get_blocking_size() const noexcept;
+    dim_t get_tail_size() const noexcept;
     void prepare_output(int ur_w);
     void store_output(int ur_w, bool last_oc_block);
     void compute(const Vmm &vreg_acc, const Vmm &vreg_wei, const Vmm &vreg_src);
@@ -198,7 +198,8 @@ struct jit_avx512_core_x8s8s32x_deconv_fwd_kernel_vmm_t {
             const memory_desc_t &dst_md)
         : kernel_(nullptr) {
 
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 16:
                 kernel_ = utils::make_unique<

--- a/src/cpu/x64/jit_brdgmm_dw_conv.cpp
+++ b/src/cpu/x64/jit_brdgmm_dw_conv.cpp
@@ -38,17 +38,17 @@ using namespace data_type;
 
 namespace {
 struct blk_info_t {
-    int n_lpad_blks;
-    int rpad_blk_start_idx;
+    dim_t n_lpad_blks;
+    dim_t rpad_blk_start_idx;
 };
-blk_info_t get_blocks_info(int sp_i, int sp_o, int k, int stride, int lpad,
-        int rpad, int blk_size) {
+blk_info_t get_blocks_info(dim_t sp_i, dim_t sp_o, dim_t k, dim_t stride,
+        dim_t lpad, dim_t rpad, dim_t blk_size) {
 
-    const int max_blks = div_up(sp_o, blk_size);
-    const int blk_shift = stride * blk_size;
-    const int n_lpad_blks = nstl::min(
+    const dim_t max_blks = div_up(sp_o, blk_size);
+    const dim_t blk_shift = stride * blk_size;
+    const dim_t n_lpad_blks = nstl::min(
             max_blks, div_up(lpad, blk_shift) + 1 /*include zero lpad*/);
-    const int rpad_blk_start_idx = saturate(
+    const dim_t rpad_blk_start_idx = saturate(
             n_lpad_blks, max_blks, (sp_i + lpad - k + 1) / blk_shift);
     return {n_lpad_blks, rpad_blk_start_idx};
 }
@@ -293,8 +293,9 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
     auto &jcp = jcp_;
 
     auto gen_batch_elements
-            = [&jcp](int fpad, int backpad, int tpad, int bpad, int lpad,
-                      int rpad, int &bs, brgemm_batch_element_t *batches) {
+            = [&jcp](dim_t fpad, dim_t backpad, dim_t tpad, dim_t bpad,
+                      dim_t lpad, dim_t rpad, int &bs,
+                      brgemm_batch_element_t *batches) {
         const bool requires_batch_pad
                 = jcp.s8s8_compensation_required || jcp.src_zero_point;
         const size_t src_w_stride = jcp.ngroups * jcp.src_dsz;
@@ -306,19 +307,20 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
         const size_t wei_h_stride = wei_w_stride * jcp.kw;
         const size_t wei_d_stride = wei_h_stride * jcp.kh;
 
-        const int adj_backpad = nstl::max(0, backpad);
-        const int adj_bpad = nstl::max(0, bpad);
+        const dim_t adj_backpad = nstl::max(dim_t(0), backpad);
+        const dim_t adj_bpad = nstl::max(dim_t(0), bpad);
 
-        for_(int kd = 0; kd < jcp.kd; ++kd)
-        for_(int kh = 0; kh < jcp.kh; ++kh)
-        for (int kw = 0; kw < jcp.kw; ++kw) {
+        for_(dim_t kd = 0; kd < jcp.kd; ++kd)
+        for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+        for (dim_t kw = 0; kw < jcp.kw; ++kw) {
             const bool padded_bs = kd < fpad || kd >= jcp.kd - adj_backpad
                     || kh < tpad || kh >= jcp.kh - adj_bpad;
             if (!requires_batch_pad && padded_bs) continue;
             auto &batch = batches[bs];
-            batch.vvpad.top = div_up(nstl::max(0, lpad - kw), jcp.stride_w);
+            batch.vvpad.top
+                    = div_up(nstl::max(dim_t(0), lpad - kw), jcp.stride_w);
             batch.vvpad.bottom = div_up(
-                    nstl::max(0, rpad - jcp.kw + kw + 1), jcp.stride_w);
+                    nstl::max(dim_t(0), rpad - jcp.kw + kw + 1), jcp.stride_w);
             batch.has_s8s8_comp_batch_pad = padded_bs;
             const dim_t offs_A
                     = kd * src_d_stride + kh * src_h_stride + kw * src_w_stride;
@@ -332,17 +334,19 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
         }
     };
 
-    const int w_shift = jcp.ow_block * jcp.stride_w;
-    const int h_shift = jcp.stride_h;
-    const int d_shift = jcp.stride_d;
+    const dim_t w_shift = jcp.ow_block * jcp.stride_w;
+    const dim_t h_shift = jcp.stride_h;
+    const dim_t d_shift = jcp.stride_d;
 
     const auto w_blk_info = get_blocks_info(jcp.iw, jcp.ow, jcp.kw,
             jcp.stride_w, jcp.l_pad, jcp.r_pad, jcp.ow_block);
-    const int rpad_0
+    const dim_t rpad_0
             = (jcp.ow_block - 1) * jcp.stride_w + jcp.kw - (jcp.iw + jcp.l_pad);
-    const int rpad_1 = rpad_0 + (nstl::max(0, -rpad_0) / w_shift + 1) * w_shift;
-    const int n_uniq_rpads
-            = 1 + div_up(nstl::max(0, jcp.r_pad - (rpad_1 - w_shift)), w_shift);
+    const dim_t rpad_1
+            = rpad_0 + (nstl::max(dim_t(0), -rpad_0) / w_shift + 1) * w_shift;
+    const dim_t n_uniq_rpads = 1
+            + div_up(nstl::max(dim_t(0), jcp.r_pad - (rpad_1 - w_shift)),
+                    w_shift);
 
     const auto h_blk_info = get_blocks_info(
             jcp.ih, jcp.oh, jcp.kh, jcp.stride_h, jcp.t_pad, jcp.b_pad, 1);
@@ -350,41 +354,41 @@ void brdgmm_dw_convolution_fwd_t::pd_t::init_batch_elements() {
     const auto d_blk_info = get_blocks_info(
             jcp.id, jcp.od, jcp.kd, jcp.stride_d, jcp.f_pad, jcp.back_pad, 1);
 
-    const int max_bs = jcp.kd * jcp.kh * jcp.kw;
-    const int n_d_uniq_blks
+    const dim_t max_bs = jcp.kd * jcp.kh * jcp.kw;
+    const dim_t n_d_uniq_blks
             = d_blk_info.n_lpad_blks + (jcp.od - d_blk_info.rpad_blk_start_idx);
-    const int n_h_uniq_blks
+    const dim_t n_h_uniq_blks
             = h_blk_info.n_lpad_blks + (jcp.oh - h_blk_info.rpad_blk_start_idx);
-    const int n_w_uniq_lpads = w_blk_info.n_lpad_blks;
-    const int uniq_blks
+    const dim_t n_w_uniq_lpads = w_blk_info.n_lpad_blks;
+    const dim_t uniq_blks
             = n_d_uniq_blks * n_h_uniq_blks * n_w_uniq_lpads * n_uniq_rpads;
 
     bs_.resize(uniq_blks, 0);
     batches_.resize(bs_.size() * max_bs);
     int bi = 0;
 
-    for_(int odb = 0; odb < n_d_uniq_blks; ++odb)
-    for_(int ohb = 0; ohb < n_h_uniq_blks; ++ohb)
-    for_(int owb = 0; owb < n_w_uniq_lpads; ++owb)
-    for (int rpad_i = 0; rpad_i < n_uniq_rpads; ++rpad_i) {
-        const int lpad = jcp.l_pad - owb * w_shift;
-        const int rpad = rpad_i == 0
+    for_(dim_t odb = 0; odb < n_d_uniq_blks; ++odb)
+    for_(dim_t ohb = 0; ohb < n_h_uniq_blks; ++ohb)
+    for_(dim_t owb = 0; owb < n_w_uniq_lpads; ++owb)
+    for (dim_t rpad_i = 0; rpad_i < n_uniq_rpads; ++rpad_i) {
+        const dim_t lpad = jcp.l_pad - owb * w_shift;
+        const dim_t rpad = rpad_i == 0
                 ? rpad_0
                 : nstl::min(jcp.r_pad, rpad_1 + (rpad_i - 1) * w_shift);
 
-        const int tpad = jcp.t_pad - ohb * h_shift;
-        const int oh = ohb < h_blk_info.n_lpad_blks
+        const dim_t tpad = jcp.t_pad - ohb * h_shift;
+        const dim_t oh = ohb < h_blk_info.n_lpad_blks
                 ? ohb
                 : (h_blk_info.rpad_blk_start_idx
                           + (ohb - h_blk_info.n_lpad_blks));
-        const int bpad = oh * h_shift + jcp.kh - (jcp.ih + jcp.t_pad);
+        const dim_t bpad = oh * h_shift + jcp.kh - (jcp.ih + jcp.t_pad);
 
-        const int fpad = jcp.f_pad - odb * d_shift;
-        const int od = odb < d_blk_info.n_lpad_blks
+        const dim_t fpad = jcp.f_pad - odb * d_shift;
+        const dim_t od = odb < d_blk_info.n_lpad_blks
                 ? odb
                 : (d_blk_info.rpad_blk_start_idx
                           + (odb - d_blk_info.n_lpad_blks));
-        const int backpad = od * d_shift + jcp.kd - (jcp.id + jcp.f_pad);
+        const dim_t backpad = od * d_shift + jcp.kd - (jcp.id + jcp.f_pad);
 
         gen_batch_elements(fpad, backpad, tpad, bpad, lpad, rpad, bs_[bi],
                 &batches_[bi * max_bs]);
@@ -399,23 +403,26 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
     auto &jcp = jcp_;
     const bool is_3d = ndims() == 5;
 
-    auto init_bcp = [&](int &idx, const int M, const int N) {
+    auto init_bcp = [&](int &idx, const dim_t M, const dim_t N) {
         const float alpha = 1.f;
         const float beta = 0.f;
-        const int LDA = jcp.ngroups * jcp.stride_w;
-        const int LDC = jcp.ngroups;
-        const int LDD = jcp.ngroups;
+        const dim_t LDA = jcp.ngroups * jcp.stride_w;
+        const dim_t LDC = jcp.ngroups;
+        const dim_t LDD = jcp.ngroups;
 
         brgemm_attr_t brg_attr;
         brg_attr.max_bs = jcp.kw * jcp.kh * jcp.kd;
-        brg_attr.max_top_vpad = nstl::max(0, jcp.l_pad);
-        brg_attr.max_bottom_vpad = nstl::max(0, jcp.r_pad);
-        brg_attr.max_top_bpad = nstl::max(0, nstl::max(jcp.t_pad, jcp.f_pad));
-        brg_attr.max_bottom_bpad
-                = nstl::max(0, nstl::max(jcp.b_pad, jcp.back_pad));
+        brg_attr.max_top_vpad
+                = static_cast<int>(nstl::max(dim_t(0), jcp.l_pad));
+        brg_attr.max_bottom_vpad
+                = static_cast<int>(nstl::max(dim_t(0), jcp.r_pad));
+        brg_attr.max_top_bpad = static_cast<int>(
+                nstl::max(dim_t(0), nstl::max(jcp.t_pad, jcp.f_pad)));
+        brg_attr.max_bottom_bpad = static_cast<int>(
+                nstl::max(dim_t(0), nstl::max(jcp.b_pad, jcp.back_pad)));
         brg_attr.hint_bs_group
                 = is_superset(jcp.isa, avx512_core) && jcp.stride_w == 1
-                ? jcp.kw
+                ? static_cast<int>(jcp.kw)
                 : 1;
 
         // only needed for strd batch_kind
@@ -478,7 +485,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
                     jcp.ow_block = ow_tail_block;
                 else { jcp.ow_block = jcp.ow; }
             } else {
-                const int max_ow_block = is_superset(jcp.isa, avx512_core)
+                const dim_t max_ow_block = is_superset(jcp.isa, avx512_core)
                         ? 6
                         : bcp_0.bd_block2 /*TODO: Tune for avx2*/;
                 jcp.ow_block = nstl::min(max_ow_block, jcp.ow);
@@ -499,7 +506,7 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
                 else
                     jcp.nb_ch_blocking = jcp.ngroups;
             } else {
-                const int max_ch_block2 = is_superset(jcp.isa, avx512_core)
+                const dim_t max_ch_block2 = is_superset(jcp.isa, avx512_core)
                         ? 4
                         : bcp_0.ld_block2 /*TODO: Tune for avx2*/;
                 jcp.nb_ch_blocking
@@ -508,14 +515,15 @@ status_t brdgmm_dw_convolution_fwd_t::pd_t::init_brdgmm_conf() {
             jcp.chb_tail = jcp.ngroups % jcp.nb_ch_blocking;
         }
 
-        const int n_owb_kernels = std::ceil(log2(jcp.nb_ow));
+        const int n_owb_kernels = static_cast<int>(std::ceil(log2(jcp.nb_ow)));
         const int num_kernels = 1 /*full ow*/ + n_owb_kernels
                 + (jcp.chb_tail != 0) + (jcp.nb_ch_blocking != jcp.ngroups)
                 + (jcp.ow_tail != 0);
         bcps_.resize(num_kernels);
 
         for (int i = 0; i < n_owb_kernels; ++i) {
-            CHECK(init_bcp(ker_idx, jcp.ow_block * (1 << i), jcp.ngroups));
+            CHECK(init_bcp(
+                    ker_idx, jcp.ow_block * (dim_t {1} << i), jcp.ngroups));
         }
 
         if (jcp.chb_tail) {
@@ -607,12 +615,13 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
                       + extra_data_offset + s8_offset)
             : nullptr;
 
-    const int chb_step = jcp.nb_ch_blocking;
-    const int chb_work = div_up(jcp.ngroups, chb_step);
-    const int ow_step = jcp.ow_block;
-    const int work_amount = jcp.mb * jcp.od * jcp.oh * jcp.nb_ow * chb_work;
+    const int chb_step = static_cast<int>(jcp.nb_ch_blocking);
+    const int chb_work = div_up(static_cast<int>(jcp.ngroups), chb_step);
+    const int ow_step = static_cast<int>(jcp.ow_block);
+    const int work_amount
+            = static_cast<int>(jcp.mb * jcp.od * jcp.oh * jcp.nb_ow * chb_work);
 
-    const int max_bs = jcp.kd * jcp.kh * jcp.kw;
+    const int max_bs = static_cast<int>(jcp.kd * jcp.kh * jcp.kw);
 
     const size_t src_ch_stride = jcp.src_dsz;
     const size_t src_w_stride = jcp.ngroups * jcp.src_dsz;
@@ -636,16 +645,19 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
             jcp.ih, jcp.oh, jcp.kh, jcp.stride_h, jcp.t_pad, jcp.b_pad, 1);
     const auto d_blk_info = get_blocks_info(
             jcp.id, jcp.od, jcp.kd, jcp.stride_d, jcp.f_pad, jcp.back_pad, 1);
-    const int n_w_blks = w_blk_info.n_lpad_blks;
-    const int n_h_blks = h_blk_info.n_lpad_blks
-            + nstl::max(0, jcp.oh - h_blk_info.rpad_blk_start_idx);
+    const int n_w_blks = static_cast<int>(w_blk_info.n_lpad_blks);
+    const int n_h_blks = static_cast<int>(h_blk_info.n_lpad_blks)
+            + nstl::max(0,
+                    static_cast<int>(jcp.oh - h_blk_info.rpad_blk_start_idx));
 
-    const int w_shift = jcp.ow_block * jcp.stride_w;
-    const int rpad_0
-            = (jcp.ow_block - 1) * jcp.stride_w + jcp.kw - (jcp.iw + jcp.l_pad);
+    const int w_shift = static_cast<int>(jcp.ow_block * jcp.stride_w);
+    const int rpad_0 = static_cast<int>(
+            (jcp.ow_block - 1) * jcp.stride_w + jcp.kw - (jcp.iw + jcp.l_pad));
     const int rpad_1 = rpad_0 + (nstl::max(0, -rpad_0) / w_shift + 1) * w_shift;
-    const int n_rpad_blks
-            = 1 + div_up(nstl::max(0, jcp.r_pad - (rpad_1 - w_shift)), w_shift);
+    const int n_rpad_blks = 1
+            + div_up(nstl::max(0,
+                             static_cast<int>(jcp.r_pad - (rpad_1 - w_shift))),
+                    w_shift);
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         int start {0}, end {0};
@@ -685,8 +697,8 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
 
             // Begin: get number of owb to process and its corresponding ker_idx
             const auto rem_work = end - iwork;
-            const int rem_row_owb
-                    = saturate(1, jcp.nb_ow - owb, rem_work / chb_work);
+            const int rem_row_owb = saturate(
+                    1, static_cast<int>(jcp.nb_ow - owb), rem_work / chb_work);
             int cur_n_owb = 1;
             int ker_idx = 0;
             if (is_n_tail) {
@@ -697,12 +709,12 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
                 ker_idx = jcp.nb_ch_blocking_idx;
             } else if (rem_row_owb == jcp.nb_ow) {
                 ker_idx = 0;
-                cur_n_owb = jcp.nb_ow;
+                cur_n_owb = static_cast<int>(jcp.nb_ow);
             } else {
                 // The ow_tail kernel is processed alone, subtract if it exists.
-                const int log_rem_owb = log2(rem_row_owb
+                const int log_rem_owb = static_cast<int>(log2(rem_row_owb
                         - (owb + rem_row_owb >= jcp.nb_ow)
-                                * (jcp.ow_tail != 0));
+                                * (jcp.ow_tail != 0)));
                 cur_n_owb = (1 << log_rem_owb);
                 ker_idx = log_rem_owb + 1; // add 1 as 0th is full row.
             }
@@ -713,19 +725,31 @@ status_t brdgmm_dw_convolution_fwd_t::execute(const exec_ctx_t &ctx) const {
             // Begin: get batch_element idx
             const int ow = owb * ow_step;
 
-            const int id_s = od * jcp.stride_d - jcp.f_pad;
-            const int ih_s = oh * jcp.stride_h - jcp.t_pad;
-            const int iw_s = ow * jcp.stride_w - jcp.l_pad;
+            const int id_s = static_cast<int>(od * jcp.stride_d - jcp.f_pad);
+            const int ih_s = static_cast<int>(oh * jcp.stride_h - jcp.t_pad);
+            const int iw_s = static_cast<int>(ow * jcp.stride_w - jcp.l_pad);
 
-            const int d_bi = nstl::min(od, d_blk_info.n_lpad_blks - 1)
-                    + nstl::max(0, od - d_blk_info.rpad_blk_start_idx + 1);
-            const int h_bi = nstl::min(oh, h_blk_info.n_lpad_blks - 1)
-                    + nstl::max(0, oh - h_blk_info.rpad_blk_start_idx + 1);
-            const int w_bi = nstl::min(owb, w_blk_info.n_lpad_blks - 1);
+            const int d_bi
+                    = nstl::min(
+                              od, static_cast<int>(d_blk_info.n_lpad_blks - 1))
+                    + nstl::max(0,
+                            static_cast<int>(
+                                    od - d_blk_info.rpad_blk_start_idx + 1));
+            const int h_bi
+                    = nstl::min(
+                              oh, static_cast<int>(h_blk_info.n_lpad_blks - 1))
+                    + nstl::max(0,
+                            static_cast<int>(
+                                    oh - h_blk_info.rpad_blk_start_idx + 1));
+            const int w_bi = nstl::min(
+                    owb, static_cast<int>(w_blk_info.n_lpad_blks - 1));
 
             const int ow_e
-                    = nstl::min(ow + cur_n_owb * jcp.ow_block, jcp.ow) - 1;
-            const int rpad = ow_e * jcp.stride_w - jcp.l_pad + jcp.kw - jcp.iw;
+                    = nstl::min(ow + cur_n_owb * static_cast<int>(jcp.ow_block),
+                              static_cast<int>(jcp.ow))
+                    - 1;
+            const int rpad = static_cast<int>(
+                    ow_e * jcp.stride_w - jcp.l_pad + jcp.kw - jcp.iw);
             const int rpad_i
                     = div_up(nstl::max(0, rpad - rpad_1 + w_shift), w_shift);
 

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -104,9 +104,9 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
             = ic_chunks_ > 1 || rtus_compute_partial_k;
     const int i_init_begin = req_extra_accum_brgemm ? 0 : 1;
     const int i_init_end = 2;
-    for_(int vM : {jcp_.M, jcp_.M_tail})
-    for_(int vN : {jcp_.N, jcp_.N_tail})
-    for_(int vK : {jcp_.K, jcp_.K_tail})
+    for_(dim_t vM : {jcp_.M, jcp_.M_tail})
+    for_(dim_t vN : {jcp_.N, jcp_.N_tail})
+    for_(dim_t vK : {jcp_.K, jcp_.K_tail})
     for (int i_init = i_init_begin; i_init < i_init_end; i_init++) {
         if (vM == 0 || vN == 0 || vK == 0) continue;
 
@@ -121,7 +121,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
                     && jcp_.M_tail > 0 && vM == jcp_.M && is_accum_kernel;
             if (skip_rtus_M_blk) continue;
 
-            const int rtus_k = is_accum_kernel
+            const dim_t rtus_k = is_accum_kernel
                     ? jcp_.rtus_ic_size
                     : jcp_.ic_without_padding - jcp_.rtus_ic_size;
             const bool is_last_m_kernel = vM == jcp_.M_tail || jcp_.nb_os == 1;
@@ -137,7 +137,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     if (need_extra_m_kernel) { // only used for 'reduced_rtus'
         assert(jcp_.K_tail == 0);
         const int rtus_K_kernels = 2;
-        for_(int vN : {jcp_.N, jcp_.N_tail})
+        for_(dim_t vN : {jcp_.N, jcp_.N_tail})
         for (int idx = 0; idx < rtus_K_kernels; idx++) {
             if (vN == 0) continue;
             auto vM = jcp_.M;
@@ -176,7 +176,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
         const auto vM = params.M_;
         const auto vN = params.N_;
         const auto vK = params.K_;
-        const int LDA = params.LDA_;
+        const dim_t LDA = params.LDA_;
 
         const int k_accum_idx = params.k_accum_idx_;
         const bool req_k_accum = one_of(k_accum_idx, 0, 2);
@@ -304,8 +304,8 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
 template <cpu_isa_t isa>
 void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
         const char *__restrict src, char *__restrict inp_buffer,
-        uint8_t *__restrict inp_buffer_mask, int g, int n, int icc, int od,
-        int oh, int ow) const {
+        uint8_t *__restrict inp_buffer_mask, int g, int n, dim_t icc, dim_t od,
+        dim_t oh, dim_t ow) const {
     const auto &jcp = pd()->jcp_;
     if (!jcp.is_rtus) return;
     assert(jcp.is_os_blocking);
@@ -332,12 +332,12 @@ void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
 
     const memory_desc_wrapper src_d(pd()->src_md());
 
-    auto call_kernel = [&](int nh, int nw, int od, int oh, int ow) {
+    auto call_kernel = [&](dim_t nh, dim_t nw, dim_t od, dim_t oh, dim_t ow) {
         assert(nh == 0 || (nw == 0 && ow == 0));
         if (utils::everyone_is(0, nh, nw)) return;
-        const int id = od * jcp.stride_d;
-        const int ih = oh * jcp.stride_h;
-        const int iw = ow * jcp.stride_w;
+        const dim_t id = od * jcp.stride_d;
+        const dim_t ih = oh * jcp.stride_h;
+        const dim_t iw = ow * jcp.stride_w;
 
         // Using blk_off to offset batch is motivated input\output striding aligment
         const auto inp_offset = src_d.off_l(0)
@@ -356,11 +356,11 @@ void brgemm_1x1_convolution_fwd_t<isa>::maybe_rtus(int ithr,
     };
 
     const bool is_os_tail = jcp.os - os < jcp.os_block;
-    int count = is_os_tail ? jcp.M_tail : jcp.M;
+    dim_t count = is_os_tail ? jcp.M_tail : jcp.M;
 
     if (count < OW || ow > 0) {
         // copy to end of row
-        const auto nw = nstl::min(count, OW - ow);
+        const dim_t nw = nstl::min<dim_t>(count, OW - ow);
         call_kernel(0, nw, od, oh, ow);
         count -= nw;
         if (count == 0) return;
@@ -393,7 +393,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
         const brgemm_exec_ctx_t &brgemm_ctx, int ithr,
         brgemm_batch_element_t *const __restrict brg_batch,
         char *const c_buffer, const char *inp_buffer, int g, int n, int ocb,
-        int od, int oh, int ow, int icc, int *last_brg_idx,
+        dim_t od, dim_t oh, dim_t ow, dim_t icc, int *last_brg_idx,
         const int32_t *src_zero_points, int32_t *src_zp_comp,
         const int32_t *dst_zero_points, int32_t *s8s8_compensation,
         const void *src_scales, const void *wei_scales, const void *dst_scales,
@@ -421,15 +421,15 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
             ? brgemm_ctx.wsp_tile + ithr * jcp.amx_buf_size_per_thread
             : nullptr;
 
-    const int id = ndims_pick(od * SD, 0, 0);
-    const int ih = ndims_pick(oh * SH, oh * SH, 0);
-    const int iw = ow * SW;
+    const dim_t id = ndims_pick(od * SD, 0, 0);
+    const dim_t ih = ndims_pick(oh * SH, oh * SH, 0);
+    const dim_t iw = ow * SW;
 
-    const int oc = ocb * jcp.oc_block;
-    const int g_oc = g * jcp.oc + oc;
+    const dim_t oc = ocb * jcp.oc_block;
+    const dim_t g_oc = g * jcp.oc + oc;
 
-    const int icb = icc * jcp.nb_ic_blocking;
-    const int ic = icb * jcp.ic_block;
+    const dim_t icb = icc * jcp.nb_ic_blocking;
+    const dim_t ic = icb * jcp.ic_block;
 
     const bool use_special_m_idx = get_extra_m_kernel_req(jcp) && is_last_os;
     const int kernel_init = static_cast<int>(icc == 0) + 2 * use_special_m_idx;
@@ -475,7 +475,7 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
 
     const auto bias_w
             = bias ? bias + (bias_d.blk_off(g_oc) * bia_dsz) : nullptr;
-    const auto nb_ic_b = nstl::min(jcp.nb_ic_blocking, jcp.nb_ic - icb)
+    const dim_t nb_ic_b = nstl::min<dim_t>(jcp.nb_ic_blocking, jcp.nb_ic - icb)
             - (is_ic_tail ? 1 : 0);
 
     const auto comp_offset = (g * jcp.nb_oc + ocb) * jcp.oc_block;
@@ -490,15 +490,16 @@ void brgemm_1x1_convolution_fwd_t<isa>::exec_ker(
 
     const bool wary_tail_read = jcp.extendable_k;
 
-    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
-                                     bool do_postops, bool brgemm_is_ic_tail) {
+    const auto call_brgemm
+            = [&](int brg_idx, dim_t ic_block_s, dim_t n_ic_blocks,
+                      bool do_postops, bool brgemm_is_ic_tail) {
         // NOTE: avoid some costly tile reconfigurations here by keeping track
         //       of the previous brg kernel tile configuration palette
         // TODO: adjust harness to avoid even more tile reconfigurations
         brgemm_palettes_.maybe_tile_configure(is_amx, *last_brg_idx, brg_idx);
 
-        for (int k = 0; k < n_ic_blocks; k++) {
-            const size_t ic_off = jcp.is_reduced_rtus
+        for (dim_t k = 0; k < n_ic_blocks; k++) {
+            const dim_t ic_off = jcp.is_reduced_rtus
                     ? (brgemm_is_ic_tail ? jcp.ic_without_padding
                                               - jcp.rtus_ic_size
                                          : 0)
@@ -578,8 +579,9 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
     const auto &jcp = pd()->jcp_;
     const bool is_amx = brgemm_convolution_utils::is_amx(isa);
 
-    const int os_chunks = div_up(jcp.nb_os, jcp.nb_os_blocking);
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_oc * os_chunks;
+    const dim_t os_chunks = div_up(jcp.nb_os, jcp.nb_os_blocking);
+    const int work_amount
+            = static_cast<int>(jcp.mb * jcp.ngroups * jcp.nb_oc * os_chunks);
 
     parallel(pd()->jcp_.nthr,
             [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
@@ -624,13 +626,13 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_os_blocking(
             if (jcp.is_rtus && (last_n != n || last_g != g))
                 std::memset(inp_buffer_mask, 0, jcp.inp_buffer_mask_size);
             const auto osb_start = oss * jcp.nb_os_blocking;
-            const auto osb_range
-                    = nstl::min(jcp.nb_os - osb_start, jcp.nb_os_blocking);
+            const dim_t osb_range = nstl::min<dim_t>(
+                    jcp.nb_os - osb_start, jcp.nb_os_blocking);
             for (int osb = 0; osb < osb_range; osb++) {
-                const int os = (osb_start + osb) * jcp.os_block;
-                const int od = os / (OH * OW);
-                const int oh = (os % (OH * OW)) / OW;
-                const int ow = os % OW;
+                const dim_t os = (osb_start + osb) * jcp.os_block;
+                const dim_t od = os / (OH * OW);
+                const dim_t oh = (os % (OH * OW)) / OW;
+                const dim_t ow = os % OW;
                 const size_t rtus_offset
                         = jcp.is_reduced_rtus ? 0 : src_dsz * os * jcp.LDA;
                 char *inp_buffer_sp
@@ -673,8 +675,8 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
 
     const auto &jcp = pd()->jcp_;
     const bool is_amx = brgemm_convolution_utils::is_amx(isa);
-    const int work_amount
-            = jcp.mb * jcp.ngroups * jcp.nb_oc * OD * OH * jcp.nb_ow;
+    const int work_amount = static_cast<int>(
+            jcp.mb * jcp.ngroups * jcp.nb_oc * OD * OH * jcp.nb_ow);
     parallel(pd()->jcp_.nthr,
             [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         if (ithr >= work_amount) return;
@@ -707,8 +709,8 @@ void brgemm_1x1_convolution_fwd_t<isa>::execute_full_spatial(
             assert(!"Unknown loop order");
 
         for (auto work = start; work < end; work++) {
-            for (int icc = 0; icc < pd()->ic_chunks_; icc++) {
-                const int ow = owb * jcp.ow_block;
+            for (dim_t icc = 0; icc < pd()->ic_chunks_; icc++) {
+                const dim_t ow = owb * jcp.ow_block;
                 exec_ker(brgemm_ctx, ithr, brg_batch, c_buffer, nullptr, g, n,
                         ocb, od, oh, ow, icc, &last_brg_idx, src_zero_points,
                         src_zp_comp, dst_zero_points, s8s8_compensation,

--- a/src/cpu/x64/jit_brgemm_1x1_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.hpp
@@ -53,8 +53,8 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
         status_t init(const engine_t *engine);
 
         struct brgemm_init_params_t {
-            brgemm_init_params_t(int k_accum_idx, int m, int n, int k,
-                    size_t lda, bool wary_tail_read)
+            brgemm_init_params_t(int k_accum_idx, dim_t m, dim_t n, dim_t k,
+                    dim_t lda, bool wary_tail_read)
                 : k_accum_idx_(k_accum_idx)
                 , M_(m)
                 , N_(n)
@@ -62,8 +62,8 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
                 , LDA_(lda)
                 , wary_tail_read_(wary_tail_read) {}
             const int k_accum_idx_; // controls brgemm:beta param
-            const int M_, N_, K_;
-            const size_t LDA_;
+            const dim_t M_, N_, K_;
+            const dim_t LDA_;
             bool wary_tail_read_ {false};
         };
 
@@ -71,7 +71,7 @@ struct brgemm_1x1_convolution_fwd_t : public primitive_t {
         std::forward_list<brgemm_init_params_t> brgemm_init_params_;
 
         bool need_postwork_ {};
-        int ic_chunks_ {};
+        dim_t ic_chunks_ {};
 
         jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
@@ -117,11 +117,11 @@ private:
 
     void maybe_rtus(int ithr, const char *__restrict src,
             char *__restrict inp_buffer, uint8_t *__restrict inp_buffer_mask,
-            int g, int n, int icc, int od, int oh, int ow) const;
+            int g, int n, dim_t icc, dim_t od, dim_t oh, dim_t ow) const;
     void exec_ker(const brgemm_exec_ctx_t &brgemm_ctx, int ithr,
             brgemm_batch_element_t *const __restrict brg_batch,
             char *const c_buffer, const char *inp_buffer, int g, int n, int ocb,
-            int od, int oh, int ow, int icc, int *last_brg_idx,
+            dim_t od, dim_t oh, dim_t ow, dim_t icc, int *last_brg_idx,
             const int32_t *src_zero_points, int32_t *src_zp_comp,
             const int32_t *dst_zero_points, int32_t *s8s8_compensation,
             const void *src_scales, const void *wei_scales,
@@ -192,7 +192,7 @@ private:
 
     const memory_desc_wrapper bias_d;
 
-    int ID, IH, IW, OD, OH, OW, SD, SH, SW;
+    dim_t ID, IH, IW, OD, OH, OW, SD, SH, SW;
     size_t bia_dsz, acc_dsz, src_dsz, wei_dsz;
     // const variables used for address calculations
     dim_t src_w_sz, src_h_sz, src_d_sz, dst_w_sz, dst_h_sz, dst_d_sz;

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -51,7 +51,7 @@ int brgemm_convolution_fwd_t<isa>::pd_t::get_brg_idx(int m,
             ? brg_indices.find({m, is_N_tail, is_K_tail, do_initialization,
                       kd_b, kd_e, kh_b, kh_e})
             : brg_indices.find({m, is_N_tail, is_K_tail, do_initialization, 0,
-                      jcp_.kd, 0, jcp_.kh});
+                      static_cast<int>(jcp_.kd), 0, static_cast<int>(jcp_.kh)});
     if (brg_idx == brg_indices.end()) return -1;
     return brg_idx->second;
 }
@@ -71,12 +71,12 @@ int brgemm_convolution_fwd_t<isa>::pd_t::get_any_brg_idx(
 }
 
 template <cpu_isa_t isa>
-void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(int icc,
-        const char *src_base, const char *wei_base, int n_ic_blocks,
-        int ic_block_s, int iid_b, int iih_b, int iiw_b,
+void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(dim_t icc,
+        const char *src_base, const char *wei_base, dim_t n_ic_blocks,
+        dim_t ic_block_s, dim_t iid_b, dim_t iih_b, dim_t iiw_b,
         const dim_t *const __restrict kw_top_vpads,
-        const dim_t *const __restrict kw_bottom_vpads, int kd_b, int kd_e,
-        int kh_b, int kh_e, int kw_b, int kw_e, int &k_l,
+        const dim_t *const __restrict kw_bottom_vpads, dim_t kd_b, dim_t kd_e,
+        dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e, dim_t &k_l,
         brgemm_batch_element_t *brg_batch) const {
     const char *ptrA {nullptr};
     const char *ptrB {nullptr};
@@ -91,10 +91,10 @@ void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(int icc,
     k_l = (kd_e - kd_b) * (kh_e - kh_b) * (kw_e - kw_b);
     if (k_l == 0) return;
 
-    const int icb = icc * jcp.nb_ic_blocking;
-    const int wei_ic_base = icb * jcp.ic_block;
+    const dim_t icb = icc * jcp.nb_ic_blocking;
+    const dim_t wei_ic_base = icb * jcp.ic_block;
 
-    for (int i_icb = 0; i_icb < n_ic_blocks; i_icb++) {
+    for (dim_t i_icb = 0; i_icb < n_ic_blocks; i_icb++) {
         const auto ic_off = (ic_block_s + i_icb) * jcp.ic_block;
         const auto wei_ic = wei_ic_base + ic_off;
         const auto n_icb_off = i_icb * k_l;
@@ -108,18 +108,18 @@ void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(int icc,
                         || jcp.brg_type == brgemm_static_offs));
 
         auto k = 0;
-        for (int kd = kd_b; kd < kd_e; kd++) {
+        for (dim_t kd = kd_b; kd < kd_e; kd++) {
             const auto id = iid_b + kd * DD;
             const auto src_base_kd = src_base_ic + id * src_d_offset;
             const auto wei_kd = maybe_invert(kd, KD);
             const auto wei_base_kd = wei_base_ic + wei_kd * wei_kd_offset;
-            for (int kh = kh_b; kh < kh_e; kh++) {
+            for (dim_t kh = kh_b; kh < kh_e; kh++) {
                 const auto ih = iih_b + kh * DH;
                 const auto src_base_kh = src_base_kd + ih * adj_src_h_offset;
                 const auto wei_kh = maybe_invert(kh, KH);
                 const auto wei_base_kh = wei_base_kd + wei_kh * wei_kh_offset;
 
-                for (int kw = kw_b; kw < kw_e; kw++) {
+                for (dim_t kw = kw_b; kw < kw_e; kw++) {
                     const auto iw = iiw_b + kw * DW;
                     const auto b_idx = n_icb_off + k;
                     const auto A_addr = src_base_kh + iw * src_iw_offset;
@@ -152,12 +152,12 @@ void brgemm_convolution_fwd_t<isa>::pd_t::init_batch(int icc,
 }
 
 template <cpu_isa_t isa>
-inline void brgemm_convolution_fwd_t<isa>::pd_t::get_A_B(int icc,
-        const char *src_base, const char *wei_base, int ic_block_s, int iid_b,
-        int iih_b, int iiw_b, int kd_b, int kh_b, const void *&ptrA,
-        const void *&ptrB) const {
-    const int icb = icc * jcp_.nb_ic_blocking;
-    const int wei_ic_base = icb * jcp_.ic_block;
+inline void brgemm_convolution_fwd_t<isa>::pd_t::get_A_B(dim_t icc,
+        const char *src_base, const char *wei_base, dim_t ic_block_s,
+        dim_t iid_b, dim_t iih_b, dim_t iiw_b, dim_t kd_b, dim_t kh_b,
+        const void *&ptrA, const void *&ptrB) const {
+    const dim_t icb = icc * jcp_.nb_ic_blocking;
+    const dim_t wei_ic_base = icb * jcp_.ic_block;
 
     // for brgemm_static_offs we need only base A_addr and B_addr
     const auto ic_off = ic_block_s * jcp_.ic_block;
@@ -181,7 +181,7 @@ inline void brgemm_convolution_fwd_t<isa>::pd_t::get_A_B(int icc,
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
+status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(dim_t vM,
         bool is_N_tail, bool is_K_tail, bool do_init, int kd_b, int kd_e,
         int kh_b, int kh_e) {
 
@@ -201,8 +201,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
                                  : vM;
     if (vN == 0 || vK == 0) return status::success;
 
-    auto brg_idx = get_brg_idx(
-            vM, do_init, is_N_tail, is_K_tail, kd_b, kd_e, kh_b, kh_e);
+    int brg_idx = get_brg_idx(static_cast<int>(vM), do_init, is_N_tail,
+            is_K_tail, kd_b, kd_e, kh_b, kh_e);
     // if brgemm_desc_t already created then skip this iteration
     if (brg_idx != -1) return status::success;
 
@@ -225,7 +225,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
                 auto M_mask = (iM >= vM) ? 0 : 1;
                 for (int ww = 0; ww < jcp_.ow_block && ibrgM < sm_size;
                         ww++, ibrgM++, iM += M_mask) {
-                    bd_mask[ibrgM] = M_mask;
+                    bd_mask[ibrgM] = static_cast<char>(M_mask);
                 }
                 for (int kk = 0; kk < jcp_.oskip && ibrgM < sm_size;
                         kk++, ibrgM++) {
@@ -245,14 +245,14 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
     std::vector<brgemm_batch_element_t> stoffs;
     if (jcp_.brg_type == brgemm_static_offs) {
         assert(one_of(jcp_.exec_type, exec_trans, exec_base));
-        const auto kd_f = nstl::min(kd_e, kd_b + KD_BLOCK);
-        const auto kh_f = nstl::min(kh_e, kh_b + KH_BLOCK);
+        const dim_t kd_f = nstl::min<dim_t>(kd_e, kd_b + KD_BLOCK);
+        const dim_t kh_f = nstl::min<dim_t>(kh_e, kh_b + KH_BLOCK);
 
         assert(jcp_.nb_ic % jcp_.nb_ic_blocking == 0);
         const auto nb_ic_blocks = jcp_.nb_ic_blocking;
 
         stoffs.resize(jcp_.max_batch + 1);
-        int k_l {0};
+        dim_t k_l {0};
 
         init_batch(0, nullptr, nullptr, nb_ic_blocks, 0, 0, 0, 0, nullptr,
                 nullptr, kd_b, kd_f, kh_b, kh_f, 0, KW, k_l, stoffs.data());
@@ -314,7 +314,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
         brgattr.max_bottom_vpad = jcp_.max_vpad;
     }
     brgattr.fpmath_mode = attr()->fpmath_.mode_;
-    brgattr.K_koef = (float)bs / KW;
+    brgattr.K_koef = (float)bs / static_cast<float>(KW);
 
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
 
@@ -329,8 +329,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(int vM,
 
     brg_idx = brgemm_descriptors_->insert(brg, bd_mask, stoffs);
 
-    const std::array<int, 8> key
-            = {vM, is_N_tail, is_K_tail, do_init, kd_b, kd_e, kh_b, kh_e};
+    const std::array<int, 8> key = {static_cast<int>(vM), is_N_tail, is_K_tail,
+            do_init, kd_b, kd_e, kh_b, kh_e};
     if (brg_indices.find(key) == brg_indices.end()) {
         brg_indices.insert({key, brg_idx});
         brg_indices_c++;
@@ -476,7 +476,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     if (jcp_.copy_block_only) {
         assert(jcp_.exec_type == exec_trans && "Missing copy kernel");
         const auto iw_block = jit_avx512_core_brgemm_conv_trans_kernel_t::dst_w(
-                jcp_, jcp_.ow_block);
+                jcp_, static_cast<int>(jcp_.ow_block));
         const auto ih_block = get_inp_size(IHP, jcp_.oh_block, KH, SH, DH - 1);
         const auto id_block = get_inp_size(IDP, jcp_.od_block, KD, SD, DD - 1);
 
@@ -510,26 +510,29 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
         assert(KD % KD_BLOCK == 0);
         assert(KH % KH_BLOCK == 0);
 
-        for (int iod = 0; iod < jcp_.od; iod++) {
-            const int iid = iod * SD - FP;
-            const int kd_s = div_up(nstl::max(0, -iid), DD);
-            const int kd_f = KD
-                    - div_up(nstl::max(0, iid - ID + (KD - 1) * DD + 1), DD);
-            for (int ioh = 0; ioh < jcp_.oh; ioh++) {
+        for (dim_t iod = 0; iod < jcp_.od; iod++) {
+            const dim_t iid = iod * SD - FP;
+            const dim_t kd_s = div_up(nstl::max<dim_t>(0, -iid), DD);
+            const dim_t kd_f = KD
+                    - div_up(nstl::max<dim_t>(0, iid - ID + (KD - 1) * DD + 1),
+                            DD);
+            for (dim_t ioh = 0; ioh < jcp_.oh; ioh++) {
 
                 const auto iih = ioh * SH - TP;
                 const auto kh_s = (jcp_.is_os_blocking || jcp_.is_relo_whi())
                         ? 0
-                        : div_up(nstl::max(0, -iih), DH);
+                        : div_up(nstl::max<dim_t>(0, -iih), DH);
                 const auto kh_f = (jcp_.is_relo_whi()) ? 1
                                                        : KH
-                                - div_up(nstl::max(0,
+                                - div_up(nstl::max<dim_t>(0,
                                                  iih - IH + (KH - 1) * DH + 1),
                                         DH);
                 const auto bs = get_bs(kd_s, kd_f, kh_s, kh_f);
                 if (bs <= 0) continue;
 
-                const std::array<int, 4> key = {kd_s, kd_f, kh_s, kh_f};
+                const std::array<int, 4> key
+                        = {static_cast<int>(kd_s), static_cast<int>(kd_f),
+                                static_cast<int>(kh_s), static_cast<int>(kh_f)};
                 if (batchsizes.find(key) == batchsizes.end()) {
                     batchsizes.insert({key, bs_c});
                     bs_c++;
@@ -537,7 +540,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
             }
         }
     } else {
-        batchsizes.insert({{0, KD, 0, KH}, bs_c});
+        batchsizes.insert(
+                {{0, static_cast<int>(KD), 0, static_cast<int>(KH)}, bs_c});
         bs_c++;
     }
 
@@ -566,8 +570,8 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
             || jcp_.src_zero_point || jcp_.dst_zero_point;
 
     const auto &Mv = (jcp_.M_tail > 0 && jcp_.M_tail != jcp_.M)
-            ? std::vector<int> {jcp_.M, jcp_.M_tail}
-            : std::vector<int> {jcp_.M};
+            ? std::vector<dim_t> {jcp_.M, jcp_.M_tail}
+            : std::vector<dim_t> {jcp_.M};
 
     std::vector<bool> bv_true {true};
     std::vector<bool> bv_false {false};
@@ -648,13 +652,13 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
             if (kw_f == jcp_.kw && kw_s == 0) break;
         }
 
-        for (int ow = (jcp_.nb_ow - 1) * jcp_.ow_block; ow >= 0;
+        for (dim_t ow = (jcp_.nb_ow - 1) * jcp_.ow_block; ow >= 0;
                 ow -= jcp_.ow_block) {
-            brgemm_convolution_utils::get_kw_range(
-                    jcp_, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+            brgemm_convolution_utils::get_kw_range(jcp_, static_cast<int>(ow),
+                    kw_s, kw_full_s, kw_full_f, kw_f);
             for (int kw = kw_s; kw < kw_f; kw++) {
                 brgemm_convolution_utils::get_ow_range(
-                        jcp_, ow, kw, ow_s, ow_f);
+                        jcp_, static_cast<int>(ow), kw, ow_s, ow_f);
                 if (ow_f - ow_s <= 0) continue;
 
                 auto M = ow_f - ow_s;
@@ -732,8 +736,8 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernel(
     bcfg->LDD = (is_init && jcp.use_buffer) ? jcp.LDC : jcp.LDD;
     bcfg->dt_c = (!is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt; // inp
     bcfg->dt_d = (is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt; // out
-    bcfg->typesize_C = types::data_type_size(bcfg->dt_c);
-    bcfg->typesize_D = types::data_type_size(bcfg->dt_d);
+    bcfg->typesize_C = static_cast<int>(types::data_type_size(bcfg->dt_c));
+    bcfg->typesize_D = static_cast<int>(types::data_type_size(bcfg->dt_d));
     bcfg->alpha = !is_init && IMPLICATION(jcp.with_sum, jcp.use_buffer);
     bcfg->beta = is_init ? 0 : 1;
     // See the comment in `add_po_kernels` why `*_pd->attr()` is needed so far.
@@ -746,7 +750,7 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernel(
 
 template <cpu_isa_t isa>
 status_t brgemm_convolution_fwd_t<isa>::add_po_kernels(
-        int i_N, int init_bcast_dim, int po_bcast_dim) {
+        int i_N, dim_t init_bcast_dim, dim_t po_bcast_dim) {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
     const auto &brgs = *(_pd->brgemm_descriptors_);
@@ -755,7 +759,7 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernels(
     if (N <= 0) return status::success;
     auto i_K = (jcp.K_tail > 0);
 
-    const auto brg_idx = _pd->get_any_brg_idx(i_N, i_K);
+    const int brg_idx = _pd->get_any_brg_idx(i_N, i_K);
 
     if (init_bcast_dim > 0) {
         if (brgs[brg_idx]) {
@@ -794,7 +798,7 @@ status_t brgemm_convolution_fwd_t<isa>::add_po_kernels(
 }
 
 template <cpu_isa_t isa>
-int brgemm_convolution_fwd_t<isa>::get_comp_oh(const int oh) const {
+dim_t brgemm_convolution_fwd_t<isa>::get_comp_oh(dim_t oh) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
@@ -802,12 +806,14 @@ int brgemm_convolution_fwd_t<isa>::get_comp_oh(const int oh) const {
             || comp_oh_kh_b.empty())
         return 0;
 
-    const int comp_oh_e = comp_oh_kh_b.size();
-    const int oh_block
-            = jcp.is_os_blocking ? nstl::min(jcp.oh_block, jcp.oh - oh) : 1;
-    for (int comp_oh_b = 0; comp_oh_b < comp_oh_e; comp_oh_b++) {
-        const auto cur_block = nstl::min(oh_block, comp_oh_e - comp_oh_b);
-        for (int i = 0; i < cur_block; i++) {
+    const dim_t comp_oh_e = comp_oh_kh_b.size();
+    const dim_t oh_block = jcp.is_os_blocking
+            ? nstl::min<dim_t>(jcp.oh_block, jcp.oh - oh)
+            : 1;
+    for (dim_t comp_oh_b = 0; comp_oh_b < comp_oh_e; comp_oh_b++) {
+        const auto cur_block
+                = nstl::min<dim_t>(oh_block, comp_oh_e - comp_oh_b);
+        for (dim_t i = 0; i < cur_block; i++) {
             if (oh_kh_b[oh + i] != comp_oh_kh_b[comp_oh_b + i]
                     || oh_kh_e[oh + i] != comp_oh_kh_e[comp_oh_b + i])
                 break;
@@ -818,16 +824,15 @@ int brgemm_convolution_fwd_t<isa>::get_comp_oh(const int oh) const {
 }
 
 template <cpu_isa_t isa>
-int brgemm_convolution_fwd_t<isa>::get_comp_ker_idx(const int kd_b,
-        const int kd_e, const int kh_b, const int kh_e, const int kw_b,
-        const int kw_e, const int oh) const {
+dim_t brgemm_convolution_fwd_t<isa>::get_comp_ker_idx(dim_t kd_b, dim_t kd_e,
+        dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e, dim_t oh) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
     if (!jcp.req_cal_comp_pad) return 0;
 
     assert(kd_e > kd_b && kh_e > kh_b);
-    for (int k = 0; k < jcp.ker_ranges_size; k++) {
+    for (dim_t k = 0; k < jcp.ker_ranges_size; k++) {
         if (kd_b == kd_bs[k] && kd_e == kd_es[k] && kh_b == kh_bs[k]
                 && kh_e == kh_es[k] && kw_b == kw_bs[k] && kw_e == kw_es[k]
                 && oh == comp_oh[k]) {
@@ -839,10 +844,9 @@ int brgemm_convolution_fwd_t<isa>::get_comp_ker_idx(const int kd_b,
 }
 
 template <cpu_isa_t isa>
-inline int brgemm_convolution_fwd_t<isa>::get_comp_offset(const int g,
-        const int ocb, const int oh, const int ow, const int kd_b,
-        const int kd_e, const int kh_b, const int kh_e, const int kw_b,
-        const int kw_e) const {
+inline dim_t brgemm_convolution_fwd_t<isa>::get_comp_offset(dim_t g, dim_t ocb,
+        dim_t oh, dim_t ow, dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e,
+        dim_t kw_b, dim_t kw_e) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
@@ -935,7 +939,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
     int N_begin = 0;
     int N_end = (jcp.N_tail == jcp.N) ? 1 : 2;
 
-    int num_po_kernels = nstl::max(jcp.M, jcp.M_tail);
+    const dim_t num_po_kernels = nstl::max<dim_t>(jcp.M, jcp.M_tail);
     kernels_po_.resize(num_po_kernels * 2 * 2);
 
     if (jcp.exec_type == exec_trans) {
@@ -979,7 +983,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         jit_brgemm_relo_copy_to_wbuffer_t::cfg_t wjcp;
         wjcp.isa = jcp.isa;
         wjcp.wei_dt = jcp.wei_dt;
-        wjcp.out_oc_block = jcp.oc_block;
+        wjcp.out_oc_block = static_cast<int>(jcp.oc_block);
         wjcp.inp_oc_block = 16;
         wjcp.rd = _pd->rd;
         wjcp.is_rd_padded_to_block = jcp.is_rd_padded_to_block;
@@ -1051,20 +1055,20 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         // apply post-ops on final iteration by kw to padded areas in ow_block
         int kw_s {0}, kw_full_s {0}, kw_full_f {0}, kw_f {0}, ow_s {0},
                 ow_f {0};
-        for (int ow = 0; ow < OW; ow += jcp.ow_block) {
-            brgemm_convolution_utils::get_kw_range(
-                    jcp, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+        for (dim_t ow = 0; ow < OW; ow += jcp.ow_block) {
+            brgemm_convolution_utils::get_kw_range(jcp, static_cast<int>(ow),
+                    kw_s, kw_full_s, kw_full_f, kw_f);
             bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
             for_(int i_N = 0; i_N < 2; i_N++)
             for (int i_side = 0; i_side < 2; i_side++) {
                 auto M = is_ow_tail ? jcp.M_tail : jcp.M;
                 if (M <= 0) continue;
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, ow, kw_s, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_s, ow_s, ow_f);
                 const auto init_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, ow, kw_f - 1, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_f - 1, ow_s, ow_f);
                 const auto po_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 CHECK(add_po_kernels(i_N, init_bcast_dim, po_bcast_dim));
@@ -1073,10 +1077,10 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
             if (kw_f == jcp.kw && kw_s == 0) break;
         }
 
-        for (int ow = (jcp.nb_ow - 1) * jcp.ow_block; ow >= 0;
+        for (dim_t ow = (jcp.nb_ow - 1) * jcp.ow_block; ow >= 0;
                 ow -= jcp.ow_block) {
-            brgemm_convolution_utils::get_kw_range(
-                    jcp, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+            brgemm_convolution_utils::get_kw_range(jcp, static_cast<int>(ow),
+                    kw_s, kw_full_s, kw_full_f, kw_f);
 
             bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
 
@@ -1085,11 +1089,11 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
                 auto M = is_ow_tail ? jcp.M_tail : jcp.M;
                 if (M <= 0) continue;
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, ow, kw_s, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_s, ow_s, ow_f);
                 const auto init_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, ow, kw_f - 1, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_f - 1, ow_s, ow_f);
                 const auto po_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 CHECK(add_po_kernels(i_N, init_bcast_dim, po_bcast_dim));
@@ -1105,9 +1109,10 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         owb_kw_bottom_vpads.resize(jcp.nb_ow * jcp.kw);
 
         for (int owb = 0; owb < jcp.nb_ow; owb++) {
-            const int ow = owb * jcp.ow_block;
+            const dim_t ow = owb * jcp.ow_block;
             const bool is_ow_tail = (jcp.ow - ow < jcp.ow_block);
-            const int ow_b {ow}, ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
+            const dim_t ow_b {ow},
+                    ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
             const auto ow_l = ow_e - ow_b;
             MAYBE_UNUSED(ow_l);
             assert(0 <= ow_l && ow_l <= jcp.ow_block);
@@ -1130,29 +1135,30 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         oh_kh_b.resize(jcp.oh);
         oh_kh_e.resize(jcp.oh);
 
-        for (int ohb = 0; ohb < jcp.nb_oh; ohb++) {
+        for (dim_t ohb = 0; ohb < jcp.nb_oh; ohb++) {
             const auto oh_begin = ohb * jcp.oh_block;
-            const auto oh_end = nstl::min(OH, oh_begin + jcp.oh_block);
-            for (int oh = oh_begin; oh < oh_end; oh++) {
-                const auto iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
-                const auto kh_s_ = div_up(nstl::max(0, -iih), DH);
-                const auto kh_s = ndims_pick(kh_s_, kh_s_, 0);
-                const auto kh_f_ = KH
-                        - div_up(
-                                nstl::max(0, iih - IH + (KH - 1) * DH + 1), DH);
-                const auto kh_f = ndims_pick(kh_f_, kh_f_, 1);
+            const dim_t oh_end = nstl::min<dim_t>(OH, oh_begin + jcp.oh_block);
+            for (dim_t oh = oh_begin; oh < oh_end; oh++) {
+                const dim_t iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
+                const dim_t kh_s_ = div_up(nstl::max<dim_t>(0, -iih), DH);
+                const dim_t kh_s = ndims_pick(kh_s_, kh_s_, 0);
+                const dim_t kh_f_ = KH
+                        - div_up(nstl::max<dim_t>(
+                                         0, iih - IH + (KH - 1) * DH + 1),
+                                DH);
+                const dim_t kh_f = ndims_pick(kh_f_, kh_f_, 1);
                 oh_kh_b[oh] = kh_s;
                 oh_kh_e[oh] = kh_f;
             }
-            for (int oh = oh_begin; oh < oh_end; oh++) {
-                const auto comp_oh_idx
+            for (dim_t oh = oh_begin; oh < oh_end; oh++) {
+                const dim_t comp_oh_idx
                         = get_comp_oh(jcp.is_os_blocking ? oh_begin : oh);
                 if (comp_oh_kh_b.size() - comp_oh_idx >= 0) {
-                    const auto comp_oh_begin
+                    const dim_t comp_oh_begin
                             = oh + comp_oh_kh_b.size() - comp_oh_idx;
-                    const auto comp_oh_end
+                    const dim_t comp_oh_end
                             = jcp.is_os_blocking ? oh_end : oh + 1;
-                    for (int comp_oh = comp_oh_begin; comp_oh < comp_oh_end;
+                    for (dim_t comp_oh = comp_oh_begin; comp_oh < comp_oh_end;
                             comp_oh++) {
                         comp_oh_kh_b.push_back(oh_kh_b[comp_oh]);
                         comp_oh_kh_e.push_back(oh_kh_e[comp_oh]);
@@ -1164,25 +1170,27 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
 
     if (jcp.req_cal_comp_pad && jcp.exec_type != exec_vpad) {
         comp_owb.resize(jcp.nb_ow, -1);
-        std::vector<int> ow_kw_b(jcp.ow, -1);
-        std::vector<int> ow_kw_e(jcp.ow, -1);
-        std::vector<int> comp_ow_kw_s(jcp.comp_ow_size, -1);
-        std::vector<int> comp_ow_kw_f(jcp.comp_ow_size, -1);
+        std::vector<dim_t> ow_kw_b(jcp.ow, -1);
+        std::vector<dim_t> ow_kw_e(jcp.ow, -1);
+        std::vector<dim_t> comp_ow_kw_s(jcp.comp_ow_size, -1);
+        std::vector<dim_t> comp_ow_kw_f(jcp.comp_ow_size, -1);
         dim_t comp_ow_l = 0;
 
-        for (int ow = 0; ow < OW;) {
+        for (dim_t ow = 0; ow < OW;) {
             assert(comp_ow_l <= jcp.comp_ow_size);
-            const auto iiw = ow * SW - LP;
-            const auto kw_s = div_up(nstl::max(0, -iiw), DW);
-            const auto kw_f = KW
-                    - div_up(nstl::max(0, iiw - IW + (KW - 1) * DW + 1), DW);
+            const dim_t iiw = ow * SW - LP;
+            const dim_t kw_s = div_up(nstl::max<dim_t>(0, -iiw), DW);
+            const dim_t kw_f = KW
+                    - div_up(nstl::max<dim_t>(0, iiw - IW + (KW - 1) * DW + 1),
+                            DW);
 
-            int ow_e = ow;
+            dim_t ow_e = ow;
             while (ow_e < OW) {
-                const auto iiw_e = ow_e * SW - LP;
-                const auto cur_kw_s = div_up(nstl::max(0, -iiw_e), DW);
-                const auto cur_kw_f = KW
-                        - div_up(nstl::max(0, iiw_e - IW + (KW - 1) * DW + 1),
+                const dim_t iiw_e = ow_e * SW - LP;
+                const dim_t cur_kw_s = div_up(nstl::max<dim_t>(0, -iiw_e), DW);
+                const dim_t cur_kw_f = KW
+                        - div_up(nstl::max<dim_t>(
+                                         0, iiw_e - IW + (KW - 1) * DW + 1),
                                 DW);
                 ow_kw_b[ow_e] = kw_s;
                 ow_kw_e[ow_e] = kw_f;
@@ -1198,8 +1206,8 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         }
 
         for (int owb = 0; owb < jcp.nb_ow; owb++) {
-            const auto ow_b = owb * jcp.ow_block;
-            const auto ow_e = nstl::min(ow_b + jcp.ow_block, OW);
+            const dim_t ow_b = owb * jcp.ow_block;
+            const dim_t ow_e = nstl::min<dim_t>(ow_b + jcp.ow_block, OW);
             const auto comp_ow_f = comp_ow_l - (ow_e - ow_b) + 1;
             MAYBE_UNUSED(comp_ow_f);
 
@@ -1209,7 +1217,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
             }
 
             for_(int i = 0; i < comp_ow_f; i++)
-            for (int ow = ow_b; ow <= ow_e; ow++) {
+            for (dim_t ow = ow_b; ow <= ow_e; ow++) {
                 if (ow == ow_e) {
                     comp_owb[owb] = i;
                     break;
@@ -1225,7 +1233,7 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
 
     // pre-calculate unique kernel combination
     if (jcp.req_cal_comp_pad) {
-        std::set<std::vector<int>> unique_kernels;
+        std::set<std::vector<dim_t>> unique_kernels;
         size_t k = 0;
         kd_bs.resize(jcp.ker_ranges_size);
         kd_es.resize(jcp.ker_ranges_size);
@@ -1235,8 +1243,9 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         kw_es.resize(jcp.ker_ranges_size);
         comp_oh.resize(jcp.ker_ranges_size);
 
-        const auto update_kernels = [&](int kd_b, int kd_e, int kh_b, int kh_e,
-                                            int kw_b, int kw_e, int oh = 0) {
+        const auto update_kernels
+                = [&](dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e,
+                          dim_t kw_b, dim_t kw_e, dim_t oh = 0) {
             unique_kernels.insert({kd_b, kd_e, kh_b, kh_e, kw_b, kw_e, oh});
             if (k == unique_kernels.size()) return;
             kd_bs[k] = kd_b;
@@ -1254,27 +1263,28 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
         for_(int ohb = 0; ohb < jcp.nb_oh; ohb++)
         for (int owb = 0; owb < jcp.nb_ow; owb++) {
             auto oh_begin = ohb * jcp.oh_block;
-            auto oh_end = nstl::min(OH, oh_begin + jcp.oh_block);
-            for (int oh = oh_begin; oh < oh_end; oh++) {
+            auto oh_end = nstl::min<dim_t>(OH, oh_begin + jcp.oh_block);
+            for (dim_t oh = oh_begin; oh < oh_end; oh++) {
                 int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
-                const int ow = owb * jcp.ow_block;
-                const int iid = ndims_pick(od * SD - FP, 0, 0);
-                const int kd_s
-                        = ndims_pick(div_up(nstl::max(0, -iid), DD), 0, 0);
-                const int kd_f = ndims_pick(KD
-                                - div_up(nstl::max(0,
+                const dim_t ow = owb * jcp.ow_block;
+                const dim_t iid = ndims_pick(od * SD - FP, 0, 0);
+                const dim_t kd_s = ndims_pick(
+                        div_up(nstl::max<dim_t>(0, -iid), DD), 0, 0);
+                const dim_t kd_f = ndims_pick(KD
+                                - div_up(nstl::max<dim_t>(0,
                                                  iid - ID + (KD - 1) * DD + 1),
                                         DD),
                         1, 1);
-                const int iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
-                const auto kh_s_ = div_up(nstl::max(0, -iih), DH);
+                const dim_t iih = ndims_pick(oh * SH - TP, oh * SH - TP, 0);
+                const auto kh_s_ = div_up(nstl::max<dim_t>(0, -iih), DH);
                 const auto kh_s = ndims_pick(kh_s_, kh_s_, 0);
                 const auto kh_f_ = KH
-                        - div_up(
-                                nstl::max(0, iih - IH + (KH - 1) * DH + 1), DH);
+                        - div_up(nstl::max<dim_t>(
+                                         0, iih - IH + (KH - 1) * DH + 1),
+                                DH);
                 const auto kh_f = ndims_pick(kh_f_, kh_f_, 1);
-                brgemm_convolution_utils::get_kw_range(
-                        jcp, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+                brgemm_convolution_utils::get_kw_range(jcp,
+                        static_cast<int>(ow), kw_s, kw_full_s, kw_full_f, kw_f);
                 if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s) {
                     if (jcp.exec_type != exec_trans) {
                         update_kernels(kd_s, kd_f, kh_s, kh_f, 0, KW);
@@ -1311,9 +1321,9 @@ struct brgemm_convolution_fwd_t<isa>::brgemm_thread_ctx_t {
     char *__restrict c_buffer {nullptr};
     char *__restrict wsp_tile {nullptr};
     int cur_brg_idx {-1};
-    int g {-1}, n {-1}, ocb {-1};
-    int od {-1}, odb {-1}, oh {-1}, ohb {-1}, owb {-1};
-    int icc {-1};
+    dim_t g {-1}, n {-1}, ocb {-1};
+    dim_t od {-1}, odb {-1}, oh {-1}, ohb {-1}, owb {-1};
+    dim_t icc {-1};
     int32_t src_zp_val {0};
     int32_t *__restrict src_zp_comp_ptr {nullptr};
     const int32_t *__restrict dst_zp_vals {nullptr};
@@ -1450,7 +1460,7 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
         dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int n {0}, g {0}, ocb {0}, odb {0}, ohb {0}, owb {0};
+        dim_t n {0}, g {0}, ocb {0}, odb {0}, ohb {0}, owb {0};
         BRGEMM_CONV_ITERATOR_INIT;
         for (auto work = start; work < end; work++) {
             btc.g = g;
@@ -1476,16 +1486,16 @@ status_t brgemm_convolution_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
                             jcp.inp_buffer_mask_size);
             }
             auto od_begin = odb * jcp.od_block;
-            auto od_end = nstl::min(OD, od_begin + jcp.od_block);
+            auto od_end = nstl::min<dim_t>(OD, od_begin + jcp.od_block);
             auto oh_begin = ohb * jcp.oh_block;
             // if is_os_blocking is true then we do only one iteration of loop
             // by oh and process entire oh block in kernel call
             auto oh_end = jcp.is_os_blocking
                     ? oh_begin + 1
-                    : nstl::min(OH, oh_begin + jcp.oh_block);
-            for_(int od = od_begin; od < od_end; od++)
-            for_(int oh = oh_begin; oh < oh_end; oh++)
-            for (int icc = 0; icc < _pd->ic_chunks; icc++) {
+                    : nstl::min<dim_t>(OH, oh_begin + jcp.oh_block);
+            for_(dim_t od = od_begin; od < od_end; od++)
+            for_(dim_t oh = oh_begin; oh < oh_end; oh++)
+            for (dim_t icc = 0; icc < _pd->ic_chunks; icc++) {
                 btc.od = od;
                 btc.oh = oh;
                 btc.icc = icc;
@@ -1548,7 +1558,7 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
         vpad_k = vpad_next_k;
     }
 
-    const int max_ker_sz = adjusted_k.size();
+    const int max_ker_sz = static_cast<int>(adjusted_k.size());
     const auto comp_buffer_ow = jcp.exec_type != exec_vpad ? jcp.ow : 1;
     // TODO: revise the thread distribution here because the work_amount may be
     // insufficient
@@ -1565,7 +1575,7 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
         if (ithr >= work_amount) return;
 
         dim_t start {0}, end {0};
-        int g {0}, ocb {0}, adj_k {0};
+        dim_t g {0}, ocb {0}, adj_k {0};
         balance211(work_amount, nthr, ithr, start, end);
         nd_iterator_init(
                 start, g, jcp.ngroups, ocb, jcp.nb_oc, adj_k, max_ker_sz);
@@ -1575,12 +1585,12 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
                     kh_ee {kh_es[k]}, kw_bb {kw_bs[k]}, kw_ee {kw_es[k]};
             assert(kd_ee > kd_bb && kh_ee > kh_bb && kw_ee > kw_bb);
 
-            const auto kd_b = maybe_invert_range(kd_bb, kd_ee, KD);
-            const auto kd_e = maybe_invert_range(kd_ee, kd_bb, KD);
-            const auto kh_b = maybe_invert_range(kh_bb, kh_ee, KH);
-            const auto kh_e = maybe_invert_range(kh_ee, kh_bb, KH);
-            const auto kw_b = maybe_invert_range(kw_bb, kw_ee, KW);
-            const auto kw_e = maybe_invert_range(kw_ee, kw_bb, KW);
+            const dim_t kd_b = maybe_invert_range(kd_bb, kd_ee, KD);
+            const dim_t kd_e = maybe_invert_range(kd_ee, kd_bb, KD);
+            const dim_t kh_b = maybe_invert_range(kh_bb, kh_ee, KH);
+            const dim_t kh_e = maybe_invert_range(kh_ee, kh_bb, KH);
+            const dim_t kw_b = maybe_invert_range(kw_bb, kw_ee, KW);
+            const dim_t kw_e = maybe_invert_range(kw_ee, kw_bb, KW);
 
             const auto inp_oc_block
                     = is_relo_with_relo_weights ? 16 : jcp.oc_block;
@@ -1636,9 +1646,9 @@ status_t brgemm_convolution_fwd_t<isa>::cal_compensation(
 template <cpu_isa_t isa>
 void brgemm_convolution_fwd_t<isa>::perform_outwork(
         const brgemm_thread_ctx_t &btc, char *dst_base, const char *bias_w,
-        int ow, int g_oc, bool is_oc_tail, int ker_ow_s, int ker_ow_f, int kd_l,
-        int kh_l, bool maybe_do_init, bool do_postwork, size_t comp_ker_offs,
-        bool do_post_comp) const {
+        dim_t ow, dim_t g_oc, bool is_oc_tail, dim_t ker_ow_s, dim_t ker_ow_f,
+        dim_t kd_l, dim_t kh_l, bool maybe_do_init, bool do_postwork,
+        size_t comp_ker_offs, bool do_post_comp) const {
 
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
@@ -1672,7 +1682,7 @@ void brgemm_convolution_fwd_t<isa>::perform_outwork(
     }
 
     auto call_outwork_ker = [&](bool is_postwork, bool has_postcomp,
-                                    int ow_pw_s, int ow_pw_l) {
+                                    dim_t ow_pw_s, dim_t ow_pw_l) {
         auto ker_po_idx = get_ker_po_idx(ow_pw_l - 1, is_postwork, is_oc_tail);
         const auto &outwork_ker = kernels_po_[ker_po_idx].get();
         assert(outwork_ker != nullptr
@@ -1726,8 +1736,9 @@ void brgemm_convolution_fwd_t<isa>::perform_outwork(
 template <cpu_isa_t isa>
 inline void brgemm_convolution_fwd_t<isa>::call_brgemm_kernel(
         const brgemm_thread_ctx_t &btc, const brgemm_kernel_t *brg_ker,
-        int batch_size, char *ptr_C, char *ptr_D, const char *bias_w, int g_oc,
-        bool do_postops, size_t comp_ker_offs, bool do_only_comp) const {
+        int batch_size, char *ptr_C, char *ptr_D, const char *bias_w,
+        dim_t g_oc, bool do_postops, size_t comp_ker_offs,
+        bool do_only_comp) const {
 
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
@@ -1885,28 +1896,30 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
     const auto g_ic = btc.g * jcp.ic + ic;
     const auto oh = btc.ohb * jcp.oh_block;
     const auto ow = btc.owb * jcp.ow_block;
-    const auto iw = nstl::max(0, ow * SW - LP);
+    const dim_t iw = nstl::max<dim_t>(0, ow * SW - LP);
 
-    int id_start {0}, id_end {0}, ih_start {0}, ih_end {0};
-    int virt_id_start {0}, virt_id_end {0}, virt_ih_start {0}, virt_ih_end {0};
+    dim_t id_start {0}, id_end {0}, ih_start {0}, ih_end {0};
+    dim_t virt_id_start {0}, virt_id_end {0}, virt_ih_start {0},
+            virt_ih_end {0};
 
-    auto get_start_end = [](int &start, int &end, int &virt_start,
-                                 int &virt_end, int b, int bs, int i, int o,
-                                 int s, int p, int k, int d, bool prev) {
-        const auto o_b = saturate(0, o, b * bs);
-        const auto prev_o_b = saturate(0, o, (b - 1) * bs);
-        const auto virt_cur_start = o_b * s - p;
-        const auto cur_start = saturate(0, i, virt_cur_start);
-        const auto virt_prev_start = prev_o_b * s - p;
-        const auto i_bs = get_inp_size(i, bs, k, s, d);
-        const auto virt_i_bs = calculate_end_padding(
+    auto get_start_end
+            = [](dim_t &start, dim_t &end, dim_t &virt_start, dim_t &virt_end,
+                      dim_t b, dim_t bs, dim_t i, dim_t o, dim_t s, dim_t p,
+                      dim_t k, dim_t d, bool prev) {
+        const dim_t o_b = saturate<dim_t>(0, o, b * bs);
+        const dim_t prev_o_b = saturate<dim_t>(0, o, (b - 1) * bs);
+        const dim_t virt_cur_start = o_b * s - p;
+        const dim_t cur_start = saturate<dim_t>(0, i, virt_cur_start);
+        const dim_t virt_prev_start = prev_o_b * s - p;
+        const dim_t i_bs = get_inp_size(i, bs, k, s, d);
+        const dim_t virt_i_bs = calculate_end_padding(
                 0, bs, 0, s, calculate_extended_filter_size(k, d));
-        const auto virt_prev_end = prev ? virt_prev_start + virt_i_bs : -p;
-        const auto prev_end = prev ? saturate(0, i, virt_prev_end) : 0;
+        const dim_t virt_prev_end = prev ? virt_prev_start + virt_i_bs : -p;
+        const dim_t prev_end = prev ? saturate<dim_t>(0, i, virt_prev_end) : 0;
         virt_start = nstl::max(virt_prev_end, virt_cur_start);
         start = nstl::max(prev_end, cur_start);
         virt_end = virt_cur_start + virt_i_bs;
-        end = saturate(0, i, cur_start + i_bs);
+        end = saturate<dim_t>(0, i, cur_start + i_bs);
     };
     get_start_end(id_start, id_end, virt_id_start, virt_id_end, btc.odb,
             jcp.od_block, nstl::min(ID, IDP - FP), OD, SD, FP, KD, DD - 1,
@@ -1944,12 +1957,12 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
         bool has_inp_buffer_overlap = true && last_btc.g == btc.g
                 && last_btc.n == btc.n && last_btc.owb == btc.owb;
 
-        for_(int id = id_start; id < id_end; id++)
-        for (int doh = 0; doh < jcp.oh_block; doh++) {
-            const int ih_overlap = doh == 0
-                    ? has_inp_buffer_overlap * nstl::max(0, KH - SH)
+        for_(dim_t id = id_start; id < id_end; id++)
+        for (dim_t doh = 0; doh < jcp.oh_block; doh++) {
+            const dim_t ih_overlap = doh == 0
+                    ? has_inp_buffer_overlap * nstl::max<dim_t>(0, KH - SH)
                     : 0;
-            const int kh_eff = jcp.kh - ih_overlap;
+            const dim_t kh_eff = jcp.kh - ih_overlap;
 
             const auto sdst = base_out_offset_start
                     + btc.ohb
@@ -1957,20 +1970,22 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                                     + jcp.stride_h * jcp.inp_ic_block)
                     + ih_overlap * jcp.inp_ic_block;
 
-            const int ih_s = (doh + oh) * jcp.stride_h - jcp.t_pad + ih_overlap;
-            const int ih_e = ih_s + kh_eff;
-            const int ih = nstl::max(0, ih_s);
-            p.t_overflow = nstl::max(0, -ih_s);
-            p.b_overflow = nstl::min<int>(kh_eff, nstl::max(0, ih_e - jcp.ih));
+            const dim_t ih_s
+                    = (doh + oh) * jcp.stride_h - jcp.t_pad + ih_overlap;
+            const dim_t ih_e = ih_s + kh_eff;
+            const dim_t ih = nstl::max<dim_t>(0, ih_s);
+            p.t_overflow = nstl::max<dim_t>(0, -ih_s);
+            p.b_overflow = nstl::min<dim_t>(
+                    kh_eff, nstl::max<dim_t>(0, ih_e - jcp.ih));
             p.kh_padding
-                    = nstl::max<int>(0, (kh_eff - p.t_overflow - p.b_overflow));
+                    = nstl::max<dim_t>(0, kh_eff - p.t_overflow - p.b_overflow);
             p.kh_offset = kh_eff;
 
-            const int iw_s = ow * jcp.stride_w - jcp.l_pad;
-            const int iw_e = iw_s + jcp.iwp;
-            p.f_overflow = nstl::max(0, -iw_s);
-            p.back_overflow = nstl::max(0, iw_e - jcp.iw);
-            p.kw_padding = nstl::max<int>(
+            const dim_t iw_s = ow * jcp.stride_w - jcp.l_pad;
+            const dim_t iw_e = iw_s + jcp.iwp;
+            p.f_overflow = nstl::max<dim_t>(0, -iw_s);
+            p.back_overflow = nstl::max<dim_t>(0, iw_e - jcp.iw);
+            p.kw_padding = nstl::max<dim_t>(
                     0, jcp.iwp - p.f_overflow - p.back_overflow);
 
             const auto first_actual_h = ih;
@@ -2000,15 +2015,16 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
         // TODO: extend M_mask (may be different for different kh) to avoid copying
         // top/bottom padded rows and avoid extra calculations in kernel
         // also for convolutions with pw == 0 the copy routine maybe not needed
-        cp.t_pad = jcp.is_os_blocking ? nstl::max(0, -virt_ih_start) : 0;
-        cp.b_pad = jcp.is_os_blocking ? nstl::max(0, virt_ih_end - IH) : 0;
+        cp.t_pad = jcp.is_os_blocking ? nstl::max<dim_t>(0, -virt_ih_start) : 0;
+        cp.b_pad = jcp.is_os_blocking ? nstl::max<dim_t>(0, virt_ih_end - IH)
+                                      : 0;
 
-        cp.h_count = nstl::max(0, rows_to_copy) + cp.t_pad + cp.b_pad;
+        cp.h_count = nstl::max<dim_t>(0, rows_to_copy) + cp.t_pad + cp.b_pad;
         inp_offset_start = base_inp_offset_start + ih_start * src_w_sz;
         // inp_buffer has physical padding
         out_offset_start = base_out_offset_start - cp.t_pad * _pd->pbuf_w_sz;
 
-        for (int id = id_start; id < id_end; id++) {
+        for (dim_t id = id_start; id < id_end; id++) {
             const auto inp_offset = inp_offset_start + id * src_h_sz;
             const auto id_buf = id - (jcp.copy_block_only ? id_start : 0) + FP;
             const auto out_offset = out_offset_start + id_buf * _pd->pbuf_h_sz;
@@ -2031,7 +2047,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                 }
                 const auto actual_iw_block = nstl::min(jcp.iw_block, IW - iw);
                 if (actual_iw_block < jcp.iw_block) {
-                    int size_to_sero = 0;
+                    dim_t size_to_sero = 0;
                     const auto zero_elem_size
                             = (dim_t)src_dsz * jcp.inp_ic_block;
                     size_to_sero
@@ -2057,28 +2073,31 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
     const char *const __restrict src = btc.brgemm_ctx.src; \
     const char *const __restrict weights = btc.weights; \
     const char *const __restrict bias = btc.brgemm_ctx.bias; \
-    const int oc = btc.ocb * jcp.oc_block; \
-    const int g_oc = btc.g * jcp.oc + oc; \
-    const int icb = btc.icc * jcp.nb_ic_blocking; \
-    const int ic = icb * jcp.ic_block; \
-    const int ow = btc.owb * jcp.ow_block; \
-    const int oh = btc.ohb * jcp.oh_block; \
-    const int iid = ndims_pick(btc.od * SD - FP, 0, 0); \
-    const int kd_s = ndims_pick(div_up(nstl::max(0, -iid), DD), 0, 0); \
-    const int kd_f = ndims_pick( \
-            KD - div_up(nstl::max(0, iid - ID + (KD - 1) * DD + 1), DD), 1, \
-            1); \
+    const dim_t oc = btc.ocb * jcp.oc_block; \
+    const dim_t g_oc = btc.g * jcp.oc + oc; \
+    const dim_t icb = btc.icc * jcp.nb_ic_blocking; \
+    const dim_t ic = icb * jcp.ic_block; \
+    const dim_t ow = btc.owb * jcp.ow_block; \
+    const dim_t oh = btc.ohb * jcp.oh_block; \
+    const dim_t iid = ndims_pick(btc.od * SD - FP, 0, 0); \
+    const dim_t kd_s \
+            = ndims_pick(div_up(nstl::max<dim_t>(0, -iid), DD), 0, 0); \
+    const dim_t kd_f = ndims_pick(KD \
+                    - div_up( \
+                            nstl::max<dim_t>(0, iid - ID + (KD - 1) * DD + 1), \
+                            DD), \
+            1, 1); \
     const auto kd_l = kd_f - kd_s; \
     const auto adj_sh = jcp.is_relo_whi() ? 1 : SH; \
     const auto adj_tp = jcp.is_relo_whi() ? 0 : TP; \
     const auto iih = ndims_pick( \
             btc.oh * adj_sh - adj_tp, btc.oh * adj_sh - adj_tp, 0); \
-    const auto kh_s_ = div_up(nstl::max(0, -iih), DH); \
+    const auto kh_s_ = div_up(nstl::max<dim_t>(0, -iih), DH); \
     const auto kh_s = (jcp.is_os_blocking || jcp.is_relo_whi()) \
             ? 0 \
             : ndims_pick(kh_s_, kh_s_, 0); \
-    const auto kh_f_ \
-            = KH - div_up(nstl::max(0, iih - IH + (KH - 1) * DH + 1), DH); \
+    const auto kh_f_ = KH \
+            - div_up(nstl::max<dim_t>(0, iih - IH + (KH - 1) * DH + 1), DH); \
     const auto kh_f = jcp.is_relo_whi() ? 1 : ndims_pick(kh_f_, kh_f_, 1); \
     const auto kh_l = kh_f - kh_s; \
     const bool is_oc_tail = (jcp.oc - oc < jcp.oc_block); \
@@ -2088,7 +2107,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
     const bool is_oh_tail = (OH - oh < jcp.oh_block); \
     const char *const __restrict bias_w \
             = bias ? bias + (bias_d.blk_off(g_oc) * bia_dsz) : nullptr; \
-    const auto nb_ic_b = nstl::min(jcp.nb_ic_blocking, jcp.nb_ic - icb) \
+    const auto nb_ic_b = nstl::min<dim_t>(jcp.nb_ic_blocking, jcp.nb_ic - icb) \
             - (is_ic_tail ? 1 : 0); \
     const memory_desc_wrapper dst_d(pd()->dst_md()); \
     char *const __restrict dst_base = btc.brgemm_ctx.dst \
@@ -2099,7 +2118,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                             + oc); \
     char *ptr_C; \
     char *ptr_D; \
-    int kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0), iiw_b(0);
+    dim_t kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0), iiw_b(0);
 
 template <cpu_isa_t isa>
 void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
@@ -2112,11 +2131,12 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
     MAYBE_UNUSED(is_ow_tail);
     MAYBE_UNUSED(is_oh_tail);
 
-    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0}, kw_b(0), kw_e(0);
+    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
+    dim_t kw_b {0}, kw_e {0};
     int ow_b {0}, ow_e {0};
 
     brgemm_convolution_utils::get_kw_range(
-            jcp, ow, kw_s, kw_full_s, kw_full_f, kw_f);
+            jcp, static_cast<int>(ow), kw_s, kw_full_s, kw_full_f, kw_f);
 
     const auto src_base = src + get_src_base_offset(btc, ic);
     const auto wei_base = weights
@@ -2124,9 +2144,9 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
                     * (btc.g * _pd->wei_g_stride
                             + btc.ocb * _pd->wei_ocb_stride);
 
-    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
-                                     size_t comp_ker_offs, bool do_postops,
-                                     bool do_only_comp) {
+    const auto call_brgemm = [&](int brg_idx, dim_t ic_block_s,
+                                     dim_t n_ic_blocks, size_t comp_ker_offs,
+                                     bool do_postops, bool do_only_comp) {
         if (brg_idx == -1) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -2146,13 +2166,15 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
                     kh_b, kh_e, kw_b, kw_e, k_l, btc.brg_batch);
             if (k_l <= 0) return;
         }
-        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
-                bias_w, g_oc, do_postops, comp_ker_offs, do_only_comp);
+        call_brgemm_kernel(btc, brg_ker, static_cast<int>(k_l * n_ic_blocks),
+                ptr_C, ptr_D, bias_w, g_oc, do_postops, comp_ker_offs,
+                do_only_comp);
     };
 
     const auto kdhw_loop = [&]() {
         if (kw_e - kw_b <= 0) return;
-        brgemm_convolution_utils::get_ow_range(jcp, ow, kw_b, ow_b, ow_e);
+        brgemm_convolution_utils::get_ow_range(
+                jcp, static_cast<int>(ow), static_cast<int>(kw_b), ow_b, ow_e);
         const auto do_init
                 = btc.icc == 0 && kd_b == kd_s && kh_b == kh_s && kw_b == kw_s;
         const auto do_postwork = _pd->need_postwork
@@ -2180,16 +2202,19 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
                     : 0;
 
             if (nb_ic_b > 0) {
-                const auto brg_idx = _pd->get_brg_idx(ow_l, do_init, is_oc_tail,
-                        false, kd_s, kd_f, kh_s, kh_f);
+                const int brg_idx = _pd->get_brg_idx(ow_l, do_init, is_oc_tail,
+                        false, static_cast<int>(kd_s), static_cast<int>(kd_f),
+                        static_cast<int>(kh_s), static_cast<int>(kh_f));
                 call_brgemm(brg_idx, 0, nb_ic_b, comp_ker_offs,
                         do_postwork && !is_ic_tail, false);
             }
 
             if (is_ic_tail) {
                 const auto use_init_ker = (do_init && nb_ic_b == 0);
-                const auto brg_ic_tail_idx = _pd->get_brg_idx(ow_l,
-                        use_init_ker, is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+                const int brg_ic_tail_idx
+                        = _pd->get_brg_idx(ow_l, use_init_ker, is_oc_tail, true,
+                                static_cast<int>(kd_s), static_cast<int>(kd_f),
+                                static_cast<int>(kh_s), static_cast<int>(kh_f));
                 call_brgemm(brg_ic_tail_idx, nb_ic_b, 1, comp_ker_offs,
                         do_postwork, false);
             }
@@ -2206,9 +2231,9 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         // kw values with left padding
         if (kw_s < kw_full_s) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK_PAD);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK_PAD);
                     for (auto kw = kw_s; kw < kw_full_s; kw++) {
                         kw_b = kw;
                         kw_e = kw + 1;
@@ -2221,11 +2246,11 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         // kw values covering full ow_block
         if (kw_full_s < kw_full_f) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                     for (kw_b = kw_full_s; kw_b < kw_full_f; kw_b += KW_BLOCK) {
-                        kw_e = nstl::min(kw_full_f, kw_b + KW_BLOCK);
+                        kw_e = nstl::min<dim_t>(kw_full_f, kw_b + KW_BLOCK);
                         kdhw_loop();
                     }
                 }
@@ -2235,9 +2260,9 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         // kw values with right padding
         if (kw_full_f < kw_f) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK_PAD);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK_PAD);
                     for (int kw = kw_full_f; kw < kw_f; kw++) {
                         kw_b = kw;
                         kw_e = kw + 1;
@@ -2250,7 +2275,8 @@ void brgemm_convolution_fwd_t<isa>::ker_base(brgemm_thread_ctx_t &btc) const {
         const auto do_init = btc.icc == 0;
         const auto do_postwork
                 = _pd->need_postwork && btc.icc == (_pd->ic_chunks - 1);
-        brgemm_convolution_utils::get_ow_range(jcp, ow, kw_b, ow_b, ow_e);
+        brgemm_convolution_utils::get_ow_range(
+                jcp, static_cast<int>(ow), static_cast<int>(kw_b), ow_b, ow_e);
         perform_outwork(btc, dst_base, bias_w, ow, g_oc, is_oc_tail, ow_b, ow_e,
                 kd_l, kh_l, do_init, do_postwork, 0, false);
     }
@@ -2271,15 +2297,15 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
             + wei_dsz
                     * (btc.g * _pd->wei_g_stride
                             + btc.ocb * _pd->wei_ocb_stride);
-    const int ow_b {ow},
+    const dim_t ow_b {ow},
             ow_e {ow + (is_ow_tail ? jcp.ow % jcp.ow_block : jcp.ow_block)};
-    const int oh_b {oh},
+    const dim_t oh_b {oh},
             oh_e {oh + (is_oh_tail ? jcp.oh % jcp.oh_block : jcp.oh_block)};
     const auto iid_shift = jcp.copy_block_only
-            ? nstl::max(0, btc.odb * jcp.od_block * SD - FP)
+            ? nstl::max<dim_t>(0, btc.odb * jcp.od_block * SD - FP)
             : 0;
     const auto iih_shift = jcp.copy_block_only
-            ? nstl::max(0, btc.ohb * jcp.oh_block * adj_sh - adj_tp)
+            ? nstl::max<dim_t>(0, btc.ohb * jcp.oh_block * adj_sh - adj_tp)
             : 0;
     const auto iiw_shift
             = jcp.copy_block_only ? (btc.owb * jcp.ow_block * SW) : 0;
@@ -2301,14 +2327,16 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
 
     const auto ker_i = (jcp.is_os_blocking ? oh_l * ow_l : ow_l);
     const auto comp_iih = ndims_pick(btc.oh * SH - TP, btc.oh * SH - TP, 0);
-    const auto comp_kh_s_ = div_up(nstl::max(0, -comp_iih), DH);
-    const auto comp_kh_f_
-            = KH - div_up(nstl::max(0, comp_iih - IH + (KH - 1) * DH + 1), DH);
+    const auto comp_kh_s_ = div_up(nstl::max<dim_t>(0, -comp_iih), DH);
+    const auto comp_kh_f_ = KH
+            - div_up(
+                    nstl::max<dim_t>(0, comp_iih - IH + (KH - 1) * DH + 1), DH);
     const auto comp_kh_s = ndims_pick(comp_kh_s_, comp_kh_s_, 0);
     const auto comp_kh_f = ndims_pick(comp_kh_f_, comp_kh_f_, 1);
 
-    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
-                                     size_t comp_ker_offs, bool do_postops) {
+    const auto call_brgemm
+            = [&](int brg_idx, dim_t ic_block_s, dim_t n_ic_blocks,
+                      size_t comp_ker_offs, bool do_postops) {
         if (brg_idx == -1) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -2340,8 +2368,8 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
             if (k_l <= 0) return;
         }
 
-        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
-                bias_w, g_oc, do_postops, comp_ker_offs, false);
+        call_brgemm_kernel(btc, brg_ker, static_cast<int>(k_l * n_ic_blocks),
+                ptr_C, ptr_D, bias_w, g_oc, do_postops, comp_ker_offs, false);
     };
 
     const auto kdhw_loop = [&]() {
@@ -2357,16 +2385,20 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
                 : 0;
 
         if (nb_ic_b > 0) {
-            const auto brg_idx = _pd->get_brg_idx(
-                    ker_i, do_init, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+            const int brg_idx = _pd->get_brg_idx(static_cast<int>(ker_i),
+                    do_init, is_oc_tail, false, static_cast<int>(kd_s),
+                    static_cast<int>(kd_f), static_cast<int>(kh_s),
+                    static_cast<int>(kh_f));
             call_brgemm(brg_idx, 0, nb_ic_b, comp_ker_offs,
                     do_postwork && !is_ic_tail);
         }
 
         if (is_ic_tail) {
             const auto use_init_ker = (do_init && nb_ic_b == 0);
-            const auto brg_ic_tail_idx = _pd->get_brg_idx(ker_i, use_init_ker,
-                    is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+            const int brg_ic_tail_idx = _pd->get_brg_idx(
+                    static_cast<int>(ker_i), use_init_ker, is_oc_tail, true,
+                    static_cast<int>(kd_s), static_cast<int>(kd_f),
+                    static_cast<int>(kh_s), static_cast<int>(kh_f));
 
             call_brgemm(
                     brg_ic_tail_idx, nb_ic_b, 1, comp_ker_offs, do_postwork);
@@ -2376,9 +2408,9 @@ void brgemm_convolution_fwd_t<isa>::ker_trans(brgemm_thread_ctx_t &btc) const {
     if (kd_f > kd_s && kh_f > kh_s) {
         // kw values covering full ow_block
         for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-            kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+            kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
             for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                 kdhw_loop();
             }
         }
@@ -2407,7 +2439,7 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
                     * (btc.g * _pd->wei_g_stride
                             + btc.ocb * _pd->wei_ocb_stride);
 
-    const int ow_b {ow}, ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
+    const dim_t ow_b {ow}, ow_e {ow + (is_ow_tail ? jcp.M_tail : jcp.M)};
     iiw_b = ow_b * SW - LP;
     ptr_D = dst_base
             + dst_dsz
@@ -2423,8 +2455,9 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
     const dim_t *const __restrict kw_bottom_vpads
             = owb_kw_bottom_vpads.data() + btc.owb * KW;
 
-    const auto call_brgemm = [&](int brg_idx, int ic_block_s, int n_ic_blocks,
-                                     size_t comp_ker_offs, bool do_postops) {
+    const auto call_brgemm
+            = [&](int brg_idx, dim_t ic_block_s, dim_t n_ic_blocks,
+                      size_t comp_ker_offs, bool do_postops) {
         if (brg_idx < 0) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -2439,8 +2472,8 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
                 kh_b, kh_e, 0, KW, k_l, btc.brg_batch);
         if (k_l <= 0) return;
 
-        call_brgemm_kernel(btc, brg_ker, k_l * n_ic_blocks, ptr_C, ptr_D,
-                bias_w, g_oc, do_postops, comp_ker_offs, false);
+        call_brgemm_kernel(btc, brg_ker, static_cast<int>(k_l * n_ic_blocks),
+                ptr_C, ptr_D, bias_w, g_oc, do_postops, comp_ker_offs, false);
     };
 
     const auto kdhw_loop = [&]() {
@@ -2455,16 +2488,20 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
                 btc.g, btc.ocb, 0, 0, kd_s, kd_f, kh_s, kh_f, 0, KW);
 
         if (nb_ic_b > 0) {
-            const auto brg_idx = _pd->get_brg_idx(
-                    ow_l, do_init, is_oc_tail, false, kd_s, kd_f, kh_s, kh_f);
+            const int brg_idx = _pd->get_brg_idx(static_cast<int>(ow_l),
+                    do_init, is_oc_tail, false, static_cast<int>(kd_s),
+                    static_cast<int>(kd_f), static_cast<int>(kh_s),
+                    static_cast<int>(kh_f));
             call_brgemm(
                     brg_idx, 0, nb_ic_b, comp_offs, do_postwork && !is_ic_tail);
         }
 
         if (is_ic_tail) {
             const auto use_init_ker = (do_init && nb_ic_b == 0);
-            const auto brg_ic_tail_idx = _pd->get_brg_idx(ow_l, use_init_ker,
-                    is_oc_tail, true, kd_s, kd_f, kh_s, kh_f);
+            const int brg_ic_tail_idx = _pd->get_brg_idx(static_cast<int>(ow_l),
+                    use_init_ker, is_oc_tail, true, static_cast<int>(kd_s),
+                    static_cast<int>(kd_f), static_cast<int>(kh_s),
+                    static_cast<int>(kh_f));
 
             call_brgemm(brg_ic_tail_idx, nb_ic_b, 1, comp_offs, do_postwork);
         }
@@ -2473,9 +2510,9 @@ void brgemm_convolution_fwd_t<isa>::ker_vpad(brgemm_thread_ctx_t &btc) const {
     if (kd_f > kd_s && kh_f > kh_s) {
         // kw values covering full ow_block
         for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-            kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+            kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
             for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                 kdhw_loop();
             }
         }

--- a/src/cpu/x64/jit_brgemm_conv.hpp
+++ b/src/cpu/x64/jit_brgemm_conv.hpp
@@ -59,19 +59,19 @@ struct brgemm_convolution_fwd_t : public primitive_t {
 
         status_t init(const engine_t *engine);
 
-        int brgs_sz_ {};
+        dim_t brgs_sz_ {};
         std::shared_ptr<brgemm_containers::brgemm_desc_container_t>
                 brgemm_descriptors_;
         bool with_sum_ = false;
         jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
 
-        int ic_chunks {};
+        dim_t ic_chunks {};
         bool need_postwork {};
         dim_t wei_g_stride {}, wei_ic_stride {}, wei_ocb_stride {};
         dim_t wei_kw_stride {}, wei_kh_stride {}, wei_kd_stride {};
         dim_t pbuf_w_sz {}, pbuf_h_sz {}, pbuf_d_sz {};
         int ndims {0};
-        int rd {0};
+        dim_t rd {0};
 
         // batch sizes info for unrolled kernels
         int bs_c {};
@@ -91,44 +91,47 @@ struct brgemm_convolution_fwd_t : public primitive_t {
 
         Arrmap<4> batchsizes;
         int brg_indices_c {0};
+        // Bounded kernel-variant lookup key/index, not tensor-scale.
         Arrmap<8> brg_indices;
 
         int get_brg_idx(int m, bool do_initialization, bool is_N_tail,
                 bool is_K_tail, int kd_b, int kd_e, int kh_b, int kh_e) const;
 
-        inline int get_bs(int kd_b, int kd_e, int kh_b, int kh_e) const {
-            const auto kd_l = nstl::min(KD_BLOCK, kd_e - kd_b);
-            const auto kh_l = nstl::min(KH_BLOCK, kh_e - kh_b);
+        inline int get_bs(
+                dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e) const {
+            const auto kd_l = nstl::min<dim_t>(KD_BLOCK, kd_e - kd_b);
+            const auto kh_l = nstl::min<dim_t>(KH_BLOCK, kh_e - kh_b);
             const auto bs = kd_l
                     * (jcp_.is_relo_whi()
                                     ? 1
                                     : (kh_l * (jcp_.is_relo_wi() ? 1 : KW)));
-            return bs;
+            return static_cast<int>(bs);
         }
 
         int get_any_brg_idx(bool is_N_tail, bool is_K_tail) const;
 
-        inline int maybe_invert(int k, int K) const {
+        inline dim_t maybe_invert(dim_t k, dim_t K) const {
             return desc()->use_inversion ? K - 1 - k : k;
         }
 
         // This method calculates the value of k_l
-        void init_batch(int icc, const char *src_base, const char *wei_base,
-                int n_ic_blocks, int ic_block_s, int iid_b, int iih_b,
-                int iiw_b, const dim_t *const __restrict kw_top_vpads,
-                const dim_t *const __restrict kw_bottom_vpads, int kd_b,
-                int kd_e, int kh_b, int kh_e, int kw_b, int kw_e, int &k_l,
-                brgemm_batch_element_t *brg_batch) const;
+        void init_batch(dim_t icc, const char *src_base, const char *wei_base,
+                dim_t n_ic_blocks, dim_t ic_block_s, dim_t iid_b, dim_t iih_b,
+                dim_t iiw_b, const dim_t *const __restrict kw_top_vpads,
+                const dim_t *const __restrict kw_bottom_vpads, dim_t kd_b,
+                dim_t kd_e, dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e,
+                dim_t &k_l, brgemm_batch_element_t *brg_batch) const;
 
-        void get_A_B(int icc, const char *src_base, const char *wei_base,
-                int ic_block_s, int iid_b, int iih_b, int iiw_b, int kd_b,
-                int kh_b, const void *&ptrA, const void *&ptrB) const;
+        void get_A_B(dim_t icc, const char *src_base, const char *wei_base,
+                dim_t ic_block_s, dim_t iid_b, dim_t iih_b, dim_t iiw_b,
+                dim_t kd_b, dim_t kh_b, const void *&ptrA,
+                const void *&ptrB) const;
 
-        status_t add_brg_descriptor(int M, bool is_N_tail, bool is_K_tail,
+        status_t add_brg_descriptor(dim_t M, bool is_N_tail, bool is_K_tail,
                 bool do_init, int kd_b, int kd_e, int kh_b, int kh_e);
 
     protected:
-        int KD {}, KH {}, KW {}, EXT_KD {}, EXT_KH {}, EXT_KW {}, KS {},
+        dim_t KD {}, KH {}, KW {}, EXT_KD {}, EXT_KH {}, EXT_KW {}, KS {},
                 KD_BLOCK {}, KH_BLOCK {}, KW_BLOCK {}, KD_BLOCK_PAD {},
                 KH_BLOCK_PAD {}, ID {}, IH {}, IW {}, IDP {}, IHP {}, IWP {},
                 OD {}, OH {}, OW {}, SD {}, SH {}, SW {}, FP {}, TP {}, LP {},
@@ -166,20 +169,21 @@ private:
         const std::vector<const void *> post_ops_binary_rhs_arg_vec;
     };
 
-    inline static int get_ker_po_idx(int m, bool do_postwork, bool is_N_tail) {
-        return (m * 2 + static_cast<int>(do_postwork)) * 2
-                + static_cast<int>(is_N_tail);
+    inline static int get_ker_po_idx(
+            dim_t m, bool do_postwork, bool is_N_tail) {
+        return static_cast<int>((m * 2 + static_cast<int>(do_postwork)) * 2
+                + static_cast<int>(is_N_tail));
     }
 
-    inline static int get_inp_size(
-            int max_src_size, int dst_size, int k, int stride, int dilate) {
-        const auto res = nstl::min(max_src_size,
+    inline static dim_t get_inp_size(dim_t max_src_size, dim_t dst_size,
+            dim_t k, dim_t stride, dim_t dilate) {
+        const auto res = nstl::min<dim_t>(max_src_size,
                 calculate_end_padding(0, dst_size, 0, stride,
                         calculate_extended_filter_size(k, dilate)));
         return res;
     }
 
-    inline int maybe_invert_range(int k, int k_inv, int K) const {
+    inline dim_t maybe_invert_range(dim_t k, dim_t k_inv, dim_t K) const {
         return pd()->desc()->use_inversion ? K - k_inv : k;
     }
 
@@ -191,13 +195,14 @@ private:
     void ker_vpad(brgemm_thread_ctx_t &btc) const;
 
     void perform_outwork(const brgemm_thread_ctx_t &btc, char *dst_base,
-            const char *bias_w, int ow, int g_oc, bool is_oc_tail, int ker_ow_s,
-            int ker_ow_f, int kd_l, int kh_l, bool maybe_do_init,
-            bool do_postwork, size_t comp_ker_offs, bool do_post_comp) const;
+            const char *bias_w, dim_t ow, dim_t g_oc, bool is_oc_tail,
+            dim_t ker_ow_s, dim_t ker_ow_f, dim_t kd_l, dim_t kh_l,
+            bool maybe_do_init, bool do_postwork, size_t comp_ker_offs,
+            bool do_post_comp) const;
 
     void call_brgemm_kernel(const brgemm_thread_ctx_t &btc,
             const brgemm_kernel_t *brg_ker, int batch_size, char *ptr_C,
-            char *ptr_D, const char *bias_w, int g_oc, bool do_postops,
+            char *ptr_D, const char *bias_w, dim_t g_oc, bool do_postops,
             size_t comp_ker_offs, bool do_only_comp) const;
 
     void maybe_conv_inp(brgemm_thread_ctx_t &btc,
@@ -209,17 +214,16 @@ private:
             const char *__restrict &wei) const;
 
     status_t add_po_kernel(brgemm_desc_t *bcfg, int ker_idx, bool is_init);
-    status_t add_po_kernels(int i_N, int init_bcast_dim, int po_bcast_dim);
+    status_t add_po_kernels(int i_N, dim_t init_bcast_dim, dim_t po_bcast_dim);
     status_t add_brg_kernel(int brg_idx);
 
     status_t cal_compensation(const char *__restrict weights,
             int32_t *src_zp_buffer, int32_t *s8s8_comp_buffer) const;
-    int get_comp_oh(const int oh) const;
-    int get_comp_ker_idx(const int kd_b, const int kd_e, const int kh_b,
-            const int kh_e, const int kw_b, const int kw_e, const int oh) const;
-    int get_comp_offset(const int g, const int ocb, const int oh, const int ow,
-            const int kd_b, const int kd_e, const int kh_b, const int kh_e,
-            const int kw_b, const int kw_e) const;
+    dim_t get_comp_oh(dim_t oh) const;
+    dim_t get_comp_ker_idx(dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e,
+            dim_t kw_b, dim_t kw_e, dim_t oh) const;
+    dim_t get_comp_offset(dim_t g, dim_t ocb, dim_t oh, dim_t ow, dim_t kd_b,
+            dim_t kd_e, dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e) const;
     inline const pd_t *pd() const {
         return static_cast<const pd_t *>(primitive_t::pd().get());
     }
@@ -247,7 +251,7 @@ private:
     std::vector<dim_t> kd_bs, kd_es, kh_bs, kh_es, kw_bs, kw_es, oh_kh_b,
             oh_kh_e, comp_oh, comp_oh_kh_b, comp_oh_kh_e, comp_owb;
 
-    int KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
+    dim_t KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
             KD_BLOCK_PAD, KH_BLOCK_PAD, ID, IH, IW, IDP, IHP, IWP, OD, OH, OW,
             SD, SH, SW, FP, TP, LP, DD, DH, DW;
     dim_t src_w_sz, src_h_sz, dst_w_sz, dst_h_sz;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_copy_kernel.cpp
@@ -74,13 +74,13 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::store(
 template <>
 void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Xbyak::Ymm>::load(
         const Xbyak::Ymm &x, const Xbyak::Address &addr, const int load_size) {
-    load_bytes(x, addr, jcp.dst_dsz * load_size, true);
+    load_bytes(x, addr, static_cast<int>(jcp.dst_dsz * load_size), true);
 }
 
 template <>
 void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Xbyak::Ymm>::store(
         const Xbyak::Address &addr, const Xbyak::Ymm &x, const int store_size) {
-    store_bytes(x, addr, jcp.dst_dsz * store_size);
+    store_bytes(x, addr, static_cast<int>(jcp.dst_dsz * store_size));
 }
 
 template <typename Vmm>
@@ -99,7 +99,7 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
     const auto iw_tail = jcp.iw % jcp.iw_block;
     const auto ic_tail = jcp.ic % jcp.ic_block;
     if (is_zmm_ && ic_tail) {
-        int simd_tail = ic_tail % simd_w;
+        int simd_tail = static_cast<int>(ic_tail % simd_w);
         uint64_t mask = (UINT64_C(1) << simd_tail) - 1;
         mov(reg_tmp, mask);
         kmovq(ktail_mask, reg_tmp);
@@ -117,8 +117,10 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
             const auto iw_off = iw * jcp.ic_without_padding * jcp.dst_dsz;
             auto nvec = is_ic_tail ? n_tail_vec : n_vec;
             for (size_t iv = 0; iv < nvec; iv++) {
-                load(vmm_tmp, ptr[inp_ptr + iw_off + iv * VL], simd_w);
-                store(ptr[dst_ptr + iw_off + iv * VL], vmm_tmp, simd_w);
+                load(vmm_tmp, ptr[inp_ptr + iw_off + iv * VL],
+                        static_cast<int>(simd_w));
+                store(ptr[dst_ptr + iw_off + iv * VL], vmm_tmp,
+                        static_cast<int>(simd_w));
             }
             const auto last_inp_off = inp_ptr + iw_off + nvec * VL;
             const auto last_dst_off = dst_ptr + iw_off + nvec * VL;
@@ -129,7 +131,7 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
                     load(zmm_tmp_mask, ptr[last_inp_off]);
                     store(ptr[last_dst_off] | ktail_mask, vmm_tmp);
                 } else {
-                    int simd_tail = ic_tail % simd_w;
+                    int simd_tail = static_cast<int>(ic_tail % simd_w);
                     load(vmm_tmp, ptr[last_inp_off], simd_tail);
                     store(ptr[last_dst_off], vmm_tmp, simd_tail);
                 }
@@ -139,8 +141,10 @@ void jit_avx512_core_brgemm_conv_bwd_copy_kernel_t<Vmm>::generate() {
                     load(zmm_tmp_mask, ptr[last_inp_off]);
                     store(ptr[last_dst_off] | kblock_tail_mask, vmm_tmp);
                 } else {
-                    load(vmm_tmp, ptr[last_inp_off], block_tail);
-                    store(ptr[last_dst_off], vmm_tmp, block_tail);
+                    load(vmm_tmp, ptr[last_inp_off],
+                            static_cast<int>(block_tail));
+                    store(ptr[last_dst_off], vmm_tmp,
+                            static_cast<int>(block_tail));
                 }
             }
         }

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -178,15 +178,15 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(
     if (jcp_.exec_type == exec_trans && is_amx) {
         std::set<int> bs_set;
         bs_set.insert(0); // for skip_accumulation case
-        for (int kd_range = 1; kd_range <= KD_BLOCK; kd_range++) {
+        for (dim_t kd_range = 1; kd_range <= KD_BLOCK; kd_range++) {
             const auto kd_l = div_up(kd_range, SD);
-            for (int kh_range = 1; kh_range <= KH_BLOCK; kh_range++) {
+            for (dim_t kh_range = 1; kh_range <= KH_BLOCK; kh_range++) {
                 const auto kh_l = div_up(kh_range, SH);
-                for (int kw_s_off = 0; kw_s_off < nstl::min(KW, SW);
+                for (int kw_s_off = 0; kw_s_off < nstl::min<dim_t>(KW, SW);
                         kw_s_off++) {
                     const auto kw_range = KW - kw_s_off;
                     const auto kw_l = div_up(kw_range, SW);
-                    bs_set.insert(kd_l * kh_l * kw_l);
+                    bs_set.insert(static_cast<int>(kd_l * kh_l * kw_l));
                 }
             }
         }
@@ -225,14 +225,14 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(
         const auto eff_iw = jcp_.iw_tail > 0 ? jcp_.iw_tail : jcp_.iw;
         for (int sw = 0; sw < SW; sw++) {
             if (eff_iw <= sw) continue;
-            const auto M_sw = static_cast<int>(div_up(eff_iw - sw, SW));
+            const dim_t M_sw = div_up(eff_iw - sw, SW);
             if (M_sw > 0 && M_sw < M_full) {
                 if (jcp_.use_uker) {
                     // AMX uker: use bd_mask with constant M to avoid tile
                     // reconfiguration. The uker skips masked rows during
                     // postops store.
                     std::vector<char> mask(M_full, 0);
-                    for (int i = 0; i < M_sw; i++)
+                    for (dim_t i = 0; i < M_sw; i++)
                         mask[i] = 1;
                     for_(int i_N = N_begin; i_N < N_end; i_N++)
                     for_(int i_init = i_init_begin; i_init < i_init_end;
@@ -261,11 +261,13 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(
         int kw_s {0}, kw_full_s {0}, kw_full_f {0}, kw_f {0}, iw_s {0},
                 M_without_overflow {0};
 
-        auto init_kernels_kw_loop = [&](int sw, int iw) -> status_t {
+        auto init_kernels_kw_loop = [&](dim_t sw, dim_t iw) -> status_t {
             const auto iw_str = iw + sw;
-            get_kw_range(iw_str, iw, kw_s, kw_full_s, kw_full_f, kw_f);
+            get_kw_range(static_cast<int>(iw_str), static_cast<int>(iw), kw_s,
+                    kw_full_s, kw_full_f, kw_f);
             for (int kw = kw_s; kw < kw_f; kw++) {
-                get_iw_range(iw_str, iw, kw, iw_s, M_without_overflow);
+                get_iw_range(static_cast<int>(iw_str), static_cast<int>(iw), kw,
+                        iw_s, M_without_overflow);
                 if (M_without_overflow <= 0) continue;
                 for_(int i_init = 0; i_init < 2; i_init++)
                 for_(int i_N = 0; i_N < 2; i_N++)
@@ -277,18 +279,18 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(
             return status::success;
         };
         for (int sw = 0; sw < SW; sw++) {
-            for (int iw = 0; iw < IW; iw += jcp_.iw_block) {
+            for (dim_t iw = 0; iw < IW; iw += jcp_.iw_block) {
                 CHECK(init_kernels_kw_loop(sw, iw));
                 if (kw_f == jcp_.kw && kw_s == 0) break;
             }
-            for (int iw = (jcp_.nb_iw - 1) * jcp_.iw_block; iw >= 0;
+            for (dim_t iw = (jcp_.nb_iw - 1) * jcp_.iw_block; iw >= 0;
                     iw -= jcp_.iw_block) {
                 CHECK(init_kernels_kw_loop(sw, iw));
                 if (kw_f == jcp_.kw && kw_s == 0) break;
             }
         }
     }
-    brgs_sz_ = brgs_->refs_size();
+    brgs_sz_ = static_cast<int>(brgs_->refs_size());
 
     auto scratchpad = scratchpad_registry().registrar();
     brgemm_convolution_bwd_utils::init_scratchpad(scratchpad, jcp_);
@@ -297,9 +299,9 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::init(
 }
 
 template <cpu_isa_t isa>
-status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
-        bool is_N_tail, bool is_K_tail, bool do_init, int bd_mask_idx,
-        const std::vector<char> &bd_mask, int bs) {
+status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(
+        dim_t vM, bool is_N_tail, bool is_K_tail, bool do_init,
+        dim_t bd_mask_idx, const std::vector<char> &bd_mask, int bs) {
 
     if (do_init && is_K_tail && jcp_.K > 0) return status::success;
 
@@ -314,8 +316,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
 
     if (vN == 0 || vK == 0) return status::success;
 
-    auto brg_idx
-            = get_brg_idx(vM, do_init, is_N_tail, is_K_tail, bd_mask_idx, bs);
+    int brg_idx = get_brg_idx(static_cast<int>(vM), do_init, is_N_tail,
+            is_K_tail, static_cast<int>(bd_mask_idx), bs);
     // if brgemm_desc_t already created then skip this iteration
     if (brg_idx != -1) return status::success;
 
@@ -382,8 +384,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(int vM,
     brg_idx = brgs_->insert(
             brg, bd_mask, std::vector<brgemm_batch_element_t> {});
 
-    const std::array<int, 6> key
-            = {vM, is_N_tail, is_K_tail, do_init, bd_mask_idx, bs};
+    const std::array<int, 6> key = {static_cast<int>(vM), is_N_tail, is_K_tail,
+            do_init, static_cast<int>(bd_mask_idx), bs};
     if (brg_indices.find(key) == brg_indices.end()) {
         brg_indices.insert({key, brg_idx});
         brg_indices_c++;
@@ -434,8 +436,8 @@ status_t brgemm_convolution_bwd_strided_t<isa>::add_po_kernel(
     bcfg->LDD = (is_init && jcp.use_buffer) ? jcp.LDC : jcp.LDD;
     bcfg->dt_c = (!is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt;
     bcfg->dt_d = (is_init && jcp.use_buffer) ? jcp.acc_dt : jcp.dst_dt;
-    bcfg->typesize_C = types::data_type_size(bcfg->dt_c);
-    bcfg->typesize_D = types::data_type_size(bcfg->dt_d);
+    bcfg->typesize_C = static_cast<int>(types::data_type_size(bcfg->dt_c));
+    bcfg->typesize_D = static_cast<int>(types::data_type_size(bcfg->dt_d));
     bcfg->alpha
             = (!is_init && IMPLICATION(jcp.with_sum, jcp.use_buffer)) ? 1 : 0;
     bcfg->beta = is_init ? 0 : 1;
@@ -448,7 +450,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::add_po_kernel(
 
 template <cpu_isa_t isa>
 void brgemm_convolution_bwd_strided_t<isa>::add_po_kernels(
-        int i_N, int init_bcast_dim, int po_bcast_dim) {
+        int i_N, dim_t init_bcast_dim, dim_t po_bcast_dim) {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
     const auto &brgs = *(_pd->brgs_);
@@ -457,7 +459,7 @@ void brgemm_convolution_bwd_strided_t<isa>::add_po_kernels(
     if (N <= 0) return;
     auto i_K = (jcp.K_tail > 0);
 
-    const auto brg_idx = _pd->get_any_brg_idx(i_N, i_K);
+    const int brg_idx = _pd->get_any_brg_idx(i_N, i_K);
 
     if (init_bcast_dim > 0) {
         if (brgs[brg_idx]) {
@@ -483,9 +485,8 @@ void brgemm_convolution_bwd_strided_t<isa>::add_po_kernels(
 }
 
 template <cpu_isa_t isa>
-int brgemm_convolution_bwd_strided_t<isa>::get_comp_ker_idx(const int kd_b,
-        const int kd_e, const int kh_b, const int kh_e, const int kw_b,
-        const int kw_e) const {
+dim_t brgemm_convolution_bwd_strided_t<isa>::get_comp_ker_idx(dim_t kd_b,
+        dim_t kd_e, dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
@@ -493,7 +494,7 @@ int brgemm_convolution_bwd_strided_t<isa>::get_comp_ker_idx(const int kd_b,
 
     assert(IMPLICATION(kd_e <= kd_b && kh_e <= kh_b,
             everyone_is(0, kd_b, kd_e, kh_b, kh_e, kw_b, kw_e)));
-    for (int k = 0; k < jcp.ker_ranges_size; k++) {
+    for (dim_t k = 0; k < jcp.ker_ranges_size; k++) {
         if (kd_b == kd_bs[k] && kd_e == kd_es[k] && kh_b == kh_bs[k]
                 && kh_e == kh_es[k] && kw_b == kw_bs[k] && kw_e == kw_es[k]) {
             return k;
@@ -504,9 +505,9 @@ int brgemm_convolution_bwd_strided_t<isa>::get_comp_ker_idx(const int kd_b,
 }
 
 template <cpu_isa_t isa>
-int brgemm_convolution_bwd_strided_t<isa>::get_comp_offset(const int g,
-        const int icb, const int iw, const int kd_b, const int kd_e,
-        const int kh_b, const int kh_e, const int kw_b, const int kw_e) const {
+dim_t brgemm_convolution_bwd_strided_t<isa>::get_comp_offset(dim_t g, dim_t icb,
+        dim_t iw, dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e, dim_t kw_b,
+        dim_t kw_e) const {
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
@@ -562,13 +563,16 @@ void brgemm_convolution_bwd_strided_t<isa>::create_kernels() {
         // create brgemm kernels for iw_blocks with padded areas and
         // apply post-ops on final iteration by kw to padded areas in iw_block
         int kw_s {0}, kw_full_s {0}, kw_full_f {0}, kw_f {0}, iw_s {0},
-                iw_f {0}, M_without_overflow {0};
+                M_without_overflow {0};
+        dim_t iw_f {0};
 
-        auto init_kernels_kw_loop = [&](int sw, int iw) {
+        auto init_kernels_kw_loop = [&](dim_t sw, dim_t iw) {
             const auto iw_str = iw + sw;
-            _pd->get_kw_range(iw_str, iw, kw_s, kw_full_s, kw_full_f, kw_f);
+            _pd->get_kw_range(static_cast<int>(iw_str), static_cast<int>(iw),
+                    kw_s, kw_full_s, kw_full_f, kw_f);
             for (int kw = kw_s; kw < kw_f; kw++) {
-                _pd->get_iw_range(iw_str, iw, kw, iw_s, M_without_overflow);
+                _pd->get_iw_range(static_cast<int>(iw_str),
+                        static_cast<int>(iw), kw, iw_s, M_without_overflow);
                 if (M_without_overflow <= 0) continue;
 
                 bool is_iw_tail = (jcp.iw - iw < jcp.iw_block);
@@ -579,14 +583,16 @@ void brgemm_convolution_bwd_strided_t<isa>::create_kernels() {
                                       SW)
                             * SW;
                     if (M <= 0) continue;
-                    _pd->get_iw_range(iw_str, iw, kw, iw_s, M_without_overflow);
+                    _pd->get_iw_range(static_cast<int>(iw_str),
+                            static_cast<int>(iw), kw, iw_s, M_without_overflow);
                     iw_f = iw_s + (M_without_overflow * SW);
                     const auto init_bcast_dim
                             = ((i_side == 0) ? (iw_s - iw_str)
                                              : (iw_str + M - iw_f))
                             / SW;
-                    _pd->get_iw_range(
-                            iw_str, iw, kw_f - kw, iw_s, M_without_overflow);
+                    _pd->get_iw_range(static_cast<int>(iw_str),
+                            static_cast<int>(iw), kw_f - kw, iw_s,
+                            M_without_overflow);
                     iw_f = iw_s + (M_without_overflow * SW);
                     const auto po_bcast_dim
                             = ((i_side == 0) ? (iw_s - iw_str)
@@ -605,11 +611,11 @@ void brgemm_convolution_bwd_strided_t<isa>::create_kernels() {
             }
         };
         for (int sw = 0; sw < SW; sw++) {
-            for (int iw = 0; iw < IW; iw += jcp.iw_block) {
+            for (dim_t iw = 0; iw < IW; iw += jcp.iw_block) {
                 init_kernels_kw_loop(sw, iw);
                 if (kw_f == jcp.kw && kw_s == 0) break;
             }
-            for (int iw = (jcp.nb_iw - 1) * jcp.iw_block; iw >= 0;
+            for (dim_t iw = (jcp.nb_iw - 1) * jcp.iw_block; iw >= 0;
                     iw -= jcp.iw_block) {
                 init_kernels_kw_loop(sw, iw);
                 if (kw_f == jcp.kw && kw_s == 0) break;
@@ -701,7 +707,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::init(engine_t *engine) {
     brg_kernels_.resize(_pd->brgs_sz_);
     brgemm_palettes_.resize(_pd->brgs_sz_);
 
-    int num_po_kernels = nstl::max(jcp.M, jcp.M_tail);
+    const dim_t num_po_kernels = nstl::max<dim_t>(jcp.M, jcp.M_tail);
     kernels_po_.resize(num_po_kernels * 2 * 2);
     for (int i = 0; i < num_po_kernels; i++) {
         for_(int i_init = 0; i_init < 2; i_init++)
@@ -882,7 +888,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
 
         dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
-        int n {0}, g {0}, icb {0}, idb {0}, ihb {0}, iwb {0};
+        dim_t n {0}, g {0}, icb {0}, idb {0}, ihb {0}, iwb {0};
 
         nd_iterator_init(start, n, jcp.mb, idb, jcp.nb_id, ihb, jcp.nb_ih, iwb,
                 jcp.nb_iw, g, jcp.ngroups, icb, jcp.nb_ic);
@@ -899,12 +905,12 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
         brgemm_bwd_thread_ctx_t btc(
                 brgemm_ctx, ithr, brg_batch, c_buffer, out_buffer, wsp_tile);
 
-        int last_n = -1;
-        int last_g = -1;
-        int last_occ = -1;
-        int last_idb = -1;
-        int last_ihb = -1;
-        int last_iwb = -1;
+        dim_t last_n = -1;
+        dim_t last_g = -1;
+        dim_t last_occ = -1;
+        dim_t last_idb = -1;
+        dim_t last_ihb = -1;
+        dim_t last_iwb = -1;
         for (auto work = start; work < end; work++) {
             btc.g = g;
             btc.n = n;
@@ -923,13 +929,13 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                     = jcp.s8s8_compensation_required ? s8s8_comp_base : nullptr;
 
             auto id_begin = idb * jcp.id_block;
-            auto id_end = nstl::min(ID, id_begin + jcp.id_block);
+            auto id_end = nstl::min<dim_t>(ID, id_begin + jcp.id_block);
             auto ih_begin = ihb * jcp.ih_block;
-            auto ih_end = nstl::min(IH, ih_begin + jcp.ih_block);
+            auto ih_end = nstl::min<dim_t>(IH, ih_begin + jcp.ih_block);
             auto iw_begin = iwb * jcp.iw_block;
 
-            for_(int id = id_begin; id < id_end; id++)
-            for (int ih = ih_begin; ih < ih_end; ih++) {
+            for_(dim_t id = id_begin; id < id_end; id++)
+            for (dim_t ih = ih_begin; ih < ih_end; ih++) {
                 // Zero out_buffer before processing the tail iw block to
                 // prevent stale scratchpad data from leaking into positions
                 // that may not be written (e.g., stride sectors with no
@@ -972,7 +978,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::execute(
                         && iwb == jcp.nb_iw - 1) {
                     const bool is_ic_tail
                             = jcp.ic - (btc.icb * jcp.ic_block) < jcp.ic_block;
-                    const int ic_size
+                    const dim_t ic_size
                             = is_ic_tail ? jcp.ic % jcp.ic_block : jcp.ic_block;
 
                     auto cp = jit_brgemm_conv_bwd_copy_kernel_args_t();
@@ -1024,7 +1030,7 @@ void brgemm_convolution_bwd_strided_t<isa>::cal_compensation(
         if (ithr >= work_amount) return;
 
         dim_t start {0}, end {0};
-        int g {0}, icb {0}, k {0};
+        dim_t g {0}, icb {0}, k {0};
         balance211(work_amount, nthr, ithr, start, end);
         nd_iterator_init(
                 start, g, jcp.ngroups, icb, jcp.nb_ic, k, jcp.ker_ranges_size);
@@ -1097,10 +1103,11 @@ void brgemm_convolution_bwd_strided_t<isa>::cal_compensation(
 
 template <cpu_isa_t isa>
 void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
-        char *dst, char *c_buffer, const char *bias_w, int id, int ih, int iw,
-        int iw_raw, int g_ic, bool is_ic_tail, int ker_iw_s, int ker_iw_f,
-        int kd_l, int kh_l, const void *post_ops_binary_rhs_arg_vec,
-        int32_t src_zp_val, int32_t *src_zp_ptr, const int32_t *dst_zp_ptr,
+        char *dst, char *c_buffer, const char *bias_w, dim_t id, dim_t ih,
+        dim_t iw, dim_t iw_raw, dim_t g_ic, bool is_ic_tail, dim_t ker_iw_s,
+        dim_t ker_iw_f, dim_t kd_l, dim_t kh_l,
+        const void *post_ops_binary_rhs_arg_vec, int32_t src_zp_val,
+        int32_t *src_zp_ptr, const int32_t *dst_zp_ptr,
         int32_t *s8s8_compensation, size_t comp_ker_offs, bool maybe_do_init,
         bool do_postwork, bool do_post_comp, const void *src_scales,
         const void *wei_scales, const void *dst_scales) const {
@@ -1138,7 +1145,7 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
     }
 
     auto call_outwork_ker = [&](bool is_postwork, bool has_postcomp,
-                                    int iw_pw_s, int iw_pw_l) {
+                                    dim_t iw_pw_s, dim_t iw_pw_l) {
         auto ker_po_idx = get_ker_po_idx(iw_pw_l - 1, is_postwork, is_ic_tail);
         const auto outwork_ker = kernels_po_[ker_po_idx].get();
         const auto comp_iw_s = get_comp_iw(iw_pw_s);
@@ -1160,7 +1167,7 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
             p.ptr_in = static_cast<void *>(jcp.use_buffer
                             ? (c_buffer
                                       + acc_dsz
-                                              * div_up(nstl::max(
+                                              * div_up(nstl::max<dim_t>(
                                                                0, iw_pw_s - iw),
                                                       SW)
                                               * jcp.LDC)
@@ -1169,7 +1176,10 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
             p.apply_comp = has_postcomp;
             char *const ptr_Cz = jcp.use_buffer
                     ? (c_buffer
-                              + acc_dsz * div_up(nstl::max(0, iw_pw_s - iw), SW)
+                              + acc_dsz
+                                      * div_up(
+                                              nstl::max<dim_t>(0, iw_pw_s - iw),
+                                              SW)
                                       * jcp.LDC)
                     : dst_base
                             + dst_dsz
@@ -1195,7 +1205,7 @@ void brgemm_convolution_bwd_strided_t<isa>::perform_outwork(char *dst_base,
 template <cpu_isa_t isa>
 void brgemm_convolution_bwd_strided_t<isa>::call_brgemm_kernel(
         brgemm_bwd_thread_ctx_t &btc, int brg_idx, int batch_size, char *ptr_C,
-        char *ptr_D, const char *bias_w, int g_ic, bool do_postops,
+        char *ptr_D, const char *bias_w, dim_t g_ic, bool do_postops,
         const void *binary_post_ops_rhs, int32_t src_zp_val,
         int32_t *src_zp_ptr, const int32_t *dst_zp_ptr, int32_t *s8s8_comp,
         bool do_only_comp, bool is_first_call_postops,
@@ -1247,9 +1257,9 @@ void brgemm_convolution_bwd_strided_t<isa>::call_brgemm_kernel(
 template <cpu_isa_t isa>
 void brgemm_convolution_bwd_strided_t<isa>::maybe_trans_inp(int ithr,
         const char *__restrict src, char *__restrict inp_buffer,
-        uint8_t *__restrict inp_buffer_mask, int g, int n, int occ, int idb,
-        int ihb, int iwb, int last_g, int last_n, int last_occ, int last_idb,
-        int last_ihb, int last_iwb) const {
+        uint8_t *__restrict inp_buffer_mask, dim_t g, dim_t n, dim_t occ,
+        dim_t idb, dim_t ihb, dim_t iwb, dim_t last_g, dim_t last_n,
+        dim_t last_occ, dim_t last_idb, dim_t last_ihb, dim_t last_iwb) const {
 
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
@@ -1279,7 +1289,7 @@ void brgemm_convolution_bwd_strided_t<isa>::maybe_trans_inp(int ithr,
     const auto ow = (iwb * jcp.iw_block + jcp.l_pad - kw_x * (jcp.dilate_w + 1))
             / jcp.stride_w;
 
-    int od_start {0}, od_end {0}, oh_start {0}, oh_end {0};
+    dim_t od_start {0}, od_end {0}, oh_start {0}, oh_end {0};
 
     const auto sh = jcp.t_pad % jcp.stride_h;
     const auto kh = (jcp.kh - 1) % jcp.stride_h;
@@ -1295,27 +1305,30 @@ void brgemm_convolution_bwd_strided_t<isa>::maybe_trans_inp(int ithr,
             / jcp.stride_d;
     od_end = od_start + jcp.od_block;
 
-    const auto rows_to_copy = min(jcp.oh, oh_end) - nstl::max(0, oh_start);
+    const dim_t rows_to_copy
+            = nstl::min<dim_t>(jcp.oh, oh_end) - nstl::max<dim_t>(0, oh_start);
     cp.iwb = iwb;
     cp.oc = oc;
-    const auto ow_buf = ow;
+    const dim_t ow_buf = ow;
     dim_t inp_offset_start, out_offset_start;
 
     cp.t_pad = 0;
     cp.b_pad = 0;
-    cp.h_count = nstl::max(0, rows_to_copy);
+    cp.h_count = nstl::max<dim_t>(0, rows_to_copy);
 
-    const auto oh_buf = nstl::max(0, oh_start);
+    const dim_t oh_buf = nstl::max<dim_t>(0, oh_start);
 
     inp_offset_start = static_cast<dim_t>(n) * src_d_sz
-            + nstl::max(0, oh_start) * src_w_sz
-            + nstl::max(0, ow) * jcp.ngroups * jcp.oc_without_padding + g_oc;
+            + nstl::max<dim_t>(0, oh_start) * src_w_sz
+            + nstl::max<dim_t>(0, ow) * jcp.ngroups * jcp.oc_without_padding
+            + g_oc;
     out_offset_start = oh_buf * pbuf_w_sz + ow_buf * jcp.oc_block;
 
-    for (int od = nstl::max(0, od_start); od < min(jcp.od, od_end); od++) {
-        const auto inp_offset = inp_offset_start + od * src_h_sz;
-        const auto od_buf = od;
-        const auto out_offset = out_offset_start + od_buf * pbuf_h_sz;
+    for (dim_t od = nstl::max<dim_t>(0, od_start);
+            od < nstl::min<dim_t>(jcp.od, od_end); od++) {
+        const dim_t inp_offset = inp_offset_start + od * src_h_sz;
+        const dim_t od_buf = od;
+        const dim_t out_offset = out_offset_start + od_buf * pbuf_h_sz;
         cp.src = src + src_dsz * inp_offset;
         cp.dst = inp_buffer + src_dsz * out_offset;
 
@@ -1337,11 +1350,11 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     const auto diff_dst = btc.brgemm_ctx.diff_dst;
     const std::vector<const void *> &post_ops_binary_rhs_arg_vec
             = btc.brgemm_ctx.post_ops_binary_rhs_arg_vec;
-    const int ic = btc.icb * jcp.ic_block;
-    const int g_ic = btc.g * jcp.ic + ic;
-    const int ocb = btc.occ * jcp.nb_oc_blocking;
-    const int oc = ocb * jcp.oc_block;
-    const int g_oc = btc.g * jcp.oc + oc;
+    const dim_t ic = btc.icb * jcp.ic_block;
+    const dim_t g_ic = btc.g * jcp.ic + ic;
+    const dim_t ocb = btc.occ * jcp.nb_oc_blocking;
+    const dim_t oc = ocb * jcp.oc_block;
+    const dim_t g_oc = btc.g * jcp.oc + oc;
     const dim_t iw = static_cast<dim_t>(btc.iwb) * jcp.iw_block + btc.sw;
     const dim_t iw_raw = static_cast<dim_t>(btc.iwb) * jcp.iw_block;
     const dim_t ih = btc.ih;
@@ -1351,9 +1364,11 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     const bool is_ic_tail = (jcp.ic - ic < jcp.ic_block);
     const char *const __restrict bias_w
             = bias ? bias + (bias_d.blk_off(g_ic) * bia_dsz) : nullptr;
-    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0}, kw_b(0), kw_e(0);
+    int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
+    dim_t kw_b {0}, kw_e {0};
     int kd_s_(0), kh_s_(0), kd_f_(0), kh_f_(0);
-    _pd->get_kw_range(iw, iw_raw, kw_s, kw_full_s, kw_full_f, kw_f);
+    _pd->get_kw_range(static_cast<int>(iw), static_cast<int>(iw_raw), kw_s,
+            kw_full_s, kw_full_f, kw_f);
 
     // od = (id + FP - kd * DD) / SD <-- general relation for all sets of (od, id, kd) that overlap
     // for a given index from diff_src, we need to find the appropriate stride sector
@@ -1374,19 +1389,19 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
             = diff_src + dst_dsz * (btc.n * dst_d_sz + g_ic);
     const auto wei_base
             = weights + wei_dsz * (btc.g * wei_icb_sz + btc.icb * wei_kd_sz);
-    const auto nb_oc_b = nstl::min(jcp.nb_oc_blocking, jcp.nb_oc - ocb)
+    const dim_t nb_oc_b = nstl::min<dim_t>(jcp.nb_oc_blocking, jcp.nb_oc - ocb)
             - (is_oc_tail ? 1 : 0);
     char *ptr_C;
     char *ptr_D;
-    int kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0);
+    dim_t kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0);
 
     const auto kd_l_full = kd_f - kd_s;
     const auto kh_l_full = kh_f - kh_s;
 
     bool is_first_call_postops = false,
          is_first_call_postops_state_changed = false;
-    const auto call_brgemm = [&](int iw, int brg_idx, int oc_block_s,
-                                     int n_oc_blocks, size_t comp_ker_offs,
+    const auto call_brgemm = [&](dim_t iw, int brg_idx, dim_t oc_block_s,
+                                     dim_t n_oc_blocks, size_t comp_ker_offs,
                                      bool do_postops, bool do_only_comp) {
         if (brg_idx < 0) {
             assert(!"Requested brgemm kernel was not created.");
@@ -1400,7 +1415,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
         int32_t *s8s8_comp = jcp.s8s8_compensation_required
                 ? &btc.s8s8_comp_ptr[comp_ker_offs]
                 : nullptr;
-        for (int i_ocb = 0; i_ocb < n_oc_blocks; i_ocb++) {
+        for (dim_t i_ocb = 0; i_ocb < n_oc_blocks; i_ocb++) {
             const auto oc_off = (oc_block_s + i_ocb) * jcp.oc_block;
             const auto src_oc = oc_off;
             const auto wei_oc = oc + oc_off;
@@ -1409,14 +1424,14 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
             const auto wei_base_oc = wei_base + wei_dsz * wei_oc * jcp.ic_block;
 
             auto k = 0;
-            for (int kd = kd_b; kd < kd_e; kd++) {
+            for (dim_t kd = kd_b; kd < kd_e; kd++) {
                 auto od = (id - kd * DD + FP);
                 if (od % SD != 0) continue;
                 od /= SD;
                 const auto diff_dst_base_kd
                         = diff_dst_base_oc + src_dsz * od * src_h_sz;
                 const auto wei_base_kd = wei_base_oc + wei_dsz * kd * wei_kh_sz;
-                for (int kh = kh_b; kh < kh_ee; kh++) {
+                for (dim_t kh = kh_b; kh < kh_ee; kh++) {
                     auto oh = (ih - kh * DH + TP);
                     if (oh % SH != 0) continue;
                     oh /= SH;
@@ -1424,7 +1439,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
                             = diff_dst_base_kd + src_dsz * oh * src_w_sz;
                     const auto wei_base_kh
                             = wei_base_kd + wei_dsz * kh * wei_kw_sz;
-                    for (int kw = kw_b; kw < kw_e; kw += SW) {
+                    for (dim_t kw = kw_b; kw < kw_e; kw += SW) {
                         auto ow = (iw - kw * DW + LP) / SW;
                         // inp_buffer layout is Cdhw<oc_block>c
                         btc.brg_batch[n_ocb_off + k].ptr.A = diff_dst_base_kh
@@ -1458,7 +1473,8 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     const auto kdhw_loop = [&]() {
         if (kw_e - kw_b <= 0 || kw_b >= jcp.kw) return;
         int iw_b {0}, M_without_overflow {0};
-        _pd->get_iw_range(iw, iw_raw, kw_b, iw_b, M_without_overflow);
+        _pd->get_iw_range(static_cast<int>(iw), static_cast<int>(iw_raw),
+                static_cast<int>(kw_b), iw_b, M_without_overflow);
         const auto iw_e = iw_b + M_without_overflow;
         const auto do_init
                 = btc.occ == 0 && kd_b == kd_s && kh_b == kh_s && kw_b == kw_s;
@@ -1470,9 +1486,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
                 && btc.occ == (oc_chunks - 1);
         if (iw_e - iw_b <= 0 && !do_init && !do_postwork) return;
 
-        const int kd_l = div_up(nstl::max(0, kd_e - kd_b), SD);
-        const int kh_l = div_up(nstl::max(0, kh_e - kh_b), SH);
-        const int kw_l = div_up(nstl::max(0, kw_e - kw_b), SW);
+        const dim_t kd_l = div_up(nstl::max<dim_t>(0, kd_e - kd_b), SD);
+        const dim_t kh_l = div_up(nstl::max<dim_t>(0, kh_e - kh_b), SH);
+        const dim_t kw_l = div_up(nstl::max<dim_t>(0, kw_e - kw_b), SW);
         k_l = kd_l * kh_l * kw_l;
         const auto iw_l = iw_e - iw_b;
 
@@ -1495,7 +1511,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
 
         if (iw_l > 0 && k_l > 0) {
             if (nb_oc_b > 0) {
-                const auto brg_idx
+                const int brg_idx
                         = _pd->get_brg_idx(ker_i, do_init, is_ic_tail, false);
                 call_brgemm(iw_b, brg_idx, 0, nb_oc_b, comp_ker_offs,
                         do_postwork && !is_oc_tail, do_only_comp);
@@ -1503,7 +1519,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
 
             if (is_oc_tail) {
                 const auto use_init_ker = (do_init && nb_oc_b == 0);
-                const auto brg_oc_tail_idx = _pd->get_brg_idx(
+                const int brg_oc_tail_idx = _pd->get_brg_idx(
                         ker_i, use_init_ker, is_ic_tail, true);
                 call_brgemm(iw_b, brg_oc_tail_idx, nb_oc_b, 1, comp_ker_offs,
                         do_postwork, do_only_comp);
@@ -1522,9 +1538,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
     if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s && kw_s < jcp.kw) {
         if (kw_s < kw_full_s) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK_PAD);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK_PAD);
                     for (auto kw = kw_s; kw < kw_full_s; kw += SW) {
                         kw_b = kw;
                         kw_e = kw + 1;
@@ -1536,11 +1552,11 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
 
         if (kw_full_s < kw_full_f) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                     for (kw_b = kw_full_s; kw_b < kw_full_f; kw_b += KW_BLOCK) {
-                        kw_e = nstl::min(kw_full_f, kw_b + KW_BLOCK);
+                        kw_e = nstl::min<dim_t>(kw_full_f, kw_b + KW_BLOCK);
                         kdhw_loop();
                     }
                 }
@@ -1549,9 +1565,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_base(
 
         if (kw_full_f < kw_f) {
             for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK_PAD) {
-                kd_e = nstl::min(kd_f, kd_b + KD_BLOCK_PAD);
+                kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK_PAD);
                 for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK_PAD) {
-                    kh_e = nstl::min(kh_f, kh_b + KH_BLOCK_PAD);
+                    kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK_PAD);
                     for (int kw = kw_full_f; kw < kw_f; kw += SW) {
                         kw_b = kw;
                         kw_e = kw + 1;
@@ -1585,10 +1601,10 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
     char *const __restrict diff_src = btc.brgemm_ctx.diff_src;
     const std::vector<const void *> &post_ops_binary_rhs_arg_vec
             = btc.brgemm_ctx.post_ops_binary_rhs_arg_vec;
-    const int ic = btc.icb * jcp.ic_block;
-    const int g_ic = btc.g * jcp.ic + ic;
-    const int ocb = btc.occ * jcp.nb_oc_blocking;
-    const int oc = ocb * jcp.oc_block;
+    const dim_t ic = btc.icb * jcp.ic_block;
+    const dim_t g_ic = btc.g * jcp.ic + ic;
+    const dim_t ocb = btc.occ * jcp.nb_oc_blocking;
+    const dim_t oc = ocb * jcp.oc_block;
     const dim_t iw = static_cast<dim_t>(btc.iwb) * jcp.iw_block + btc.sw;
     const dim_t ih = btc.ih;
     const dim_t id = btc.id;
@@ -1616,7 +1632,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
     const bool is_ic_tail = (jcp.ic - ic < jcp.ic_block);
     const char *const __restrict bias_w
             = bias ? bias + (bias_d.blk_off(g_ic) * bia_dsz) : nullptr;
-    const auto nb_oc_b = nstl::min(jcp.nb_oc_blocking, jcp.nb_oc - ocb)
+    const dim_t nb_oc_b = nstl::min<dim_t>(jcp.nb_oc_blocking, jcp.nb_oc - ocb)
             - (is_oc_tail ? 1 : 0);
 
     const bool is_tail_iwb = btc.iwb == jcp.nb_iw - 1;
@@ -1627,7 +1643,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                     : diff_src + dst_dsz * (btc.n * dst_d_sz + g_ic));
     char *ptr_C;
     char *ptr_D;
-    int kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0);
+    dim_t kd_b(0), kd_e(0), kh_b(0), kh_e(0), k_l(0);
 
     const auto wei_base
             = weights + wei_dsz * (btc.g * wei_icb_sz + btc.icb * wei_kd_sz);
@@ -1655,8 +1671,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
 
     bool is_first_call_postops = false,
          is_first_call_postops_state_changed = false;
-    const auto call_brgemm = [&](int brg_idx, int oc_block_s, int n_oc_blocks,
-                                     size_t comp_ker_offs, bool do_postops) {
+    const auto call_brgemm
+            = [&](int brg_idx, dim_t oc_block_s, dim_t n_oc_blocks,
+                      size_t comp_ker_offs, bool do_postops) {
         if (brg_idx < 0) {
             assert(!"Requested brgemm kernel was not created.");
             return;
@@ -1672,7 +1689,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                 : nullptr;
 
         int k_sum = 0;
-        for (int i_ocb = 0; i_ocb < n_oc_blocks; i_ocb++) {
+        for (dim_t i_ocb = 0; i_ocb < n_oc_blocks; i_ocb++) {
             const auto oc_off = (oc_block_s + i_ocb) * jcp.oc_block;
             const auto wei_oc = oc + oc_off;
             const auto n_ocb_off = i_ocb * k_l;
@@ -1680,14 +1697,14 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
             const auto wei_base_oc = wei_base + wei_dsz * wei_oc * jcp.ic_block;
 
             auto k = 0;
-            for (int kd = kd_b; kd < kd_e; kd++) {
+            for (dim_t kd = kd_b; kd < kd_e; kd++) {
                 auto od = (id - kd * DD + FP);
                 if (od % SD != 0) continue;
                 od /= SD;
                 const auto pbuf_base_kd
                         = pbuf_base_oc + src_dsz * od * pbuf_h_sz;
                 const auto wei_base_kd = wei_base_oc + wei_dsz * kd * wei_kh_sz;
-                for (int kh = kh_b; kh < kh_ee; kh++) {
+                for (dim_t kh = kh_b; kh < kh_ee; kh++) {
                     auto oh = (ih - kh * DH + TP);
                     if (oh % SH != 0) continue;
                     oh /= SH;
@@ -1695,7 +1712,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                             = pbuf_base_kd + src_dsz * oh * pbuf_w_sz;
                     const auto wei_base_kh
                             = wei_base_kd + wei_dsz * kh * wei_kw_sz;
-                    for (int kw = kw_s; kw < kw_e; kw += SW) {
+                    for (dim_t kw = kw_s; kw < kw_e; kw += SW) {
                         const auto ow = (iw - kw * DW + LP) / SW;
                         // inp_buffer layout is Cdhw<oc_block>c
                         btc.brg_batch[n_ocb_off + k].ptr.A = pbuf_base_kh
@@ -1721,7 +1738,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                             * (btc.n * dst_d_sz + g_ic + id * dst_h_sz
                                     + ih * dst_w_sz
                                     + iw_begin * jcp.ic_without_padding);
-            const int ic_len = is_ic_tail ? (jcp.ic - ic) : jcp.ic_block;
+            const dim_t ic_len = is_ic_tail ? (jcp.ic - ic) : jcp.ic_block;
             const auto ic_bytes = static_cast<size_t>(ic_len) * dst_dsz;
             const auto stride_bytes = static_cast<size_t>(jcp.stride_w)
                     * jcp.ic_without_padding * dst_dsz;
@@ -1763,9 +1780,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
         const auto do_postwork = need_postwork && btc.occ == (oc_chunks - 1)
                 && kd_e == kd_f && kh_e == kh_f;
 
-        const int kd_l = div_up(nstl::max(0, kd_e - kd_b), SD);
-        const int kh_l = div_up(nstl::max(0, kh_e - kh_b), SH);
-        const int kw_l = div_up(nstl::max(0, kw_f - kw_s), SW);
+        const dim_t kd_l = div_up(nstl::max<dim_t>(0, kd_e - kd_b), SD);
+        const dim_t kh_l = div_up(nstl::max<dim_t>(0, kh_e - kh_b), SH);
+        const dim_t kw_l = div_up(nstl::max<dim_t>(0, kw_f - kw_s), SW);
         k_l = kd_l * kh_l * kw_l;
 
         const auto comp_ker_offs = kd_l * kh_l > 0
@@ -1780,11 +1797,14 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                 // AMX: always use full_m, masked descriptor for postops
                 const auto is_masked
                         = do_postops_here && (ker_i_postops < full_m);
-                brg_idx = _pd->get_brg_idx(full_m, do_init, is_ic_tail, false,
-                        is_masked ? ker_i_postops : 0, k_l);
+                brg_idx = _pd->get_brg_idx(static_cast<int>(full_m), do_init,
+                        is_ic_tail, false,
+                        is_masked ? static_cast<int>(ker_i_postops) : 0,
+                        static_cast<int>(k_l));
             } else {
                 // Non-AMX: use actual reduced M for postops call
-                const auto m = do_postops_here ? ker_i_postops : full_m;
+                const int m = do_postops_here ? static_cast<int>(ker_i_postops)
+                                              : static_cast<int>(full_m);
                 brg_idx = _pd->get_brg_idx(m, do_init, is_ic_tail, false);
             }
             call_brgemm(brg_idx, 0, nb_oc_b, comp_ker_offs, do_postops_here);
@@ -1795,10 +1815,13 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
             const auto use_init_ker = (do_init && nb_oc_b == 0);
             if (jcp.use_uker) {
                 const auto is_masked = do_postwork && (ker_i_postops < full_m);
-                brg_oc_tail_idx = _pd->get_brg_idx(full_m, use_init_ker,
-                        is_ic_tail, true, is_masked ? ker_i_postops : 0, k_l);
+                brg_oc_tail_idx = _pd->get_brg_idx(static_cast<int>(full_m),
+                        use_init_ker, is_ic_tail, true,
+                        is_masked ? static_cast<int>(ker_i_postops) : 0,
+                        static_cast<int>(k_l));
             } else {
-                const auto m = do_postwork ? ker_i_postops : full_m;
+                const int m = do_postwork ? static_cast<int>(ker_i_postops)
+                                          : static_cast<int>(full_m);
                 brg_oc_tail_idx
                         = _pd->get_brg_idx(m, use_init_ker, is_ic_tail, true);
             }
@@ -1810,9 +1833,9 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
     if (kd_f > kd_s && kh_f > kh_s && kw_f > kw_s) {
         // kw values covering full ow_block
         for (kd_b = kd_s; kd_b < kd_f; kd_b += KD_BLOCK) {
-            kd_e = nstl::min(kd_f, kd_b + KD_BLOCK);
+            kd_e = nstl::min<dim_t>(kd_f, kd_b + KD_BLOCK);
             for (kh_b = kh_s; kh_b < kh_f; kh_b += KH_BLOCK) {
-                kh_e = nstl::min(kh_f, kh_b + KH_BLOCK);
+                kh_e = nstl::min<dim_t>(kh_f, kh_b + KH_BLOCK);
                 kdhw_loop();
             }
         }
@@ -1835,7 +1858,7 @@ void brgemm_convolution_bwd_strided_t<isa>::ker_trans(
                                 * (btc.n * dst_d_sz + g_ic + id * dst_h_sz
                                         + ih * dst_w_sz
                                         + iw_begin * jcp.ic_without_padding);
-                const int ic_len = is_ic_tail ? (jcp.ic - ic) : jcp.ic_block;
+                const dim_t ic_len = is_ic_tail ? (jcp.ic - ic) : jcp.ic_block;
                 const auto ic_bytes = static_cast<size_t>(ic_len) * dst_dsz;
                 const auto stride_bytes = static_cast<size_t>(jcp.stride_w)
                         * jcp.ic_without_padding * dst_dsz;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.hpp
@@ -58,20 +58,21 @@ struct brgemm_convolution_bwd_strided_t : public primitive_t {
         const int first_bs = 0;
 
         // need custom hasher to use array as key in unordered_map
-        template <int asize>
+        template <int asize, typename T = int>
         struct hasher_t {
-            size_t operator()(const std::array<int, asize> &a) const {
+            size_t operator()(const std::array<T, asize> &a) const {
                 size_t seed = 0;
                 for (auto e : a)
                     seed = hash_combine(seed, e);
                 return seed;
             }
         };
-        template <int asize>
-        using Arrmap = std::unordered_map<std::array<int, asize>, int,
-                hasher_t<asize>>;
+        template <int asize, typename T = int>
+        using Arrmap = std::unordered_map<std::array<T, asize>, T,
+                hasher_t<asize, T>>;
 
         int brg_indices_c {0};
+        // Bounded kernel-variant lookup key/index, not tensor-scale.
         Arrmap<6> brg_indices;
 
         int get_brg_idx(int m, bool do_initialization, bool is_N_tail,
@@ -94,8 +95,8 @@ struct brgemm_convolution_bwd_strided_t : public primitive_t {
             return 0;
         }
 
-        status_t add_brg_descriptor(int M, bool is_N_tail, bool is_K_tail,
-                bool do_init, int bd_mask_idx = 0,
+        status_t add_brg_descriptor(dim_t M, bool is_N_tail, bool is_K_tail,
+                bool do_init, dim_t bd_mask_idx = 0,
                 const std::vector<char> &bd_mask = {}, int bs = 0);
         void get_kw_range(int iw, int iw_raw, int &kw_s, int &kw_full_s,
                 int &kw_full_e, int &kw_e) const;
@@ -166,10 +167,10 @@ private:
         char *out_buffer;
         char *wsp_tile;
         int cur_brg_idx;
-        int g, n, icb;
-        int id, idb, ih, ihb, iwb;
-        int occ;
-        int sw;
+        dim_t g, n, icb;
+        dim_t id, idb, ih, ihb, iwb;
+        dim_t occ;
+        dim_t sw;
         const void *src_scales;
         const void *wei_scales;
         const void *dst_scales;
@@ -179,12 +180,13 @@ private:
         int32_t *s8s8_comp_ptr;
     };
 
-    inline static int get_ker_po_idx(int m, bool do_postwork, bool is_N_tail) {
-        return (m * 2 + static_cast<int>(do_postwork)) * 2
-                + static_cast<int>(is_N_tail);
+    inline static int get_ker_po_idx(
+            dim_t m, bool do_postwork, bool is_N_tail) {
+        return static_cast<int>((m * 2 + static_cast<int>(do_postwork)) * 2
+                + static_cast<int>(is_N_tail));
     }
 
-    inline int get_comp_iw(const int iw) const {
+    inline dim_t get_comp_iw(dim_t iw) const {
         return utils::div_up(IW, SW) * (iw % SW) + iw / SW;
     }
 
@@ -192,10 +194,10 @@ private:
     void ker_trans(brgemm_bwd_thread_ctx_t &btc, char *inp_buffer) const;
 
     void perform_outwork(char *dst_base, char *dst, char *c_buffer,
-            const char *bias_w, int od, int oh, int ow, int iw_raw, int g_oc,
-            bool is_oc_tail, int ker_ow_s, int ker_ow_f, int kd_l, int kh_l,
-            const void *post_ops_binary_rhs_arg_vec, int32_t src_zp_val,
-            int32_t *src_zp_ptr, const int32_t *dst_zp_ptr,
+            const char *bias_w, dim_t od, dim_t oh, dim_t ow, dim_t iw_raw,
+            dim_t g_oc, bool is_oc_tail, dim_t ker_ow_s, dim_t ker_ow_f,
+            dim_t kd_l, dim_t kh_l, const void *post_ops_binary_rhs_arg_vec,
+            int32_t src_zp_val, int32_t *src_zp_ptr, const int32_t *dst_zp_ptr,
             int32_t *s8s8_compensation, size_t comp_ker_offs,
             bool maybe_do_init, bool do_postwork, bool do_post_comp,
             const void *src_scales, const void *wei_scales,
@@ -203,28 +205,27 @@ private:
 
     void call_brgemm_kernel(brgemm_bwd_thread_ctx_t &btc, int brg_idx,
             int batch_size, char *ptr_C, char *ptr_D, const char *bias_w,
-            int g_ic, bool do_postops, const void *binary_post_ops_rhs,
+            dim_t g_ic, bool do_postops, const void *binary_post_ops_rhs,
             int32_t src_zp_val, int32_t *src_zp_ptr, const int32_t *dst_zp_ptr,
             int32_t *s8s8_comp, bool do_only_comp, bool is_first_call_postops,
             const char *dst_orig_override = nullptr) const;
 
     void maybe_trans_inp(int ithr, const char *__restrict input,
             char *__restrict inp_buffer, uint8_t *__restrict inp_buffer_mask,
-            int g, int n, int icc, int odb, int ohb, int owb, int last_g,
-            int last_n, int last_icc, int last_odb, int last_ohb,
-            int last_owb) const;
+            dim_t g, dim_t n, dim_t icc, dim_t odb, dim_t ohb, dim_t owb,
+            dim_t last_g, dim_t last_n, dim_t last_icc, dim_t last_odb,
+            dim_t last_ohb, dim_t last_owb) const;
 
     status_t add_po_kernel(brgemm_desc_t *bcfg, int ker_idx, bool is_init);
-    void add_po_kernels(int i_N, int init_bcast_dim, int po_bcast_dim);
+    void add_po_kernels(int i_N, dim_t init_bcast_dim, dim_t po_bcast_dim);
     status_t add_brg_kernel(int brg_idx);
 
     void cal_compensation(const char *__restrict weights,
             int32_t *src_zp_buffer, int32_t *s8s8_comp_buffer) const;
-    int get_comp_ker_idx(const int kd_b, const int kd_e, const int kh_b,
-            const int kh_e, const int kw_b, const int kw_e) const;
-    int get_comp_offset(const int g, const int icb, const int iw,
-            const int kd_b, const int kd_e, const int kh_b, const int kh_e,
-            const int kw_b, const int kw_e) const;
+    dim_t get_comp_ker_idx(dim_t kd_b, dim_t kd_e, dim_t kh_b, dim_t kh_e,
+            dim_t kw_b, dim_t kw_e) const;
+    dim_t get_comp_offset(dim_t g, dim_t icb, dim_t iw, dim_t kd_b, dim_t kd_e,
+            dim_t kh_b, dim_t kh_e, dim_t kw_b, dim_t kw_e) const;
     void create_kernels();
 
     const pd_t *pd() const {
@@ -254,7 +255,7 @@ private:
     // precalculated values
     std::vector<dim_t> kd_bs, kd_es, kh_bs, kh_es, kw_bs, kw_es;
 
-    int KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
+    dim_t KD, KH, KW, EXT_KD, EXT_KH, EXT_KW, KS, KD_BLOCK, KH_BLOCK, KW_BLOCK,
             KD_BLOCK_PAD, KH_BLOCK_PAD, ID, IH, IW, ODP, OHP, OWP, OD, OH, OW,
             SD, SH, SW, FP, TP, LP, DD, DH, DW;
     dim_t src_w_sz, src_h_sz, src_d_sz, dst_w_sz, dst_h_sz, dst_d_sz, wei_oc_sz,
@@ -262,7 +263,7 @@ private:
     dim_t pbuf_w_sz, pbuf_h_sz, pbuf_d_sz;
     dim_t comp_icb_sz, comp_ker_sz, comp_kw_sz, comp_iw_sz;
 
-    int oc_chunks;
+    dim_t oc_chunks;
     bool need_postwork;
     bool need_compensation;
     bool is_amx;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.cpp
@@ -48,16 +48,16 @@ jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::
     , n_tail_vec((jcp.oc_without_padding % jcp.oc_block) / jcp.simd_w) {}
 
 template <typename Vmm>
-int jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::inp_w(
-        int out_w) const {
+dim_t jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::inp_w(
+        dim_t out_w) const {
     const auto res = div_up(out_w + jcp.l_pad % jcp.stride_w, jcp.stride_w)
             + (jcp.ext_kw - 1 - jcp.l_pad % jcp.stride_w) / jcp.stride_w;
     return res;
 }
 
 template <typename Vmm>
-int jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::inp_w_start(
-        int iwb) const {
+dim_t jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::inp_w_start(
+        dim_t iwb) const {
     const auto sw = jcp.l_pad % jcp.stride_w;
     const auto kw = (jcp.kw - 1) % jcp.stride_w;
     const auto kw_x = (jcp.kw - 1) - nstl::modulo(kw - sw, jcp.stride_w);
@@ -104,13 +104,13 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::store(
 template <>
 void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Xbyak::Ymm>::load(
         const Xbyak::Ymm &x, const Xbyak::Address &addr, const int load_size) {
-    load_bytes(x, addr, jcp.src_dsz * load_size, true);
+    load_bytes(x, addr, static_cast<int>(jcp.src_dsz * load_size), true);
 }
 
 template <>
 void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Xbyak::Ymm>::store(
         const Xbyak::Address &addr, const Xbyak::Ymm &x, const int store_size) {
-    store_bytes(x, addr, jcp.src_dsz * store_size);
+    store_bytes(x, addr, static_cast<int>(jcp.src_dsz * store_size));
 }
 
 template <typename Vmm>
@@ -312,7 +312,7 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
     int start_last_partial_block = -1;
     int end_last_partial_block = -1;
 
-    int iw_block_tail = jcp.iw % jcp.iw_block;
+    dim_t iw_block_tail = jcp.iw % jcp.iw_block;
 
     for (int iwb = 0; iwb < jcp.nb_iw; iwb++) {
         const auto inp_block = inp_w(jcp.iw_block);
@@ -350,14 +350,14 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
     if (start_first_partial_block != -1) {
         for (int b = start_first_partial_block; b <= end_first_partial_block;
                 b++) {
-            int cur_iw_block = (b == jcp.nb_iw - 1 && iw_block_tail > 0)
+            dim_t cur_iw_block = (b == jcp.nb_iw - 1 && iw_block_tail > 0)
                     ? iw_block_tail
                     : jcp.iw_block;
             const auto inp_block = inp_w(cur_iw_block);
             const auto inp_start = inp_w_start(b);
             const auto inp_end = inp_start + inp_block;
             const auto block_lpad = -inp_start;
-            const auto block_len = nstl::min(jcp.ow, inp_end);
+            const dim_t block_len = nstl::min<dim_t>(jcp.ow, inp_end);
             Xbyak::Label skip_first_partial_block;
             cmp(reg_iwb, b);
             jne(skip_first_partial_block, T_NEAR);
@@ -378,14 +378,15 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
     if (start_last_partial_block != -1) {
         for (int b = start_last_partial_block; b <= end_last_partial_block;
                 b++) {
-            int cur_iw_block = (b == jcp.nb_iw - 1 && iw_block_tail > 0)
+            dim_t cur_iw_block = (b == jcp.nb_iw - 1 && iw_block_tail > 0)
                     ? iw_block_tail
                     : jcp.iw_block;
             const auto inp_block = inp_w(cur_iw_block);
             const auto inp_start = inp_w_start(b);
             const auto inp_end = inp_start + inp_block;
             const auto block_lpad = 0;
-            const auto block_len = nstl::min(jcp.ow, inp_end) - inp_start;
+            const dim_t block_len
+                    = nstl::min<dim_t>(jcp.ow, inp_end) - inp_start;
             Xbyak::Label skip_last_partial_block;
             cmp(reg_iwb, b);
             jne(skip_last_partial_block, T_NEAR);
@@ -405,7 +406,7 @@ void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block(
 
 template <typename Vmm>
 void jit_avx512_core_brgemm_conv_bwd_trans_kernel_t<Vmm>::copy_iw_block_body(
-        int lpad, int iw_len, int ow_len, bool is_oc_tail) {
+        dim_t lpad, dim_t iw_len, dim_t ow_len, bool is_oc_tail) {
     const auto dst_width = inp_w(iw_len) + lpad;
     for (dim_t ind_w = 0; ind_w < dst_width; ind_w++) {
         auto ow_idx = ind_w - lpad;

--- a/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_trans_kernel.hpp
@@ -89,10 +89,11 @@ protected:
             bool do_load = true);
     void generate() override;
     void copy_iw_block(bool is_oc_tail);
-    void copy_iw_block_body(int lpad, int iw_len, int ow_len, bool is_oc_tail);
+    void copy_iw_block_body(
+            dim_t lpad, dim_t iw_len, dim_t ow_len, bool is_oc_tail);
 
-    int inp_w(int out_w) const;
-    int inp_w_start(int iwb) const;
+    dim_t inp_w(dim_t out_w) const;
+    dim_t inp_w_start(dim_t iwb) const;
 };
 
 } // namespace jit_avx512_core_brgemm_conv_bwd_trans_kernel

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -436,8 +436,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         bcast_simd = acc_simd_w;
     }
 
-    int ur, ur_block, ur_block_tail;
-    int nb_kd, nb_kh, nb_kw;
+    dim_t ur, ur_block, ur_block_tail;
+    dim_t nb_kd, nb_kh, nb_kw;
     int max_regs;
     int bcast_simd;
     float eff;
@@ -455,7 +455,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     static constexpr float mem_k = 15.f;
     static constexpr int bench_iterations = 1;
 
-    int sp, sp_block, nb_sp;
+    dim_t sp, sp_block, nb_sp;
 
     void get_from_jcp(const jit_brgemm_conv_conf_t &jcp) { *this = jcp; }
     void save_to_jcp(jit_brgemm_conv_conf_t &jcp) const { jcp = *this; }
@@ -475,16 +475,16 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     void update_blocks();
     bool fast_check_ic_block() const;
     float est_eff();
-    void iterate_ker_block(brg_blocking_t &best_brgb, int kd_block,
-            int kh_block, bool maybe_use_buffer, int max_iw_block_thr);
+    void iterate_ker_block(brg_blocking_t &best_brgb, dim_t kd_block,
+            dim_t kh_block, bool maybe_use_buffer, dim_t max_iw_block_thr);
     status_t calc_blocks();
 
     bool fast_check_ic_block_1x1() const;
     float est_eff_1x1();
 
     // utils
-    static int get_inp_size(
-            int max_src_size, int dst_size, int k, int stride, int dilate) {
+    static dim_t get_inp_size(dim_t max_src_size, dim_t dst_size, dim_t k,
+            dim_t stride, dim_t dilate) {
         auto adj_str = nstl::min(k, stride);
         const auto res = nstl::min(max_src_size,
                 calculate_end_padding(0, dst_size, 0, adj_str,
@@ -492,8 +492,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         return res;
     }
 
-    static int get_inp_block_size(
-            int out_size, int stride, int ext_k, int padding) {
+    static dim_t get_inp_block_size(
+            dim_t out_size, dim_t stride, dim_t ext_k, dim_t padding) {
         const auto res = div_up(out_size + padding % stride, stride)
                 + (ext_k - 1 - padding % stride) / stride;
         return res;
@@ -513,13 +513,13 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         return est_ur;
     }
 
-    int inp_w(int out_w, int ker_w) const {
+    dim_t inp_w(dim_t out_w, dim_t ker_w) const {
         return get_inp_size(ow, out_w, ker_w, stride_w, dilate_w);
     }
 
-    int rnd_simd(int val) const { return rnd_up(val, simd_w); }
+    dim_t rnd_simd(dim_t val) const { return rnd_up(val, simd_w); }
 
-    int rnd_inp_simd(int out_w, int ker_w, int voc) const {
+    dim_t rnd_inp_simd(dim_t out_w, dim_t ker_w, dim_t voc) const {
         const auto vsp = inp_w(out_w, ker_w);
         return ((stride_w == 1 && voc >= oc) ? rnd_up(vsp * voc, simd_w)
                                              : vsp * rnd_up(voc, simd_w));
@@ -594,7 +594,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
             is_bf32));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
-    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
+    ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
     if (ur == 0) return status::invalid_arguments;
     ur_block = brg.bd_block;
     if (is_1x1 && is_amx(isa) && M > 0 && M_tail > 0) {
@@ -653,8 +653,8 @@ status_t brg_blocking_t::get_brgemm_ur(
 
                     brgemm_attr_t brgattr;
                     brgattr.max_bs = max_batch;
-                    const auto max_vpad = (exec_type == exec_vpad)
-                            ? nstl::max(l_pad, r_pad)
+                    const int max_vpad = (exec_type == exec_vpad)
+                            ? static_cast<int>(nstl::max(l_pad, r_pad))
                             : 0;
                     brgattr.max_top_vpad = max_vpad;
                     brgattr.max_bottom_vpad = max_vpad;
@@ -731,22 +731,29 @@ float brg_blocking_t::est_eff() {
     const auto icblock = ic_block / acc_simd_w;
 
     const auto brgemm_microkernel_eff
-            = (static_cast<float>(icblock) * ur) / ((ur + icblock) * max_regs);
+            = (static_cast<float>(icblock) * static_cast<float>(ur))
+            / static_cast<float>((ur + icblock) * max_regs);
 
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
-    const auto brgemm_eff = squeeze_val(ur
-                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+    const auto ur_eff = static_cast<float>(sp_block)
+            / static_cast<float>(rnd_up(sp_block, ur));
+    const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    static_cast<float>(ur)
+                                            / static_cast<float>(sp_block)))
                     / 64,
             0.5f);
 
     const auto sp_amount = nb_id * nb_ih * nb_sp;
     const auto work_amount = mb * ngroups * nb_ic * sp_amount;
-    const auto sp_eff = (static_cast<float>(sp) / rnd_up(sp, sp_block));
+    const auto sp_eff = (static_cast<float>(sp)
+            / static_cast<float>(rnd_up(sp, sp_block)));
 
     const auto thr_eff = static_cast<float>(work_amount)
-            / utils::rnd_up(work_amount, nthr);
+            / static_cast<float>(utils::rnd_up(work_amount, nthr));
 
-    const auto ic_block_eff = static_cast<float>(ic) / rnd_up(ic, ic_block);
+    const auto ic_block_eff
+            = static_cast<float>(ic) / static_cast<float>(rnd_up(ic, ic_block));
 
     const auto job = div_up(work_amount, nthr);
 
@@ -758,9 +765,9 @@ float brg_blocking_t::est_eff() {
             thr_jobs[ithr] = 0;
             if (ithr >= work_amount) continue;
             dim_t thr_job = 0;
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr, ithr, start, end);
-            int n {0}, g {0}, icb {0}, idp {0}, ihp {0}, spb {0};
+            dim_t n {0}, g {0}, icb {0}, idp {0}, ihp {0}, spb {0};
             if (loop_order == loop_ndhwgc)
                 nd_iterator_init(start, n, mb, idp, id, ihp, ih, spb, nb_sp, g,
                         ngroups, icb, nb_ic);
@@ -769,10 +776,10 @@ float brg_blocking_t::est_eff() {
                         ihp, ih, spb, nb_sp);
 
             for (auto work = start; work < end; work++) {
-                const int icp = icb * ic_block;
-                const auto ic_sz = nstl::min(ic - icp, ic_block);
-                int sp_sz = 0;
-                const int spp = spb * sp_block;
+                const dim_t icp = icb * ic_block;
+                const auto ic_sz = nstl::min<dim_t>(ic - icp, ic_block);
+                dim_t sp_sz = 0;
+                const dim_t spp = spb * sp_block;
                 sp_sz = nstl::min(sp - spp, sp_block);
                 thr_job += sp_sz * ic_sz;
 
@@ -795,7 +802,8 @@ float brg_blocking_t::est_eff() {
             sum_job += thr_jobs[ithr];
         }
         job_eff = max_job == 0 ? 1
-                               : static_cast<float>(sum_job) / (max_job * nthr);
+                               : static_cast<float>(sum_job)
+                        / static_cast<float>(max_job * nthr);
 
     } else {
         job_eff = thr_eff;
@@ -851,25 +859,25 @@ float brg_blocking_t::est_eff() {
     loop[l].wei.set(wei_is, 1);
 
     const auto dim_ic = (loop_order == loop_ndhwgc) ? 1 : sp_amount;
-    const auto nb_ic_thr = nstl::min(nb_ic, div_up(job, dim_ic));
-    const auto ic_thr = nstl::min(ic, nb_ic_thr * ic_block);
+    const dim_t nb_ic_thr = nstl::min<dim_t>(nb_ic, div_up(job, dim_ic));
+    const dim_t ic_thr = nstl::min<dim_t>(ic, nb_ic_thr * ic_block);
     const auto nsimd_ic_thr = div_up(ic_thr, simd_w);
 
     const auto dim_sp = (loop_order == loop_ndhwgc) ? ngroups * nb_ic : 1;
-    const auto nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
-    const auto sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
+    const dim_t nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
+    const dim_t sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
 
     const auto dim_ih = nb_sp * dim_sp;
-    const int nb_ih_thr = nstl::min(nb_ih, div_up(job, dim_ih));
-    const int ih_thr = nstl::min(ih, nb_ih_thr * ih_block);
+    const dim_t nb_ih_thr = nstl::min<dim_t>(nb_ih, div_up(job, dim_ih));
+    const dim_t ih_thr = nstl::min<dim_t>(ih, nb_ih_thr * ih_block);
 
     const auto dim_id = nb_ih * dim_ih;
-    const int nb_id_thr = nstl::min(nb_id, div_up(job, dim_id));
-    const int id_thr = nstl::min(id, nb_id_thr * id_block);
+    const dim_t nb_id_thr = nstl::min<dim_t>(nb_id, div_up(job, dim_id));
+    const dim_t id_thr = nstl::min<dim_t>(id, nb_id_thr * id_block);
 
     src_is = kd * kh * rnd_inp_simd(sp_block, kw, oc);
 
-    auto wei_op = kd * kh * kw * icblock * oc;
+    dim_t wei_op = kd * kh * kw * icblock * oc;
 
     if (loop_order == loop_ndhwgc) {
         // -- harness: loop by ic_block --
@@ -912,7 +920,8 @@ float brg_blocking_t::est_eff() {
 
     // -- harness: loop by mb --
     l++;
-    const auto mb_thr = nstl::min(mb, div_up(job, sp_amount * ngroups * nb_ic));
+    const dim_t mb_thr
+            = nstl::min<dim_t>(mb, div_up(job, sp_amount * ngroups * nb_ic));
     loop[l].src.set(id_thr * ih_thr * src_is, 1);
     loop[l].dst.set(id_thr * ih_thr * sp_thr * nsimd_ic_thr * simd_w, 1);
     loop[l].wei.set(kd * kh * kw * nsimd_ic_thr * simd_w * oc, mb_thr);
@@ -947,24 +956,27 @@ float brg_blocking_t::est_eff() {
         dst_rp *= loop[il].dst.repeatn;
         wei_rp *= loop[il].wei.repeatn;
     }
-    const auto src_ops = (src_op * src_rp) / iterations;
-    const auto dst_ops = (dst_op * dst_rp) / iterations;
-    const auto wei_ops = (wei_op * wei_rp) / iterations;
+    const auto src_ops = (static_cast<float>(src_op) * src_rp) / iterations;
+    const auto dst_ops = (static_cast<float>(dst_op) * dst_rp) / iterations;
+    const auto wei_ops = (static_cast<float>(wei_op) * wei_rp) / iterations;
 
     const auto src_cost = src_mem_k * src_ops;
     const auto dst_cost = dst_mem_k * dst_ops;
     const auto wei_cost = wei_mem_k * wei_ops;
     const auto call_kernel_cost = job * oc_chunks * nb_kd * nb_kh * nb_kw;
 
-    const auto cache_eff = (static_cast<dim_t>(mb) * id * ih * sp * oc * ic)
-            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto cache_eff = static_cast<float>(mb * id * ih * sp * oc * ic)
+            / (static_cast<float>(nthr)
+                    * (src_cost + dst_cost + wei_cost
+                            + static_cast<float>(call_kernel_cost)));
     const auto res_eff = ic_block_eff * brgemm_microkernel_eff * sp_eff
             * job_eff * ur_eff * cache_eff * brgemm_eff;
     return res_eff;
 }
 
-void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
-        int kh_block_, bool maybe_use_buffer, int max_iw_block_thr) {
+void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb,
+        dim_t kd_block_, dim_t kh_block_, bool maybe_use_buffer,
+        dim_t max_iw_block_thr) {
     kd_block = kd_block_;
     kh_block = kh_block_;
 
@@ -976,14 +988,14 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
     const auto w_block_size = 2 * src_dsz * oc * owp + dst_dsz * iw * ic_block;
     const auto other_size = wei_dsz * kd * kh * kw * oc * ic_block
             + acc_dsz * 2 * amx_h * ic_block;
-    const auto L2_available = nstl::min(static_cast<size_t>(div_up(L2, 2)),
-            other_size > L2 ? 0 : L2 - other_size);
+    const auto L2_available = nstl::min<size_t>(
+            div_up(L2, 2), other_size > L2 ? 0 : L2 - other_size);
     if (odp * ohp * w_block_size > L2_available) {
-        id_block = utils::saturate(
-                1, id, int(L2_available / (ohp * w_block_size)));
+        id_block = utils::saturate<dim_t>(
+                1, id, L2_available / (ohp * w_block_size));
         if (id_block == 1)
-            ih_block = utils::saturate(
-                    1, ih, int(L2_available / (w_block_size)));
+            ih_block = utils::saturate<dim_t>(
+                    1, ih, L2_available / w_block_size);
         else
             ih_block = ih;
     } else {
@@ -998,16 +1010,20 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
         const auto src_w_block_size
                 = src_dsz * oc * owp + dst_dsz * iw * ic_block;
         if (src_w_block_size < L1) {
-            cur_id_block = utils::saturate(
-                    1, id, int(L1 / (ohp * src_w_block_size)));
+            cur_id_block = utils::saturate<dim_t>(
+                    1, id, L1 / (ohp * src_w_block_size));
             if (cur_id_block == 1)
                 cur_ih_block
-                        = utils::saturate(1, ih, int(L1 / (src_w_block_size)));
+                        = utils::saturate<dim_t>(1, ih, L1 / src_w_block_size);
         }
         for (; cur_id_block > 1; cur_id_block--) {
             const auto sp_size = cur_id_block * cur_ih_block * owp;
-            if ((static_cast<float>(id) / rnd_up(id, cur_id_block)) > 0.9f
-                    && static_cast<float>(sp_size) / rnd_up(sp, amx_h) > 0.8f) {
+            if ((static_cast<float>(id)
+                        / static_cast<float>(rnd_up(id, cur_id_block)))
+                            > 0.9f
+                    && static_cast<float>(sp_size)
+                                    / static_cast<float>(rnd_up(sp, amx_h))
+                            > 0.8f) {
                 L1_fit_res = true;
                 break;
             }
@@ -1015,7 +1031,9 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
         if (cur_id_block == 1) {
             for (; cur_ih_block > 1; cur_ih_block--) {
                 const auto sp_size = cur_ih_block * owp;
-                if ((static_cast<float>(ih) / rnd_up(ih, cur_ih_block)) > 0.9f
+                if ((static_cast<float>(ih)
+                            / static_cast<float>(rnd_up(ih, cur_ih_block)))
+                                > 0.9f
                         && sp_size > 128) {
                     L1_fit_res = true;
                     break;
@@ -1053,11 +1071,11 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
 
     // --- Select iw_block ----
     const auto max_iw_block_L2 = iw;
-    auto start_iw_block = nstl::min(max_iw_block_thr, max_iw_block_L2);
+    auto start_iw_block = nstl::min<dim_t>(max_iw_block_thr, max_iw_block_L2);
     sp = has_uneven_iw ? rnd_up(iw, stride_w) : iw;
     const auto start_sp_block
             = has_uneven_iw ? rnd_up(start_iw_block, stride_w) : start_iw_block;
-    auto prev_spb = 0;
+    auto prev_spb = dim_t(0);
     for (auto ns = 1; ns <= sp; ns++) {
         const auto spb = div_up(sp, ns);
         if (spb == prev_spb || spb > start_sp_block) continue;
@@ -1105,7 +1123,7 @@ status_t brg_blocking_t::calc_blocks() {
     const auto maybe_use_buffer = (dst_dt != acc_dt || with_sum);
 
     // kd/kh block should be either kd/kh or a multiple of stride_d/stride_h
-    std::vector<int> kd_blocks(1), kh_blocks(1);
+    std::vector<dim_t> kd_blocks(1), kh_blocks(1);
     kd_blocks[0] = kd;
     kh_blocks[0] = kh;
     if (kd != 1) {
@@ -1118,9 +1136,10 @@ status_t brg_blocking_t::calc_blocks() {
     }
 
     const auto thr_eff_threshold = 0.9f;
-    const auto max_iw_block_thr = utils::saturate(1, sp,
-            static_cast<int>(ceil(
-                    mb * ngroups * nb_ic * is / (thr_eff_threshold * nthr))));
+    const auto max_iw_block_thr = utils::saturate<dim_t>(1, sp,
+            static_cast<dim_t>(
+                    ceil(static_cast<float>(mb * ngroups * nb_ic * is)
+                            / (thr_eff_threshold * static_cast<float>(nthr)))));
 
     iw_block = is_block = sp_block = -1;
     brg_blocking_t best_brgb = *this;
@@ -1153,7 +1172,8 @@ bool brg_blocking_t::fast_check_ic_block_1x1() const {
                 = id * ih * iw >= 64 * stride_d * stride_h * stride_w;
         res = (rnd_ic % ic_block == 0 && big_spatial);
     } else if (ic_block == 48) {
-        const auto ic_block_eff = static_cast<float>(ic) / rnd_up(ic, ic_block);
+        const auto ic_block_eff = static_cast<float>(ic)
+                / static_cast<float>(rnd_up(ic, ic_block));
         res = (ic_block_eff >= 0.95f);
     } else
         res = true;
@@ -1164,14 +1184,16 @@ bool brg_blocking_t::fast_check_ic_block_1x1() const {
 float brg_blocking_t::est_eff_1x1() {
     const auto icblock = ic_block / acc_simd_w;
 
-    auto calc_ave_blk = [&](int dim, int block, bool use_ave) -> float {
-        const int nb = dim / block;
+    auto calc_ave_blk = [&](dim_t dim, dim_t block, bool use_ave) -> float {
+        const dim_t nb = dim / block;
         constexpr int max_nb = 2; // only consider 2x2 tile blocking
-        const int block2 = nstl::min(max_nb, nb);
-        const int nb2 = nb / block2;
-        const int nb2_tail = nb % block2;
+        const dim_t block2 = nstl::min<dim_t>(max_nb, nb);
+        const dim_t nb2 = nb / block2;
+        const dim_t nb2_tail = nb % block2;
         if (!use_ave) return block2;
-        return (float(nb2) * block2 + nb2_tail) / div_up(nb, block2);
+        return (float(nb2) * static_cast<float>(block2)
+                       + static_cast<float>(nb2_tail))
+                / static_cast<float>(div_up(nb, block2));
     };
     const bool use_ocb_ave = true;
     const auto icb_ave = calc_ave_blk(ic_block, acc_simd_w, use_ocb_ave);
@@ -1187,46 +1209,54 @@ float brg_blocking_t::est_eff_1x1() {
             || (ic == 1024 && oc == 512) || (ic == 256 && oc == 1024)
             || (ic == 512 && oc == 1024) || (ic == 512 && oc == 2048);
     const auto amx_fac = maskrcnn_cond
-            ? (div_up(M + M_tail, 16) / (M_n_sp_blks + M_tail_n_sp_blks))
+            ? (static_cast<float>(div_up(M + M_tail, 16))
+                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks))
             : (static_cast<float>(div_up(M + M_tail, 16))
-                      / (M_n_sp_blks + M_tail_n_sp_blks));
+                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks));
 
     const auto brgemm_microkernel_eff = is_amx(isa)
             ? amx_fac * (static_cast<float>(icb_ave) * spb_ave)
                     / (icb_ave + spb_ave)
-            : (static_cast<float>(icblock) * ur) / ((ur + icblock) * max_regs);
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
-    const auto brgemm_eff = squeeze_val(ur
-                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+            : (static_cast<float>(icblock) * static_cast<float>(ur))
+                    / static_cast<float>((ur + icblock) * max_regs);
+    const auto ur_eff = static_cast<float>(sp_block)
+            / static_cast<float>(rnd_up(sp_block, ur));
+    const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    static_cast<float>(ur)
+                                            / static_cast<float>(sp_block)))
                     / 64,
             0.5f);
 
     const auto sp_amount = nb_id * nb_ih * nb_sp;
     const auto work_amount = mb * ngroups * nb_ic * sp_amount;
 
-    const auto sp_eff = static_cast<float>(sp) / rnd_up(sp, sp_block);
+    const auto sp_eff
+            = static_cast<float>(sp) / static_cast<float>(rnd_up(sp, sp_block));
     const auto thr_eff = static_cast<float>(work_amount)
-            / utils::rnd_up(work_amount, nthr);
-    const auto ic_block_eff = static_cast<float>(ic) / rnd_up(ic, ic_block);
+            / static_cast<float>(utils::rnd_up(work_amount, nthr));
+    const auto ic_block_eff
+            = static_cast<float>(ic) / static_cast<float>(rnd_up(ic, ic_block));
 
     const auto job = div_up(work_amount, nthr);
 
     const auto dim_ic = (loop_order == loop_ndhwgc) ? 1 : sp_amount;
-    const auto nb_ic_thr = nstl::min(nb_ic, div_up(job, dim_ic));
-    const auto ic_thr = nstl::min(ic, nb_ic_thr * ic_block);
+    const dim_t nb_ic_thr = nstl::min<dim_t>(nb_ic, div_up(job, dim_ic));
+    const dim_t ic_thr = nstl::min<dim_t>(ic, nb_ic_thr * ic_block);
     const auto nsimd_ic_thr = div_up(ic_thr, simd_w);
 
     const auto dim_sp = (loop_order == loop_ndhwgc) ? ngroups * nb_ic : 1;
-    const auto nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
-    const auto sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
+    const dim_t nb_sp_thr = nstl::min(nb_sp, div_up(job, dim_sp));
+    const dim_t sp_thr = nstl::min(sp, nb_sp_thr * sp_block);
 
     const auto dim_ih = nb_sp * dim_sp;
-    const int nb_ih_thr = nstl::min(nb_ih, div_up(job, dim_ih));
-    const int ih_thr = nstl::min(ih, nb_ih_thr * ih_block);
+    const dim_t nb_ih_thr = nstl::min<dim_t>(nb_ih, div_up(job, dim_ih));
+    const dim_t ih_thr = nstl::min<dim_t>(ih, nb_ih_thr * ih_block);
 
     const auto dim_id = nb_ih * dim_ih;
-    const int nb_id_thr = nstl::min(nb_id, div_up(job, dim_id));
-    const int id_thr = nstl::min(id, nb_id_thr * id_block);
+    const dim_t nb_id_thr = nstl::min<dim_t>(nb_id, div_up(job, dim_id));
+    const dim_t id_thr = nstl::min<dim_t>(id, nb_id_thr * id_block);
 
     auto job_eff = 1.f;
     if (job < nthr) {
@@ -1235,9 +1265,9 @@ float brg_blocking_t::est_eff_1x1() {
             thr_jobs[ithr] = 0;
             if (ithr >= work_amount) continue;
             dim_t thr_job = 0;
-            int start {0}, end {0};
+            dim_t start {0}, end {0};
             balance211(work_amount, nthr, ithr, start, end);
-            int n {0}, g {0}, icb {0}, idp {0}, ihp {0}, spb {0};
+            dim_t n {0}, g {0}, icb {0}, idp {0}, ihp {0}, spb {0};
             nd_iterator_init(start, n, mb, idp, id, ihp, ih, spb, nb_sp, g,
                     ngroups, icb, nb_ic);
 
@@ -1250,10 +1280,10 @@ float brg_blocking_t::est_eff_1x1() {
             }
 
             for (auto work = start; work < end; work++) {
-                const int icp = icb * ic_block;
-                const auto ic_sz = nstl::min(ic - icp, ic_block);
-                int sp_sz = 0;
-                const int spp = spb * sp_block;
+                const dim_t icp = icb * ic_block;
+                const auto ic_sz = nstl::min<dim_t>(ic - icp, ic_block);
+                dim_t sp_sz = 0;
+                const dim_t spp = spb * sp_block;
                 sp_sz = nstl::min(sp - spp, sp_block);
                 thr_job += sp_sz * ic_sz;
                 nd_iterator_step(n, mb, idp, id, ihp, ih, spb, nb_sp, g,
@@ -1277,7 +1307,8 @@ float brg_blocking_t::est_eff_1x1() {
         }
 
         job_eff = max_job == 0 ? 1
-                               : static_cast<float>(sum_job) / (max_job * nthr);
+                               : static_cast<float>(sum_job)
+                        / static_cast<float>(max_job * nthr);
     } else {
         job_eff = thr_eff;
     }
@@ -1308,7 +1339,7 @@ float brg_blocking_t::est_eff_1x1() {
     loop[l].src.set(sp_block * oc_blocking_size, 1);
     loop[l].dst.set(sp_block * ic_block, oc_chunks);
     auto wei_is = ic_blocking_size;
-    auto wei_op = icblock * oc;
+    dim_t wei_op = icblock * oc;
     loop[l].wei.set(wei_is, 1);
 
     if (loop_order == loop_ndhwgc) {
@@ -1350,7 +1381,8 @@ float brg_blocking_t::est_eff_1x1() {
 
     // -- harness: loop by mb --
     l++;
-    const auto mb_thr = nstl::min(mb, div_up(job, sp_amount * ngroups * nb_ic));
+    const dim_t mb_thr
+            = nstl::min<dim_t>(mb, div_up(job, sp_amount * ngroups * nb_ic));
     loop[l].src.set(id_thr * ih_thr * sp_thr * rnd_simd(oc_blocking_size), 1);
     loop[l].dst.set(nsimd_ic_thr * simd_w * id_thr * ih_thr * sp_thr, 1);
     loop[l].wei.set(nsimd_ic_thr * oc * simd_w, mb_thr);
@@ -1383,9 +1415,9 @@ float brg_blocking_t::est_eff_1x1() {
         dst_rp *= loop[il].dst.repeatn;
         wei_rp *= loop[il].wei.repeatn;
     }
-    const auto src_ops = (src_op * src_rp) / iterations;
-    const auto dst_ops = (dst_op * dst_rp) / iterations;
-    const auto wei_ops = (wei_op * wei_rp) / iterations;
+    const auto src_ops = (static_cast<float>(src_op) * src_rp) / iterations;
+    const auto dst_ops = (static_cast<float>(dst_op) * dst_rp) / iterations;
+    const auto wei_ops = (static_cast<float>(wei_op) * wei_rp) / iterations;
 
     const auto src_cost = src_mem_k * src_ops;
     const auto dst_cost = dst_mem_k * dst_ops;
@@ -1394,8 +1426,10 @@ float brg_blocking_t::est_eff_1x1() {
 
     const auto up_sp_size = id * ih;
 
-    const auto cache_eff = (static_cast<dim_t>(mb) * up_sp_size * sp * oc * ic)
-            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto cache_eff = static_cast<float>(mb * up_sp_size * sp * oc * ic)
+            / (static_cast<float>(nthr)
+                    * (src_cost + dst_cost + wei_cost
+                            + static_cast<float>(call_kernel_cost)));
 
     const auto res_eff = ic_block_eff * brgemm_microkernel_eff * sp_eff
             * job_eff * ur_eff * cache_eff * brgemm_eff;
@@ -1518,7 +1552,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             = jcp.is_f32_f16 || jcp.is_f32_bf16 ? jcp.src_dt : jcp.wei_dt;
     const data_type_t last_oc_block_dt
             = get_mac_emu_data_type(wei_dt, isa, isa == avx512_core_fp16);
-    jcp.vnni_block = data_type_vnni_granularity(last_oc_block_dt);
+    jcp.vnni_block
+            = static_cast<int>(data_type_vnni_granularity(last_oc_block_dt));
 
     // TODO: optimize grouped convolutions with small oc
     const bool is_grouped_small_oc
@@ -1697,26 +1732,27 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     return status::success;
 }
 
-void set_k_range(int P, int D, int S, dim_t i, dim_t O, int K, int &k_s,
+void set_k_range(dim_t P, dim_t D, dim_t S, dim_t i, dim_t O, dim_t K, int &k_s,
         int &k_f, bool is_w) {
-    int s(0), o_test(0);
+    dim_t s(0), o_test(0);
     while (true) {
         o_test = i + P - s * D;
         if (o_test % S == 0) break;
         s++;
     }
 
-    k_f = is_w ? K : nstl::min(K, static_cast<int>(div_up(i + P + 1, D)));
+    k_f = static_cast<int>(
+            is_w ? K : nstl::min<dim_t>(K, div_up(i + P + 1, D)));
     k_s = is_w ? 0
                : static_cast<int>(
-                         div_up(nstl::max((dim_t)0, i + P - O * S + 1), D));
+                         div_up(nstl::max<dim_t>(0, i + P - O * S + 1), D));
 
     while (k_s % S != s)
         k_s++;
 }
 
-void get_iw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw, int kw,
-        int &iw_s, int &M_without_overflow) {
+void get_iw_range(const jit_brgemm_conv_conf_t &jcp, dim_t iw, dim_t iw_raw,
+        dim_t kw, int &iw_s, int &M_without_overflow) {
     // This function is needed for exec_base only
     using namespace dnnl::impl::utils;
     using namespace nstl;
@@ -1734,9 +1770,9 @@ void get_iw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw, int kw,
     auto ow = (iw - kw * DW + LP) / SW;
     auto ow_l_ovf = ow;
     const auto ow_r_ovf = ow_l_ovf + (M - 1) - OW + 1;
-    iw_s = iw;
+    iw_s = static_cast<int>(iw);
 
-    int ker_idx = 0;
+    dim_t ker_idx = 0;
     if (ow_l_ovf < 0) {
         ow_l_ovf = nstl::abs(ow_l_ovf);
         ker_idx += ow_l_ovf;
@@ -1745,21 +1781,23 @@ void get_iw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw, int kw,
 
     if (ow_r_ovf > 0) ker_idx += ow_r_ovf;
 
-    int iw_f = iw_s + (M - ker_idx);
+    dim_t iw_s_d = iw_s;
+    dim_t iw_f = iw_s_d + (M - ker_idx);
 
-    iw_s = nstl::min(iw_s, iw + M);
-    iw_f = nstl::min(nstl::max(iw_f, iw_s), iw + M);
+    iw_s_d = nstl::min<dim_t>(iw_s_d, iw + M);
+    iw_f = nstl::min<dim_t>(nstl::max<dim_t>(iw_f, iw_s_d), iw + M);
 
-    M_without_overflow = iw_f - iw_s;
-    iw_s = iw;
-    ow = (iw_s - kw * DW + LP) / SW;
-    while (ow < 0 && iw_s + SW < IW) {
-        iw_s += SW;
-        ow = (iw_s - kw * DW + LP) / SW;
+    M_without_overflow = static_cast<int>(iw_f - iw_s_d);
+    iw_s_d = iw;
+    ow = (iw_s_d - kw * DW + LP) / SW;
+    while (ow < 0 && iw_s_d + SW < IW) {
+        iw_s_d += SW;
+        ow = (iw_s_d - kw * DW + LP) / SW;
     }
+    iw_s = static_cast<int>(iw_s_d);
 }
 
-void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw,
+void get_kw_range(const jit_brgemm_conv_conf_t &jcp, dim_t iw, dim_t iw_raw,
         int &kw_s, int &kw_full_s, int &kw_full_f, int &kw_f) {
     // This function is needed for exec_base only
     using namespace dnnl::impl::utils;
@@ -1774,16 +1812,16 @@ void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw,
     const bool is_iw_tail = (IW - iw_raw < IW_BLOCK);
     const auto M = div_up(is_iw_tail ? IW_TAIL : IW_BLOCK, SW);
     kw_s = kw_full_s = kw_full_f = kw_f = -1;
-    for (int kw = 0; kw < KW; kw++) {
+    for (dim_t kw = 0; kw < KW; kw++) {
         int iw_s {0}, iw_f {0}, M_without_overflow {0};
         get_iw_range(jcp, iw, iw_raw, kw, iw_s, M_without_overflow);
         iw_f = iw_s + M_without_overflow;
         if (iw_s < iw_f) {
-            if (kw_s == -1) kw_s = kw;
-            kw_f = kw + 1;
+            if (kw_s == -1) kw_s = static_cast<int>(kw);
+            kw_f = static_cast<int>(kw + 1);
             if (iw_f - iw_s == M) {
-                if (kw_full_s == -1) kw_full_s = kw;
-                kw_full_f = kw + 1;
+                if (kw_full_s == -1) kw_full_s = static_cast<int>(kw);
+                kw_full_f = static_cast<int>(kw + 1);
             }
         }
     }
@@ -1794,7 +1832,7 @@ void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw,
     }
     if (kw_full_f == -1) kw_full_s = kw_full_f = kw_f;
 
-    int s(0), o_test(0);
+    dim_t s(0), o_test(0);
     while (true) {
         o_test = iw + LP - s * DW;
         if (o_test % SW == 0) break;
@@ -1839,7 +1877,7 @@ dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,
 
     const bool fill_k_ranges
             = !any_null(kd_bs, kd_es, kh_bs, kh_es, kw_bs, kw_es);
-    std::set<std::vector<int>> unique_kernels;
+    std::set<std::vector<dim_t>> unique_kernels;
     dim_t k = 0;
     if (fill_k_ranges) {
         kd_bs->resize(jcp.ker_ranges_size);
@@ -1850,8 +1888,8 @@ dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,
         kw_es->resize(jcp.ker_ranges_size);
     }
 
-    const auto update_kernels
-            = [&](int kd_b, int kd_e, int kh_b, int kh_e, int kw_b, int kw_e) {
+    const auto update_kernels = [&](dim_t kd_b, dim_t kd_e, dim_t kh_b,
+                                        dim_t kh_e, dim_t kw_b, dim_t kw_e) {
         unique_kernels.insert({kd_b, kd_e, kh_b, kh_e, kw_b, kw_e});
         if (k == static_cast<dim_t>(unique_kernels.size())) return;
         if (fill_k_ranges) {
@@ -1866,19 +1904,19 @@ dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,
         assert(IMPLICATION(fill_k_ranges, k <= jcp.ker_ranges_size));
     };
 
-    for_(int idb = 0; idb < jcp.nb_id; idb++)
-    for_(int ihb = 0; ihb < jcp.nb_ih; ihb++)
-    for (int iwb = 0; iwb < jcp.nb_iw; iwb++) {
+    for_(dim_t idb = 0; idb < jcp.nb_id; idb++)
+    for_(dim_t ihb = 0; ihb < jcp.nb_ih; ihb++)
+    for (dim_t iwb = 0; iwb < jcp.nb_iw; iwb++) {
         auto id_begin = idb * ID_BLOCK;
         auto id_end = nstl::min(ID, id_begin + ID_BLOCK);
         auto ih_begin = ihb * IH_BLOCK;
         auto ih_end = jcp.is_is_blocking ? ih_begin + 1
                                          : nstl::min(IH, ih_begin + IH_BLOCK);
-        for_(int id = id_begin; id < id_end; id++)
-        for_(int ih = ih_begin; ih < ih_end; ih++)
-        for (int sw = 0; sw < SW; sw++) {
-            const int iw = iwb * IW_BLOCK + sw;
-            const int iw_raw = iwb * IW_BLOCK;
+        for_(dim_t id = id_begin; id < id_end; id++)
+        for_(dim_t ih = ih_begin; ih < ih_end; ih++)
+        for (dim_t sw = 0; sw < SW; sw++) {
+            const dim_t iw = iwb * IW_BLOCK + sw;
+            const dim_t iw_raw = iwb * IW_BLOCK;
 
             int kw_s {0}, kw_full_s {0}, kw_f {0}, kw_full_f {0};
             int kd_s_(0), kh_s_(0), kd_f_(0), kh_f_(0);
@@ -1902,8 +1940,8 @@ dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,
                     if (kw_full_s < kw_full_f) {
                         for (auto kw = kw_full_s; kw < kw_full_f;
                                 kw += KW_BLOCK) {
-                            const auto kw_e
-                                    = nstl::min(kw_full_f, kw + KW_BLOCK);
+                            const auto kw_e = nstl::min<dim_t>(
+                                    kw_full_f, kw + KW_BLOCK);
                             update_kernels(kd_s, kd_f, kh_s, kh_f, kw, kw_e);
                         }
                     }
@@ -1940,12 +1978,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     const memory_desc_wrapper diff_src_d(&diff_src_md);
     const memory_desc_wrapper bias_d(&bias_md);
 
-    jcp.l_ovf = nstl::max(0, jcp.ext_kw - 1 - jcp.l_pad) / jcp.stride_w;
-    jcp.r_ovf = nstl::max(0, jcp.ext_kw - 1 - jcp.r_pad) / jcp.stride_w;
-    jcp.t_ovf = nstl::max(0, jcp.ext_kh - 1 - jcp.t_pad) / jcp.stride_h;
-    jcp.b_ovf = nstl::max(0, jcp.ext_kh - 1 - jcp.b_pad) / jcp.stride_h;
-    jcp.f_ovf = nstl::max(0, jcp.ext_kd - 1 - jcp.f_pad) / jcp.stride_d;
-    jcp.back_ovf = nstl::max(0, jcp.kd - 1 - jcp.back_pad) / jcp.stride_d;
+    jcp.l_ovf = nstl::max<dim_t>(0, jcp.ext_kw - 1 - jcp.l_pad) / jcp.stride_w;
+    jcp.r_ovf = nstl::max<dim_t>(0, jcp.ext_kw - 1 - jcp.r_pad) / jcp.stride_w;
+    jcp.t_ovf = nstl::max<dim_t>(0, jcp.ext_kh - 1 - jcp.t_pad) / jcp.stride_h;
+    jcp.b_ovf = nstl::max<dim_t>(0, jcp.ext_kh - 1 - jcp.b_pad) / jcp.stride_h;
+    jcp.f_ovf = nstl::max<dim_t>(0, jcp.ext_kd - 1 - jcp.f_pad) / jcp.stride_d;
+    jcp.back_ovf
+            = nstl::max<dim_t>(0, jcp.kd - 1 - jcp.back_pad) / jcp.stride_d;
 
     jcp.odp = jcp.od + jcp.f_ovf + jcp.back_ovf;
     jcp.ohp = jcp.oh + jcp.t_ovf + jcp.b_ovf;
@@ -1955,7 +1994,7 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     // ======================= blocking =================================
 
     const int min_ic_block = jcp.acc_simd_w;
-    int selected_ur = 0;
+    dim_t selected_ur = 0;
 
     //-----------------------------------------------------------------------
 
@@ -2006,7 +2045,8 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         best_brgb.ic_block = min_ic_block;
         brg_blocking_t cur_brgb = zero<decltype(best_brgb)>();
         cur_brgb.get_from_jcp(jcp);
-        const auto start_icb = nstl::min(div_up(jcp.ic, jcp.acc_simd_w), 4);
+        const auto start_icb
+                = nstl::min<dim_t>(div_up(jcp.ic, jcp.acc_simd_w), 4);
 
         auto finish_icb = 1;
         for (auto icb = start_icb; icb >= finish_icb; icb--) {

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.hpp
@@ -39,13 +39,13 @@ constexpr size_t P4K = 4096;
 
 bool is_amx(cpu_isa_t isa);
 
-void set_k_range(int P, int D, int S, dim_t i, dim_t O, int K, int &k_s,
+void set_k_range(dim_t P, dim_t D, dim_t S, dim_t i, dim_t O, dim_t K, int &k_s,
         int &k_f, bool is_w = false);
 
-void get_iw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw, int kw,
-        int &iw_s, int &M_without_overflow);
+void get_iw_range(const jit_brgemm_conv_conf_t &jcp, dim_t iw, dim_t iw_raw,
+        dim_t kw, int &iw_s, int &M_without_overflow);
 
-void get_kw_range(const jit_brgemm_conv_conf_t &jcp, int iw, int iw_raw,
+void get_kw_range(const jit_brgemm_conv_conf_t &jcp, dim_t iw, dim_t iw_raw,
         int &kw_s, int &kw_full_s, int &kw_full_f, int &kw_f);
 
 dim_t precalculate_comp_pad_kernels(const jit_brgemm_conv_conf_t &jcp,

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -221,7 +221,7 @@ void brgemm_convolution_bwd_weights_t::pd_t::copy2jit_jcp() {
     jit_jcp_.oc_block = jcp_.oc_block;
     jit_jcp_.nb_oc_blocking = jcp_.nb_oc_blocking;
 
-    jit_jcp_.ic_tail = jcp_.tr_ic_tail;
+    jit_jcp_.ic_tail = static_cast<int>(jcp_.tr_ic_tail);
     jit_jcp_.oc_tail = jcp_.oc_tail;
 
     jit_jcp_.tr_iw = jcp_.tr_iw;
@@ -233,7 +233,7 @@ void brgemm_convolution_bwd_weights_t::pd_t::copy2jit_jcp() {
 }
 
 status_t brgemm_convolution_bwd_weights_t::add_brg_kernel(
-        int bs, int M, int i_N, int i_K, int i_init) {
+        int bs, dim_t M, int i_N, int i_K, int i_init) {
     if (M <= 0) return status::success;
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
@@ -275,8 +275,12 @@ status_t brgemm_convolution_bwd_weights_t::init(engine_t *engine) {
     }
     if (jcp.transform_to_vnni) {
         CHECK(safe_ptr_assign(diff_wei_trans_kernel_,
-                new jit_diff_wei_trans_to_vnni_t(jcp.wei_dt, jcp.kd, jcp.kh,
-                        jcp.kw, jcp.ic_block, jcp.oc_block, jcp.nb_ic)));
+                new jit_diff_wei_trans_to_vnni_t(jcp.wei_dt,
+                        static_cast<int>(jcp.kd), static_cast<int>(jcp.kh),
+                        static_cast<int>(jcp.kw),
+                        static_cast<int>(jcp.ic_block),
+                        static_cast<int>(jcp.oc_block),
+                        static_cast<int>(jcp.nb_ic))));
         CHECK(diff_wei_trans_kernel_->create_kernel());
     }
 
@@ -336,10 +340,10 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
     int ithr_but_oc = 0;
     int ithr_but_ic = 0;
 
-    int img_start = 0, img_end = 0, img_work = 0;
-    int g_start = 0, g_end = 0, g_work = 0;
-    int oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
-    int ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
+    dim_t img_start = 0, img_end = 0, img_work = 0;
+    dim_t g_start = 0, g_end = 0, g_work = 0;
+    dim_t oc_b_start = 0, oc_b_end = 0, oc_b_work = 0;
+    dim_t ic_b_start = 0, ic_b_end = 0, ic_b_work = 0;
 
     int cur_brg_idx = -1;
     brgemm_batch_element_t *__restrict brg_batch;
@@ -404,7 +408,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
         ithr_but_ic
                 = (ithr_mb * jcp.nthr_g + ithr_g) * jcp.nthr_oc_b + ithr_oc_b;
 
-        int work_amount = jcp.nthr_mb_work;
+        dim_t work_amount = jcp.nthr_mb_work;
         /* reduction dimension */
         balance211(work_amount, jcp.nthr_mb, ithr_mb, img_start, img_end);
         img_work = img_end - img_start;
@@ -417,7 +421,8 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
         oc_b_work = oc_b_end - oc_b_start;
 
         if (jcp.transform_to_vnni) {
-            const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+            const int vnni_granularity
+                    = static_cast<int>(data_type_vnni_granularity(jcp.wei_dt));
             if (vnni_granularity == 0) {
                 assert(!"Invalid vnni granularity.");
                 return;
@@ -426,8 +431,9 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             const auto icb_work = div_up(jcp.nb_ic, vnni_granularity);
             balance211(
                     icb_work, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
-            ic_b_start = nstl::min(jcp.nb_ic, ic_b_start * vnni_granularity);
-            ic_b_end = nstl::min(jcp.nb_ic, ic_b_end * vnni_granularity);
+            ic_b_start = nstl::min<dim_t>(
+                    jcp.nb_ic, ic_b_start * vnni_granularity);
+            ic_b_end = nstl::min<dim_t>(jcp.nb_ic, ic_b_end * vnni_granularity);
         } else {
             balance211(
                     jcp.nb_ic, jcp.nthr_ic_b, ithr_ic_b, ic_b_start, ic_b_end);
@@ -450,35 +456,36 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
 
     const pd_t *pd() const { return self->pd(); }
 
-    inline int get_inp_start(int out_s, int pad, int str) const {
-        return nstl::max(0, -pad + out_s * str);
+    inline dim_t get_inp_start(dim_t out_s, dim_t pad, dim_t str) const {
+        return nstl::max<dim_t>(0, -pad + out_s * str);
     }
 
-    inline int get_inp_end(int out_e, int is, int pad, int str, int ek) const {
-        return nstl::min(is, -pad + (out_e - 1) * str + ek);
+    inline dim_t get_inp_end(
+            dim_t out_e, dim_t is, dim_t pad, dim_t str, dim_t ek) const {
+        return nstl::min<dim_t>(is, -pad + (out_e - 1) * str + ek);
     }
 
-    inline int get_id_start(int od_s) const {
+    inline dim_t get_id_start(dim_t od_s) const {
         return get_inp_start(od_s, jcp.f_pad, jcp.stride_d);
     }
-    inline int get_ih_start(int oh_s) const {
+    inline dim_t get_ih_start(dim_t oh_s) const {
         return get_inp_start(oh_s, jcp.t_pad, jcp.stride_h);
     }
 
-    inline int get_id_end(int od_e) const {
+    inline dim_t get_id_end(dim_t od_e) const {
         return get_inp_end(od_e, jcp.id, jcp.f_pad, jcp.stride_d, jcp.ext_kd);
     }
-    inline int get_ih_end(int oh_e) const {
+    inline dim_t get_ih_end(dim_t oh_e) const {
         return get_inp_end(oh_e, jcp.ih, jcp.t_pad, jcp.stride_h, jcp.ext_kh);
     }
 
-    size_t tr_src_buf_number(int g, int icb) const {
+    size_t tr_src_buf_number(dim_t g, dim_t icb) const {
         return jcp.global_transpose
                 ? ithr_mb * jcp.nb_ic * jcp.ngroups + g * jcp.nb_ic + icb
                 : ithr;
     }
 
-    size_t tr_diff_dst_buf_number(int g, int ocb) const {
+    size_t tr_diff_dst_buf_number(dim_t g, dim_t ocb) const {
         // for current loop order (xoi) if jcp.tr_ocb_chunk then we can reuse
         // same area in tr_diff_dst buffer
         if (jcp.tr_ocb_chunk)
@@ -493,7 +500,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                     : ithr;
     }
 
-    size_t tr_src_off(int g, int icb, int id, int ih) const {
+    size_t tr_src_off(dim_t g, dim_t icb, dim_t id, dim_t ih) const {
         const size_t tr_row_size = jcp.tr_iw * jcp.ic_block;
         const size_t tr_3d_size = tr_row_size * jcp.ih_block;
         // Aligned to buffer end to use guard elements
@@ -502,14 +509,16 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 * jcp.src_dsz;
     }
 
-    inline size_t tr_ic_block_src_off(int g, int tr_icb, int id, int ih) const {
-        const int nb_tr_icb = jcp.ic_block / jcp.tr_ic_block;
+    inline size_t tr_ic_block_src_off(
+            dim_t g, dim_t tr_icb, dim_t id, dim_t ih) const {
+        const dim_t nb_tr_icb = jcp.ic_block / jcp.tr_ic_block;
         return tr_src_off(g, tr_icb / nb_tr_icb, id, ih)
                 + (tr_icb % nb_tr_icb) * jcp.tr_ic_block * jcp.tr_iw
                 * jcp.src_dsz;
     }
 
-    inline size_t tr_diff_dst_off(int g, int ocb, int od, int oh) const {
+    inline size_t tr_diff_dst_off(
+            dim_t g, dim_t ocb, dim_t od, dim_t oh) const {
         const size_t tr_row_size = jcp.tr_ow * jcp.oc_block;
         const size_t tr_3d_size = tr_row_size * jcp.oh_block;
         return (tr_diff_dst_buf_number(g, ocb) * jcp.tr_diff_dst_buf_size
@@ -517,24 +526,25 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 * jcp.dst_dsz;
     }
 
-    void trans_src_nxc(char *tr_src, const char *src_base, int tr_icb,
-            int row_count, int ih_s) const {
-        const int src_stride = jcp.iw * jcp.ngroups * jcp.ic * jcp.src_dsz;
-        const int tr_src_stride = jcp.tr_iw * jcp.ic_block * jcp.src_dsz;
+    void trans_src_nxc(char *tr_src, const char *src_base, dim_t tr_icb,
+            dim_t row_count, dim_t ih_s) const {
+        const dim_t src_stride = jcp.iw * jcp.ngroups * jcp.ic * jcp.src_dsz;
+        const dim_t tr_src_stride = jcp.tr_iw * jcp.ic_block * jcp.src_dsz;
 
-        int sp_work = row_count;
+        dim_t sp_work = row_count;
         const char *src = src_base;
-        const int tr_ic_tail_work
+        const dim_t tr_ic_tail_work
                 = jcp.tr_ic_tail ? jcp.tr_ic_tail : jcp.tr_ic_block;
-        for (int iwork = 0; iwork < sp_work; iwork++) {
+        for (dim_t iwork = 0; iwork < sp_work; iwork++) {
             // For 1x1 convolutions with strides we transpose only
             // needed lines
             if (IMPLICATION(jcp.kh == 1, (ih_s + iwork) % jcp.stride_h == 0)) {
                 auto ctx = jit_trans_src_t::ctx_t();
                 ctx.src = src;
                 ctx.tr_src = tr_src;
-                ctx.ch_work = (tr_icb + 1) == jcp.nb_tr_ic ? tr_ic_tail_work
-                                                           : jcp.tr_ic_block;
+                ctx.ch_work = static_cast<int>((tr_icb + 1) == jcp.nb_tr_ic
+                                ? tr_ic_tail_work
+                                : jcp.tr_ic_block);
                 ctx.src_prf = nullptr;
                 ctx.tr_src_prf = nullptr;
                 (*self->trans_kernel_)(&ctx);
@@ -545,25 +555,27 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
     }
 
     void trans_dst_nxc(char *tr_diff_dst, const char *diff_dst_base,
-            int spatial_start, dim_t spatial_start_offset, int ocb_start,
-            dim_t chb_stride, int row_count) const {
-        const int diff_dst_stride = jcp.ow * jcp.ngroups * jcp.oc * jcp.dst_dsz;
-        const int tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block * jcp.dst_dsz;
-        int work_rest = row_count;
-        int max_spatial_work = jcp.od * jcp.oh;
-        int sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
+            dim_t spatial_start, dim_t spatial_start_offset, dim_t ocb_start,
+            dim_t chb_stride, dim_t row_count) const {
+        const dim_t diff_dst_stride
+                = jcp.ow * jcp.ngroups * jcp.oc * jcp.dst_dsz;
+        const dim_t tr_diff_dst_stride = jcp.tr_ow * jcp.oc_block * jcp.dst_dsz;
+        dim_t work_rest = row_count;
+        const dim_t max_spatial_work = jcp.od * jcp.oh;
+        dim_t sp_work = nstl::min(work_rest, max_spatial_work - spatial_start);
         const char *diff_dst
                 = diff_dst_base + spatial_start_offset * jcp.dst_dsz;
-        int ocb = 0;
-        const int oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
+        dim_t ocb = 0;
+        const dim_t oc_tail_work = jcp.oc_tail ? jcp.oc_tail : jcp.oc_block;
         while (work_rest > 0) {
-            for (int iwork = 0; iwork < sp_work; iwork++) {
+            for (dim_t iwork = 0; iwork < sp_work; iwork++) {
                 auto ctx = jit_trans_dst_t::ctx_t();
                 ctx.src = diff_dst;
                 ctx.tr_src = tr_diff_dst;
                 assert(ocb_start + ocb < jcp.nb_oc);
-                ctx.ch_work = (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
-                                                                 : jcp.oc_block;
+                ctx.ch_work = static_cast<int>(
+                        (ocb_start + ocb + 1) == jcp.nb_oc ? oc_tail_work
+                                                           : jcp.oc_block);
                 ctx.src_prf = nullptr;
                 ctx.tr_src_prf = nullptr;
                 (*self->trans_dst_kernel_)(&ctx);
@@ -577,19 +589,20 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
         }
     }
 
-    void maybe_global_transpose(int img, int ocb_s, int ocb_e, int icb_s,
-            int icb_e, int od_s, int odb_s, int odb_e, int oh_s, int ohb_s,
-            int ohb_e) const {
+    void maybe_global_transpose(dim_t img, dim_t ocb_s, dim_t ocb_e,
+            dim_t icb_s, dim_t icb_e, dim_t od_s, dim_t odb_s, dim_t odb_e,
+            dim_t oh_s, dim_t ohb_s, dim_t ohb_e) const {
         if (!jcp.global_transpose) return;
 
         using simple_barrier::barrier;
         // use tr_ic_block to transform src
         assert(jcp.ic_block % jcp.tr_ic_block == 0);
-        const int nb_tr_icb = jcp.ic_block / jcp.tr_ic_block;
-        const int tr_icb_s = icb_s * nb_tr_icb;
-        const int tr_icb_e = nstl::min(icb_e * nb_tr_icb, jcp.nb_tr_ic);
-        const int tr_icb_work = tr_icb_e - tr_icb_s;
-        const int ocb_work = ocb_e - ocb_s;
+        const dim_t nb_tr_icb = jcp.ic_block / jcp.tr_ic_block;
+        const dim_t tr_icb_s = icb_s * nb_tr_icb;
+        const dim_t tr_icb_e
+                = nstl::min<dim_t>(icb_e * nb_tr_icb, jcp.nb_tr_ic);
+        const dim_t tr_icb_work = tr_icb_e - tr_icb_s;
+        const dim_t ocb_work = ocb_e - ocb_s;
 
         // The barrier should stay outside of work condition to avoid
         // possible hang
@@ -606,25 +619,26 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             const auto ihb_s = get_ih_start(ohb_s);
             const auto ihb_e = get_ih_end(ohb_e);
 
-            int work_amount
+            dim_t work_amount
                     = g_work * tr_icb_work * (idb_e - idb_s) * (ihb_e - ihb_s);
-            int tr_start {0}, tr_end {0};
+            dim_t tr_start {0}, tr_end {0};
             balance211(work_amount, jcp.nthr_oc_b, ithr_oc_b, tr_start, tr_end);
 
-            int g {0}, tr_ic_b {0}, jd {0}, jh {0};
+            dim_t g {0}, tr_ic_b {0}, jd {0}, jh {0};
             nd_iterator_init(tr_start, g, g_work, tr_ic_b, tr_icb_work, jd,
                     idb_e - idb_s, jh, ihb_e - ihb_s);
 
             while (tr_start < tr_end) {
-                int g_ = g + g_start;
-                int tr_ic_b_ = tr_ic_b + tr_icb_s;
+                dim_t g_ = g + g_start;
+                dim_t tr_ic_b_ = tr_ic_b + tr_icb_s;
 
-                int jd_s = jd + idb_s;
+                dim_t jd_s = jd + idb_s;
 
-                int jh_s = jh + ihb_s;
-                int jh_e = jh_s + nstl::min(tr_end - tr_start, ihb_e - jh_s);
+                dim_t jh_s = jh + ihb_s;
+                dim_t jh_e = jh_s + nstl::min(tr_end - tr_start, ihb_e - jh_s);
 
-                const int ic_off_idx = g_ * jcp.ic + tr_ic_b_ * jcp.tr_ic_block;
+                const dim_t ic_off_idx
+                        = g_ * jcp.ic + tr_ic_b_ * jcp.tr_ic_block;
 
                 const char *p_src {nullptr};
                 if (jcp.harness == harness_2d_reduction) {
@@ -653,26 +667,26 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             barrier(&tr_diff_dst_bctx[ithr_but_ic], jcp.nthr_ic_b);
 
         if (ocb_work > 0) {
-            int jd = 0;
-            int jh = 0;
-            int work_amount
+            dim_t jd = 0;
+            dim_t jh = 0;
+            dim_t work_amount
                     = g_work * ocb_work * (odb_e - odb_s) * (ohb_e - ohb_s);
-            int tr_start = 0;
-            int tr_end = 0;
+            dim_t tr_start = 0;
+            dim_t tr_end = 0;
             balance211(work_amount, jcp.nthr_ic_b, ithr_ic_b, tr_start, tr_end);
 
-            int g = 0;
-            int oc_b = 0;
+            dim_t g = 0;
+            dim_t oc_b = 0;
             nd_iterator_init(tr_start, g, g_work, oc_b, ocb_work, jd,
                     odb_e - odb_s, jh, ohb_e - ohb_s);
 
             while (tr_start < tr_end) {
-                int g_ = g + g_start;
-                int oc_b_ = oc_b + ocb_s;
-                int jd_s = jd + odb_s;
-                int jh_s = jh + ohb_s;
-                int jh_e = jh_s + nstl::min(tr_end - tr_start, ohb_e - jh_s);
-                const int oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
+                dim_t g_ = g + g_start;
+                dim_t oc_b_ = oc_b + ocb_s;
+                dim_t jd_s = jd + odb_s;
+                dim_t jh_s = jh + ohb_s;
+                dim_t jh_e = jh_s + nstl::min(tr_end - tr_start, ohb_e - jh_s);
+                const dim_t oc_off_idx = g_ * jcp.oc + oc_b_ * jcp.oc_block;
 
                 const char *p_diff_dst {nullptr};
                 if (jcp.harness == harness_2d_reduction) {
@@ -699,18 +713,18 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             barrier(&tr_diff_dst_bctx[ithr_but_ic], jcp.nthr_ic_b);
     }
 
-    void maybe_local_traspose(char *&p_src, char *&p_dst, int img, int g,
-            int ic_b, int oc_b, int od_s, int odb_s, int odb_e, int oh_s,
-            int ohb_s, int ohb_e) const {
+    void maybe_local_traspose(char *&p_src, char *&p_dst, dim_t img, dim_t g,
+            dim_t ic_b, dim_t oc_b, dim_t od_s, dim_t odb_s, dim_t odb_e,
+            dim_t oh_s, dim_t ohb_s, dim_t ohb_e) const {
 
-        const int idb_s = get_id_start(odb_s);
-        const int ihb_s = get_ih_start(ohb_s);
+        const dim_t idb_s = get_id_start(odb_s);
+        const dim_t ihb_s = get_ih_start(ohb_s);
 
-        const int idb_e = get_id_end(odb_e);
-        const int ihb_e = get_ih_end(ohb_e);
+        const dim_t idb_e = get_id_end(odb_e);
+        const dim_t ihb_e = get_ih_end(ohb_e);
 
-        const int id_s = get_id_start(od_s);
-        const int ih_s = get_ih_start(oh_s);
+        const dim_t id_s = get_id_start(od_s);
+        const dim_t ih_s = get_ih_start(oh_s);
 
         if (jcp.global_transpose) {
             p_src = &tr_src[tr_src_off(g, ic_b, 0, 0)];
@@ -718,17 +732,17 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             return;
         }
 
-        const int nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ic_b_end)
+        const dim_t nb_ic_blocks = (ic_b + jcp.nb_ic_blocking > ic_b_end)
                 ? 1
                 : jcp.nb_ic_blocking;
 
-        const int nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > oc_b_end)
+        const dim_t nb_oc_blocks = (oc_b + jcp.nb_oc_blocking > oc_b_end)
                 ? 1
                 : jcp.nb_oc_blocking;
 
-        for_(int idb = idb_s; idb < idb_e; idb++)
-        for (int icb = 0; icb < nb_ic_blocks; icb++) {
-            const int ic_off_idx = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
+        for_(dim_t idb = idb_s; idb < idb_e; idb++)
+        for (dim_t icb = 0; icb < nb_ic_blocks; icb++) {
+            const dim_t ic_off_idx = g * jcp.ic + (ic_b + icb) * jcp.ic_block;
             char *p_tr_src
                     = &tr_src[tr_src_off(0, 0, idb - id_s, ihb_s - ih_s)];
             char *tr_src_local
@@ -750,9 +764,9 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
 
         p_src = &tr_src[tr_src_off(0, 0, 0, 0)]; // p_tr_src;
 
-        for_(int odb = odb_s; odb < odb_e; odb++)
-        for (int ocb = 0; ocb < nb_oc_blocks; ocb++) {
-            const int oc_off_idx = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
+        for_(dim_t odb = odb_s; odb < odb_e; odb++)
+        for (dim_t ocb = 0; ocb < nb_oc_blocks; ocb++) {
+            const dim_t oc_off_idx = g * jcp.oc + (oc_b + ocb) * jcp.oc_block;
             const char *p_raw_diff_dst {nullptr};
             if (jcp.harness == harness_2d_reduction) {
                 p_raw_diff_dst
@@ -775,7 +789,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
     }
 
     bool just_init_output(
-            int start, int end, float *diff_wei, float *diff_bias) {
+            dim_t start, dim_t end, float *diff_wei, float *diff_bias) {
         if (g_start >= g_end || oc_b_start >= oc_b_end
                 || ic_b_start >= ic_b_end)
             return false;
@@ -783,7 +797,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             // for rare case if thread has no work by spatial dimension then we
             // need to initialize the output at least
             if (jcp.with_bias) {
-                for_(int g = g_start; g < g_end; ++g)
+                for_(dim_t g = g_start; g < g_end; ++g)
                 {
                     void *p_bias = diff_bias + g * rnd_up(jcp.oc, jcp.oc_block)
                             + oc_b_start * jcp.oc_block;
@@ -792,8 +806,8 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
                 }
             }
 
-            for_(int g = g_start; g < g_end; ++g)
-            for (int oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
                 auto wei_offs_ext = pd()->ndims() == 3
                         ? wht_blk_off(diff_weights_d, g, oc_b, ic_b_start, 0)
                         : (pd()->ndims() == 4
@@ -817,8 +831,8 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
             // For small ic we may calculate only needed part of diff_weights.
             // So we have to initialize diff_weights
             // TODO: initialize only not calculated part of diff_weights
-            for_(int g = g_start; g < g_end; ++g)
-            for (int oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
+            for_(dim_t g = g_start; g < g_end; ++g)
+            for (dim_t oc_b = oc_b_start; oc_b < oc_b_end; oc_b++) {
                 auto wei_offs_ext = pd()->ndims() == 3
                         ? wht_blk_off(diff_weights_d, g, oc_b, ic_b_start, 0)
                         : (pd()->ndims() == 4
@@ -843,7 +857,7 @@ struct brgemm_convolution_bwd_weights_t::thread_info_t {
 };
 
 void brgemm_convolution_bwd_weights_t::call_brgemm_kernel(
-        thread_info_t &btc, int brg_idx, int batch_size, void *ptr_C) const {
+        thread_info_t &btc, int brg_idx, dim_t batch_size, void *ptr_C) const {
 
     const auto brg_ker = brg_kernels_[brg_idx];
     assert(brg_ker != nullptr);
@@ -861,10 +875,10 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kd * jcp.kh * jcp.kw;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_spblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_spblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() != data_type::f32)
@@ -884,26 +898,26 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    int img {0}, oh_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, oh_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int img_s {0};
+    dim_t img_s {0};
     nd_iterator_init(start, img_s, jcp.mb, oh_s, jcp.oh);
     img = img_s;
 
     auto do_brgemm_call
-            = [&](int g, int bs, int ic_b, int oc_b, int ohb_s, int bs_ih_s,
-                      const char *p_src, const char *p_dst, int kh, int kw,
-                      bool do_init) {
-        const int ihb_s = ti->get_ih_start(ohb_s);
+            = [&](dim_t g, dim_t bs, dim_t ic_b, dim_t oc_b, dim_t ohb_s,
+                      dim_t bs_ih_s, const char *p_src, const char *p_dst,
+                      dim_t kh, dim_t kw, bool do_init) {
+        const dim_t ihb_s = ti->get_ih_start(ohb_s);
 
-        const int bs_oh_s = utils::saturate(0, jcp.oh,
+        const dim_t bs_oh_s = utils::saturate<dim_t>(0, jcp.oh,
                 (bs_ih_s + jcp.t_pad - kh * (jcp.dilate_h + 1)) / jcp.stride_h);
 
         auto ocb_end = get_end(oc_b, jcp.nb_oc_blocking, ti->oc_b_end);
         auto icb_end = get_end(ic_b, jcp.nb_ic_blocking, ti->ic_b_end);
-        const int src_stride_w_shift = jcp.tr_iw / jcp.stride_w;
+        const dim_t src_stride_w_shift = jcp.tr_iw / jcp.stride_w;
         const auto a_off = _pd->filter_w_to_src(kw) / jcp.stride_w
                 + (kw % jcp.stride_w) * src_stride_w_shift
                 + (bs_ih_s - ihb_s) * jcp.tr_iw * jcp.ic_block;
@@ -924,7 +938,7 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
         auto brg_idx = _pd->get_brg_idx(
                 bs, M_tail ? jcp.M_tail : jcp.M, do_init, N_tail, false);
 
-        for (int ohb = 0; ohb < bs; ohb++) {
+        for (dim_t ohb = 0; ohb < bs; ohb++) {
             ti->brg_batch[ohb].ptr.A = (char *)ptr_A
                     + ohb * jcp.tr_iw * jcp.ic_block * jcp.stride_h
                             * jcp.src_dsz;
@@ -938,14 +952,15 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
     if (ti->just_init_output(start, end, diff_wei, diff_bias)) return;
 
     while (start < end) {
-        const int oh_e = _pd->get_finish_oh(
+        const dim_t oh_e = _pd->get_finish_oh(
                 oh_s, start, get_end(start, jcp.oh_block, end));
-        int height_block = jcp.global_transpose ? oh_e - oh_s : optimal_spblock;
+        dim_t height_block
+                = jcp.global_transpose ? oh_e - oh_s : optimal_spblock;
 
         // loop by ohb_s have only one iteration for global_transpose case
         // because height_block = oh_e - oh_s
-        for (int ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block) {
-            const int ohb_e = get_end(ohb_s, height_block, oh_e);
+        for (dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += height_block) {
+            const dim_t ohb_e = get_end(ohb_s, height_block, oh_e);
             assert(ohb_e <= jcp.oh);
 
             ti->maybe_global_transpose(img,
@@ -955,20 +970,20 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
                     jcp.tr_icb_chunk ? 0 : ti->ic_b_end, 0, 0, 1, oh_s, ohb_s,
                     ohb_e);
 
-            for_(int g = ti->g_start; g < ti->g_end; ++g)
-            for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+            for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+            for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                     oc_b += jcp.nb_oc_blocking) {
-                const int oc_b_e
+                const dim_t oc_b_e
                         = get_end(oc_b, jcp.nb_oc_blocking, ti->oc_b_end);
 
                 if (jcp.tr_ocb_chunk)
                     ti->maybe_global_transpose(img, oc_b, oc_b_e, 0, 0, 0, 0, 1,
                             oh_s, ohb_s, ohb_e);
 
-                for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+                for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                         ic_b += jcp.nb_ic_blocking) {
 
-                    const int ic_b_e
+                    const dim_t ic_b_e
                             = get_end(ic_b, jcp.nb_ic_blocking, ti->ic_b_end);
 
                     if (oc_b == ti->oc_b_start && jcp.tr_icb_chunk)
@@ -1007,15 +1022,16 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
 
                     const auto do_init = (start == ti->img_start);
 
-                    for (int kh = 0; kh < jcp.kh; kh++) {
-                        const int bs_ih_s = _pd->get_start_ih(kh, ohb_s);
-                        const int bs_ih_e = _pd->get_finish_ih(kh, ohb_e);
-                        const auto bs = div_up(
-                                nstl::max(0, bs_ih_e - bs_ih_s), jcp.stride_h);
+                    for (dim_t kh = 0; kh < jcp.kh; kh++) {
+                        const dim_t bs_ih_s = _pd->get_start_ih(kh, ohb_s);
+                        const dim_t bs_ih_e = _pd->get_finish_ih(kh, ohb_e);
+                        const auto bs
+                                = div_up(nstl::max<dim_t>(0, bs_ih_e - bs_ih_s),
+                                        jcp.stride_h);
                         if (bs == 0 && !do_init) continue;
 
-                        for_(int s = 0; s < jcp.stride_w; s++)
-                        for (int kw = s; kw < jcp.kw; kw += jcp.stride_w)
+                        for_(dim_t s = 0; s < jcp.stride_w; s++)
+                        for (dim_t kw = s; kw < jcp.kw; kw += jcp.stride_w)
                             do_brgemm_call(g, bs, ic_b, oc_b, ohb_s, bs_ih_s,
                                     p_src, p_dst, kh, kw, do_init);
                     }
@@ -1023,8 +1039,10 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_2d(
             }
         }
 
-        nd_iterator_jump(start, get_end(start, jcp.oh_block, end), img, jcp.mb,
-                oh_s, jcp.oh);
+        dim_t jump_start = start;
+        const dim_t jump_end = get_end(start, jcp.oh_block, end);
+        nd_iterator_jump(jump_start, jump_end, img, jcp.mb, oh_s, jcp.oh);
+        start = jump_start;
     }
 }
 
@@ -1035,10 +1053,10 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
     const auto _pd = pd();
     const auto &jcp = _pd->jcp_;
 
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kd * jcp.kh * jcp.kw;
-    const int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
-    const int optimal_spblock = jcp.spatial_blk_size;
+    const dim_t bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+    const dim_t optimal_spblock = jcp.spatial_blk_size;
 
     float *diff_wei;
     if (diff_weights_d.data_type() != data_type::f32)
@@ -1058,30 +1076,31 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
                     : ti->bia_reduction + (ti->ithr_mb - 1) * bias_buf_size;
     }
 
-    int img {0}, od_s {0};
-    int start = ti->img_start;
-    int end = ti->img_end;
+    dim_t img {0}, od_s {0};
+    dim_t start = ti->img_start;
+    dim_t end = ti->img_end;
 
-    int img_s {0};
+    dim_t img_s {0};
     nd_iterator_init(start, img_s, jcp.mb, od_s, jcp.od);
     img = img_s;
 
     auto do_brgemm_call
-            = [&](int g, int bs_d, int bs_h, int ic_b, int oc_b, int od_s,
-                      int oh_s, int bs_id_s, int bs_ih_s, const char *p_src,
-                      const char *p_dst, int kd, int kh, int kw, bool do_init) {
-        const int id_s = ti->get_id_start(od_s);
-        const int ih_s = ti->get_ih_start(oh_s);
+            = [&](dim_t g, dim_t bs_d, dim_t bs_h, dim_t ic_b, dim_t oc_b,
+                      dim_t od_s, dim_t oh_s, dim_t bs_id_s, dim_t bs_ih_s,
+                      const char *p_src, const char *p_dst, dim_t kd, dim_t kh,
+                      dim_t kw, bool do_init) {
+        const dim_t id_s = ti->get_id_start(od_s);
+        const dim_t ih_s = ti->get_ih_start(oh_s);
 
-        const int bs_od_s = utils::saturate(0, jcp.od,
+        const dim_t bs_od_s = utils::saturate<dim_t>(0, jcp.od,
                 (bs_id_s + jcp.f_pad - kd * (jcp.dilate_d + 1)) / jcp.stride_d);
 
-        const int bs_oh_s = utils::saturate(0, jcp.oh,
+        const dim_t bs_oh_s = utils::saturate<dim_t>(0, jcp.oh,
                 (bs_ih_s + jcp.t_pad - kh * (jcp.dilate_h + 1)) / jcp.stride_h);
 
         auto ocb_end = get_end(oc_b, jcp.nb_oc_blocking, ti->oc_b_end);
         auto icb_end = get_end(ic_b, jcp.nb_ic_blocking, ti->ic_b_end);
-        const int src_stride_w_shift = jcp.tr_iw / jcp.stride_w;
+        const dim_t src_stride_w_shift = jcp.tr_iw / jcp.stride_w;
         const auto a_off = _pd->filter_w_to_src(kw) / jcp.stride_w
                 + (kw % jcp.stride_w) * src_stride_w_shift
                 + (bs_ih_s - ih_s) * jcp.tr_iw * jcp.ic_block
@@ -1102,8 +1121,8 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
         auto brg_idx = _pd->get_brg_idx(
                 bs, M_tail ? jcp.M_tail : jcp.M, do_init, N_tail, false);
 
-        for (int odb = 0; odb < bs_d; odb++) {
-            for (int ohb = 0; ohb < bs_h; ohb++) {
+        for (dim_t odb = 0; odb < bs_d; odb++) {
+            for (dim_t ohb = 0; ohb < bs_h; ohb++) {
                 const auto a_off_batch = (odb * jcp.ih_block * jcp.stride_d
                                                  + ohb * jcp.stride_h)
                         * jcp.tr_iw * jcp.ic_block * jcp.src_dsz;
@@ -1125,17 +1144,17 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
     const auto oh_e = jcp.oh;
 
     while (start < end) {
-        const int od_e = _pd->get_finish_od(
+        const dim_t od_e = _pd->get_finish_od(
                 od_s, start, get_end(start, jcp.od_block, end));
-        int sp_block = jcp.global_transpose ? od_e - od_s : optimal_spblock;
+        dim_t sp_block = jcp.global_transpose ? od_e - od_s : optimal_spblock;
 
         // loop by odb_s have only one iteration for global_transpose case
         // because sp_block = od_e - od_s
-        for (int odb_s = od_s; odb_s < od_e; odb_s += sp_block) {
-            const int odb_e = get_end(odb_s, sp_block, od_e);
+        for (dim_t odb_s = od_s; odb_s < od_e; odb_s += sp_block) {
+            const dim_t odb_e = get_end(odb_s, sp_block, od_e);
             assert(odb_e <= jcp.od);
 
-            for (int ohb_s = oh_s; ohb_s < oh_e; ohb_s += jcp.oh_block) {
+            for (dim_t ohb_s = oh_s; ohb_s < oh_e; ohb_s += jcp.oh_block) {
                 const auto ohb_e = get_end(ohb_s, jcp.oh_block, jcp.oh);
 
                 ti->maybe_global_transpose(img,
@@ -1145,19 +1164,19 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
                         jcp.tr_icb_chunk ? 0 : ti->ic_b_end, od_s, odb_s, odb_e,
                         oh_s, ohb_s, ohb_e);
 
-                for_(int g = ti->g_start; g < ti->g_end; ++g)
-                for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
+                for_(dim_t g = ti->g_start; g < ti->g_end; ++g)
+                for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end;
                         oc_b += jcp.nb_oc_blocking) {
-                    const int oc_b_e
+                    const dim_t oc_b_e
                             = get_end(oc_b, jcp.nb_oc_blocking, ti->oc_b_end);
                     if (jcp.tr_ocb_chunk)
                         ti->maybe_global_transpose(img, oc_b, oc_b_e, 0, 0,
                                 od_s, odb_s, odb_e, oh_s, ohb_s, ohb_e);
 
-                    for (int ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
+                    for (dim_t ic_b = ti->ic_b_start; ic_b < ti->ic_b_end;
                             ic_b += jcp.nb_ic_blocking) {
 
-                        const int ic_b_e = get_end(
+                        const dim_t ic_b_e = get_end(
                                 ic_b, jcp.nb_ic_blocking, ti->ic_b_end);
 
                         if (oc_b == ti->oc_b_start && jcp.tr_icb_chunk)
@@ -1170,7 +1189,7 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
                                 oc_b, od_s, odb_s, odb_e, oh_s, ohb_s, ohb_e);
 
                         if (jcp.with_bias && ic_b == 0) {
-                            for (int iodb = odb_s; iodb < odb_e; iodb++) {
+                            for (dim_t iodb = odb_s; iodb < odb_e; iodb++) {
                                 auto bp = jit_conv_args_t();
 
                                 bp.bias = diff_bias
@@ -1205,28 +1224,28 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
                         const auto do_init
                                 = (start == ti->img_start && ohb_s == oh_s);
 
-                        for (int kd = 0; kd < jcp.kd; kd++) {
-                            const int bs_id_s = _pd->get_start_id(kd, odb_s);
-                            const int bs_id_e = _pd->get_finish_id(kd, odb_e);
-                            const auto bs_d
-                                    = div_up(nstl::max(0, bs_id_e - bs_id_s),
-                                            jcp.stride_d);
+                        for (dim_t kd = 0; kd < jcp.kd; kd++) {
+                            const dim_t bs_id_s = _pd->get_start_id(kd, odb_s);
+                            const dim_t bs_id_e = _pd->get_finish_id(kd, odb_e);
+                            const auto bs_d = div_up(
+                                    nstl::max<dim_t>(0, bs_id_e - bs_id_s),
+                                    jcp.stride_d);
                             // bs_d may be 0 but we may still need to call brgemm to
                             // initialize output
                             if (bs_d == 0 && !do_init) continue;
 
-                            for (int kh = 0; kh < jcp.kh; kh++) {
-                                const int bs_ih_s
+                            for (dim_t kh = 0; kh < jcp.kh; kh++) {
+                                const dim_t bs_ih_s
                                         = _pd->get_start_ih(kh, ohb_s);
-                                const int bs_ih_e
+                                const dim_t bs_ih_e
                                         = _pd->get_finish_ih(kh, ohb_e);
                                 const auto bs_h = div_up(
-                                        nstl::max(0, bs_ih_e - bs_ih_s),
+                                        nstl::max<dim_t>(0, bs_ih_e - bs_ih_s),
                                         jcp.stride_h);
                                 if (bs_h == 0 && !do_init) continue;
 
-                                for_(int s = 0; s < jcp.stride_w; s++)
-                                for (int kw = s; kw < jcp.kw;
+                                for_(dim_t s = 0; s < jcp.stride_w; s++)
+                                for (dim_t kw = s; kw < jcp.kw;
                                         kw += jcp.stride_w)
                                     do_brgemm_call(g, bs_d, bs_h, ic_b, oc_b,
                                             od_s, oh_s, bs_id_s, bs_ih_s, p_src,
@@ -1238,8 +1257,10 @@ void brgemm_convolution_bwd_weights_t::compute_diff_weights_3d(
             }
         }
 
-        nd_iterator_jump(start, get_end(start, jcp.od_block, end), img, jcp.mb,
-                od_s, jcp.od);
+        dim_t jump_start = start;
+        const dim_t jump_end = get_end(start, jcp.od_block, end);
+        nd_iterator_jump(jump_start, jump_end, img, jcp.mb, od_s, jcp.od);
+        start = jump_start;
     }
 }
 
@@ -1248,7 +1269,8 @@ void brgemm_convolution_bwd_weights_t::store_in_vnni_format(
     const auto &jcp = pd()->jcp_;
     if (one_of(0, ti->g_work, ti->oc_b_work, ti->ic_b_work)) return;
 
-    const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+    const int vnni_granularity
+            = static_cast<int>(data_type_vnni_granularity(jcp.wei_dt));
     if (vnni_granularity == 0) {
         assert(!"Invalid vnni granularity.");
         return;
@@ -1257,15 +1279,15 @@ void brgemm_convolution_bwd_weights_t::store_in_vnni_format(
     const auto icb2_work = div_up(ti->ic_b_work, vnni_granularity);
     const auto work = ti->g_work * ti->oc_b_work * icb2_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, jcp.nthr_mb, ti->ithr_mb, start, end);
-    int sub_g_start {0}, sub_oc_b_start {0}, sub_icb2_start {0};
+    dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_icb2_start {0};
     nd_iterator_init(start, sub_g_start, ti->g_work, sub_oc_b_start,
             ti->oc_b_work, sub_icb2_start, icb2_work);
-    for (int w = start; w < end; w++) {
-        const int g = ti->g_start + sub_g_start;
-        const int oc_b = ti->oc_b_start + sub_oc_b_start;
-        const int ic_b = ti->ic_b_start + vnni_granularity * sub_icb2_start;
+    for (dim_t w = start; w < end; w++) {
+        const dim_t g = ti->g_start + sub_g_start;
+        const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+        const dim_t ic_b = ti->ic_b_start + vnni_granularity * sub_icb2_start;
         jit_conv_args_t p = jit_conv_args_t();
 
         float *input = ti->wei_bia_reduction + wei_offset_int(g, oc_b, ic_b, 0);
@@ -1287,7 +1309,7 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
     const memory_desc_wrapper diff_weights_d(pd()->diff_weights_md(0));
 
     const auto &jcp = pd()->jcp_;
-    const int wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
+    const dim_t wei_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block * jcp.nb_ic
             * jcp.ic_block * jcp.kh * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1);
 
     const auto wei_dt = diff_weights_d.data_type();
@@ -1301,8 +1323,8 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
             if (jcp.transform_to_vnni) {
                 store_in_vnni_format(ti);
             } else {
-                for_(int g = ti->g_start; g < ti->g_end; g++)
-                for (int oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
+                for_(dim_t g = ti->g_start; g < ti->g_end; g++)
+                for (dim_t oc_b = ti->oc_b_start; oc_b < ti->oc_b_end; oc_b++) {
                     const size_t acc_size = (size_t)ti->ic_b_work * jcp.kh
                             * jcp.kw * ((jcp.ndims == 5) ? jcp.kd : 1)
                             * jcp.ic_block * jcp.oc_block;
@@ -1316,10 +1338,10 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
         }
         if (pd()->with_bias() && !is_f32_bias && ti->ithr_ic_b == 0
                 && ti->ic_b_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
-                int result_start_idx
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
+                dim_t result_start_idx
                         = g * jcp.oc + ti->oc_b_start * jcp.oc_block;
-                int buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t buffer_start_idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 const size_t acc_size
                         = nstl::min(jcp.oc, ti->oc_b_end * jcp.oc_block)
@@ -1338,7 +1360,7 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
     if (jcp.global_transpose)
         simple_barrier::barrier(ti->wei_bia_reduction_bctx, jcp.nthr);
 
-    const int ic_b_kh_work
+    const dim_t ic_b_kh_work
             = ti->ic_b_work * ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
     if (ic_b_kh_work <= 0 || ti->oc_b_work == 0 || ti->g_work == 0) {
         // TODO: double check if a barrier is needed here
@@ -1348,24 +1370,24 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
         return;
     }
 
-    const int work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
+    const dim_t work = ti->g_work * ti->oc_b_work * ic_b_kh_work;
 
-    int start {0}, end {0};
+    dim_t start {0}, end {0};
     balance211(work, jcp.nthr_mb, ti->ithr_mb, start, end);
     if (!jcp.transform_to_vnni && start == end) return;
 
     const int _start_nthr_mb = 1;
     for (int thr_mb = _start_nthr_mb; thr_mb < jcp.nthr_mb; ++thr_mb) {
-        int w = start;
-        int sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
+        dim_t w = start;
+        dim_t sub_g_start {0}, sub_oc_b_start {0}, sub_ic_b_kh_start {0};
         nd_iterator_init(w, sub_g_start, ti->g_work, sub_oc_b_start,
                 ti->oc_b_work, sub_ic_b_kh_start, ic_b_kh_work);
         while (w < end) {
-            const int g = ti->g_start + sub_g_start;
-            const int oc_b = ti->oc_b_start + sub_oc_b_start;
-            const int ic_b = ti->ic_b_start
+            const dim_t g = ti->g_start + sub_g_start;
+            const dim_t oc_b = ti->oc_b_start + sub_oc_b_start;
+            const dim_t ic_b = ti->ic_b_start
                     + sub_ic_b_kh_start / ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
-            const int kX
+            const dim_t kX
                     = sub_ic_b_kh_start % ((jcp.ndims == 5) ? jcp.kd : jcp.kh);
 
             const size_t acc_size = (size_t)jcp.kw * jcp.ic_block * jcp.oc_block
@@ -1414,22 +1436,23 @@ void brgemm_convolution_bwd_weights_t::reduce_and_convert_diff_weights_and_bias(
         }
         if (jcp.with_bias && ti->ithr_ic_b == 0 && ti->ic_b_work > 0
                 && ti->ithr_mb == 0 && ti->img_work > 0) {
-            for (int g = ti->g_start; g < ti->g_end; g++) {
+            for (dim_t g = ti->g_start; g < ti->g_end; g++) {
                 float *bias_reduced = is_f32_bias ? (float *)(ti->diff_bias)
                                                   : ti->bia_reduction;
                 int thr_mb_buffer_idx = is_f32_bias ? thr_mb - 1 : thr_mb;
-                int bias_buf_size = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
+                const dim_t bias_buf_size
+                        = jcp.ngroups * jcp.nb_oc * jcp.oc_block;
                 float *bias_to_reduce
                         = ti->bia_reduction + thr_mb_buffer_idx * bias_buf_size;
                 const size_t acc_size
                         = nstl::min(jcp.oc, ti->oc_b_end * jcp.oc_block)
                         - ti->oc_b_start * jcp.oc_block;
-                int idx = g * rnd_up(jcp.oc, jcp.oc_block)
+                dim_t idx = g * rnd_up(jcp.oc, jcp.oc_block)
                         + ti->oc_b_start * jcp.oc_block;
                 if (!is_f32_bias && thr_mb == jcp.nthr_mb - 1) {
                     // the last iteration for bfloat16 requires conversion and
                     // store to diff_weights array
-                    int diff_bias_idx
+                    dim_t diff_bias_idx
                             = g * jcp.oc + ti->oc_b_start * jcp.oc_block;
                     if (bia_dt == bf16)
                         add_floats_and_cvt_to_bfloat16(
@@ -1583,9 +1606,9 @@ void brgemm_convolution_bwd_weights_t::execute_backward_weights(
                     = ctx.get_scratchpad_grantor().template get<const float>(
                             key_conv_padded_bias);
             auto diff_bias_in = CTX_OUT_MEM(float *, DNNL_ARG_DIFF_BIAS);
-            const int padded_stride = rnd_up(jcp.oc, jcp.oc_block);
-            const int stride = jcp.oc;
-            for (int g = 0; g < jcp.ngroups; ++g) {
+            const dim_t padded_stride = rnd_up(jcp.oc, jcp.oc_block);
+            const dim_t stride = jcp.oc;
+            for (dim_t g = 0; g < jcp.ngroups; ++g) {
                 utils::array_copy(diff_bias_in + g * stride,
                         diff_bias + g * padded_stride, stride);
             }

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.hpp
@@ -59,63 +59,64 @@ struct brgemm_convolution_bwd_weights_t : public primitive_t {
         jit_conv_conf_t jit_jcp_;
         void copy2jit_jcp();
 
-        int brgs_sz_ = 0;
+        dim_t brgs_sz_ = 0;
         std::shared_ptr<brgemm_containers::brgemm_desc_container_t> brgs_;
 
-        int bs_c = 0;
+        dim_t bs_c = 0;
         std::vector<int> batchsizes;
         bool are_empty_bs {false};
 
-        int get_brg_idx(int bs, int m, bool do_initialization, bool is_N_tail,
-                bool is_K_tail) const {
+        int get_brg_idx(dim_t bs, dim_t m, bool do_initialization,
+                bool is_N_tail, bool is_K_tail) const {
             auto my_bs = jcp_.var_bs ? 1 : bs;
             auto bs_idx = jcp_.use_uker ? batchsizes[my_bs] : 0;
             assert(bs_idx >= 0);
-            return (((m * bs_c + bs_idx) * 2
-                            + static_cast<int>(do_initialization))
-                                   * 2
-                           + static_cast<int>(is_N_tail))
-                    * 2
-                    + static_cast<int>(is_K_tail);
+            return static_cast<int>(
+                    (((m * bs_c + bs_idx) * 2
+                             + static_cast<int>(do_initialization))
+                                    * 2
+                            + static_cast<int>(is_N_tail))
+                            * 2
+                    + static_cast<int>(is_K_tail));
         }
-        inline int filter_w_to_src(int kw) const {
+        inline dim_t filter_w_to_src(dim_t kw) const {
             return kw * (jcp_.dilate_w + 1);
         }
-        inline int filter_h_to_src(int kh) const {
+        inline dim_t filter_h_to_src(dim_t kh) const {
             return kh * (jcp_.dilate_h + 1) - jcp_.t_pad;
         }
-        inline int filter_d_to_src(int kd) const {
+        inline dim_t filter_d_to_src(dim_t kd) const {
             return kd * (jcp_.dilate_d + 1) - jcp_.f_pad;
         }
-        inline int get_start_ih(int kh, int oh_s) const {
-            const auto real_ih = filter_h_to_src(kh) + oh_s * jcp_.stride_h;
-            return utils::saturate(0, jcp_.ih,
+        inline dim_t get_start_ih(dim_t kh, dim_t oh_s) const {
+            const dim_t real_ih = filter_h_to_src(kh) + oh_s * jcp_.stride_h;
+            return utils::saturate<dim_t>(0, jcp_.ih,
                     real_ih
-                            + utils::rnd_up(
-                                    nstl::max(0, -real_ih), jcp_.stride_h));
+                            + utils::rnd_up(nstl::max<dim_t>(0, -real_ih),
+                                    jcp_.stride_h));
         }
-        inline int get_finish_ih(int kh, int oh_e) const {
-            return utils::saturate(0, jcp_.ih,
+        inline dim_t get_finish_ih(dim_t kh, dim_t oh_e) const {
+            return utils::saturate<dim_t>(0, jcp_.ih,
                     filter_h_to_src(kh) + (oh_e - 1) * jcp_.stride_h + 1);
         }
-        inline int get_start_id(int kd, int od_s) const {
-            const auto real_id = filter_d_to_src(kd) + od_s * jcp_.stride_d;
-            return utils::saturate(0, jcp_.id,
+        inline dim_t get_start_id(dim_t kd, dim_t od_s) const {
+            const dim_t real_id = filter_d_to_src(kd) + od_s * jcp_.stride_d;
+            return utils::saturate<dim_t>(0, jcp_.id,
                     real_id
-                            + utils::rnd_up(
-                                    nstl::max(0, -real_id), jcp_.stride_d));
+                            + utils::rnd_up(nstl::max<dim_t>(0, -real_id),
+                                    jcp_.stride_d));
         }
-        inline int get_finish_id(int kd, int od_e) const {
-            return utils::saturate(0, jcp_.id,
+        inline dim_t get_finish_id(dim_t kd, dim_t od_e) const {
+            return utils::saturate<dim_t>(0, jcp_.id,
                     filter_d_to_src(kd) + (od_e - 1) * jcp_.stride_d + 1);
         }
 
-        inline int get_finish_oh(int oh_s, int start, int end) const {
-            int work_rem = end - start;
+        inline dim_t get_finish_oh(dim_t oh_s, dim_t start, dim_t end) const {
+            const dim_t work_rem = end - start;
             return (oh_s + work_rem > jcp_.oh ? jcp_.oh : oh_s + work_rem);
         }
-        inline int get_finish_od(int od_s, int start, int end) const {
-            int work_rem = end - start;
+        inline dim_t get_finish_od(dim_t od_s, dim_t start, dim_t end) const {
+            const dim_t work_rem = end - start;
             return (od_s + work_rem > jcp_.od ? jcp_.od : od_s + work_rem);
         }
     };
@@ -151,12 +152,12 @@ private:
     brgemm_containers::brgemm_kernel_container_t brg_kernels_;
     brgemm_containers::brgemm_palette_container_t brgemm_palettes_;
 
-    status_t add_brg_kernel(int bs, int M, int i_N, int i_K, int i_init);
-    void call_brgemm_kernel(
-            thread_info_t &btc, int brg_idx, int batch_size, void *ptr_C) const;
+    status_t add_brg_kernel(int bs, dim_t M, int i_N, int i_K, int i_init);
+    void call_brgemm_kernel(thread_info_t &btc, int brg_idx, dim_t batch_size,
+            void *ptr_C) const;
 
-    inline dim_t wei_offset_int(
-            int g, int oc_b, int ic_b, int kd, int kh, int kw) const {
+    inline dim_t wei_offset_int(dim_t g, dim_t oc_b, dim_t ic_b, dim_t kd,
+            dim_t kh, dim_t kw) const {
         const auto &jcp = pd()->jcp_;
         const dim_t kw_offset = jcp.ic_block * jcp.oc_block;
         dim_t extra_offset = ((kd * jcp.kh + kh) * jcp.kw + kw) * kw_offset;
@@ -165,7 +166,8 @@ private:
                 + extra_offset;
     }
 
-    inline dim_t wei_offset_int(int g, int oc_b, int ic_b, int kX) const {
+    inline dim_t wei_offset_int(
+            dim_t g, dim_t oc_b, dim_t ic_b, dim_t kX) const {
         const auto &jcp = pd()->jcp_;
         const dim_t kh_offset = jcp.kw * jcp.ic_block * jcp.oc_block;
         dim_t extra_offset
@@ -177,17 +179,17 @@ private:
         return res;
     }
 
-    inline dim_t wei_offset_ext(int g, int oc_b, int ic_b) const {
+    inline dim_t wei_offset_ext(dim_t g, dim_t oc_b, dim_t ic_b) const {
         const auto &jcp = pd()->jcp_;
-        const int vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
+        const dim_t vnni_granularity = data_type_vnni_granularity(jcp.wei_dt);
         if (vnni_granularity == 0) {
             assert(!"Invalid vnni granularity.");
             return 0;
         }
 
-        const int vnni_ic_b = ic_b / vnni_granularity;
-        const int vnni_ic_block = vnni_granularity * jcp.ic_block;
-        const int vnni_nb_ic = utils::div_up(jcp.ic, vnni_ic_block);
+        const dim_t vnni_ic_b = ic_b / vnni_granularity;
+        const dim_t vnni_ic_block = vnni_granularity * jcp.ic_block;
+        const dim_t vnni_nb_ic = utils::div_up(jcp.ic, vnni_ic_block);
         const dim_t kh_offset
                 = static_cast<dim_t>(jcp.kw) * jcp.oc_block * vnni_ic_block;
         const auto res
@@ -196,7 +198,7 @@ private:
         return res;
     }
 
-    inline int get_end(int start, int step, int limit) const {
+    inline dim_t get_end(dim_t start, dim_t step, dim_t limit) const {
         return nstl::min(start + step, limit);
     }
 };

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.cpp
@@ -63,14 +63,14 @@ jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::
     , isa_max_regs(isa_num_vregs(jcp_.isa)) {}
 
 template <typename Vmm>
-size_t jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::out_oc_offset(
-        const int n, const int w) const {
-    return static_cast<size_t>(out_dsz_) * n * m_block2_ + w * out_ow_sz_;
+dim_t jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::out_oc_offset(
+        const dim_t n, const dim_t w) const {
+    return out_dsz_ * n * m_block2_ + w * out_ow_sz_;
 }
 template <typename Vmm>
-size_t jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::inp_ic_offset(
+dim_t jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::inp_ic_offset(
         const int m_block, const int icb, const int m, const int n) const {
-    return static_cast<size_t>(inp_dsz_) * n * m_block2_ * last_ic_block_
+    return inp_dsz_ * n * m_block2_ * last_ic_block_
             + ((icb * m_block) + m) * inp_ic_sz_;
 }
 template <typename Vmm>
@@ -81,7 +81,8 @@ Vmm jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::accum(
 
 template <typename Vmm>
 void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
-        const int m_block, const int n_block, const int ow_b, const int ow_e) {
+        const int m_block, const int n_block, const dim_t ow_b,
+        const dim_t ow_e) {
     if (jcp_.src_zero_point) {
         for_(int m = 0; m < m_block; m++)
         for (int n = 0; n < n_block; n++) {
@@ -90,7 +91,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
             auto vmm_tmp2 = vmm_one_bytes;
             uni_vpmulld(vmm_tmp, vmm, vmm_zp_shift);
 
-            for (int w = ow_b; w < ow_e; w++) {
+            for (dim_t w = ow_b; w < ow_e; w++) {
                 const auto offset = out_oc_offset(n, w);
                 auto zp_addr = is_superset(jcp_.isa, avx512_core)
                         ? EVEX_compress_addr(reg_zp_comp_out, offset)
@@ -110,7 +111,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
             auto vmm_tmp2 = vmm_one_bytes;
             uni_vpmulld(vmm_tmp, vmm, vmm_cp_shift);
 
-            for (int w = ow_b; w < ow_e; w++) {
+            for (dim_t w = ow_b; w < ow_e; w++) {
                 const auto offset = out_oc_offset(n, w);
                 auto cp_addr = is_superset(jcp_.isa, avx512_core)
                         ? EVEX_compress_addr(reg_comp_out, offset)
@@ -130,10 +131,10 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::store_accumulators(
 
 template <typename Vmm>
 void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow_body(
-        const int n_block, const int ow_b, const int ow_e) {
+        const int n_block, const dim_t ow_b, const dim_t ow_e) {
 
     if (jcp_.src_zero_point) {
-        for_(int w = ow_b; w < ow_e; w++)
+        for_(dim_t w = ow_b; w < ow_e; w++)
         for (int n = 0; n < n_block; n++) {
             auto vmm_tmp = vmm_tmp_1();
             const auto offset = out_oc_offset(n, w);
@@ -147,7 +148,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow_body(
     }
 
     if (jcp_.s8s8_compensation_required) {
-        for_(int w = ow_b; w < ow_e; w++)
+        for_(dim_t w = ow_b; w < ow_e; w++)
         for (int n = 0; n < n_block; n++) {
             auto vmm_tmp = vmm_tmp_1();
             const auto offset = out_oc_offset(n, w);
@@ -160,8 +161,8 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow_body(
 }
 
 template <typename Vmm>
-void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow(
-        const int m_block, const int n_block, const int ow_b, const int ow_e) {
+void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::copy_ow(const int m_block,
+        const int n_block, const dim_t ow_b, const dim_t ow_e) {
     mov(reg_ker_l, ptr[param1 + GET_OFF(ker_l)]);
     mov(reg_aux_zp_comp_out, reg_zp_comp_out);
     mov(reg_aux_comp_out, reg_comp_out);
@@ -283,22 +284,24 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::bwd_kw_iw_loop(const int icb,
     const auto LP = jcp_.l_pad;
     const auto nb_iw = div_up(jcp_.iw, SW);
 
-    std::vector<int> ker_kw_ow_b(SW * KW, -1);
-    std::vector<int> ker_kw_ow_e(SW * KW, -1);
+    std::vector<dim_t> ker_kw_ow_b(SW * KW, -1);
+    std::vector<dim_t> ker_kw_ow_e(SW * KW, -1);
 
     for_(int sw = 0; sw < SW; sw++)
     for (int iwb = 0; iwb < nb_iw; iwb++) {
         const auto iw = iwb * SW + sw;
         const auto ker_iw = sw * nb_iw + iwb;
 
-        int s {0}, o_test {0};
+        dim_t s {0}, o_test {0};
         while (true) {
             o_test = iw + LP - s * DW;
             if (o_test % SW == 0) break;
             s++;
         }
-        const int k_f = nstl::min(jcp_.kw, div_up(iw + LP + 1, DW));
-        int k_s = div_up(nstl::max(0, iw + LP - jcp_.ow * SW + 1), DW);
+        const int k_f = static_cast<int>(
+                nstl::min<dim_t>(jcp_.kw, div_up(iw + LP + 1, DW)));
+        int k_s = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, iw + LP - jcp_.ow * SW + 1), DW));
         while (k_s % SW != s)
             k_s++;
 
@@ -333,25 +336,26 @@ template <typename Vmm>
 void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::fwd_kw_ow_loop(const int icb,
         const int icb_tail, const int ic_step, const int m_block,
         const int mb_tail, const int n_block, const bool use_inversion) {
-    std::vector<int> kw_ow_b(jcp_.kw, -1);
-    std::vector<int> kw_ow_e(jcp_.kw, -1);
-    std::vector<int> comp_ow_kw_s(jcp_.comp_ow_size, -1);
-    std::vector<int> comp_ow_kw_f(jcp_.comp_ow_size, -1);
+    std::vector<dim_t> kw_ow_b(jcp_.kw, -1);
+    std::vector<dim_t> kw_ow_e(jcp_.kw, -1);
+    std::vector<dim_t> comp_ow_kw_s(jcp_.comp_ow_size, -1);
+    std::vector<dim_t> comp_ow_kw_f(jcp_.comp_ow_size, -1);
     dim_t comp_ow_l = 0;
     const auto DW = jcp_.dilate_w + 1;
 
-    for (int ow = 0; ow < jcp_.ow;) {
+    for (dim_t ow = 0; ow < jcp_.ow;) {
         const auto iiw = ow * jcp_.stride_w - jcp_.l_pad;
-        const auto kw_s = div_up(nstl::max(0, -iiw), DW);
+        const auto kw_s = div_up(nstl::max<dim_t>(0, -iiw), DW);
         const auto kw_f = jcp_.kw
-                - div_up(nstl::max(0, iiw - jcp_.iw + (jcp_.kw - 1) * DW + 1),
+                - div_up(nstl::max<dim_t>(
+                                 0, iiw - jcp_.iw + (jcp_.kw - 1) * DW + 1),
                         DW);
-        int ow_e = ow;
+        dim_t ow_e = ow;
         while (ow_e < jcp_.ow) {
             const auto iiw_e = ow_e * jcp_.stride_w - jcp_.l_pad;
-            const auto cur_kw_s = div_up(nstl::max(0, -iiw_e), DW);
+            const auto cur_kw_s = div_up(nstl::max<dim_t>(0, -iiw_e), DW);
             const auto cur_kw_f = jcp_.kw
-                    - div_up(nstl::max(0,
+                    - div_up(nstl::max<dim_t>(0,
                                      iiw_e - jcp_.iw + (jcp_.kw - 1) * DW + 1),
                             DW);
             if (cur_kw_s != kw_s || cur_kw_f != kw_f) break;
@@ -365,7 +369,7 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::fwd_kw_ow_loop(const int icb,
         ow = ow_e;
     }
 
-    for_(int ow = 0; ow < comp_ow_l; ow++)
+    for_(dim_t ow = 0; ow < comp_ow_l; ow++)
     for (int kw = 0; kw < jcp_.kw; kw++) {
         if (kw >= comp_ow_kw_s[ow] && kw < comp_ow_kw_f[ow]) {
             const auto inv_kw = use_inversion ? jcp_.kw - 1 - kw : kw;
@@ -446,22 +450,25 @@ int jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::compute_ic_step(
     int best_ic_step = 1;
     float best_block_eff = 0.f;
 
-    int max_ic_step
-            = nstl::min(static_cast<size_t>(m_block), div_up(nb_ic_, m_block));
+    int max_ic_step = static_cast<int>(
+            nstl::min<dim_t>(m_block, div_up(nb_ic_, m_block)));
 
     // Introduce ic_step to increase kernel efficiency
     // Compute the ic_step based on the optimal kernel efficiency
     for (int ic_s = max_ic_step; ic_s >= 1; --ic_s) {
         const auto blocks = ic_s * m_block;
-        const float block_disb
-                = static_cast<float>(nb_ic_) / rnd_up(nb_ic_, blocks);
-        const float eff = (static_cast<float>(n_block) * blocks)
-                / ((n_block + blocks) * max_ic_step);
+        const float block_disb = static_cast<float>(nb_ic_)
+                / static_cast<float>(rnd_up(nb_ic_, blocks));
+        const float eff = static_cast<float>(n_block)
+                * static_cast<float>(blocks)
+                / static_cast<float>((n_block + blocks) * max_ic_step);
         const float block_eff = block_disb * eff;
-        float block_footprint = static_cast<float>(inp_dsz_) * blocks
-                * (jcp_.prop_kind == backward_data ? jcp_.ic_block
-                                                   : jcp_.oc_block)
-                * last_ic_block_;
+        float block_footprint = static_cast<float>(inp_dsz_)
+                * static_cast<float>(blocks)
+                * static_cast<float>(jcp_.prop_kind == backward_data
+                                ? jcp_.ic_block
+                                : jcp_.oc_block)
+                * static_cast<float>(last_ic_block_);
         if (block_footprint <= static_cast<float>(
                     platform::get_per_core_cache_size(1))
                 && (block_eff > best_block_eff)) {
@@ -501,18 +508,19 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::generate() {
     const int max_regs = isa_max_regs
             - (is_int8_avx512_core ? 6
                                    : (jcp_.s8s8_compensation_required ? 4 : 3));
-    const int nb = div_up(
+    const int nb = static_cast<int>(div_up(
             nstl::min(jcp_.prop_kind == backward_data ? jcp_.ic : jcp_.oc,
                     jcp_.prop_kind == backward_data ? jcp_.ic_block
                                                     : jcp_.oc_block),
-            m_block2_);
+            m_block2_));
     const int nb2 = nb / n_max_regs_;
     const int nb2_tail = nb % n_max_regs_;
     const int n_block = (nb2 == 0) ? nstl::max(1, nb2_tail) : n_max_regs_;
 
     const size_t m_max_regs = max_regs / n_block;
-    const int m_block = nstl::min(m_max_regs, nb_ic_);
-    const int ic_step = compute_ic_step(m_max_regs, m_block, n_block);
+    const int m_block = static_cast<int>(nstl::min<dim_t>(m_max_regs, nb_ic_));
+    const int ic_step
+            = compute_ic_step(static_cast<int>(m_max_regs), m_block, n_block);
 
     assert(m_block * n_block <= max_regs);
 
@@ -526,26 +534,27 @@ void jit_uni_brgemm_conv_comp_pad_kernel_t<Vmm>::generate() {
     mov(reg_use_inversion, ptr[param1 + GET_OFF(use_inversion)]);
     cmp(reg_use_inversion, 0);
     jz(label_kw_without_inversion, T_NEAR);
-    kw_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block, true);
+    kw_loop(static_cast<int>(icb), static_cast<int>(icb_tail), ic_step, m_block,
+            static_cast<int>(mb_tail), n_block, true);
     jmp(label_done, T_NEAR);
 
     L_aligned(label_kw_without_inversion);
-    kw_loop(icb, icb_tail, ic_step, m_block, mb_tail, n_block, false);
+    kw_loop(static_cast<int>(icb), static_cast<int>(icb_tail), ic_step, m_block,
+            static_cast<int>(mb_tail), n_block, false);
 
     L_aligned(label_done);
 
     postamble();
 }
 template <typename Vmm>
-size_t jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::out_oc_offset(
-        const int n, const int w) const {
-    return static_cast<size_t>(out_dsz_) * n * inp_oc_block_ + w * out_ow_sz_;
+dim_t jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::out_oc_offset(
+        const dim_t n, const dim_t w) const {
+    return out_dsz_ * n * inp_oc_block_ + w * out_ow_sz_;
 }
 template <typename Vmm>
-size_t jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::inp_ic_offset(
-        const int kw, const int ic, const int n) const {
-    return static_cast<size_t>(kw) * inp_kw_sz_ + n * inp_oc_sz_
-            + ic * inp_ic_sz_;
+dim_t jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::inp_ic_offset(
+        const dim_t kw, const dim_t ic, const dim_t n) const {
+    return kw * inp_kw_sz_ + n * inp_oc_sz_ + ic * inp_ic_sz_;
 }
 
 template <typename Vmm>
@@ -563,10 +572,10 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::zero_accumulators(
 }
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store_accumulators(
-        const int n_block, const int ow_b, const int ow_e) {
+        const int n_block, const dim_t ow_b, const dim_t ow_e) {
     if (jcp_.src_zero_point) {
         for_(int n = 0; n < n_block; n++)
-        for (int w = ow_b; w < ow_e; w++) {
+        for (dim_t w = ow_b; w < ow_e; w++) {
             auto vmm = accum(n);
             const auto offset = out_oc_offset(n, w);
             auto zp_addr = ptr[reg_aux_zp_comp_out + offset];
@@ -576,7 +585,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store_accumulators(
 
     if (jcp_.s8s8_compensation_required) {
         for_(int n = 0; n < n_block; n++)
-        for (int w = ow_b; w < ow_e; w++) {
+        for (dim_t w = ow_b; w < ow_e; w++) {
             auto vmm = accum(n, true);
             const auto offset = out_oc_offset(n, w);
             auto cp_addr = ptr[reg_aux_comp_out + offset];
@@ -587,7 +596,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store_accumulators(
 
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store(
-        const int n_block, const int ow_b, const int ow_e) {
+        const int n_block, const dim_t ow_b, const dim_t ow_e) {
     mov(reg_aux_zp_comp_out, reg_zp_comp_out);
     mov(reg_aux_comp_out, reg_comp_out);
     mov(reg_ker_l, ptr[param1 + GET_OFF(ker_l)]);
@@ -609,29 +618,30 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::store(
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::kw_loop(
         const int n_block) {
-    std::vector<int> ow_kw_b(jcp_.ow, -1);
-    std::vector<int> ow_kw_e(jcp_.ow, -1);
+    std::vector<dim_t> ow_kw_b(jcp_.ow, -1);
+    std::vector<dim_t> ow_kw_e(jcp_.ow, -1);
     int prev_comp_ow = 0;
     const auto DW = jcp_.dilate_w + 1;
-    for (int ow = 0; ow < jcp_.ow; ow++) {
+    for (dim_t ow = 0; ow < jcp_.ow; ow++) {
         const auto iiw = ow * jcp_.stride_w - jcp_.l_pad;
-        const auto kw_s = div_up(nstl::max(0, -iiw), DW);
+        const auto kw_s = div_up(nstl::max<dim_t>(0, -iiw), DW);
         const auto kw_f = jcp_.kw
-                - div_up(nstl::max(0, iiw - jcp_.iw + (jcp_.kw - 1) * DW + 1),
+                - div_up(nstl::max<dim_t>(
+                                 0, iiw - jcp_.iw + (jcp_.kw - 1) * DW + 1),
                         DW);
         ow_kw_b[ow] = kw_s;
         ow_kw_e[ow] = kw_f;
     }
 
-    for (int ow = 0; ow < jcp_.ow;) {
+    for (dim_t ow = 0; ow < jcp_.ow;) {
         const auto kw_b = ow_kw_b[ow];
         const auto kw_e = ow_kw_e[ow];
-        int ow_e = ow + 1;
+        dim_t ow_e = ow + 1;
         while (ow_e < jcp_.ow) {
             if (ow_kw_b[ow_e] != kw_b || ow_kw_e[ow_e] != kw_e) break;
             ow_e++;
         }
-        const auto ow_l = nstl::min(ow_e - ow, jcp_.ow_block);
+        const auto ow_l = nstl::min<dim_t>(ow_e - ow, jcp_.ow_block);
 
         if (kw_b < kw_e) {
             zero_accumulators(n_block);
@@ -645,7 +655,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::kw_loop(
 
 template <typename Vmm>
 void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::compute(
-        const int n_block, const int kw_b, const int kw_e) {
+        const int n_block, const dim_t kw_b, const dim_t kw_e) {
     Xbyak::Label label_kh_loop, label_end;
     mov(reg_kh_l, ptr[param1 + GET_OFF(kh_l)]);
     mov(reg_aux_in, reg_in);
@@ -654,7 +664,7 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::compute(
     {
         cmp(reg_kh_l, 0);
         je(label_end, T_NEAR);
-        for_(int kw = kw_b; kw < kw_e; kw++)
+        for_(dim_t kw = kw_b; kw < kw_e; kw++)
         for_(int n = 0; n < n_block; n++)
         for (int ic = 0; ic < jcp_.ic; ic++) {
             auto vmm = accum(n);
@@ -696,9 +706,10 @@ void jit_uni_brgemm_conv_relo_comp_pad_kernel_t<Vmm>::generate() {
     mov(reg32_scratch, 128);
     uni_vpbroadcastd(vmm_cp_shift, reg32_scratch);
 
-    const int last_oc_block = nstl::min(
-            jcp_.oc_block, jcp_.oc - (jcp_.nb_oc - 1) * jcp_.oc_block);
-    const int max_n_block = div_up(jcp_.oc_block, inp_oc_block_);
+    const int last_oc_block = static_cast<int>(nstl::min(
+            jcp_.oc_block, jcp_.oc - (jcp_.nb_oc - 1) * jcp_.oc_block));
+    const int max_n_block
+            = static_cast<int>(div_up(jcp_.oc_block, inp_oc_block_));
     const int last_n_block = div_up(last_oc_block, inp_oc_block_);
 
     Xbyak::Label label_last_ocb, label_done;

--- a/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_comp_pad_kernel.hpp
@@ -56,15 +56,15 @@ protected:
     static constexpr bool is_ymm_ = std::is_same<Vmm, Xbyak::Ymm>::value;
 
     jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
-    const int inp_dsz_;
-    const int out_dsz_;
-    const size_t nb_ic_;
-    const size_t inp_ic_sz_;
-    const size_t inp_kw_sz_;
-    const size_t inp_kh_sz_;
-    const size_t inp_kd_sz_;
-    const size_t out_ow_sz_;
-    const size_t out_ker_sz_;
+    const dim_t inp_dsz_;
+    const dim_t out_dsz_;
+    const dim_t nb_ic_;
+    const dim_t inp_ic_sz_;
+    const dim_t inp_kw_sz_;
+    const dim_t inp_kh_sz_;
+    const dim_t inp_kd_sz_;
+    const dim_t out_ow_sz_;
+    const dim_t out_ker_sz_;
     const int isa_max_regs;
 
     // Register decomposition
@@ -103,14 +103,14 @@ protected:
     const Vmm &vmm_tmp_1() const noexcept { return vmm_tmp; }
 
     Vmm accum(const int n_block, const int m, const int n) const;
-    size_t out_oc_offset(const int n, const int w) const;
-    size_t inp_ic_offset(
+    dim_t out_oc_offset(const dim_t n, const dim_t w) const;
+    dim_t inp_ic_offset(
             const int m_block, const int icb, const int m, const int n) const;
     int compute_ic_step(
             const int m_max_regs, const int m_block, const int n_block) const;
 
     void store_accumulators(const int m_block, const int n_block,
-            const int ow_b, const int ow_e);
+            const dim_t ow_b, const dim_t ow_e);
     void zero_accumulators(const int m_block, const int n_block);
     void compute(const int ic_step, const int m_block, const int n_block,
             const int m_tail, const bool is_mb_tail);
@@ -118,9 +118,9 @@ protected:
             const int m_block, const int mb_tail, const int n_block);
     void kdh_loop(const int icb, const int icb_tail, const int ic_step,
             const int m_block, const int mb_tail, const int n_block);
-    void copy_ow(const int m_block, const int n_block, const int ow_b,
-            const int ow_e);
-    void copy_ow_body(const int n_block, const int ow_b, const int ow_e);
+    void copy_ow(const int m_block, const int n_block, const dim_t ow_b,
+            const dim_t ow_e);
+    void copy_ow_body(const int n_block, const dim_t ow_b, const dim_t ow_e);
     void kw_loop(const int icb, const int icb_tail, const int ic_step,
             const int m_block, const int mb_tail, const int n_block,
             const bool use_inversion);
@@ -147,15 +147,15 @@ struct jit_uni_brgemm_conv_relo_comp_pad_kernel_t : public jit_generator_t {
 
 protected:
     jit_brgemm_conv_conf_t jcp_ = utils::zero<decltype(jcp_)>();
-    const int inp_dsz_;
-    const int out_dsz_;
+    const dim_t inp_dsz_;
+    const dim_t out_dsz_;
     const int inp_oc_block_;
-    const size_t inp_ic_sz_;
-    const size_t inp_kw_sz_;
-    const size_t inp_kh_sz_;
-    const size_t inp_oc_sz_;
-    const size_t out_ow_sz_;
-    const size_t out_ker_sz_;
+    const dim_t inp_ic_sz_;
+    const dim_t inp_kw_sz_;
+    const dim_t inp_kh_sz_;
+    const dim_t inp_oc_sz_;
+    const dim_t out_ow_sz_;
+    const dim_t out_ker_sz_;
     const int isa_max_regs_;
 
     // Register decomposition
@@ -178,13 +178,14 @@ protected:
     const int n_max_regs_ = 4;
 
     Vmm accum(const int n, const bool has_s8s8_shift = false) const;
-    size_t out_oc_offset(const int n, const int w) const;
-    size_t inp_ic_offset(const int kw, const int ic, const int m) const;
+    dim_t out_oc_offset(const dim_t n, const dim_t w) const;
+    dim_t inp_ic_offset(const dim_t kw, const dim_t ic, const dim_t m) const;
     void zero_accumulators(const int n_block);
-    void store_accumulators(const int n_block, const int ow_b, const int ow_e);
-    void store(const int n_block, const int ow_b, const int ow_e);
+    void store_accumulators(
+            const int n_block, const dim_t ow_b, const dim_t ow_e);
+    void store(const int n_block, const dim_t ow_b, const dim_t ow_e);
     void kw_loop(const int n_block);
-    void compute(const int n_block, const int kw_b, const int kw_e);
+    void compute(const int n_block, const dim_t kw_b, const dim_t kw_e);
     void load_params();
 
     void generate() override;

--- a/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.cpp
@@ -45,10 +45,11 @@ void jit_brgemm_relo_copy_to_wbuffer_t::generate() {
 
     preamble();
 
-    const int vnni_width = data_type_vnni_granularity(wjcp.wei_dt);
-    const auto wei_dsz = types::data_type_size(wjcp.wei_dt);
-    const auto inp_ocb_size = wjcp.inp_oc_block * vnni_width * wei_dsz;
-    const auto out_ocb_size = wjcp.out_oc_block * vnni_width * wei_dsz;
+    const int vnni_width
+            = static_cast<int>(data_type_vnni_granularity(wjcp.wei_dt));
+    const dim_t wei_dsz = types::data_type_size(wjcp.wei_dt);
+    const dim_t inp_ocb_size = wjcp.inp_oc_block * vnni_width * wei_dsz;
+    const dim_t out_ocb_size = wjcp.out_oc_block * vnni_width * wei_dsz;
     const auto oc_chunks = wjcp.out_oc_block / wjcp.inp_oc_block;
     const auto has_ocb_tail = (oc_chunks != wjcp.last_occ_to_copy);
     auto nb_rd = div_up(wjcp.rd, vnni_width);

--- a/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.hpp
+++ b/src/cpu/x64/jit_brgemm_conv_relo_copy_kernel.hpp
@@ -31,10 +31,10 @@ struct jit_brgemm_relo_copy_to_wbuffer_t : public jit_generator_t {
         data_type_t wei_dt {data_type_t::dnnl_data_type_undef};
         int out_oc_block {0};
         int inp_oc_block {0};
-        int rd {0};
+        dim_t rd {0};
         bool is_rd_padded_to_block {false};
-        int inp_ocb_offs {0};
-        int last_occ_to_copy {0};
+        dim_t inp_ocb_offs {0};
+        dim_t last_occ_to_copy {0};
     };
 
     struct ctx_t {

--- a/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_trans_kernel.cpp
@@ -40,7 +40,7 @@ jit_avx512_core_brgemm_conv_trans_kernel_t::
               jcp.is_reduced_rtus ? jcp.rtus_padded_ic_size : jcp.inp_ic_block)
     , ic_block_offset(inp_dsz * ic_block_sz)
     , iw_size(inp_dsz * jcp.ngroups * jcp.ic_without_padding)
-    , dst_w_block(dst_w(jcp, jcp.ow_block))
+    , dst_w_block(dst_w(jcp, static_cast<int>(jcp.ow_block)))
     , dst_stride(jcp.copy_block_only ? dst_w_block : jcp.iwp)
     , VL(cpu_isa_traits_t<avx512_core>::vlen)
     , n_vec(ic_block_sz / jcp.simd_w)
@@ -54,7 +54,7 @@ jit_avx512_core_brgemm_conv_trans_kernel_t::
 
 int get_inp_size(int dst_size, int ext_k, int stride, int dilate) {
     const auto res = calculate_end_padding(0, dst_size, 0, stride, ext_k);
-    return res;
+    return static_cast<int>(res);
 }
 
 int get_inp_start(int b, int b_size, int stride, int pad) {
@@ -62,23 +62,26 @@ int get_inp_start(int b, int b_size, int stride, int pad) {
 }
 
 int jit_avx512_core_brgemm_conv_trans_kernel_t::inp_w(int out_w, int kw) const {
-    return get_inp_size(out_w, kw, jcp.stride_w, jcp.dilate_w);
+    return get_inp_size(out_w, kw, static_cast<int>(jcp.stride_w),
+            static_cast<int>(jcp.dilate_w));
 }
 
 int jit_avx512_core_brgemm_conv_trans_kernel_t::inp_w(int out_w) const {
-    return inp_w(out_w, jcp.ext_kw);
+    return inp_w(out_w, static_cast<int>(jcp.ext_kw));
 }
 
 int jit_avx512_core_brgemm_conv_trans_kernel_t::dst_w(
         const jit_brgemm_conv_conf_t &ajcp, int out_w) {
     int res = 0;
-    res = get_inp_size(out_w, ajcp.ext_kw, ajcp.stride_w, ajcp.dilate_w);
+    res = get_inp_size(out_w, static_cast<int>(ajcp.ext_kw),
+            static_cast<int>(ajcp.stride_w), static_cast<int>(ajcp.dilate_w));
     if (ajcp.is_os_blocking) res = rnd_up(res, ajcp.stride_w);
     return res;
 }
 
 int jit_avx512_core_brgemm_conv_trans_kernel_t::inp_w_start(int owb) const {
-    return get_inp_start(owb, jcp.ow_block, jcp.stride_w, jcp.l_pad);
+    return get_inp_start(owb, static_cast<int>(jcp.ow_block),
+            static_cast<int>(jcp.stride_w), static_cast<int>(jcp.l_pad));
 }
 
 // use different vmovdqu32/16/8 due to case when tail mask used
@@ -284,7 +287,9 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::generate() {
 void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
         bool is_ic_tail) {
     if (jcp.nb_ow == 1) {
-        copy_ow_block_body(jcp.l_pad, jcp.ow_block, jcp.iw, is_ic_tail);
+        copy_ow_block_body(static_cast<int>(jcp.l_pad),
+                static_cast<int>(jcp.ow_block), static_cast<int>(jcp.iw),
+                is_ic_tail);
         return;
     }
 
@@ -301,10 +306,10 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
 
     const auto adj_iw = nstl::min(jcp.iw, jcp.iwp - jcp.l_pad);
 
-    int ow_block_tail = jcp.ow % jcp.ow_block;
+    const int ow_block_tail = static_cast<int>(jcp.ow % jcp.ow_block);
 
     for (int owb = 0; owb < jcp.nb_ow; owb++) {
-        const auto inp_block = inp_w(jcp.ow_block);
+        const auto inp_block = inp_w(static_cast<int>(jcp.ow_block));
         const auto inp_start = inp_w_start(owb);
         const auto inp_end = inp_start + inp_block;
         if (inp_start + inp_block < 0) {
@@ -331,7 +336,7 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
         cmp(reg_owb, end_first_zero_block);
         jg(skip_first_zero_blocks, T_NEAR);
         // zero block
-        copy_ow_block_body(0, jcp.ow_block, 0, is_ic_tail);
+        copy_ow_block_body(0, static_cast<int>(jcp.ow_block), 0, is_ic_tail);
         jmp(copy_block_done_label, T_NEAR);
 
         L(skip_first_zero_blocks);
@@ -341,16 +346,17 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
                 b++) {
             int cur_ow_block = (b == jcp.nb_ow - 1 && ow_block_tail > 0)
                     ? ow_block_tail
-                    : jcp.ow_block;
+                    : static_cast<int>(jcp.ow_block);
             const auto inp_block = inp_w(cur_ow_block);
             const auto inp_start = inp_w_start(b);
             const auto inp_end = inp_start + inp_block;
             const auto block_lpad = -inp_start;
-            const auto block_len = nstl::min(adj_iw, inp_end);
+            const auto block_len = nstl::min<dim_t>(adj_iw, inp_end);
             Xbyak::Label skip_first_partial_block;
             cmp(reg_owb, b);
             jne(skip_first_partial_block, T_NEAR);
-            copy_ow_block_body(block_lpad, jcp.ow_block, block_len, is_ic_tail);
+            copy_ow_block_body(block_lpad, static_cast<int>(jcp.ow_block),
+                    static_cast<int>(block_len), is_ic_tail);
             jmp(copy_block_done_label, T_NEAR);
             L(skip_first_partial_block);
         }
@@ -359,7 +365,8 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
         Xbyak::Label skip_full_blocks;
         cmp(reg_owb, end_full_block);
         jg(skip_full_blocks, T_NEAR);
-        copy_ow_block_body(0, jcp.ow_block, inp_w(jcp.ow_block), is_ic_tail);
+        copy_ow_block_body(0, static_cast<int>(jcp.ow_block),
+                inp_w(static_cast<int>(jcp.ow_block)), is_ic_tail);
         jmp(copy_block_done_label, T_NEAR);
 
         L(skip_full_blocks);
@@ -369,16 +376,18 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
                 b++) {
             int cur_ow_block = (b == jcp.nb_ow - 1 && ow_block_tail > 0)
                     ? ow_block_tail
-                    : jcp.ow_block;
+                    : static_cast<int>(jcp.ow_block);
             const auto inp_block = inp_w(cur_ow_block);
             const auto inp_start = inp_w_start(b);
             const auto inp_end = inp_start + inp_block;
             const auto block_lpad = 0;
-            const auto block_len = nstl::min(adj_iw, inp_end) - inp_start;
+            const auto block_len
+                    = nstl::min<dim_t>(adj_iw, inp_end) - inp_start;
             Xbyak::Label skip_last_partial_block;
             cmp(reg_owb, b);
             jne(skip_last_partial_block, T_NEAR);
-            copy_ow_block_body(block_lpad, cur_ow_block, block_len, is_ic_tail);
+            copy_ow_block_body(block_lpad, cur_ow_block,
+                    static_cast<int>(block_len), is_ic_tail);
             jmp(copy_block_done_label, T_NEAR);
 
             L(skip_last_partial_block);
@@ -387,7 +396,7 @@ void jit_avx512_core_brgemm_conv_trans_kernel_t::copy_ow_block(
 
     // if not any above case then owb is among last zero blocks
     // check is this needed and check may it be partial
-    copy_ow_block_body(0, jcp.ow_block, 0, is_ic_tail);
+    copy_ow_block_body(0, static_cast<int>(jcp.ow_block), 0, is_ic_tail);
 
     L(copy_block_done_label);
 }

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -110,8 +110,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         max_regs = isa == isa_undef ? 0 : isa_num_vregs(isa);
     }
 
-    int ur, ur_block, ur_block_tail, adj_ocblock;
-    int nb_kd, nb_kh, nb_kw;
+    dim_t ur, ur_block, ur_block_tail, adj_ocblock;
+    dim_t nb_kd, nb_kh, nb_kw;
     int max_regs;
     float eff;
     static unsigned L1;
@@ -125,7 +125,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     static float mem_k;
     static constexpr int bench_iterations = 1;
 
-    int sp, sp_block, nb_sp;
+    dim_t sp, sp_block, nb_sp;
 
     void get_from_jcp(const jit_brgemm_conv_conf_t &jcp) { *this = jcp; }
     void save_to_jcp(jit_brgemm_conv_conf_t &jcp) const { jcp = *this; }
@@ -145,8 +145,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     void update_blocks();
     bool fast_check_oc_block() const;
     float est_eff();
-    void iterate_ker_block(brg_blocking_t &best_brgb, int kd_block,
-            int kh_block, bool maybe_use_buffer, int max_ow_block_thr);
+    void iterate_ker_block(brg_blocking_t &best_brgb, dim_t kd_block,
+            dim_t kh_block, bool maybe_use_buffer, dim_t max_ow_block_thr);
     status_t calc_blocks();
 
     bool fast_check_oc_block_1x1() const;
@@ -154,8 +154,8 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     void calc_blocks_1x1();
 
     // utils
-    static int get_inp_size(
-            int max_src_size, int dst_size, int k, int stride, int dilate) {
+    static dim_t get_inp_size(dim_t max_src_size, dim_t dst_size, dim_t k,
+            dim_t stride, dim_t dilate) {
         const auto res = nstl::min(max_src_size,
                 calculate_end_padding(0, dst_size, 0, stride,
                         calculate_extended_filter_size(k, dilate)));
@@ -169,7 +169,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         return (k > 1.f) ? (k - 1 + eff) / k : eff * koeff;
     }
 
-    static int estimate_ur(cpu_isa_t isa, int oc_block) {
+    static int estimate_ur(cpu_isa_t isa, dim_t oc_block) {
         if (one_of(isa, avx2, avx2_vnni, avx2_vnni_2)) {
             switch (oc_block) {
                 case 32: return 3;
@@ -187,13 +187,13 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
         }
     }
 
-    int inp_w(int out_w, int ker_w) const {
+    dim_t inp_w(dim_t out_w, dim_t ker_w) const {
         return get_inp_size(iw, out_w, ker_w, stride_w, dilate_w);
     }
 
-    int rnd_simd(int val) const { return rnd_up(val, simd_w); }
+    dim_t rnd_simd(dim_t val) const { return rnd_up(val, simd_w); }
 
-    int rnd_inp_simd(int out_w, int ker_w, int vic) const {
+    dim_t rnd_inp_simd(dim_t out_w, dim_t ker_w, dim_t vic) const {
         const auto vsp = inp_w(out_w, ker_w);
         return ((stride_w == 1 && vic >= ic) ? rnd_up(vsp * vic, simd_w)
                                              : vsp * rnd_up(vic, simd_w));
@@ -216,15 +216,17 @@ dim_t get_comp_ow_size(const jit_brgemm_conv_conf_t &jcp) {
 
     for (int ow = 0; ow < jcp.ow;) {
         const auto iiw = ow * SW - LP;
-        const auto kw_s = div_up(nstl::max(0, -iiw), DW);
-        const auto kw_f
-                = KW - div_up(nstl::max(0, iiw - IW + (KW - 1) * DW + 1), DW);
+        const auto kw_s = div_up(nstl::max<dim_t>(0, -iiw), DW);
+        const auto kw_f = KW
+                - div_up(nstl::max<dim_t>(0, iiw - IW + (KW - 1) * DW + 1), DW);
         int ow_e = ow;
         while (ow_e < jcp.ow) {
             const auto iiw_e = ow_e * SW - LP;
-            const auto cur_kw_s = div_up(nstl::max(0, -iiw_e), DW);
+            const auto cur_kw_s = div_up(nstl::max<dim_t>(0, -iiw_e), DW);
             const auto cur_kw_f = KW
-                    - div_up(nstl::max(0, iiw_e - IW + (KW - 1) * DW + 1), DW);
+                    - div_up(
+                            nstl::max<dim_t>(0, iiw_e - IW + (KW - 1) * DW + 1),
+                            DW);
             if (cur_kw_s != kw_s || cur_kw_f != kw_f) break;
             if (ow_e - ow < jcp.ow_block) comp_ow_size++;
             ow_e++;
@@ -453,13 +455,13 @@ void brg_blocking_t::select_ic_block() {
         MAYBE_UNUSED(ic_padded_block);
         // Note: bf32 requires ic_block be less than 64, otherwise it results
         // in incorrect output.
-        ic_block = is_bf32 && (!is_rtus) ? nstl::min(64, ic) : ic;
+        ic_block = is_bf32 && (!is_rtus) ? nstl::min<dim_t>(64, ic) : ic;
         nb_ic = utils::div_up(ic, ic_block); // trivially 1 for now
         inp_ic_block = ic_block;
         return;
     }
     auto nb_simd = utils::div_up(ic, simd_w);
-    auto max_simd_blocks = nstl::min(5 * simd_w, nb_simd);
+    auto max_simd_blocks = nstl::min<dim_t>(5 * simd_w, nb_simd);
     const auto nb_icb_eff_threshold = 0.5f;
     const auto padded_rd
             = vnni_block * (is_rd_padded_to_block ? acc_simd_w : 1);
@@ -488,10 +490,10 @@ void brg_blocking_t::select_ic_block() {
             if (exec_type == exec_trans) {
                 // TODO: double check calculation of ic_block here:
                 // for example for ic == 48
-                auto simd_blocks = 1;
-                for (int nb_icb = max_simd_blocks; nb_icb >= 1; nb_icb--) {
+                dim_t simd_blocks = 1;
+                for (dim_t nb_icb = max_simd_blocks; nb_icb >= 1; nb_icb--) {
                     auto nb_icb_eff = static_cast<float>(nb_simd)
-                            / rnd_up(nb_simd, nb_icb);
+                            / static_cast<float>(rnd_up(nb_simd, nb_icb));
                     if (nb_icb_eff >= nb_icb_eff_threshold) {
                         simd_blocks = nb_icb;
                         break;
@@ -503,20 +505,20 @@ void brg_blocking_t::select_ic_block() {
         }
     } else {
         const auto est_ur = sp_block > 0
-                ? nstl::min(sp_block, estimate_ur(isa, oc_block))
+                ? nstl::min<dim_t>(sp_block, estimate_ur(isa, oc_block))
                 : estimate_ur(isa, oc_block);
         const auto inp_ur = is_os_blocking ? est_ur : inp_w(est_ur, kw_block);
 
         if (kw_block > 1) {
             // try to fit src into L1
             const auto inp_per_ic = static_cast<unsigned int>(inp_ur) * src_dsz;
-            max_simd_blocks = saturate(1, max_simd_blocks,
-                    static_cast<int>(L1 / (inp_per_ic * simd_w)));
+            max_simd_blocks = utils::saturate<dim_t>(
+                    1, max_simd_blocks, L1 / (inp_per_ic * simd_w));
         }
         // try to fit all batch for ur into L2
         const bool adjust = wei_plain && math::is_pow2(oc)
                 && utils::everyone_is(1, kd_block, kh_block, kw_block);
-        const int adj_oc_block = adjust ? oc : oc_block; // due to aliasing
+        const dim_t adj_oc_block = adjust ? oc : oc_block; // due to aliasing
         const auto wei_per_ic = static_cast<unsigned int>(kd_block) * kh_block
                 * kw_block * adj_oc_block * wei_dsz;
         const auto inp_per_ic = static_cast<unsigned int>(kd_block) * kh_block
@@ -524,9 +526,8 @@ void brg_blocking_t::select_ic_block() {
         const auto out_size
                 = static_cast<unsigned int>(ur) * oc_block * dst_dsz;
 
-        max_simd_blocks = saturate(1, max_simd_blocks,
-                static_cast<int>((L2 - out_size)
-                        / ((wei_per_ic + inp_per_ic) * simd_w)));
+        max_simd_blocks = utils::saturate<dim_t>(1, max_simd_blocks,
+                (L2 - out_size) / ((wei_per_ic + inp_per_ic) * simd_w));
 
         // use nb_simd as max_simd_blocks for some shapes on avx2
         // TODO: optimize max_simd_blocks
@@ -534,17 +535,18 @@ void brg_blocking_t::select_ic_block() {
             max_simd_blocks = nb_simd;
 
         auto simd_blocks = 1;
-        for (int nb_icb = nstl::min(max_simd_blocks, nb_simd); nb_icb >= 1;
-                nb_icb--) {
-            auto nb_icb_eff
-                    = static_cast<float>(nb_simd) / rnd_up(nb_simd, nb_icb);
+        for (int nb_icb
+                = static_cast<int>(nstl::min<dim_t>(max_simd_blocks, nb_simd));
+                nb_icb >= 1; nb_icb--) {
+            auto nb_icb_eff = static_cast<float>(nb_simd)
+                    / static_cast<float>(rnd_up(nb_simd, nb_icb));
             if (nb_icb_eff >= nb_icb_eff_threshold) {
                 simd_blocks = nb_icb;
                 break;
             }
         }
 
-        ic_block = nstl::min(
+        ic_block = nstl::min<dim_t>(
                 exec_type == exec_trans ? rnd_up(ic, padded_rd) : ic,
                 simd_blocks * simd_w);
     }
@@ -660,15 +662,18 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     brgemm_attr_t brgattr;
     brgattr.use_uker = use_uker;
     brgattr.max_bs = max_batch;
-    max_vpad = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
+    max_vpad = exec_type == exec_vpad
+            ? static_cast<int>(nstl::max(l_pad, r_pad))
+            : 0;
     brgattr.max_top_vpad = max_vpad;
     brgattr.max_bottom_vpad = max_vpad;
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
-    ur = brg.bd_block * nstl::max(1, brg.bd_block2);
+    ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
     ur_block = brg.bd_block;
-    adj_ocblock = nstl::max(1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
+    adj_ocblock = nstl::max<dim_t>(
+            1, (brg.ldb2 != 0 ? brg.ld_block2 : brg.ldb2_tail));
     if (((is_1x1 && is_amx(isa)) || max_vpad > 0) && M > 0 && M_tail > 0) {
         brgemm_desc_t brg_sp_tail;
 
@@ -761,7 +766,9 @@ status_t brg_blocking_t::get_brgemm_ur(
         brgemm_attr_t brgattr;
         brgattr.use_uker = use_uker;
         brgattr.max_bs = max_batch;
-        max_vpad = exec_type == exec_vpad ? nstl::max(l_pad, r_pad) : 0;
+        max_vpad = exec_type == exec_vpad
+                ? static_cast<int>(nstl::max(l_pad, r_pad))
+                : 0;
         brgattr.max_top_vpad = max_vpad;
         brgattr.max_bottom_vpad = max_vpad;
         brgattr.fpmath_mode = attr->fpmath_.mode_;
@@ -871,20 +878,27 @@ float brg_blocking_t::est_eff() {
     const auto N_regs = static_cast<float>(adj_ocblock);
     const auto M_regs = is_amx(isa) ? div_up(ur, amx_h) : ur;
     const auto tot_regs = is_amx(isa) ? brgemm_desc_t::AMX_TILES_NUM : max_regs;
-    const auto brgemm_microkernel_eff
-            = (N_regs * M_regs) / ((N_regs + M_regs) * tot_regs);
+    const auto brgemm_microkernel_eff = (N_regs * static_cast<float>(M_regs))
+            / ((N_regs + static_cast<float>(M_regs))
+                    * static_cast<float>(tot_regs));
 
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
-    const auto brgemm_eff = squeeze_val(ur
-                    * (2.f - nstl::min(1.9f, static_cast<float>(ur) / sp_block))
+    const auto ur_eff = static_cast<float>(sp_block)
+            / static_cast<float>(rnd_up(sp_block, ur));
+    const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    static_cast<float>(ur)
+                                            / static_cast<float>(sp_block)))
                     / 64,
             0.5f);
 
     const dim_t sp_amount = static_cast<dim_t>(nb_od) * nb_oh * nb_sp;
     const auto work_amount = sp_amount * mb * ngroups * nb_oc;
-    const auto sp_eff = (static_cast<float>(sp) / rnd_up(sp, sp_block));
+    const auto sp_eff = (static_cast<float>(sp)
+            / static_cast<float>(rnd_up(sp, sp_block)));
 
-    const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+    const auto oc_block_eff
+            = static_cast<float>(oc) / static_cast<float>(rnd_up(oc, oc_block));
 
     const auto job = div_up(work_amount, static_cast<dim_t>(nthr));
 
@@ -901,7 +915,7 @@ float brg_blocking_t::est_eff() {
 
     const float job_eff = max_job == 0
             ? 1.f
-            : static_cast<float>(sum_job) / (max_job * nthr);
+            : static_cast<float>(sum_job) / static_cast<float>(max_job * nthr);
 
     const auto ic_blocking_size = ic_block * nb_ic_blocking;
     const auto oc_blocking_size = oc_block * ic_blocking_size;
@@ -964,7 +978,7 @@ float brg_blocking_t::est_eff() {
             = nstl::min(static_cast<dim_t>(nb_sp), div_up(job, dim_sp));
     const auto sp_thr = nstl::min(static_cast<dim_t>(sp), nb_sp_thr * sp_block);
 
-    int nb_oh_thr {1}, oh_thr {1}, nb_od_thr {1}, od_thr {1};
+    dim_t nb_oh_thr {1}, oh_thr {1}, nb_od_thr {1}, od_thr {1};
     if (!is_os_blocking) {
         const auto dim_oh = nb_sp * dim_sp;
         nb_oh_thr = nstl::min(static_cast<dim_t>(nb_oh), div_up(job, dim_oh));
@@ -1057,34 +1071,37 @@ float brg_blocking_t::est_eff() {
         dst_rp *= loop[il].dst.repeatn;
         wei_rp *= loop[il].wei.repeatn;
     }
-    const auto src_ops = (src_op * src_rp) / iterations;
-    const auto dst_ops = (dst_op * dst_rp) / iterations;
-    const auto wei_ops = (wei_op * wei_rp) / iterations;
+    const auto src_ops = (static_cast<float>(src_op) * src_rp) / iterations;
+    const auto dst_ops = (static_cast<float>(dst_op) * dst_rp) / iterations;
+    const auto wei_ops = (static_cast<float>(wei_op) * wei_rp) / iterations;
 
     const auto src_cost = src_mem_k * src_ops;
     const auto dst_cost = dst_mem_k * dst_ops;
     const auto wei_cost = wei_mem_k * wei_ops;
-    const auto call_kernel_cost
-            = 1000.f * job * ic_chunks * nb_kd * nb_kh * nb_kw;
+    const auto call_kernel_cost = 1000.f * static_cast<float>(job)
+            * static_cast<float>(ic_chunks) * static_cast<float>(nb_kd)
+            * static_cast<float>(nb_kh) * static_cast<float>(nb_kw);
 
     // Avoid huge batch sizes if possible (ie prefer to block on kd/kh/kw).
-    const float gemm_batch_bytes
-            = sizeof(brgemm_batch_element_t) * gemm_batch_size;
+    const float gemm_batch_bytes = sizeof(brgemm_batch_element_t)
+            * static_cast<float>(gemm_batch_size);
     const float batch_eff = uses_batch_elements(brg_type, exec_type)
-            ? nstl::min(1.f, L2 / (gemm_batch_bytes))
+            ? nstl::min(1.f, static_cast<float>(L2) / (gemm_batch_bytes))
             : 1.f;
 
-    const auto cache_eff = (static_cast<dim_t>(mb) * od * oh * sp * ic * oc)
-            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto cache_eff = static_cast<float>(mb * od * oh * sp * ic * oc)
+            / (static_cast<float>(nthr)
+                    * (src_cost + dst_cost + wei_cost + call_kernel_cost));
     const auto res_eff = oc_block_eff * brgemm_microkernel_eff * sp_eff
             * job_eff * ur_eff * cache_eff * brgemm_eff * batch_eff;
     return res_eff;
 }
 
-void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
-        int kh_block_, bool maybe_use_buffer, int max_ow_block_thr) {
+void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb,
+        dim_t kd_block_, dim_t kh_block_, bool maybe_use_buffer,
+        dim_t max_ow_block_thr) {
 
-    unsigned est_k_amount = ic * oc_block * wei_dsz;
+    unsigned est_k_amount = static_cast<unsigned>(ic * oc_block * wei_dsz);
 
     kd_block = kd_block_;
     kh_block = kh_block_;
@@ -1117,14 +1134,14 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
                 = 2 * src_dsz * ic_size * iwp + dst_dsz * ow * oc_block;
         const auto other_size = wei_dsz * kd * kh * kw * ic_size * oc_block
                 + acc_dsz * 2 * amx_h * oc_block;
-        const auto L2_available = nstl::min(static_cast<size_t>(div_up(L2, 2)),
-                other_size > L2 ? 0 : L2 - other_size);
+        const auto L2_available = nstl::min<size_t>(
+                div_up(L2, 2), other_size > L2 ? 0 : L2 - other_size);
         if (idp * ihp * w_block_size > L2_available) {
-            od_block = utils::saturate(
-                    1, od, int(L2_available / (ihp * w_block_size)));
+            od_block = utils::saturate<dim_t>(
+                    1, od, L2_available / (ihp * w_block_size));
             if (od_block == 1)
-                oh_block = utils::saturate(
-                        1, oh, int(L2_available / (w_block_size)));
+                oh_block = utils::saturate<dim_t>(
+                        1, oh, L2_available / w_block_size);
             else
                 oh_block = oh;
         } else {
@@ -1139,16 +1156,19 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
             const auto src_w_block_size
                     = src_dsz * ic * iwp + dst_dsz * ow * oc_block;
             if (src_w_block_size < L1) {
-                cur_od_block = utils::saturate(
-                        1, od, int(L1 / (ihp * src_w_block_size)));
+                cur_od_block = utils::saturate<dim_t>(
+                        1, od, L1 / (ihp * src_w_block_size));
                 if (cur_od_block == 1)
-                    cur_oh_block = utils::saturate(
-                            1, oh, static_cast<int>(L1 / src_w_block_size));
+                    cur_oh_block = utils::saturate<dim_t>(
+                            1, oh, L1 / src_w_block_size);
             }
             for (; cur_od_block > 1; cur_od_block--) {
                 const auto sp_size = cur_od_block * cur_oh_block * iwp;
-                if ((static_cast<float>(od) / rnd_up(od, cur_od_block)) > 0.9f
-                        && static_cast<float>(sp_size) / rnd_up(sp, amx_h)
+                if ((static_cast<float>(od)
+                            / static_cast<float>(rnd_up(od, cur_od_block)))
+                                > 0.9f
+                        && static_cast<float>(sp_size)
+                                        / static_cast<float>(rnd_up(sp, amx_h))
                                 > 0.8f) {
                     L1_fit_res = true;
                     break;
@@ -1158,7 +1178,8 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
                 auto tmp_oh_block = cur_oh_block;
                 while (tmp_oh_block >= 1) {
                     const auto sp_size = tmp_oh_block * iwp;
-                    if ((static_cast<float>(oh) / rnd_up(oh, tmp_oh_block))
+                    if ((static_cast<float>(oh)
+                                / static_cast<float>(rnd_up(oh, tmp_oh_block)))
                                     > 0.9f
                             && sp_size > 128) {
                         L1_fit_res = true;
@@ -1189,11 +1210,11 @@ void brg_blocking_t::iterate_ker_block(brg_blocking_t &best_brgb, int kd_block_,
 
     // --- Select ow_block ----
     const auto max_ow_block_L2 = ow;
-    auto start_ow_block = nstl::min(max_ow_block_thr, max_ow_block_L2);
+    auto start_ow_block = nstl::min<dim_t>(max_ow_block_thr, max_ow_block_L2);
 
     sp = ow * (is_os_blocking ? oh : 1);
     const auto start_sp_block = is_os_blocking ? ow : start_ow_block;
-    auto prev_spb = 0;
+    auto prev_spb = dim_t(0);
     for (auto ns = 1; ns <= sp; ns++) {
         const auto spb = div_up(sp, ns);
         if (spb == prev_spb || spb > start_sp_block) continue;
@@ -1232,7 +1253,7 @@ status_t brg_blocking_t::calc_blocks() {
     // results then we need the out buffer
     const auto maybe_use_buffer = (dst_dt != acc_dt || with_sum);
 
-    std::vector<int> kd_blocks(1), kh_blocks(1);
+    std::vector<dim_t> kd_blocks(1), kh_blocks(1);
     kd_blocks[0] = kd;
     kh_blocks[0] = kh;
     if (kd != 1) {
@@ -1245,9 +1266,10 @@ status_t brg_blocking_t::calc_blocks() {
     }
 
     const auto thr_eff_threshold = 0.9f;
-    const auto max_ow_block_thr = utils::saturate(1, ow,
-            static_cast<int>(ceil(
-                    mb * ngroups * nb_oc * os / (thr_eff_threshold * nthr))));
+    const auto max_ow_block_thr = utils::saturate<dim_t>(1, ow,
+            static_cast<dim_t>(
+                    ceil(static_cast<float>(mb * ngroups * nb_oc * os)
+                            / (thr_eff_threshold * static_cast<float>(nthr)))));
 
     ow_block = os_block = sp_block = -1;
     brg_blocking_t best_brgb = *this;
@@ -1286,7 +1308,8 @@ bool brg_blocking_t::fast_check_oc_block_1x1() const {
                 = od * oh * ow >= 64 * stride_d * stride_h * stride_w;
         res = (rnd_oc % oc_block == 0 && big_spatial);
     } else if (oc_block == 48) {
-        const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+        const auto oc_block_eff = static_cast<float>(oc)
+                / static_cast<float>(rnd_up(oc, oc_block));
         res = (oc_block_eff >= 0.95f);
     } else
         res = true;
@@ -1296,14 +1319,16 @@ bool brg_blocking_t::fast_check_oc_block_1x1() const {
 
 float brg_blocking_t::est_eff_1x1() {
 
-    auto calc_ave_blk = [&](int dim, int block, bool use_ave) -> float {
-        const int nb = dim / block;
+    auto calc_ave_blk = [&](dim_t dim, dim_t block, bool use_ave) -> float {
+        const dim_t nb = dim / block;
         constexpr int max_nb = 2; // only consider 2x2 tile blocking
-        const int block2 = nstl::min(max_nb, nb);
-        const int nb2 = nb / block2;
-        const int nb2_tail = nb % block2;
+        const dim_t block2 = nstl::min<dim_t>(max_nb, nb);
+        const dim_t nb2 = nb / block2;
+        const dim_t nb2_tail = nb % block2;
         if (!use_ave) return block2;
-        return (float(nb2) * block2 + nb2_tail) / div_up(nb, block2);
+        return (float(nb2) * static_cast<float>(block2)
+                       + static_cast<float>(nb2_tail))
+                / static_cast<float>(div_up(nb, block2));
     };
     const bool use_ocb_ave = true;
     const auto ocb_ave = calc_ave_blk(oc_block, acc_simd_w, use_ocb_ave);
@@ -1319,21 +1344,27 @@ float brg_blocking_t::est_eff_1x1() {
             || (ic == 1024 && oc == 512) || (ic == 256 && oc == 1024)
             || (ic == 512 && oc == 1024) || (ic == 512 && oc == 2048);
     const auto amx_fac = maskrcnn_cond
-            ? (div_up(M + M_tail, 16) / (M_n_sp_blks + M_tail_n_sp_blks))
+            ? (static_cast<float>(div_up(M + M_tail, 16))
+                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks))
             : (static_cast<float>(div_up(M + M_tail, 16))
-                      / (M_n_sp_blks + M_tail_n_sp_blks));
+                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks));
 
     const auto brgemm_microkernel_eff = is_amx(isa)
             ? amx_fac * (static_cast<float>(ocb_ave) * spb_ave)
                     / (ocb_ave + spb_ave)
-            : (static_cast<float>(adj_ocblock) * ur)
-                    / ((ur + adj_ocblock) * max_regs);
-    const auto ur_eff = static_cast<float>(sp_block) / rnd_up(sp_block, ur);
+            : (static_cast<float>(adj_ocblock) * static_cast<float>(ur))
+                    / static_cast<float>((ur + adj_ocblock) * max_regs);
+    const auto ur_eff = static_cast<float>(sp_block)
+            / static_cast<float>(rnd_up(sp_block, ur));
 
     // heuristic sp_block: for reduced rtus, prioritize a smaller sp_block
-    const auto heur_sp_block = is_reduced_rtus ? 1.f / sp_block : sp_block;
-    const auto brgemm_eff = squeeze_val(
-            ur * (2.f - nstl::min(1.9f, static_cast<float>(ur) / heur_sp_block))
+    const auto heur_sp_block = is_reduced_rtus
+            ? 1.f / static_cast<float>(sp_block)
+            : static_cast<float>(sp_block);
+    const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
+                    * (2.f
+                            - nstl::min(1.9f,
+                                    static_cast<float>(ur) / heur_sp_block))
                     / 64,
             0.5f);
 
@@ -1342,8 +1373,10 @@ float brg_blocking_t::est_eff_1x1() {
     const auto work_amount
             = static_cast<dim_t>(mb) * ngroups * nb_oc * sp_amount;
 
-    const auto sp_eff = static_cast<float>(sp) / rnd_up(sp, sp_block);
-    const auto oc_block_eff = static_cast<float>(oc) / rnd_up(oc, oc_block);
+    const auto sp_eff
+            = static_cast<float>(sp) / static_cast<float>(rnd_up(sp, sp_block));
+    const auto oc_block_eff
+            = static_cast<float>(oc) / static_cast<float>(rnd_up(oc, oc_block));
 
     const auto job = div_up(work_amount, nthr);
 
@@ -1391,8 +1424,9 @@ float brg_blocking_t::est_eff_1x1() {
 
     const dim_t sum_job = static_cast<dim_t>(mb) * od * oh * ow * ngroups * oc;
 
-    const float job_eff
-            = max_job == 0 ? 1 : static_cast<float>(sum_job) / (max_job * nthr);
+    const float job_eff = max_job == 0
+            ? 1.f
+            : static_cast<float>(sum_job) / static_cast<float>(max_job * nthr);
 
     const auto ic_blocking_size = ic_block * nb_ic_blocking;
     const auto oc_blocking_size = oc_block * ic_blocking_size;
@@ -1505,19 +1539,21 @@ float brg_blocking_t::est_eff_1x1() {
         dst_rp *= loop[il].dst.repeatn;
         wei_rp *= loop[il].wei.repeatn;
     }
-    const auto src_ops = (src_op * src_rp) / iterations;
-    const auto dst_ops = (dst_op * dst_rp) / iterations;
-    const auto wei_ops = (wei_op * wei_rp) / iterations;
+    const auto src_ops = (static_cast<float>(src_op) * src_rp) / iterations;
+    const auto dst_ops = (static_cast<float>(dst_op) * dst_rp) / iterations;
+    const auto wei_ops = (static_cast<float>(wei_op) * wei_rp) / iterations;
 
     const auto src_cost = src_mem_k * src_ops;
     const auto dst_cost = dst_mem_k * dst_ops;
     const auto wei_cost = wei_mem_k * wei_ops;
-    const auto call_kernel_cost = 1000.f * job * ic_chunks;
+    const auto call_kernel_cost
+            = 1000.f * static_cast<float>(job) * static_cast<float>(ic_chunks);
 
     const auto up_sp_size = is_os_blocking ? 1 : od * oh;
 
-    const auto cache_eff = (static_cast<dim_t>(mb) * up_sp_size * sp * ic * oc)
-            / (nthr * (src_cost + dst_cost + wei_cost + call_kernel_cost));
+    const auto cache_eff = static_cast<float>(mb * up_sp_size * sp * ic * oc)
+            / (static_cast<float>(nthr)
+                    * (src_cost + dst_cost + wei_cost + call_kernel_cost));
 
     const auto res_eff = oc_block_eff * brgemm_microkernel_eff * sp_eff
             * job_eff * ur_eff * cache_eff * brgemm_eff;
@@ -1557,17 +1593,17 @@ void brg_blocking_t::calc_blocks_1x1() {
     const auto max_sp_block_L2 = os;
     // TODO: nb_os_blocking always is 1 for now. Update this code
     nb_os_blocking = 1;
-    int start_sp_block = 0;
+    dim_t start_sp_block = 0;
 
     if (is_os_blocking) {
         ow_block = 0;
 
         const auto max_os_block_thr
                 = (src_dsz * ic >= 1024 && src_dsz * ic < 4096)
-                ? nstl::max(nstl::min(16, os),
+                ? nstl::max<dim_t>(nstl::min<dim_t>(16, os),
                           div_up(os, div_up(nthr, mb * div_up(oc, oc_block))))
-                : nstl::max(div_up(2048, oc_block),
-                          static_cast<int>(div_up(mb * ngroups * os, nthr)));
+                : nstl::max<dim_t>(div_up(2048, oc_block),
+                          div_up(mb * ngroups * os, nthr));
         const auto max_os_block_L2 = max_sp_block_L2;
 
         auto max_os_block_aliasing = 1000000 / nthr;
@@ -1584,32 +1620,34 @@ void brg_blocking_t::calc_blocks_1x1() {
         max_os_block_aliasing
                 = nstl::min(div_up(1001, dst_dsz), max_os_block_aliasing);
 
-        start_sp_block = utils::saturate(1, os,
-                nstl::min(nstl::min(max_os_block_thr, max_os_block_L2),
+        start_sp_block = utils::saturate<dim_t>(1, os,
+                nstl::min<dim_t>(
+                        nstl::min<dim_t>(max_os_block_thr, max_os_block_L2),
                         max_os_block_aliasing));
 
     } else {
         os_block = 0;
 
-        const auto max_ow_block_thr = utils::saturate(1, ow,
-                static_cast<int>(ceil(mb * ngroups * nb_oc * os
-                        / (thr_eff_threshold * nthr))));
+        const auto max_ow_block_thr = utils::saturate<dim_t>(1, ow,
+                static_cast<dim_t>(ceil(
+                        static_cast<float>(mb * ngroups * nb_oc * os)
+                        / (thr_eff_threshold * static_cast<float>(nthr)))));
         const auto max_ow_block_L2 = max_sp_block_L2;
 
-        start_sp_block = utils::saturate(
-                1, ow, nstl::min(max_ow_block_thr, max_ow_block_L2));
+        start_sp_block = utils::saturate<dim_t>(
+                1, ow, nstl::min<dim_t>(max_ow_block_thr, max_ow_block_L2));
     }
     os_block = ow_block = sp_block = -1;
     brg_blocking_t best_brgb = *this;
 
-    auto prev_spb = 0;
+    auto prev_spb = dim_t(0);
     for (auto ns = 1; ns <= sp; ns++) {
         auto spb = div_up(sp, ns);
         if (is_amx(isa)) {
-            auto min_dis = 16;
-            auto best_w = 16;
-            const auto max_tile_width = nstl::min(16, sp);
-            const auto min_tile_width = utils::saturate(1, 11, sp / 2);
+            dim_t min_dis = 16;
+            dim_t best_w = 16;
+            const auto max_tile_width = nstl::min<dim_t>(16, sp);
+            const auto min_tile_width = utils::saturate<dim_t>(1, 11, sp / 2);
             if (spb < min_tile_width) break;
             for (auto w = max_tile_width; w >= min_tile_width; w--) {
                 const auto dis = nstl::additive_inverse_modulo(spb, w);
@@ -1623,7 +1661,8 @@ void brg_blocking_t::calc_blocks_1x1() {
         }
         if (spb == prev_spb || spb > start_sp_block) continue;
         prev_spb = spb;
-        os_block = ow_block = sp_block = spb;
+        sp_block = spb;
+        os_block = ow_block = spb;
         select_ic_block();
         const status_t st = estimate_brgemm_ur();
         if (st != status::success) continue;
@@ -1781,7 +1820,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                                                                    : jcp.wei_dt;
     const data_type_t vnni_block_dt
             = get_mac_emu_data_type(vnni_dt, isa, isa == avx10_1_512);
-    jcp.vnni_block = data_type_vnni_granularity(vnni_block_dt);
+    jcp.vnni_block
+            = static_cast<int>(data_type_vnni_granularity(vnni_block_dt));
 
     if (one_of(jcp.prop_kind, prop_kind::forward_training,
                 prop_kind::forward_inference)
@@ -1983,7 +2023,7 @@ void adjust_nthr(jit_brgemm_conv_conf_t &jcp, const memory_desc_wrapper &src_d,
     const bool out_small = dst_d.size() < threshold;
     if (in_small && out_small && jcp.ngroups < jcp.nthr
             && jcp.nb_oc < jcp.nthr) {
-        int nthr = nstl::max(jcp.ngroups, jcp.nb_oc);
+        int nthr = static_cast<int>(nstl::max<dim_t>(jcp.ngroups, jcp.nb_oc));
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 }
@@ -2050,13 +2090,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     const int min_oc_block = jcp.acc_simd_w;
 
-    int selected_ur = 0;
+    dim_t selected_ur = 0;
     MAYBE_UNUSED(selected_ur);
 
     auto try_exec_type = [&]() {
         brg_blocking_t best_brgb = zero<decltype(best_brgb)>();
         best_brgb.oc_block = min_oc_block;
-        const int est_amx_job = div_up(jcp.mb * div_up(jcp.os, 4 * 16)
+        const dim_t est_amx_job = div_up(jcp.mb * div_up(jcp.os, 4 * 16)
                         * jcp.ngroups * div_up(jcp.oc, 4 * 16),
                 jcp.nthr);
         const bool small_amx_job = est_amx_job < 64 || jcp.oc < 256;
@@ -2069,7 +2109,8 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                 && jcp.oh * jcp.ow >= 150 * 150)
             start_ocb = 2;
 
-        start_ocb = nstl::min(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
+        start_ocb = static_cast<int>(
+                nstl::min<dim_t>(div_up(jcp.oc, jcp.acc_simd_w), start_ocb));
 
         auto finish_ocb = 1;
         for (auto ocb = start_ocb; ocb >= finish_ocb; ocb--) {
@@ -2105,8 +2146,9 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     // TODO: this logic seems not taking dilation into which can avoid pure
     // kernel-in-pad cases.
-    if (!is_amx(isa) && div_up(nstl::max(0, jcp.l_pad), jcp.stride_w) < jcp.kw
-            && div_up(nstl::max(0, jcp.r_pad), jcp.stride_w) < jcp.kw) {
+    if (!is_amx(isa)
+            && div_up(nstl::max<dim_t>(0, jcp.l_pad), jcp.stride_w) < jcp.kw
+            && div_up(nstl::max<dim_t>(0, jcp.r_pad), jcp.stride_w) < jcp.kw) {
         try_exec_vpad = true;
     }
 
@@ -2154,11 +2196,11 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                 && IMPLICATION(jcp.id > 1, relo_conv_weights_wi == false)
                 && !cd.use_inversion && jcp.dilate_w == 0;
 
-        const auto rnd_kwic = (float)jcp.kw * rnd_up(jcp.ic, jcp.simd_w);
-        const auto src_per_ic
-                = (float)jcp.src_dsz * jcp.mb * jcp.id * jcp.ih * jcp.iw;
-        const auto wei_per_ic
-                = (float)jcp.wei_dsz * jcp.oc * jcp.kd * jcp.kh * jcp.kw;
+        const auto rnd_kwic = (float)jcp.kw * (float)rnd_up(jcp.ic, jcp.simd_w);
+        const auto src_per_ic = (float)jcp.src_dsz * (float)jcp.mb
+                * (float)jcp.id * (float)jcp.ih * (float)jcp.iw;
+        const auto wei_per_ic = (float)jcp.wei_dsz * (float)jcp.oc
+                * (float)jcp.kd * (float)jcp.kh * (float)jcp.kw;
         bool perf_relo = false;
         if (is_amx(jcp.isa)) {
             if (jcp.ic < jcp.simd_w / 2
@@ -2184,7 +2226,7 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     bool relo_conv_weights_whi = true;
     if (!jcp.wei_plain && relo_supported_isa && relo_reasonable_isa
             && !jcp.is_fp8) {
-        const int rd_whi = jcp.kh * jcp.kw * jcp.ic;
+        const dim_t rd_whi = jcp.kh * jcp.kw * jcp.ic;
         //TODO: support fp8
         if (jcp.ic % jcp.vnni_block == 0
                 && IMPLICATION(rd_whi > jcp.simd_w, rd_whi % jcp.simd_w == 0)
@@ -2197,13 +2239,13 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                 && IMPLICATION(jcp.s8s8_compensation_required,
                         everyone_is(0, jcp.t_pad, jcp.b_pad));
 
-        const float rnd_rd_whi = rnd_up(rd_whi, jcp.simd_w);
-        const auto rnd_khkwic
-                = (float)jcp.kh * jcp.kw * rnd_up(jcp.ic, jcp.simd_w);
-        const auto src_per_ic
-                = (float)jcp.src_dsz * jcp.mb * jcp.id * jcp.ih * jcp.iw;
-        const auto wei_per_ic
-                = (float)jcp.wei_dsz * jcp.oc * jcp.kd * jcp.kh * jcp.kw;
+        const float rnd_rd_whi = (float)rnd_up(rd_whi, jcp.simd_w);
+        const auto rnd_khkwic = (float)jcp.kh * (float)jcp.kw
+                * (float)rnd_up(jcp.ic, jcp.simd_w);
+        const auto src_per_ic = (float)jcp.src_dsz * (float)jcp.mb
+                * (float)jcp.id * (float)jcp.ih * (float)jcp.iw;
+        const auto wei_per_ic = (float)jcp.wei_dsz * (float)jcp.oc
+                * (float)jcp.kd * (float)jcp.kh * (float)jcp.kw;
         // Heuristics for determining relo_whi makes sense for performance
         bool perf_relo = false;
         if (is_amx(jcp.isa)) {
@@ -2212,9 +2254,10 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
                                 && rnd_rd_whi / rnd_khkwic < 0.5f
                                 && IMPLICATION(relo_conv_weights_whi,
                                         wei_per_ic / src_per_ic <= 4)))
-                    && rd_whi / rnd_rd_whi > rd_wi / rnd_rd_wi
+                    && (float)rd_whi / rnd_rd_whi > (float)rd_wi / rnd_rd_wi
                     && (jcp.ow > 48 || jcp.ow % 16 == 0)
-                    && IMPLICATION(try_relo_wi, rd_whi / rnd_rd_whi > 0.7f))
+                    && IMPLICATION(
+                            try_relo_wi, (float)rd_whi / rnd_rd_whi > 0.7f))
                 perf_relo = true;
         } else {
             if (one_of(jcp.wei_dt, f32, s8)) {
@@ -2363,13 +2406,14 @@ status_t init_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         dim_t ds = jcp.copy_block_only
                 ? (brg_blocking_t::get_inp_size(jcp.idp, jcp.od_block, jcp.kd,
                            jcp.stride_d, jcp.dilate_d)
-                          + nstl::max(0, jcp.f_pad)
-                          + nstl::max(0, jcp.back_pad))
+                          + nstl::max<dim_t>(0, jcp.f_pad)
+                          + nstl::max<dim_t>(0, jcp.back_pad))
                 : jcp.idp;
         dim_t hs = jcp.copy_block_only
                 ? (brg_blocking_t::get_inp_size(jcp.ihp, jcp.oh_block, jcp.kh,
                            jcp.stride_h, jcp.dilate_h)
-                          + nstl::max(0, jcp.t_pad) + nstl::max(0, jcp.b_pad))
+                          + nstl::max<dim_t>(0, jcp.t_pad)
+                          + nstl::max<dim_t>(0, jcp.b_pad))
                 : jcp.ihp;
         if (jcp.is_os_blocking)
             hs = div_up(rnd_up(hs * jcp.iwp, jcp.brgM), jcp.iwp)
@@ -2499,9 +2543,9 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     if (is_amx(isa)) {
         // round up ic if needed
-        const int n_vnni_blocks = utils::div_up(jcp.ic, jcp.vnni_block);
-        const int ic_block
-                = nstl::min(jcp.acc_simd_w, n_vnni_blocks) * jcp.vnni_block;
+        const dim_t n_vnni_blocks = utils::div_up(jcp.ic, jcp.vnni_block);
+        const dim_t ic_block = nstl::min<dim_t>(jcp.acc_simd_w, n_vnni_blocks)
+                * jcp.vnni_block;
 
         jcp.extendable_k = jcp.ic > jcp.simd_w && jcp.ic % jcp.simd_w;
 
@@ -2514,11 +2558,11 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         // try to choose optimal loop order
         // TODO: incorporate loop order into smart blocking selection
         auto wei_size = (size_t)jcp.oc * jcp.ic * jcp.wei_dsz;
-        auto max_size = 0.75f * brg_blocking_t::L2;
+        auto max_size = 0.75f * static_cast<float>(brg_blocking_t::L2);
         const dim_t os = static_cast<dim_t>(jcp.od) * jcp.oh * jcp.ow;
         const dim_t os_cutoff = 400; // approximate and empiric
-        const bool use_loop_ngcdhw
-                = max_size < wei_size || (jcp.mb == 1 && os < os_cutoff);
+        const bool use_loop_ngcdhw = max_size < static_cast<float>(wei_size)
+                || (jcp.mb == 1 && os < os_cutoff);
         jcp.loop_order = use_loop_ngcdhw ? loop_ngcdhw : loop_ndhwgc;
     }
 
@@ -2531,10 +2575,10 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
 
     brg_blocking_t best_brgb = zero<decltype(best_brgb)>();
     best_brgb.oc_block = min_oc_block;
-    auto start_ocb = 4;
-    start_ocb = nstl::min(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
+    dim_t start_ocb = 4;
+    start_ocb = nstl::min<dim_t>(div_up(jcp.oc, jcp.acc_simd_w), start_ocb);
 
-    auto finish_ocb = 1;
+    dim_t finish_ocb = 1;
 
     const bool is_os_blocking_ok
             = utils::everyone_is(1, jcp.stride_d, jcp.stride_h)
@@ -2632,10 +2676,10 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
      **/
     constexpr int int8_outer_vnni_block = 16; // currently, only for AMX
     const int ic_padded_block = int8_outer_vnni_block * jcp.vnni_block;
-    const int ic_vnni_block = jcp.ic_without_padding / ic_padded_block;
-    const int effective_rtus_ic_block
+    const dim_t ic_vnni_block = jcp.ic_without_padding / ic_padded_block;
+    const dim_t effective_rtus_ic_block
             = jcp.ic_without_padding - (ic_vnni_block * ic_padded_block);
-    const int rtus_padded_ic_size
+    const dim_t rtus_padded_ic_size
             = rnd_up(effective_rtus_ic_block, ic_padded_block);
     // used as K dimension for BRGeMM:
     jcp.rtus_ic_size = jcp.is_reduced_rtus ? effective_rtus_ic_block : 1;
@@ -2816,8 +2860,11 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         dim_t dst_size = dst_spatial * jcp.oc * src_type_size;
         dim_t wei_size = (dim_t)jcp.oc * jcp.ic * wei_ks * wei_type_size;
 
-        float wei_compensation_scale = 0.5f * (dst_size + src_size) / wei_size;
-        float oi_channels_ratio = (float)(oc_chunks) / ic_chunks;
+        float wei_compensation_scale = 0.5f
+                * static_cast<float>(dst_size + src_size)
+                / static_cast<float>(wei_size);
+        float oi_channels_ratio
+                = (float)(oc_chunks) / static_cast<float>(ic_chunks);
 
         auto get_src_coef = [=]() {
             float src_coef = nstl::max(1.0f / oi_channels_ratio, 1.0f);
@@ -2852,12 +2899,16 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         const auto thr_oc_b = div_up(oc_chunks, nb_oc_job * nthr_oc_b);
 
         const auto thr_oc_amount = thr_oc_b * nb_oc_job;
-        float src_v
-                = src_type_size * src_coef * thr_g * thr_ic_amount * thr_src_sp;
-        float dst_v
-                = src_type_size * dst_coef * thr_g * thr_oc_amount * thr_dst_sp;
-        float wei_v = acc_type_size * wei_coef * thr_g * thr_oc_amount
-                * thr_ic_amount * wei_ks;
+        float src_v = src_type_size * src_coef * static_cast<float>(thr_g)
+                * static_cast<float>(thr_ic_amount)
+                * static_cast<float>(thr_src_sp);
+        float dst_v = src_type_size * dst_coef * static_cast<float>(thr_g)
+                * static_cast<float>(thr_oc_amount)
+                * static_cast<float>(thr_dst_sp);
+        float wei_v = acc_type_size * wei_coef * static_cast<float>(thr_g)
+                * static_cast<float>(thr_oc_amount)
+                * static_cast<float>(thr_ic_amount)
+                * static_cast<float>(wei_ks);
 
         return src_v + dst_v + wei_v;
     };
@@ -2872,7 +2923,7 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
             return;
         }
 
-        nthr_g_ = jcp.ngroups;
+        nthr_g_ = static_cast<int>(jcp.ngroups);
         const int nthr = jcp.nthr / nthr_g_;
 
         float best_mem_cost
@@ -2883,11 +2934,12 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         const int nthr_mb_max = nstl::min(nthr, jcp.nthr_mb_work);
         for (int nthr_mb = 1; nthr_mb <= nthr_mb_max; ++nthr_mb) {
             const int nthr_par = nthr / nthr_mb;
-            const int nthr_oc_b_max = nstl::min(nthr_par,
-                    oc_chunks); // Amount of nb_oc_blocks
+            const int nthr_oc_b_max = static_cast<int>(nstl::min<dim_t>(
+                    nthr_par, oc_chunks)); // Amount of nb_oc_blocks
             for (int nthr_oc_b = 1; nthr_oc_b <= nthr_oc_b_max; ++nthr_oc_b) {
-                int nthr_ic_b = nstl::min(
-                        nthr_par / nthr_oc_b, (jcp.nb_ic / jcp.nb_ic_blocking));
+                int nthr_ic_b = static_cast<int>(
+                        nstl::min<dim_t>(nthr_par / nthr_oc_b,
+                                (jcp.nb_ic / jcp.nb_ic_blocking)));
 
                 float mem_cost
                         = calc_mem_cost(nthr_mb, nthr_g_, nthr_oc_b, nthr_ic_b);
@@ -2951,13 +3003,18 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         // Keep dimension values as a vector
         std::vector<std::pair<double, bwd_w_dims>> dv;
         const auto ks = jcp.kd * jcp.kh * jcp.kw;
-        double v = (jcp.ngroups > 1) ? static_cast<double>(jcp.ic) * jcp.oc
-                        * jcp.ngroups * jcp.ngroups * ks
-                                     : 1;
+        double v = (jcp.ngroups > 1)
+                ? static_cast<double>(jcp.ic) * static_cast<double>(jcp.oc)
+                        * static_cast<double>(jcp.ngroups)
+                        * static_cast<double>(jcp.ngroups)
+                        * static_cast<double>(ks)
+                : 1;
         dv.emplace_back(v, bwd_w_dims::g);
-        v = 5 * div_up(jcp.ic, jcp.amx_h) * ks;
+        v = 5 * static_cast<double>(div_up(jcp.ic, jcp.amx_h))
+                * static_cast<double>(ks);
         dv.emplace_back(v, bwd_w_dims::ic);
-        v = 3 * div_up(jcp.oc, jcp.amx_h) * ks;
+        v = 3 * static_cast<double>(div_up(jcp.oc, jcp.amx_h))
+                * static_cast<double>(ks);
         dv.emplace_back(v, bwd_w_dims::oc);
         v = div_up(jcp.mb * jcp.od * jcp.oh * jcp.ow, jcp.amx_w);
         dv.emplace_back(v, bwd_w_dims::sp);
@@ -2978,7 +3035,7 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
                 xd = 1;
                 for (int j = i + 1; j < nd; j++)
                     xd *= dv[j].first;
-                xd = pow(xd / jcp.nthr, 1.f / (nd - i - 1));
+                xd = pow(xd / jcp.nthr, 1.f / static_cast<float>(nd - i - 1));
             } else {
                 v = nstl::min(dvf / xd, maxvf);
             }
@@ -2996,7 +3053,7 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
             const auto maxvf = static_cast<double>(maxv[dvs]);
             const auto new_dvf = dvf * knorm;
             dvf = utils::saturate(1., maxvf, new_dvf);
-            knorm *= pow(new_dvf / dvf, 1.f / (nd - i - 1));
+            knorm *= pow(new_dvf / dvf, 1.f / static_cast<float>(nd - i - 1));
             tot_v *= dvf;
         }
         std::sort(dv.begin(), dv.end());
@@ -3100,10 +3157,11 @@ void balance_bwd_w(jit_brgemm_conv_conf_t &jcp) {
         }
         nthr = nthr_mb * nthr_g * nthr_oc_b * nthr_ic_b;
     } else if (jcp.kw > 100 && jcp.id == 1 && jcp.ih == 1) {
-        nthr_g = nstl::min(jcp.nthr, jcp.ngroups);
-        nthr_oc_b = nstl::min(jcp.nthr / nthr_g, div_up(jcp.nb_oc, 2));
-        nthr_ic_b = nstl::min(
-                jcp.nthr / (nthr_g * nthr_oc_b), div_up(jcp.nb_ic, 2));
+        nthr_g = static_cast<int>(nstl::min<dim_t>(jcp.nthr, jcp.ngroups));
+        nthr_oc_b = static_cast<int>(
+                nstl::min<dim_t>(jcp.nthr / nthr_g, div_up(jcp.nb_oc, 2)));
+        nthr_ic_b = static_cast<int>(nstl::min<dim_t>(
+                jcp.nthr / (nthr_g * nthr_oc_b), div_up(jcp.nb_ic, 2)));
         nthr_mb = jcp.nthr / (nthr_g * nthr_oc_b * nthr_ic_b);
         nthr = nthr_mb * nthr_g * nthr_oc_b * nthr_ic_b;
     }
@@ -3169,7 +3227,7 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
             && everyone_is(0, jcp.f_pad, jcp.back_pad, jcp.t_pad, jcp.b_pad))
         jcp.var_bs = false;
 
-    jcp.typesize_in = jcp.src_dsz;
+    jcp.typesize_in = static_cast<int>(jcp.src_dsz);
     jcp.typesize_out = sizeof(float);
 
     bool ok = true
@@ -3251,7 +3309,7 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_pad_h = jcp.ext_kh / 2;
+    const dim_t max_pad_h = jcp.ext_kh / 2;
     const bool boundaries_ok = true && jcp.l_pad < jcp.ext_kw
             && jcp.r_pad < jcp.ext_kw && jcp.t_pad <= max_pad_h
             && jcp.b_pad <= max_pad_h && jcp.f_pad < jcp.ext_kd
@@ -3265,8 +3323,8 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.nb_ic = utils::div_up(jcp.ic, jcp.ic_block);
     jcp.nb_oc = utils::div_up(jcp.oc, jcp.oc_block);
 
-    jcp.ic_tail = jcp.ic % jcp.ic_block;
-    jcp.oc_tail = jcp.oc % jcp.oc_block;
+    jcp.ic_tail = static_cast<int>(jcp.ic % jcp.ic_block);
+    jcp.oc_tail = static_cast<int>(jcp.oc % jcp.oc_block);
 
     jcp.nb_oc_blocking = (jcp.nb_oc > 1) ? 2 : 1;
     jcp.nb_ic_blocking = (jcp.nb_ic > 1) ? 2 : 1;
@@ -3277,13 +3335,13 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     // TODO: Find more shapes (especially 3D with large spatials) for which
     // local transposition will be beneficial. Furthermore, for TBB threads
     // more shapes can potentially benefit from spatial blocking
-    int optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
+    dim_t optimal_blk_size = is_3d ? jcp.od : is_2d ? jcp.oh : jcp.ow;
 
     jcp.global_transpose = dnnl_thr_syncable();
     jcp.spatial_blk_size = optimal_blk_size;
 
     const int tr_round = 32; // To load full tile register
-    int tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
+    dim_t tr_pad = rnd_up(nstl::max(jcp.l_pad, jcp.r_pad + 1), tr_round);
     jcp.tr_iw = rnd_up(div_up(jcp.iw + jcp.l_pad + jcp.r_pad, jcp.stride_w),
                         tr_round)
             * jcp.stride_w;
@@ -3294,9 +3352,9 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.tr_ow = rnd_up(jcp.ow, rnd_val);
     if (jcp.tr_ow > tr_round) {
         // we may increase tr_ow to have better bd_block in brgemm kernel
-        int best_bdb = jcp.tr_ow / rnd_val;
-        int best_tr_ow = jcp.tr_ow;
-        for (int tr_ow = jcp.tr_ow; tr_ow <= rnd_up(jcp.tr_ow, tr_round);
+        dim_t best_bdb = jcp.tr_ow / rnd_val;
+        dim_t best_tr_ow = jcp.tr_ow;
+        for (dim_t tr_ow = jcp.tr_ow; tr_ow <= rnd_up(jcp.tr_ow, tr_round);
                 tr_ow += rnd_val) {
             for (int i = tr_round; i > 0; i -= rnd_val) {
                 if (tr_ow % i == 0) {
@@ -3325,9 +3383,15 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     }
 
     switch (jcp.harness) {
-        case harness_2d_reduction: jcp.nthr_mb_work = jcp.mb * jcp.oh; break;
-        case harness_3d_reduction: jcp.nthr_mb_work = jcp.mb * jcp.od; break;
-        default: assert(!"Invalid harness"); jcp.nthr_mb_work = jcp.mb;
+        case harness_2d_reduction:
+            jcp.nthr_mb_work = static_cast<int>(jcp.mb * jcp.oh);
+            break;
+        case harness_3d_reduction:
+            jcp.nthr_mb_work = static_cast<int>(jcp.mb * jcp.od);
+            break;
+        default:
+            assert(!"Invalid harness");
+            jcp.nthr_mb_work = static_cast<int>(jcp.mb);
     }
 
     balance_bwd_w(jcp);
@@ -3362,19 +3426,22 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.tr_ocb_chunk = tr_ocb_chunk_allowed && (jcp.oh * jcp.ow > 38 * 38);
     jcp.tr_icb_chunk = false;
 
-    const int irow_size = jcp.src_dsz * jcp.tr_iw * jcp.ic_block
-            * div_up(jcp.nb_ic, jcp.nthr_ic_b)
+    const dim_t irow_size = static_cast<dim_t>(jcp.src_dsz) * jcp.tr_iw
+            * jcp.ic_block * div_up(jcp.nb_ic, jcp.nthr_ic_b)
             * 2 /*we have real and transposed input */;
-    const int orow_size = jcp.dst_dsz * jcp.tr_ow * jcp.oc_block
-            * div_up(jcp.nb_oc, jcp.nthr_oc_b)
+    const dim_t orow_size = static_cast<dim_t>(jcp.dst_dsz) * jcp.tr_ow
+            * jcp.oc_block * div_up(jcp.nb_oc, jcp.nthr_oc_b)
             * 2 /*we have real and transposed diff_dst*/;
-    int oh_block_limit = nstl::max(1.f,
-            nstl::max(0.f, 0.8f * brg_blocking_t::L2 - jcp.kh * irow_size)
-                    / (irow_size + orow_size));
+    dim_t oh_block_limit = static_cast<dim_t>(nstl::max(1.f,
+            nstl::max(0.f,
+                    0.8f * static_cast<float>(brg_blocking_t::L2)
+                            - static_cast<float>(jcp.kh)
+                                    * static_cast<float>(irow_size))
+                    / static_cast<float>(irow_size + orow_size)));
     // try to split oh by equal oh blocks
     oh_block_limit = div_up(jcp.oh, div_up(jcp.oh, oh_block_limit));
-    jcp.oh_block = utils::saturate(1, jcp.oh, oh_block_limit);
-    jcp.ih_block = nstl::min(jcp.ih,
+    jcp.oh_block = utils::saturate<dim_t>(1, jcp.oh, oh_block_limit);
+    jcp.ih_block = nstl::min<dim_t>(jcp.ih,
             jcp.stride_h
                     * brg_blocking_t::get_inp_size(jcp.ih, jcp.oh_block, jcp.kh,
                             jcp.stride_h, jcp.dilate_h));
@@ -3383,12 +3450,13 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     // among nthr_oc_b
     jcp.tr_ic_block = jcp.ic_block;
     if (jcp.ic <= jcp.ic_block) {
-        for (int itr_icb = jcp.ic_block; itr_icb > 1; itr_icb--) {
+        for (dim_t itr_icb = jcp.ic_block; itr_icb > 1; itr_icb--) {
             if (jcp.ic_block % itr_icb != 0) continue;
             const auto icb_per_thr_ic_b = div_up(jcp.nb_ic, jcp.nthr_ic_b);
             const auto ic_per_thr_ic_b
-                    = nstl::min(jcp.ic, icb_per_thr_ic_b * jcp.ic_block);
-            const auto ic_block_per_thr_ic_b = nstl::min(jcp.ic, jcp.ic_block);
+                    = nstl::min<dim_t>(jcp.ic, icb_per_thr_ic_b * jcp.ic_block);
+            const auto ic_block_per_thr_ic_b
+                    = nstl::min<dim_t>(jcp.ic, jcp.ic_block);
             if (ic_block_per_thr_ic_b % itr_icb != 0) continue;
             const auto tr_icb_per_thr = div_up(ic_per_thr_ic_b, itr_icb);
             const auto sp_per_thr_mb
@@ -3418,14 +3486,17 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
     jcp.tr_diff_dst_buf_size = jcp.tr_diff_dst_block_size
             * (jcp.global_transpose ? 1 : jcp.nb_oc_blocking);
 
-    const int iframe_size = irow_size * jcp.id;
-    const int oframe_size = orow_size * jcp.od;
-    int od_block_limit = nstl::max(1.f,
-            nstl::max(0.f, 0.8f * brg_blocking_t::L2 - jcp.kd * iframe_size)
-                    / (iframe_size + oframe_size));
+    const dim_t iframe_size = irow_size * jcp.id;
+    const dim_t oframe_size = orow_size * jcp.od;
+    dim_t od_block_limit = static_cast<dim_t>(nstl::max(1.f,
+            nstl::max(0.f,
+                    0.8f * static_cast<float>(brg_blocking_t::L2)
+                            - static_cast<float>(jcp.kd)
+                                    * static_cast<float>(iframe_size))
+                    / static_cast<float>(iframe_size + oframe_size)));
     // try to split od by equal od blocks
     od_block_limit = div_up(jcp.od, div_up(jcp.od, od_block_limit));
-    jcp.od_block = utils::saturate(1, jcp.od, od_block_limit);
+    jcp.od_block = utils::saturate<dim_t>(1, jcp.od, od_block_limit);
 
     jcp.use_interleave_stores = false;
     jcp.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf0;
@@ -3561,10 +3632,10 @@ void get_ow_range(const jit_brgemm_conv_conf_t &jcp, int ow, int kw, int &ow_s,
         ow_s += ker_idx;
     }
     if (iw_rp > 0) ker_idx += div_up(iw_rp, SW);
-    ow_f = nstl::max(ow_s, ow_s + (M - ker_idx));
+    ow_f = static_cast<int>(nstl::max<dim_t>(ow_s, ow_s + (M - ker_idx)));
 
-    ow_s = nstl::min(ow_s, ow + M);
-    ow_f = nstl::min(ow_f, ow + M);
+    ow_s = static_cast<int>(nstl::min<dim_t>(ow_s, ow + M));
+    ow_f = static_cast<int>(nstl::min<dim_t>(ow_f, ow + M));
 }
 
 // Sets pairs of `kw_s`-`kw_f` and `kw_full_s`-`kw_full_f` based on given `jcp`.

--- a/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
+++ b/src/cpu/x64/jit_gemm_x8s8s32x_convolution_utils.cpp
@@ -14,7 +14,6 @@
 * limitations under the License.
 *******************************************************************************/
 
-#include <cstdlib>
 #include <functional>
 
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
@@ -50,9 +49,9 @@ struct jit_pp_ker_t : pp_ker_t, public jit_generator_t {
 
 private:
     void apply_postops(
-            const Xbyak::Reg64 &reg_dst, const int idx, const size_t offset);
+            const Xbyak::Reg64 &reg_dst, const int idx, const dim_t offset);
     void generate() override;
-    void append_zp_src_comp(size_t offset, int idx, bool apply_mask);
+    void append_zp_src_comp(dim_t offset, int idx, bool apply_mask);
     void load_as_f32(const Xbyak::Zmm &dst, const Xbyak::Opmask &mask,
             const Xbyak::Address &src_addr, const data_type_t &src_dt);
 
@@ -74,14 +73,14 @@ private:
         float dst_scale;
         float sum_scale;
         float signed_scale;
-        size_t len;
-        size_t oc_offset;
+        dim_t len;
+        dim_t oc_offset;
         const int32_t *zp_src;
         const int32_t *zp_dst;
         const int32_t *zp_src_comp;
         const int32_t *zp_src_pad_comp;
-        size_t g_oc_offset_prologue;
-        size_t g_oc_offset;
+        dim_t g_oc_offset_prologue;
+        dim_t g_oc_offset;
         const void *post_ops_binary_rhs_arg_vec;
         const void *dst_orig;
         dim_t h;
@@ -95,9 +94,9 @@ private:
     std::unique_ptr<injector::jit_uni_postops_injector_t<Xbyak::Zmm>>
             postops_injector_;
 
-    size_t number_of_reserved_zmm_regs_;
-    const size_t bias_data_type_size_;
-    const size_t dst_data_type_size_;
+    int number_of_reserved_zmm_regs_;
+    const dim_t bias_data_type_size_;
+    const dim_t dst_data_type_size_;
     const bool saturation_needed_;
 
     const Xbyak::Reg64 &reg_param_ = rdi;
@@ -130,11 +129,11 @@ private:
     const Xbyak::Opmask &kreg_rem_mask_short_ = k3;
     const Xbyak::Opmask &kreg_rem_mask_vlen_ = k4;
 
-    static constexpr size_t def_unroll_ = 4u;
-    size_t zmm_step_;
-    const size_t bias_step_factor_;
-    const size_t sum_step_factor_;
-    const size_t max_unroll_;
+    static constexpr int def_unroll_ = 4;
+    int zmm_step_;
+    const int bias_step_factor_;
+    const int sum_step_factor_;
+    const int max_unroll_;
 
     std::unique_ptr<jit_gemm_x8s8s32x_zp_pad_comp_helper_t> zp_pad_comp_helper_;
 };
@@ -215,27 +214,29 @@ void jit_pp_ker_t::operator()(void *void_dst, const acc_data_t *acc,
 
     char *dst = (char *)void_dst;
 
+    const dim_t start_dim = start;
+    const dim_t end_dim = end;
     ker_args_t args;
-    const auto dv = std::div(start, jcp_.oc);
-    const size_t oc_offset = dv.rem;
-    const size_t os_offset = dv.quot;
-    args.acc = acc + start;
+    const dim_t oc_offset = start_dim % jcp_.oc;
+    const dim_t os_offset = start_dim / jcp_.oc;
+    const dim_t dst_os_stride = jcp_.dst_os_stride;
+    const dim_t scale_idx_mult = jcp_.scale_idx_mult;
+    args.acc = acc + start_dim;
     args.dst = dst
-            + (os_offset * jcp_.dst_os_stride + oc_offset)
-                    * dst_data_type_size_;
+            + (os_offset * dst_os_stride + oc_offset) * dst_data_type_size_;
 
-    const ptrdiff_t g_oc_offset = g * jcp_.oc;
-    const ptrdiff_t g_oc_offset_prologue = g_oc_offset + oc_offset;
+    const dim_t g_oc_offset = g * jcp_.oc;
+    const dim_t g_oc_offset_prologue = g_oc_offset + oc_offset;
     args.bias = bias + g_oc_offset_prologue * bias_data_type_size_;
     args.zp_src = zp.src + (jcp_.zp.src_is_common ? 0 : g_oc_offset_prologue);
     args.zp_src_comp
             = zp.src_comp ? zp.src_comp + g_oc_offset_prologue : nullptr;
     args.zp_dst = zp.dst;
-    args.scales = scales + jcp_.scale_idx_mult * g_oc_offset_prologue;
+    args.scales = scales + scale_idx_mult * g_oc_offset_prologue;
     args.dst_scale = dst_scale;
     args.sum_scale = sum_scale;
     args.signed_scale = signed_scale;
-    args.len = end - start;
+    args.len = end_dim - start_dim;
     args.oc_offset = oc_offset;
 
     args.g_oc_offset = g_oc_offset;
@@ -245,10 +246,8 @@ void jit_pp_ker_t::operator()(void *void_dst, const acc_data_t *acc,
     args.dst_orig = dst_orig;
 
     if (zp_pad_comp_helper_) {
-        const auto hw
-                = std::div(static_cast<dim_t>(os_offset), chunk_desc.w_size_);
-        args.h = hw.quot + chunk_desc.h_off_;
-        args.w = hw.rem + chunk_desc.w_off_;
+        args.h = os_offset / chunk_desc.w_size_ + chunk_desc.h_off_;
+        args.w = os_offset % chunk_desc.w_size_ + chunk_desc.w_off_;
         args.w_size = chunk_desc.w_size_ + chunk_desc.w_off_;
         args.w_off = chunk_desc.w_off_;
         args.zp_src_pad_comp = zp.src_pad_comp;
@@ -292,10 +291,11 @@ Xbyak::Zmm jit_pp_ker_t::get_masked_vreg_dst(int idx, bool apply_mask) const {
     return vreg_dst;
 }
 
-void jit_pp_ker_t::append_zp_src_comp(size_t offset, int idx, bool apply_mask) {
+void jit_pp_ker_t::append_zp_src_comp(dim_t offset, int idx, bool apply_mask) {
     const auto vreg_dst_masked = get_masked_vreg_dst(idx, apply_mask);
     const auto vreg_dst = get_vreg_dst(idx);
-    const auto zp_src_comp_offset = offset * sizeof(int32_t);
+    const dim_t zp_src_comp_offset
+            = offset * static_cast<dim_t>(sizeof(int32_t));
     const auto zp_src_comp_addr = ptr[reg_zp_src_comp_ + zp_src_comp_offset];
 
     vpaddd(vreg_dst_masked, vreg_dst, zp_src_comp_addr);
@@ -309,7 +309,7 @@ void jit_pp_ker_t::append_zp_src_comp(size_t offset, int idx, bool apply_mask) {
 }
 
 void jit_pp_ker_t::apply_postops(
-        const Xbyak::Reg64 &reg_dst, const int idx, const size_t offset) {
+        const Xbyak::Reg64 &reg_dst, const int idx, const dim_t offset) {
 #define PARAM_OFF(x) offsetof(ker_args_t, x)
     if (jcp_.with_eltwise || jcp_.with_binary) {
         if (jcp_.with_binary) {
@@ -317,8 +317,8 @@ void jit_pp_ker_t::apply_postops(
             const auto vmm_idx = vreg_dst_idx(idx);
 
             rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_dst);
-            rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(vmm_idx,
-                    offset * types::data_type_size(jcp_.dst_data_type));
+            rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
+                    vmm_idx, offset * dst_data_type_size_);
             rhs_arg_params.vmm_tail_idx_.emplace(vmm_idx);
 
             postops_injector_->compute_vector(
@@ -351,8 +351,10 @@ void jit_pp_ker_t::generate() {
     using namespace Xbyak;
     using namespace utils;
 
-    size_t vlen = cpu_isa_traits_t<avx512_core>::vlen / sizeof(float);
+    int vlen = static_cast<int>(
+            cpu_isa_traits_t<avx512_core>::vlen / sizeof(float));
     for (; vlen >= 1 && (jcp_.oc % vlen != 0); --vlen) {}
+    const dim_t dst_os_stride = jcp_.dst_os_stride;
 
     preamble();
 
@@ -406,15 +408,17 @@ void jit_pp_ker_t::generate() {
     // Load accumulated value, convert to float, apply sum (if any),
     // bias (if any), scaling, and relu (if any);
     // then convert to destination type and store
-    const auto compute = [&](size_t offset, int idx, bool apply_mask) {
-        auto acc_addr = ptr[reg_acc_ + offset * sizeof(acc_data_t)];
+    const auto compute = [&](dim_t offset, int idx, bool apply_mask) {
+        auto acc_addr = ptr[reg_acc_
+                + offset * static_cast<dim_t>(sizeof(acc_data_t))];
 
         const auto &mask_reg
                 = apply_mask ? kreg_rem_mask_short_ : kreg_rem_mask_vlen_;
 
         if (jcp_.scale_idx_mult > 0) {
             assert(jcp_.scale_idx_mult == 1);
-            const auto scale_addr = ptr[reg_scales_ + offset * sizeof(float)];
+            const auto scale_addr = ptr[reg_scales_
+                    + offset * static_cast<dim_t>(sizeof(float))];
             auto vreg_scale = vreg_scale_;
             vreg_scale = vreg_scale | mask_reg;
             vmovups(vreg_scale, scale_addr);
@@ -479,21 +483,22 @@ void jit_pp_ker_t::generate() {
 
     // Advance all pointers by an immediate
     const auto advance_ptrs_imm
-            = [&](const size_t offset, const size_t binary_offset) {
+            = [&](const dim_t offset, const dim_t binary_offset) {
         add(reg_dst_, offset * dst_data_type_size_);
-        add(reg_acc_, offset * sizeof(acc_data_t));
+        add(reg_acc_, offset * static_cast<dim_t>(sizeof(acc_data_t)));
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            add(reg_scales_, offset * sizeof(float));
+            add(reg_scales_, offset * static_cast<dim_t>(sizeof(float)));
         }
         if (jcp_.with_bias) add(reg_bias_, offset * bias_data_type_size_);
         if (jcp_.zp.src_exists) {
-            add(reg_zp_src_comp_, offset * sizeof(int32_t));
+            add(reg_zp_src_comp_, offset * static_cast<dim_t>(sizeof(int32_t)));
 
             if (zp_pad_comp_helper_) {
                 zp_pad_comp_helper_->zp_src_comp_pad_operation(
                         [&](const Xbyak::Reg64 &reg_zp_pad_comp) {
-                    add(reg_zp_pad_comp, offset * sizeof(int32_t));
+                    add(reg_zp_pad_comp,
+                            offset * static_cast<dim_t>(sizeof(int32_t)));
                 });
             }
         }
@@ -502,14 +507,17 @@ void jit_pp_ker_t::generate() {
     // Advance all pointers by a value stored in a register
     const auto advance_ptrs_reg
             = [&](const Reg64 offset, const Reg64 binary_offset) {
-        lea(reg_dst_, ptr[reg_dst_ + offset * dst_data_type_size_]);
+        lea(reg_dst_,
+                ptr[reg_dst_ + offset * static_cast<int>(dst_data_type_size_)]);
         lea(reg_acc_, ptr[reg_acc_ + offset * sizeof(acc_data_t)]);
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
             lea(reg_scales_, ptr[reg_scales_ + offset * sizeof(float)]);
         }
         if (jcp_.with_bias)
-            lea(reg_bias_, ptr[reg_bias_ + offset * bias_data_type_size_]);
+            lea(reg_bias_,
+                    ptr[reg_bias_
+                            + offset * static_cast<int>(bias_data_type_size_)]);
 
         if (jcp_.zp.src_exists) {
             lea(reg_zp_src_comp_,
@@ -529,16 +537,16 @@ void jit_pp_ker_t::generate() {
     const auto rewind_ptrs = [&]() {
         if (jcp_.with_bias) sub(reg_bias_, jcp_.oc * bias_data_type_size_);
         if (jcp_.zp.src_exists) {
-            const auto offset = jcp_.oc * sizeof(int32_t);
+            const dim_t offset = jcp_.oc * static_cast<dim_t>(sizeof(int32_t));
             sub(reg_zp_src_comp_, offset);
             if (zp_pad_comp_helper_)
                 zp_pad_comp_helper_->load_next_point_zp_src_comp_pad_addr();
         }
         if (jcp_.scale_idx_mult) {
             assert(jcp_.scale_idx_mult == 1);
-            sub(reg_scales_, jcp_.oc * sizeof(float));
+            sub(reg_scales_, jcp_.oc * static_cast<dim_t>(sizeof(float)));
         }
-        add(reg_dst_, (jcp_.dst_os_stride - jcp_.oc) * dst_data_type_size_);
+        add(reg_dst_, (dst_os_stride - jcp_.oc) * dst_data_type_size_);
     };
 
     //                    <--------- OC --------------->
@@ -602,8 +610,8 @@ void jit_pp_ker_t::generate() {
         Label main_loop;
         L(main_loop);
         {
-            size_t OC_loop, OC_tail;
-            if (static_cast<size_t>(jcp_.oc) < max_unroll_ * vlen) {
+            dim_t OC_loop, OC_tail;
+            if (jcp_.oc < max_unroll_ * vlen) {
                 // Fully unroll small loops
                 OC_loop = 0;
                 OC_tail = jcp_.oc;
@@ -614,9 +622,9 @@ void jit_pp_ker_t::generate() {
 
             assert(!!OC_loop || !!OC_tail);
 
-            const int vlen_tail = OC_tail % vlen;
+            const dim_t vlen_tail = OC_tail % vlen;
             if (vlen_tail) {
-                unsigned tail_mask = (1 << vlen_tail) - 1;
+                const uint32_t tail_mask = (uint32_t(1) << vlen_tail) - 1;
                 mov(reg_tmp_, tail_mask);
                 kmovq(kreg_rem_mask_short_, reg_tmp_);
             }
@@ -626,8 +634,8 @@ void jit_pp_ker_t::generate() {
                 Label oc_loop;
                 L(oc_loop);
                 {
-                    for (size_t offset = 0; offset < OC_loop; offset += vlen)
-                        compute(offset, offset / vlen, false);
+                    for (dim_t offset = 0; offset < OC_loop; offset += vlen)
+                        compute(offset, static_cast<int>(offset / vlen), false);
                     advance_ptrs_imm(OC_loop, vlen);
                     sub(reg_tmp_, OC_loop);
                     jnz(oc_loop);
@@ -635,12 +643,12 @@ void jit_pp_ker_t::generate() {
             }
 
             if (OC_tail) {
-                for (size_t offset = 0; offset < OC_tail; offset += vlen) {
+                for (dim_t offset = 0; offset < OC_tail; offset += vlen) {
                     bool use_mask = (offset + vlen) > OC_tail;
-                    compute(offset, offset / vlen, use_mask);
+                    compute(offset, static_cast<int>(offset / vlen), use_mask);
                 }
-                const size_t oc_tail_rem = OC_tail % vlen;
-                const size_t binary_offset = oc_tail_rem ? oc_tail_rem : vlen;
+                const dim_t oc_tail_rem = OC_tail % vlen;
+                const dim_t binary_offset = oc_tail_rem ? oc_tail_rem : vlen;
                 advance_ptrs_imm(OC_tail, binary_offset);
             }
 

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -89,14 +89,14 @@ struct jit_conv_conf_t {
 
     int simd_w;
     int ndims;
-    int mb;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
-    int id, ih, iw, od, oh, ow;
-    int f_pad, l_pad, t_pad;
-    int back_pad, r_pad, b_pad;
-    int kd, kh, kw;
-    int stride_d, stride_h, stride_w;
-    int dilate_d, dilate_h, dilate_w;
+    dim_t mb;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t f_pad, l_pad, t_pad;
+    dim_t back_pad, r_pad, b_pad;
+    dim_t kd, kh, kw;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t dilate_d, dilate_h, dilate_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool with_bias;
     bool with_sum;
@@ -109,7 +109,7 @@ struct jit_conv_conf_t {
     bool with_binary_no_bcast;
 
     bool is_fused_conv;
-    int dw_conv_buffer_oc;
+    dim_t dw_conv_buffer_oc;
 
     post_ops_t::entry_t::eltwise_t eltwise;
     post_ops_t post_ops;
@@ -117,36 +117,37 @@ struct jit_conv_conf_t {
 
     int nthr, nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b, nthr_oh;
 
-    int idp, ihp, iwp, ohp, owp, icp;
-    int nb_ic, ic_block;
-    int nb_oc, oc_block;
-    int nb_iw, iw_block;
-    int nb_ow, ow_block;
+    dim_t idp, ihp, iwp, ohp, owp, icp;
+    dim_t nb_ic, nb_oc;
+    dim_t ic_block, oc_block; // may span the whole ic/oc (e.g. 1st convolution)
+    dim_t nb_iw, iw_block;
+    dim_t nb_ow, ow_block;
     int nb_oc_blocking; /* used in jit kernels for nb_oc work blocking taking
                            into account vector registers distribution */
     int nb_oc_blocking_thr_chunk; /* used for distribution of nb_oc work
                                       within threads */
     int nb_ic_blocking, nb_ic_blocking_max; // blocking of nb_ic work
-    int nb_ic_L2;
-    int h_blocking;
-    int nb_oc_L2;
+    dim_t nb_ic_L2;
+    dim_t h_blocking;
+    dim_t nb_oc_L2;
     int ic_tail, oc_tail, ch_tail;
     int ur_h, ur_w;
-    int ur_w_tail, ur_w_blocks;
+    int ur_w_tail;
+    dim_t ur_w_blocks;
     int ur_ic, ur_kw;
     bool is_1stconv;
     int nonblk_group_off;
     /* fma avx512_core */
     conv_kernel_kind_t kernel_kind;
 
-    int tr_iw, tr_ih;
-    int tr_kw, tr_kh;
-    int tr_src_num_guard_elems;
+    dim_t tr_iw, tr_ih;
+    dim_t tr_kw, tr_kh;
+    dim_t tr_src_num_guard_elems;
 
     // Transpose buffer management
     size_t tr_src_buf_size, tr_src_buf_count;
     size_t tr_diff_dst_buf_size, tr_diff_dst_buf_count;
-    int nthr_mb_work;
+    dim_t nthr_mb_work;
 
     int typesize_in;
     int typesize_out;
@@ -172,18 +173,20 @@ struct jit_conv_conf_t {
     int is_ic_scale, is_oc_scale;
     int max_regs_ur; // maximum accumulation registers
     // dw conv
-    int nb_ch, ch_block, nb_ch_blocking;
+    dim_t nb_ch;
+    int ch_block;
+    int nb_ch_blocking;
     bool is_depthwise, is_fast_depthwise, is_resrc_depthwise;
     int aligned_threads;
     // large spatial
-    int ih_blk_size, oh_blk_size;
+    dim_t ih_blk_size, oh_blk_size;
     // s8s8 convolution
     bool signed_input;
     bool need_saturation;
     float wei_adj_scale;
     // zero-point compensation
     bool src_zero_point;
-    int zp_pbuff_size;
+    dim_t zp_pbuff_size;
     bool dst_zero_point;
     bool zp_src_is_common; // common, otherwise (TODO) per-channel
     bool req_zero_point_buffer; // used for calculating padding compensation
@@ -194,14 +197,15 @@ struct jit_conv_conf_t {
     bool with_dst_scales = false;
 
     // a separate parallel region
-    int ow_pad, oh_pad, od_pad; // output elements with padding & filter overlap
+    dim_t ow_pad, oh_pad,
+            od_pad; // output elements with padding & filter overlap
 
     //output elements requiring zero-point padding compensation
-    int f_pad_output, back_pad_output;
-    int t_pad_output, b_pad_output;
-    int l_pad_output, r_pad_output;
+    dim_t f_pad_output, back_pad_output;
+    dim_t t_pad_output, b_pad_output;
+    dim_t l_pad_output, r_pad_output;
     // The number of output blocks corresponding to {l_pad, no_pad, r_pad}
-    int l_pad_blk, no_pad_w_blk, r_pad_blk;
+    dim_t l_pad_blk, no_pad_w_blk, r_pad_blk;
 
     bool od_mid, oh_mid, ow_mid; // indicate if there is overlap between the
             //width and height padded regions
@@ -215,25 +219,25 @@ struct jit_conv_conf_t {
 
     cpu_isa_t isa;
     // bf16 bwdw conv
-    int tr_ow;
+    dim_t tr_ow;
     bool is_hw_transp; // spatial dim height-width transposed
-    int spatial_blk_size; // Height/depth block size inside the driver
+    dim_t spatial_blk_size; // Height/depth block size inside the driver
     bool global_transpose; // diff_dst & src tensors are transposed in one go
     bool use_nt_stores_ddst; // Use non temporal stores in diff_dst transform
 
     // Needed for Intel(R) Advanced Matrix Extensions (Intel(R) AMX) kernels
     bool is_nspc; // activations in nwc, nhwc, or ndhwc layout
     bool is_relo; // reduced lowering optimization
-    int nreduce; // used with is_relo
+    dim_t nreduce; // used with is_relo
     bool is_pbuffer_strided; // does pbuffer have strided sectors?
-    int n_stride_sets; // number of stride sectors (or sets) in pbuffer
-    int kw_step; // usually stride_w, unless !is_pbuffer_strided
-    int kw_per_tile; // mostly for 1st convs
+    dim_t n_stride_sets; // number of stride sectors (or sets) in pbuffer
+    dim_t kw_step; // usually stride_w, unless !is_pbuffer_strided
+    dim_t kw_per_tile; // mostly for 1st convs
     // The suffix _int refers to the block sizes of the src and diff_dst tiles,
     // as opposed to the vector registers. This distinction is needed due to
     // support for blocked layout (ie nChw16c) with bf16 data type.
-    int ic_block_int, ic_block_int_np, oc_block_int;
-    int nb_ic_int, nb_oc_int;
+    dim_t ic_block_int, ic_block_int_np, oc_block_int;
+    dim_t nb_ic_int, nb_oc_int;
     int nb_ih_blocking, nb_oh_blocking;
 
     int full_tile_width;
@@ -241,7 +245,7 @@ struct jit_conv_conf_t {
     int tile_width;
     int tile_tail;
     int oh_per_tile;
-    int iw_blocks, ow_blocks;
+    dim_t iw_blocks, ow_blocks;
 
     int per_one_pstore;
 
@@ -249,7 +253,7 @@ struct jit_conv_conf_t {
     size_t wei_buffer_size;
     size_t wsp_buffer_size;
 
-    int nb_os;
+    dim_t nb_os;
     int nb_os_blocking;
     int nb_os2_blocking;
     int os_tail;
@@ -260,12 +264,12 @@ struct jit_conv_conf_t {
 };
 
 // calculates filter size taking into account dilation
-inline int calculate_extended_filter_size(int filter_size, int dilation) {
+inline dim_t calculate_extended_filter_size(dim_t filter_size, dim_t dilation) {
     return (filter_size - 1) * (dilation + 1) + 1;
 }
 
-inline int calculate_end_padding(int start_padding, int dst_size, int src_size,
-        int spatial_stride, int dilated_filter_size) {
+inline dim_t calculate_end_padding(dim_t start_padding, dim_t dst_size,
+        dim_t src_size, dim_t spatial_stride, dim_t dilated_filter_size) {
     return (dst_size - 1) * spatial_stride + dilated_filter_size
             - (src_size + start_padding);
 }
@@ -456,12 +460,12 @@ struct jit_1x1_conv_conf_t {
     bool has_vnni;
 
     int ndims;
-    int mb;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
-    int id, ih, iw, od, oh, ow;
-    int f_pad, t_pad, l_pad;
-    int kd, kh, kw;
-    int stride_d, stride_h, stride_w;
+    dim_t mb;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t f_pad, t_pad, l_pad;
+    dim_t kd, kh, kw;
+    dim_t stride_d, stride_h, stride_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool with_bias;
     bool with_sum;
@@ -477,18 +481,21 @@ struct jit_1x1_conv_conf_t {
     int ur, ur_tail;
 
     dim_t reduce_dim;
-    int reduce_block, nb_reduce, nb_reduce_blocking, nb_reduce_blocking_max;
-    int load_dim, load_block, nb_load, nb_load_blocking, nb_load_blocking_max,
-            nb_load_chunk;
+    dim_t nb_reduce, nb_reduce_blocking, nb_reduce_blocking_max;
+    int reduce_block;
+    dim_t load_dim;
+    dim_t nb_load, nb_load_blocking, nb_load_blocking_max;
+    int load_block, nb_load_chunk;
     dim_t bcast_dim;
-    int bcast_block, nb_bcast, nb_bcast_blocking, nb_bcast_blocking_max;
+    dim_t nb_bcast, nb_bcast_blocking, nb_bcast_blocking_max;
+    int bcast_block;
 
     int reduce_loop_unroll;
     dim_t reduce_loop_bcast_step;
-    int reduce_loop_load_step;
-    int load_loop_load_step, load_loop_iter_step;
-    int bcast_loop_output_step, bcast_loop_output_substep;
-    int bcast_loop_bcast_step, bcast_loop_bcast_substep;
+    dim_t reduce_loop_load_step;
+    dim_t load_loop_load_step, load_loop_iter_step;
+    dim_t bcast_loop_output_step, bcast_loop_output_substep;
+    dim_t bcast_loop_bcast_step, bcast_loop_bcast_substep;
     int load_grp_count;
     conv_1x1_loop_order_t loop_order;
     bool use_vmovntps;
@@ -689,17 +696,19 @@ struct jit_uni_resampling_args_t {
 struct jit_brdgmm_conv_conf_t {
 
     int nthr;
-    int mb, ngroups, ic, oc;
-    int id, ih, iw, od, oh, ow;
-    int f_pad, back_pad, l_pad, r_pad, t_pad, b_pad;
-    int kd, kh, kw;
-    int stride_d, stride_h, stride_w;
-    int nb_ch, ch_block, chb_tail;
-    int nb_ch_blocking;
-    int ow_block, ow_tail, nb_ow;
+    dim_t mb, ngroups, ic, oc;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t f_pad, back_pad, l_pad, r_pad, t_pad, b_pad;
+    dim_t kd, kh, kw;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t nb_ch;
+    int ch_block;
+    dim_t chb_tail;
+    dim_t nb_ch_blocking;
+    dim_t nb_ow, ow_block, ow_tail;
     // idx of jit kernel when mutiple jit kernels are used in a primitive.
     int chb_tail_idx, ow_tail_idx, nb_ch_blocking_idx;
-    int adjusted_batch_size;
+    dim_t adjusted_batch_size;
 
     bool with_bias;
     bool with_post_ops;
@@ -751,12 +760,12 @@ struct jit_brgemm_conv_conf_t {
     conv_harness_t harness;
     int simd_w, acc_simd_w, amx_w, amx_h;
     int ndims;
-    int mb;
-    int ngroups, ic, oc, oc_without_padding, ic_without_padding;
+    dim_t mb;
+    dim_t ngroups, ic, oc, oc_without_padding, ic_without_padding;
 
-    int od_block, oh_block, nb_od,
+    dim_t od_block, oh_block, nb_od,
             nb_oh; // blocking  - included in parallelization
-    int id_block, ih_block, nb_id, nb_ih;
+    dim_t id_block, ih_block, nb_id, nb_ih;
     dim_t inp_buffer_size, inp_buffer_mask_size, out_buffer_size;
     conv_brgemm_exec_type_t exec_type;
 
@@ -770,15 +779,17 @@ struct jit_brgemm_conv_conf_t {
     }
     inline bool is_relo() const { return is_relo_whi() || is_relo_wi(); }
 
-    int id, ih, iw, od, oh, ow, os, is, idp, ihp, iwp, icp, odp, ohp, owp, ocp;
-    int f_pad, l_pad, t_pad;
-    int back_pad, r_pad, b_pad;
-    int l_ovf, r_ovf, t_ovf, b_ovf, f_ovf, back_ovf;
-    int kd, kh, kw;
-    int ext_kd, ext_kh, ext_kw;
-    int kd_block, kh_block, kw_block, kd_block_pad, kh_block_pad, kw_block_pad;
-    int stride_d, stride_h, stride_w;
-    int dilate_d, dilate_h, dilate_w;
+    dim_t id, ih, iw, od, oh, ow, os, is, idp, ihp, iwp, icp, odp, ohp, owp,
+            ocp;
+    dim_t f_pad, l_pad, t_pad;
+    dim_t back_pad, r_pad, b_pad;
+    dim_t l_ovf, r_ovf, t_ovf, b_ovf, f_ovf, back_ovf;
+    dim_t kd, kh, kw;
+    dim_t ext_kd, ext_kh, ext_kw;
+    dim_t kd_block, kh_block, kw_block, kd_block_pad, kh_block_pad,
+            kw_block_pad;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t dilate_d, dilate_h, dilate_w;
     format_tag_t src_tag, wei_tag, dst_tag; // temporary workaround
     bool with_bias;
     bool with_sum;
@@ -790,15 +801,15 @@ struct jit_brgemm_conv_conf_t {
     bool is_os_blocking;
     bool is_rtus;
     bool is_reduced_rtus;
-    size_t rtus_ic_size, rtus_padded_ic_size;
+    dim_t rtus_ic_size, rtus_padded_ic_size;
     bool ununroll_bd_loop {false};
-    int nb_ic, ic_block, inp_ic_block;
-    int nb_tr_ic, tr_ic_block, tr_ic_tail;
-    int nb_oc, oc_block;
-    int nb_iw, iw_block, iw_tail;
-    int nb_ow, ow_block, ow_tail;
-    int nb_is, is_block;
-    int nb_os, os_block;
+    dim_t nb_ic, ic_block, inp_ic_block;
+    dim_t nb_tr_ic, tr_ic_block, tr_ic_tail;
+    dim_t nb_oc, oc_block;
+    dim_t nb_iw, iw_block, iw_tail;
+    dim_t nb_ow, ow_block, ow_tail;
+    dim_t nb_is, is_block;
+    dim_t nb_os, os_block;
     int nb_oc_blocking;
     int nb_ic_blocking;
     int nb_is_blocking;
@@ -827,19 +838,19 @@ struct jit_brgemm_conv_conf_t {
     bool with_dst_scales;
     int is_ic_scale, is_oc_scale;
 
-    int LDA, LDB, LDC, LDD;
+    dim_t LDA, LDB, LDC, LDD;
 
-    int M, N, K, M_tail, N_tail, K_tail;
+    dim_t M, N, K, M_tail, N_tail, K_tail;
     // Note: M for brgemm kernel. For use_store_mask it is usually greater than
     // M (M_tail). Otherwise it is equal to M (M_tail).
-    int brgM, brgM_tail;
-    int gemm_batch_size, adjusted_batch_size;
+    dim_t brgM, brgM_tail;
+    dim_t gemm_batch_size, adjusted_batch_size;
     brgemm_batch_kind_t brg_type;
     // strides for brg_type == brgemm_strd
     dim_t brg_stride_a, brg_stride_b;
     int nthr;
 
-    int max_batch;
+    dim_t max_batch;
     int max_vpad;
     dim_t amx_buf_size_per_thread;
 
@@ -850,7 +861,7 @@ struct jit_brgemm_conv_conf_t {
     bool copy_block_only;
     bool amx_tile_load_xx;
     int use_M_mask;
-    int oskip, iskip;
+    dim_t oskip, iskip;
     bool brgemm_bd_loop_innermost;
 
     bool use_uker;
@@ -877,11 +888,11 @@ struct jit_brgemm_conv_conf_t {
     int ic_tail, oc_tail;
     size_t tr_src_block_size, tr_src_buf_size, tr_src_buf_count;
     size_t tr_diff_dst_block_size, tr_diff_dst_buf_size, tr_diff_dst_buf_count;
-    int tr_src_num_guard_elems;
+    dim_t tr_src_num_guard_elems;
     bool global_transpose; // diff_dst & src tensors are transposed in one go
     int nthr_mb_work;
-    int tr_iw, tr_ow;
-    int spatial_blk_size; // Height/depth block size inside the driver
+    dim_t tr_iw, tr_ow;
+    dim_t spatial_blk_size; // Height/depth block size inside the driver
     int typesize_in;
     int typesize_out;
     bool tr_ocb_chunk = false;

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -78,7 +78,7 @@ void jit_sse41_1x1_conv_kernel_f32_t::generate_bcast_loop(int load_loop_blk) {
     L(bcast_loop);
     {
         assert(jcp.bcast_block % jcp.ur == 0);
-        int num_substeps = jcp.bcast_block / jcp.ur;
+        const int num_substeps = static_cast<int>(jcp.bcast_block / jcp.ur);
         assert(num_substeps > 0 && num_substeps < 10);
         for (int i = 0; i < num_substeps; i++) {
             generate_reduce_loop(load_loop_blk, jcp.ur);
@@ -670,7 +670,8 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
             args_ok, VERBOSE_BLOCKING_FAIL, "bad blocking parameters");
 
     jcp.ur = 1;
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
 
     int load_blocking {0};
     int load_blocking_max {0};
@@ -705,12 +706,13 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         jcp.load_loop_iter_step = jcp.oc_block;
 
         load_blocking = is_data_layout_nxc
-                ? jcp.load_dim
+                ? static_cast<int>(jcp.load_dim)
                 : 120; // assumes the kernel is jcp.ur x 3
-        load_blocking_max = is_data_layout_nxc ? jcp.load_dim : 144;
+        load_blocking_max
+                = is_data_layout_nxc ? static_cast<int>(jcp.load_dim) : 144;
         bcast_blocking = 128; // affects load balancing across threads
         bcast_blocking_max = 192;
-        reduce_blocking = is_data_layout_nxc ? jcp.reduce_dim
+        reduce_blocking = is_data_layout_nxc ? static_cast<int>(jcp.reduce_dim)
                                              : 128; // affects L1$ utilization
     } else if (jcp.prop_kind == backward_data) {
         jcp.reduce_dim = jcp.oc;
@@ -768,7 +770,7 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
 
         /* --- */
 
-        load_blocking = div_up(jcp.load_dim, jcp.load_block);
+        load_blocking = static_cast<int>(div_up(jcp.load_dim, jcp.load_block));
         while (true) {
             if (load_blocking <= 32)
                 break;
@@ -783,7 +785,8 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
         load_blocking_max = load_blocking;
         assert(jcp.load_dim % load_blocking == 0);
 
-        bcast_blocking = div_up(jcp.bcast_dim, jcp.bcast_block);
+        bcast_blocking
+                = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
         while (true) {
             if (bcast_blocking <= 9)
                 break;

--- a/src/cpu/x64/jit_sse41_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_convolution.cpp
@@ -48,7 +48,8 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward(
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->dw_conv_pd_ != nullptr
             ? binary_injector::prepare_binary_args(
                       pd()->dw_conv_pd_->jcp_.post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const auto &scratchpad = ctx.get_scratchpad_grantor();
@@ -85,18 +86,19 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
 
     auto par_conv = jit_1x1_conv_args_t();
 
-    const int nb_oc = jcp.nb_load;
-    const int nb_ic = jcp.nb_reduce;
-    const int nb_ic_blocking = jcp.nb_reduce_blocking;
+    const dim_t nb_oc = jcp.nb_load;
+    const dim_t nb_ic = jcp.nb_reduce;
+    const dim_t nb_ic_blocking = jcp.nb_reduce_blocking;
 
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
     const bool is_dst_layout_nxc = utils::one_of(
@@ -107,25 +109,25 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     // Begin: declare Variables needed for dw conv.
     data_t *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<data_t *> addrs;
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int &n, int &g, int &bcast_step, int bcast_end,
-                      int &oh, int &ow, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t &n, dim_t &g, dim_t &bcast_step,
+                              dim_t bcast_end, dim_t &oh, dim_t &ow, dim_t &ih,
+                              dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
 
         bcast_step = step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         ow = os % jcp.ow;
         oh = os / jcp.ow;
 
@@ -135,19 +137,19 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         par_conv.bcast_dim = this_block_size(os, jcp.os, bcast_step * os_block);
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
         load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         par_conv.load_dim = this_block_size(
                 ocb * jcp.oc_block, jcp.oc, load_step * jcp.oc_block);
     };
 
-    auto inner_ker = [&](int ocb, int icb, int n, int g, int oh, int ow, int ih,
-                             int iw) {
-        const size_t _ocb = g * nb_oc + ocb;
-        const size_t _icb = g * nb_ic + icb;
+    auto inner_ker = [&](dim_t ocb, dim_t icb, dim_t n, dim_t g, dim_t oh,
+                             dim_t ow, dim_t ih, dim_t iw) {
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g * nb_ic + icb;
 
-        const int oc_off_idx = (is_dst_layout_nxc ? jcp.oc_block : 1) * _ocb;
-        const size_t dst_off = data_blk_off(dst_d, n, oc_off_idx, oh, ow);
+        const dim_t oc_off_idx = (is_dst_layout_nxc ? jcp.oc_block : 1) * _ocb;
+        const dim_t dst_off = data_blk_off(dst_d, n, oc_off_idx, oh, ow);
         par_conv.output_data = jcp.with_dw_conv
                 ? pbuf + (oh % pd()->dw_conv_pd_->jcp_.kh) * row_offset
                 : &dst[dst_off];
@@ -160,7 +162,7 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         par_conv.reduce_dim = this_block_size(
                 icb * jcp.ic_block, jcp.ic, nb_ic_blocking * jcp.ic_block);
 
-        const int ic_off_idx = (is_src_layout_nxc ? jcp.ic_block : 1) * _icb;
+        const dim_t ic_off_idx = (is_src_layout_nxc ? jcp.ic_block : 1) * _icb;
 
         const size_t src_off = data_blk_off(src_d, n, ic_off_idx, ih, iw);
         par_conv.bcast_data = &src[src_off];
@@ -176,19 +178,20 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         (*kernel_)(&par_conv);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
 
-        int iwork = bcast_start;
+        dim_t iwork = bcast_start;
         while (iwork < bcast_end) {
-            int n {0}, g {0}, bcast_step, oh, ow, ih, iw;
+            dim_t n {0}, g {0}, oh, ow, ih, iw;
+            dim_t bcast_step;
             init_bcast(iwork, n, g, bcast_step, bcast_end, oh, ow, ih, iw);
-            int ocb = 0;
+            dim_t ocb = 0;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                for (int icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
+                for (dim_t icb = 0; icb < nb_ic; icb += nb_ic_blocking) {
                     inner_ker(ocb, icb, n, g, oh, ow, ih, iw);
                 }
                 ocb += load_step;
@@ -197,9 +200,10 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
         auto &jcp_dw = pd()->dw_conv_pd_->jcp_;
-        int oh_1x1 = nstl::max(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
+        dim_t oh_1x1
+                = nstl::max<dim_t>(dw_oh * jcp_dw.stride_h - jcp_dw.t_pad, 0);
 
         for (int i = 0; i < jcp_dw.kh; ++i)
             addrs[i] = pbuf + ((oh_1x1++) % jcp_dw.kh) * row_offset;
@@ -207,31 +211,31 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         const auto ocb_end = ocb_start + load_step;
         const auto wch_stride = (is_src_layout_nxc ? 1 : jcp_dw.iw)
                 * jcp_dw.nb_ch_blocking * jcp_dw.ch_block;
-        const int dil_h = jcp_dw.dilate_h + 1;
-        const int str_h = jcp_dw.stride_h;
-        const int ch_num = jcp_dw.nb_ch_blocking;
+        const dim_t dil_h = jcp_dw.dilate_h + 1;
+        const dim_t str_h = jcp_dw.stride_h;
+        const dim_t ch_num = jcp_dw.nb_ch_blocking;
 
-        for (int ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
+        for (dim_t ch = ocb_start; ch < ocb_end; ch += jcp_dw.nb_ch_blocking) {
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp_dw.t_pad - dw_oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp_dw.ih,
-                              (int)(dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
-                                      - jcp_dw.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp_dw.t_pad - dw_oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp_dw.ih,
+                              dw_oh * str_h + (jcp_dw.kh - 1) * dil_h
+                                      - jcp_dw.t_pad + 1)
                     - jcp_dw.ih;
 
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp_dw.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            const int ow = 0;
-            const int kw = 0;
+            const dim_t ow = 0;
+            const dim_t kw = 0;
             jit_conv_args_t par_conv_dw;
 
             par_conv_dw.src = addrs.data();
 
-            const size_t ch_step = is_dst_layout_nxc
+            const dim_t ch_step = is_dst_layout_nxc
                     ? jcp_dw.ch_block
                     : dw_dst_d.blk_off(0, 1, 0, 0);
             par_conv_dw.dst
@@ -242,9 +246,10 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
                 par_conv_dw.bias
                         = &bias_dw[dw_bias_d.blk_off(ch * jcp_dw.ch_block)];
 
-            par_conv_dw.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv_dw.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
-            par_conv_dw.load_work = (nstl::min(ch + ch_num, jcp_dw.nb_ch) - ch)
+            par_conv_dw.load_work
+                    = (nstl::min<dim_t>(ch + ch_num, jcp_dw.nb_ch) - ch)
                     * jcp_dw.ch_block;
 
             par_conv_dw.post_ops_binary_rhs_arg_vec
@@ -272,32 +277,34 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
         row_offset = dw_conv_buffer_size_ / jcp_dw.kh;
         addrs.resize(jcp_dw.kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw.oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, 1);
+                bcast_end, nb_oc, ocb_start, ocb_end, dim_t(1));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n, g, oh_dw;
+                dim_t n, g, oh_dw;
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw.oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw.kh, jcp.oh);
-                oh_1x1 = nstl::max(
+                const dim_t oh_1x1_range
+                        = oh_dw * jcp_dw.stride_h - jcp_dw.t_pad;
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw.kh, jcp.oh);
+                oh_1x1 = nstl::max<dim_t>(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw.oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -313,8 +320,8 @@ void jit_sse41_1x1_convolution_fwd_t::execute_forward_thr(const int ithr,
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
-        int start {0}, end {0};
+        const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
         conv_1x1(start, end, 0, jcp.nb_load);
     }

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.cpp
@@ -66,17 +66,18 @@ jit_sse41_conv_fwd_kernel_f32_t::jit_sse41_conv_fwd_kernel_f32_t(
 
 void jit_sse41_conv_fwd_kernel_f32_t::oh_step_unroll_kw(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int dilate_w = jcp.dilate_w + 1;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const int ic_blk = static_cast<int>(jcp.ic_block);
 
     for (int ki = 0; ki < kw; ki++) {
-        int jj_start = div_up(nstl::max(0, pad_l - ki * dilate_w), stride_w);
-        int jj_end = ur_w
-                - div_up(nstl::max(0,
+        int jj_start = static_cast<int>(
+                div_up(nstl::max<dim_t>(0, pad_l - ki * dilate_w), stride_w));
+        int jj_end = static_cast<int>(ur_w
+                - div_up(nstl::max<dim_t>(0,
                                  ki * dilate_w + pad_r - (kw - 1) * dilate_w),
-                        stride_w);
+                        stride_w));
         for (int ifm2 = 0; ifm2 < ic_blk; ifm2++) {
             for (int jj = jj_start; jj < jj_end; jj++) {
                 size_t inp_off = get_input_offset(
@@ -104,8 +105,8 @@ void jit_sse41_conv_fwd_kernel_f32_t::oh_step_nopad(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
     Label kw_loop;
 
-    int kw = jcp.kw;
-    int ic_blk = jcp.ic_block;
+    const dim_t kw = jcp.kw;
+    const int ic_blk = static_cast<int>(jcp.ic_block);
 
     xor_(ki_iter, ki_iter);
     L(kw_loop);
@@ -183,8 +184,8 @@ void jit_sse41_conv_fwd_kernel_f32_t::apply_postops(
 
 void jit_sse41_conv_fwd_kernel_f32_t::width_blk_step(
         int ur_w, int pad_l, int pad_r, int oc_blocks) {
-    int kw = jcp.kw;
-    int oc_blk = jcp.oc_block;
+    const int kw = static_cast<int>(jcp.kw);
+    const int oc_blk = static_cast<int>(jcp.oc_block);
 
     xor_(simd_iter, simd_iter);
 
@@ -294,25 +295,27 @@ void jit_sse41_conv_fwd_kernel_f32_t::width_blk_step(
 }
 
 inline void jit_sse41_conv_fwd_kernel_f32_t::solve_common(int oc_blocks) {
-    int ur_w = jcp.ur_w;
-    int ur_w_tail = jcp.ur_w_tail;
-    int n_oi = jcp.ow / ur_w;
-    int iw = jcp.iw;
-    int kw = jcp.kw;
-    int str_w = jcp.stride_w;
+    const int ur_w = jcp.ur_w;
+    const int ur_w_tail = jcp.ur_w_tail;
+    int n_oi = static_cast<int>(jcp.ow / ur_w);
+    const dim_t iw = jcp.iw;
+    const dim_t kw = jcp.kw;
+    const dim_t str_w = jcp.stride_w;
 
-    int l_pad = jcp.l_pad;
-    int r_pad = nstl::max(0, jcp.r_pad);
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, str_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    const dim_t l_pad = jcp.l_pad;
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            str_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
     if (r_pad1 > 0) n_oi--;
 
     if (l_pad > 0) {
         n_oi--;
         if (n_oi < 0 && r_pad1 > 0)
-            width_blk_step(ur_w, l_pad, r_pad1, oc_blocks); // "lrpad"
+            width_blk_step(ur_w, static_cast<int>(l_pad), r_pad1,
+                    oc_blocks); // "lrpad"
         else
-            width_blk_step(ur_w, l_pad, 0, oc_blocks); // "lpad"
+            width_blk_step(ur_w, static_cast<int>(l_pad), 0,
+                    oc_blocks); // "lpad"
         add(reg_input, get_input_offset(0, filter_w_to_input(0, ur_w, l_pad)));
         add(reg_output, get_output_offset(0, ur_w));
     }
@@ -420,8 +423,8 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = (ndims == 3) ? 0 : cd.dilates[0];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -505,7 +508,7 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
 
     jcp.ur_h = 1; /* no code-unrolling by h so far */
     jcp.ur_w = 3;
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     jcp.nb_oc_blocking
@@ -518,24 +521,26 @@ status_t jit_sse41_conv_fwd_kernel_f32_t::init_conf(jit_conv_conf_t &jcp,
             && IMPLICATION(mimo, jcp.ic % simd_w == 0);
     VDISPATCH_CONV_IC(args_ok, VERBOSE_BLOCKING_FAIL, "bad parameters");
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
 
     // kernel needs 1 temporary YMM register
     const int num_avail_regs = 15;
     if (r_pad_no_tail > jcp.ur_w * jcp.stride_w && jcp.ow / jcp.ur_w > 1) {
         /* recalculate ur_w, nb_oc_blocking and ur_w_tail */
-        jcp.ur_w = nstl::min(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
-                nstl::min(jcp.ow, num_avail_regs / 2));
+        jcp.ur_w = static_cast<int>(
+                nstl::min<dim_t>(r_pad_no_tail / jcp.stride_w + jcp.ur_w_tail,
+                        nstl::min<dim_t>(jcp.ow, num_avail_regs / 2)));
         jcp.nb_oc_blocking = (num_avail_regs - jcp.ur_w) / jcp.ur_w;
         jcp.ur_w_tail = jcp.ow % jcp.ur_w;
         /* check again ... */
-        r_pad_no_tail = nstl::max(0,
+        r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                        jcp.stride_w, ext_kw));
+                        jcp.stride_w, ext_kw)));
 
-        VDISPATCH_CONV_IC(jcp.ur_w >= nstl::max(jcp.l_pad, r_pad_no_tail),
+        VDISPATCH_CONV_IC(
+                jcp.ur_w >= nstl::max<dim_t>(jcp.l_pad, r_pad_no_tail),
                 VERBOSE_UNSUPPORTED_PAD_FEATURE,
                 "width unroll exceeds padding size");
     }

--- a/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_sse41_conv_kernel_f32.hpp
@@ -73,51 +73,47 @@ private:
     inline void width_blk_step(int ur_w, int pad_l, int pad_r, int oc_blocks);
     inline void solve_common(int oc_blocks);
 
-    inline dim_t filter_w_to_input(int ki, int oi = 0, int pad_l = 0) const {
-        return static_cast<dim_t>(ki) * (jcp.dilate_w + 1)
-                + static_cast<dim_t>(oi) * jcp.stride_w - pad_l;
+    inline dim_t filter_w_to_input(
+            dim_t ki, dim_t oi = 0, dim_t pad_l = 0) const {
+        return ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l;
     }
 
-    inline dim_t filter_h_to_input(int ki) const {
-        return static_cast<dim_t>(ki) * (jcp.dilate_h + 1) * jcp.iw;
+    inline dim_t filter_h_to_input(dim_t ki) const {
+        return ki * (jcp.dilate_h + 1) * jcp.iw;
     }
 
-    inline dim_t get_input_offset(int i_ic, int i_iw) const {
+    inline dim_t get_input_offset(dim_t i_ic, dim_t i_iw) const {
         dim_t offset;
         if (utils::one_of(jcp.src_tag, format_tag::ncw, format_tag::nchw,
                     format_tag::ncdhw)) {
-            offset = static_cast<dim_t>(i_ic) * jcp.ih * jcp.iw + i_iw;
+            offset = i_ic * jcp.ih * jcp.iw + i_iw;
         } else if (utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc,
                            format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic * jcp.ngroups + i_ic;
+            offset = i_iw * jcp.ic * jcp.ngroups + i_ic;
         } else {
-            offset = static_cast<dim_t>(i_iw) * jcp.ic_block + i_ic;
+            offset = i_iw * jcp.ic_block + i_ic;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_output_offset(int i_oc_block, int i_ow) const {
+    inline dim_t get_output_offset(dim_t i_oc_block, dim_t i_ow) const {
         dim_t offset;
         if (utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc,
                     format_tag::ndhwc)) {
-            offset = static_cast<dim_t>(i_ow) * jcp.oc * jcp.ngroups
-                    + i_oc_block * jcp.oc_block;
+            offset = i_ow * jcp.oc * jcp.ngroups + i_oc_block * jcp.oc_block;
         } else {
-            offset = (static_cast<dim_t>(i_oc_block) * jcp.oh * jcp.ow + i_ow)
-                    * jcp.oc_block;
+            offset = (i_oc_block * jcp.oh * jcp.ow + i_ow) * jcp.oc_block;
         }
         return sizeof(float) * offset;
     }
 
-    inline dim_t get_kernel_offset(int i_oc_block, int ki, int i_ic) const {
-        dim_t block_step_size = static_cast<dim_t>(jcp.ic_block) * jcp.oc_block;
-        dim_t ic_block_step_size
-                = static_cast<dim_t>(jcp.kh) * jcp.kw * block_step_size;
-        dim_t oc_block_step_size
-                = static_cast<dim_t>(jcp.nb_ic) * ic_block_step_size;
-        dim_t offset = static_cast<dim_t>(i_oc_block) * oc_block_step_size
-                + static_cast<dim_t>(ki) * block_step_size
-                + static_cast<dim_t>(i_ic) * jcp.oc_block;
+    inline dim_t get_kernel_offset(
+            dim_t i_oc_block, dim_t ki, dim_t i_ic) const {
+        dim_t block_step_size = jcp.ic_block * jcp.oc_block;
+        dim_t ic_block_step_size = jcp.kh * jcp.kw * block_step_size;
+        dim_t oc_block_step_size = jcp.nb_ic * ic_block_step_size;
+        dim_t offset = i_oc_block * oc_block_step_size + ki * block_step_size
+                + i_ic * jcp.oc_block;
         return sizeof(float) * offset;
     }
 

--- a/src/cpu/x64/jit_sse41_convolution.cpp
+++ b/src/cpu/x64/jit_sse41_convolution.cpp
@@ -52,7 +52,7 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper weights_d(pd()->weights_md(0));
     const memory_desc_wrapper bias_d(pd()->weights_md(1));
 
-    int ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
+    const dim_t ocb_work = div_up(jcp.nb_oc, jcp.nb_oc_blocking);
     const size_t work_amount = jcp.mb * jcp.ngroups * ocb_work * jcp.oh;
 
     const bool is_src_layout_nxc
@@ -66,26 +66,27 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
         size_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int icbb = 0;
+        dim_t icbb = 0;
         while (icbb < jcp.nb_ic) {
-            int icb_step = jcp.nb_ic_blocking;
-            int icb_step_rem = jcp.nb_ic - icbb;
+            dim_t icb_step = jcp.nb_ic_blocking;
+            const dim_t icb_step_rem = jcp.nb_ic - icbb;
             if (icb_step_rem < jcp.nb_ic_blocking_max) icb_step = icb_step_rem;
 
             size_t n {0}, g {0}, ocbb {0}, oh {0};
             nd_iterator_init(start, n, jcp.mb, g, jcp.ngroups, ocbb, ocb_work,
                     oh, jcp.oh);
             for (size_t iwork = start; iwork < end; ++iwork) {
-                int ocb = ocbb * jcp.nb_oc_blocking;
-                int ocb_num = jcp.nb_oc_blocking;
+                const dim_t ocb = ocbb * jcp.nb_oc_blocking;
+                const dim_t ocb_num = jcp.nb_oc_blocking;
 
-                for (int icb = icbb; icb < icbb + icb_step; ++icb) {
+                for (dim_t icb = icbb; icb < icbb + icb_step; ++icb) {
                     auto par_conv = jit_conv_args_t();
 
-                    const int ij = oh * jcp.stride_h;
-                    const int i_t_overflow = nstl::max(0, jcp.t_pad - ij);
-                    const int i_b_overflow
-                            = nstl::max(jcp.ih,
+                    const dim_t ij = oh * jcp.stride_h;
+                    const dim_t i_t_overflow
+                            = nstl::max<dim_t>(0, jcp.t_pad - ij);
+                    const dim_t i_b_overflow
+                            = nstl::max<dim_t>(jcp.ih,
                                       ij + (jcp.kh - 1) * (jcp.dilate_h + 1)
                                               - jcp.t_pad + 1)
                             - jcp.ih;
@@ -97,7 +98,7 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                             = g * (is_src_layout_nxc ? jcp.ic : jcp.nb_ic)
                             + icb * (is_src_layout_nxc ? jcp.ic_block : 1);
 
-                    const int ih = nstl::max(ij - jcp.t_pad
+                    const dim_t ih = nstl::max<dim_t>(ij - jcp.t_pad
                                     + div_up(i_t_overflow, (jcp.dilate_h + 1))
                                             * (jcp.dilate_h + 1),
                             0);
@@ -105,7 +106,7 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
                     par_conv.dst = &dst[src_blk_off(dst_d, n, _oc, oh, 0)];
 
-                    const int wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
+                    const dim_t wh = div_up(i_t_overflow, (jcp.dilate_h + 1));
                     par_conv.filt = &weights[wht_blk_off(
                             weights_d, g, ocb, icb, wh, 0)];
 
@@ -122,13 +123,13 @@ void jit_sse41_convolution_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                     }
 
                     par_conv.oc_blocks
-                            = nstl::min(ocb + ocb_num, jcp.nb_oc) - ocb;
+                            = nstl::min<dim_t>(ocb + ocb_num, jcp.nb_oc) - ocb;
 
                     par_conv.kw_padding = 0;
-                    const int kh_padding = jcp.kh
+                    const dim_t kh_padding = jcp.kh
                             - div_up(i_t_overflow, (jcp.dilate_h + 1))
                             - div_up(i_b_overflow, (jcp.dilate_h + 1));
-                    par_conv.kh_padding = nstl::max(0, kh_padding);
+                    par_conv.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
                     par_conv.post_ops_binary_rhs_arg_vec
                             = post_ops_binary_rhs_arg_vec.data();

--- a/src/cpu/x64/jit_transpose_utils.cpp
+++ b/src/cpu/x64/jit_transpose_utils.cpp
@@ -54,10 +54,10 @@ struct jit_trans_iw_ic_t : public jit_trans_src_t, public jit_generator_t {
     }
 
 private:
-    int typesize = 0;
+    dim_t typesize = 0;
     bool is_layout_nxc = false;
     static constexpr int transpose_size = 16;
-    size_t src_stride = 0, tr_src_stride = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
 
     Opmask kLoadMask1 = k1;
     Opmask kLoadMask2 = k2;
@@ -111,14 +111,17 @@ private:
         jit_generator_t::vmovdqa32(z, ptr[imm_addr64]);
     }
 
-    void transpose(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
-    void transpose_2b(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
-    void transpose_1b(int nrows, int l_pad, int r_pad, bool nontemporal_stores);
+    void transpose(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
+    void transpose_2b(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
+    void transpose_1b(
+            dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores);
     void generate() override;
 };
 
 void jit_trans_iw_ic_t::transpose(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 16, "Unsupported transpose size");
     if (!nrows) return;
@@ -132,7 +135,7 @@ void jit_trans_iw_ic_t::transpose(
 }
 
 void jit_trans_iw_ic_t::transpose_2b(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
     auto load_ymm = [this](int i) {
         vmovups(src_ymm(i), EVEX_compress_addr(reg_src, i * src_stride));
     };
@@ -141,28 +144,28 @@ void jit_trans_iw_ic_t::transpose_2b(
         mov(regw_tmp, w);
         jit_generator_t::kmovd(k, regw_tmp);
     };
-    int l_pad_tail {0}, l_pad_rows {0};
-    int r_pad_tail {0}, r_pad_rows {0};
+    dim_t l_pad_tail {0}, l_pad_rows {0};
+    dim_t r_pad_tail {0}, r_pad_rows {0};
 
     if (l_pad > 0) {
-        int store_pad = 2 * transpose_size;
+        dim_t store_pad = 2 * transpose_size;
         l_pad_rows = l_pad / store_pad;
         l_pad_tail = div_up(l_pad % store_pad, 2);
         kmovw(kLPad, (1 << l_pad_tail) - 1);
     }
     if (r_pad > 0) {
-        int store_pad = div_up(r_pad, 2);
+        dim_t store_pad = div_up(r_pad, 2);
         r_pad_rows = store_pad / transpose_size;
         r_pad_tail = store_pad % transpose_size;
         kmovw(kRPad, (1 << r_pad_tail) - 1);
     }
 
-    auto padding = [this](Reg64 base, int addr_shift, int pad_rows,
-                           int pad_tail, const Opmask &mask, int i) {
+    auto padding = [this](Reg64 base, dim_t addr_shift, dim_t pad_rows,
+                           dim_t pad_tail, const Opmask &mask, dim_t i) {
         // note: pad can be bigger than 16 because of dilation
-        const size_t row_offset = 2 * transpose_size * typesize;
+        const dim_t row_offset = 2 * transpose_size * typesize;
         const auto pshift = addr_shift * typesize + i * tr_src_stride;
-        for (int i_row = 0; i_row < pad_rows; i_row++) {
+        for (dim_t i_row = 0; i_row < pad_rows; i_row++) {
             auto addr = EVEX_compress_addr(base, pshift + i_row * row_offset);
             vmovups(addr, zmm_zero);
         }
@@ -174,14 +177,14 @@ void jit_trans_iw_ic_t::transpose_2b(
         }
     };
 
-    auto store = [&](Zmm r, int i) {
+    auto store = [&](Zmm r, dim_t i) {
         mov(reg_tr_src_tmp, reg_tr_src);
         if (l_pad > 0) {
             padding(reg_tr_src_tmp, 0, l_pad_rows, l_pad_tail, kLPad, i);
             add(reg_tr_src_tmp, l_pad * typesize);
         }
         if (r_pad > 0) {
-            int addr_shift = nrows - r_pad % 2;
+            dim_t addr_shift = nrows - r_pad % 2;
             padding(reg_tr_src_tmp, addr_shift, r_pad_rows, r_pad_tail, kRPad,
                     i);
         }
@@ -194,12 +197,12 @@ void jit_trans_iw_ic_t::transpose_2b(
     };
 
     if (l_pad > 0 || r_pad > 0) vpxord(zmm_zero, zmm_zero, zmm_zero);
-    int store_tail = rnd_up(nrows, 2);
+    dim_t store_tail = rnd_up(nrows, 2);
     kmovw(kTail, (1 << store_tail / 2) - 1);
 
-    const int ic_block = conf_->ic_block;
+    const dim_t ic_block = conf_->ic_block;
     const bool is_short_block = ic_block != 16;
-    const int ic_tail = conf_->ic_tail;
+    const dim_t ic_tail = conf_->ic_tail;
     // Assertion below as we need vmovdqu16 for ic_tails.
     // If needed, can be extended by using load_bytes() helper.
     assert(IMPLICATION(ic_tail, mayiuse(avx512_core)));
@@ -245,14 +248,14 @@ void jit_trans_iw_ic_t::transpose_2b(
 
         // for odd numbers we need to mix row with zeroes
         if (nrows % 2) {
-            int i = nrows - 1;
+            int i = static_cast<int>(nrows - 1);
             auto zmm_src0 = src_zmm(i);
             vmovdqu16(zmm_src0 | kLoadMask1 | T_z,
                     EVEX_compress_addr(reg_src, i * src_stride));
             vpermw(zmm_src0, vidx5, zmm_src0);
         }
 
-        for (int i = rnd_up(nrows, 2); i < 16; i += 2) {
+        for (int i = static_cast<int>(rnd_up(nrows, 2)); i < 16; i += 2) {
             vpxord(src_zmm(i), src_zmm(i), src_zmm(i));
         }
     } else {
@@ -277,7 +280,7 @@ void jit_trans_iw_ic_t::transpose_2b(
 
         // for odd numbers we need to mix row with zeroes
         if (nrows % 2) {
-            int i = nrows - 1;
+            int i = static_cast<int>(nrows - 1);
             auto src0 = src_ymm(i);
             auto src1 = src_ymm(i + 1); // zero
 
@@ -396,7 +399,7 @@ void jit_trans_iw_ic_t::transpose_2b(
 }
 
 void jit_trans_iw_ic_t::transpose_1b(
-        int nrows, int l_pad, int r_pad, bool nontemporal_stores) {
+        dim_t nrows, dim_t l_pad, dim_t r_pad, bool nontemporal_stores) {
 
     auto load = [this, nrows](int i) {
         auto zmm_src = src_zmm(i);
@@ -407,7 +410,7 @@ void jit_trans_iw_ic_t::transpose_1b(
             vpxord(zmm_src, zmm_src, zmm_src);
     };
 
-    int l_pad_tail {0}, r_pad_tail {0}, l_pad_rows {0}, r_pad_rows {0};
+    dim_t l_pad_tail {0}, r_pad_tail {0}, l_pad_rows {0}, r_pad_rows {0};
 
     if (l_pad > 0) {
         l_pad_rows = l_pad / transpose_size;
@@ -420,13 +423,13 @@ void jit_trans_iw_ic_t::transpose_1b(
         kmovw(kRPad, (1 << r_pad_tail) - 1);
     }
 
-    auto padding = [this](Reg64 base, int addr_shift, int pad_rows,
-                           int pad_tail, const Opmask &mask, int i) {
+    auto padding = [this](Reg64 base, dim_t addr_shift, dim_t pad_rows,
+                           dim_t pad_tail, const Opmask &mask, dim_t i) {
         // note: pad can be bigger than 16 because of dilation
-        const size_t row_off = transpose_size;
+        const dim_t row_off = transpose_size;
         auto xmm_zero = Xmm(zmm_zero.getIdx());
         const auto pshift = addr_shift * typesize + i * tr_src_stride;
-        for (int i_row = 0; i_row < pad_rows; i_row++) {
+        for (dim_t i_row = 0; i_row < pad_rows; i_row++) {
             auto addr = EVEX_compress_addr(base, pshift + i_row * row_off);
             vmovups(addr, xmm_zero);
         }
@@ -437,7 +440,7 @@ void jit_trans_iw_ic_t::transpose_1b(
         }
     };
 
-    auto store = [&](Zmm r, int i) {
+    auto store = [&](Zmm r, dim_t i) {
         mov(reg_tr_src_tmp, reg_tr_src);
         if (l_pad > 0) {
             padding(reg_tr_src_tmp, 0, l_pad_rows, l_pad_tail, kLPad, i);
@@ -455,7 +458,7 @@ void jit_trans_iw_ic_t::transpose_1b(
     };
 
     if (l_pad > 0 || r_pad > 0) vpxord(zmm_zero, zmm_zero, zmm_zero);
-    int store_tail = rnd_up(nrows, 4);
+    dim_t store_tail = rnd_up(nrows, 4);
     kmovw(kTail, (1 << store_tail) - 1);
 
     // load rows and swap bytes
@@ -479,7 +482,8 @@ void jit_trans_iw_ic_t::transpose_1b(
         vpermb(zmm_src0, vidx1, zmm_src0);
     }
     // zero rest zmm_src
-    for (int i = rnd_up(nrows, 4); i < transpose_size; i += 4) {
+    for (int i = static_cast<int>(rnd_up(nrows, 4)); i < transpose_size;
+            i += 4) {
         auto zmm_src0 = src_zmm(i);
         vpxord(zmm_src0, zmm_src0, zmm_src0);
     }
@@ -537,7 +541,7 @@ void jit_trans_iw_ic_t::transpose_1b(
         return mod * 4 + div;
     };
 
-    const int ic_block = conf_->ic_block;
+    const dim_t ic_block = conf_->ic_block;
     for (int col_idx = 0; col_idx < ic_block; col_idx++) {
         store(src_zmm(get_vec_idx(col_idx)), col_idx);
     }
@@ -547,7 +551,7 @@ void jit_trans_iw_ic_t::generate() {
     preamble();
 
     if (mayiuse(avx512_core)) {
-        const int ic_block = conf_->ic_block;
+        const dim_t ic_block = conf_->ic_block;
         const int ic_tail = conf_->ic_tail;
         if (conf_->stride_w > 1 || is_layout_nxc) {
             kmovd(kLoadMask1, (1 << ic_block) - 1);
@@ -607,39 +611,41 @@ void jit_trans_iw_ic_t::generate() {
     } else
         assert(!"unsupported data type");
 
-    const int ic_block = conf_->ic_block;
-    const size_t src_mult
+    const dim_t ic_block = conf_->ic_block;
+    const dim_t src_mult
             = is_layout_nxc ? conf_->ngroups * conf_->ic : ic_block;
-    const int iw = conf_->iw;
-    const int tr_iw = conf_->tr_iw;
-    const int str_w = conf_->stride_w;
+    const dim_t iw = conf_->iw;
+    const dim_t tr_iw = conf_->tr_iw;
+    const dim_t str_w = conf_->stride_w;
     assert(tr_iw % str_w == 0);
-    const int tr_iw_s = tr_iw / str_w;
+    const dim_t tr_iw_s = tr_iw / str_w;
     assert(transpose_size >= ic_block);
 
     // Data for every strided case is placed consecutively
     // For 1x1 convolutions with strides we transpose only needed elements
     const auto str_w_end = (conf_->kw == 1) ? 1 : str_w;
-    for (int s = 0; s < str_w_end; s++) {
-        const int left_pad = div_up(nstl::max(0, conf_->l_pad - s), str_w);
-        const int iw1 = iw + conf_->l_pad;
-        const int iw_s = (s < (iw1 % str_w) ? div_up(nstl::max(0, iw1), str_w)
-                                            : iw1 / str_w)
+    for (dim_t s = 0; s < str_w_end; s++) {
+        const dim_t left_pad
+                = div_up(nstl::max<dim_t>(0, conf_->l_pad - s), str_w);
+        const dim_t iw1 = iw + conf_->l_pad;
+        const dim_t iw_s
+                = (s < (iw1 % str_w) ? div_up(nstl::max<dim_t>(0, iw1), str_w)
+                                     : iw1 / str_w)
                 - left_pad;
-        const int right_pad = tr_iw_s - iw_s - left_pad;
+        const dim_t right_pad = tr_iw_s - iw_s - left_pad;
 
-        const int transposes
-                = utils::div_up(nstl::max(0, iw_s), transpose_size);
-        int loop_iters = nstl::max(0, transposes - 1);
-        int tail = iw_s - loop_iters * transpose_size;
+        const dim_t transposes
+                = utils::div_up(nstl::max<dim_t>(0, iw_s), transpose_size);
+        dim_t loop_iters = nstl::max<dim_t>(0, transposes - 1);
+        dim_t tail = iw_s - loop_iters * transpose_size;
 
         src_stride = src_mult * typesize * str_w;
         tr_src_stride = tr_iw * typesize;
 
         bool nontemporal_stores = false;
 
-        const size_t src_step = src_mult * transpose_size * str_w * typesize;
-        const size_t tr_src_step = transpose_size * typesize;
+        const dim_t src_step = src_mult * transpose_size * str_w * typesize;
+        const dim_t tr_src_step = transpose_size * typesize;
 
         mov(reg_src, ptr[param1 + GET_OFF(src)]);
         mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
@@ -647,8 +653,8 @@ void jit_trans_iw_ic_t::generate() {
         mov(reg_tr_src_prf, ptr[param1 + GET_OFF(tr_src_prf)]);
 
         if (str_w > 1) {
-            int tr_src_shift = s;
-            int src_shift = (str_w - (conf_->l_pad % str_w) + s) % str_w;
+            dim_t tr_src_shift = s;
+            dim_t src_shift = (str_w - (conf_->l_pad % str_w) + s) % str_w;
             add(reg_src, src_shift * src_mult * typesize);
             add(reg_tr_src, tr_src_shift * tr_iw_s * typesize);
             add(reg_src_prf, src_shift * src_mult * typesize);
@@ -709,12 +715,12 @@ struct jit_trans_ow_oc_t : public jit_trans_dst_t, public jit_generator_t {
     }
 
 private:
-    int typesize = 0;
+    dim_t typesize = 0;
     bool is_layout_nxc = false;
-    int vnni_block = 0;
+    dim_t vnni_block = 0;
     static constexpr int transpose_size = 16;
-    size_t src_stride = 0, tr_src_stride = 0;
-    int tail = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
+    dim_t tail = 0;
 
     Opmask kFF = k1;
     Opmask mask_lo = k2;
@@ -755,18 +761,19 @@ private:
         return Xmm(i);
     }
 
-    void transpose(int nrows, bool nontemporal_stores, bool do_convert = true);
+    void transpose(
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void transpose_2b(
-            int nrows, bool nontemporal_stores, bool do_convert = true);
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void transpose_1b(
-            int nrows, bool nontemporal_stores, bool do_convert = true);
+            dim_t nrows, bool nontemporal_stores, bool do_convert = true);
     void generate() override;
 };
 
 // do_convert (default is 'true') is a flag that determines when to do the
 // transformation of the input data and when to simply zero out the output data
 void jit_trans_ow_oc_t::transpose(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 16, "Unsupported transpose size");
     if (!nrows) return;
@@ -779,7 +786,7 @@ void jit_trans_ow_oc_t::transpose(
 }
 
 void jit_trans_ow_oc_t::transpose_2b(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
 
     auto load_ymm = [this](int i) {
         auto ymm_reg = src_ymm(i);
@@ -827,7 +834,7 @@ void jit_trans_ow_oc_t::transpose_2b(
             } else {
                 vpxord(zmm_src0, zmm_src0, zmm_src0);
             }
-            store(zmm_src0, nrows - 1);
+            store(zmm_src0, static_cast<int>(nrows - 1));
         }
     } else {
         for (int i = 0; i < rnd_dn(nrows, 2); i += 2) {
@@ -856,11 +863,11 @@ void jit_trans_ow_oc_t::transpose_2b(
             store(zmm_src0, i);
         }
         if (row_pad > 0) {
-            auto src0 = src_ymm(nrows - 1);
-            auto src1 = src_ymm(nrows);
+            auto src0 = src_ymm(static_cast<int>(nrows - 1));
+            auto src1 = src_ymm(static_cast<int>(nrows));
             auto zmm_src0 = src_zmm(30);
             if (do_convert) {
-                load_ymm(nrows - 1);
+                load_ymm(static_cast<int>(nrows - 1));
 
                 vpxor(src1, src1, src1);
                 vpunpckhwd(src1, src0, src1);
@@ -872,13 +879,13 @@ void jit_trans_ow_oc_t::transpose_2b(
             } else {
                 vpxord(zmm_src0, zmm_src0, zmm_src0);
             }
-            store(zmm_src0, nrows - 1);
+            store(zmm_src0, static_cast<int>(nrows - 1));
         }
     }
 }
 
 void jit_trans_ow_oc_t::transpose_1b(
-        int nrows, bool nontemporal_stores, bool do_convert) {
+        dim_t nrows, bool nontemporal_stores, bool do_convert) {
     auto load_xmm = [this](int i) {
         auto xmm_reg = src_xmm(i);
         auto addr = EVEX_compress_addr(reg_src, i * src_stride);
@@ -997,12 +1004,12 @@ void jit_trans_ow_oc_t::generate() {
         vmovdqa64(vidx4 /*vreg_idx_hi_128*/, (const int64_t *)idx_hi_8);
     }
 
-    const int oc_block = conf_->oc_block;
-    const size_t src_mult
+    const dim_t oc_block = conf_->oc_block;
+    const dim_t src_mult
             = is_layout_nxc ? conf_->ngroups * conf_->oc : oc_block;
-    const int ow = conf_->ow;
-    const int transposes = utils::div_up(ow, transpose_size);
-    int loop_iters = nstl::max(0, transposes - 1);
+    const dim_t ow = conf_->ow;
+    const dim_t transposes = utils::div_up(ow, transpose_size);
+    dim_t loop_iters = nstl::max<dim_t>(0, transposes - 1);
     tail = ow - loop_iters * transpose_size;
 
     src_stride = src_mult * typesize;
@@ -1010,10 +1017,11 @@ void jit_trans_ow_oc_t::generate() {
 
     bool nontemporal_stores = conf_->use_nt_stores_ddst;
 
-    const size_t src_step = src_mult * transpose_size * typesize;
-    const size_t tr_src_step = (size_t)oc_block * transpose_size * typesize;
+    const dim_t src_step = src_mult * transpose_size * typesize;
+    const dim_t tr_src_step = oc_block * transpose_size * typesize;
 
-    const auto zero_tr_ow = nstl::max(0, conf_->tr_ow - rnd_up(ow, vnni_block));
+    const dim_t zero_tr_ow
+            = nstl::max<dim_t>(0, conf_->tr_ow - rnd_up(ow, vnni_block));
 
     mov(reg_src, ptr[param1 + GET_OFF(src)]);
     mov(reg_tr_src, ptr[param1 + GET_OFF(tr_src)]);
@@ -1047,11 +1055,11 @@ void jit_trans_ow_oc_t::generate() {
     transpose(tail, nontemporal_stores);
     if (zero_tr_ow) {
         const auto zero_transposes = utils::div_up(zero_tr_ow, transpose_size);
-        const auto zero_loop_iters = nstl::max(0, zero_transposes - 1);
+        const auto zero_loop_iters = nstl::max<dim_t>(0, zero_transposes - 1);
         const auto zero_tail = zero_tr_ow - zero_loop_iters * transpose_size;
 
         // shift over tail
-        add(reg_tr_src, (size_t)oc_block * rnd_up(tail, vnni_block) * typesize);
+        add(reg_tr_src, oc_block * rnd_up(tail, vnni_block) * typesize);
 
         // zero the tr_ow - ow
         if (zero_loop_iters) {
@@ -1077,7 +1085,7 @@ void jit_trans_ow_oc_t::generate() {
 // -------------------------------------------------
 */
 
-void jit_transpose4x16_src_t::transpose(int nrows) {
+void jit_transpose4x16_src_t::transpose(dim_t nrows) {
     assert(nrows >= 0 && nrows <= transpose_size);
     static_assert(transpose_size == 4, "Unsupported transpose size");
     if (!nrows) return;
@@ -1135,8 +1143,9 @@ void jit_transpose4x16_src_t::transpose(int nrows) {
         load(i);
     }
 
-    for (size_t i = nrows; i < 4; i++) {
-        vpxord(src_zmm(i), src_zmm(i), src_zmm(i));
+    for (dim_t i = nrows; i < 4; i++) {
+        const int reg_idx = static_cast<int>(i);
+        vpxord(src_zmm(reg_idx), src_zmm(reg_idx), src_zmm(reg_idx));
     }
 
     vmovupd(tmp0, src0);
@@ -1200,16 +1209,16 @@ alignas(64) static constexpr const int32_t idxP[16]
 void jit_transpose4x16_src_t::generate() {
     preamble();
 
-    const int ic_block = params->ic_block;
-    const int is = params->is;
-    int tail = is % transpose_size;
+    const dim_t ic_block = params->ic_block;
+    const dim_t is = params->is;
+    dim_t tail = is % transpose_size;
 
     src_stride = ic_block * typesize;
     assert(src_stride == 64);
     tr_src_stride = ic_block * typesize;
 
-    const int src_step = ic_block * transpose_size * typesize;
-    const int tr_src_step = ic_block * transpose_size * typesize;
+    const dim_t src_step = ic_block * transpose_size * typesize;
+    const dim_t tr_src_step = ic_block * transpose_size * typesize;
 
 #define GET_TR_OFF(x) offsetof(jit_transpose_src_args_t, x)
     mov(reg_loop, ptr[param1 + GET_TR_OFF(size)]);
@@ -1275,9 +1284,9 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
     /* Reorder part of F32 weights tensor
        from [VNNI_GRANULARITY][I][kd][kh][kw][16i][16o] to VNNI format [kd][kh][kw][16i][16o][VNNI_GRANULARITY][i]
        and down-convert it to required float. */
-    const int ts_out = types::data_type_size(out_dt_);
-    const int ts_inp = 4;
-    const int simd_w = 16;
+    const dim_t ts_out = types::data_type_size(out_dt_);
+    const dim_t ts_inp = 4;
+    const dim_t simd_w = 16;
 
     const Reg64 &reg_output = r15;
     const Reg64 &reg_output_kd = r14;
@@ -1316,7 +1325,7 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
     auto get_zmm_src = [&](int idx, int ic) { return Zmm(4 * idx + ic); };
     auto get_zmm_bf16 = [&](int ic) { return Zmm(16 + ic); };
 
-    const int vnni_granularity = data_type_vnni_granularity(out_dt_);
+    const dim_t vnni_granularity = data_type_vnni_granularity(out_dt_);
 
     Xbyak::Label prm_table, zero_buffer;
     Xbyak::Label kd_loop_label, kh_loop_label;
@@ -1477,10 +1486,10 @@ void jit_diff_wei_trans_to_vnni_t::generate() {
         L(prm_table);
         uint8_t prm_array[64];
         for (size_t i = 0; i < 16; i++) {
-            prm_array[4 * i] = i;
-            prm_array[4 * i + 1] = i + 16;
-            prm_array[4 * i + 2] = i + 32;
-            prm_array[4 * i + 3] = i + 48;
+            prm_array[4 * i] = static_cast<uint8_t>(i);
+            prm_array[4 * i + 1] = static_cast<uint8_t>(i + 16);
+            prm_array[4 * i + 2] = static_cast<uint8_t>(i + 32);
+            prm_array[4 * i + 3] = static_cast<uint8_t>(i + 48);
         }
 
         for (size_t i = 0; i < 64; ++i)

--- a/src/cpu/x64/jit_transpose_utils.hpp
+++ b/src/cpu/x64/jit_transpose_utils.hpp
@@ -90,7 +90,7 @@ struct jit_transpose4x16_src_t : public jit_generator_t {
 private:
     static const int typesize = sizeof(float);
 
-    int src_stride = 0, tr_src_stride = 0;
+    dim_t src_stride = 0, tr_src_stride = 0;
 
     Xbyak::Reg64 imm_addr64 = rbx;
 
@@ -112,8 +112,8 @@ private:
     Xbyak::Reg64 reg_tr_src_tmp = r13;
     Xbyak::Reg32 regw_tmp = r14d;
 
-    void transpose_block(int ur, int nrows);
-    void transpose(int nrows);
+    void transpose_block(dim_t ur, dim_t nrows);
+    void transpose(dim_t nrows);
     void generate() override;
 };
 

--- a/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
+++ b/src/cpu/x64/jit_uni_1x1_conv_utils.hpp
@@ -87,7 +87,7 @@ inline void rtus_prepare(conv_pd_t *self, const convolution_desc_t *&conv_d,
     if (ndims == 4) self->rtus_.conv_d_.strides[1] = 1;
     utils::array_set(self->rtus_.conv_d_.padding[0], 0, 2);
     if (ndims == 4) utils::array_set(self->rtus_.conv_d_.padding[1], 0, 2);
-    const int ic = src_d->dims[1];
+    const dim_t ic = src_d->dims[1];
     if (self->desc()->prop_kind == prop_kind::backward_data) {
         data_type_t data_type = self->rtus_.conv_d_.diff_src_desc.data_type;
         src_d = &(self->rtus_.conv_d_.diff_src_desc = *dst_d);
@@ -113,9 +113,9 @@ inline void rtus_prepare_space_info(conv_pd_t *self,
     const bool is_nspc
             = utils::one_of(jcp.src_tag, format_tag::nhwc, format_tag::nwc);
 
-    const size_t factor = utils::pick_by_prop_kind(self->desc()->prop_kind,
+    const dim_t factor = utils::pick_by_prop_kind(self->desc()->prop_kind,
             jcp.nb_reduce, jcp.nb_load_blocking_max, jcp.nb_bcast_blocking);
-    size_t typesize
+    const dim_t typesize
             = types::data_type_size(self->invariant_src_md()->data_type);
 
     self->rtus_.space_per_thread_
@@ -156,19 +156,20 @@ struct rtus_driver_t : public jit_generator_t {
     Xbyak::Reg64 reg_icb_remainder = rcx;
     Xbyak::Reg64 reg_ws_copy = r15;
 
-    int iw_, stride_w_;
-    int src_step_h_, src_step_icb_, ws_step_icb_, vlen_, vlen_shift_;
+    dim_t iw_, stride_w_;
+    dim_t src_step_h_, src_step_icb_, ws_step_icb_;
+    int vlen_, vlen_shift_;
     bool src_to_ws_;
-    size_t typesize_;
-    int ic_, ic_tail_;
+    dim_t typesize_;
+    dim_t ic_, ic_tail_;
     bool is_nspc_;
 
     Xbyak::Xmm reg_zero;
     Xbyak::Xmm reg_v;
 
-    rtus_driver_t(int iw, int stride_w, int src_step_h, int src_step_icb,
-            int ws_step_icb, bool src_to_ws, size_t typesize, int ic,
-            bool is_nspc = false)
+    rtus_driver_t(dim_t iw, dim_t stride_w, dim_t src_step_h,
+            dim_t src_step_icb, dim_t ws_step_icb, bool src_to_ws,
+            dim_t typesize, dim_t ic, bool is_nspc = false)
         : jit_generator_t(jit_name(), isa)
         , iw_(iw)
         , stride_w_(stride_w)
@@ -189,7 +190,7 @@ struct rtus_driver_t : public jit_generator_t {
          * fail to work on reg_v, reg_zero because of this
          * data_type change, e.g. uni_vpxor doen't
          * work on reg_zero now*/
-        auto Vmm = [this](int idx, size_t typesize) {
+        auto Vmm = [this](int idx, dim_t typesize) {
             Xmm res;
             if (is_nspc_) {
                 switch (isa) {
@@ -235,13 +236,13 @@ struct rtus_driver_t : public jit_generator_t {
         vlen_ = reg_v.getBit() / 8;
         vlen_shift_ = 0;
 
-        int tvlen = is_nspc_ ? typesize_ : vlen_;
+        dim_t tvlen = is_nspc_ ? typesize_ : vlen_;
         while (tvlen > 1) {
             tvlen /= 2;
             vlen_shift_++;
         }
 
-        const int simd_w = vlen_ / sizeof(float);
+        const dim_t simd_w = vlen_ / sizeof(float);
         ic_tail_ = ic_ % simd_w;
     }
 
@@ -328,7 +329,7 @@ struct rtus_driver_t : public jit_generator_t {
         }
 
         auto load_reg = [this](const Xmm &vreg, const Reg64 &reg,
-                                const int64_t offset, const int load_size) {
+                                const dim_t offset, const int load_size) {
             if (isa == avx512_core) {
                 const Address &addr = ptr[reg + offset];
                 switch (typesize_) {
@@ -349,7 +350,7 @@ struct rtus_driver_t : public jit_generator_t {
         };
 
         auto store_reg = [this](const Reg64 &reg, const Xmm &vreg,
-                                 const int64_t offset, const int store_size) {
+                                 const dim_t offset, const int store_size) {
             if (isa == avx512_core) {
                 const Address &addr = ptr[reg + offset];
                 switch (typesize_) {
@@ -372,15 +373,15 @@ struct rtus_driver_t : public jit_generator_t {
         mov(reg_ws_copy, reg_ws);
         shl(reg_icb, vlen_shift_);
 
-        const size_t w_step_factor = ic_ * typesize_;
-        const size_t max_load_store_bytes = isa == sse41
-                ? typesize_ == 4 ? 16 : 8
-                : typesize_ == 4 ? 32
-                                 : 16;
-        const size_t load_store_size
+        const dim_t w_step_factor = ic_ * typesize_;
+        const int max_load_store_bytes = isa == sse41 ? typesize_ == 4 ? 16 : 8
+                : typesize_ == 4                      ? 32
+                                                      : 16;
+        const int load_store_size
                 = isa == avx512_core ? vlen_ : max_load_store_bytes;
-        size_t load_store_tail_size = (typesize_ == 1 ? max_load_store_bytes
-                                                      : ic_tail_ * typesize_);
+        const int load_store_tail_size = typesize_ == 1
+                ? max_load_store_bytes
+                : static_cast<int>(ic_tail_ * typesize_);
 
         Label is_loop, ic_loop, ic_loop_tail, ic_loop_finish;
         L(is_loop);
@@ -550,25 +551,25 @@ inline status_t init_rtus_driver(conv_t *self) {
     if (!conf.rtus_.reduce_src_) return status::success;
 
     const auto &cd = *conf.desc();
-    const int ndims = conf.ndims();
-    const int stride_h = (conf.ndims() == 3) ? 1 : cd.strides[0];
-    const int stride_w = cd.strides[ndims - 3];
+    const dim_t ndims = conf.ndims();
+    const dim_t stride_h = (conf.ndims() == 3) ? 1 : cd.strides[0];
+    const dim_t stride_w = cd.strides[ndims - 3];
 
     const bool is_bwd_data = cd.prop_kind == prop_kind::backward_data;
     const auto &src_d = is_bwd_data ? *conf.diff_src_md() : *conf.src_md();
 
-    const int ih = ndims == 3 ? 1 : src_d.dims[2];
-    const int iw = src_d.dims[ndims - 1];
-    const int ic = src_d.dims[1];
+    const dim_t ih = ndims == 3 ? 1 : src_d.dims[2];
+    const dim_t iw = src_d.dims[ndims - 1];
+    const dim_t ic = src_d.dims[1];
 
     const auto src_tag = memory_desc_wrapper(src_d).matches_one_of_tag(
             format_tag::nhwc, format_tag::nwc);
     const bool is_nspc = src_tag != format_tag::undef;
-    const int src_step_h = stride_h * iw;
-    const int src_step_icb = !is_nspc ? ih * iw : 1;
-    const int ws_step_icb = !is_nspc ? conf.jcp_.is : 1;
+    const dim_t src_step_h = stride_h * iw;
+    const dim_t src_step_icb = !is_nspc ? ih * iw : 1;
+    const dim_t ws_step_icb = !is_nspc ? conf.jcp_.is : 1;
     const bool src_to_ws = !is_bwd_data;
-    const size_t typesize
+    const dim_t typesize
             = types::data_type_size(self->pd()->invariant_src_md()->data_type);
 
     CHECK(safe_ptr_assign(self->rtus_driver_,
@@ -578,19 +579,22 @@ inline status_t init_rtus_driver(conv_t *self) {
     return self->rtus_driver_->create_kernel();
 }
 
-inline int best_divider(int value, int min_divider, int max_divider,
+inline int best_divider(dim_t value, int min_divider, dim_t max_divider,
         bool find_max, int step = 1) {
     using namespace dnnl::impl::utils;
-    max_divider = nstl::max(1, nstl::min(max_divider, value));
-    min_divider = nstl::max(1, nstl::min(min_divider, max_divider));
+    const int max_divider_int = static_cast<int>(
+            nstl::max<dim_t>(1, nstl::min<dim_t>(max_divider, value)));
+    min_divider = nstl::max(1, nstl::min(min_divider, max_divider_int));
 
-    auto loss_ratio = [](int total, int chunk) {
-        return float(rnd_up(total, chunk) - total) / rnd_up(total, chunk);
+    auto loss_ratio = [](dim_t total, int chunk) {
+        return float(rnd_up(total, chunk) - total)
+                / float(rnd_up(total, chunk));
     };
 
     float min_loss = FLT_MAX;
-    int x_divider = max_divider;
-    for (int divider = max_divider; divider >= min_divider; divider -= step) {
+    int x_divider = max_divider_int;
+    for (int divider = max_divider_int; divider >= min_divider;
+            divider -= step) {
         const float loss = loss_ratio(value, divider);
         if ((find_max && loss < min_loss) || (!find_max && loss <= min_loss)) {
             min_loss = loss;

--- a/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
+++ b/src/cpu/x64/jit_uni_deconv_zp_pad_str_kernel.cpp
@@ -59,13 +59,14 @@ void jit_uni_deconv_zp_pad_str_kernel_base_t::compute() {
     for (dim_t icb = 0; icb < jcp_.nb_ic; ++icb) {
         const bool is_last_icb = icb == jcp_.nb_ic - 1;
 
-        const int n_inner_ic_blk = jcp_.is_depthwise
-                ? 1
-                : (is_last_icb && ic_tail_exists
-                                  ? utils::div_up(jcp_.ic_without_padding
-                                                    % jcp_.ic_block,
-                                            4)
-                                  : (jcp_.ic_block / 4));
+        const int n_inner_ic_blk = static_cast<int>(jcp_.is_depthwise
+                        ? 1
+                        : (is_last_icb && ic_tail_exists
+                                          ? utils::div_up(
+                                                    jcp_.ic_without_padding
+                                                            % jcp_.ic_block,
+                                                    4)
+                                          : (jcp_.ic_block / 4)));
 
         const dim_t outer_wei_offset = icb * outer_icb_step;
 
@@ -82,10 +83,14 @@ template <cpu_isa_t isa, typename Vmm>
 jit_uni_deconv_zp_pad_str_kernel_t<isa,
         Vmm>::jit_uni_deconv_zp_pad_str_kernel_t(const jit_conv_conf_t &jcp)
     : jit_uni_deconv_zp_pad_str_kernel_base_t(jcp)
-    , result_acc_(reserve_vmm())
-    , vmm_tmp_((jcp.has_vnni || jcp.is_depthwise) ? 0 : reserve_vmm())
-    , vmm_one_bytes_(jcp.is_depthwise ? 0 : reserve_vmm())
-    , vmm_one_words_((jcp.has_vnni || jcp.is_depthwise) ? 0 : reserve_vmm())
+    , result_acc_(static_cast<int>(reserve_vmm()))
+    , vmm_tmp_((jcp.has_vnni || jcp.is_depthwise)
+                      ? 0
+                      : static_cast<int>(reserve_vmm()))
+    , vmm_one_bytes_(jcp.is_depthwise ? 0 : static_cast<int>(reserve_vmm()))
+    , vmm_one_words_((jcp.has_vnni || jcp.is_depthwise)
+                      ? 0
+                      : static_cast<int>(reserve_vmm()))
     , current_vmm_(number_reserved_vmms_) {}
 
 template <cpu_isa_t isa, typename Vmm>
@@ -158,7 +163,7 @@ template <cpu_isa_t isa, typename Vmm,
         typename T = std::integral_constant<bool, (isa < avx512_core)>>
 struct helper_store_t {
     static void store(jit_generator_t *gen, const Vmm &vmm,
-            const Xbyak::Reg64 &reg_dst, const size_t size,
+            const Xbyak::Reg64 &reg_dst, const int size,
             const Xbyak::Opmask &opmask) {
         gen->store_bytes(vmm, reg_dst, 0, size);
     }
@@ -168,7 +173,7 @@ using isa_at_least_avx512_core = std::false_type;
 template <cpu_isa_t isa, typename Vmm>
 struct helper_store_t<isa, Vmm, isa_at_least_avx512_core> {
     static void store(jit_generator_t *gen, const Vmm &vmm,
-            const Xbyak::Reg64 &reg_dst, const size_t size,
+            const Xbyak::Reg64 &reg_dst, const int size,
             const Xbyak::Opmask &opmask) {
         using namespace Xbyak::util;
         gen->vmovups(gen->ptr[reg_dst], vmm | opmask);
@@ -184,7 +189,7 @@ void jit_uni_deconv_zp_pad_str_kernel_t<isa, Vmm>::store_result() {
         cmp(reg_last_oc_block_, 0);
         je(store_no_tail, T_NEAR);
         helper_store_t<isa, Vmm>::store(this, result_acc_, reg_dst_,
-                tail_size_ * sizeof(int32_t), ktail_mask_);
+                static_cast<int>(tail_size_ * sizeof(int32_t)), ktail_mask_);
         jmp(end, T_NEAR);
     }
 
@@ -220,7 +225,7 @@ struct helper_create_deconv_ker_t {
     static jit_uni_deconv_zp_pad_str_kernel_base_t *
     create_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp) {
 
-        const int ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+        const dim_t ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
         switch (ch_block) {
             case 8:
                 if (isa == avx2) {
@@ -242,7 +247,7 @@ template <cpu_isa_t isa>
 struct helper_create_deconv_ker_t<isa, isa_at_least_avx512_core> {
     static jit_uni_deconv_zp_pad_str_kernel_base_t *
     create_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp) {
-        const int ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
+        const dim_t ch_block = jcp.is_depthwise ? jcp.ch_block : jcp.ic_block;
         switch (ch_block) {
             case 16:
                 return new jit_uni_deconv_zp_pad_str_kernel_t<avx512_core,
@@ -325,10 +330,10 @@ void compute_deconv_zp_pad_str_comp_ker(const jit_conv_conf_t &jcp,
             : 1;
 
     parallel(nthrs, [=](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int ch_b {0}, oc_b {0}, d {0}, h {0}, w {0};
+        dim_t ch_b {0}, oc_b {0}, d {0}, h {0}, w {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, ch_b, jcp.nb_ch, oc_b, jcp.nb_oc, d, jcp.kd,
                     h, jcp.kh, w, jcp.kw);

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -63,7 +63,7 @@ jit_uni_dw_conv_fwd_kernel_f32_t<isa>::jit_uni_dw_conv_fwd_kernel_f32_t(
     }
 }
 
-bool check_if_tail_load(const bool is_ch_tail, const int c_tail, const int ch,
+bool check_if_tail_load(const bool is_ch_tail, const dim_t c_tail, const int ch,
         const int ur_ch_blocks, const int vlen, const int i) {
     return is_ch_tail && (ch + 1 == ur_ch_blocks) && ((i + 1) * vlen > c_tail);
 }
@@ -77,7 +77,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
-    const int c_tail = jcp.oc % jcp.ch_block;
+    const dim_t c_tail = jcp.oc % jcp.ch_block;
 
     const int repeats = max_repeats();
     for (int i = 0; i < repeats; i++) {
@@ -90,11 +90,12 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                 Vmm vmm_acc
                         = get_acc_reg(i * ur_ch_blocks * ur_w + ch * ur_w + ow);
 
-                const int b_off = ch * ch_blk + i * vlen;
+                const dim_t b_off = ch * ch_blk + i * vlen;
                 if (this->jcp.with_bias) {
                     if (is_tail_load) {
                         load_tail(vmm_acc, reg_bias, b_off * sizeof(float),
-                                (c_tail - i * vlen) * sizeof(float));
+                                static_cast<int>(
+                                        (c_tail - i * vlen) * sizeof(float)));
                     } else {
                         uni_vmovups(vmm_acc,
                                 vmmword[reg_bias + b_off * sizeof(float)]);
@@ -103,7 +104,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                     uni_vpxor(vmm_acc, vmm_acc, vmm_acc);
                 }
 
-                const int o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
                 if (this->jcp.with_sum) {
                     if (is_tail_load) {
                         if (this->jcp.with_bias) {
@@ -111,12 +112,13 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
                             auto vmm_tmp = get_ker_reg(0);
                             add_tail_from_mem(vmm_acc, vmm_tmp, reg_output,
                                     o_off * sizeof(float),
-                                    (c_tail - i * vlen) * sizeof(float));
+                                    static_cast<int>((c_tail - i * vlen)
+                                            * sizeof(float)));
                         } else {
                             // nothing to add, just load dst.
                             load_tail(vmm_acc, reg_output,
                                     o_off * sizeof(float),
-                                    c_tail * sizeof(float));
+                                    static_cast<int>(c_tail * sizeof(float)));
                         }
                     } else {
                         // blocked layout has dst padded, so no tail handling.
@@ -132,10 +134,10 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::load_src(
 template <cpu_isa_t isa>
 void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
         int ur_ch_blocks, int ur_w, int pad_l, int pad_r, bool is_ch_tail) {
-    int ch_blk = jcp.ch_block;
-    int dilate_h = jcp.dilate_h + 1;
-    int dilate_w = jcp.dilate_w + 1;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t dilate_h = jcp.dilate_h + 1;
+    const dim_t dilate_w = jcp.dilate_w + 1;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto iw_stride = src_layout_nxc ? jcp.ngroups : ch_blk;
@@ -145,25 +147,25 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
             : (jcp.is_fused_conv ? 1 : jcp.ih) * jcp.iw * ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
 
-    auto get_input_spatial_index = [=](int oi, int ki) {
+    auto get_input_spatial_index = [=](dim_t oi, dim_t ki) -> dim_t {
         return (ki * dilate_w + oi * stride_w - pad_l);
     };
 
-    auto get_input_offset = [&](int ii, int ci, int rep) {
+    auto get_input_offset = [&](dim_t ii, dim_t ci, dim_t rep) -> dim_t {
         return (ci * icb_stride + ii * iw_stride + rep * vlen)
                 * jcp.typesize_in;
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise) {
         // find bounds of input spatial indices
         bool first = true;
-        for (int ki = 0; ki < jcp.kw; ki++) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; oi++) {
-                int ii = get_input_spatial_index(oi, ki);
+        for (dim_t ki = 0; ki < jcp.kw; ki++) {
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; oi++) {
+                const dim_t ii = get_input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -184,7 +186,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
             mov(aux_reg_input, ptr[aux_reg_input_buffer_ptr]);
             add(aux_reg_input, reg_iw_offset);
         }
-        const int c_tail = jcp.oc % jcp.ch_block;
+        const dim_t c_tail = jcp.oc % jcp.ch_block;
         const int repeats = max_repeats();
         for (int i = 0; i < repeats; i++) {
             for (int ch = 0; ch < ur_ch_blocks; ch++) {
@@ -195,44 +197,47 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
                     continue;
                 if (jcp.is_resrc_depthwise) {
                     // now we can load input once and reuse up to jcp.kw times
-                    for (int ii = ii_start; ii <= ii_end; ii++) {
-                        Vmm vmm_src = get_src_reg(ii);
-                        const int inp_off = get_input_offset(ii, ch, i);
+                    for (dim_t ii = ii_start; ii <= ii_end; ii++) {
+                        Vmm vmm_src = get_src_reg(static_cast<int>(ii));
+                        const dim_t inp_off = get_input_offset(ii, ch, i);
                         if (is_tail_load) {
                             load_tail(vmm_src, aux_reg_input, inp_off,
-                                    (c_tail - i * vlen) * jcp.typesize_in);
+                                    static_cast<int>((c_tail - i * vlen)
+                                            * jcp.typesize_in));
                         } else {
                             uni_vmovups(vmm_src, ptr[aux_reg_input + inp_off]);
                         }
                     }
                 }
-                for (int kw = 0; kw < jcp.kw; kw++) {
-                    const int ker_off = ch * jcp.kh * jcp.kw * ch_blk
+                for (dim_t kw = 0; kw < jcp.kw; kw++) {
+                    const dim_t ker_off = ch * jcp.kh * jcp.kw * ch_blk
                             + kw * ch_blk + i * vlen;
 
                     Vmm vmm_ker = get_ker_reg(0);
                     uni_vmovups(vmm_ker,
                             ptr[aux_reg_kernel + ker_off * sizeof(float)]);
 
-                    int ow_start = get_ow_start(kw, pad_l);
-                    int ow_end = get_ow_end(ur_w, kw, pad_r);
-                    for (int ow = ow_start; ow < ow_end; ow++) {
+                    const dim_t ow_start = get_ow_start(kw, pad_l);
+                    const dim_t ow_end = get_ow_end(ur_w, kw, pad_r);
+                    for (dim_t ow = ow_start; ow < ow_end; ow++) {
 
-                        const int ii = get_input_spatial_index(ow, kw);
-                        Vmm vmm_src = jcp.is_resrc_depthwise ? get_src_reg(ii)
-                                                             : get_src_reg(0);
+                        const dim_t ii = get_input_spatial_index(ow, kw);
+                        Vmm vmm_src = jcp.is_resrc_depthwise
+                                ? get_src_reg(static_cast<int>(ii))
+                                : get_src_reg(0);
                         if (!jcp.is_resrc_depthwise) {
-                            const int inp_off = get_input_offset(ii, ch, i);
+                            const dim_t inp_off = get_input_offset(ii, ch, i);
                             if (is_tail_load) {
                                 load_tail(vmm_src, aux_reg_input, inp_off,
-                                        (c_tail - i * vlen) * jcp.typesize_in);
+                                        static_cast<int>((c_tail - i * vlen)
+                                                * jcp.typesize_in));
                             } else {
                                 uni_vmovups(
                                         vmm_src, ptr[aux_reg_input + inp_off]);
                             }
                         }
-                        Vmm vmm_acc = get_acc_reg(
-                                i * ur_ch_blocks * ur_w + ch * ur_w + ow);
+                        Vmm vmm_acc = get_acc_reg(static_cast<int>(
+                                i * ur_ch_blocks * ur_w + ch * ur_w + ow));
                         uni_vfmadd231ps(vmm_acc, vmm_src, vmm_ker);
                     }
                 }
@@ -288,7 +293,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_postops(
             const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
             const auto mask_tail_blocked_layout
                     = jcp.oc_without_padding % jcp.ch_block && !dst_layout_nxc;
-            const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+            const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
             iterate(repeats, ur_ch_blocks, ur_w, mask_tail_blocked_layout,
                     [&](const int r, const int ch, const int ow,
                             const bool mask_flag_blocked_layout) {
@@ -411,7 +416,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
     const auto ocb_stride = dst_layout_nxc ? ch_blk : jcp.oh * jcp.ow * ch_blk;
     const auto ow_stride = dst_layout_nxc ? jcp.ngroups : ch_blk;
     const int vlen = cpu_isa_traits_t<isa>::vlen / sizeof(float);
-    const int c_tail = jcp.oc_without_padding % jcp.ch_block;
+    const dim_t c_tail = jcp.oc_without_padding % jcp.ch_block;
 
     const int repeats = max_repeats();
     for (int i = 0; i < repeats; i++) {
@@ -421,12 +426,13 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::store_dst(
             if ((ch + 1 == ur_ch_blocks) && is_ch_tail && c_tail <= i * vlen)
                 continue;
             for (int ow = 0; ow < ur_w; ow++) {
-                const int o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
+                const dim_t o_off = ch * ocb_stride + ow * ow_stride + i * vlen;
                 Vmm vmm_dst
                         = get_acc_reg(i * ur_ch_blocks * ur_w + ch * ur_w + ow);
                 if (is_tail_load) {
                     store_tail(vmm_dst, reg_output, o_off * sizeof(float),
-                            (c_tail - i * vlen) * sizeof(float));
+                            static_cast<int>(
+                                    (c_tail - i * vlen) * sizeof(float)));
                 } else
                     uni_vmovups(vmmword[reg_output + o_off * sizeof(float)],
                             vmm_dst);
@@ -468,8 +474,8 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
     mov(aux_reg_ch_blocks, reg_ch_blocks);
     if (ch_loop) {
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int ch_block_tail = jcp.nb_ch
-                - (utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
+        const int ch_block_tail = static_cast<int>(jcp.nb_ch
+                - utils::rnd_dn(jcp.oc / jcp.ch_block, jcp.nb_ch_blocking));
         const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
 
         push(reg_kernel);
@@ -518,26 +524,26 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
 template <cpu_isa_t isa>
 void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
 
-    int iw = jcp.iw;
-    int ow = jcp.ow;
-    int kw = jcp.kw;
-    int l_pad = jcp.l_pad;
+    int iw = static_cast<int>(jcp.iw);
+    int ow = static_cast<int>(jcp.ow);
+    int kw = static_cast<int>(jcp.kw);
+    int l_pad = static_cast<int>(jcp.l_pad);
     int ur_w = jcp.ur_w;
     int ur_w_tail = jcp.ur_w_tail;
-    int stride_w = jcp.stride_w;
+    int stride_w = static_cast<int>(jcp.stride_w);
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
     size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
     size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
 
-    int inp_shift_pad
+    const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
 
-    int r_pad = nstl::max(0, jcp.r_pad);
+    int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     int n_oi = ow / ur_w;
-    int r_pad1 = calculate_end_padding(l_pad, ur_w * n_oi, iw, stride_w,
-            calculate_extended_filter_size(kw, jcp.dilate_w));
+    int r_pad1 = static_cast<int>(calculate_end_padding(l_pad, ur_w * n_oi, iw,
+            stride_w, calculate_extended_filter_size(kw, jcp.dilate_w)));
 
     assert(jcp.nb_ow <= 1);
 
@@ -623,7 +629,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
         const auto oc_tail = jcp.oc_without_padding % jcp.ch_block;
         if (oc_tail != 0) {
             // Prepare masks for tailing
-            const int oc_tail_shift
+            const dim_t oc_tail_shift
                     = jcp.ch_block - jcp.oc_without_padding % jcp.ch_block;
             static constexpr auto zmm_full_mask = ((1 << 16) - 1);
             Reg32 reg_tail_32 = reg_tail.cvt32();
@@ -633,7 +639,7 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::generate() {
     }
 
     if (is_src_layout_nxc()) {
-        ow_loop(jcp.nb_ch);
+        ow_loop(static_cast<int>(jcp.nb_ch));
     } else {
         cmp(reg_ch_blocks, (jcp.nb_ch_blocking - 1) * jcp.ch_block);
         jle(ch_blocks_tail ? ch_blocks_tail_label : exit_label, T_NEAR);
@@ -669,7 +675,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_vmm(
 template <>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>::load_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
-    int bytes = (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     load_bytes(vmm, addr, bytes);
 }
 template <>
@@ -689,7 +696,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_vmm(
 template <>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<avx2>::store_vmm(
         Vmm &vmm, const Xbyak::Address &addr, bool tail) {
-    int bytes = (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     store_bytes(vmm, addr, bytes);
 }
 template <>
@@ -716,14 +724,14 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::load_ddst(
 template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
         int ur_ch_blocks, int ur_str_w, bool is_last_ch) {
-    int kw = jcp.kw;
-    int kh = jcp.kh;
-    int ow = jcp.ow;
-    int oh = jcp.oh;
+    const dim_t kw = jcp.kw;
+    const dim_t kh = jcp.kh;
+    const dim_t ow = jcp.ow;
+    const dim_t oh = jcp.oh;
 
-    int ch_blk = jcp.ch_block;
-    int stride_h = jcp.stride_h;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_blk = jcp.ch_block;
+    const dim_t stride_h = jcp.stride_h;
+    const dim_t stride_w = jcp.stride_w;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
     const size_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
@@ -759,7 +767,7 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
                     if (last_block && isa == sse41 && tail_simd_overlap(r))
                         break;
 
-                    int ker_off = ch * kh * kw * ch_blk + r * simd_w_;
+                    const dim_t ker_off = ch * kh * kw * ch_blk + r * simd_w_;
                     Vmm vmm_ker = get_ker_reg(0);
                     load_vmm(vmm_ker,
                             ptr[aux1_reg_kernel + ker_off * sizeof(float)],
@@ -805,10 +813,10 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
 template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_dsrc(
         int ur_ch_blocks, int ur_str_w, bool is_last_ch) {
-    int ch_block = jcp.ch_block;
-    int iw = jcp.iw;
-    int ih = jcp.ih;
-    int stride_w = jcp.stride_w;
+    const dim_t ch_block = jcp.ch_block;
+    const dim_t iw = jcp.iw;
+    const dim_t ih = jcp.ih;
+    const dim_t stride_w = jcp.stride_w;
 
     const auto dsrc_layout_nxc = is_dsrc_layout_nxc();
     const size_t ch_block_step = ch_block * (dsrc_layout_nxc ? 1 : ih * iw);
@@ -857,9 +865,9 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::ch_loop_body(
         assert(is_ddst_layout_nxc());
 
         Label ch_loop_label, ch_tail_label, skip_ch_tail_label;
-        const int nb_oc = jcp.oc / jcp.ch_block;
-        const int ch_block_tail
-                = jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking));
+        const int nb_oc = static_cast<int>(jcp.oc / jcp.ch_block);
+        const int ch_block_tail = static_cast<int>(
+                jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking)));
         const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
 
         const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kh
@@ -955,7 +963,7 @@ void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
     if (is_dsrc_layout_nxc()) {
         if (isa == avx512_core && (jcp.ch_tail > 0)) {
             Label masking_done;
-            const size_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
+            const dim_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
             kxnorw(k_ch_tail_mask, k_ch_tail_mask,
                     k_ch_tail_mask); // dummy mask all 1's
             cmp(reg_ch_blocks, channel_step);
@@ -967,7 +975,7 @@ void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::generate() {
             L(masking_done);
         }
 
-        unroll_width_body(jcp.nb_ch);
+        unroll_width_body(static_cast<int>(jcp.nb_ch));
     } else {
 
         auto ch_blocks_loop = [&](int ch_blocks) {
@@ -1005,7 +1013,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::load_xmm(
 template <>
 inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::load_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
-    int bytes = (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     load_bytes(vmm, addr, bytes);
 }
 template <>
@@ -1026,7 +1035,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::store_xmm(
 template <>
 inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<avx2>::store_xmm(
         Vmm &vmm, const Xbyak::Address &addr, bool compute_tail) {
-    int bytes = (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float);
+    int bytes = static_cast<int>(
+            (compute_tail ? jcp.ch_tail : jcp.ch_block) * sizeof(float));
     store_bytes(vmm, addr, bytes);
 }
 template <>
@@ -1068,8 +1078,8 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter() {
     for (int ch = 0; ch < jcp.nb_ch_blocking; ++ch) {
         for (int r = 0; r < reg_repeats_; ++r) {
             for (int i = 0; i < jcp.kw; ++i) {
-                Vmm vmm_acc
-                        = get_acc_reg(r * jcp.kw + i * jcp.nb_ch_blocking + ch);
+                Vmm vmm_acc = get_acc_reg(static_cast<int>(
+                        r * jcp.kw + i * jcp.nb_ch_blocking + ch));
                 uni_vpxor(vmm_acc, vmm_acc, vmm_acc);
             }
         }
@@ -1083,7 +1093,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::load_filter(
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
-        const int reg_set = r * jcp.kw;
+        const int reg_set = static_cast<int>(r * jcp.kw);
         for (int i = 0; i < jcp.kw; ++i) {
             size_t off_filter = static_cast<size_t>(
                     (i * jcp.ch_block + r * simd_w_) * sizeof(float));
@@ -1156,23 +1166,24 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
 
     assert(one_of(isa, avx2, avx512_core));
 
-    const size_t ch_step = jcp.ngroups;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const dim_t ch_step = jcp.ngroups;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const dim_t right_border = jcp.iw - iw_block;
+    const dim_t r_pad = jcp.r_pad;
+    const int cascade_input
+            = static_cast<int>(nstl::min<dim_t>(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const dim_t input_overlap = nstl::max<dim_t>(jcp.kw - l_pad, 0);
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
 
     /* LOAD initial input registers, then cascade LOADs and FMAs*/
     for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
-        int output_sp_offset = i_ur * ch_step;
+        const dim_t output_sp_offset = i_ur * ch_step;
         if (i_ur == 0) {
             for (int c = 0; c < input_overlap; ++c) {
-                int input_sp = c - pad_offset;
-                int input_sp_offset = input_sp * ch_step;
+                const dim_t input_sp = c - pad_offset;
+                const dim_t input_sp_offset = input_sp * ch_step;
                 if (input_sp_offset < 0 && unroll_w == jcp.ow) continue;
 
                 const bool over_steps_bdry = true && is_last_block
@@ -1191,9 +1202,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
             }
         } else {
             for (int c = 0; c < cascade_input; ++c) {
-                int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                int input_sp = overlap + c - pad_offset;
-                int input_sp_offset = input_sp * ch_step;
+                const dim_t overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
+                const dim_t input_sp = overlap + c - pad_offset;
+                const dim_t input_sp_offset = input_sp * ch_step;
                 if (input_sp_offset < 0 || overlap + c + l_pad > right_border)
                     continue;
 
@@ -1205,15 +1216,16 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
                     bool masked_load = is_last_ch && ch == nb_ch_blocking - 1;
                     size_t input_offset = static_cast<size_t>(
                             (input_sp_offset + ch * simd_w_) * sizeof(float));
-                    Vmm vmm_input = get_input_reg(
-                            ((overlap + c) % jcp.kw) * jcp.nb_ch_blocking + ch);
+                    Vmm vmm_input = get_input_reg(static_cast<int>(
+                            ((overlap + c) % jcp.kw) * jcp.nb_ch_blocking
+                            + ch));
                     load_xmm(vmm_input, ptr[reg_tmp_input + input_offset],
                             masked_load);
                 }
             }
         }
         for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-            int io_overlap = i_kw + (i_ur * jcp.stride_w);
+            const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
             /* Don't apply FMAs that fall into the padded region */
             if (io_overlap - l_pad < 0
@@ -1229,9 +1241,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step_nxc(
                 size_t output_offset = static_cast<size_t>(
                         (output_sp_offset + ch * simd_w_) * sizeof(float));
 
-                Vmm vmm_input = get_input_reg(
+                Vmm vmm_input = get_input_reg(static_cast<int>(
                         ((io_overlap - l_pad) % jcp.kw) * jcp.nb_ch_blocking
-                        + ch);
+                        + ch));
                 Vmm vmm_acc = get_acc_reg(i_kw * jcp.nb_ch_blocking + ch);
                 if (masked_load) {
                     Vmm vmm_output = get_output_reg(0);
@@ -1253,14 +1265,15 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         bool is_last_ch) {
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : simd_w_;
-    const int iw_block = ow_block * jcp.stride_w;
-    const int right_border = jcp.iw - iw_block;
-    const int r_pad = jcp.r_pad;
-    const int cascade_input = nstl::min(jcp.stride_w, jcp.kw);
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : simd_w_;
+    const int iw_block = static_cast<int>(ow_block * jcp.stride_w);
+    const dim_t right_border = jcp.iw - iw_block;
+    const dim_t r_pad = jcp.r_pad;
+    const int cascade_input
+            = static_cast<int>(nstl::min<dim_t>(jcp.stride_w, jcp.kw));
 
     /* preamble count for number of cascaded LOAD + FMA operation */
-    const int input_overlap = nstl::max(jcp.kw - l_pad, 0);
+    const dim_t input_overlap = nstl::max<dim_t>(jcp.kw - l_pad, 0);
     const bool is_last_block = (unroll_w + ow_block == jcp.ow);
     const bool nxc_sse41_offset = is_layout_nxc() && isa == sse41;
 
@@ -1270,7 +1283,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
         bool masked_load
                 = IMPLICATION(isa == sse41, tail_in_first_simd) && is_last_ch;
         for (int i_ur = 0; i_ur < unroll_w; ++i_ur) {
-            int output_sp_offset = nxc_sse41_offset
+            const dim_t output_sp_offset = nxc_sse41_offset
                     ? i_ur * ch_step + r * simd_w_
                     : (i_ur * reg_repeats_ + r) * ch_step;
             size_t output_offset
@@ -1280,8 +1293,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                     masked_load);
             if (i_ur == 0) {
                 for (int c = 0; c < input_overlap; ++c) {
-                    int input_sp = c - pad_offset;
-                    int input_sp_offset = nxc_sse41_offset
+                    const dim_t input_sp = c - pad_offset;
+                    const dim_t input_sp_offset = nxc_sse41_offset
                             ? input_sp * ch_step + r * simd_w_
                             : (input_sp * reg_repeats_ + r) * ch_step;
                     if (input_sp_offset < 0 && unroll_w == jcp.ow) continue;
@@ -1299,9 +1312,10 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                 }
             } else {
                 for (int c = 0; c < cascade_input; ++c) {
-                    int overlap = (i_ur - 1) * jcp.stride_w + input_overlap;
-                    int input_sp = overlap + c - pad_offset;
-                    int input_sp_offset = nxc_sse41_offset
+                    const dim_t overlap
+                            = (i_ur - 1) * jcp.stride_w + input_overlap;
+                    const dim_t input_sp = overlap + c - pad_offset;
+                    const dim_t input_sp_offset = nxc_sse41_offset
                             ? input_sp * ch_step + r * simd_w_
                             : (input_sp * reg_repeats_ + r) * ch_step;
                     if (input_sp_offset < 0
@@ -1315,14 +1329,14 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
 
                     size_t input_offset = static_cast<size_t>(
                             input_sp_offset * sizeof(float));
-                    Vmm vmm_input = get_input_reg(
-                            ((overlap + c) % jcp.kw) * reg_repeats_ + r);
+                    Vmm vmm_input = get_input_reg(static_cast<int>(
+                            ((overlap + c) % jcp.kw) * reg_repeats_ + r));
                     load_xmm(vmm_input, ptr[reg_tmp_input + input_offset],
                             masked_load);
                 }
             }
             for (int i_kw = 0; i_kw < jcp.kw; ++i_kw) {
-                int io_overlap = i_kw + (i_ur * jcp.stride_w);
+                const dim_t io_overlap = i_kw + (i_ur * jcp.stride_w);
 
                 /* Don't apply FMAs that fall into the padded region */
                 if (io_overlap - l_pad < 0
@@ -1333,9 +1347,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_unroll_ow_step(
                         && (io_overlap - jcp.l_pad + jcp.r_pad > right_border);
                 if (over_steps_bdry) continue;
 
-                Vmm vmm_input = get_input_reg(
-                        ((io_overlap - l_pad) % jcp.kw) * reg_repeats_ + r);
-                Vmm vmm_acc = get_acc_reg(r * jcp.kw + i_kw);
+                Vmm vmm_input = get_input_reg(static_cast<int>(
+                        ((io_overlap - l_pad) % jcp.kw) * reg_repeats_ + r));
+                Vmm vmm_acc = get_acc_reg(static_cast<int>(r * jcp.kw + i_kw));
                 Vmm vmm_aux = isa == sse41 ? get_aux_reg() : vmm_input;
                 if (isa == sse41) uni_vmovups(vmm_aux, vmm_input);
                 uni_vfmadd231ps(vmm_acc, vmm_aux, vmm_output);
@@ -1365,7 +1379,8 @@ template <>
 inline void
 jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::compute_bias_step_unroll(
         const int unroll_w, int nb_ch_blocking, bool is_last_ch) {
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
+    const int ch_step
+            = static_cast<int>(is_ddst_layout_nxc() ? jcp.ngroups : simd_w_);
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
@@ -1387,7 +1402,7 @@ template <cpu_isa_t isa>
 inline void
 jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_bias_step_unroll(
         const int unroll_w, int nb_ch_blocking, bool is_last_ch) {
-    const int ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
+    const dim_t ch_step = is_ddst_layout_nxc() ? jcp.ngroups : simd_w_;
     for (int i = 0; i < unroll_w; ++i) {
         for (int ch = 0; ch < nb_ch_blocking; ++ch) {
             Vmm vmm_bias = get_bias_reg(ch);
@@ -1410,7 +1425,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<sse41>::store_filter(
     for (int r = 0; r < reg_repeats_; ++r) {
         bool tail_in_first_simd = (r + 1) * simd_w_ >= jcp.ch_tail;
         bool masked_load = tail_in_first_simd && is_last_ch;
-        const int reg_set = r * jcp.kw;
+        const int reg_set = static_cast<int>(r * jcp.kw);
         for (int i = 0; i < jcp.kw; ++i) {
             size_t off_filter = static_cast<size_t>(
                     (i * jcp.ch_block + r * simd_w_) * sizeof(float));
@@ -1472,8 +1487,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
     Label oh_label;
     Label ow_blk_label;
 
-    const int unroll_w = nstl::min(max_unroll_w_, jcp.ow);
-    const int unroll_w_trips = jcp.ow / unroll_w;
+    const int unroll_w
+            = static_cast<int>(nstl::min<dim_t>(max_unroll_w_, jcp.ow));
+    const int unroll_w_trips = static_cast<int>(jcp.ow / unroll_w);
     const int tail_w = jcp.ow > max_unroll_w_ ? jcp.ow % max_unroll_w_ : 0;
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1803,7 +1819,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
     mov(reg_tmp_input, reg_input_baddr);
     mov(reg_tmp_filter, reg_filter_baddr);
 
-    const int input_bottom_padding_overlap
+    const dim_t input_bottom_padding_overlap
             = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
 
     const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
@@ -1843,7 +1859,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         add(reg_kh, jcp.stride_h);
 
         /* Final number of kernel elements that overlap with input */
-        const int inp_ker_overlap = nstl::min(jcp.kh, jcp.ih);
+        const dim_t inp_ker_overlap = nstl::min<dim_t>(jcp.kh, jcp.ih);
         cmp(reg_kh, inp_ker_overlap);
         jle(common_block_label, T_NEAR);
 
@@ -1851,7 +1867,7 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
         if (jcp.t_pad <= jcp.oh * jcp.stride_h) {
             /* Filter has moved beyond padding (adjust for stride effects) */
             if (jcp.t_pad % jcp.stride_h != 0) {
-                int inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
+                const dim_t inp_corr = jcp.stride_h - jcp.t_pad % jcp.stride_h;
                 add(reg_tmp_filter, filter_shift * inp_corr);
                 add(reg_tmp_input, input_shift * inp_corr);
             }
@@ -1910,8 +1926,8 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::calculate_w_unrolling(
 
     const bool do_unroll_w = jcp.ow > max_unroll_w_;
     if (do_unroll_w) {
-        unroll_w = nstl::min(block_size_, jcp.ow);
-        unroll_trips = jcp.ow / unroll_w;
+        unroll_w = static_cast<int>(nstl::min<dim_t>(block_size_, jcp.ow));
+        unroll_trips = static_cast<int>(jcp.ow / unroll_w);
         /* calculate tail */
         unroll_w_tail = jcp.ow % unroll_w;
         /* Perform some rebalancing if tail too small*/
@@ -1927,7 +1943,7 @@ void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::calculate_w_unrolling(
             }
         }
     } else {
-        unroll_w_tail = jcp.ow;
+        unroll_w_tail = static_cast<int>(jcp.ow);
     }
 }
 
@@ -1937,7 +1953,7 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
 
     Label ow_blk_label; // for computing 'ow middle' block
     int pad_offset = 0;
-    int l_pad = jcp.l_pad;
+    int l_pad = static_cast<int>(jcp.l_pad);
 
     int unroll_w_tail = 0;
     int unroll_w = 0;
@@ -1985,8 +2001,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
 
     /* compute right padded block */
     if (unroll_w_tail) {
-        compute_h_loop(
-                unroll_w_tail, l_pad, pad_offset, jcp.ow - unroll_w_tail);
+        compute_h_loop(unroll_w_tail, l_pad, pad_offset,
+                static_cast<int>(jcp.ow - unroll_w_tail));
     }
 }
 

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.hpp
@@ -97,15 +97,16 @@ private:
     void store_tail(
             Vmm &vmm, const Xbyak::Reg64 &reg, int64_t offset, int store_size);
 
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
 
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
@@ -219,14 +220,17 @@ private:
      * is no larger than 3*/
     inline Vmm get_bias_reg(int idx = 0) { return Vmm(idx); }
     inline Vmm get_output_reg(int idx) {
-        int vmm_idx = jcp.is_fast_depthwise
-                ? idx + 2 * jcp.kw * jcp.nb_ch_blocking
+        // `jcp.kw` is a genuine (dim_t) kernel-width dimension, but is
+        // assumed no larger than 3 here (see comment above), so the
+        // resulting register index is bounded and narrowed once here.
+        const int vmm_idx = jcp.is_fast_depthwise
+                ? idx + static_cast<int>(2 * jcp.kw * jcp.nb_ch_blocking)
                 : idx + req_aux_vmm;
         return Vmm(vmm_idx);
     }
     inline Vmm get_input_reg(int idx) {
-        int vmm_idx = jcp.is_fast_depthwise
-                ? idx + jcp.kw * jcp.nb_ch_blocking
+        const int vmm_idx = jcp.is_fast_depthwise
+                ? idx + static_cast<int>(jcp.kw * jcp.nb_ch_blocking)
                 : idx + 4 * reg_repeats_ + req_aux_vmm;
         return Vmm(vmm_idx);
     }

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_utils.cpp
@@ -134,8 +134,8 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[0];
     jcp.dilate_w = cd.dilates[1];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -146,8 +146,10 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
     VDISPATCH_CONV_IC(!kernel_outside_src, VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "weights and src size mismatch");
 
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
 
     jcp.loop_order = loop_ngcw;
 
@@ -155,25 +157,28 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
             : utils::one_of(isa, avx512_core, avx512_core_fp16) ? 6
             : isa == avx2                                       ? 4
                                                                 : 3;
-    jcp.ur_w = nstl::min(jcp.ur_w, jcp.ow);
+    jcp.ur_w = static_cast<int>(nstl::min<dim_t>(jcp.ur_w, jcp.ow));
 
     jcp.ch_block = simd_w;
     jcp.nb_ch = div_up(jcp.oc, jcp.ch_block);
     jcp.nb_ch_blocking = is_superset(isa, avx512_core) ? 4
             : isa == avx2                              ? 3
                                                        : 2;
-    if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
+    if (jcp.nb_ch < jcp.nb_ch_blocking)
+        jcp.nb_ch_blocking = static_cast<int>(jcp.nb_ch);
 
     if (is_data_layout_nxc) {
         jcp.loop_order = loop_nhwcg;
-        const int resrc_depthwise_ur_w = (31 - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        const int resrc_depthwise_ur_w
+                = static_cast<int>((31 - jcp.kw + jcp.stride_w)
+                        / (jcp.nb_ch_blocking + jcp.stride_w));
         jcp.is_resrc_depthwise = (!is_bf16 && !is_f16)
                 && is_superset(isa, avx512_core) && jcp.stride_w < jcp.kw
                 && jcp.kw <= 5 && jcp.dilate_w == 0
                 && resrc_depthwise_ur_w >= 2;
         if (jcp.is_resrc_depthwise) {
-            jcp.ur_w = nstl::min(jcp.ow, resrc_depthwise_ur_w);
+            jcp.ur_w = static_cast<int>(
+                    nstl::min<dim_t>(jcp.ow, resrc_depthwise_ur_w));
         }
         bool cache_aliasing
                 = (jcp.ngroups * jcp.iw * jcp.typesize_in) % 1024 == 0;
@@ -211,9 +216,9 @@ status_t jit_uni_dw_conv_fwd_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
-    int r_pad_no_tail = nstl::max(0,
+    int r_pad_no_tail = static_cast<int>(nstl::max<dim_t>(0,
             calculate_end_padding(jcp.l_pad, jcp.ow - jcp.ur_w_tail, jcp.iw,
-                    jcp.stride_w, ext_kw));
+                    jcp.stride_w, ext_kw)));
     VDISPATCH_CONV_IC(!(jcp.l_pad > jcp.ur_w || r_pad_no_tail > jcp.ur_w),
             VERBOSE_UNSUPPORTED_PAD_FEATURE,
             "width unroll exceeds padding size");
@@ -334,8 +339,8 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
     jcp.dilate_h = cd.dilates[0];
     jcp.dilate_w = cd.dilates[1];
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -408,8 +413,10 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
             && jcp.ngroups <= weights_d.padded_dims()[0];
     VDISPATCH_CONV_IC(args_ok, VERBOSE_BAD_PARAM, "");
 
-    jcp.typesize_out = types::data_type_size(diff_src_d.data_type());
-    jcp.typesize_in = types::data_type_size(diff_dst_d.data_type());
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(diff_src_d.data_type()));
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(diff_dst_d.data_type()));
 
     jcp.ur_w = is_bf16           ? (isa_has_bf16(jcp.isa) ? 6 : 4)
             : isa == avx512_core ? 6
@@ -418,10 +425,11 @@ status_t jit_uni_dw_conv_bwd_data_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.loop_order = is_data_layout_nxc ? loop_nhwcg : loop_ngcw;
 
-    jcp.ch_tail = jcp.ngroups % jcp.ch_block;
+    jcp.ch_tail = static_cast<int>(jcp.ngroups % jcp.ch_block);
     jcp.nb_ch = div_up(jcp.ic, jcp.ch_block);
     jcp.nb_ch_blocking = isa == avx512_core ? 4 : isa == avx2 ? 3 : 2;
-    if (jcp.nb_ch < jcp.nb_ch_blocking) jcp.nb_ch_blocking = jcp.nb_ch;
+    if (jcp.nb_ch < jcp.nb_ch_blocking)
+        jcp.nb_ch_blocking = static_cast<int>(jcp.nb_ch);
 
     const size_t max_ch_off
             = static_cast<size_t>(jcp.nb_ch_blocking - 1) * jcp.ch_block;
@@ -517,12 +525,12 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
 
     jcp.with_bias = cd.diff_bias_desc.format_kind != format_kind::undef;
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    jcp.r_pad = nstl::max(0,
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    jcp.r_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw));
-    jcp.b_pad = nstl::max(0,
+    jcp.b_pad = nstl::max<dim_t>(0,
             calculate_end_padding(
                     jcp.t_pad, jcp.oh, jcp.ih, jcp.stride_h, ext_kh));
 
@@ -578,7 +586,7 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     }
 
     jcp.ch_block = isa == avx512_core ? 16 : 8;
-    jcp.ch_tail = jcp.oc_without_padding % jcp.ch_block;
+    jcp.ch_tail = static_cast<int>(jcp.oc_without_padding % jcp.ch_block);
 
     // note: bf16 to be supported in the next commit
     bool ok_to_pad_channels
@@ -610,15 +618,17 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     constexpr int max_reg_idx = isa == avx512_core ? 31 : 15;
     // Note: anything larger than 4 didn't show significant speedup
     const int max_isa_unroll = jcp.is_fast_depthwise ? 4 : 1;
-    int max_ch_unroll = nstl::min(max_isa_unroll, max_reg_idx / (2 * jcp.kw));
-    jcp.nb_ch_blocking = nstl::min(jcp.nb_ch, max_ch_unroll);
+    int max_ch_unroll = static_cast<int>(
+            nstl::min<dim_t>(max_isa_unroll, max_reg_idx / (2 * jcp.kw)));
+    jcp.nb_ch_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.nb_ch, max_ch_unroll));
 
     /* kernel applicability check wrt boundaries
      * the conditions are quite general across the kernels we have,
      * but ideally the check should belong to a specific kernel... */
-    const int max_hpad = (jcp.kh - 1 + 1) / 2;
-    const int max_wpad = (jcp.kw - 1 + 1) / 2;
-    const int min_ih = jcp.kh + nstl::modulo(-jcp.t_pad, jcp.stride_h);
+    const dim_t max_hpad = (jcp.kh - 1 + 1) / 2;
+    const dim_t max_wpad = (jcp.kw - 1 + 1) / 2;
+    const dim_t min_ih = jcp.kh + nstl::modulo(-jcp.t_pad, jcp.stride_h);
     const bool boundaries_ok = true && jcp.t_pad <= max_hpad
             && jcp.b_pad <= max_hpad && jcp.l_pad <= max_wpad
             && jcp.r_pad <= max_wpad
@@ -633,7 +643,8 @@ status_t jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::init_conf(
     /* BF16: accumulation of output happens in f32, down-conversion to bf16
      * happens during the reduction phase. */
     jcp.typesize_out = sizeof(float);
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
     jcp.bia_dt = jcp.with_bias ? cd.diff_bias_desc.data_type : data_type::undef;
 
     jcp.harness = is_data_layout_nxc ? harness_nxc : harness_mb_reduction;
@@ -707,8 +718,9 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::balance(
          * per-thread load when the number of threads is high (e.g. > 16).
          */
         jcp.oh_blk_size = 15;
-        jcp.nthr_g = nstl::min(jcp.nb_ch, nthreads);
-        jcp.nthr_mb = nstl::min(nstl::max(1, nthreads / jcp.nthr_g), jcp.mb);
+        jcp.nthr_g = static_cast<int>(nstl::min<dim_t>(jcp.nb_ch, nthreads));
+        jcp.nthr_mb = static_cast<int>(nstl::min<dim_t>(
+                nstl::max<dim_t>(1, nthreads / jcp.nthr_g), jcp.mb));
         jcp.nthr = jcp.nthr_g * jcp.nthr_mb;
     } else if (jcp.harness == harness_nxc) {
         /* Allocate threads and partition space with regards to 'nb_ch', 'mb'
@@ -743,15 +755,16 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
     const int env_max_nthr_oh = nthreads; // DNNL_MAX_NTHR_OH
     const int env_min_oh_block = 1; // DNNL_MIN_OH_BLOCK
 
-    const int ch_outer_blocks = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
-    int max_g = nstl::min(env_max_nthr_g, nstl::min(ch_outer_blocks, nthreads));
+    const dim_t ch_outer_blocks = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
+    int max_g = static_cast<int>(nstl::min<dim_t>(
+            env_max_nthr_g, nstl::min<dim_t>(ch_outer_blocks, nthreads)));
     for (int g = max_g; g >= 1; --g) {
         int cur_nthr_g = g;
         auto div_nthr_g = nthreads / cur_nthr_g;
 
         int available_nthr_mb = div_nthr_g;
-        int max_mb = nstl::min(
-                env_max_nthr_mb, nstl::min(jcp.mb, available_nthr_mb));
+        int max_mb = static_cast<int>(nstl::min<dim_t>(
+                env_max_nthr_mb, nstl::min<dim_t>(jcp.mb, available_nthr_mb)));
         for (int mb = max_mb; mb >= 1; --mb) {
             int cur_nthr_mb = mb;
             auto div_nthr_mb = available_nthr_mb / cur_nthr_mb;
@@ -759,27 +772,30 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
             // used to skip cases where efficiency can only worsen
             bool prev_under_blocked = false;
 
-            int available_nthr_oh = nstl::min(
-                    jcp.oh, nstl::min(env_max_nthr_oh, div_nthr_mb));
-            int max_oh_block = jcp.oh;
+            int available_nthr_oh = static_cast<int>(nstl::min<dim_t>(
+                    jcp.oh, nstl::min(env_max_nthr_oh, div_nthr_mb)));
+            int max_oh_block = static_cast<int>(jcp.oh);
             // Note: maybe it's worth exploring a heuristic to determine
             // optimal_min(oh_block)
-            int min_oh_block
-                    = nstl::max(1, nstl::min(jcp.oh, env_min_oh_block));
+            int min_oh_block = static_cast<int>(nstl::max<dim_t>(
+                    1, nstl::min<dim_t>(jcp.oh, env_min_oh_block)));
             for (int oh_block = max_oh_block; oh_block >= min_oh_block;
                     --oh_block) {
 
                 // Calculate most efficient approximation for thread use and/or
                 // blocking:
-                int approx_g_block = utils::div_up(ch_outer_blocks, cur_nthr_g);
-                int approx_mb_block = utils::div_up(jcp.mb, cur_nthr_mb);
-                int approx_oh_block = utils::div_up(jcp.oh, oh_block);
+                int approx_g_block = static_cast<int>(
+                        utils::div_up(ch_outer_blocks, cur_nthr_g));
+                int approx_mb_block
+                        = static_cast<int>(utils::div_up(jcp.mb, cur_nthr_mb));
+                int approx_oh_block
+                        = static_cast<int>(utils::div_up(jcp.oh, oh_block));
 
                 int cur_nthr_oh = nstl::min(available_nthr_oh, approx_oh_block);
 
                 // calculate thread use efficiency
                 int total_nthr = cur_nthr_g * cur_nthr_mb * cur_nthr_oh;
-                float thr_eff = ((float)total_nthr) / nthreads;
+                float thr_eff = ((float)total_nthr) / (float)nthreads;
                 assert(total_nthr <= nthreads);
 
                 // efficiency can only worsen, skip
@@ -790,17 +806,17 @@ void jit_uni_dw_conv_bwd_weights_kernel_t<isa, kernel_dt>::partition_nthr_nxc(
                 // calculate imbalance
                 float imbalance_g = ((float)std::abs(approx_g_block * cur_nthr_g
                                             - ch_outer_blocks))
-                        / ch_outer_blocks;
+                        / (float)ch_outer_blocks;
                 float imbalance_mb
                         = ((float)std::abs(
                                   approx_mb_block * cur_nthr_mb - jcp.mb))
-                        / jcp.mb;
+                        / (float)jcp.mb;
                 float imbalance_oh
                         = ((float)std::abs(oh_block * cur_nthr_oh - jcp.oh))
-                        / jcp.oh;
-                float total_imbalance = imbalance_g * (jcp.mb * jcp.oh)
-                        + imbalance_mb * (ch_outer_blocks * jcp.oh)
-                        + imbalance_oh * (ch_outer_blocks * jcp.mb);
+                        / (float)jcp.oh;
+                float total_imbalance = imbalance_g * (float)(jcp.mb * jcp.oh)
+                        + imbalance_mb * (float)(ch_outer_blocks * jcp.oh)
+                        + imbalance_oh * (float)(ch_outer_blocks * jcp.mb);
 
                 /* 1) When 'prioritize_threading == true'
                  * First Condition: pick the blocking strategy that uses the

--- a/src/cpu/x64/jit_uni_dw_convolution.cpp
+++ b/src/cpu/x64/jit_uni_dw_convolution.cpp
@@ -77,24 +77,24 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
             bias = const_cast<float *>(bias_in);
     }
 
-    const int dil_h = jcp.dilate_h + 1;
-    const int str_h = jcp.stride_h;
+    const dim_t dil_h = jcp.dilate_h + 1;
+    const dim_t str_h = jcp.stride_h;
     const int ch_step = jcp.nb_ch_blocking;
-    const int ow = 0;
-    const int iw = 0;
-    const int kw = 0;
-    const int chb_work = utils::div_up(jcp.nb_ch, ch_step);
+    const dim_t ow = 0;
+    const dim_t iw = 0;
+    const dim_t kw = 0;
+    const dim_t chb_work = utils::div_up(jcp.nb_ch, ch_step);
     const auto is_src_layout_nxc = jcp.src_tag == format_tag::nhwc;
     const auto is_dst_layout_nxc = jcp.dst_tag == format_tag::nhwc;
 
-    const int work_amount = jcp.mb * chb_work * jcp.oh;
+    const dim_t work_amount = jcp.mb * chb_work * jcp.oh;
     const auto nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
-        int n {0}, chb {0}, oh {0};
+        dim_t n {0}, chb {0}, oh {0};
         if (jcp.loop_order == loop_ngcw)
             utils::nd_iterator_init(
                     start, n, jcp.mb, chb, chb_work, oh, jcp.oh);
@@ -107,26 +107,24 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
         auto iwork = start;
         while (iwork < end) {
 
-            int ch = chb * ch_step;
+            const dim_t ch = chb * ch_step;
 
-            const int i_t_overflow
-                    = nstl::max(0, (int)(jcp.t_pad - oh * str_h));
-            const int i_b_overflow
-                    = nstl::max(jcp.ih,
-                              (int)(oh * str_h + (jcp.kh - 1) * dil_h
-                                      - jcp.t_pad + 1))
+            const dim_t i_t_overflow
+                    = nstl::max<dim_t>(0, jcp.t_pad - oh * str_h);
+            const dim_t i_b_overflow
+                    = nstl::max<dim_t>(jcp.ih,
+                              oh * str_h + (jcp.kh - 1) * dil_h - jcp.t_pad + 1)
                     - jcp.ih;
 
-            const int ih
-                    = nstl::max((int)(oh * str_h - jcp.t_pad
-                                        + div_up(i_t_overflow, dil_h) * dil_h),
-                            0);
-            const int kh = div_up(i_t_overflow, dil_h);
-            const int kh_padding = jcp.kh - div_up(i_t_overflow, dil_h)
+            const dim_t ih = nstl::max<dim_t>(0,
+                    oh * str_h - jcp.t_pad
+                            + div_up(i_t_overflow, dil_h) * dil_h);
+            const dim_t kh = div_up(i_t_overflow, dil_h);
+            const dim_t kh_padding = jcp.kh - div_up(i_t_overflow, dil_h)
                     - div_up(i_b_overflow, dil_h);
 
-            const auto ic_off_idx = is_src_layout_nxc ? ch * jcp.ch_block : ch;
-            const auto oc_off_idx = is_dst_layout_nxc ? ch * jcp.ch_block : ch;
+            const dim_t ic_off_idx = is_src_layout_nxc ? ch * jcp.ch_block : ch;
+            const dim_t oc_off_idx = is_dst_layout_nxc ? ch * jcp.ch_block : ch;
 
             auto par_conv = jit_conv_args_t();
             par_conv.src = jcp.is_fused_conv
@@ -137,12 +135,12 @@ void jit_uni_dw_convolution_fwd_t<isa, src_type, dst_type>::execute_forward(
             par_conv.filt = &weights[weights_d.blk_off(ch, 0, 0, kh, kw)];
             if (bias) par_conv.bias = &bias[bias_d.blk_off(ch * jcp.ch_block)];
 
-            par_conv.kh_padding = (size_t)nstl::max(0, kh_padding);
+            par_conv.kh_padding = nstl::max<dim_t>(0, kh_padding);
 
             assert(IMPLICATION(
                     jcp.loop_order == loop_nhwcg, is_src_layout_nxc));
             // For is_src_layout_nxc maximize jit work along contiguous dim.
-            const int work_rem = end - iwork;
+            const dim_t work_rem = end - iwork;
             par_conv.load_work = utils::this_block_size(ch * jcp.ch_block,
                     jcp.oc_without_padding,
                     (is_src_layout_nxc ? work_rem * ch_step : ch_step)
@@ -191,35 +189,36 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
 
     const auto &jcp = pd()->jcp_;
 
-    auto kernel_params
-            = [=](int ur_str_w, int iw, int oh, int ih, int i_t_overflow,
-                      int i_b_overflow, int stride_off_h, int ch, int n,
-                      int work_remaining) {
+    auto kernel_params = [=](dim_t ur_str_w, dim_t iw, dim_t oh, dim_t ih,
+                                 dim_t i_t_overflow, dim_t i_b_overflow,
+                                 dim_t stride_off_h, dim_t ch, dim_t n,
+                                 dim_t work_remaining) {
         auto par_conv = jit_conv_args_t();
         const bool is_dsrc_layout_nxc
                 = utils::one_of(jcp.src_tag, format_tag::nwc, format_tag::nhwc);
         const bool is_ddst_layout_nxc
                 = utils::one_of(jcp.dst_tag, format_tag::nwc, format_tag::nhwc);
-        const int nb_ch_blocking = jcp.nb_ch_blocking;
+        const dim_t nb_ch_blocking = jcp.nb_ch_blocking;
 
-        const int i_l_overflow = nstl::max(0, (jcp.kw - 1 - iw - jcp.l_pad));
-        const int i_r_overflow
-                = nstl::max(0, (jcp.kw - 1 - (jcp.iw - 1 - iw) - jcp.r_pad));
+        const dim_t i_l_overflow
+                = nstl::max<dim_t>(0, jcp.kw - 1 - iw - jcp.l_pad);
+        const dim_t i_r_overflow = nstl::max<dim_t>(
+                0, jcp.kw - 1 - (jcp.iw - 1 - iw) - jcp.r_pad);
 
-        int ow = iw + jcp.l_pad - i_r_overflow;
-        int stride_off_w = ow % jcp.stride_w;
+        dim_t ow = iw + jcp.l_pad - i_r_overflow;
+        const dim_t stride_off_w = ow % jcp.stride_w;
         ow /= jcp.stride_w;
 
-        const int ic_offset = is_dsrc_layout_nxc ? ch * jcp.ch_block : ch;
+        const dim_t ic_offset = is_dsrc_layout_nxc ? ch * jcp.ch_block : ch;
         par_conv.src = &diff_src[diff_src_d.blk_off(n, ic_offset, ih, iw)];
-        const int oc_offset = is_ddst_layout_nxc ? ch * jcp.ch_block : ch;
+        const dim_t oc_offset = is_ddst_layout_nxc ? ch * jcp.ch_block : ch;
         par_conv.dst = &diff_dst[diff_dst_d.blk_off(n, oc_offset, oh, ow)];
         par_conv.filt = &weights[weights_d.blk_off(ch, 0, 0,
                 i_b_overflow + stride_off_h, i_r_overflow + stride_off_w)];
 
-        par_conv.kh_padding = nstl::max(
+        par_conv.kh_padding = nstl::max<dim_t>(
                 0, jcp.kh - i_t_overflow - i_b_overflow - stride_off_h);
-        par_conv.kw_padding = nstl::max(
+        par_conv.kw_padding = nstl::max<dim_t>(
                 0, jcp.kw - i_l_overflow - i_r_overflow - stride_off_w);
 
         par_conv.ur_str_w = ur_str_w;
@@ -234,10 +233,10 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
         return par_conv;
     };
 
-    const int aux_w
-            = nstl::min(jcp.iw, jcp.iw - jcp.kw + jcp.r_pad + jcp.stride_w);
-    const int chb_work = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
-    const dim_t work_amount = static_cast<dim_t>(jcp.mb) * chb_work * jcp.ih;
+    const dim_t aux_w = nstl::min<dim_t>(
+            jcp.iw, jcp.iw - jcp.kw + jcp.r_pad + jcp.stride_w);
+    const dim_t chb_work = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
+    const dim_t work_amount = jcp.mb * chb_work * jcp.ih;
     const auto nthr = jcp.nthr;
 
     parallel(nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
@@ -255,23 +254,24 @@ void jit_uni_dw_convolution_bwd_data_t<isa, diff_dst_type,
 
         auto iwork = start;
         while (iwork < end) {
-            int ch = chb * jcp.nb_ch_blocking;
+            const dim_t ch = chb * jcp.nb_ch_blocking;
 
-            const int work_rem = end - iwork;
+            const dim_t work_rem = end - iwork;
             const dim_t i_t_overflow
                     = nstl::max(dim_t(0), jcp.kh - 1 - ih - jcp.t_pad);
             const dim_t i_b_overflow = nstl::max(
                     dim_t(0), jcp.kh - 1 - (jcp.ih - 1 - ih) - jcp.b_pad);
 
-            int oh = ih + jcp.t_pad - i_b_overflow;
-            int stride_off_h = oh % jcp.stride_h;
+            dim_t oh = ih + jcp.t_pad - i_b_overflow;
+            const dim_t stride_off_h = oh % jcp.stride_h;
             oh /= jcp.stride_h;
 
-            for (int i_str_w = 0; i_str_w < jcp.stride_w; i_str_w++) {
+            for (dim_t i_str_w = 0; i_str_w < jcp.stride_w; i_str_w++) {
                 // left border
-                int iw = i_str_w;
-                int l_border = nstl::min(jcp.kw - 1 - jcp.l_pad, jcp.iw);
-                int ur_str_w = 1;
+                dim_t iw = i_str_w;
+                const dim_t l_border
+                        = nstl::min<dim_t>(jcp.kw - 1 - jcp.l_pad, jcp.iw);
+                dim_t ur_str_w = 1;
                 for (; iw < l_border; iw += jcp.stride_w) {
                     jit_conv_args_t par_conv = kernel_params(ur_str_w, iw, oh,
                             ih, i_t_overflow, i_b_overflow, stride_off_h, ch, n,
@@ -374,24 +374,24 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
             ? diff_bias_f32_to_bf16_accum
             : CTX_OUT_MEM(f32_data_t *, DNNL_ARG_DIFF_BIAS);
 
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         auto conv_params = jit_dw_conv_args_t();
-        const int h_block_size = jcp.oh_blk_size;
+        const dim_t h_block_size = jcp.oh_blk_size;
 
-        const int ch_outer_blocks
+        const dim_t ch_outer_blocks
                 = utils::div_up(jcp.nb_ch, jcp.nb_ch_blocking);
         const int ithr_g = ithr % jcp.nthr_g;
-        int g_start {0}, g_end {0};
+        dim_t g_start {0}, g_end {0};
         balance211(ch_outer_blocks, jcp.nthr_g, ithr_g, g_start, g_end);
 
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
-        int mb_start {0}, mb_end {0};
+        dim_t mb_start {0}, mb_end {0};
         balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         const int ithr_oh = (ithr / (jcp.nthr_mb * jcp.nthr_g)) % jcp.nthr_oh;
-        const int nb_oh = div_up(jcp.oh, jcp.oh_blk_size);
-        int nb_oh_start {0}, nb_oh_end {0};
+        const dim_t nb_oh = div_up(jcp.oh, jcp.oh_blk_size);
+        dim_t nb_oh_start {0}, nb_oh_end {0};
         balance211(nb_oh, jcp.nthr_oh, ithr_oh, nb_oh_start, nb_oh_end);
 
         const size_t wei_size
@@ -416,23 +416,24 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 ? diff_bias_reduction_buffer + (ithr_block - 1) * bias_size
                 : nullptr;
         const int g_step = jcp.nb_ch_blocking;
-        for (int g_ = g_start; g_ < g_end; ++g_) {
-            const int g = g_ * jcp.nb_ch_blocking;
+        for (dim_t g_ = g_start; g_ < g_end; ++g_) {
+            const dim_t g = g_ * jcp.nb_ch_blocking;
             unsigned char last_g_flag
                     = (g + g_step) >= jcp.nb_ch ? FLAG_OC_LAST : 0;
             unsigned char zero_filter_flag = FLAG_ZERO_FILTER;
             unsigned char zero_bias_flag = jcp.with_bias ? FLAG_ZERO_BIAS : 0;
-            for (int mb = mb_start; mb < mb_end; mb++) {
-                for (int nb_oh = nb_oh_start; nb_oh < nb_oh_end; ++nb_oh) {
-                    const int oh_s = nb_oh * h_block_size;
-                    const int h_work = nstl::min(h_block_size, jcp.oh - oh_s);
-                    const int oh_e = oh_s + h_work;
-                    const int ih = -jcp.t_pad + oh_s * jcp.stride_h;
-                    const int kh_top_overflow = nstl::max(0, -ih);
-                    const int kh_bottom_overflow
-                            = nstl::max(0, ih - jcp.ih + jcp.kh);
-                    const int kh_padding_offset
-                            = nstl::min(jcp.kh - 1, kh_top_overflow);
+            for (dim_t mb = mb_start; mb < mb_end; mb++) {
+                for (dim_t nb_oh = nb_oh_start; nb_oh < nb_oh_end; ++nb_oh) {
+                    const dim_t oh_s = nb_oh * h_block_size;
+                    const dim_t h_work
+                            = nstl::min<dim_t>(h_block_size, jcp.oh - oh_s);
+                    const dim_t oh_e = oh_s + h_work;
+                    const dim_t ih = -jcp.t_pad + oh_s * jcp.stride_h;
+                    const dim_t kh_top_overflow = nstl::max<dim_t>(0, -ih);
+                    const dim_t kh_bottom_overflow
+                            = nstl::max<dim_t>(0, ih - jcp.ih + jcp.kh);
+                    const dim_t kh_padding_offset
+                            = nstl::min<dim_t>(jcp.kh - 1, kh_top_overflow);
                     conv_params.kh_count
                             = jcp.kh - kh_top_overflow - kh_bottom_overflow;
                     conv_params.filter_pad_off
@@ -499,21 +500,21 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
     const size_t wei_size = jcp.ngroups * jcp.kh * jcp.kw;
     const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
 
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
 
     auto set_kernel_params
-            = [=](jit_dw_conv_args_t *conv_params, const int batch,
-                      const int group, const int oh_start, const int work_size,
-                      const unsigned char exec_flag, const size_t kh_padding,
-                      const size_t filter_off) {
-        const int tpad_underflow_off = jcp.t_pad - filter_off;
+            = [=](jit_dw_conv_args_t *conv_params, const dim_t batch,
+                      const dim_t group, const dim_t oh_start,
+                      const dim_t work_size, const unsigned char exec_flag,
+                      const size_t kh_padding, const size_t filter_off) {
+        const dim_t tpad_underflow_off = jcp.t_pad - filter_off;
 
         conv_params->exec_flags = exec_flag;
         conv_params->kh_count = jcp.kh - kh_padding;
 
-        const int oh_s = oh_start;
-        const int oh_e = oh_start + work_size;
-        const int ih_s = oh_s * jcp.stride_h;
+        const dim_t oh_s = oh_start;
+        const dim_t oh_e = oh_start + work_size;
+        const dim_t ih_s = oh_s * jcp.stride_h;
 
         conv_params->filter_pad_off
                 = filter_off * jcp.kw * ch_block * jcp.typesize_out;
@@ -537,18 +538,18 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         assert(nthr == jcp.nthr);
 
         auto conv_params = jit_dw_conv_args_t();
-        const int h_block_size = jcp.oh_blk_size;
-        const int nb_ch = jcp.nb_ch;
+        const dim_t h_block_size = jcp.oh_blk_size;
+        const dim_t nb_ch = jcp.nb_ch;
 
         /* assign iteration space to thread */
         const int ithr_g = ithr % jcp.nthr_g;
         const int ithr_mb = (ithr / jcp.nthr_g) % jcp.nthr_mb;
 
         /* split dimensions */
-        int g_start {0}, g_end {0};
+        dim_t g_start {0}, g_end {0};
         balance211(nb_ch, jcp.nthr_g, ithr_g, g_start, g_end);
 
-        int mb_start {0}, mb_end {0};
+        dim_t mb_start {0}, mb_end {0};
         balance211(jcp.mb, jcp.nthr_mb, ithr_mb, mb_start, mb_end);
 
         auto i_mb = diff_weights_type == bf16 ? ithr_mb : ithr_mb - 1;
@@ -560,7 +561,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 ? diff_bias
                 : diff_bia_reduction_buf + (ithr_mb - 1) * bias_size;
 
-        for (int g = g_start; g < g_end; ++g) {
+        for (dim_t g = g_start; g < g_end; ++g) {
             unsigned char last_g_flag = g == nb_ch - 1 ? FLAG_OC_LAST : 0;
             unsigned char zero_filter_flag = FLAG_ZERO_FILTER;
             unsigned char zero_bias_flag = jcp.with_bias ? FLAG_ZERO_BIAS : 0;
@@ -570,14 +571,16 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
 
             if (jcp.with_bias) conv_params.bias = &diff_bia[g * ch_block];
 
-            for (int mb = mb_start; mb < mb_end; ++mb) {
-                int oh = 0;
+            for (dim_t mb = mb_start; mb < mb_end; ++mb) {
+                dim_t oh = 0;
                 while (oh < jcp.oh) {
-                    const int h_work = nstl::min(h_block_size, jcp.oh - oh);
-                    auto kh_t_padding = nstl::max(0, jcp.t_pad - oh);
-                    auto kh_b_padding
+                    const dim_t h_work
+                            = nstl::min<dim_t>(h_block_size, jcp.oh - oh);
+                    const dim_t kh_t_padding
+                            = nstl::max<dim_t>(0, jcp.t_pad - oh);
+                    const dim_t kh_b_padding
                             = (oh * jcp.stride_h + jcp.kh > jcp.ih + jcp.t_pad)
-                            ? nstl::max(jcp.b_pad - (h_work - 1), 0)
+                            ? nstl::max<dim_t>(jcp.b_pad - (h_work - 1), 0)
                             : 0;
 
                     set_kernel_params(&conv_params, mb, g, oh, h_work,
@@ -622,26 +625,26 @@ void jit_uni_dw_convolution_bwd_weights_t<avx512_core, bf16>::execute_reduction(
     const size_t wei_size
             = utils::rnd_up(jcp.ngroups, jcp.ch_block) * jcp.kh * jcp.kw;
     const size_t bias_size = jcp.with_bias ? jcp.ngroups : 0;
-    const int ch_block = jcp.ch_block;
+    const dim_t ch_block = jcp.ch_block;
 
     /* Apply single-threaded 'mb' reduction */
     if (jcp.with_bias && jcp.nthr_mb > 1) {
         for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
             size_t b_accum_offset = (thr_mb - 1) * bias_size;
-            const int bias_ch_tail = jcp.ch_tail;
-            const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+            const dim_t bias_ch_tail = jcp.ch_tail;
+            const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
 
-            for (int g = 0; g < nb_ch; ++g) {
+            for (dim_t g = 0; g < nb_ch; ++g) {
                 /* Reduction on Bias */
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     size_t bias_offset = g * ch_block + g_block;
                     diff_bias[bias_offset]
                             += diff_bia_reduction_buf[b_accum_offset
                                     + bias_offset];
                 }
             }
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 size_t bias_offset = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
                         += diff_bia_reduction_buf[b_accum_offset + bias_offset];
@@ -685,19 +688,19 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
 
     /* Apply single-threaded 'mb' reduction */
     for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t wei_size
                 = static_cast<size_t>(jcp.ngroups * jcp.kh * jcp.kw);
         const size_t mb_accum_offset = (thr_mb - 1) * wei_size;
         const size_t bias_size = jcp.ngroups;
         const size_t b_accum_offset = (thr_mb - 1) * bias_size;
 
-        const int bias_ch_tail = jcp.ch_tail;
-        const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-        for (int g = 0; g < nb_ch; ++g) {
+        const dim_t bias_ch_tail = jcp.ch_tail;
+        const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+        for (dim_t g = 0; g < nb_ch; ++g) {
             if (jcp.with_bias) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -705,11 +708,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
                                     + bias_offset];
                 }
             }
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = (g * jcp.kh + kh) * jcp.kw + kw;
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t wei_offset = static_cast<size_t>(
                             wei_sp_offset * ch_block + g_block);
                     diff_weights[wei_offset]
@@ -720,7 +723,7 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
         }
         // handle reduction for channel tail
         if (jcp.with_bias) {
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -729,11 +732,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction(
             }
         }
         if (bias_ch_tail > 0) {
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = static_cast<size_t>(
                         ((nb_ch * jcp.kh + kh) * jcp.kw + kw) * ch_block);
-                for (int g = 0; g < bias_ch_tail; ++g) {
+                for (dim_t g = 0; g < bias_ch_tail; ++g) {
                     const size_t wei_offset = wei_sp_offset + g;
                     diff_weights[wei_offset]
                             += diff_wei_reduction_buffer[mb_accum_offset
@@ -767,7 +770,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
 
     /* Apply single-threaded 'mb' reduction */
     for (int thr_mb = 1; thr_mb < jcp.nthr_mb; ++thr_mb) {
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t wei_size
                 = static_cast<size_t>(jcp.ngroups * jcp.kh * jcp.kw);
         const size_t mb_accum_offset = (thr_mb - 1) * wei_size;
@@ -775,11 +778,11 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
         const size_t b_accum_offset = (thr_mb - 1) * bias_size;
 
         if (jcp.with_bias) { // Reduction on Bias:
-            const int bias_ch_tail = jcp.ch_tail;
-            const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-            for (int g = 0; g < nb_ch; ++g) {
+            const dim_t bias_ch_tail = jcp.ch_tail;
+            const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+            for (dim_t g = 0; g < nb_ch; ++g) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -788,7 +791,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                 }
             }
             // handle reduction for channel tail
-            for (int g = 0; g < bias_ch_tail; g++) {
+            for (dim_t g = 0; g < bias_ch_tail; g++) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -857,17 +860,17 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                     reduction_size);
 
             const bool compute_bias = jcp.with_bias;
-            const int ch_block = jcp.ch_block;
+            const dim_t ch_block = jcp.ch_block;
             const size_t bias_size = jcp.ngroups;
             const size_t bias_accum_offset = ithr_offset * bias_size;
             if (compute_bias) {
                 const size_t nb_ch_offset = NB_CH * ch_block;
-                const int bias_ch_tail = jcp.ch_tail;
+                const dim_t bias_ch_tail = jcp.ch_tail;
                 const bool compute_ch_tail
                         = (NB_CH == jcp.nb_ch - 1) && bias_ch_tail > 0;
                 if (!compute_ch_tail) {
                     PRAGMA_OMP_SIMD()
-                    for (int g_block = 0; g_block < ch_block; ++g_block) {
+                    for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                         const size_t bias_offset
                                 = static_cast<size_t>(nb_ch_offset + g_block);
                         diff_bias[bias_offset]
@@ -876,7 +879,7 @@ void jit_uni_dw_convolution_bwd_weights_t<isa, src_type,
                     }
                 } else {
                     // handle reduction for channel tail
-                    for (int g = 0; g < bias_ch_tail; g++) {
+                    for (dim_t g = 0; g < bias_ch_tail; g++) {
                         const size_t bias_offset
                                 = static_cast<size_t>(nb_ch_offset + g);
                         diff_bias[bias_offset]
@@ -929,17 +932,17 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
                 utils::rnd_up(jcp.ngroups, jcp.ch_block) * jcp.kh * jcp.kw);
         const size_t reduction_offset = ithr_offset * wei_size;
 
-        const int ch_block = jcp.ch_block;
+        const dim_t ch_block = jcp.ch_block;
         const size_t bias_size = jcp.ngroups;
         size_t b_accum_offset = ithr_offset * bias_size;
 
         const bool compute_bias = jcp.with_bias;
-        const int bias_ch_tail = jcp.ch_tail;
-        const int nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
-        for (int g = 0; g < nb_ch; ++g) {
+        const dim_t bias_ch_tail = jcp.ch_tail;
+        const dim_t nb_ch = bias_ch_tail > 0 ? jcp.nb_ch - 1 : jcp.nb_ch;
+        for (dim_t g = 0; g < nb_ch; ++g) {
             if (compute_bias) {
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t bias_offset
                             = static_cast<size_t>(g * ch_block + g_block);
                     diff_bias[bias_offset]
@@ -947,12 +950,12 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
                                     + bias_offset];
                 }
             }
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset
                         = static_cast<size_t>((g * jcp.kh + kh) * jcp.kw + kw);
                 PRAGMA_OMP_SIMD()
-                for (int g_block = 0; g_block < ch_block; ++g_block) {
+                for (dim_t g_block = 0; g_block < ch_block; ++g_block) {
                     const size_t wei_offset = static_cast<size_t>(
                             wei_sp_offset * ch_block + g_block);
                     diff_weights[wei_offset]
@@ -963,7 +966,7 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
         }
         // handle reduction for channel tail
         if (compute_bias) {
-            for (int g = 0; g < bias_ch_tail; ++g) {
+            for (dim_t g = 0; g < bias_ch_tail; ++g) {
                 const size_t bias_offset
                         = static_cast<size_t>(nb_ch * ch_block + g);
                 diff_bias[bias_offset]
@@ -972,11 +975,11 @@ void jit_uni_dw_convolution_bwd_weights_t<sse41, f32>::execute_reduction_nxc(
             }
         }
         if (bias_ch_tail > 0) {
-            for_(int kh = 0; kh < jcp.kh; ++kh)
-            for (int kw = 0; kw < jcp.kw; ++kw) {
+            for_(dim_t kh = 0; kh < jcp.kh; ++kh)
+            for (dim_t kw = 0; kw < jcp.kw; ++kw) {
                 const size_t wei_sp_offset = static_cast<size_t>(
                         (nb_ch * jcp.kh + kh) * jcp.kw + kw);
-                for (int g = 0; g < bias_ch_tail; ++g) {
+                for (dim_t g = 0; g < bias_ch_tail; ++g) {
                     const size_t wei_offset
                             = static_cast<size_t>(wei_sp_offset * ch_block + g);
                     diff_weights[wei_offset]

--- a/src/cpu/x64/jit_uni_ncsp_convolution.cpp
+++ b/src/cpu/x64/jit_uni_ncsp_convolution.cpp
@@ -91,10 +91,11 @@ status_t reduction_helper_t::reshape_weights(
         // matmul to conv: remove batch, restore spatial
         for (int d = 0; d < ndims_ch; ++d)
             reduce[d] = i_md->dims[d + 1]; // g, o, i
-        for (int d = ndims_ch; d < ndims_out; ++d)
+        for (int d = static_cast<int>(ndims_ch); d < ndims_out; ++d)
             reduce[d] = 1; // d, h, w
     }
-    return memory_desc_reshape(*o_md, *i_md, ndims_out, reduce);
+    return memory_desc_reshape(
+            *o_md, *i_md, static_cast<int>(ndims_out), reduce);
 }
 
 status_t reduction_helper_t::reshape_for_transpose(

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -1455,8 +1455,8 @@ void jit_uni_pool_kernel_t<isa>::generate() {
             const int ow_s = i * ur_w;
             const int ow_e = nstl::min(ow, ow_s + ur_w);
             const int cur_l_pad = l_pad - i * ur_stride_w;
-            const int cur_r_pad = nstl::max(
-                    0, calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+            const int cur_r_pad = static_cast<int>(nstl::max(dim_t(0),
+                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw)));
             const int cur_ur_w = ow_e - ow_s;
             process_oi(cur_ur_w, ur_bc, cur_l_pad, cur_r_pad,
                     with_c_tail_processing);
@@ -1486,8 +1486,8 @@ void jit_uni_pool_kernel_t<isa>::generate() {
                 i < n_oi_iterations; ++i) {
             const int ow_s = i * ur_w;
             const int ow_e = nstl::min(ow, ow_s + ur_w);
-            const int cur_r_pad = nstl::max(
-                    0, calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+            const int cur_r_pad = static_cast<int>(nstl::max(dim_t(0),
+                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw)));
             const int cur_ur_w = ow_e - ow_s;
             process_oi(cur_ur_w, ur_bc, 0, cur_r_pad, with_c_tail_processing);
         }

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -117,9 +117,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::bcast_loop(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::output_ptr(
+dim_t jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::output_ptr(
         const int i_load, const int i_ur) {
-    const size_t ur_stride = jcp.with_dw_conv
+    const dim_t ur_stride = jcp.with_dw_conv
             ? jcp.nb_load_blocking * jcp.oc_block * i_ur
             : jcp.oc_without_padding * i_ur;
 
@@ -158,9 +158,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::apply_postops(
         // Sum post-op requires binary parameters to be set.
         if (jcp.with_binary || jcp.with_sum) {
             iterate(ur, load_loop_blk, [&](const int i_ur, const int i_load) {
-                const int ur_stride
+                const dim_t ur_stride
                         = jcp.oc_without_padding * jcp.ngroups * i_ur;
-                const size_t aux_output_offset = jcp.typesize_out
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (ur_stride + i_load * jcp.load_block);
                 const auto vmm_idx
                         = vreg_accum_idx(load_loop_blk, i_load, i_ur);
@@ -220,7 +220,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
         assert(i_reduce <= jcp.reduce_loop_unroll);
         assert(jcp.reduce_loop_unroll == jcp.reduce_block);
 
-        int offt = (jcp.ic_without_padding * i_ur + i_reduce);
+        const dim_t offt = jcp.ic_without_padding * i_ur + i_reduce;
 
         return ptr[aux_reg_bcast_data + jcp.typesize_in * offt];
     };
@@ -229,7 +229,7 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
         int u0 = i_reduce % jcp.reduce_loop_unroll;
         int u1 = i_reduce / jcp.reduce_loop_unroll;
 
-        int offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
+        const dim_t offt = (i_load * jcp.reduce_dim + u0) * jcp.load_block;
 
         return ptr[aux_reg_load_data + u1 * jcp.reduce_loop_load_step
                 + jcp.typesize_in * offt];
@@ -267,10 +267,13 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
             if (jcp.signed_input) {
                 mov(reg_comp_data, ptr[rsp + reg_comp_data_off]);
                 cvt2ps(data_type::s32, vmm_comp, reg_comp_data,
-                        sizeof(int32_t) * jcp.oc_block * i_load, load_size);
+                        static_cast<int>(
+                                sizeof(int32_t) * jcp.oc_block * i_load),
+                        load_size);
             }
             if (jcp.src_zero_point) {
-                const int zp_offset = sizeof(int32_t) * i_load * jcp.oc_block;
+                const int zp_offset = static_cast<int>(
+                        sizeof(int32_t) * i_load * jcp.oc_block);
                 load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation,
                         zp_offset, load_size);
                 uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_zp);
@@ -307,8 +310,8 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
                 if (!jcp.is_oc_scale) {
                     uni_vbroadcastss(vmm_scales_tmp, ptr[reg_wei_scales]);
                 } else {
-                    int scale_offset = jcp.is_oc_scale
-                            * (sizeof(float) * jcp.oc_block * i_load);
+                    const int scale_offset = static_cast<int>(jcp.is_oc_scale
+                            * (sizeof(float) * jcp.oc_block * i_load));
                     if (mask_flag) {
                         uni_vpxor(
                                 vmm_scales_tmp, vmm_scales_tmp, vmm_scales_tmp);
@@ -347,7 +350,9 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
                 if (jcp.signed_input || jcp.with_dst_scales)
                     mov(reg_bias_data, ptr[rsp + reg_bias_data_off]);
                 cvt2ps(jcp.bia_dt, vmm_bias, reg_bias_data,
-                        jcp.typesize_bia * jcp.oc_block * i_load, load_size);
+                        static_cast<int>(
+                                jcp.typesize_bia * jcp.oc_block * i_load),
+                        load_size);
             }
 
             for (int i_ur = 0; i_ur < ur; ++i_ur) {
@@ -430,9 +435,10 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::reduce_loop(
     auto fma_block = [&](bool last_block) {
         int reduce_step = 4;
         int ic_tail_size = jcp.ic_without_padding % reduce_step;
-        int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
-                ? rnd_up(jcp.ic_without_padding % jcp.ic_block, reduce_step)
-                : jcp.reduce_loop_unroll;
+        const int loop_unroll = last_block && jcp.ic != jcp.ic_without_padding
+                ? static_cast<int>(rnd_up(
+                          jcp.ic_without_padding % jcp.ic_block, reduce_step))
+                : static_cast<int>(jcp.reduce_loop_unroll);
         for (int i_reduce = 0; i_reduce < loop_unroll;
                 i_reduce += reduce_step) {
             for (int i_load = 0; i_load < load_loop_blk; ++i_load)
@@ -756,10 +762,13 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     jcp.ic_block = jcp.oc_block = simd_w;
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     const int SMALL_SPATIAL = 7 * 7;
     const int BIG_REDUCE_DIM = 512;
@@ -785,9 +794,9 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             && (jcp.oh <= size_threshold && jcp.ow <= size_threshold)) {
         if (jcp.os <= SMALL_SPATIAL && jcp.oc * jcp.ic < L2_size)
             max_regs = min_regs = 3;
-        jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
     } else {
-        const int spatial = jcp.od * jcp.oh;
+        const dim_t spatial = jcp.od * jcp.oh;
         jcp.ur = 1;
         for (int ur_w = max_regs; ur_w >= min_regs; ur_w--) {
             if ((spatial >= size_threshold && spatial % ur_w == 0)
@@ -797,7 +806,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             }
         }
         if (jcp.ur == 1) {
-            jcp.ur = nstl::min<dim_t>(max_regs, jcp.os);
+            jcp.ur = static_cast<int>(nstl::min<dim_t>(max_regs, jcp.os));
             int os_tail = jcp.os % max_regs;
             for (int i = max_regs; i >= min_regs; i--) {
                 int i_tail = jcp.os % i;
@@ -810,7 +819,8 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
         }
     }
 
-    if (jcp.with_dw_conv) jcp.ur = nstl::min(jcp.ow, jcp.ur);
+    if (jcp.with_dw_conv)
+        jcp.ur = static_cast<int>(nstl::min<dim_t>(jcp.ow, jcp.ur));
     jcp.reduce_dim = jcp.ic;
     jcp.reduce_block = jcp.ic_block;
 
@@ -838,8 +848,10 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     jcp.loop_order = reduce_src ? loop_blr : loop_lbr;
 
-    int nb_bcast = div_up(jcp.bcast_dim, jcp.bcast_block);
-    int nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
+    const int nb_bcast
+            = static_cast<int>(div_up(jcp.bcast_dim, jcp.bcast_block));
+    const int nb_reduce
+            = static_cast<int>(div_up(jcp.reduce_dim, jcp.reduce_block));
 
     reduce_blocking = nb_reduce;
     if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.reduce_dim >= BIG_REDUCE_DIM)
@@ -852,7 +864,7 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
 
     bool cmp_reduce = reduce_blocking <= jcp.reduce_dim;
     if (cmp_reduce) jcp.loop_order = reduce_src ? loop_rbl : loop_rlb;
-    load_blocking = jcp.load_dim;
+    load_blocking = static_cast<int>(jcp.load_dim);
 
     jcp.load_grp_count = div_up(jcp.nthr, jcp.mb * jcp.ngroups * nb_bcast);
     jcp.load_grp_count = best_divider(
@@ -864,24 +876,26 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     } else if (jcp.bcast_dim <= SMALL_SPATIAL && jcp.mb <= jcp.nthr
             && jcp.load_dim > 256 && jcp.load_dim / jcp.reduce_dim >= 4) {
         jcp.load_grp_count = nstl::max(jcp.load_grp_count, 2);
-        load_blocking = jcp.load_block;
+        load_blocking = static_cast<int>(jcp.load_block);
     }
 
-    bcast_blocking = div_up(jcp.mb * jcp.ngroups * nb_bcast,
-                             div_up(jcp.nthr, jcp.load_grp_count))
-            * jcp.bcast_block;
-    bcast_blocking = nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking);
+    bcast_blocking
+            = static_cast<int>(div_up(jcp.mb * jcp.ngroups * nb_bcast,
+                                       div_up(jcp.nthr, jcp.load_grp_count))
+                    * jcp.bcast_block);
+    bcast_blocking
+            = static_cast<int>(nstl::min<dim_t>(jcp.bcast_dim, bcast_blocking));
     bcast_blocking = rnd_up(bcast_blocking, jcp.bcast_block);
 
-    int space_for_bcast = (L2_capacity - /* kernel_size - */
+    dim_t space_for_bcast = (L2_capacity - /* kernel_size - */
             2 * jcp.load_block * reduce_blocking - jcp.ur * reduce_blocking
             - 3 * 1024);
     if (jcp.reduce_dim * jcp.bcast_dim > L2_capacity) space_for_bcast /= 2;
 
-    int bcast_in_cache
-            = nstl::max(jcp.bcast_block, space_for_bcast / reduce_blocking);
-    bcast_blocking = nstl::min(
-            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block));
+    const dim_t bcast_in_cache = nstl::max<dim_t>(
+            jcp.bcast_block, space_for_bcast / reduce_blocking);
+    bcast_blocking = static_cast<int>(nstl::min<dim_t>(
+            bcast_blocking, rnd_dn(bcast_in_cache, jcp.bcast_block)));
 
     load_blocking_max = load_blocking;
     bcast_blocking_max = bcast_blocking * 3 / 2;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.hpp
@@ -36,7 +36,9 @@ struct jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t : public jit_generator_t {
     jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t(const jit_1x1_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md);
 
-    int get_tail_size() { return jcp.oc_without_padding % jcp.oc_block; }
+    int get_tail_size() {
+        return static_cast<int>(jcp.oc_without_padding % jcp.oc_block);
+    }
 
     jit_1x1_conv_conf_t jcp;
     const primitive_attr_t &attr_;
@@ -110,7 +112,7 @@ private:
     int vreg_accum_idx(
             const int load_loop_blk, const int i_load, const int i_ur);
     Vmm vreg_accum(const int load_loop_blk, const int i_load, const int i_ur);
-    int output_ptr(const int i_load, const int i_ur);
+    dim_t output_ptr(const int i_load, const int i_ur);
     void bcast_loop(int load_loop_blk);
     void apply_postops(
             const int ur, const int load_loop_blk, const bool mask_flag_in);

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.cpp
@@ -54,7 +54,8 @@ status_t jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward(
             = binary_injector::prepare_binary_args(pd()->jcp_.post_ops, ctx);
     const auto &post_ops_binary_rhs_arg_vec_dw = pd()->jcp_dw_
             ? binary_injector::prepare_binary_args(pd()->jcp_dw_->post_ops, ctx,
-                      pd()->jcp_.post_ops.entry_.size() + 1)
+                      static_cast<unsigned>(
+                              pd()->jcp_.post_ops.entry_.size() + 1))
             : std::vector<const void *> {};
 
     const int32_t *src_zero_points = CTX_IN_MEM(
@@ -114,12 +115,12 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
             ? scratchpad.get<char>(key_conv_rtus_space)
             : nullptr;
 
-    const int work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
+    const dim_t work_amount = jcp.mb * jcp.ngroups * jcp.nb_bcast;
 
     const int ndims = dst_d.ndims();
-    const int stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
-    const int stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
-    const int stride_w = pd()->desc()->strides[ndims - 3];
+    const dim_t stride_d = (ndims == 5) ? pd()->desc()->strides[0] : 1;
+    const dim_t stride_h = (ndims == 3) ? 1 : pd()->desc()->strides[ndims - 4];
+    const dim_t stride_w = pd()->desc()->strides[ndims - 3];
 
     auto offset = weights_d.size() - weights_d.additional_buffer_size();
     char *w = const_cast<char *>(weights);
@@ -142,15 +143,16 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     auto p = jit_1x1_conv_args_t();
 
     auto rp = typename rtus_driver_t<isa>::call_params_t();
-    const int nb_oc = jcp.nb_load;
+    const dim_t nb_oc = jcp.nb_load;
     // override some constants for fused dw_conv
-    const int os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
-    const int nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
-    const int nb_bcast_blocking = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
-    const int nb_bcast_blocking_max
+    const dim_t os_block = jcp.with_dw_conv ? jcp.ow : jcp.bcast_block;
+    const dim_t nb_bcast = jcp.with_dw_conv ? jcp.oh : jcp.nb_bcast;
+    const dim_t nb_bcast_blocking
+            = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking;
+    const dim_t nb_bcast_blocking_max
             = jcp.with_dw_conv ? 1 : jcp.nb_bcast_blocking_max;
-    const int nb_load_blocking = jcp.nb_load_blocking;
-    const int nb_load_blocking_max = jcp.with_dw_conv
+    const dim_t nb_load_blocking = jcp.nb_load_blocking;
+    const dim_t nb_load_blocking_max = jcp.with_dw_conv
             ? jcp.nb_load_blocking
             : jcp.nb_load_blocking_max;
 
@@ -185,27 +187,27 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
     char *pbuf {nullptr};
     size_t row_offset {};
-    const int nb_buffer = jcp.nb_load_blocking;
+    const dim_t nb_buffer = jcp.nb_load_blocking;
     std::vector<char *> addrs;
     // End
 
-    auto step = [](int default_step, int remaining, int tail_step) {
+    auto dim_step = [](dim_t default_step, dim_t remaining, dim_t tail_step) {
         assert(default_step <= tail_step);
         return remaining < tail_step ? remaining : default_step;
     };
 
-    auto init_bcast
-            = [&](int iwork, int bcast_end, int &n, int &g, int &bcast_step,
-                      int &od, int &oh, int &ow, int &id, int &ih, int &iw) {
-        int osb {0};
+    auto init_bcast = [&](dim_t iwork, dim_t bcast_end, dim_t &n, dim_t &g,
+                              dim_t &bcast_step, dim_t &od, dim_t &oh,
+                              dim_t &ow, dim_t &id, dim_t &ih, dim_t &iw) {
+        dim_t osb {0};
         nd_iterator_init(iwork, n, jcp.mb, g, jcp.ngroups, osb, nb_bcast);
-        bcast_step = step(
+        bcast_step = dim_step(
                 nb_bcast_blocking, nb_bcast - osb, nb_bcast_blocking_max);
         bcast_step = nstl::min(bcast_step, bcast_end - iwork);
 
-        const int os = osb * os_block;
+        const dim_t os = osb * os_block;
         od = os / (jcp.oh * jcp.ow);
-        const int os_2d = os % (jcp.oh * jcp.ow);
+        const dim_t os_2d = os % (jcp.oh * jcp.ow);
         oh = os_2d / jcp.ow;
         ow = os_2d % jcp.ow;
 
@@ -218,8 +220,9 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         rp.os = p.bcast_dim;
     };
 
-    auto init_load = [&](int ocb, int ocb_end, int &load_step) {
-        load_step = step(nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
+    auto init_load = [&](dim_t ocb, dim_t ocb_end, dim_t &load_step) {
+        load_step = dim_step(
+                nb_load_blocking, ocb_end - ocb, nb_load_blocking_max);
         p.load_dim = this_block_size(ocb * jcp.oc_block, ocb_end * jcp.oc_block,
                 load_step * jcp.oc_block);
 
@@ -231,15 +234,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
     auto init_reduce = [&]() {
         p.reduce_dim = this_block_size(
-                0, jcp.ic_without_padding, jcp.ic_without_padding);
+                dim_t {0}, jcp.ic_without_padding, jcp.ic_without_padding);
         rp.icb = p.reduce_dim;
     };
 
-    auto ker_1x1 = [&](int ocb, int ocb_start, int n, int g, int od, int oh,
-                           int ow, int id, int ih, int iw) {
+    auto ker_1x1 = [&](dim_t ocb, dim_t ocb_start, dim_t n, dim_t g, dim_t od,
+                           dim_t oh, dim_t ow, dim_t id, dim_t ih, dim_t iw) {
         const int icb = 0; // Start from the first IC block
-        const int _ocb = g * nb_oc + ocb;
-        const int _icb = g;
+        const dim_t _ocb = g * nb_oc + ocb;
+        const dim_t _icb = g;
 
         const auto src_offset
                 = data_blk_off(src_d, n, _icb * jcp.ic_block, id, ih, iw);
@@ -286,18 +289,18 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         (*kernel_)(&p);
     };
 
-    auto conv_1x1
-            = [&](int bcast_start, int bcast_end, int ocb_start, int ocb_end) {
+    auto conv_1x1 = [&](dim_t bcast_start, dim_t bcast_end, dim_t ocb_start,
+                            dim_t ocb_end) {
         if (bcast_start >= bcast_end || ocb_start >= ocb_end) return;
         if (jcp.loop_order == loop_rlb) {
             init_reduce();
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                    dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                             id {0}, ih {0}, iw {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
@@ -307,13 +310,13 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
                 ocb += load_step;
             }
         } else if (jcp.loop_order == loop_lbr) {
-            int ocb = ocb_start;
+            dim_t ocb = ocb_start;
             while (ocb < ocb_end) {
-                int load_step;
+                dim_t load_step;
                 init_load(ocb, ocb_end, load_step);
-                int iwork = bcast_start;
+                dim_t iwork = bcast_start;
                 while (iwork < bcast_end) {
-                    int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                    dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                             id {0}, ih {0}, iw {0};
                     init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow,
                             id, ih, iw);
@@ -325,15 +328,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
             }
         } else if (jcp.loop_order == loop_rbl) {
             init_reduce();
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                         id {0}, ih {0}, iw {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
                     ocb += load_step;
@@ -341,15 +344,15 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
                 iwork += bcast_step;
             }
         } else if (jcp.loop_order == loop_blr) {
-            int iwork = bcast_start;
+            dim_t iwork = bcast_start;
             while (iwork < bcast_end) {
-                int n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
+                dim_t n {0}, g {0}, bcast_step {0}, od {0}, oh {0}, ow {0},
                         id {0}, ih {0}, iw {0};
                 init_bcast(iwork, bcast_end, n, g, bcast_step, od, oh, ow, id,
                         ih, iw);
-                int ocb = ocb_start;
+                dim_t ocb = ocb_start;
                 while (ocb < ocb_end) {
-                    int load_step;
+                    dim_t load_step;
                     init_load(ocb, ocb_end, load_step);
                     init_reduce();
                     ker_1x1(ocb, ocb_start, n, g, od, oh, ow, id, ih, iw);
@@ -362,21 +365,22 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         }
     };
 
-    auto ker_dw = [&](int n, int ocb_start, int load_step, int &dw_oh) {
-        int oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
-        int oh_1x1_begin = nstl::max(oh_1x1, 0);
+    auto ker_dw = [&](dim_t n, dim_t ocb_start, dim_t load_step, dim_t &dw_oh) {
+        dim_t oh_1x1 = dw_oh * jcp_dw->stride_h - jcp_dw->t_pad;
+        dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1, 0);
 
-        for (int i = 0; i < jcp_dw->kh; ++i)
+        for (dim_t i = 0; i < jcp_dw->kh; ++i)
             addrs[i] = pbuf + ((oh_1x1_begin++) % jcp_dw->kh) * row_offset;
 
         const auto ocb_end = ocb_start + load_step;
         const size_t src_ch_stride = jcp_dw->nb_ch_blocking * jcp_dw->ch_block;
         auto par_conv_dw = jit_conv_args_t();
 
-        par_conv_dw.t_overflow = nstl::min(jcp_dw->kh, nstl::max(0, -oh_1x1));
-        par_conv_dw.b_overflow = nstl::min(
-                jcp_dw->kh, nstl::max(0, oh_1x1 - jcp.oh + jcp_dw->kh));
-        par_conv_dw.kh_padding = nstl::max<int>(0,
+        par_conv_dw.t_overflow
+                = nstl::max<dim_t>(0, nstl::min<dim_t>(jcp_dw->kh, -oh_1x1));
+        par_conv_dw.b_overflow = nstl::max<dim_t>(
+                0, nstl::min<dim_t>(jcp_dw->kh, oh_1x1 - jcp.oh + jcp_dw->kh));
+        par_conv_dw.kh_padding = nstl::max<dim_t>(0,
                 jcp_dw->kh - par_conv_dw.t_overflow - par_conv_dw.b_overflow);
 
         const size_t dst_offset = n * jcp_dw->ngroups * jcp_dw->oh * jcp_dw->ow
@@ -385,7 +389,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         const auto wht_h_stride = dw_weights_d.blk_off(0, 0, 0, 1);
         const auto wei_stride = (!jcp_dw->signed_input) * par_conv_dw.t_overflow
                 * wht_h_stride;
-        for (int ocb = ocb_start; ocb < ocb_end;
+        for (dim_t ocb = ocb_start; ocb < ocb_end;
                 ocb += jcp_dw->nb_ch_blocking) {
 
             par_conv_dw.src = addrs.data();
@@ -416,7 +420,7 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
 
             (*kernel_dw_)(&par_conv_dw);
 
-            for (int i = 0; i < jcp_dw->kh; ++i)
+            for (dim_t i = 0; i < jcp_dw->kh; ++i)
                 addrs[i] += src_ch_stride;
         }
     };
@@ -431,33 +435,35 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
         row_offset = dw_conv_buffer_size_ / jcp_dw->kh;
         addrs.resize(jcp_dw->kh);
 
-        int bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start, ocb_end;
         balance2D(nthr, ithr, jcp.mb * jcp.ngroups * jcp_dw->oh, bcast_start,
-                bcast_end, nb_oc, ocb_start, ocb_end, jcp.load_grp_count);
+                bcast_end, nb_oc, ocb_start, ocb_end,
+                static_cast<dim_t>(jcp.load_grp_count));
 
         while (ocb_start < ocb_end) {
-            int load_step;
+            dim_t load_step;
             init_load(ocb_start, ocb_end, load_step);
 
-            int oh_1x1 = 0;
+            dim_t oh_1x1 = 0;
             auto bcast_iter = bcast_start;
             while (bcast_iter < bcast_end) {
-                int n {0}, g {0}, oh_dw {0};
+                dim_t n {0}, g {0}, oh_dw {0};
                 nd_iterator_init(bcast_iter, n, jcp.mb, g, jcp.ngroups, oh_dw,
                         jcp_dw->oh);
                 if (oh_dw == 0) oh_1x1 = 0; // Reset over mb boundary
-                const int oh_1x1_range
+                const dim_t oh_1x1_range
                         = oh_dw * jcp_dw->stride_h - jcp_dw->t_pad;
-                const int oh_1x1_begin = nstl::max(oh_1x1_range, 0);
-                const int oh_1x1_end
-                        = nstl::min(oh_1x1_range + jcp_dw->kh, jcp.oh);
+                const dim_t oh_1x1_begin = nstl::max<dim_t>(oh_1x1_range, 0);
+                const dim_t oh_1x1_end
+                        = nstl::min<dim_t>(oh_1x1_range + jcp_dw->kh, jcp.oh);
                 oh_1x1 = nstl::max(
                         oh_1x1_begin, oh_1x1); // Skip rows computed previously
 
                 // dw_spatial to 1x1 spatial conversion. if jcp.oh != jcp_dw->oh
-                const int bcast_start_1x1
+                const dim_t bcast_start_1x1
                         = n * jcp.ngroups * jcp.oh + g * jcp.oh + oh_1x1;
-                const int bcast_end_1x1 = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
+                const dim_t bcast_end_1x1
+                        = bcast_start_1x1 - oh_1x1 + oh_1x1_end;
 
                 conv_1x1(bcast_start_1x1, bcast_end_1x1, ocb_start,
                         ocb_start + load_step);
@@ -473,10 +479,10 @@ void jit_uni_x8s8s32x_1x1_convolution_fwd_t<isa>::execute_forward_thr(
     if (jcp.with_dw_conv) {
         conv_dw();
     } else {
-        int bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
+        dim_t bcast_start {0}, bcast_end {0}, ocb_start {0}, ocb_end {0};
         balance2D(nthr, ithr, work_amount, bcast_start, bcast_end,
                 jcp.nb_load / jcp.nb_load_chunk, ocb_start, ocb_end,
-                jcp.load_grp_count);
+                static_cast<dim_t>(jcp.load_grp_count));
         if (jcp.nb_load_chunk > 1) {
             ocb_start *= jcp.nb_load_chunk;
             ocb_end *= jcp.nb_load_chunk;

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_convolution.hpp
@@ -314,8 +314,8 @@ struct jit_uni_x8s8s32x_1x1_convolution_fwd_t : public primitive_t {
             while (jcp_1x1.nb_load_blocking % jcp_dw_->nb_ch_blocking != 0)
                 --jcp_dw_->nb_ch_blocking;
 
-            jcp_dw_->dw_conv_buffer_oc
-                    = jcp_1x1.nb_load_blocking * jcp_1x1.oc_block;
+            jcp_dw_->dw_conv_buffer_oc = static_cast<int>(
+                    jcp_1x1.nb_load_blocking * jcp_1x1.oc_block);
             jcp_1x1.bcast_loop_output_step = jcp_1x1.ur
                     * (jcp_1x1.nb_load_blocking * jcp_1x1.oc_block)
                     * jcp_1x1.typesize_out;

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.cpp
@@ -141,7 +141,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
             iterate(nb_oc_block, ur_w, last_oc_block_flag,
                     oc_blk_is_smaller_than_vmm,
                     [&](const bool mask_flag, const int k, const int j) {
-                const size_t aux_output_offset = jcp.typesize_out
+                const dim_t aux_output_offset = jcp.typesize_out
                         * (k * oc_block
                                 + j * jcp.oc_without_padding * jcp.ngroups);
                 const auto vmm_idx = vmm_out_idx(j, k);
@@ -168,9 +168,10 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         int ur_w, bool last_oc_block_flag) {
-    int nb_oc_block
+    const int nb_oc_block
             = jcp.is_depthwise ? jcp.nb_ch_blocking : jcp.nb_oc_blocking;
-    int oc_block = jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
+    const int oc_block
+            = static_cast<int>(jcp.is_depthwise ? jcp.ch_block : jcp.oc_block);
 
     mov(reg_bias, ptr[param1 + GET_OFF(bias)]);
     if (jcp.signed_input)
@@ -184,14 +185,15 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
 
     for (int k = 0; k < nb_oc_block; ++k) {
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
-        const int load_size = mask_flag ? get_tail_size() : get_blocking_size();
+        const int load_size = static_cast<int>(
+                mask_flag ? get_tail_size() : get_blocking_size());
         if (jcp.signed_input) {
-            const int comp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * k * oc_block;
             load_data(data_type::s32, vmm_comp, reg_compensation, comp_offset,
                     load_size);
         }
         if (jcp.src_zero_point) {
-            const int zp_offset = sizeof(int32_t) * k * oc_block;
+            const dim_t zp_offset = sizeof(int32_t) * k * oc_block;
             load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation,
                     zp_offset, load_size);
             uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_zp);
@@ -224,7 +226,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
             if (!jcp.is_oc_scale) {
                 uni_vbroadcastss(vmm_scales_tmp, ptr[reg_wei_scales]);
             } else {
-                int scale_offset
+                const dim_t scale_offset
                         = jcp.is_oc_scale * (sizeof(float) * k * oc_block);
                 if (mask_flag) {
                     load_data(data_type::s32, vmm_scales_tmp, reg_wei_scales,
@@ -259,8 +261,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         // temporary vector register for scales. Load bias data into it after
         // scales are processed.
         if (jcp.with_bias) {
-            int bias_offset = jcp.typesize_bia * k * oc_block;
-            cvt2ps(jcp.bia_dt, vmm_bias, reg_bias, bias_offset, load_size);
+            const dim_t bias_offset = jcp.typesize_bia * k * oc_block;
+            cvt2ps(jcp.bia_dt, vmm_bias, reg_bias,
+                    static_cast<int>(bias_offset), load_size);
         }
 
         for (int j = 0; j < ur_w; ++j) {
@@ -351,17 +354,19 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         const bool mask_flag = last_oc_block_flag && k == nb_oc_block - 1;
         for (int j = 0; j < ur_w; ++j) {
             Vmm r_vmm = vmm_out(j, k);
-            int aux_output_offset = jcp.typesize_out
+            const dim_t aux_output_offset = jcp.typesize_out
                     * (k * oc_block + j * jcp.oc_without_padding * jcp.ngroups);
             store_data(jcp.dst_dt, r_vmm, reg_out, aux_output_offset,
-                    mask_flag ? get_tail_size() : get_blocking_size());
+                    static_cast<int>(
+                            mask_flag ? get_tail_size() : get_blocking_size()));
         }
     }
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
 
     if (!(utils::one_of(isa, avx2) && std::is_same<Vmm, Xbyak::Ymm>::value)
             && !(utils::one_of(isa, sse41)
@@ -376,11 +381,11 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
         uni_vpbroadcastd(vmm_zp, ptr[reg_src_zero_point]);
     }
 
-    auto input_spatial_index = [this, pad_l](int oi, int ki) {
+    auto input_spatial_index = [this, pad_l](dim_t oi, int ki) -> dim_t {
         return (ki * (jcp.dilate_w + 1) + oi * jcp.stride_w - pad_l);
     };
 
-    auto input_offset2 = [this](int ii, int ci) {
+    auto input_offset2 = [this](dim_t ii, int ci) -> dim_t {
         if (jcp.is_fused_conv)
             return jcp.typesize_in
                     * (ii * jcp.dw_conv_buffer_oc + ci * jcp.ch_block);
@@ -389,11 +394,11 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
     };
 
     auto input_offset3 = [this, input_offset2, input_spatial_index](
-                                 int oi, int ci, int ki) {
+                                 dim_t oi, int ci, int ki) {
         return jcp.typesize_in * input_offset2(input_spatial_index(oi, ki), ci);
     };
 
-    auto kernel_offset = [this](int ci, int ki) {
+    auto kernel_offset = [this](int ci, int ki) -> dim_t {
         return jcp.typesize_in * ((ci * jcp.kh * jcp.kw + ki) * jcp.ch_block);
     };
 
@@ -407,16 +412,16 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
         }
     };
 
-    int ii_start = 0;
-    int ii_end = -1;
+    dim_t ii_start = 0;
+    dim_t ii_end = -1;
     if (jcp.is_resrc_depthwise && !h_padded) {
         // find bounds of input spatial indices
         bool first = true;
         for (int ki = 0; ki < jcp.kw; ++ki) {
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
-            for (int oi = oi_start; oi < oi_end; ++oi) {
-                int ii = input_spatial_index(oi, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
+            for (dim_t oi = oi_start; oi < oi_end; ++oi) {
+                const dim_t ii = input_spatial_index(oi, ki);
                 if (first || ii < ii_start) ii_start = ii;
                 if (first || ii > ii_end) ii_end = ii;
                 first = false;
@@ -429,21 +434,23 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
                 && ci == jcp.nb_ch_blocking - 1;
         if (jcp.is_resrc_depthwise && !h_padded) {
             // now we can load input once and reuse up to jcp.kw times
-            for (int ii = ii_start; ii <= ii_end; ++ii) {
-                int aux_input_offset = input_offset2(ii, ci);
-                const Vmm vmm_inp_tmp = vmm_inp(ii, jcp.nb_ch_blocking);
+            for (dim_t ii = ii_start; ii <= ii_end; ++ii) {
+                dim_t aux_input_offset = input_offset2(ii, ci);
+                const Vmm vmm_inp_tmp
+                        = vmm_inp(static_cast<int>(ii), jcp.nb_ch_blocking);
 
                 load_data(data_type::u8, vmm_inp_tmp, aux_reg_inp,
                         aux_input_offset,
-                        mask_flag ? get_tail_size() : get_blocking_size());
+                        static_cast<int>(mask_flag ? get_tail_size()
+                                                   : get_blocking_size()));
                 if (jcp.signed_input)
                     uni_vpaddb(vmm_inp_tmp, vmm_inp_tmp, vmm_shift);
             }
         }
         for (int ki = 0; ki < jcp.kw; ++ki) {
-            int aux_kernel_offset = kernel_offset(ci, ki);
-            int oi_start = get_ow_start(ki, pad_l);
-            int oi_end = get_ow_end(ur_w, ki, pad_r);
+            dim_t aux_kernel_offset = kernel_offset(ci, ki);
+            const dim_t oi_start = get_ow_start(ki, pad_l);
+            const dim_t oi_end = get_ow_end(ur_w, ki, pad_r);
 
             if (compute_kernel) {
                 uni_vpmovsxbd(vmm_wei, ptr[aux_reg_ker + aux_kernel_offset]);
@@ -452,28 +459,32 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
                     for (int oi = 0; oi < ur_w; ++oi)
                         compute(vmm_out(oi, ci), vmm_wei, vmm_shift);
                 } else {
-                    int start = jcp.signed_input ? 0 : oi_start;
-                    int end = jcp.signed_input ? ur_w : oi_end;
-                    for (int oi = start; oi < end; ++oi) {
+                    const dim_t start = jcp.signed_input ? 0 : oi_start;
+                    const dim_t end = jcp.signed_input ? ur_w : oi_end;
+                    for (dim_t oi = start; oi < end; ++oi) {
                         if (oi >= oi_start && oi < oi_end) {
                             if (jcp.is_resrc_depthwise) {
-                                int ii = input_spatial_index(oi, ki);
-                                vmm_dw_src = vmm_inp(ii, jcp.nb_ch_blocking);
+                                const dim_t ii = input_spatial_index(oi, ki);
+                                vmm_dw_src = vmm_inp(static_cast<int>(ii),
+                                        jcp.nb_ch_blocking);
                             } else {
-                                int aux_input_offset
+                                const dim_t aux_input_offset
                                         = input_offset3(oi, ci, ki);
                                 load_data(data_type::u8, vmm_dw_src,
                                         aux_reg_inp, aux_input_offset,
-                                        mask_flag ? get_tail_size()
-                                                  : get_blocking_size());
+                                        static_cast<int>(mask_flag
+                                                        ? get_tail_size()
+                                                        : get_blocking_size()));
                                 if (jcp.signed_input)
                                     uni_vpaddb(
                                             vmm_dw_src, vmm_dw_src, vmm_shift);
                             }
-                            compute(vmm_out(oi, ci), vmm_wei, vmm_dw_src);
+                            compute(vmm_out(static_cast<int>(oi), ci), vmm_wei,
+                                    vmm_dw_src);
                         } else {
                             assert(jcp.signed_input);
-                            compute(vmm_out(oi, ci), vmm_wei, vmm_shift);
+                            compute(vmm_out(static_cast<int>(oi), ci), vmm_wei,
+                                    vmm_shift);
                         }
                     }
                 }
@@ -502,17 +513,19 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker_dw(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
-        int pad_l, int pad_r, ic_block_t last_ic_block_flag, bool h_padded) {
+        dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag,
+        bool h_padded) {
     if (jcp.is_depthwise)
         return compute_ker_dw(ur_w, pad_l, pad_r, last_ic_block_flag, h_padded);
 
-    int kw = jcp.kw;
-    int stride_w = jcp.stride_w;
-    int ic_block = jcp.ic_block;
-    int oc_block = jcp.oc_block;
-    int ch_block_all = jcp.ch_block * ic_block * oc_block;
+    const dim_t kw = jcp.kw;
+    const dim_t stride_w = jcp.stride_w;
+    const int ic_block = static_cast<int>(jcp.ic_block);
+    const int oc_block = static_cast<int>(jcp.oc_block);
+    const int ch_block_all
+            = static_cast<int>(jcp.ch_block * ic_block * oc_block);
 
-    int nb_oc_block = jcp.nb_oc_blocking;
+    const int nb_oc_block = jcp.nb_oc_blocking;
 
     const bool compute_kernel = IMPLICATION(h_padded, jcp.signed_input);
 
@@ -523,14 +536,15 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
         mov(reg_src_zero_point, ptr[param1 + GET_OFF(src_zero_point)]);
     }
 
-    auto input_offset = [this, stride_w, pad_l](int oi, int ic, int ki) {
+    auto input_offset
+            = [this, stride_w, pad_l](dim_t oi, int ic, int ki) -> dim_t {
         return jcp.typesize_in
                 * ((ki * (jcp.dilate_w + 1) + oi * stride_w - pad_l)
                                 * jcp.ic_without_padding * jcp.ngroups
                         + ic_sub_step * ic);
     };
     auto kernel_offset
-            = [this, ch_block_all, oc_block](int ii, int ic, int ki) {
+            = [this, ch_block_all, oc_block](int ii, int ic, int ki) -> dim_t {
         return jcp.typesize_in
                 * ((ii * jcp.nb_ic * jcp.kd * jcp.kh * jcp.kw + ki)
                                 * ch_block_all
@@ -547,18 +561,19 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
     };
 
     for (int ki = 0; ki < kw; ++ki) {
-        const int ow_start = get_ow_start(ki, pad_l);
-        const int ow_end = get_ow_end(ur_w, ki, pad_r);
+        const dim_t ow_start = get_ow_start(ki, pad_l);
+        const dim_t ow_end = get_ow_end(ur_w, ki, pad_r);
         const int ic_tail_size = jcp.ic_without_padding % ic_sub_step;
 
-        const int _start = jcp.signed_input ? 0 : ow_start;
-        const int _end = jcp.signed_input ? ur_w : ow_end;
+        const dim_t _start = jcp.signed_input ? 0 : ow_start;
+        const dim_t _end = jcp.signed_input ? ur_w : ow_end;
 
         /* Skip the last loads of input
             if (ic % 8) / ic_sub_step < ic_block / ic_sub_step */
-        const int icb = (last_ic_block_flag != no_last_block)
-                ? div_up((jcp.ic_without_padding % ic_block), ic_sub_step)
-                : ic_block / ic_sub_step;
+        const int icb = static_cast<int>((last_ic_block_flag != no_last_block)
+                        ? div_up((jcp.ic_without_padding % ic_block),
+                                  ic_sub_step)
+                        : ic_block / ic_sub_step);
 
         if (compute_kernel) {
             for (int ic = 0; ic < icb; ++ic) {
@@ -569,45 +584,54 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                         uni_vmovups(inp, vmm_shift);
                     }
                 } else {
-                    for (int jj = _start; jj < _end; ++jj) {
-                        int aux_input_offset = input_offset(jj, ic, ki);
+                    for (dim_t jj = _start; jj < _end; ++jj) {
+                        dim_t aux_input_offset = input_offset(jj, ic, ki);
                         if (jj >= ow_start && jj < ow_end) {
                             const bool need_partial_ic_bcast = true
                                     && last_ic_block_flag == last_sp_block
                                     && ic_tail_size != 0 && ic == icb - 1;
 
                             if (need_partial_ic_bcast) {
-                                const auto inp_bcastd_vmm
-                                        = vmm_inp(jj, nb_oc_block);
+                                const auto inp_bcastd_vmm = vmm_inp(
+                                        static_cast<int>(jj), nb_oc_block);
                                 const auto inp_bcastd
                                         = Xmm(inp_bcastd_vmm.getIdx());
                                 load_bytes(inp_bcastd_vmm, aux_reg_inp,
                                         aux_input_offset, ic_tail_size);
-                                uni_vpbroadcastd(
-                                        vmm_inp(jj, nb_oc_block), inp_bcastd);
+                                uni_vpbroadcastd(vmm_inp(static_cast<int>(jj),
+                                                         nb_oc_block),
+                                        inp_bcastd);
                             } else {
-                                uni_vpbroadcastd(vmm_inp(jj, nb_oc_block),
+                                uni_vpbroadcastd(vmm_inp(static_cast<int>(jj),
+                                                         nb_oc_block),
                                         ptr[aux_reg_inp + aux_input_offset]);
                             }
                             if (jcp.signed_input)
-                                uni_vpaddb(vmm_inp(jj, nb_oc_block),
-                                        vmm_inp(jj, nb_oc_block), vmm_shift);
+                                uni_vpaddb(vmm_inp(static_cast<int>(jj),
+                                                   nb_oc_block),
+                                        vmm_inp(static_cast<int>(jj),
+                                                nb_oc_block),
+                                        vmm_shift);
                         } else {
                             // fill padded area with shifted value in
                             // first iteration
                             if (jcp.signed_input && ic == 0) {
-                                const Vmm inp = vmm_inp(jj, nb_oc_block);
+                                const Vmm inp = vmm_inp(
+                                        static_cast<int>(jj), nb_oc_block);
                                 uni_vmovups(inp, vmm_shift);
                             }
                         }
                     }
                 }
                 for (int ii = 0; ii < nb_oc_block; ++ii) {
-                    const int aux_kernel_offset = kernel_offset(ii, ic, ki);
+                    const dim_t aux_kernel_offset = kernel_offset(ii, ic, ki);
                     uni_vmovdqu(vmm_wei, ptr[aux_reg_ker + aux_kernel_offset]);
-                    for (int jj = _start; jj < _end; ++jj) {
-                        const Vmm inp = vmm_inp(h_padded ? 0 : jj, nb_oc_block);
-                        compute(vmm_out(jj, ii), vmm_wei, inp);
+                    for (dim_t jj = _start; jj < _end; ++jj) {
+                        const Vmm inp
+                                = vmm_inp(static_cast<int>(h_padded ? 0 : jj),
+                                        nb_oc_block);
+                        compute(vmm_out(static_cast<int>(jj), ii), vmm_wei,
+                                inp);
                     }
                 }
             }
@@ -622,7 +646,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                     for (int ii = 0; ii < nb_oc_block; ii++) {
                         uni_vpxor(vmm_tmp, vmm_tmp, vmm_tmp);
                         for (int ic = 0; ic < icb; ic++) {
-                            const int aux_kernel_offset
+                            const dim_t aux_kernel_offset
                                     = kernel_offset(ii, ic, ki);
                             if (jcp.has_vnni) {
                                 vpdpbusd(vmm_tmp, vmm_zp_one,
@@ -647,7 +671,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
-        int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag) {
+        int ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag) {
 
     Label kd_label, kh_label, skip_kd_loop, skip_kh_loop;
     Label f_overflow_label, no_f_overflow_label, d_h_f_overflow_label,
@@ -655,9 +679,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
             no_b_overflow_label, back_overflow_label, no_back_overflow_label,
             d_h_back_overflow_label;
 
-    int ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
-    int shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
-    int shift_input_ptr
+    const dim_t ch_block_all = jcp.ch_block * jcp.ic_block * jcp.oc_block;
+    const dim_t shift_kernel_ptr = jcp.typesize_in * jcp.kw * ch_block_all;
+    const dim_t shift_input_ptr
             = jcp.typesize_in * jcp.iw * jcp.ic_without_padding * jcp.ngroups;
 
     if (jcp.src_zero_point && !jcp.is_depthwise) {
@@ -804,7 +828,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
-        int ur_w, int pad_l, int pad_r, bool is_last_sp_block) {
+        int ur_w, dim_t pad_l, dim_t pad_r, bool is_last_sp_block) {
     prepare_output(ur_w);
 
     // IC loop
@@ -837,7 +861,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
     }
     // End of IC Loop
     if (do_icb_loop) {
-        int inp_step = jcp.ic_block;
+        const int inp_step = static_cast<int>(jcp.ic_block);
         const size_t ker_step = (size_t)jcp.kd * jcp.kh * jcp.kw * jcp.oc_block
                 * jcp.ic_block;
         add(reg_inp, jcp.typesize_in * inp_step);
@@ -877,17 +901,20 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     Label permute_index_table;
-    int in_ic_shift = jcp.is_fused_conv ? jcp.dw_conv_buffer_oc
-                                        : jcp.ic_without_padding * jcp.ngroups;
-    const int urw_inp_stride = jcp.ur_w * jcp.stride_w;
-    const int n_urw_l_pad = nstl::min(
-            div_up(nstl::max(0, jcp.l_pad), urw_inp_stride), jcp.ow / jcp.ur_w);
-    const int inp_shift_pad = nstl::max(0,
+    int in_ic_shift = static_cast<int>(jcp.is_fused_conv
+                    ? jcp.dw_conv_buffer_oc
+                    : jcp.ic_without_padding * jcp.ngroups);
+    const int urw_inp_stride = static_cast<int>(jcp.ur_w * jcp.stride_w);
+    const int n_urw_l_pad = static_cast<int>(nstl::min<dim_t>(
+            div_up(nstl::max<dim_t>(0, jcp.l_pad), urw_inp_stride),
+            jcp.ow / jcp.ur_w));
+    const int inp_shift_pad = static_cast<int>(nstl::max<dim_t>(0,
             jcp.typesize_in * (n_urw_l_pad * urw_inp_stride - jcp.l_pad)
-                    * in_ic_shift);
-    int inp_shift = jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift);
-    int out_shift = jcp.typesize_out
-            * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups);
+                    * in_ic_shift));
+    int inp_shift = static_cast<int>(
+            jcp.typesize_in * (jcp.ur_w * jcp.stride_w * in_ic_shift));
+    int out_shift = static_cast<int>(jcp.typesize_out
+            * (jcp.ur_w * jcp.oc_without_padding * jcp.ngroups));
     preamble();
 
     if (jcp.is_depthwise) {
@@ -936,19 +963,20 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
         mov(reg_oc_blocks, ptr[param1 + GET_OFF(oc_blocks)]);
     }
 
-    const int extended_filter_size
-            = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int r_pad = nstl::max(0, jcp.r_pad);
+    const int extended_filter_size = static_cast<int>(
+            calculate_extended_filter_size(jcp.kw, jcp.dilate_w));
+    const int r_pad = static_cast<int>(nstl::max<dim_t>(0, jcp.r_pad));
     const int ow_with_no_rpad = 1
-            + (jcp.iw + jcp.l_pad + nstl::min(0, jcp.r_pad)
-                      - extended_filter_size)
-                    / jcp.stride_w;
-    const int n_urw_per_ow_block = jcp.ow_block / jcp.ur_w;
-    const int max_safe_iw = nstl::max(0,
+            + static_cast<int>(
+                    (jcp.iw + jcp.l_pad + nstl::min<dim_t>(0, jcp.r_pad)
+                            - extended_filter_size)
+                    / jcp.stride_w);
+    const int n_urw_per_ow_block = static_cast<int>(jcp.ow_block / jcp.ur_w);
+    const int max_safe_iw = static_cast<int>(nstl::max<dim_t>(0,
             jcp.iw
                     - div_up(static_cast<int>(ic_sub_step),
-                            jcp.ic_without_padding));
-    const int max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
+                            jcp.ic_without_padding)));
+    const dim_t max_safe_ow = jcp.ic_without_padding % ic_sub_step == 0
             ? jcp.ow
             : (max_safe_iw + jcp.l_pad - extended_filter_size) / jcp.stride_w;
     Label middle_block_label, done_compute;
@@ -1009,13 +1037,14 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
         // middle_region:
         int n_urw_middle_block_loop = 0;
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_ow + jcp.ur_w <= jcp.ow && cur_r_pad == 0) {
             n_urw_middle_block_loop
-                    = nstl::max(0,
-                              nstl::min(ow_with_no_rpad, max_safe_ow) - cur_ow)
+                    = static_cast<int>(nstl::max<dim_t>(0,
+                              nstl::min<dim_t>(ow_with_no_rpad, max_safe_ow)
+                                      - cur_ow))
                     / jcp.ur_w;
             cur_ow += n_urw_middle_block_loop * jcp.ur_w;
         }
@@ -1025,8 +1054,8 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
         // r_pad or last_sp_block
         if (cur_ow + jcp.ur_w <= jcp.ow) {
             if (r_pad_fall_through_n_urw == 0) ++n_labels;
-            const int n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
-            n_labels += nstl::max(0,
+            const dim_t n_urw_r_pad_region = (jcp.ow - cur_ow) / jcp.ur_w;
+            n_labels += nstl::max<dim_t>(0,
                     div_up(r_pad_fall_through_n_urw + n_urw_r_pad_region,
                             n_urw_per_ow_block)
                             - 1);
@@ -1053,9 +1082,10 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
             L(middle_or_rpad_check);
             // harness passes shifted src pointer that does not take
             // left-padding into account. So, we must re-shift here.
-            const int inp_shift_pad_middle_block = -1 * jcp.typesize_in
-                    * nstl::min(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
-                    * in_ic_shift;
+            const int inp_shift_pad_middle_block = static_cast<int>(-1
+                    * jcp.typesize_in
+                    * nstl::min<dim_t>(jcp.l_pad, n_urw_l_pad * urw_inp_stride)
+                    * in_ic_shift);
             add(reg_inp, inp_shift_pad_middle_block);
         }
         if (r_pad_fall_through_n_urw != 0) {
@@ -1098,7 +1128,7 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     int label_cntr = 0;
     int cur_l_pad = 0;
     if (jcp.l_pad > 0) {
-        for (cur_l_pad = jcp.l_pad;
+        for (cur_l_pad = static_cast<int>(jcp.l_pad);
                 cur_l_pad > 0 && cur_ow + jcp.ur_w <= jcp.ow;
                 cur_l_pad -= urw_inp_stride) {
             if (jcp.nb_ow > 1 && cur_n_oi == 0) {
@@ -1114,9 +1144,9 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
             }
 
             cur_ow += jcp.ur_w;
-            int cur_r_pad = nstl::max(0,
+            int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                     calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                            jcp.stride_w, extended_filter_size));
+                            jcp.stride_w, extended_filter_size)));
             icb_loop(jcp.ur_w, cur_l_pad, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_out, out_shift);
             dec(reg_oi);
@@ -1136,13 +1166,14 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
 
     // middle_block
     {
-        int cur_r_pad = nstl::max(0,
+        int cur_r_pad = static_cast<int>(nstl::max<dim_t>(0,
                 calculate_end_padding(jcp.l_pad, cur_ow + jcp.ur_w, jcp.iw,
-                        jcp.stride_w, extended_filter_size));
+                        jcp.stride_w, extended_filter_size)));
         if (cur_r_pad == 0 && cur_ow + jcp.ur_w <= jcp.ow) {
             int n_oi_middle_block_loop
-                    = nstl::max(0,
-                              nstl::min(ow_with_no_rpad, max_safe_ow) - cur_ow)
+                    = static_cast<int>(nstl::max<dim_t>(0,
+                              nstl::min<dim_t>(ow_with_no_rpad, max_safe_ow)
+                                      - cur_ow))
                     / jcp.ur_w;
             if (jcp.nb_ow == 1 && n_oi_middle_block_loop > 1)
                 mov(reg_oi, n_oi_middle_block_loop);
@@ -1179,8 +1210,8 @@ void jit_uni_x8s8s32x_fwd_kernel_vmm_t<isa, Vmm>::generate() {
                 L(ow_block_jmp_table[label_cntr++]);
             }
             cur_ow += jcp.ur_w;
-            int cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow, jcp.iw,
-                    jcp.stride_w, extended_filter_size);
+            const dim_t cur_r_pad = calculate_end_padding(jcp.l_pad, cur_ow,
+                    jcp.iw, jcp.stride_w, extended_filter_size);
             assert(cur_r_pad > 0 || cur_ow > max_safe_ow); // else, why be here?
             icb_loop(jcp.ur_w, 0, cur_r_pad, cur_ow > max_safe_ow);
             add(reg_inp, inp_shift);
@@ -1291,9 +1322,9 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     jcp.dilate_h = is_1d ? 0 : cd.dilates[ndims - 4];
     jcp.dilate_w = cd.dilates[ndims - 3];
 
-    int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.ow, jcp.iw, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -1472,10 +1503,13 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
             {eltwise, binary, sum}, jcp.post_ops, &dst_d, false, false, false));
     VDISPATCH_CONV_IC(post_ops_ok_, VERBOSE_UNSUPPORTED_POSTOP);
 
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_ic = jcp.ic / jcp.ic_block;
@@ -1492,7 +1526,8 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     // factor smaller than the left padding (special requirement for SSD:fc6),
     // then search for a smaller OC blocking that satisfies both constraints.
     auto is_oc_blocking_ok = [&](int block) {
-        int ur_w = nstl::min(jcp.ow, jcp.max_regs_ur / (block + 1));
+        int ur_w = static_cast<int>(
+                nstl::min<dim_t>(jcp.ow, jcp.max_regs_ur / (block + 1)));
         return jcp.nb_oc % block == 0 && jcp.l_pad <= ur_w
                 && jcp.ow % ur_w != 1;
     };
@@ -1500,28 +1535,28 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     // choose nb_oc work chunk size for distribution within threads
     int max_threading_nb_oc_chunk = 4;
 
-    jcp.nb_oc_blocking_thr_chunk
-            = nstl::min(max_threading_nb_oc_chunk, jcp.nb_oc);
+    jcp.nb_oc_blocking_thr_chunk = static_cast<int>(
+            nstl::min<dim_t>(max_threading_nb_oc_chunk, jcp.nb_oc));
     for (; jcp.nb_oc_blocking_thr_chunk > 1; --jcp.nb_oc_blocking_thr_chunk) {
         if (is_oc_blocking_ok(jcp.nb_oc_blocking_thr_chunk)) break;
     }
 
-    auto get_thr_eff = [&](int nb_ow, int nthr) {
-        int base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
+    auto get_thr_eff = [&](dim_t nb_ow, int nthr) {
+        const dim_t base_work_amount = jcp.mb * jcp.nb_ch * jcp.od * jcp.oh
                 * (jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk);
-        auto work_amount = base_work_amount * nb_ow;
-        return float(work_amount) / rnd_up(work_amount, nthr);
+        const dim_t work_amount = base_work_amount * nb_ow;
+        return float(work_amount) / float(rnd_up(work_amount, nthr));
     };
 
     auto get_ow_block = [&jcp, get_thr_eff](int ur_w, int nthr) {
-        int res_ow_block = jcp.ow;
+        dim_t res_ow_block = jcp.ow;
         float best_thr_eff = get_thr_eff(1, nthr);
         float thr_eff;
 
-        int max_nb_ow = div_up(jcp.ow, ur_w);
-        for (int nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
-            int ow_block
-                    = nstl::min(rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
+        const dim_t max_nb_ow = div_up(jcp.ow, ur_w);
+        for (dim_t nb_ow = 1; nb_ow <= max_nb_ow; nb_ow++) {
+            const dim_t ow_block = nstl::min<dim_t>(
+                    rnd_up(div_up(jcp.ow, nb_ow), ur_w), jcp.ow);
             if (ow_block < jcp.nb_oc_blocking_thr_chunk * jcp.oc_block
                     && best_thr_eff > 0.8f)
                 break;
@@ -1533,20 +1568,20 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
             }
             if (best_thr_eff > 0.9f) break;
         }
-        return res_ow_block;
+        return static_cast<int>(res_ow_block);
     };
 
     // choose oc blocking for computational kernel
     jcp.nb_oc_blocking = jcp.nb_oc_blocking_thr_chunk;
 
     if (jcp.is_resrc_depthwise)
-        jcp.ur_w = (jcp.max_regs_ur - jcp.kw + jcp.stride_w)
-                / (jcp.nb_ch_blocking + jcp.stride_w);
+        jcp.ur_w = static_cast<int>((jcp.max_regs_ur - jcp.kw + jcp.stride_w)
+                / (jcp.nb_ch_blocking + jcp.stride_w));
     else
         jcp.ur_w = jcp.max_regs_ur
                 / (jcp.is_depthwise ? jcp.nb_ch_blocking
                                     : jcp.nb_oc_blocking + 1);
-    if (jcp.ow < jcp.ur_w) jcp.ur_w = jcp.ow;
+    if (jcp.ow < jcp.ur_w) jcp.ur_w = static_cast<int>(jcp.ow);
     jcp.ur_w_tail = jcp.ow % jcp.ur_w;
 
     jcp.ow_block = jcp.ow;
@@ -1568,10 +1603,10 @@ status_t jit_uni_x8s8s32x_fwd_kernel_t<isa>::init_conf(jit_conv_conf_t &jcp,
     const unsigned int L1_cache_size = platform::get_per_core_cache_size(1);
 
     if (jcp.ngroups < jcp.nthr && (total_size < L1_cache_size)) {
-        int ow_block = jcp.ow_block;
+        int ow_block = static_cast<int>(jcp.ow_block);
         float best_thr_eff = thr_eff;
         float eff = -1.0f;
-        int end_nthr = with_groups ? jcp.ngroups : 1;
+        const int end_nthr = with_groups ? static_cast<int>(jcp.ngroups) : 1;
         for (int nthr = jcp.nthr / 2; nthr >= end_nthr; nthr--) {
             ow_block = get_ow_block(jcp.ur_w, nthr);
             eff = get_thr_eff(div_up(jcp.ow, ow_block), nthr);

--- a/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_conv_kernel.hpp
@@ -147,33 +147,37 @@ private:
         assert(idx < ker_max_reg);
         return Vmm(ker_max_reg - idx);
     }
-    int get_ow_start(int ki, int pad_l) {
+    dim_t get_ow_start(dim_t ki, dim_t pad_l) {
         return utils::div_up(
-                nstl::max(0, pad_l - ki * (jcp.dilate_w + 1)), jcp.stride_w);
+                nstl::max<dim_t>(0, pad_l - ki * (jcp.dilate_w + 1)),
+                jcp.stride_w);
     }
-    int get_ow_end(int ur_w, int ki, int pad_r) {
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t pad_r) {
         return ur_w
                 - utils::div_up(
-                        nstl::max(0,
+                        nstl::max<dim_t>(0,
                                 pad_r - (jcp.kw - 1 - ki) * (jcp.dilate_w + 1)),
                         jcp.stride_w);
     }
-    int get_blocking_size() {
+    dim_t get_blocking_size() {
         return jcp.is_depthwise ? jcp.ch_block : jcp.oc_block;
     }
     int get_tail_size() {
-        return jcp.is_depthwise ? jcp.ngroups % jcp.ch_block
-                                : jcp.oc_without_padding % jcp.oc_block;
+        return static_cast<int>(jcp.is_depthwise
+                        ? jcp.ngroups % jcp.ch_block
+                        : jcp.oc_without_padding % jcp.oc_block);
     }
 
     void prepare_output(int ur_w);
     void store_output(int ur_w, bool last_oc_block_flag);
-    void compute_ker_dw(int ur_w, int pad_l, int pad_r,
+    void compute_ker_dw(int ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded);
-    void compute_ker(int ur_w, int pad_l, int pad_r,
+    void compute_ker(int ur_w, dim_t pad_l, dim_t pad_r,
             ic_block_t last_ic_block_flag, bool h_padded = false);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ic_block_t last_ic_block_flag);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool is_last_spatial_block);
+    void kh_loop(
+            int ur_w, dim_t pad_l, dim_t pad_r, ic_block_t last_ic_block_flag);
+    void icb_loop(
+            int ur_w, dim_t pad_l, dim_t pad_r, bool is_last_spatial_block);
     void generate() override;
 
     void cvt2ps(data_type_t type_in, const Vmm &vmm_in, const Xbyak::Reg64 &reg,
@@ -188,7 +192,8 @@ struct jit_uni_x8s8s32x_fwd_kernel_t {
     jit_uni_x8s8s32x_fwd_kernel_t(const jit_conv_conf_t &ajcp,
             const primitive_attr_t &attr, const memory_desc_t &dst_md)
         : kernel_(nullptr) {
-        int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+        const dim_t ch_block
+                = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
         switch (ch_block) {
             case 8:
                 if (utils::one_of(isa, avx2)) {

--- a/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_convolution.cpp
@@ -85,12 +85,13 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
+            = jcp.mb * nb_groups * oc_chunks * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -110,7 +111,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -129,18 +130,19 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
         while (start < end) {
             for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                const dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
+                const dim_t ow_s = owb * jcp.ow_block;
+                const dim_t iw_s = ow_s * jcp.stride_w;
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -152,17 +154,17 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d(
                 auto src_w = src + src_d.blk_off(n, g_ic, ih_s, iw_s);
                 auto wht_w = weights + wht_blk_off(weights_d, g, ocb, 0);
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow = nstl::min(
-                            jcp.kh, div_up(nstl::max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0,
+                    const dim_t dilate_h = jcp.dilate_h + 1;
+                    const dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(nstl::max<dim_t>(0, -ij), dilate_h));
+                    const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(nstl::max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    const dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     const size_t wei_stride
@@ -269,12 +271,12 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
                     + (jcp.signed_input ? ch_offset : 0)
             : nullptr;
 
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
-    int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
+    const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.nb_ow;
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -290,7 +292,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, gg {0}, occ {0}, owb {0};
+        dim_t n {0}, gg {0}, occ {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, gg,
@@ -311,13 +313,13 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_1d(
             default: assert(!"unsupported loop order");
         }
         while (start < end) {
-            int ocb = occ * jcp.nb_oc_blocking;
-            int gb = gg * jcp.nb_ch_blocking;
-            int g = gb * group_block;
-            int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
-            int g_ic = g * jcp.nb_ic * jcp.ic_block;
-            int ow_s = owb * jcp.ow_block;
-            int iw_s = ow_s * jcp.stride_w;
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t gb = gg * jcp.nb_ch_blocking;
+            const dim_t g = gb * group_block;
+            const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+            const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
+            const dim_t ow_s = owb * jcp.ow_block;
+            const dim_t iw_s = ow_s * jcp.stride_w;
 
             p.bias = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                           : nullptr;
@@ -419,8 +421,8 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.nb_ch * jcp.ch_block : 0)
             : nullptr;
-    int nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
-    int group_block = jcp.ch_block;
+    const dim_t nb_groups = jcp.nb_ch / jcp.nb_ch_blocking;
+    const dim_t group_block = jcp.ch_block;
 
     parallel_nd(jcp.mb, jcp.oh, jcp.nb_ow, nb_groups,
             [= COMPAT_THIS_CAPTURE](dim_t n, dim_t oh_s, dim_t owb, dim_t gg) {
@@ -429,12 +431,12 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
         size_t src_h_stride = src_d.blk_off(0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
 
-        int gb = gg * jcp.nb_ch_blocking;
-        int g = gb * group_block;
+        const dim_t gb = gg * jcp.nb_ch_blocking;
+        const dim_t g = gb * group_block;
 
-        int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-        int ow_s = owb * jcp.ow_block;
-        int iw_s = ow_s * jcp.stride_w;
+        const dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+        const dim_t ow_s = owb * jcp.ow_block;
+        const dim_t iw_s = ow_s * jcp.stride_w;
 
         auto bias_w = bias ? bias + (bias_d.blk_off(g) * bia_dt_size) : nullptr;
         const int32_t *compensation_w
@@ -459,14 +461,15 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_2d_dw(
                 ? static_cast<const float *>(wei_scales) + jcp.is_oc_scale * g
                 : nullptr;
 
-        int dilate_h = jcp.dilate_h + 1;
-        int i_t_overflow
-                = nstl::min(jcp.kh, div_up(nstl::max(0, -ih_s), dilate_h));
-        int i_b_overflow = nstl::min(jcp.kh,
-                div_up(nstl::max(
+        const dim_t dilate_h = jcp.dilate_h + 1;
+        const dim_t i_t_overflow = nstl::min<dim_t>(
+                jcp.kh, div_up(nstl::max<dim_t>(0, -ih_s), dilate_h));
+        const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                div_up(nstl::max<dim_t>(
                                0, ih_s - jcp.ih + (jcp.kh - 1) * dilate_h + 1),
                         dilate_h));
-        int kh_padding = nstl::max(0, jcp.kh - i_t_overflow - i_b_overflow);
+        const dim_t kh_padding
+                = nstl::max<dim_t>(0, jcp.kh - i_t_overflow - i_b_overflow);
 
         size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)
                 ? 0
@@ -542,13 +545,13 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
             ? reinterpret_cast<int32_t *>(&w[offset])
                     + (jcp.signed_input ? jcp.ngroups * jcp.oc : 0)
             : nullptr;
-    int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
-    int nb_groups = jcp.nb_ch;
-    int work_amount
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking_thr_chunk;
+    const dim_t nb_groups = jcp.nb_ch;
+    const dim_t work_amount
             = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh * jcp.nb_ow;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
+        dim_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_conv_args_t();
@@ -570,7 +573,7 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
         size_t wht_d_stride = wht_blk_off(weights_d, 0, 0, 0, 1);
         size_t wht_h_stride = wht_blk_off(weights_d, 0, 0, 0, 0, 1);
 
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0}, owb {0};
         switch (jcp.loop_order) {
             case loop_cwgn:
                 nd_iterator_init(start, occ, oc_chunks, owb, jcp.nb_ow, g,
@@ -589,30 +592,31 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
         while (start < end) {
             for (int occ1 = 0; occ1 < jcp.nb_oc_blocking_thr_chunk;
                     occ1 += jcp.nb_oc_blocking) {
-                int ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
-                int g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
+                const dim_t ocb = occ * jcp.nb_oc_blocking_thr_chunk + occ1;
+                const dim_t g_oc = (g * jcp.nb_oc + ocb) * jcp.oc_block;
 
-                int g_ic = g * jcp.nb_ic * jcp.ic_block;
+                const dim_t g_ic = g * jcp.nb_ic * jcp.ic_block;
 
-                int work_rem = end - start;
-                int ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
-                int oh_e = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
+                const dim_t work_rem = end - start;
+                dim_t ih_s = -jcp.t_pad + oh_s * jcp.stride_h;
+                dim_t oh_e
+                        = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
                 if (jcp.loop_order == loop_nhwcg)
                     oh_e = oh_s + 1; // step instead
-                int ow_s = owb * jcp.ow_block;
-                int iw_s = ow_s * jcp.stride_w;
-                int id_s = -jcp.f_pad + od_s * jcp.stride_d;
-                int dilate_d = jcp.dilate_d + 1;
-                int d_f_overflow = nstl::min(
-                        jcp.kd, div_up(nstl::max(0, -id_s), dilate_d));
-                int d_back_overflow = nstl::min(jcp.kd,
-                        div_up(nstl::max(0,
+                const dim_t ow_s = owb * jcp.ow_block;
+                const dim_t iw_s = ow_s * jcp.stride_w;
+                const dim_t id_s = -jcp.f_pad + od_s * jcp.stride_d;
+                const dim_t dilate_d = jcp.dilate_d + 1;
+                const dim_t d_f_overflow = nstl::min<dim_t>(
+                        jcp.kd, div_up(nstl::max<dim_t>(0, -id_s), dilate_d));
+                const dim_t d_back_overflow = nstl::min<dim_t>(jcp.kd,
+                        div_up(nstl::max<dim_t>(0,
                                        id_s - jcp.id + (jcp.kd - 1) * dilate_d
                                                + 1),
                                 dilate_d));
 
-                int kd_padding
-                        = nstl::max(0, jcp.kd - d_f_overflow - d_back_overflow);
+                const dim_t kd_padding = nstl::max<dim_t>(
+                        0, jcp.kd - d_f_overflow - d_back_overflow);
 
                 auto bias_w = bias ? bias + (bias_d.blk_off(g_oc) * bia_dt_size)
                                    : nullptr;
@@ -634,17 +638,17 @@ status_t jit_uni_x8s8s32x_convolution_fwd_t<isa>::execute_forward_3d(
                                           : d_f_overflow)
                                 * wht_d_stride;
 
-                for (int oj = oh_s, ij = ih_s; oj < oh_e;
+                for (dim_t oj = oh_s, ij = ih_s; oj < oh_e;
                         ++oj, ij += jcp.stride_h) {
-                    int dilate_h = jcp.dilate_h + 1;
-                    int i_t_overflow = nstl::min(
-                            jcp.kh, div_up(nstl::max(0, -ij), dilate_h));
-                    int i_b_overflow = nstl::min(jcp.kh,
-                            div_up(nstl::max(0,
+                    const dim_t dilate_h = jcp.dilate_h + 1;
+                    const dim_t i_t_overflow = nstl::min<dim_t>(
+                            jcp.kh, div_up(nstl::max<dim_t>(0, -ij), dilate_h));
+                    const dim_t i_b_overflow = nstl::min<dim_t>(jcp.kh,
+                            div_up(nstl::max<dim_t>(0,
                                            ij - jcp.ih + (jcp.kh - 1) * dilate_h
                                                    + 1),
                                     dilate_h));
-                    int kh_padding = nstl::max(
+                    const dim_t kh_padding = nstl::max<dim_t>(
                             0, jcp.kh - i_t_overflow - i_b_overflow);
 
                     size_t wei_stride = (jcp.signed_input || jcp.src_zero_point)

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -239,9 +239,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
             VERBOSE_UNSUPPORTED_FEATURE,
             "unsupported shape with 'stride = 1' when 'dilate > 0'");
 
-    const int ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
-    const int ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
-    const int ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
+    const dim_t ext_kw = calculate_extended_filter_size(jcp.kw, jcp.dilate_w);
+    const dim_t ext_kh = calculate_extended_filter_size(jcp.kh, jcp.dilate_h);
+    const dim_t ext_kd = calculate_extended_filter_size(jcp.kd, jcp.dilate_d);
     jcp.r_pad = calculate_end_padding(
             jcp.l_pad, jcp.iw, jcp.ow, jcp.stride_w, ext_kw);
     jcp.b_pad = calculate_end_padding(
@@ -280,10 +280,13 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
 
     jcp.dst_dt = dst_d.data_type();
     jcp.bia_dt = jcp.with_bias ? bias_d.data_type() : data_type::undef;
-    jcp.typesize_bia
-            = jcp.with_bias ? types::data_type_size(bias_d.data_type()) : 0;
-    jcp.typesize_in = types::data_type_size(src_d.data_type());
-    jcp.typesize_out = types::data_type_size(dst_d.data_type());
+    jcp.typesize_bia = jcp.with_bias
+            ? static_cast<int>(types::data_type_size(bias_d.data_type()))
+            : 0;
+    jcp.typesize_in
+            = static_cast<int>(types::data_type_size(src_d.data_type()));
+    jcp.typesize_out
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     jcp.nb_ch = div_up(jcp.ngroups, jcp.ch_block);
     jcp.nb_oc = jcp.oc / jcp.oc_block;
@@ -293,18 +296,18 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
     const int regs = jcp.has_vnni ? 14 : 12;
 
     jcp.nb_ch_blocking = 1;
-    jcp.nb_oc_blocking = nstl::min(4, jcp.nb_oc);
+    jcp.nb_oc_blocking = static_cast<int>(nstl::min<dim_t>(4, jcp.nb_oc));
     for (; jcp.nb_oc_blocking > 1; jcp.nb_oc_blocking--)
         if (jcp.nb_oc % jcp.nb_oc_blocking == 0
                 && jcp.l_pad <= regs / (jcp.nb_oc_blocking + 1))
             break;
 
     jcp.ur_w = regs / (jcp.nb_oc_blocking + 1);
-    const int l_overflow = max(
+    const dim_t l_overflow = max<dim_t>(
             0, ((jcp.kw - 1) * (jcp.dilate_w + 1) - jcp.l_pad) / jcp.stride_w);
 
     if (jcp.ow < jcp.ur_w) {
-        jcp.ur_w = jcp.ow;
+        jcp.ur_w = static_cast<int>(jcp.ow);
         jcp.ur_w_tail = 0;
     } else {
         for (; jcp.ur_w >= 1; jcp.ur_w--) {
@@ -318,9 +321,9 @@ status_t jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::init_conf(
             const bool left_boundary_covered
                     = jcp.ur_w >= l_overflow * jcp.stride_w;
             jcp.ur_w_tail = jcp.ow % jcp.ur_w;
-            const int r_overflow_no_tail = max(0,
-                    ((jcp.kw - 1) * (jcp.dilate_w + 1) - max(0, jcp.r_pad)
-                            - jcp.ur_w_tail)
+            const dim_t r_overflow_no_tail = max<dim_t>(0,
+                    ((jcp.kw - 1) * (jcp.dilate_w + 1)
+                            - max<dim_t>(0, jcp.r_pad) - jcp.ur_w_tail)
                             / jcp.stride_w);
             const bool right_boundary_covered
                     = jcp.ur_w >= r_overflow_no_tail * jcp.stride_w;
@@ -358,7 +361,7 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_t<isa>::jit_uni_x8s8s32x_deconv_fwd_kernel_t(
         const memory_desc_wrapper &dst_d)
     : kernel_(nullptr) {
 
-    const int ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
+    const dim_t ch_block = ajcp.is_depthwise ? ajcp.ch_block : ajcp.ic_block;
     switch (ch_block) {
         case 8:
             if (isa == avx2) {
@@ -456,25 +459,25 @@ jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 Vmm jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::vmm_out(
-        int i_ur, int i_oc) const {
-    const int idx = i_ur * jcp_.nb_oc_blocking + i_oc;
+        dim_t i_ur, dim_t i_oc) const {
+    const dim_t idx = i_ur * jcp_.nb_oc_blocking + i_oc;
     assert(idx < ker_max_regs_);
     /* remap the reg indices to avoid using xmm0 in eltwise injector */
-    return Vmm(15 - idx);
+    return Vmm(15 - static_cast<int>(idx));
 }
 
 template <cpu_isa_t isa, typename Vmm>
 Vmm jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::vmm_inp(
-        int i_ic, int nb_x_blocking) const {
-    const int idx = i_ic + nb_x_blocking * jcp_.ur_w;
+        dim_t i_ic, dim_t nb_x_blocking) const {
+    const dim_t idx = i_ic + nb_x_blocking * jcp_.ur_w;
     assert(idx < ker_max_regs_);
-    return Vmm(15 - idx);
+    return Vmm(15 - static_cast<int>(idx));
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
-        int ki, int l_overflow) const noexcept {
-    int res = (jcp_.ow - 1 + jcp_.r_pad) % jcp_.stride_w
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
+        dim_t ki, dim_t l_overflow) const noexcept {
+    dim_t res = (jcp_.ow - 1 + jcp_.r_pad) % jcp_.stride_w
             + l_overflow * jcp_.stride_w
             - (jcp_.kw - 1 - ki) * (jcp_.dilate_w + 1);
     while (res < 0)
@@ -483,11 +486,11 @@ int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_start(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
-        int ur_w, int ki, int r_overflow) const noexcept {
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
+        dim_t ur_w, dim_t ki, dim_t r_overflow) const noexcept {
     if (utils::one_of(ur_w, jcp_.ow, jcp_.ur_w_tail))
-        ur_w += nstl::min(0, jcp_.r_pad); // remove negative padding
-    int res = (ur_w - 1 + jcp_.l_pad) % jcp_.stride_w
+        ur_w += nstl::min<dim_t>(0, jcp_.r_pad); // remove negative padding
+    dim_t res = (ur_w - 1 + jcp_.l_pad) % jcp_.stride_w
             + r_overflow * jcp_.stride_w - ki * (jcp_.dilate_w + 1);
     while (res < 0)
         res += jcp_.stride_w;
@@ -495,13 +498,13 @@ int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_ow_end(
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_blocking_size()
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_blocking_size()
         const noexcept {
     return jcp_.is_depthwise ? jcp_.ch_block : jcp_.oc_block;
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_tail_size()
+dim_t jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::get_tail_size()
         const noexcept {
     return jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
                              : jcp_.oc_without_padding % jcp_.oc_block;
@@ -526,7 +529,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute(
 
 template <cpu_isa_t isa, typename Vmm>
 std::function<Vmm()> jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::prepare_round_robin_vmm_inp_generator(int ur_w) const noexcept {
+        Vmm>::prepare_round_robin_vmm_inp_generator(dim_t ur_w) const noexcept {
 
     const int start_vmm_idx = vmm_inp(ur_w - 1, jcp_.nb_oc_blocking).getIdx();
     const int end_vmm_idx = vmm_inp(0, jcp_.nb_oc_blocking).getIdx() + 1;
@@ -543,8 +546,8 @@ std::function<Vmm()> jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::apply_zp_src_pad_str_comp(int ur_w, int l_overflow,
-        int r_overflow, bool h_padded) {
+        Vmm>::apply_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+        dim_t r_overflow, bool h_padded) {
     Xbyak::Label end_zp_pad, no_tail;
 
     // apply once per icb loop, zp src stride paddding compensation calculate as
@@ -574,8 +577,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
-        Vmm>::append_zp_src_pad_str_comp(int ur_w, int l_overflow,
-        int r_overflow, bool h_padded, bool last_oc_block) {
+        Vmm>::append_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+        dim_t r_overflow, bool h_padded, bool last_oc_block) {
 
     const auto &reg_zp_src_pad_comp = reg_scratch_;
     const auto get_next_comp_vmm = prepare_round_robin_vmm_inp_generator(ur_w);
@@ -597,35 +600,35 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 
     const auto load_zp_src_pad_comp
             = [&](const Vmm zp_pad_comp_vmm, const Xbyak::Address &comp_addr,
-                      const int ocb) {
+                      const dim_t ocb) {
         const bool is_tail = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
 
         if (is_tail)
             load_data(data_type::s32, zp_pad_comp_vmm, comp_addr,
-                    get_tail_size());
+                    static_cast<int>(get_tail_size()));
         else
             uni_vmovups(zp_pad_comp_vmm, comp_addr);
     };
 
-    const auto get_zp_src_comp_pad_off = [&](int it_kw, int ocb) {
-        const auto kw_offset = it_kw * jcp_.oc_without_padding * jcp_.ngroups;
-        const auto oc_offset = ocb * jcp_.oc_block;
+    const auto get_zp_src_comp_pad_off = [&](dim_t it_kw, dim_t ocb) {
+        const dim_t kw_offset = it_kw * jcp_.oc_without_padding * jcp_.ngroups;
+        const dim_t oc_offset = ocb * jcp_.oc_block;
 
         return (kw_offset + oc_offset) * sizeof(int32_t);
     };
 
-    for (int it_kw = 0; it_kw < jcp_.kw; ++it_kw) {
-        const int ow_start = get_ow_start(it_kw, l_overflow);
-        const int ow_end = get_ow_end(ur_w, it_kw, r_overflow);
+    for (dim_t it_kw = 0; it_kw < jcp_.kw; ++it_kw) {
+        const dim_t ow_start = get_ow_start(it_kw, l_overflow);
+        const dim_t ow_end = get_ow_end(ur_w, it_kw, r_overflow);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
             Vmm zp_src_comp_pad_vmm; // will be assigned later
             bool ocb_zp_loaded = false;
 
             const auto zp_src_comp_pad_off
                     = get_zp_src_comp_pad_off(it_kw, ocb);
 
-            for (int it_ow = 0; it_ow < ur_w; ++it_ow) {
+            for (dim_t it_ow = 0; it_ow < ur_w; ++it_ow) {
 
                 const bool inside_padded_area = h_padded
                         || !(it_ow >= ow_start && it_ow < ow_end
@@ -666,17 +669,17 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
-        int l_overflow, int r_overflow, ker_block_t last_ic_block_flag,
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(dim_t ur_w,
+        dim_t l_overflow, dim_t r_overflow, ker_block_t last_ic_block_flag,
         bool h_padded) {
 
     const bool signed_input_or_src_zp
             = (jcp_.signed_input || jcp_.src_zero_point);
 
-    const int ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
-    const int ur_w_stride = signed_input_or_src_zp ? 1 : jcp_.stride_w;
+    const dim_t ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
+    const dim_t ur_w_stride = signed_input_or_src_zp ? 1 : jcp_.stride_w;
 
-    const auto src_offset = [this](int oj, int icb, int ki) {
+    const auto src_offset = [this](dim_t oj, dim_t icb, dim_t ki) {
         return jcp_.typesize_in
                 * (((oj + jcp_.l_pad - ki * (jcp_.dilate_w + 1))
                            / jcp_.stride_w)
@@ -684,24 +687,25 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                         + icb * 4);
     };
 
-    const auto kernel_offset = [this, ch_block_all](int ocb, int icb, int ki) {
+    const auto kernel_offset
+            = [this, ch_block_all](dim_t ocb, dim_t icb, dim_t ki) {
         return jcp_.typesize_in
                 * ((ocb * jcp_.nb_ic * jcp_.kd * jcp_.kh * jcp_.kw + ki)
                                 * ch_block_all
                         + icb * jcp_.oc_block * IC_SUB_STEP);
     };
 
-    for (int ki = 0; ki < jcp_.kw; ki++) {
+    for (dim_t ki = 0; ki < jcp_.kw; ki++) {
 
-        const int jj_start = get_ow_start(ki, l_overflow);
-        const int jj_end = get_ow_end(ur_w, ki, r_overflow);
+        const dim_t jj_start = get_ow_start(ki, l_overflow);
+        const dim_t jj_end = get_ow_end(ur_w, ki, r_overflow);
 
-        const int _start = (signed_input_or_src_zp) ? 0 : jj_start;
-        const int _end = (signed_input_or_src_zp) ? ur_w : jj_end;
+        const dim_t _start = (signed_input_or_src_zp) ? 0 : jj_start;
+        const dim_t _end = (signed_input_or_src_zp) ? ur_w : jj_end;
 
-        const int tail_size = jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
-                                                : jcp_.ic_without_padding % 4;
-        const int n_ic_blocks = jcp_.is_depthwise
+        const dim_t tail_size = jcp_.is_depthwise ? jcp_.ngroups % jcp_.ch_block
+                                                  : jcp_.ic_without_padding % 4;
+        const dim_t n_ic_blocks = jcp_.is_depthwise
                 ? 1
                 : (last_ic_block_flag != no_last_block
                                   ? div_up(jcp_.ic_without_padding
@@ -709,7 +713,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                             4)
                                   : jcp_.ic_block / 4);
 
-        for (int icb1 = 0; icb1 < n_ic_blocks; icb1++) {
+        for (dim_t icb1 = 0; icb1 < n_ic_blocks; icb1++) {
             if (h_padded) {
                 /* fill padded area with shifted values */
                 if (jcp_.signed_input) {
@@ -719,9 +723,9 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                 }
             } else {
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
-                    const int aux_src_off = src_offset(jj, icb1, ki);
+                    const dim_t aux_src_off = src_offset(jj, icb1, ki);
                     const auto vmm_src = vmm_inp(jj, jcp_.nb_oc_blocking);
 
                     if (jj >= jj_start && jj < jj_end
@@ -734,12 +738,14 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                     && tail_size;
                             load_data(data_type::u8, vmm_src, aux_reg_src_,
                                     aux_src_off,
-                                    mask_flag ? tail_size : jcp_.ch_block);
+                                    static_cast<int>(mask_flag
+                                                    ? tail_size
+                                                    : jcp_.ch_block));
                         } else if ((last_ic_block_flag == last_sp_block)
                                 && tail_size != 0 && icb1 == n_ic_blocks - 1) {
                             const auto vmm_inp_tmp = Xmm(vmm_src.getIdx());
                             load_bytes(vmm_inp_tmp, aux_reg_src_, aux_src_off,
-                                    tail_size);
+                                    static_cast<int>(tail_size));
                             uni_vpbroadcastd(vmm_src, vmm_inp_tmp);
                         } else {
                             uni_vpbroadcastd(
@@ -756,8 +762,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                     }
                 }
             }
-            for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-                const int aux_filt_off = kernel_offset(ocb, icb1, ki);
+            for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+                const dim_t aux_filt_off = kernel_offset(ocb, icb1, ki);
 
                 if (_end - _start > 0) {
                     if (jcp_.is_depthwise) {
@@ -768,7 +774,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
                                 vmm_wei_, ptr[aux_reg_filt_ + aux_filt_off]);
                 }
 
-                for (int jj = _start; jj < _end; jj += ur_w_stride) {
+                for (dim_t jj = _start; jj < _end; jj += ur_w_stride) {
 
                     const bool inside_padded_area = h_padded
                             || !(jj >= jj_start && jj < jj_end
@@ -790,22 +796,22 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::compute_ker(int ur_w,
 }
 
 template <cpu_isa_t isa, typename Vmm>
-void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
-        int l_overflow, int r_overflow, ker_block_t last_ic_block_flag) {
+void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(dim_t ur_w,
+        dim_t l_overflow, dim_t r_overflow, ker_block_t last_ic_block_flag) {
 
     const bool signed_input_or_src_zp
             = (jcp_.signed_input || jcp_.src_zero_point);
 
-    const int ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
-    const int shift_src_ih = jcp_.typesize_in * (jcp_.dilate_h + 1) * jcp_.iw
+    const dim_t ch_block_all = jcp_.ch_block * jcp_.ic_block * jcp_.oc_block;
+    const dim_t shift_src_ih = jcp_.typesize_in * (jcp_.dilate_h + 1) * jcp_.iw
             * jcp_.ngroups * jcp_.ic_without_padding;
-    const int shift_src_id = jcp_.typesize_in * (jcp_.dilate_d + 1) * jcp_.ih
+    const dim_t shift_src_id = jcp_.typesize_in * (jcp_.dilate_d + 1) * jcp_.ih
             * jcp_.iw * jcp_.ngroups * jcp_.ic_without_padding;
-    const int stride_h = signed_input_or_src_zp ? 1 : jcp_.stride_h;
-    const int shift_filt_kh
+    const dim_t stride_h = signed_input_or_src_zp ? 1 : jcp_.stride_h;
+    const dim_t shift_filt_kh
             = jcp_.typesize_in * jcp_.kw * ch_block_all * stride_h;
-    const int stride_d = signed_input_or_src_zp ? 1 : jcp_.stride_d;
-    const int shift_filt_kd
+    const dim_t stride_d = signed_input_or_src_zp ? 1 : jcp_.stride_d;
+    const dim_t shift_filt_kd
             = jcp_.typesize_in * jcp_.kw * ch_block_all * jcp_.kh * stride_d;
 
     Label kd_loop_label, kh_loop_label, skip_kh_loop, skip_kd_loop;
@@ -848,7 +854,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
                 || ((!signed_input_or_src_zp)
                         && ((min(jcp_.f_pad, jcp_.back_pad) < 0)
                                 || ((jcp_.kd - 1) * (jcp_.dilate_d + 1)
-                                        < nstl::max(
+                                        < nstl::max<dim_t>(
                                                 jcp_.f_pad, jcp_.back_pad))))) {
             cmp(reg_ki_, 0);
             je(skip_kd_loop, T_NEAR);
@@ -886,7 +892,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
             || ((!signed_input_or_src_zp)
                     && ((min(jcp_.t_pad, jcp_.b_pad) < 0)
                             || ((jcp_.kh - 1) * (jcp_.dilate_h + 1)
-                                    < nstl::max(jcp_.t_pad, jcp_.b_pad))))) {
+                                    < nstl::max<dim_t>(
+                                            jcp_.t_pad, jcp_.b_pad))))) {
         cmp(reg_kh_, 0);
         je(skip_kh_loop, T_NEAR);
     }
@@ -989,9 +996,9 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::kh_loop(int ur_w,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::prepare_output(
-        int ur_w) {
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-        for (int ur = 0; ur < ur_w; ur++) {
+        dim_t ur_w) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const Vmm vmm = vmm_out(ur, ocb);
             uni_vpxor(vmm, vmm, vmm);
         }
@@ -1006,23 +1013,23 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::prepare_output(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::cvt2ps(
-        data_type_t type_in, const Vmm vmm_in, const Reg64 reg, int offset,
-        int load_size) {
+        data_type_t type_in, const Vmm vmm_in, const Reg64 reg, dim_t offset,
+        dim_t load_size) {
 
-    load_data(type_in, vmm_in, reg, offset, load_size);
+    load_data(type_in, vmm_in, reg, offset, static_cast<int>(load_size));
     if (type_in != data_type::f32) uni_vcvtdq2ps(vmm_in, vmm_in);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
-        int ur_w, bool last_oc_block) {
+        dim_t ur_w, bool last_oc_block) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
     // Sum post-op requires binary parameters to be set.
     if (jcp_.with_binary || jcp_.with_sum) {
         for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
             const bool mask_flag
                     = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-            for (int ur = 0; ur < ur_w; ur++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const int vmm_idx = vmm_out(ur, ocb).getIdx();
                 const size_t aux_output_offset = jcp_.typesize_out
                         * (ocb * jcp_.oc_block
@@ -1035,15 +1042,15 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::apply_postops(
             }
         }
     }
-    const int nb_oc_block
+    const dim_t nb_oc_block
             = jcp_.is_depthwise ? jcp_.nb_ch_blocking : jcp_.nb_oc_blocking;
     postops_injector_->compute_vector_range(
-            16 - nb_oc_block * ur_w, 16, rhs_arg_params);
+            static_cast<int>(16 - nb_oc_block * ur_w), 16, rhs_arg_params);
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
-        int ur_w, bool last_oc_block) {
+        dim_t ur_w, bool last_oc_block) {
     mov(reg_bias_, ptr[param1_ + GET_OFF(bias)]);
 
     if (jcp_.signed_input)
@@ -1059,24 +1066,24 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         const auto &vmm_zp_comp = vmm_scales_;
         uni_vbroadcastss(vmm_src_zp, ptr[reg_zp_src_]);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            const int zp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            const dim_t zp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
             const bool mask_flag
                     = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-            const int load_size
+            const dim_t load_size
                     = mask_flag ? get_tail_size() : get_blocking_size();
             load_data(data_type::s32, vmm_zp_comp, reg_zp_compensation_,
-                    zp_offset, load_size);
+                    zp_offset, static_cast<int>(load_size));
             uni_vpmulld(vmm_zp_comp, vmm_zp_comp, vmm_src_zp);
 
-            for (int ur = 0; ur < ur_w; ur++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const auto vmm_dst = vmm_out(ur, ocb);
                 uni_vpaddd(vmm_dst, vmm_dst, vmm_zp_comp);
             }
         }
     }
 
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
 
         // TODO: scales support is done not in the most optimal way.
@@ -1107,7 +1114,7 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
             if (!jcp_.is_oc_scale) {
                 uni_vbroadcastss(vmm_scales_tmp_, ptr[reg_wei_scales_]);
             } else {
-                const int scale_offset = jcp_.is_oc_scale
+                const dim_t scale_offset = jcp_.is_oc_scale
                         * (sizeof(float) * ocb * jcp_.oc_block);
                 if (mask_flag) {
                     uni_vpxor(
@@ -1145,18 +1152,18 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         // after scales are processed.
         const auto vmm_bias_ = vmm_tmp_;
         if (jcp_.with_bias) {
-            int bias_offset = jcp_.typesize_bia * ocb * jcp_.oc_block;
+            dim_t bias_offset = jcp_.typesize_bia * ocb * jcp_.oc_block;
             cvt2ps(jcp_.bia_dt, vmm_bias_, reg_bias_, bias_offset,
                     mask_flag ? get_tail_size() : get_blocking_size());
         }
 
         if (jcp_.signed_input) {
-            const int comp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
+            const dim_t comp_offset = sizeof(int32_t) * ocb * jcp_.oc_block;
             cvt2ps(data_type::s32, vmm_comp_, reg_compensation_, comp_offset,
                     mask_flag ? get_tail_size() : get_blocking_size());
         }
 
-        for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const Vmm vmm = vmm_out(ur, ocb);
             uni_vcvtdq2ps(vmm, vmm);
             if (jcp_.signed_input) uni_vaddps(vmm, vmm, vmm_comp_);
@@ -1174,8 +1181,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         mov(reg_dst_scales_, ptr[param1_ + GET_OFF(dst_scales)]);
         uni_vbroadcastss(vmm_dst_scales_, ptr[reg_dst_scales_]);
 
-        for_(int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
-        for (int ur = 0; ur < ur_w; ur++) {
+        for_(dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const auto vmm = vmm_out(ur, ocb);
             uni_vmulps(vmm, vmm, vmm_dst_scales_);
         }
@@ -1187,8 +1194,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         uni_vbroadcastss(vmm_zp_dst, ptr[reg_zp_dst_]);
         uni_vcvtdq2ps(vmm_zp_dst, vmm_zp_dst);
 
-        for_(int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
-        for (int ur = 0; ur < ur_w; ur++) {
+        for_(dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++)
+        for (dim_t ur = 0; ur < ur_w; ur++) {
             const auto vmm_dst = vmm_out(ur, ocb);
             uni_vaddps(vmm_dst, vmm_dst, vmm_zp_dst);
         }
@@ -1201,8 +1208,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     // saturation will happen when storing data
     if (jcp_.dst_dt == data_type::u8) {
         uni_vpxor(vmm_zero_, vmm_zero_, vmm_zero_);
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vmaxps(vmm, vmm, vmm_zero_);
             }
@@ -1216,8 +1223,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
         uni_vmovq(xmm_saturation, reg_ptr_saturation_ubound_);
         uni_vbroadcastss(vmm_saturation_, xmm_saturation);
 
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vminps(vmm, vmm, vmm_saturation_);
             }
@@ -1225,8 +1232,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     }
 
     if (one_of(jcp_.dst_dt, data_type::u8, data_type::s8, data_type::s32)) {
-        for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
-            for (int ur = 0; ur < ur_w; ur++) {
+        for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+            for (dim_t ur = 0; ur < ur_w; ur++) {
                 const Vmm vmm = vmm_out(ur, ocb);
                 uni_vcvtps2dq(vmm, vmm);
             }
@@ -1234,24 +1241,25 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::store_output(
     }
 
     /* write out register to output_addr */
-    for (int ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
+    for (dim_t ocb = 0; ocb < jcp_.nb_oc_blocking; ocb++) {
         const bool mask_flag = last_oc_block && ocb == jcp_.nb_oc_blocking - 1;
-        for (int ur = 0; ur < ur_w; ur++) {
-            const int aux_dst_off = jcp_.typesize_out
+        for (dim_t ur = 0; ur < ur_w; ur++) {
+            const dim_t aux_dst_off = jcp_.typesize_out
                     * (ur * jcp_.ngroups * jcp_.oc_without_padding
                             + ocb * jcp_.oc_block);
             const Vmm r_vmm = vmm_out(ur, ocb);
             store_data(jcp_.dst_dt, r_vmm, reg_dst_, aux_dst_off,
-                    mask_flag ? get_tail_size() : get_blocking_size());
+                    static_cast<int>(
+                            mask_flag ? get_tail_size() : get_blocking_size()));
         }
     }
 }
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::icb_loop(
-        int ur_w, int l_overflow, int r_overflow, bool is_last_sp_block) {
+        dim_t ur_w, dim_t l_overflow, dim_t r_overflow, bool is_last_sp_block) {
 
-    const int shift_src_icb = jcp_.typesize_in * jcp_.ic_block;
+    const dim_t shift_src_icb = jcp_.typesize_in * jcp_.ic_block;
     const size_t shift_filt_icb = (size_t)jcp_.typesize_in * jcp_.kd * jcp_.kh
             * jcp_.kw * jcp_.ic_block * jcp_.oc_block;
 
@@ -1343,22 +1351,22 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa, Vmm>::generate() {
     mov(reg_filt_, ptr[param1_ + GET_OFF(filt)]);
     mov(reg_dst_, ptr[param1_ + GET_OFF(dst)]);
 
-    const int dst_shift = jcp_.typesize_out * jcp_.ur_w * jcp_.ngroups
+    const dim_t dst_shift = jcp_.typesize_out * jcp_.ur_w * jcp_.ngroups
             * jcp_.oc_without_padding;
-    const int src_shift = jcp_.typesize_in * (jcp_.ur_w / jcp_.stride_w)
+    const dim_t src_shift = jcp_.typesize_in * (jcp_.ur_w / jcp_.stride_w)
             * jcp_.ngroups * jcp_.ic_without_padding;
 
-    const int l_overflow = max(0,
+    const dim_t l_overflow = max<dim_t>(0,
             ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - jcp_.l_pad) / jcp_.stride_w);
-    const int r_overflow = max(0,
-            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - max(0, jcp_.r_pad))
+    const dim_t r_overflow = max<dim_t>(0,
+            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - max<dim_t>(0, jcp_.r_pad))
                     / jcp_.stride_w);
 
-    const int r_overflow1 = nstl::max(0,
-            ((jcp_.kw - 1) * (jcp_.dilate_w + 1) - nstl::max(0, jcp_.r_pad)
-                    - jcp_.ur_w_tail)
+    const dim_t r_overflow1 = nstl::max<dim_t>(0,
+            ((jcp_.kw - 1) * (jcp_.dilate_w + 1)
+                    - nstl::max<dim_t>(0, jcp_.r_pad) - jcp_.ur_w_tail)
                     / jcp_.stride_w);
-    int nur_w = jcp_.ow / jcp_.ur_w;
+    dim_t nur_w = jcp_.ow / jcp_.ur_w;
     if (r_overflow1 > 0) nur_w--;
 
     if (jcp_.ur_w == jcp_.ow) {
@@ -1523,8 +1531,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const void *src_scales
             = CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC);
@@ -1544,8 +1552,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * nb_groups * oc_chunks;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1561,7 +1569,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
         }
 
-        int n {0}, g {0}, occ {0};
+        dim_t n {0}, g {0}, occ {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks);
         else if (jcp.loop_order == loop_cgn)
@@ -1570,10 +1578,10 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_1d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
 
             p.dst = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
             p.src = src + src_d.blk_off(n, g_ic);
@@ -1648,8 +1656,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t nb_groups = jcp.nb_ch;
 
     const size_t src_h_stride = src_d.blk_off(0, 0, 1);
     const size_t dst_h_stride = dst_d.blk_off(0, 0, 1);
@@ -1673,8 +1681,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        const int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
+        dim_t start {0}, end {0};
+        const dim_t work_amount = jcp.mb * nb_groups * oc_chunks * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1691,7 +1699,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     oh_s, jcp.oh);
@@ -1702,12 +1710,12 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
-            const int work_rem = end - start;
-            const int oh_e
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t work_rem = end - start;
+            const dim_t oh_e
                     = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
 
             const auto dst_w = dst + dst_dt_size * dst_d.blk_off(n, g_oc);
@@ -1719,17 +1727,18 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
             const int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    const int dilate_h = jcp.dilate_h + 1;
+                    const dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    const int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    const dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    const int o_b_overflow
-                            = div_up(max(0,
+                    const dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1737,15 +1746,16 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    const int o_t_overflow = max(
+                    const dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    const int o_b_overflow = max(0,
+                    const dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    const int overflow_kh_hi = jcp.kh - 1
+                    const dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    const int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    const dim_t overflow_kh_lo
+                            = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1753,21 +1763,21 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_2d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                const int wei_stride
+                const dim_t wei_stride
                         = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
                 p.src = src_w + ih_max * src_h_stride;
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
-                p.filt = wht_w + wei_stride;
+                p.filt = wht_w + static_cast<size_t>(wei_stride);
                 p.bias = bias_w;
                 p.compensation = compensation_w;
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
@@ -1837,8 +1847,8 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                 weights_d, weights, src_zero_points, zp_src_comp_scratch,
                 zp_src_pad_comp_kernel_.get());
 
-    const int oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
-    const int &nb_groups = jcp.nb_ch;
+    const dim_t oc_chunks = jcp.nb_oc / jcp.nb_oc_blocking;
+    const dim_t &nb_groups = jcp.nb_ch;
 
     const size_t src_d_stride = src_d.blk_off(0, 0, 1);
     const size_t src_h_stride = src_d.blk_off(0, 0, 0, 1);
@@ -1865,8 +1875,9 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             : nullptr;
 
     parallel(jcp.nthr, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
-        int start {0}, end {0};
-        int work_amount = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
+        dim_t start {0}, end {0};
+        const dim_t work_amount
+                = jcp.mb * nb_groups * oc_chunks * jcp.od * jcp.oh;
         balance211(work_amount, nthr, ithr, start, end);
 
         auto p = jit_deconv_args_t();
@@ -1883,7 +1894,7 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
         }
 
         /*loop order = cgn*/
-        int n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
+        dim_t n {0}, g {0}, occ {0}, od_s {0}, oh_s {0};
         if (jcp.loop_order == loop_ngc)
             nd_iterator_init(start, n, jcp.mb, g, nb_groups, occ, oc_chunks,
                     od_s, jcp.od, oh_s, jcp.oh);
@@ -1894,25 +1905,26 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             assert(!"unsupported loop order");
         while (start < end) {
 
-            const int ocb = occ * jcp.nb_oc_blocking;
-            const int g_oc
+            const dim_t ocb = occ * jcp.nb_oc_blocking;
+            const dim_t g_oc
                     = (g * jcp.ch_block * jcp.nb_oc + ocb) * jcp.oc_block;
-            const int g_ic = g * jcp.ch_block * jcp.ic;
-            const int work_rem = end - start;
-            const int oh_e
+            const dim_t g_ic = g * jcp.ch_block * jcp.ic;
+            const dim_t work_rem = end - start;
+            const dim_t oh_e
                     = oh_s + work_rem > jcp.oh ? jcp.oh : oh_s + work_rem;
-            int input_d_s = 0, kd_len = 0, kd_lo = 0;
-            int d_t_overflow, d_back_overflow;
+            dim_t input_d_s = 0, kd_len = 0, kd_lo = 0;
+            dim_t d_t_overflow, d_back_overflow;
 
             if (jcp.dilate_d != 0 && jcp.stride_d == 1) {
                 /* dilation */
-                int dilate_d = jcp.dilate_d + 1;
+                const dim_t dilate_d = jcp.dilate_d + 1;
                 // Note: use div_up to account for "holes" in filter
                 d_t_overflow = div_up(
-                        max(0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
+                        max<dim_t>(
+                                0, (jcp.kd - 1) * dilate_d - od_s - jcp.f_pad),
                         dilate_d);
                 d_back_overflow
-                        = div_up(max(0,
+                        = div_up(max<dim_t>(0,
                                          (jcp.kd - 1) * dilate_d + 1 - jcp.od
                                                  + od_s - jcp.back_pad),
                                 dilate_d);
@@ -1920,15 +1932,15 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                 kd_lo = d_back_overflow;
                 input_d_s = od_s + jcp.f_pad - d_back_overflow * dilate_d;
             } else {
-                const int d_t_overflow = max(
+                const dim_t d_t_overflow = max<dim_t>(
                         0, (jcp.kd - (od_s + 1 + jcp.f_pad)) / jcp.stride_d);
-                const int d_back_overflow = max(0,
+                const dim_t d_back_overflow = max<dim_t>(0,
                         ((od_s + jcp.kd) - (jcp.od + jcp.back_pad))
                                 / jcp.stride_d);
-                const int overflow_kd_hi = jcp.kd - 1
+                const dim_t overflow_kd_hi = jcp.kd - 1
                         - modulo(jcp.od + jcp.back_pad - (od_s + 1),
                                 jcp.stride_d);
-                const int overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
+                const dim_t overflow_kd_lo = (od_s + jcp.f_pad) % jcp.stride_d;
 
                 kd_len = (overflow_kd_hi - overflow_kd_lo) / jcp.stride_d + 1
                         - d_t_overflow - d_back_overflow;
@@ -1950,17 +1962,18 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
             const int32_t *compensation_w
                     = (jcp.signed_input) ? compensation + g_oc : nullptr;
 
-            for (int oj = oh_s; oj < oh_e; oj++) {
-                int ih_max = 0, kh_lo = 0, kh_len = 0;
+            for (dim_t oj = oh_s; oj < oh_e; oj++) {
+                dim_t ih_max = 0, kh_lo = 0, kh_len = 0;
                 if (jcp.dilate_h != 0 && jcp.stride_h == 1) {
                     /* dilation */
-                    const int dilate_h = jcp.dilate_h + 1;
+                    const dim_t dilate_h = jcp.dilate_h + 1;
                     // Note: use div_up to account for "holes" in filter
-                    const int o_t_overflow = div_up(
-                            max(0, (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
+                    const dim_t o_t_overflow = div_up(
+                            max<dim_t>(0,
+                                    (jcp.kh - 1) * dilate_h - oj - jcp.t_pad),
                             dilate_h);
-                    const int o_b_overflow
-                            = div_up(max(0,
+                    const dim_t o_b_overflow
+                            = div_up(max<dim_t>(0,
                                              (jcp.kh - 1) * dilate_h + 1
                                                      - jcp.oh + oj - jcp.b_pad),
                                     dilate_h);
@@ -1968,15 +1981,16 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                     kh_lo = o_b_overflow;
                     ih_max = oj + jcp.t_pad - o_b_overflow * dilate_h;
                 } else {
-                    const int o_t_overflow = max(
+                    const dim_t o_t_overflow = max<dim_t>(
                             0, (jcp.kh - (oj + 1 + jcp.t_pad)) / jcp.stride_h);
-                    const int o_b_overflow = max(0,
+                    const dim_t o_b_overflow = max<dim_t>(0,
                             ((oj + jcp.kh) - (jcp.oh + jcp.b_pad))
                                     / jcp.stride_h);
-                    const int overflow_kh_hi = jcp.kh - 1
+                    const dim_t overflow_kh_hi = jcp.kh - 1
                             - modulo(jcp.oh + jcp.b_pad - (oj + 1),
                                     jcp.stride_h);
-                    const int overflow_kh_lo = (oj + jcp.t_pad) % jcp.stride_h;
+                    const dim_t overflow_kh_lo
+                            = (oj + jcp.t_pad) % jcp.stride_h;
 
                     kh_len = (overflow_kh_hi - overflow_kh_lo) / jcp.stride_h
                             + 1 - o_t_overflow - o_b_overflow;
@@ -1984,32 +1998,32 @@ status_t jit_uni_x8s8s32x_deconvolution_fwd_t<isa>::execute_forward_3d(
                     ih_max = (oj + jcp.t_pad - kh_lo) / jcp.stride_h;
                 }
 
-                const int wei_stride
+                const dim_t wei_stride
                         = (!jcp.signed_input && !jcp.src_zero_point)
                         ? kh_lo * wht_kh_stride
                         : 0;
                 p.src = src_w + ih_max * src_h_stride;
                 p.dst = dst_w + dst_dt_size * oj * dst_h_stride;
-                p.filt = wht_w + wei_stride;
+                p.filt = wht_w + static_cast<size_t>(wei_stride);
                 p.bias = bias_w;
                 p.compensation = compensation_w;
                 /* Note: Currently this kernel doesn't support dilations and
                 strides together */
                 p.t_overflow = jcp.dilate_h > 0
                         ? jcp.kh - kh_len - kh_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kh
                                           - (kh_lo
-                                                  + max(0, kh_len - 1)
+                                                  + max<dim_t>(0, kh_len - 1)
                                                           * jcp.stride_h
                                                   + 1));
                 p.b_overflow = kh_lo;
                 p.f_overflow = jcp.dilate_d > 0
                         ? jcp.kd - kd_len - kd_lo
-                        : max(0,
+                        : max<dim_t>(0,
                                   jcp.kd
                                           - (kd_lo
-                                                  + max(0, kd_len - 1)
+                                                  + max<dim_t>(0, kd_len - 1)
                                                           * jcp.stride_d
                                                   + 1));
                 p.back_overflow = kd_lo;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.hpp
@@ -119,31 +119,32 @@ private:
     const Vmm vmm_comp_ = Vmm(1);
     const Vmm vmm_bias_ = vmm_zero_;
 
-    Vmm vmm_out(int i_ur, int i_oc) const;
-    Vmm vmm_inp(int i_ic, int nb_x_blocking) const;
+    Vmm vmm_out(dim_t i_ur, dim_t i_oc) const;
+    Vmm vmm_inp(dim_t i_ic, dim_t nb_x_blocking) const;
 
-    int get_ow_start(int ki, int l_overflow) const noexcept;
-    int get_ow_end(int ur_w, int ki, int r_overflow) const noexcept;
-    int get_blocking_size() const noexcept;
-    int get_tail_size() const noexcept;
+    dim_t get_ow_start(dim_t ki, dim_t l_overflow) const noexcept;
+    dim_t get_ow_end(dim_t ur_w, dim_t ki, dim_t r_overflow) const noexcept;
+    dim_t get_blocking_size() const noexcept;
+    dim_t get_tail_size() const noexcept;
 
-    void prepare_output(int ur_w);
-    void apply_postops(int ur_w, bool last_oc_block);
-    void store_output(int ur_w, bool last_oc_block);
-    void compute_ker(int ur_w, int l_overflow, int r_overflow,
+    void prepare_output(dim_t ur_w);
+    void apply_postops(dim_t ur_w, bool last_oc_block);
+    void store_output(dim_t ur_w, bool last_oc_block);
+    void compute_ker(dim_t ur_w, dim_t l_overflow, dim_t r_overflow,
             ker_block_t last_ic_block_flag, bool h_padded = false);
     void compute(const Vmm vreg_acc, const Vmm vreg_wei, const Vmm vreg_src);
     std::function<Vmm()> prepare_round_robin_vmm_inp_generator(
-            int ur_w) const noexcept;
+            dim_t ur_w) const noexcept;
     void apply_zp_src_pad_str_comp(
-            int ur_w, int l_overflow, int r_overflow, bool h_padded);
-    void append_zp_src_pad_str_comp(int ur_w, int l_overflow, int r_overflow,
-            bool h_padded, bool last_oc_block);
-    void kh_loop(int ur_w, int pad_l, int pad_r, ker_block_t last_ker_block);
-    void icb_loop(int ur_w, int pad_l, int pad_r, bool last_block);
+            dim_t ur_w, dim_t l_overflow, dim_t r_overflow, bool h_padded);
+    void append_zp_src_pad_str_comp(dim_t ur_w, dim_t l_overflow,
+            dim_t r_overflow, bool h_padded, bool last_oc_block);
+    void kh_loop(
+            dim_t ur_w, dim_t pad_l, dim_t pad_r, ker_block_t last_ker_block);
+    void icb_loop(dim_t ur_w, dim_t pad_l, dim_t pad_r, bool last_block);
     void generate() override;
     void cvt2ps(data_type_t type_in, const Vmm vmm_in, const Reg64 reg,
-            int offset, int load_size);
+            dim_t offset, dim_t load_size);
 };
 
 template <cpu_isa_t isa>


### PR DESCRIPTION
It's a conv (PR Nr.4) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
Total number of warnings 2939 => 1694. 
Depends on #5750 and #5776 .