### PR TITLE
cpu: pooling: eliminate implicit narrowings

### DIFF
--- a/src/cpu/nchw_pooling.cpp
+++ b/src/cpu/nchw_pooling.cpp
@@ -82,9 +82,10 @@ status_t nchw_pooling_fwd_t<data_type::f32>::execute_forward(
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[ws_offset] = value;
+                ws[ws_offset] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset] = value;
+                reinterpret_cast<int *>(ws)[ws_offset]
+                        = static_cast<int>(value);
         }
     };
 
@@ -284,9 +285,10 @@ status_t nchw_pooling_fwd_t<d_type>::execute_forward(
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[ws_offset] = value;
+                ws[ws_offset] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[ws_offset] = value;
+                reinterpret_cast<int *>(ws)[ws_offset]
+                        = static_cast<int>(value);
         }
     };
 

--- a/src/cpu/nchw_pooling.hpp
+++ b/src/cpu/nchw_pooling.hpp
@@ -183,7 +183,7 @@ struct nchw_pooling_bwd_t : public primitive_t {
 
         dim_t channel_block_size_ {1};
         int nthr_; // To not exceed the limit in execute used for set up.
-        int nbuf_ {0};
+        dim_t nbuf_ {0};
 
     private:
         void init_scratchpad() {

--- a/src/cpu/nhwc_pooling.cpp
+++ b/src/cpu/nhwc_pooling.cpp
@@ -82,7 +82,7 @@ void nhwc_pooling_fwd_t<d_type>::array_add(
 template <data_type_t d_type>
 void nhwc_pooling_fwd_t<d_type>::array_nhwc_max(const dim_t n, ker_data_t *dst,
         const ker_data_t *src, unsigned char *ws, const size_t ws_offset,
-        const data_type_t ws_dt, const int index) const {
+        const data_type_t ws_dt, const dim_t index) const {
     assert(ws);
 #if SAFE_TO_USE_OMP_SIMD
     PRAGMA_OMP_SIMD()

--- a/src/cpu/nhwc_pooling.hpp
+++ b/src/cpu/nhwc_pooling.hpp
@@ -140,7 +140,7 @@ private:
     void array_add(const dim_t n, const ker_data_t *src, ker_data_t *dst) const;
     void array_nhwc_max(const dim_t n, ker_data_t *dst, const ker_data_t *src,
             unsigned char *ws, const size_t ws_offset, const data_type_t ws_dt,
-            const int index) const;
+            const dim_t index) const;
     void array_nhwc_initialize(const dim_t n, ker_data_t *dst,
             unsigned char *ws, const size_t ws_offset,
             const data_type_t ws_dt) const;

--- a/src/cpu/ref_pooling.cpp
+++ b/src/cpu/ref_pooling.cpp
@@ -90,9 +90,9 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 assert(0 <= value
                         && value <= numeric_limits<typename prec_traits_t<
                                         data_type::u8>::type>::max());
-                ws[off] = value;
+                ws[off] = static_cast<unsigned char>(value);
             } else
-                reinterpret_cast<int *>(ws)[off] = value;
+                reinterpret_cast<int *>(ws)[off] = static_cast<int>(value);
         }
     };
 
@@ -137,7 +137,7 @@ status_t ref_pooling_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 }
             }
         }
-        int num_summands;
+        dim_t num_summands;
         if (alg == alg_kind::pooling_avg_include_padding)
             num_summands = KW * KH * KD;
         else {

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -560,11 +560,11 @@ struct jit_1x1_conv_args_t {
 
 struct jit_pool_conf_t {
     int ndims;
-    int mb, c, c_without_padding;
-    int id, ih, iw, od, oh, ow;
-    int stride_d, stride_h, stride_w;
-    int kd, kh, kw;
-    int f_pad, t_pad, l_pad;
+    dim_t mb, c, c_without_padding;
+    dim_t id, ih, iw, od, oh, ow;
+    dim_t stride_d, stride_h, stride_w;
+    dim_t kd, kh, kw;
+    dim_t f_pad, t_pad, l_pad;
     alg_kind_t alg;
     bool is_training;
     bool pad_w_is_null;
@@ -573,7 +573,8 @@ struct jit_pool_conf_t {
     bool is_c_padded;
     data_type_t ind_dt;
 
-    int c_block, c_tail, nb_c;
+    int c_block, c_tail;
+    dim_t nb_c;
     int ur_bc, ur_bc_tail;
     int ur_c, ur_c_tail;
     int ur;

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -32,8 +32,8 @@ static bcast_set_t get_supported_bcast_strategies() {
     return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc};
 }
 
-static inline dim_t get_offset(
-        const memory_desc_wrapper &mdw, int n, int c, int d, int h, int w) {
+static inline dim_t get_offset(const memory_desc_wrapper &mdw, dim_t n, dim_t c,
+        dim_t d, dim_t h, dim_t w) {
     switch (mdw.ndims()) {
         case 3: return mdw.blk_off(n, c, w);
         case 4: return mdw.blk_off(n, c, h, w);
@@ -146,8 +146,12 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     Vmm max_base_vr(int idx) const { return vreg(max_vidx_base + idx); }
     Vmm avg_base_vr(int idx) const { return vreg(avg_vidx_base + idx); }
 
-    size_t sizeof_src_dt() const { return data_type_size(jpp.src_dt); }
-    size_t sizeof_dst_dt() const { return data_type_size(jpp.dst_dt); }
+    int sizeof_src_dt() const {
+        return static_cast<int>(data_type_size(jpp.src_dt));
+    }
+    int sizeof_dst_dt() const {
+        return static_cast<int>(data_type_size(jpp.dst_dt));
+    }
 
     /* max pooling */
     Vmm vreg_src(int idx) const { return max_base_vr(idx); } // [0    .. ur_c-1]
@@ -206,18 +210,23 @@ struct jit_uni_i8i8_pooling_fwd_ker_t : public jit_generator_t {
     void init_tmp_reg();
     void init_mask();
 
+    // Narrows a small, fixed-range value (SIMD lane index or blend mask) to the
+    // Xbyak 8-bit immediate at the single instruction-emit boundary.
+    static uint8_t to_imm_uint8_t(int v) noexcept {
+        assert(v >= 0 && v <= UINT8_MAX);
+        return static_cast<uint8_t>(v);
+    }
+
     void load_vreg_mask_q(int ll) {};
 
-    void load_src_max_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
-    void load_src_avg_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+    void load_src_max_op(int jj, int ll, int offset, bool masked, uint64_t msk);
+    void load_src_avg_op(int jj, int ll, int offset, bool masked, uint64_t msk);
     void load_src(int jj, int ll, int c_tail);
 
     void store_dst_max_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+            int jj, int ll, int offset, bool masked, uint64_t msk);
     void store_dst_avg_op(
-            int jj, int ll, size_t offset, bool masked, uint64_t msk);
+            int jj, int ll, int offset, bool masked, uint64_t msk);
     void store_dst(int jj, int ll, int c_tail);
 
     void compute_avg_step(int ur_c, int c_tail);
@@ -279,33 +288,34 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_vreg_mask_q(int ll) {
 
     // extract ll-th part of mask (ll-th QWORD)
     vpblendd(vreg_mask_q, vreg_zeros, vreg_mask,
-            0x3 << 2 * ll); // 0x3 - mask for 2 x DWORD
+            to_imm_uint8_t(0x3 << 2 * ll)); // 0x3 - mask for 2 x DWORD
 
     // Move mask from ll-th pos to 0-th pos
-    if (ll > 0) vpermq(vreg_mask_q, vreg_mask_q, ll);
+    if (ll > 0) vpermq(vreg_mask_q, vreg_mask_q, to_imm_uint8_t(ll));
 }
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
         if (jpp.src_dt == s32)
-            for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
+            for (int i = 0; i < jpp.c_tail; i++)
                 pinsrd(vreg_src(jj),
                         ptr[aux_reg_src_w + offset + i * data_type_size(s32)],
-                        i);
+                        to_imm_uint8_t(i));
         else
             for (int i = 0; i < jpp.c_tail; i++)
-                pinsrb(vreg_src(jj), ptr[aux_reg_src_w + offset + i], i);
+                pinsrb(vreg_src(jj), ptr[aux_reg_src_w + offset + i],
+                        to_imm_uint8_t(i));
     } else
         movups(vreg_src(jj), ptr[aux_reg_src_w + offset]);
 }
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -318,7 +328,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
             // Example:  idx=[31..0]
             //    vreg_src = [x,x,x,x,.....,x,-,-,-,-,-] ; x => byte data
             //    shift to transform vreg_src = [-,-,-,-,-,x,..,x,x,x,x,]
-            const uint8_t shift = cpu_isa_traits_t<avx2>::vlen - jpp.c_tail;
+            const uint8_t shift = static_cast<uint8_t>(
+                    cpu_isa_traits_t<avx2>::vlen - jpp.c_tail);
 
             if (jpp.safe_c_tail) {
 
@@ -361,7 +372,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -375,24 +386,25 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     const Vmm &vr_src = vreg_src_s32(jj, ll);
 
     if (jpp.src_dt == s32) {
         if (masked)
-            for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
+            for (int i = 0; i < jpp.c_tail; i++)
                 pinsrd(vr_src,
                         ptr[aux_reg_src_w + offset + i * data_type_size(s32)],
-                        i);
+                        to_imm_uint8_t(i));
         else
             movups(vr_src, ptr[aux_reg_src_w + offset]);
     } else if (utils::one_of(jpp.src_dt, s8, u8)) {
         if (masked) {
             const int copy_range = math::ilog2q(jpp.tail[ll] + 1);
             for (int i = 0; i < copy_range; i++)
-                pinsrb(vr_src, ptr[aux_reg_src_w + offset + i], i);
+                pinsrb(vr_src, ptr[aux_reg_src_w + offset + i],
+                        to_imm_uint8_t(i));
 
             if (jpp.src_dt == s8)
                 pmovsxbd(vr_src, vr_src);
@@ -410,7 +422,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::load_src_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     auto load_i8 = [&](bool is_signed, const Vmm &vr_src) {
@@ -430,10 +442,11 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
             const int msk_gran = cpu_isa_traits_t<avx2>::vlen
                     / data_type_size(avg_proc_dt);
 
-            const uint8_t shift = cpu_isa_traits_t<avx2>::vlen
-                    - (jpp.c_tail > (ll + 1) * msk_gran
-                                    ? msk_gran
-                                    : jpp.c_tail - (ll * msk_gran));
+            const uint8_t shift
+                    = static_cast<uint8_t>(cpu_isa_traits_t<avx2>::vlen
+                            - (jpp.c_tail > (ll + 1) * msk_gran
+                                            ? msk_gran
+                                            : jpp.c_tail - (ll * msk_gran)));
             if (jpp.safe_c_tail) {
                 /* load src_tail at 'src_address - shift' so that it does not
                  * spill over the memory boundary */
@@ -500,7 +513,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::load_src_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     const Vmm &vr_src
@@ -542,17 +555,18 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::load_src(int jj, int ll, int c_tail) {
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
         if (jpp.src_dt == s32)
-            for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
+            for (int i = 0; i < jpp.c_tail; i++)
                 pextrd(ptr[reg_ptr_dst_i8 + offset + i * data_type_size(s32)],
-                        vreg_dst(jj), i);
+                        vreg_dst(jj), to_imm_uint8_t(i));
         else if (utils::one_of(jpp.src_dt, u8, s8))
             for (int i = 0; i < jpp.c_tail; i++)
-                pextrb(ptr[reg_ptr_dst_i8 + offset + i], vreg_dst(jj), i);
+                pextrb(ptr[reg_ptr_dst_i8 + offset + i], vreg_dst(jj),
+                        to_imm_uint8_t(i));
         else
             assert(!"unsupported src data type");
     } else
@@ -561,7 +575,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     Label store_data_safely, done;
@@ -569,7 +583,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_max_op(
     int c_block = jpp.c_block;
 
     const uint64_t low_mask = (1ULL << (c_block / 2)) - 1;
-    const uint8_t shift = cpu_isa_traits_t<avx2>::vlen - jpp.c_tail;
+    const uint8_t shift
+            = static_cast<uint8_t>(cpu_isa_traits_t<avx2>::vlen - jpp.c_tail);
 
     if (masked) {
         switch (jpp.src_dt) {
@@ -633,7 +648,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_max_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     if (masked) {
@@ -653,7 +668,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_max_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -663,9 +678,9 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
 
     if (jpp.src_dt == s32) {
         if (masked)
-            for (size_t i = 0; i < static_cast<size_t>(jpp.c_tail); i++)
+            for (int i = 0; i < jpp.c_tail; i++)
                 pextrd(ptr[reg_ptr_dst_i8 + offset + i * data_type_size(s32)],
-                        vr_dst, i);
+                        vr_dst, to_imm_uint8_t(i));
         else
             movups(ptr[reg_ptr_dst_i8 + offset], vr_dst);
     } else if (utils::one_of(jpp.src_dt, s8, u8)) {
@@ -679,14 +694,14 @@ void jit_uni_i8i8_pooling_fwd_ker_t<sse41>::store_dst_avg_op(
                 ? math::ilog2q(jpp.tail[ll] + 1)
                 : cpu_isa_traits_t<sse41>::vlen / data_type_size(avg_proc_dt);
         for (int i = 0; i < copy_range; i++)
-            pextrb(ptr[reg_ptr_dst_i8 + offset + i], vr_dst, i);
+            pextrb(ptr[reg_ptr_dst_i8 + offset + i], vr_dst, to_imm_uint8_t(i));
     } else
         assert(!"unsupported src data type");
 }
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -742,7 +757,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
 
         if (is_masked && (ll_end > jpp.c_tail)) { //implies this tail not full.
             Label store_data_safely, done;
-            const uint8_t shift = msk_gran - jpp.c_tail % msk_gran;
+            const uint8_t shift
+                    = static_cast<uint8_t>(msk_gran - jpp.c_tail % msk_gran);
 
             if (!jpp.safe_c_tail) {
                 cmp(reg_ptr_maskmovdqu_dst, reg_dst_safe_access);
@@ -786,7 +802,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
 
 template <>
 void jit_uni_i8i8_pooling_fwd_ker_t<avx512_core>::store_dst_avg_op(
-        int jj, int ll, size_t offset, bool masked, uint64_t msk) {
+        int jj, int ll, int offset, bool masked, uint64_t msk) {
     using namespace data_type;
 
     // Don't generate useless code
@@ -882,9 +898,9 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_max_step(
         int ur_c, int c_tail) {
     Label l_kd, l_kh, l_kw;
 
-    int ih = jpp.ih;
-    int iw = jpp.iw;
-    int c = jpp.c;
+    auto ih = jpp.ih;
+    auto iw = jpp.iw;
+    auto c = jpp.c;
 
     for (int jj = 0; jj < ur_c; jj++)
         uni_vmovups(vreg_dst(jj), vreg_tmp);
@@ -932,11 +948,12 @@ void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_avg_step(
 
     Label l_kd, l_kh, l_kw;
 
-    int ih = jpp.ih;
-    int iw = jpp.iw;
-    int c = jpp.c;
+    auto ih = jpp.ih;
+    auto iw = jpp.iw;
+    auto c = jpp.c;
 
-    const int num_ll = data_type_size(avg_proc_dt) / data_type_size(jpp.src_dt);
+    const int num_ll = static_cast<int>(
+            data_type_size(avg_proc_dt) / data_type_size(jpp.src_dt));
 
     for (int jj = 0; jj < ur_c; jj++) {
         for (int ll = 0; ll < num_ll; ll++) {
@@ -1041,11 +1058,11 @@ template <cpu_isa_t isa>
 void jit_uni_i8i8_pooling_fwd_ker_t<isa>::compute_c_block() {
     Label l_main_loop;
 
-    int nb_c = jpp.nb_c;
+    auto nb_c = jpp.nb_c;
     int c_block = jpp.c_block;
     int ur_c = jpp.ur_c;
     int ur_c_tail = jpp.ur_c_tail;
-    int c_steps = nb_c / ur_c;
+    auto c_steps = nb_c / ur_c;
     int c_tail = jpp.c_tail;
 
     xor_(c_iter, c_iter);
@@ -1075,13 +1092,13 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
     // AVX2 mask initialization: mask stored in Ymm-regs
     auto init = [&](uint64_t bit_mask, bool need_ymm_mask = true,
                         bool need_mmx_mask = false) {
-        const size_t QW_PER_VREG = cpu_isa::vlen / sizeof(uint64_t);
+        const int QW_PER_VREG = cpu_isa::vlen / sizeof(uint64_t);
 
         const size_t DBITS = 8 * sizeof_src_dt();
         const uint64_t VMSK = 1ULL << (DBITS - 1);
         const size_t D_PER_QW = (8 * sizeof(uint64_t)) / DBITS;
         uint64_t vmask[QW_PER_VREG];
-        for (size_t i = 0; i < QW_PER_VREG; i++) {
+        for (int i = 0; i < QW_PER_VREG; i++) {
             uint64_t qw_vmask = 0ULL;
             for (size_t j = 0; j < D_PER_QW; j++) {
                 if (bit_mask & 1) qw_vmask |= VMSK << DBITS * j;
@@ -1106,7 +1123,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
             const uint8 qw_dst_idx[QW_PER_VREG]
                     = {0, 1, 0, 1}; // qword index in 128-bit xreg
 
-            for (size_t i = 0; i < QW_PER_VREG; i++) {
+            for (int i = 0; i < QW_PER_VREG; i++) {
                 mov(reg_mask, vmask[i]);
                 vpinsrq(Xmm(xdst_i[i]), Xmm(xsrc_i[i]), reg_mask,
                         qw_dst_idx[i]);
@@ -1122,7 +1139,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
             vinserti128(vreg_mask, vreg_mask, xreg_mask_hi, 1);
 
             // Compute mask algned to left from vreg_mask and store it in vreg_mask_2 to be use for tail processing.
-            const uint8_t shift = 32 - jpp.c_tail;
+            const uint8_t shift = static_cast<uint8_t>(32 - jpp.c_tail);
             vperm2i128(vreg_mask_2, vreg_mask, vreg_mask, 0x08);
             if (shift <= 16) {
                 vpalignr(vreg_mask_2, vreg_mask, vreg_mask_2, 16 - shift);
@@ -1137,7 +1154,7 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::init_mask() {
 
             // Only in MMX regs ?
             if (!need_ymm_mask)
-                for (size_t i = 0; i < QW_PER_VREG; i++) {
+                for (int i = 0; i < QW_PER_VREG; i++) {
                     mov(reg_mask, vmask[i]);
                     movq(mmx_mask(i), reg_mask);
                 }
@@ -1302,11 +1319,11 @@ status_t jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(
     jpp.t_pad = is_1d ? 0 : pd.padding[0][ndims - 4];
     jpp.l_pad = pd.padding[0][ndims - 3];
 
-    int back_pad = calculate_end_padding(
+    const auto back_pad = calculate_end_padding(
             jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
-    int bottom_pad = calculate_end_padding(
+    const auto bottom_pad = calculate_end_padding(
             jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
-    int right_pad = calculate_end_padding(
+    const auto right_pad = calculate_end_padding(
             jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
 
     VDISPATCH_POOLING_IC(

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -283,7 +283,7 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         jpp.is_f16 = false;
         jpp.is_fp8 = false;
         jpp.src_dt = jpp.dst_dt = data_type::f32;
-        jpp.dt_size = types::data_type_size(jpp.src_dt);
+        jpp.dt_size = static_cast<int>(types::data_type_size(jpp.src_dt));
         jpp.tag_kind = jit_memory_tag_kind_t::ncsp;
 
         // used to initialize binary post-ops
@@ -292,7 +292,8 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
                     data_type::f32, blocked_fmt_tag));
         }
     } else {
-        jpp.dt_size = types::data_type_size(src_d.data_type());
+        jpp.dt_size
+                = static_cast<int>(types::data_type_size(src_d.data_type()));
         jpp.tag_kind = (fmt_tag == nspc_fmt_tag)
                 ? jit_memory_tag_kind_t::nspc
                 : jit_memory_tag_kind_t::blocked;
@@ -366,11 +367,11 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
     jpp.t_pad = (ndims == 3) ? 0 : pd.padding[0][ndims - 4];
     jpp.l_pad = pd.padding[0][ndims - 3];
 
-    const int back_pad = calculate_end_padding(
+    const auto back_pad = calculate_end_padding(
             jpp.f_pad, jpp.od, jpp.id, jpp.stride_d, jpp.kd);
-    const int bottom_pad = calculate_end_padding(
+    const auto bottom_pad = calculate_end_padding(
             jpp.t_pad, jpp.oh, jpp.ih, jpp.stride_h, jpp.kh);
-    const int right_pad = calculate_end_padding(
+    const auto right_pad = calculate_end_padding(
             jpp.l_pad, jpp.ow, jpp.iw, jpp.stride_w, jpp.kw);
 
     VDISPATCH_POOLING_IC(
@@ -424,10 +425,13 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
 
     // select jpp.ur_bc
     if (jpp.tag_kind == jit_memory_tag_kind_t::nspc) {
-        auto min_ur_w = nstl::max(1, utils::div_up(jpp.l_pad, jpp.stride_w));
-        int min_ur_w1 = utils::div_up(nstl::max(0, right_pad), jpp.stride_w);
+        auto min_ur_w
+                = nstl::max(dim_t(1), utils::div_up(jpp.l_pad, jpp.stride_w));
+        auto min_ur_w1
+                = utils::div_up(nstl::max(dim_t(0), right_pad), jpp.stride_w);
         if (min_ur_w < min_ur_w1) { min_ur_w = min_ur_w1; }
-        jpp.ur_bc = nstl::min(jpp.nb_c, nstl::max(1, jpp.ur / min_ur_w));
+        jpp.ur_bc = static_cast<int>(
+                nstl::min(jpp.nb_c, nstl::max(dim_t(1), jpp.ur / min_ur_w)));
         //take into account threading - to have enough work for parallelization
         float best_eff = 0;
         for (int ur_bc = jpp.ur_bc; ur_bc > 0; ur_bc--) {
@@ -449,7 +453,8 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         //take into account cache re-usage after zeroing on backward
         if (jpp.is_backward && ndims < 5 && !jpp.needs_f32_accum_for_bf16) {
             const int L2 = platform::get_per_core_cache_size(2) / jpp.dt_size;
-            int ur_bc = nstl::max(1, L2 / (jpp.kh * jpp.iw * jpp.c_block));
+            const int ur_bc = static_cast<int>(
+                    nstl::max(dim_t(1), L2 / (jpp.kh * jpp.iw * jpp.c_block)));
             jpp.ur_bc = nstl::min(jpp.ur_bc, ur_bc);
         }
 
@@ -468,7 +473,7 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(
         utils::array_copy(dims, src_d.dims(), ndims);
 
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
-        dims[0] = nstl::min(dnnl_get_max_threads(), jpp.mb * nb2_c);
+        dims[0] = nstl::min<dim_t>(dnnl_get_max_threads(), jpp.mb * nb2_c);
         dims[1] = jpp.f32_accum_block_size;
 
         CHECK(memory_desc_init_by_tag(
@@ -484,7 +489,8 @@ void jit_uni_pool_kernel_t<isa>::init_scratchpad(
 
     // scratchpad for c_block slice of input and/or output
     using namespace memory_tracking::names;
-    const int nscr = nstl::min(dnnl_get_max_threads(), jpp.mb * jpp.nb_c);
+    const dim_t nscr
+            = nstl::min<dim_t>(dnnl_get_max_threads(), jpp.mb * jpp.nb_c);
     if (jpp.tag_kind == jit_memory_tag_kind_t::ncsp) {
         scratchpad.book(key_pool_src_plain2blocked_cvt,
                 static_cast<size_t>(jpp.c_block) * jpp.id * jpp.ih * jpp.iw
@@ -538,7 +544,7 @@ inline void jit_uni_pool_kernel_t<isa>::pop_vmm_val(const int idx) {
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::load(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
+        const int idx, const reg64_t &reg_ptr, const dim_t offset,
         const bool is_c_tail_proccessing) {
     io_[dt]->load(vmmword[reg_ptr + offset], Vmm(idx),
             is_c_tail_proccessing && !jpp.is_c_padded);
@@ -546,7 +552,7 @@ inline void jit_uni_pool_kernel_t<isa>::load(const data_type_t dt,
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::store(const data_type_t dt,
-        const int idx, const reg64_t &reg_ptr, const int offset,
+        const int idx, const reg64_t &reg_ptr, const dim_t offset,
         const bool is_c_tail_proccessing) {
     if (is_c_tail_proccessing && jpp.is_c_padded && jpp.with_postops)
         pad_with_zeros(idx);
@@ -565,7 +571,8 @@ inline void jit_uni_pool_kernel_t<isa>::pad_with_zeros(const int idx) {
             const auto c_tail = jpp.c_tail % sse41_single_block_size;
             std::bitset<8> tail_mask((1 << c_tail) - 1);
             tail_mask.flip();
-            uni_vblendps(Vmm(idx), Vmm(idx), xmm_tmp_1, tail_mask.to_ulong());
+            uni_vblendps(Vmm(idx), Vmm(idx), xmm_tmp_1,
+                    static_cast<int>(tail_mask.to_ulong()));
         }
     } else if (isa == avx || isa == avx2) {
         uni_vxorps(ymm_tmp_1, ymm_tmp_1, ymm_tmp_1);
@@ -576,14 +583,15 @@ inline void jit_uni_pool_kernel_t<isa>::pad_with_zeros(const int idx) {
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::load_indices(
-        const int indr_i, const int step_index, bool is_c_tail_processing) {
+        const int indr_i, const dim_t step_index, bool is_c_tail_processing) {
     if (jpp.ind_dt == data_type::u8) {
         auto indvr = vreg(indr_i);
         auto indxr = xreg(indr_i);
         if (isa == sse41) {
             if (is_c_tail_processing && !jpp.is_c_padded) {
                 for (int i = 0; i < jpp.c_tail % (jpp.c_block / 2); i++)
-                    pinsrb(indxr, ptr[reg_index + step_index + i], i);
+                    pinsrb(indxr, ptr[reg_index + step_index + i],
+                            to_imm_uint8_t(i));
             } else {
                 movd(indxr, ptr[reg_index + step_index]);
             }
@@ -591,7 +599,8 @@ inline void jit_uni_pool_kernel_t<isa>::load_indices(
         } else if (isa == avx || isa == avx2) {
             if (is_c_tail_processing && !jpp.is_c_padded) {
                 for (int i = 0; i < jpp.c_tail; i++)
-                    vpinsrb(indxr, indxr, ptr[reg_index + step_index + i], i);
+                    vpinsrb(indxr, indxr, ptr[reg_index + step_index + i],
+                            to_imm_uint8_t(i));
             } else {
                 vmovq(indxr, ptr[reg_index + step_index]);
             }
@@ -620,7 +629,7 @@ inline void jit_uni_pool_kernel_t<isa>::load_indices(
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
-        const int step_index, const bool is_c_tail_processing,
+        const dim_t step_index, const bool is_c_tail_processing,
         const bool is_first_w_block) {
     if (jpp.ind_dt == data_type::u8) {
         auto xr = xreg(indr_i);
@@ -638,7 +647,8 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
                     // bytes which should be stored are located in
                     // least significant bits(8 to be precise) of 32 bits parts
                     // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                    pextrb(ptr[reg_index + step_index + i], xr, 4 * i);
+                    pextrb(ptr[reg_index + step_index + i], xr,
+                            to_imm_uint8_t(4 * i));
                 }
             }
         } else if (utils::one_of(isa, avx, avx2, avx2_vnni_2)) {
@@ -651,7 +661,8 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
                     // bytes which should be stored are located in
                     // least significant bits(8 to be precise) of 32 bits parts
                     // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
-                    vpextrb(ptr[reg_index + step_index + i], xr, 4 * i);
+                    vpextrb(ptr[reg_index + step_index + i], xr,
+                            to_imm_uint8_t(4 * i));
                 }
 
                 if (jpp.c_tail > (jpp.c_block / 2)) {
@@ -663,7 +674,7 @@ inline void jit_uni_pool_kernel_t<isa>::store_indices(const int indr_i,
                         // of xmm thus we need to store 0, 4, 8 and 12 byte of xmm
                         vpextrb(ptr[reg_index + step_index + (jpp.c_block / 2)
                                         + i],
-                                higher_128bits, 4 * i);
+                                higher_128bits, to_imm_uint8_t(4 * i));
                     }
                 }
             } else {
@@ -755,7 +766,7 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
     if (end_idx - start_idx == 0) return;
     if (jpp.with_binary && !sse41_postops_disabled) {
 
-        const int c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
+        const auto c_off = (jpp.tag_kind == jit_memory_tag_kind_t::nspc)
                 ? jpp.c
                 : c_block;
 
@@ -791,15 +802,15 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_bc, int ur_w, int c_block,
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(
-        int jj, int ur_w, int pad_l, int pad_r, bool with_c_tail_proccessing) {
+inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(int jj,
+        int ur_w, dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
     if (jpp.alg == pooling_avg_exclude_padding) {
-        int kw = jpp.kw;
-        int stride_w = jpp.stride_w;
+        auto kw = jpp.kw;
+        auto stride_w = jpp.stride_w;
 
-        int non_zero_kw = kw;
-        non_zero_kw -= nstl::max(0, pad_l - jj * stride_w);
-        non_zero_kw -= nstl::max(0, pad_r - (ur_w - 1 - jj) * stride_w);
+        auto non_zero_kw = kw;
+        non_zero_kw -= nstl::max(dim_t(0), pad_l - jj * stride_w);
+        non_zero_kw -= nstl::max(dim_t(0), pad_r - (ur_w - 1 - jj) * stride_w);
 
         if (non_zero_kw != prev_kw) {
             mov(tmp_gpr, float2int((float)non_zero_kw));
@@ -822,15 +833,15 @@ inline void jit_uni_pool_kernel_t<isa>::maybe_recalculate_divisor(
 }
 
 template <cpu_isa_t isa>
-inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
-        int pad_r, bool with_c_tail_proccessing) {
+inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc,
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
 
     auto iw = jpp.iw;
     auto kw = jpp.kw;
     auto stride_w = jpp.stride_w;
     auto c_block = jpp.c_block;
     auto dt_size = jpp.dt_size;
-    const int c_off
+    const auto c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
     Label kd_label, kh_label;
 
@@ -877,21 +888,23 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const int jj_start = static_cast<int>(
+                    utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w));
+            const int jj_end = ur_w
+                    - static_cast<int>(utils::div_up(
+                            nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w));
 
             for_(int jj = jj_start; jj < jj_end; jj++)
             for (int bci = 0; bci < ur_bc; bci++) {
                 const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
                 const auto inpr_i = reg_ind(1, bci, jj, ur_bc, ur_w);
                 auto inpvr = vreg(inpr_i);
-                int aux_input_offset
+                auto aux_input_offset
                         = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
                 if (aux_input_offset >= iw * c_off) continue;
-                int input_offset = dt_size * aux_input_offset;
+                auto input_offset = dt_size * aux_input_offset;
                 if (jpp.is_backward) {
                     load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input,
                             input_offset, is_tail_processing(bci));
@@ -948,12 +961,12 @@ inline void jit_uni_pool_kernel_t<isa>::avg_step(int ur_w, int ur_bc, int pad_l,
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
-        int pad_l, int pad_r, bool with_c_tail_proccessing) {
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int stride_w = jpp.stride_w;
-    int c_block = jpp.c_block;
-    const int c_off
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
+    auto iw = jpp.iw;
+    auto kw = jpp.kw;
+    auto stride_w = jpp.stride_w;
+    auto c_block = jpp.c_block;
+    const auto c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
     Label kd_label, kh_label;
 
@@ -997,11 +1010,13 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const int jj_start = static_cast<int>(
+                    utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w));
+            const int jj_end = ur_w
+                    - static_cast<int>(utils::div_up(
+                            nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w));
             for_(int jj = jj_start; jj < jj_end; jj++)
             for (int bci = 0; bci < ur_bc; bci++) {
                 const auto accvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
@@ -1009,10 +1024,10 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
                 const auto inpvr = vreg(inpr_i);
                 const auto indvr = vreg(reg_ind(2, bci, jj, ur_bc, ur_w));
                 const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
-                int aux_input_offset
+                auto aux_input_offset
                         = (ki + jj * stride_w - pad_l) * c_off + bci * c_block;
                 if (aux_input_offset >= iw * c_off) continue;
-                int input_offset = jpp.dt_size * aux_input_offset;
+                auto input_offset = jpp.dt_size * aux_input_offset;
                 load(jpp.src_dt, reg_idx(inpr_i), aux_reg_input, input_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
@@ -1104,22 +1119,23 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_fwd(int ur_w, int ur_bc,
 
 template <cpu_isa_t isa>
 inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
-        int pad_l, int pad_r, bool with_c_tail_proccessing) {
+        dim_t pad_l, dim_t pad_r, bool with_c_tail_proccessing) {
 
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int stride_w = jpp.stride_w;
-    int c_block = jpp.c_block;
-    const int output_c_off
+    auto iw = jpp.iw;
+    auto kw = jpp.kw;
+    auto stride_w = jpp.stride_w;
+    auto c_block = jpp.c_block;
+    const auto output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
-    const int input_c_off = jpp.needs_f32_accum_for_bf16
+    const auto input_c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : output_c_off;
     const auto input_dt
             = jpp.needs_f32_accum_for_bf16 ? data_type::f32 : jpp.src_dt;
-    const size_t input_dt_size = types::data_type_size(input_dt);
-    const size_t output_dt_size = jpp.dt_size;
-    assert(output_dt_size == types::data_type_size(jpp.dst_dt));
+    const int input_dt_size = static_cast<int>(types::data_type_size(input_dt));
+    const int output_dt_size = jpp.dt_size;
+    assert(output_dt_size
+            == static_cast<int>(types::data_type_size(jpp.dst_dt)));
 
     Label kd_label, kh_label;
 
@@ -1166,11 +1182,13 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
     xor_(kj, kj);
     L(kh_label);
     {
-        for (int ki = 0; ki < kw; ki++) {
-            int jj_start = utils::div_up(nstl::max(0, pad_l - ki), stride_w);
-            int jj_end = ur_w
-                    - utils::div_up(
-                            nstl::max(0, ki + pad_r - (kw - 1)), stride_w);
+        for (dim_t ki = 0; ki < kw; ki++) {
+            const int jj_start = static_cast<int>(
+                    utils::div_up(nstl::max(dim_t(0), pad_l - ki), stride_w));
+            const int jj_end = ur_w
+                    - static_cast<int>(utils::div_up(
+                            nstl::max(dim_t(0), ki + pad_r - (kw - 1)),
+                            stride_w));
             for_(int jj = jj_start; jj < jj_end; jj++)
             for (int bci = 0; bci < ur_bc; bci++) {
                 const auto outvr = vreg(reg_ind(0, bci, jj, ur_bc, ur_w));
@@ -1178,10 +1196,10 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
                 const auto inpr_i = reg_ind(2, bci, jj, ur_bc, ur_w);
                 const auto inpvr = vreg(inpr_i);
                 const auto cvtvr = vreg(reg_ind(3, bci, jj, ur_bc, ur_w));
-                int aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
+                auto aux_inp_offset = (ki + jj * stride_w - pad_l) * input_c_off
                         + bci * c_block;
                 if (aux_inp_offset >= iw * input_c_off) continue;
-                int inp_offset = input_dt_size * aux_inp_offset;
+                auto inp_offset = input_dt_size * aux_inp_offset;
                 load(input_dt, reg_idx(inpr_i), aux_reg_input, inp_offset,
                         is_tail_processing(bci));
                 if (isa == sse41) {
@@ -1254,7 +1272,7 @@ inline void jit_uni_pool_kernel_t<isa>::max_step_bwd(int ur_w, int ur_bc,
 template <cpu_isa_t isa>
 void jit_uni_pool_kernel_t<isa>::zero_diff_src(
         int ur_bc, bool with_c_tail_proccessing) {
-    const int c_off = jpp.needs_f32_accum_for_bf16
+    const auto c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c
                                                              : jpp.c_block);
@@ -1281,7 +1299,7 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
     const auto src_dt
             = jpp.needs_f32_accum_for_bf16 ? data_type::f32 : jpp.src_dt;
     const auto dt_size = types::data_type_size(src_dt);
-    const int width_size = jpp.iw * c_off * dt_size;
+    const dim_t width_size = jpp.iw * c_off * dt_size;
 
     auto aux_reg_zero_ptr = tmp_gpr;
 
@@ -1292,12 +1310,12 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
         L(l_ih_loop);
         {
             const auto vlen = cpu_isa_traits_t<isa>::vlen;
-            const int step = c_off * dt_size;
+            const auto step = c_off * dt_size;
 
             // TODO: maybe a big code generated here
-            for_(int i = 0; i < width_size; i += step)
+            for_(dim_t i = 0; i < width_size; i += step)
             for (int bci = 0; bci < ur_bc; bci++) {
-                const int offs = i + bci * jpp.c_block * dt_size;
+                const auto offs = i + bci * jpp.c_block * dt_size;
                 if (isa == sse41) {
                     bool is_needed_c_tail_processing = false;
                     if (is_tail_processing(bci)
@@ -1337,23 +1355,24 @@ void jit_uni_pool_kernel_t<isa>::generate() {
 
     this->preamble();
 
-    int ow = jpp.ow;
-    int iw = jpp.iw;
-    int kw = jpp.kw;
-    int kh = jpp.kh;
-    int c_block = jpp.c_block;
-    int stride_w = jpp.stride_w;
-    int l_pad = jpp.l_pad;
-    const int output_c_off
+    auto ow = jpp.ow;
+    auto iw = jpp.iw;
+    auto kw = jpp.kw;
+    auto kh = jpp.kh;
+    auto c_block = jpp.c_block;
+    auto stride_w = jpp.stride_w;
+    auto l_pad = jpp.l_pad;
+    const auto output_c_off
             = (jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c : c_block;
-    const int input_c_off = jpp.needs_f32_accum_for_bf16
+    const auto input_c_off = jpp.needs_f32_accum_for_bf16
             ? jpp.f32_accum_block_size
             : output_c_off;
 
     int vlen = cpu_isa_traits_t<isa>::vlen;
 
-    const size_t input_dt_size
-            = jpp.needs_f32_accum_for_bf16 ? sizeof(float) : jpp.dt_size;
+    const int input_dt_size = jpp.needs_f32_accum_for_bf16
+            ? static_cast<int>(sizeof(float))
+            : jpp.dt_size;
 
     if (use_bf16_emulation()) io_.init_bf16();
 
@@ -1367,7 +1386,7 @@ void jit_uni_pool_kernel_t<isa>::generate() {
     mov(reg_nbc, ptr[reg_param + GET_OFF(ur_bc)]);
 
     auto process_oi
-            = [&](int ur_w, int ur_bc, int lpad, int rpad,
+            = [&](int ur_w, int ur_bc, dim_t lpad, dim_t rpad,
                       bool with_c_tail_proccessing, bool inc_reg = true) {
         step(ur_w, ur_bc, lpad, rpad, with_c_tail_proccessing);
 
@@ -1399,13 +1418,14 @@ void jit_uni_pool_kernel_t<isa>::generate() {
         auto output_dt_size = jpp.dt_size;
         auto shift = (isa == sse41) ? vlen : 0;
         add(reg_input,
-                input_dt_size * nstl::max(0, ur_w * stride_w - lpad)
+                input_dt_size * nstl::max(dim_t(0), ur_w * stride_w - lpad)
                                 * input_c_off
                         - shift);
         add(reg_output, output_dt_size * ur_w * output_c_off - shift);
         if (jpp.alg == pooling_max && (jpp.is_training || jpp.is_backward)) {
             auto ishift = (isa == sse41) ? jpp.c_block / 2 : 0;
-            auto ind_dt_size = types::data_type_size(jpp.ind_dt);
+            auto ind_dt_size
+                    = static_cast<int>(types::data_type_size(jpp.ind_dt));
             add(reg_index, (ur_w * output_c_off - ishift) * ind_dt_size);
         }
     };
@@ -1445,27 +1465,28 @@ void jit_uni_pool_kernel_t<isa>::generate() {
             }
         }
 
-        const int ur_w = nstl::min(jpp.ow, jpp.ur / jpp.ur_bc);
-        const int n_oi_iterations = utils::div_up(ow, ur_w);
-        const int ur_stride_w = ur_w * stride_w;
-        const int l_pad_iterations
+        const int ur_w = static_cast<int>(
+                nstl::min<dim_t>(jpp.ow, jpp.ur / jpp.ur_bc));
+        const auto n_oi_iterations = utils::div_up(ow, ur_w);
+        const auto ur_stride_w = ur_w * stride_w;
+        const auto l_pad_iterations
                 = nstl::min(n_oi_iterations, utils::div_up(l_pad, ur_stride_w));
 
-        for (int i = 0; i < l_pad_iterations; ++i) {
-            const int ow_s = i * ur_w;
-            const int ow_e = nstl::min(ow, ow_s + ur_w);
-            const int cur_l_pad = l_pad - i * ur_stride_w;
-            const int cur_r_pad = static_cast<int>(nstl::max(dim_t(0),
-                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw)));
-            const int cur_ur_w = ow_e - ow_s;
+        for (dim_t i = 0; i < l_pad_iterations; ++i) {
+            const auto ow_s = i * ur_w;
+            const auto ow_e = nstl::min(ow, ow_s + ur_w);
+            const auto cur_l_pad = l_pad - i * ur_stride_w;
+            const auto cur_r_pad = nstl::max(dim_t(0),
+                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+            const int cur_ur_w = static_cast<int>(ow_e - ow_s);
             process_oi(cur_ur_w, ur_bc, cur_l_pad, cur_r_pad,
                     with_c_tail_processing);
         }
 
-        const int rem_n_oi_iters = n_oi_iterations - l_pad_iterations;
-        const int cur_iw = l_pad_iterations * ur_stride_w - l_pad;
-        const int cur_iw_rightmost_idx = cur_iw + kw - 1;
-        const int no_pad_full_n_oi_iters = utils::saturate<int>(
+        const auto rem_n_oi_iters = n_oi_iterations - l_pad_iterations;
+        const auto cur_iw = l_pad_iterations * ur_stride_w - l_pad;
+        const auto cur_iw_rightmost_idx = cur_iw + kw - 1;
+        const dim_t no_pad_full_n_oi_iters = utils::saturate<dim_t>(
                 0, rem_n_oi_iters, (iw - cur_iw_rightmost_idx) / ur_stride_w);
 
         if (no_pad_full_n_oi_iters > 0) {
@@ -1482,13 +1503,13 @@ void jit_uni_pool_kernel_t<isa>::generate() {
             }
         }
 
-        for (int i = l_pad_iterations + no_pad_full_n_oi_iters;
+        for (dim_t i = l_pad_iterations + no_pad_full_n_oi_iters;
                 i < n_oi_iterations; ++i) {
-            const int ow_s = i * ur_w;
-            const int ow_e = nstl::min(ow, ow_s + ur_w);
-            const int cur_r_pad = static_cast<int>(nstl::max(dim_t(0),
-                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw)));
-            const int cur_ur_w = ow_e - ow_s;
+            const auto ow_s = i * ur_w;
+            const auto ow_e = nstl::min(ow, ow_s + ur_w);
+            const auto cur_r_pad = nstl::max(dim_t(0),
+                    calculate_end_padding(l_pad, ow_e, iw, stride_w, kw));
+            const int cur_ur_w = static_cast<int>(ow_e - ow_s);
             process_oi(cur_ur_w, ur_bc, 0, cur_r_pad, with_c_tail_processing);
         }
     };

--- a/src/cpu/x64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.hpp
@@ -72,6 +72,13 @@ private:
     Zmm zreg(int idx) const noexcept { return Zmm(reg_idx(idx)); }
     Vmm vreg(int idx) const noexcept { return Vmm(reg_idx(idx)); }
 
+    // Narrows a small, fixed-range value (SIMD lane index or blend mask) to the
+    // Xbyak 8-bit immediate at the single instruction-emit boundary.
+    static uint8_t to_imm_uint8_t(int v) noexcept {
+        assert(v >= 0 && v <= UINT8_MAX);
+        return static_cast<uint8_t>(v);
+    }
+
     const Xbyak::AddressFrame &vmmword = (isa == sse41)  ? xword
             : utils::one_of(isa, avx, avx2, avx2_vnni_2) ? yword
                                                          : zword;
@@ -137,33 +144,33 @@ private:
     bool sse_high_half = false;
     bool disable_postops_when_sse_high_half_processed_ = false;
 
-    int prev_kw = 0;
+    dim_t prev_kw = 0;
 
     void put_one_in_vmm();
     void uni_broadcast_reg_val(const int reg_idx, const int vmm_idx);
     void push_vmm_val(const int idx);
     void pop_vmm_val(const int idx);
     void load(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
-            const int offset, const bool is_c_tail_proccessing);
+            const dim_t offset, const bool is_c_tail_proccessing);
     void store(const data_type_t dt, const int idx, const reg64_t &reg_ptr,
-            const int offset, const bool is_c_tail_proccessing);
+            const dim_t offset, const bool is_c_tail_proccessing);
     void pad_with_zeros(int idx);
-    void load_indices(int indr_i, int step_index, bool is_c_tail_processing);
-    void store_indices(int indr_i, int step_index, bool is_c_tail_processing,
+    void load_indices(int indr_i, dim_t step_index, bool is_c_tail_processing);
+    void store_indices(int indr_i, dim_t step_index, bool is_c_tail_processing,
             bool is_first_w_block);
 
-    void maybe_recalculate_divisor(int jj, int ur_w, int pad_l, int pad_r,
+    void maybe_recalculate_divisor(int jj, int ur_w, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
-    void avg_step(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void avg_step(int ur_w, int ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
-    void max_step_fwd(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void max_step_fwd(int ur_w, int ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
-    void max_step_bwd(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void max_step_bwd(int ur_w, int ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing);
 
     void zero_diff_src(int ur_bc, bool with_c_tail_proccessing);
 
-    void step(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void step(int ur_w, int ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_proccessing) {
         if (jpp.alg == alg_kind::pooling_max) {
             if (jpp.is_backward)
@@ -176,7 +183,7 @@ private:
             avg_step(ur_w, ur_bc, pad_l, pad_r, with_c_tail_proccessing);
     }
 
-    void step_high_half(int ur_w, int ur_bc, int pad_l, int pad_r,
+    void step_high_half(int ur_w, int ur_bc, dim_t pad_l, dim_t pad_r,
             bool with_c_tail_processing) {
         add(reg_input, sizeof(float) * 4);
         add(reg_output, sizeof(float) * 4);
@@ -186,7 +193,8 @@ private:
                 assert(!"Unknown data type for indices");
                 return;
             }
-            add(reg_index, types::data_type_size(jpp.ind_dt) * 4);
+            add(reg_index,
+                    static_cast<int>(types::data_type_size(jpp.ind_dt)) * 4);
         }
 
         step(ur_w, ur_bc, pad_l, pad_r, with_c_tail_processing);

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -184,7 +184,7 @@ struct transpose_ncsp_to_block_fmt_t {
         , block_size_(block_size)
         , offset_multiplier_(offset_multiplier) {}
 
-    void operator()(std::size_t ithr, int n, int b_c) const {
+    void operator()(std::size_t ithr, dim_t n, dim_t b_c) const {
         const dim_t cs
                 = nstl::min(c_without_padding_ - b_c * c_block_, c_block_);
         const src_data_t *src_nscp = src_nscp_base_
@@ -199,8 +199,8 @@ struct transpose_ncsp_to_block_fmt_t {
 private:
     trans_wrapper_t *transposer_;
     trans_wrapper_t *transposer_tail_;
-    const int c_without_padding_;
-    const int c_block_;
+    const dim_t c_without_padding_;
+    const dim_t c_block_;
     const src_data_t *src_nscp_base_;
     const memory_desc_wrapper &src_nscp_desc_;
     dst_data_t *__restrict dst_blocked_base_;
@@ -241,8 +241,8 @@ struct transpose_block_fmt_to_ncsp_t {
 private:
     trans_wrapper_t *transposer_;
     trans_wrapper_t *transposer_tail_;
-    const int c_without_padding_;
-    const int c_block_;
+    const dim_t c_without_padding_;
+    const dim_t c_block_;
     const src_data_t *__restrict src_blocked_base_;
     const dim_t block_size_;
     dst_data_t *dst_ncsp_base_;
@@ -257,8 +257,8 @@ public:
             const memory_desc_wrapper &src_d, const memory_desc_wrapper &dst_d,
             const memory_desc_wrapper &indices_d, const char *indices,
             const data_type_t wsp_dt, const exec_ctx_t &ctx)
-        : src_sp_(static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw)
-        , dst_sp_(static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow)
+        : src_sp_(jpp.id * jpp.ih * jpp.iw)
+        , dst_sp_(jpp.od * jpp.oh * jpp.ow)
         , src_slice_(src_sp_ * jpp.c_block)
         , dst_slice_(dst_sp_ * jpp.c_block)
         , transpose_src_(jpp.tag_kind == jit_memory_tag_kind_t::ncsp)
@@ -292,40 +292,40 @@ public:
     inline bool should_transpose_dst() const noexcept { return transpose_dst_; }
 
     const void *get_src_addr(
-            std::size_t ithr, int ih, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t ih, const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_src_wsp_ + ithr * src_slice_;
         return static_cast<const void *>(&wsp[ih * jpp.iw * jpp.c_block]);
     }
 
     const void *get_dst_addr(
-            std::size_t ithr, int oh, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t oh, const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_dst_wsp_ + ithr * dst_slice_;
         return static_cast<const void *>(&wsp[oh * jpp.ow * jpp.c_block]);
     }
 
     const void *get_indices_addr(
-            std::size_t ithr, int oh, const jit_pool_conf_t &jpp) const {
+            std::size_t ithr, dim_t oh, const jit_pool_conf_t &jpp) const {
         const char *const wsp
                 = cvt_slice_ind_wsp_ + ithr * dst_slice_ * ind_dt_size_;
         return static_cast<const void *>(
                 &wsp[oh * jpp.ow * jpp.c_block * ind_dt_size_]);
     }
 
-    const void *get_src_addr_3d(std::size_t ithr, int id, int ih,
+    const void *get_src_addr_3d(std::size_t ithr, dim_t id, dim_t ih,
             const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_src_wsp_ + ithr * src_slice_;
         return static_cast<const void *>(&wsp[ih * jpp.iw * jpp.c_block
                 + id * jpp.ih * jpp.iw * jpp.c_block]);
     }
 
-    const void *get_dst_addr_3d(std::size_t ithr, int od, int oh,
+    const void *get_dst_addr_3d(std::size_t ithr, dim_t od, dim_t oh,
             const jit_pool_conf_t &jpp) const {
         const wsp_data_t *const wsp = cvt_slice_dst_wsp_ + ithr * dst_slice_;
         return static_cast<const void *>(&wsp[oh * jpp.ow * jpp.c_block
                 + od * jpp.oh * jpp.ow * jpp.c_block]);
     }
 
-    const void *get_indices_addr_3d(std::size_t ithr, int od, int oh,
+    const void *get_indices_addr_3d(std::size_t ithr, dim_t od, dim_t oh,
             const jit_pool_conf_t &jpp) const {
         const char *const wsp
                 = cvt_slice_ind_wsp_ + ithr * dst_slice_ * ind_dt_size_;
@@ -334,11 +334,11 @@ public:
                         + od * jpp.oh * jpp.ow * jpp.c_block * ind_dt_size_]);
     }
 
-    void execute_transpose_input(std::size_t ithr, int n, int b_c) const {
+    void execute_transpose_input(std::size_t ithr, dim_t n, dim_t b_c) const {
         execute_transpose_input_(ithr, n, b_c);
     }
 
-    void execute_transpose_output(std::size_t ithr, int n, int b_c) const {
+    void execute_transpose_output(std::size_t ithr, dim_t n, dim_t b_c) const {
         execute_transpose_output_(ithr, n, b_c);
     }
 
@@ -360,8 +360,8 @@ protected:
     wsp_data_t *__restrict cvt_slice_dst_wsp_;
     char *__restrict cvt_slice_ind_wsp_;
 
-    std::function<void(std::size_t, int, int)> execute_transpose_input_;
-    std::function<void(std::size_t, int, int)> execute_transpose_output_;
+    std::function<void(std::size_t, dim_t, dim_t)> execute_transpose_input_;
+    std::function<void(std::size_t, dim_t, dim_t)> execute_transpose_output_;
 };
 
 template <typename data_t, typename wsp_data_t, impl::data_type_t d_type>
@@ -554,8 +554,7 @@ void bwd_f32_accum_for_bf16_t::cvt_to_bf16_slice_2d(int ithr, bfloat16_t *dst,
             cvt_float_to_bfloat16(cur_dst, cur_src, nelems);
         } else {
             const auto c_b = jpp_.c_block * b_c;
-            const auto c_e = nstl::min(
-                    static_cast<dim_t>(jpp_.c), jpp_.c_block * (b_c + ur_bc));
+            const auto c_e = nstl::min(jpp_.c, jpp_.c_block * (b_c + ur_bc));
 
             if (c_b >= c_e) return;
 
@@ -609,8 +608,7 @@ void bwd_f32_accum_for_bf16_t::cvt_to_bf16_slice_3d(int ithr, bfloat16_t *dst,
                     dst + dst_d.blk_off(n), blk_data(ithr), nelems);
         } else {
             const auto c_b = jpp_.c_block * b_c;
-            const auto c_e = nstl::min(
-                    static_cast<dim_t>(jpp_.c), jpp_.c_block * (b_c + ur_bc));
+            const auto c_e = nstl::min(jpp_.c, jpp_.c_block * (b_c + ur_bc));
 
             if (c_b >= c_e) return;
 
@@ -653,9 +651,10 @@ status_t jit_uni_pooling_fwd_t<isa, d_type>::init_ncsp_trans_ctx() {
 
     const auto &jpp = pd()->jpp_;
     trans_ctx_ = utils::make_unique<trans_context_t>();
-    const dim_t src_sp = static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw;
-    const dim_t dst_sp = static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow;
-    const auto res = std::div(jpp.c_without_padding, jpp.c_block);
+    const dim_t src_sp = jpp.id * jpp.ih * jpp.iw;
+    const dim_t dst_sp = jpp.od * jpp.oh * jpp.ow;
+    const auto res
+            = std::div(jpp.c_without_padding, static_cast<dim_t>(jpp.c_block));
     const dim_t &nb_c = res.quot;
     const dim_t &c_tail = res.rem;
     const memory_desc_wrapper indices_d = pd()->workspace_md();
@@ -716,18 +715,18 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
     const auto trans_src = transpose_facade->should_transpose_src();
     const auto trans_dst = transpose_facade->should_transpose_dst();
 
-    const auto ker = [= COMPAT_THIS_CAPTURE](std::size_t ithr, int n, int b_c,
-                             int oh, int ur_bc) {
+    const auto ker = [= COMPAT_THIS_CAPTURE](std::size_t ithr, dim_t n,
+                             dim_t b_c, dim_t oh, dim_t ur_bc) {
         assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
         assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
-        const int c_off
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -768,8 +767,9 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         args.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
         args.kh_padding_shift = i_t_overflow * jpp.kw;
         args.ker_area_h = static_cast<float>(jpp.kh
-                - nstl::max(0, oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
-                - nstl::max(0, jpp.t_pad - oh * jpp.stride_h));
+                - nstl::max(dim_t(0),
+                        oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
+                - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h));
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         args.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
@@ -782,7 +782,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         parallel_nd(jpp.mb, jpp.oh, nb2_c, [=](dim_t n, dim_t oh, dim_t b2_c) {
             const auto b_c = b2_c * jpp.ur_bc;
-            const auto ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+            const auto ur_bc = nstl::min<dim_t>(jpp.ur_bc, jpp.nb_c - b_c);
             ker(0, n, b_c, oh, ur_bc);
         });
     } else {
@@ -800,8 +800,7 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
         } else {
             // nChw16c, nChw8c format
             parallel(nthr, [=](dim_t ithr, dim_t nthr) {
-                dim_t work_amount
-                        = static_cast<dim_t>(jpp.mb) * jpp.nb_c * jpp.oh;
+                dim_t work_amount = jpp.mb * jpp.nb_c * jpp.oh;
                 if (ithr >= work_amount) return;
 
                 dim_t start {0}, end {0};
@@ -848,18 +847,18 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
     const auto trans_src = transpose_facade->should_transpose_src();
     const auto trans_dst = transpose_facade->should_transpose_dst();
 
-    auto ker
-            = [= COMPAT_THIS_CAPTURE](int n, int b_c, int od, int oh, int id,
-                      int d_t_overflow, int d_b_overflow, int ur_bc, int ithr) {
+    auto ker = [= COMPAT_THIS_CAPTURE](dim_t n, dim_t b_c, dim_t od, dim_t oh,
+                       dim_t id, dim_t d_t_overflow, dim_t d_b_overflow,
+                       dim_t ur_bc, int ithr) {
         assert(ur_bc == jpp.ur_bc || ur_bc == jpp.ur_bc_tail);
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
-        const int c_off
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -900,15 +899,16 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         args.kh_padding_shift
                 = i_t_overflow * jpp.kw + d_t_overflow * jpp.kw * jpp.kh;
         args.kd_padding_shift = (i_t_overflow + i_b_overflow) * jpp.kw;
-        args.ker_area_h = (float)(jpp.kh
-                                  - nstl::max(0,
-                                          oh * jpp.stride_h - jpp.t_pad + jpp.kh
-                                                  - jpp.ih)
-                                  - nstl::max(0, jpp.t_pad - oh * jpp.stride_h))
+        args.ker_area_h
+                = (float)(jpp.kh
+                          - nstl::max(dim_t(0),
+                                  oh * jpp.stride_h - jpp.t_pad + jpp.kh
+                                          - jpp.ih)
+                          - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h))
                 * (jpp.kd
-                        - nstl::max(0,
+                        - nstl::max(dim_t(0),
                                 od * jpp.stride_d - jpp.f_pad + jpp.kd - jpp.id)
-                        - nstl::max(0, jpp.f_pad - od * jpp.stride_d));
+                        - nstl::max(dim_t(0), jpp.f_pad - od * jpp.stride_d));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
@@ -922,13 +922,12 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         parallel_nd(jpp.mb, jpp.od, nb2_c, [=](dim_t n, dim_t od, dim_t b2_c) {
             const dim_t b_c = b2_c * jpp.ur_bc;
-            const dim_t ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+            const dim_t ur_bc = nstl::min<dim_t>(jpp.ur_bc, jpp.nb_c - b_c);
 
             const dim_t ik = od * jpp.stride_d;
             const dim_t d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
             const dim_t d_b_overflow
-                    = nstl::max(dim_t(jpp.id), ik + jpp.kd - jpp.f_pad)
-                    - jpp.id;
+                    = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
             const dim_t id = nstl::max(ik - jpp.f_pad, dim_t(0));
             for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                 ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, ur_bc,
@@ -938,18 +937,19 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
     } else {
         if (trans_src || trans_dst) {
             parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                    [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                    [=](int ithr, int nthr, dim_t n, dim_t b_c) {
                 if (trans_src)
                     transpose_facade->execute_transpose_input(ithr, n, b_c);
 
-                for (int od = 0; od < jpp.od; ++od) {
-                    const int ik = od * jpp.stride_d;
-                    const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-                    const int d_b_overflow
+                for (dim_t od = 0; od < jpp.od; ++od) {
+                    const auto ik = od * jpp.stride_d;
+                    const auto d_t_overflow
+                            = nstl::max(dim_t(0), jpp.f_pad - ik);
+                    const auto d_b_overflow
                             = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad)
                             - jpp.id;
-                    const int id = nstl::max(ik - jpp.f_pad, 0);
-                    for (int oh = 0; oh < jpp.oh; ++oh) {
+                    const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
+                    for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                         ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
                                 ithr);
                     }
@@ -961,12 +961,12 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
         } else {
             parallel_nd(jpp.mb, jpp.nb_c, jpp.od,
                     [=](dim_t n, dim_t b_c, dim_t od) {
-                const int ik = od * jpp.stride_d;
-                const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-                const int d_b_overflow
+                const auto ik = od * jpp.stride_d;
+                const auto d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
+                const auto d_b_overflow
                         = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
-                const int id = nstl::max(ik - jpp.f_pad, 0);
-                for (int oh = 0; oh < jpp.oh; ++oh) {
+                const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
+                for (dim_t oh = 0; oh < jpp.oh; ++oh) {
                     ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, 1,
                             first_ithr);
                 }
@@ -989,9 +989,10 @@ status_t jit_uni_pooling_bwd_t<isa, d_type>::init_ncsp_trans_ctx() {
 
     const auto &jpp = pd()->jpp_;
     trans_ctx_ = utils::make_unique<trans_context_t>();
-    const dim_t diff_src_sp = static_cast<dim_t>(jpp.id) * jpp.ih * jpp.iw;
-    const dim_t diff_dst_sp = static_cast<dim_t>(jpp.od) * jpp.oh * jpp.ow;
-    const auto res = std::div(jpp.c_without_padding, jpp.c_block);
+    const dim_t diff_src_sp = jpp.id * jpp.ih * jpp.iw;
+    const dim_t diff_dst_sp = jpp.od * jpp.oh * jpp.ow;
+    const auto res
+            = std::div(jpp.c_without_padding, static_cast<dim_t>(jpp.c_block));
     const dim_t &nb_c = res.quot;
     const dim_t &c_tail = res.rem;
     const memory_desc_wrapper indices_d = pd()->workspace_md();
@@ -1055,19 +1056,21 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
 
     auto f32_accum = std::make_shared<bwd_f32_accum_for_bf16_t>(jpp, ctx);
 
-    auto get_first_ih = [=](int oh) {
-        return nstl::min(nstl::max(oh * jpp.stride_h - jpp.t_pad, 0), jpp.ih);
+    auto get_first_ih = [=](dim_t oh) {
+        return nstl::min(
+                nstl::max(oh * jpp.stride_h - jpp.t_pad, dim_t(0)), jpp.ih);
     };
 
-    auto get_last_ih = [=](int oh) {
+    auto get_last_ih = [=](dim_t oh) {
         return nstl::min(
-                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, dim_t(0)),
+                jpp.ih);
     };
-    const auto ker = [= COMPAT_THIS_CAPTURE](
-                             int ithr, int n, int b_c, int oh, int ur_bc) {
+    const auto ker = [= COMPAT_THIS_CAPTURE](int ithr, dim_t n, dim_t b_c,
+                             dim_t oh, dim_t ur_bc) {
         jit_uni_pooling_args_t args;
 
-        const int ih = get_first_ih(oh);
+        const auto ih = get_first_ih(oh);
         assert(IMPLICATION(pd()->ndims() == 3, utils::everyone_is(0, ih, oh)));
         assert(pd()->ndims() != 3 || utils::everyone_is(0, ih, oh));
 
@@ -1095,8 +1098,8 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
             }
         }
 
-        const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
-        const int zero_ih_end = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
+        const auto zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+        const auto zero_ih_end = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
 
         args.zero_id = 1;
         args.zero_ih = zero_ih_end - zero_ih_start;
@@ -1109,26 +1112,28 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
             args.zero_ptr
                     = &diff_src[diff_src_d.blk_off(n, c_off, zero_ih_start, 0)];
 
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - oh * jpp.stride_h);
-        const int i_b_overflow
+        const dim_t i_t_overflow
+                = nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h);
+        const dim_t i_b_overflow
                 = nstl::max(jpp.ih, oh * jpp.stride_h + jpp.kh - jpp.t_pad)
                 - jpp.ih;
         args.kh_padding = jpp.kh - i_t_overflow - i_b_overflow;
         args.kh_padding_shift = i_t_overflow * jpp.kw;
         args.ker_area_h = static_cast<float>(jpp.kh
-                - nstl::max(0, oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
-                - nstl::max(0, jpp.t_pad - oh * jpp.stride_h));
+                - nstl::max(dim_t(0),
+                        oh * jpp.stride_h - jpp.t_pad + jpp.kh - jpp.ih)
+                - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         (*kernel_)(&args);
     };
 
-    auto process_block = [=](int ithr, int n, int b_c, int ur_bc) {
+    auto process_block = [=](int ithr, dim_t n, dim_t b_c, dim_t ur_bc) {
         if (transpose_facade->should_transpose_dst())
             transpose_facade->execute_transpose_input(ithr, n, b_c);
 
-        for (int oh = 0; oh < jpp.oh; ++oh)
+        for (dim_t oh = 0; oh < jpp.oh; ++oh)
             ker(ithr, n, b_c, oh, ur_bc);
 
         if (transpose_facade->should_transpose_src())
@@ -1152,11 +1157,11 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward(
 
         std::size_t start {0}, end {0};
         balance211(work_amount, nthr, ithr, start, end);
-        int n {0}, b2_c {0};
+        dim_t n {0}, b2_c {0};
         utils::nd_iterator_init(start, n, jpp.mb, b2_c, nb2_c);
         for (size_t iwork = start; iwork < end; ++iwork) {
             const auto b_c = b2_c * jpp.ur_bc;
-            const auto ur_bc = nstl::min(jpp.ur_bc, jpp.nb_c - b_c);
+            const auto ur_bc = nstl::min<dim_t>(jpp.ur_bc, jpp.nb_c - b_c);
 
             process_block(ithr, n, b_c, ur_bc);
             utils::nd_iterator_step(n, jpp.mb, b2_c, nb2_c);
@@ -1193,27 +1198,29 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             ? sizeof(bwd_f32_accum_for_bf16_t::value_type)
             : jpp.dt_size;
 
-    auto get_last_ih = [=](int oh) {
+    auto get_last_ih = [=](dim_t oh) {
         return nstl::min(
-                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, 0), jpp.ih);
+                nstl::max(oh * jpp.stride_h - jpp.t_pad + jpp.kh, dim_t(0)),
+                jpp.ih);
     };
 
-    auto get_last_id = [=](int od) {
+    auto get_last_id = [=](dim_t od) {
         return nstl::min(
-                nstl::max(od * jpp.stride_d - jpp.f_pad + jpp.kd, 0), jpp.id);
+                nstl::max(od * jpp.stride_d - jpp.f_pad + jpp.kd, dim_t(0)),
+                jpp.id);
     };
 
-    auto ker = [= COMPAT_THIS_CAPTURE](int n, int b_c, int od, int oh, int id,
-                       int d_t_overflow, int d_b_overflow, bool zero_inp,
-                       int kd, int ur_bc, int ithr) {
+    auto ker = [= COMPAT_THIS_CAPTURE](dim_t n, dim_t b_c, dim_t od, dim_t oh,
+                       dim_t id, dim_t d_t_overflow, dim_t d_b_overflow,
+                       bool zero_inp, dim_t kd, dim_t ur_bc, int ithr) {
         jit_uni_pooling_args_t args;
 
-        const int ij = oh * jpp.stride_h;
-        const int i_t_overflow = nstl::max(0, jpp.t_pad - ij);
-        const int i_b_overflow
+        const auto ij = oh * jpp.stride_h;
+        const auto i_t_overflow = nstl::max(dim_t(0), jpp.t_pad - ij);
+        const auto i_b_overflow
                 = nstl::max(jpp.ih, ij + jpp.kh - jpp.t_pad) - jpp.ih;
-        const int ih = nstl::max(ij - jpp.t_pad, 0);
-        const int c_off
+        const auto ih = nstl::max(ij - jpp.t_pad, dim_t(0));
+        const auto c_off
                 = ((jpp.tag_kind == jit_memory_tag_kind_t::nspc) ? jpp.c_block
                                                                  : 1)
                 * b_c;
@@ -1244,14 +1251,14 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         }
 
         if (zero_inp) {
-            const int zero_id_start = (od == 0) ? 0 : get_last_id(od - 1);
-            const int zero_id_end
+            const auto zero_id_start = (od == 0) ? 0 : get_last_id(od - 1);
+            const auto zero_id_end
                     = (od == jpp.od - 1) ? jpp.id : get_last_id(od);
 
             args.zero_id = zero_id_end - zero_id_start;
 
-            const int zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
-            const int zero_ih_end
+            const auto zero_ih_start = (oh == 0) ? 0 : get_last_ih(oh - 1);
+            const auto zero_ih_end
                     = (oh == jpp.oh - 1) ? jpp.ih : get_last_ih(oh);
             args.zero_ih = zero_ih_end - zero_ih_start;
 
@@ -1274,29 +1281,31 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         args.kh_padding_shift = i_t_overflow * jpp.kw
                 + d_t_overflow * jpp.kw * jpp.kh + kd * jpp.kw * jpp.kh;
         args.kd_padding_shift = (i_t_overflow + i_b_overflow) * jpp.kw;
-        args.ker_area_h = (float)(jpp.kh
-                                  - nstl::max(0,
-                                          oh * jpp.stride_h - jpp.t_pad + jpp.kh
-                                                  - jpp.ih)
-                                  - nstl::max(0, jpp.t_pad - oh * jpp.stride_h))
+        args.ker_area_h
+                = (float)(jpp.kh
+                          - nstl::max(dim_t(0),
+                                  oh * jpp.stride_h - jpp.t_pad + jpp.kh
+                                          - jpp.ih)
+                          - nstl::max(dim_t(0), jpp.t_pad - oh * jpp.stride_h))
                 * (jpp.kd
-                        - nstl::max(0,
+                        - nstl::max(dim_t(0),
                                 od * jpp.stride_d - jpp.f_pad + jpp.kd - jpp.id)
-                        - nstl::max(0, jpp.f_pad - od * jpp.stride_d));
+                        - nstl::max(dim_t(0), jpp.f_pad - od * jpp.stride_d));
 
         args.ur_bc = ur_bc;
         args.b_c = b_c;
         (*kernel_)(&args);
     };
 
-    auto process_simple = [=](int n, int b_c, int od, int ur_bc, int ithr) {
-        const int ik = od * jpp.stride_d;
-        const int d_t_overflow = nstl::max(0, jpp.f_pad - ik);
-        const int d_b_overflow
+    auto process_simple
+            = [=](dim_t n, dim_t b_c, dim_t od, dim_t ur_bc, int ithr) {
+        const auto ik = od * jpp.stride_d;
+        const auto d_t_overflow = nstl::max(dim_t(0), jpp.f_pad - ik);
+        const auto d_b_overflow
                 = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
-        const int id = nstl::max(ik - jpp.f_pad, 0);
+        const auto id = nstl::max(ik - jpp.f_pad, dim_t(0));
 
-        for (int oh = 0; oh < jpp.oh; ++oh) {
+        for (dim_t oh = 0; oh < jpp.oh; ++oh) {
             ker(n, b_c, od, oh, id, d_t_overflow, d_b_overflow, true, 0, ur_bc,
                     ithr);
         }
@@ -1318,11 +1327,11 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                 });
             } else {
                 parallel_nd_ext(nthr, jpp.mb, nb2_c,
-                        [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b2_c) {
+                        [=](int ithr, dim_t nthr, dim_t n, dim_t b2_c) {
                     const dim_t b_c = b2_c * jpp.ur_bc;
                     const dim_t ur_bc
                             = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
+                    for (dim_t od = 0; od < jpp.od; ++od) {
                         process_simple(n, b_c, od, ur_bc, ithr);
                     }
                     f32_accum->cvt_to_bf16_slice_3d(ithr,
@@ -1333,10 +1342,10 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
             assert(jpp.ur_bc == 1);
             if (trans_src || trans_dst || jpp.needs_f32_accum_for_bf16) {
                 parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                        [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                        [=](int ithr, dim_t nthr, dim_t n, dim_t b_c) {
                     if (trans_src)
                         transpose_facade->execute_transpose_input(ithr, n, b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
+                    for (dim_t od = 0; od < jpp.od; ++od) {
                         process_simple(n, b_c, od, 1, ithr);
                     }
                     if (trans_dst)
@@ -1370,7 +1379,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                     const size_t chunk_size
                             = (size_t)jpp.id * jpp.ih * jpp.iw * jpp.c_block;
                     parallel_nd_ext(nthr, jpp.mb, jpp.nb_c,
-                            [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b_c) {
+                            [=](int ithr, dim_t nthr, dim_t n, dim_t b_c) {
                         const size_t offset
                                 = ((size_t)n * jpp.nb_c + b_c) * chunk_size;
                         PRAGMA_OMP_SIMD()
@@ -1384,7 +1393,7 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
         const auto nb2_c = utils::div_up(jpp.nb_c, jpp.ur_bc);
         if (trans_src || trans_dst || jpp.needs_f32_accum_for_bf16) {
             parallel_nd_ext(nthr, jpp.mb, nb2_c,
-                    [=](dim_t ithr, dim_t nthr, dim_t n, dim_t b2_c) {
+                    [=](int ithr, int nthr, dim_t n, dim_t b2_c) {
                 const dim_t b_c = b2_c * jpp.ur_bc;
 
                 if (trans_dst) {
@@ -1395,15 +1404,15 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
 
                     const void *src = transpose_facade->get_src_addr_3d(
                             ithr, 0, 0, jpp);
-                    std::memset((void *)src, zero_val, block_size);
+                    std::memset((void *)src, 0, block_size);
                 }
 
                 if (jpp.needs_f32_accum_for_bf16) f32_accum->zero_data(ithr);
 
-                const dim_t ur_bc = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
+                const dim_t ur_bc = nstl::min<dim_t>(jpp.ur_bc, jpp.nb_c - b_c);
                 for (dim_t kd = 0; kd < jpp.kd; ++kd) {
-                    for (int od = 0; od < jpp.od; ++od) {
-                        const dim_t ik = static_cast<dim_t>(od) * jpp.stride_d;
+                    for (dim_t od = 0; od < jpp.od; ++od) {
+                        const dim_t ik = od * jpp.stride_d;
                         const dim_t d_t_overflow
                                 = nstl::max(dim_t(0), jpp.f_pad - ik);
                         const dim_t d_b_overflow
@@ -1432,9 +1441,9 @@ void jit_uni_pooling_bwd_t<isa, d_type>::execute_backward_3d(
                 parallel_nd(jpp.mb, nb2_c, [=](dim_t n, dim_t b2_c) {
                     const dim_t b_c = b2_c * jpp.ur_bc;
                     const dim_t ur_bc
-                            = nstl::min(dim_t(jpp.ur_bc), jpp.nb_c - b_c);
-                    for (int od = 0; od < jpp.od; ++od) {
-                        const dim_t ik = static_cast<dim_t>(od) * jpp.stride_d;
+                            = nstl::min<dim_t>(jpp.ur_bc, jpp.nb_c - b_c);
+                    for (dim_t od = 0; od < jpp.od; ++od) {
+                        const dim_t ik = od * jpp.stride_d;
                         const dim_t d_t_overflow
                                 = nstl::max(dim_t(0), jpp.f_pad - ik);
                         const dim_t d_b_overflow


### PR DESCRIPTION
It's a pooling (PR Nr.5) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
Total number of warnings decreased 1680 => 1514.
Eliminates c4244 warnings via widening local variables to dim_t and using low-level wrapper from jit-generator. 