### PR TITLE
cpu: x64: disable AMX when no tile palette is supported

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.cpp
+++ b/src/cpu/x64/cpu_isa_traits.cpp
@@ -263,7 +263,12 @@ status_t set_cpu_isa_hints(dnnl_cpu_isa_hints_t isa_hints) {
 namespace amx {
 
 int get_max_palette() {
-    if (mayiuse(amx_tile)) {
+    // Guard on the raw AMX-TILE CPUID bit (not mayiuse(amx_tile)) for two
+    // reasons: (1) CPUID leaf 0x1D is only defined when AMX-TILE is present, so
+    // this avoids reading an out-of-range leaf on older CPUs; (2) mayiuse(
+    // amx_tile) itself calls this function, so guarding on it here would cause
+    // infinite recursion.
+    if (cpu().has(Xbyak::util::Cpu::tAMX_TILE)) {
         static const unsigned int EAX = []() {
             unsigned int data[4] = {};
             Xbyak::util::Cpu::getCpuidEx(0x1D, 0, data);

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -392,6 +392,11 @@ inline bool is_available() {
 
 namespace amx {
 
+// Return the maximum tile palette supported by the CPU (CPUID.1D:EAX), or `0`
+// when AMX is not supported. Exported because it is referenced from the inline
+// mayiuse() below, which is instantiated across separately-linked modules.
+int DNNL_API get_max_palette();
+
 // Return the target palette for AMX instructions. Currently this is `0` if AMX
 // instructions are not supported, and `1` if they are.
 int get_target_palette();
@@ -464,8 +469,14 @@ inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
                     && cpu().has(Cpu::tAPX_F) && cpu().has(Cpu::tMOVRS)
                     && x64::apx::is_available());
         case amx_tile:
+            // Some (mis-configured) hypervisors/VMs advertise AMX support via
+            // CPUID (AMX-TILE bit) and XCR0, but report zero supported tile
+            // palettes in CPUID.1D:EAX. Executing any AMX instruction on such a
+            // system raises #UD (illegal instruction). Require a non-zero
+            // palette so AMX is reported unavailable there.
             REG_AMX_ISA(return cpu().has(Cpu::tAMX_TILE)
-                    && x64::amx::is_available());
+                    && x64::amx::is_available()
+                    && x64::amx::get_max_palette() != 0);
         case amx_int8:
             REG_AMX_ISA(return mayiuse(amx_tile, soft)
                     && cpu().has(Cpu::tAMX_INT8));


### PR DESCRIPTION
Some misconfigured hypervisors/VMs advertise AMX support via CPUID (AMX-TILE bit) and XCR0[18:17], so mayiuse(amx_tile) returns true, yet report zero supported tile palettes in CPUID.1D:EAX. Executing any AMX instruction (e.g. tilezero/ldtilecfg) on such a system raises #UD (illegal instruction).

Gate amx::init() on a direct CPUID.1D:EAX check so that AMX is reported unavailable when no palette is supported, allowing dispatch to fall back to non-AMX kernels.

Fixes: https://github.com/uxlfoundation/oneDNN/issues/5689
