### PR TITLE
xe: copy plan: optimize dword-stride repack

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.cpp
@@ -249,6 +249,7 @@ void CopyPlan::transform()
 
     sort(SortType::Register);
 
+    optimizeTranspose();
     optimizeIntegerDownconvert();
     optimizeZip();
     optimizeZipAdjacent();
@@ -2935,6 +2936,83 @@ void CopyPlan::sort(SortType type)
     std::stable_sort(insns.begin(), insns.end(), [=](const CopyInstruction &i1, const CopyInstruction &i2) {
         return sortOrder(i1) < sortOrder(i2);
     });
+}
+
+// Optimization pass: Convert long chains of small-SIMD equal-strided movs
+// to a few larger-SIMD movs.
+// Example input:
+//    mov (2) r3.0:ub<1>      r3.0:ub<2>
+//    mov (2) r3.4:ub<1>      r3.4:ub<2>
+//    mov (2) r3.8:ub<1>      r3.8:ub<2>
+//    mov (2) r3.12:ub<1>     r3.12:ub<2>
+//    mov (2) r3.16:ub<1>     r3.16:ub<2>
+//    mov (2) r3.20:ub<1>     r3.20:ub<2>
+//    mov (2) r3.24:ub<1>     r3.24:ub<2>
+//    mov (2) r3.28:ub<1>     r3.28:ub<2>
+// Output:
+//    mov (8) r3.0:ub<4>      r3.0:ub<4>  /* removed */
+//    mov (8) r3.1:ub<4>      r3.2:ub<4>
+//
+void CopyPlan::optimizeTranspose()
+{
+    const auto grf = ngen::GRF::bytes(hw);
+    auto transposable = [grf](const CopyOperand &o1, const CopyOperand &o2, int offset) {
+        if (o1.kind != CopyOperand::GRF || o2.kind != CopyOperand::GRF) return false;
+        if (o1.type != o2.type || o1.stride != o2.stride) return false;
+        if (o1.temp != o2.temp) return false;
+        if (o1.temp && o1.value != o2.value) return false;
+        if (o1.neg != o2.neg) return false;
+        if (o1.abs != o2.abs) return false;
+
+        auto grf_diff = o2.grf - o1.grf;
+        auto dist = bytesToElements(grf, o1.type) * grf_diff + (o2.offset - o1.offset);
+        return dist == offset;
+    };
+
+    auto ninsn = insns.size();
+    for (size_t n1 = 0; n1 < ninsn; n1++) {
+        auto &i1 = insns[n1];
+        if (i1.op != Opcode::mov || i1.simd == 0) continue;
+        const int8_t dstride = bytesToElements(4, i1.dst.type);
+        const int8_t sstride = bytesToElements(4, i1.src0.type);
+
+        int simd = 1;
+        size_t n2 = n1 + 1;
+        auto end = i1.range.end + 1;
+        for (; n2 < ninsn; n2++, simd++) {
+            auto &i2 = insns[n2];
+            if (i1.phase != i2.phase) break;
+            if (i2.op != Opcode::mov) break;
+            if (i1.simd != i2.simd) break;
+            if (i1.sat != i2.sat) break;
+            if (!transposable(i1.src0, i2.src0, dstride * simd)) break;
+            if (!transposable(i1.dst, i2.dst, sstride * simd)) break;
+            if (i2.range.start != end) break;  // ensure joins are valid
+            end = i2.range.end + 1;
+        }
+
+        size_t n = n1 + 1;
+        n1 = n2 - 1;
+
+        if (i1.simd >= simd) continue;
+
+        for (; n < n2; n++)
+            join(i1, insns[n]);
+
+        auto simd0 = i1.simd;
+        i1.simd = simd;
+        auto soffset = i1.src0.stride;
+        auto doffset = i1.dst.stride;
+        i1.src0.stride = sstride;
+        i1.dst.stride = dstride;
+        for (int i = 1; i < simd0; ++i) {
+            auto &i2 = split(i1, false);
+            i2.src0.offset += i * soffset;
+            i2.dst.offset += i * doffset;
+        }
+    }
+
+    mergeChanges();
 }
 
 // Optimization pass: zip together interleaved operations.

--- a/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/copy_plan.hpp
@@ -305,6 +305,7 @@ protected:
     void optimizeIntegerDownconvert();
     void optimizeSaturate();
     void optimizeMoveToIntPipe();
+    void optimizeTranspose();
 
     CopyOperand bfImmediate(uint16_t bits, bool ternary);
     CopyOperand zipImmediates(const CopyOperand &o1, const CopyOperand &o2, uint8_t stride);


### PR DESCRIPTION
Targets scatter load repacks, i.e. packed u4/u8 <-> strided u4/u8 and eventually u2, found primarily in IR-based kernels.