### PR TITLE
[rls-v3.13] xe: ggemm: limit unroll_n on XeHPG for u8 weights to avoid generation errors

### DIFF
--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -248,7 +248,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
                 bool is_xelpg = (product.family == ngen::ProductFamily::ARL
                         || product.family == ngen::ProductFamily::MTL);
                 if (!dev_info->mayiuse_systolic()) max_wg_n = 2;
-                max_n_unroll = (problem.Ta_ext.bits() < 8
+                max_n_unroll = (problem.Ta_ext.bits() <= 8
                                        && problem.Ta_ext.isInteger())
                         ? sg_size_ * problem.Ta_ext
                         : 16;

--- a/tests/benchdnn/inputs/matmul/test_matmul_grouped_gpu
+++ b/tests/benchdnn/inputs/matmul/test_matmul_grouped_gpu
@@ -97,3 +97,19 @@
 --wtag=acb
 --match=gs128
 --batch=shapes_grouped_moe
+
+########################################
+# WoQ F16/U8/F16                       #
+# scale_b: f16 block (E, 1, N)         #
+# zero-point_b: u8 block (E, 1, N)     #
+# + bias f16                           #
+########################################
+
+--reset
+--dt=f16:u8:f16
+--bia-dt=f16 --bia_mask=2
+--attr-scales=wei:5:f16
+--attr-zero-points=wei:5:u8
+--attr-fpmath=f16:true
+--wtag=acb
+--batch=shapes_grouped_moe


### PR DESCRIPTION
# Description

This PR fixes an issue with WoQ where the microkernel generation failed for larger shapes. This PR limits the max n unroll to 8 when the weight is u8.

Fixes: [MFDNN-15372](https://jira.devtools.intel.com/browse/MFDNN-15372)
Backports: [#5802](https://github.com/uxlfoundation/oneDNN/pull/5802)