### PR TITLE
[GPU] Fix bdpas miscompilation with gcc13

### DIFF
--- a/third_party/ngen/ngen.hpp
+++ b/third_party/ngen/ngen.hpp
@@ -2606,8 +2606,9 @@ static inline void encodeDPAS(Instruction12 &i, Opcode op, DataType defaultType,
 
     encodeCommon12(i, op, emod, dst, tag);
 
-    i.ternary.dst  = encodeTernaryOperand12<true,  false>(dst,  tag).bits;
-    i.ternary.src0 = encodeTernaryOperand12<false, false>(src0, tag).bits;
+    // same as (i.ternary.dst/src0 = ...), update directly to avoid gcc13 bug
+    i.qword[0] |= uint64_t(encodeTernaryOperand12<true,  false>(dst,  tag).bits) << 48;
+    i.qword[1] |= uint64_t(encodeTernaryOperand12<false, false>(src0, tag).bits);
     i.ternary.src1 = encodeTernaryOperand12<false, false>(src1, tag).bits;
     i.ternary.src2 = encodeTernaryOperand12<false, false>(src2, tag).bits;
 


### PR DESCRIPTION
Found an issue with gcc13 when `bdpas` is incorrectly compiled with `dst/src0` as `null`. Reproduced this with the latest main with gcc13 and OpenCL runtime. PR implements a workaround.

Test case:

```bash
$ ONEDNN_JIT_DUMP=1 ./build/tests/benchdnn/benchdnn -v5 --engine=gpu --matmul --engine=gpu --stag=ab --wtag=ba --dtag=ab --dt=f8_e4m3:f8_e4m3:bf16 --attr-scales=src:per_tensor:e8m0:1x32+wei:per_tensor:e8m0:32x1 128x128:128x128
```

Before the PR:

```bash
$ iga64 -d -p 3px dnnl_dump_gpu_gemm_kernel.0.bin | grep bdpas | head                                                          (W)     bdpas.8x8 (16|M0)        null:f        null:f            r40:hf8           r7.0:hf8          r56.0:ub          r39.0:ub         {Atomic}
(W)     bdpas.8x8 (16|M0)        null:f        null:f            r40:hf8           r11.0:hf8         r56.0:ub          r39.8:ub         {Atomic}
(W)     bdpas.8x8 (16|M0)        null:f        null:f            r40:hf8           r15.0:hf8         r56.0:ub          r39.16:ub        {Atomic}
...
```

After the PR:

```bash
$ iga64 -d -p 3px dnnl_dump_gpu_gemm_kernel.0.bin | grep bdpas | head
(W)     bdpas.8x8 (16|M0)        r48:f         r48:f             r40:hf8           r7.0:hf8          r56.0:ub          r39.0:ub         {Atomic}
(W)     bdpas.8x8 (16|M0)        r58:f         r58:f             r40:hf8           r11.0:hf8         r56.0:ub          r39.8:ub         {Atomic}
...

```