### PR TITLE
cpu: rv64: pool: route f32 nspc fwd to baked kernel

### DIFF
--- a/src/cpu/rv64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_pool_kernel.cpp
@@ -71,6 +71,15 @@ static pool_binary_bcast_t classify_binary_src1(
     return pool_binary_bcast_t::none;
 }
 
+// Map an effective channel-vector LMUL (1/2/4) to the xbyak_riscv LMUL enum.
+static Xbyak_riscv::LMUL pool_lmul_to_enum(int lmul) {
+    switch (lmul) {
+        case 2: return Xbyak_riscv::LMUL::m2;
+        case 4: return Xbyak_riscv::LMUL::m4;
+        default: return Xbyak_riscv::LMUL::m1;
+    }
+}
+
 // Fill the shape/stride/kernel/padding fields shared verbatim by all three
 // init_conf paths (baked, native forward, native backward). Channel bookkeeping
 // (c / c_block / c_without_padding) differs per path and stays with the caller.
@@ -135,6 +144,12 @@ jit_uni_pool_kernel_t<isa>::jit_uni_pool_kernel_t(
     // descriptor there. The rv64 kernel builds its injector in generate() from
     // jpp.post_ops instead, so it never reads dst_md.
     UNUSED(dst_md);
+    // jpp.c_block is the base SIMD block (vlen/32) for blocked/f16 paths, or
+    // base*LMUL for the widened f32 nspc forward-inference path (init_conf
+    // scales it there). Recover the effective LMUL for tile register spacing.
+    const int base = (int)(get_platform_vlen() / 32);
+    lmul_ = (base > 0) ? jpp.c_block / base : 1;
+    if (lmul_ != 1 && lmul_ != 2 && lmul_ != 4) lmul_ = 1;
 }
 
 static status_t set_binary_postops_formats(
@@ -309,6 +324,24 @@ status_t jit_uni_pool_kernel_t<isa>::init_conf(jit_pool_conf_t &jpp,
         CHECK(set_binary_postops_formats(attr.post_ops_, dst_d.md_));
     jpp.post_ops = attr.post_ops_;
 
+    // Widen the channel vector for f32 nspc forward inference to amortise the
+    // per-channel-block call count, the cost that made the plain baked kernel
+    // slower than the native full-C kernel.
+    if (jpp.tag_kind == jit_pool_tag_kind_t::nspc && !jpp.is_f16
+            && !jpp.is_backward && !jpp.is_training && !jpp.with_postops) {
+        const int base = (int)(vlen / 32);
+        int lmul = (base > 0) ? 16 / base : 1;
+        if (lmul != 1 && lmul != 2 && lmul != 4) lmul = 1;
+        if (lmul > 1) {
+            jpp.c_block *= lmul;
+            jpp.nb_c = utils::div_up(jpp.c, jpp.c_block);
+            jpp.c_tail = jpp.c % jpp.c_block;
+            const int max_ur
+                    = tile_size / 2 / lmul; // 2*ur*lmul <= tile_size (24)
+            if (jpp.ur > max_ur) jpp.ur = max_ur;
+        }
+    }
+
     UNUSED(scratchpad); // no plain<->blocked transpose on RVV
     return status::success;
 }
@@ -369,8 +402,9 @@ void jit_uni_pool_kernel_t<isa>::set_vl_e32() {
     // dependency. Mask-undisturbed (VMA::mu) is REQUIRED, not optional here:
     // max_step_bwd() runs a masked vfadd_vv under this vtype and then stores the
     // whole vector, so the masked-off (non-argmax) lanes must keep their loaded
-    // diff_src value. All other pool vsetvli sites use VMA::ma.
-    vsetvli(t0, reg_vl, SEW::e32, LMUL::m1, VTA::ta, VMA::mu);
+    // diff_src value. All other pool vsetvli sites use VMA::ma. LMUL follows the
+    // effective channel-vector width (lmul_); the f32 nspc fwd path widens it.
+    vsetvli(t0, reg_vl, SEW::e32, pool_lmul_to_enum(lmul_), VTA::ta, VMA::mu);
 }
 
 template <cpu_isa_t isa>
@@ -963,6 +997,12 @@ status_t jit_uni_pool_ncsp_kernel_t<isa, d_type>::init_conf(
     else
         return status::unimplemented;
     jpp.use_native = true;
+
+    // f32 nspc forward inference routes to the baked kernel. f16 nspc, ncsp,
+    // and f32 nspc training stay on this native kernel.
+    if (d_type == data_type::f32 && jpp.tag_kind == jit_pool_tag_kind_t::nspc
+            && !jpp.is_training)
+        return status::unimplemented;
 
     // f32 nspc builds the shape-baked interior kernel, which fully unrolls the
     // width sweep over max_p = (ur_w-1)*sw + kw input positions. Its per-channel

--- a/src/cpu/rv64/jit_uni_pool_kernel.hpp
+++ b/src/cpu/rv64/jit_uni_pool_kernel.hpp
@@ -75,11 +75,18 @@ private:
     using Reg = Xbyak_riscv::Reg;
     using FReg = Xbyak_riscv::FReg;
 
-    // Tile registers: 24-register acc/input/index space at v8..v31.
+    // Tile registers: 24-register acc/input/index space at v8..v31. With LMUL>1
+    // (f32 nspc forward inference only) each logical tile vector is a group of
+    // lmul_ consecutive physical registers, so tile indices are spaced by lmul_.
     static constexpr int tile_base = 8;
     static constexpr int tile_size = 24;
-    Vmm vreg(int idx) const { return Vmm(tile_base + idx); }
+    Vmm vreg(int idx) const { return Vmm(tile_base + idx * lmul_); }
     static int reg_ind(int shift, int j, int ur_w) { return shift * ur_w + j; }
+    // Effective channel-vector LMUL (1, 2, or 4). 1 everywhere except the f32 nspc
+    // forward-inference path, where the channel vector is widened (c_block grows
+    // past vlen/32) to amortise the per-channel-block call count. Derived in the
+    // ctor from jpp.c_block.
+    int lmul_ = 1;
 
     // Reserved scratch (see class comment).
     const Vmm v_mask = Vmm(0);

--- a/src/cpu/rv64/jit_uni_pooling.cpp
+++ b/src/cpu/rv64/jit_uni_pooling.cpp
@@ -867,8 +867,17 @@ void jit_uni_pooling_fwd_t<isa>::execute_forward_blk(const data_t *src,
         (*kernel_)(&arg);
     };
 
-    parallel_nd(jpp.mb, (dim_t)jpp.nb_c, (dim_t)jpp.oh,
-            [&](dim_t n, dim_t b_c, dim_t oh) { ker(n, b_c, oh); });
+    // Parallelise over (mb, oh) and loop the channel blocks inside each task.
+    // The fine-grained (mb, nb_c, oh) split made one tiny task per channel block,
+    // which scaled poorly on multi-core (per-call preamble amortised over little
+    // work, plus output false-sharing between adjacent, contiguous channel blocks
+    // handed to different threads). One task per (mb, oh) row matches the native
+    // kernel's spatial parallelism; a single thread then writes the row's
+    // contiguous nspc channels without contention.
+    parallel_nd(jpp.mb, (dim_t)jpp.oh, [&](dim_t n, dim_t oh) {
+        for (dim_t b_c = 0; b_c < (dim_t)jpp.nb_c; ++b_c)
+            ker(n, b_c, oh);
+    });
 }
 
 template <cpu_isa_t isa>
@@ -915,15 +924,15 @@ void jit_uni_pooling_fwd_t<isa>::execute_forward_blk_3d(const data_t *src,
         (*kernel_)(&arg);
     };
 
-    parallel_nd(jpp.mb, (dim_t)jpp.nb_c, (dim_t)jpp.od,
-            [&](dim_t n, dim_t b_c, dim_t od) {
+    parallel_nd(jpp.mb, (dim_t)jpp.od, [&](dim_t n, dim_t od) {
         const int ik = od * jpp.stride_d;
         const int d_t_over = nstl::max(0, jpp.f_pad - ik);
         const int d_b_over
                 = nstl::max(jpp.id, ik + jpp.kd - jpp.f_pad) - jpp.id;
         const dim_t id = nstl::max(ik - jpp.f_pad, 0);
-        for (dim_t oh = 0; oh < jpp.oh; ++oh)
-            ker(n, b_c, od, oh, id, d_t_over, d_b_over);
+        for (dim_t b_c = 0; b_c < (dim_t)jpp.nb_c; ++b_c)
+            for (dim_t oh = 0; oh < jpp.oh; ++oh)
+                ker(n, b_c, od, oh, id, d_t_over, d_b_over);
     });
 }
 

--- a/src/cpu/rv64/jit_uni_pooling.hpp
+++ b/src/cpu/rv64/jit_uni_pooling.hpp
@@ -108,24 +108,13 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
                 if (st == status::success) return status::success;
             }
 
-            // Baked kernel: blocked (all fwd props) and the plain training cases
-            // native declined (f16/post-op max training).
+            // Baked kernel: blocked (all fwd props), the plain training cases
+            // native declined (f16/post-op max training), and f32 nspc forward
+            // inference, whose channel vector the baked kernel widens via LMUL.
             auto scratchpad = scratchpad_registry().registrar();
             status_t st = jit_uni_pool_kernel_t<isa>::init_conf(
                     jpp_, scratchpad, attr_, this);
             VDISPATCH_POOLING(st == status::success, VERBOSE_UNSUPPORTED_TAG);
-
-            // f32 nspc reaching the baked kernel (a case the native kernel
-            // declined) issues many narrow per-channel-block calls with little
-            // per-element work, so it defers to the nhwc_pooling reduction. f16
-            // nspc keeps the baked kernel (its f16<->f32 conversion outweighs the
-            // call overhead), and blocked has no reduction fallback, so both
-            // stay.
-            VDISPATCH_POOLING(
-                    !(d_type == data_type::f32
-                            && jpp_.tag_kind == jit_pool_tag_kind_t::nspc),
-                    VERBOSE_IMPL_HEURISTIC_FAIL,
-                    "f32 nspc forward defers to the nhwc_pooling reduction");
             return status::success;
         }
 


### PR DESCRIPTION
# Description

This PR routes f32 NHWC (`nspc`) forward-inference pooling to the x64/aarch64-style baked kernel (`jit_uni_pool_kernel_t`) and widens its channel vector with RVV LMUL, closing a large performance gap with the native `jit_uni_pool_interior_kernel_t` that previously handled this path. The baked kernel is the design oneDNN uses on x64 and aarch64 for forward pooling; aligning rv64 with it (rather than the custom native nspc kernel) is the goal of this change.

This version provides:

1. **Dispatch routing**: f32 nspc forward inference now runs the baked kernel instead of the native interior/ncsp kernels, matching the x64/aarch64 design.
2. **LMUL channel-vector widening**: the baked kernel's per-call channel vector grows from `c_block` (4 lanes on VLEN=128) to 16 lanes (LMUL=4), amortising the per-channel-block call overhead that made the plain baked kernel slower than the native full-C kernel.
3. **Driver parallelisation coarsening**: `execute_forward_blk` parallelises over `(mb, oh)` with the channel-block loop inside each task, which is essential for multi-core scaling once the channel vector is widened.

## Key Features

- **Algorithm**: forward inference, max and average pooling (include/exclude padding).
- **Data type**: `f32` .
- **Layout**: NHWC plain (`nspc`) — the layout benchdnn's `--tag=axb` resolves to.
- **Mechanism**: JIT with `xbyak_riscv_v`; LMUL register-group spacing in the 24-register accumulator/input tile.

# Checklist

## General

- [x] Do all benchdnn pool tests pass? — all 27 f32 shapes pass (`--mode=c`) at LMUL=4.
- [x] Have you formatted the code using clang-format? — clang-format-18 applied to all four files.

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on SG2044 (XuanTie C920, VLEN=128), GCC 14.2, `-march=rv64gcv -O3`, `ONEDNN_CPU_RUNTIME=OMP`. We draw comparisons among:

1. **baseline**: upstream/main `e1f436a812` — the native `jit_uni_pool_interior_kernel_t` + `jit_uni_pool_ncsp_kernel_t` (the path that previously handled f32 nspc forward inference).
2. **this PR**: f32 nspc forward inference on the baked kernel with LMUL=4 and the coarsened driver.

Both are measured with `OMP_NUM_THREADS` set to the `taskset` core count (1 for `c27`, 8 for `c20-28`). This is required: with `OMP_NUM_THREADS` unset, libgomp spawns threads for every online CPU (~60) regardless of `taskset` affinity, oversubscribing the pinned cores; the baked kernel's finer task granularity is hurt far more than the native kernel's under oversubscription, which masks the gain entirely.

### Single-Core Performance (`taskset -c 27`, `OMP_NUM_THREADS=1`)

| Batch | baseline native (ms) | this PR LMUL=4 (ms) | Speedup |
|-------|----------------------|---------------------|---------|
| alexnet (3 layers) | 443.5 | 316.4 | 1.40× |
| resnet_50 (2 layers) | 165.6 | 119.9 | 1.38× |
| googlenet_v1 (11 layers) | 1299.0 | 918.4 | 1.41× |
| googlenet_v3 (11 layers) | 2289.2 | 1863.5 | 1.23× |
| **Total (27 layers)** | **4197.3** | **3218.2** | **1.30×** |

### 8-Core Performance (`taskset -c 20-28`, `OMP_NUM_THREADS=8`)

| Batch | baseline native (ms) | this PR LMUL=4 (ms) | Speedup |
|-------|----------------------|---------------------|---------|
| alexnet (3 layers) | 74.6 | 64.2 | 1.16× |
| resnet_50 (2 layers) | 40.1 | 26.2 | 1.53× |
| googlenet_v1 (11 layers) | 211.5 | 171.8 | 1.23× |
| googlenet_v3 (11 layers) | 426.2 | 327.3 | 1.30× |
| **Total (27 layers)** | **752.4** | **589.5** | **1.28×** |

**Summary:**
- Single-core: **1.30×** (−23%) overall; per-batch 1.23×–1.41×.
- 8-core: **1.28×** (−22%) overall; per-batch 1.16×–1.53×.

### LMUL Selection

LMUL=4 is the best baked configuration; LMUL=1 and LMUL=2 are both slower than the native baseline, confirming the widening is what makes the baked path competitive.

| Config (alexnet) | single-core (ms) | 8-core (ms) |
|------------------|------------------|-------------|
| baseline native | 443.5 | 74.6 |
| baked LMUL=1 | 459.2 | 112.3 |
| baked LMUL=2 | 658.8 | 105.7 |
| baked LMUL=4 | 316.4 | 64.2 |

LMUL=2 is the worst of the three: it pays half the OW-unroll of LMUL=1 (ur 6 vs 12) for only 2× the channel width — the wrong tradeoff for these shapes. LMUL=8 is infeasible (the 24-register tile cannot fit `2*ur*8` acc+input groups).

### Coarsening is Essential for Multi-Core

With the driver left at the fine-grained `parallel_nd(mb, nb_c, oh)`, 8-core LMUL=4 regresses (alexnet 155.8 ms vs native 74.6 ms) because the many one-channel-block tasks contend. The coarsened `parallel_nd(mb, oh)` makes LMUL=4 win on 8-core instead (64.2 ms). Single-core is identical either way (the coarsening only redistributes the same work across threads).
