### PR TITLE
cpu: rv64: softmax: improve f32 path by vectorizing softmax/logsoftmax reduction

### DIFF
--- a/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
@@ -35,6 +35,9 @@ using namespace Xbyak_riscv;
 #define F16_EXP_SUB_SUM_OFF(field) \
     static_cast<int32_t>(offsetof( \
             jit_rvv_softmax_f16_exp_sub_sum_kernel_t::call_params_t, field))
+#define F32_EXP_SUB_SUM_OFF(field) \
+    static_cast<int32_t>(offsetof( \
+            jit_rvv_softmax_f32_exp_sub_sum_kernel_t::call_params_t, field))
 
 namespace {
 
@@ -55,6 +58,13 @@ void dispatch_f16_strided(
 void dispatch_f16_exp_sub_sum(
         const jit_rvv_softmax_f16_exp_sub_sum_kernel_t::call_params_t *p) {
     static const jit_rvv_softmax_f16_exp_sub_sum_kernel_t kernel;
+    kernel(p);
+}
+
+template <bool store_exp>
+void dispatch_f32_exp_sub_sum(
+        const jit_rvv_softmax_f32_exp_sub_sum_kernel_t::call_params_t *p) {
+    static const jit_rvv_softmax_f32_exp_sub_sum_kernel_t kernel(store_exp);
     kernel(p);
 }
 
@@ -401,6 +411,158 @@ void jit_rvv_softmax_f16_exp_sub_sum_kernel_t::generate() {
 #else
     ret();
 #endif
+}
+
+jit_rvv_softmax_f32_exp_sub_sum_kernel_t::
+        jit_rvv_softmax_f32_exp_sub_sum_kernel_t(bool store_exp)
+    : jit_generator_t("jit_rvv_softmax_f32_exp_sub_sum_kernel")
+    , store_exp_(store_exp) {
+    create_kernel();
+}
+
+// Same range-reduced polynomial exp as the f16 kernel (which already computes
+// in f32 internally); the input is simply loaded as f32 instead of widened
+// from f16. The accumulator uses VTA::tu so a final short tail folds into the
+// low lanes and the closing vfredosum still produces the exact ordered sum.
+void jit_rvv_softmax_f32_exp_sub_sum_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_dst = a2;
+    const Reg reg_len = a3;
+    const Reg reg_sum = a4;
+    const Reg reg_sub_tmp = t2;
+    const Reg reg_vl = t0;
+    const Reg reg_bytes = t1;
+    const Reg reg_maxexp = t4;
+    const Reg reg_minexp = t5;
+    const Reg reg_imm = t6;
+
+    const FReg f_zero = ft0;
+    const FReg f_lower = ft1;
+    const FReg f_upper = ft2;
+    const FReg f_round = ft3;
+    const FReg f_log2_recip = ft4;
+    const FReg f_log2_high = ft5;
+    const FReg f_log2_low = ft6;
+    const FReg f_sub = fa0;
+    const FReg f_poly = ft7;
+    const FReg f_poly_coeff = ft8;
+    const FReg f_sum = ft10;
+
+    const VReg v_x(8);
+    const VReg v_bias(12);
+    const VReg v_poly(16);
+    const VReg v_tmpv(20);
+    const VReg v_acc(24);
+    const VReg v_red(28);
+    const VReg v_mask(0);
+
+    auto load_f32_bits = [&](const FReg &freg, uint32_t bits) {
+        li(reg_imm, static_cast<int64_t>(bits));
+        fmv_w_x(freg, reg_imm);
+    };
+    auto load_f32 = [&](const FReg &freg, float value) {
+        load_f32_bits(freg, utils::bit_cast<uint32_t>(value));
+    };
+
+    ld(reg_src, reg_param, F32_EXP_SUB_SUM_OFF(src));
+    ld(reg_dst, reg_param, F32_EXP_SUB_SUM_OFF(dst));
+    ld(reg_len, reg_param, F32_EXP_SUB_SUM_OFF(len));
+    ld(reg_sum, reg_param, F32_EXP_SUB_SUM_OFF(sum));
+    lw(reg_sub_tmp, reg_param, F32_EXP_SUB_SUM_OFF(sub));
+    fmv_w_x(f_sub, reg_sub_tmp);
+
+    fmv_w_x(f_zero, x0);
+    load_f32(f_lower, -103.9720840454f);
+    load_f32(f_upper, 88.7762626647950f);
+    load_f32_bits(f_round, 0x4b400000u);
+    load_f32_bits(f_log2_recip, 0x3fb8aa3bu);
+    load_f32_bits(f_log2_high, 0xbf317200u);
+    load_f32_bits(f_log2_low, 0xb5bfbe8eu);
+    load_f32_bits(f_poly, 0x3ab4a000u);
+    li(reg_minexp, static_cast<int64_t>(0xC1000000u));
+    li(reg_maxexp, static_cast<int64_t>(0x3F800000u));
+
+    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    vfmv_v_f(v_acc, f_zero);
+
+    Label loop, finish;
+    L(loop);
+    beqz(reg_len, finish);
+
+    // tu (not ta): on a short final vector v_poly's tail is stale; under tu the
+    // accumulator update vfadd_vv(v_acc, v_acc, v_poly) keeps v_acc's tail, so
+    // the closing vfredosum sums only the valid lanes.
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4, VTA::tu, VMA::ma);
+    vle32_v(v_x, reg_src);
+    slli(reg_bytes, reg_vl, 2);
+    add(reg_src, reg_src, reg_bytes);
+
+    vfsub_vf(v_x, v_x, f_sub);
+    vfmv_v_f(v_bias, f_round);
+    vmflt_vf(v_mask, v_x, f_lower);
+    vfmerge_vfm(v_x, v_x, f_lower);
+    vmfgt_vf(v_mask, v_x, f_upper);
+    vfmerge_vfm(v_x, v_x, f_upper);
+    vfmacc_vf(v_bias, f_log2_recip, v_x);
+    vfsub_vf(v_tmpv, v_bias, f_round);
+    vfmacc_vf(v_x, f_log2_high, v_tmpv);
+    vfmacc_vf(v_x, f_log2_low, v_tmpv);
+    vfmv_v_f(v_poly, f_poly);
+    load_f32_bits(f_poly_coeff, 0x3c092f6eu);
+    vfmul_vv(v_poly, v_poly, v_x);
+    vfadd_vf(v_poly, v_poly, f_poly_coeff);
+    load_f32_bits(f_poly_coeff, 0x3d2aadadu);
+    vfmul_vv(v_poly, v_poly, v_x);
+    vfadd_vf(v_poly, v_poly, f_poly_coeff);
+    load_f32_bits(f_poly_coeff, 0x3e2aaa28u);
+    vfmul_vv(v_poly, v_poly, v_x);
+    vfadd_vf(v_poly, v_poly, f_poly_coeff);
+    load_f32_bits(f_poly_coeff, 0x3efffffbu);
+    vfmul_vv(v_poly, v_poly, v_x);
+    vfadd_vf(v_poly, v_poly, f_poly_coeff);
+    load_f32_bits(f_poly_coeff, 0x3f800000u);
+    vfmul_vv(v_poly, v_poly, v_x);
+    vfadd_vf(v_poly, v_poly, f_poly_coeff);
+    vsll_vi(v_bias, v_bias, 23);
+    vmin_vx(v_tmpv, v_bias, reg_maxexp);
+    vmax_vx(v_tmpv, v_tmpv, reg_minexp);
+    vsub_vv(v_bias, v_bias, v_tmpv);
+    vadd_vx(v_bias, v_bias, reg_maxexp);
+    vadd_vx(v_tmpv, v_tmpv, reg_maxexp);
+    vfmul_vv(v_x, v_x, v_bias);
+    vfmadd_vv(v_poly, v_x, v_bias);
+    vfmul_vv(v_poly, v_poly, v_tmpv);
+    vfadd_vv(v_acc, v_acc, v_poly);
+
+    if (store_exp_) {
+        vse32_v(v_poly, reg_dst);
+        add(reg_dst, reg_dst, reg_bytes);
+    }
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(finish);
+    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    vfmv_v_f(v_red, f_zero);
+    vfredosum_vs(v_red, v_acc, v_red);
+    vfmv_f_s(f_sum, v_red);
+    fsw(f_sum, reg_sum, 0);
+    ret();
+#else
+    ret();
+#endif
+}
+
+void jit_rvv_softmax_f32_exp_sub_sum(const float *src, float *dst, dim_t len,
+        float sub, float *sum, bool store_exp) {
+    const jit_rvv_softmax_f32_exp_sub_sum_kernel_t::call_params_t p {
+            src, dst, len, sub, sum};
+    if (store_exp)
+        dispatch_f32_exp_sub_sum<true>(&p);
+    else
+        dispatch_f32_exp_sub_sum<false>(&p);
 }
 
 } // namespace rv64

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
@@ -116,6 +116,34 @@ protected:
     void generate() override;
 };
 
+// f32 exp/sub/sum kernel. Computes exp(src - sub), accumulates the ordered
+// sum into *sum, and (when store_exp is set) writes the exp values to dst.
+// softmax uses store_exp=true (dst holds the exp result for the later scale);
+// logsoftmax uses store_exp=false (only the sum is required).
+struct jit_rvv_softmax_f32_exp_sub_sum_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const float *src;
+        float *dst;
+        dim_t len;
+        float sub;
+        float *sum;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_softmax_f32_exp_sub_sum_kernel_t)
+
+    explicit jit_rvv_softmax_f32_exp_sub_sum_kernel_t(bool store_exp);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    bool store_exp_;
+};
+
 void jit_rvv_softmax_f16_affine_from_f16(const dnnl::impl::float16_t *src,
         dnnl::impl::float16_t *dst, dim_t len, float sub, float mul);
 
@@ -130,6 +158,9 @@ void jit_rvv_softmax_f16_scatter(const dnnl::impl::float16_t *src,
 
 void jit_rvv_softmax_f16_exp_sub_sum(const dnnl::impl::float16_t *src,
         float *tmp, dim_t len, float sub, float *sum);
+
+void jit_rvv_softmax_f32_exp_sub_sum(const float *src, float *dst, dim_t len,
+        float sub, float *sum, bool store_exp);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/rvv_softmax.cpp
+++ b/src/cpu/rv64/rvv_softmax.cpp
@@ -36,18 +36,25 @@ rvv_softmax_fwd_t::rvv_softmax_fwd_t(const pd_t *apd) : primitive_t(apd) {
 
 namespace {
 
-// f32 compute kernel
+// f32 compute kernel. jit_exp selects the vectorized exp/sub/sum kernel for the
+// reduction; the caller gates it on axis length and stride so that very short
+// or memory-bound (large-stride) reductions keep the scalar exp path.
 void compute_softmax_f32_rvv(const float *src, float *dst, dim_t len,
         bool is_logsoftmax, bool is_softmax_inf_as_zero,
-        const jit_rvv_softmax_affine_kernel_t *affine_kernel) {
+        const jit_rvv_softmax_affine_kernel_t *affine_kernel, bool jit_exp) {
     float max_val = -INFINITY;
     for (dim_t i = 0; i < len; ++i)
         max_val = src[i] > max_val ? src[i] : max_val;
 
     if (is_logsoftmax) {
         float sum_exp = 0.f;
-        for (dim_t i = 0; i < len; ++i) {
-            sum_exp += expf(src[i] - max_val);
+        if (jit_exp) {
+            jit_rvv_softmax_f32_exp_sub_sum(
+                    src, dst, len, max_val, &sum_exp, false);
+        } else {
+            for (dim_t i = 0; i < len; ++i) {
+                sum_exp += expf(src[i] - max_val);
+            }
         }
         const float log_sum = logf(sum_exp);
 
@@ -67,10 +74,20 @@ void compute_softmax_f32_rvv(const float *src, float *dst, dim_t len,
         float sum_exp = 0.f;
         const bool all_minus_inf
                 = is_softmax_inf_as_zero && (max_val == -INFINITY);
-        for (dim_t i = 0; i < len; ++i) {
-            float e = all_minus_inf ? 0.f : expf(src[i] - max_val);
-            dst[i] = e;
-            sum_exp += e;
+        if (jit_exp) {
+            if (all_minus_inf) {
+                for (dim_t i = 0; i < len; ++i)
+                    dst[i] = 0.f;
+            } else {
+                jit_rvv_softmax_f32_exp_sub_sum(
+                        src, dst, len, max_val, &sum_exp, true);
+            }
+        } else {
+            for (dim_t i = 0; i < len; ++i) {
+                float e = all_minus_inf ? 0.f : expf(src[i] - max_val);
+                dst[i] = e;
+                sum_exp += e;
+            }
         }
 
         const float inv_sum = sum_exp ? (1.0f / sum_exp) : 1.0f;
@@ -186,12 +203,24 @@ status_t rvv_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
             const dim_t outer_stride = pd()->axis_size(true) * rsp.inner_size;
             const int nthr = pd()->nthr_;
 
+            // Use the vectorized exp kernel only when it pays off: the axis
+            // must fill at least one LMUL=4 e32 vector (16 elements at VLEN=128;
+            // on larger VLEN the kernel still runs a correct partial vector),
+            // and a strided axis must have a moderate stride so the reduction is
+            // not dominated by the gather/scatter memory traffic.
+            constexpr dim_t exp_jit_min_len = 16;
+            constexpr dim_t exp_jit_max_inner = 8192;
+            const bool jit_exp = affine_kernel_.get()
+                    && rsp.axis_size >= exp_jit_min_len
+                    && rsp.inner_size <= exp_jit_max_inner;
+
             if (rsp.inner_size == 1) {
                 parallel_nd(rsp.outer_size, [&](dim_t outer) {
                     const dim_t base = outer * outer_stride;
                     compute_softmax_f32_rvv(src_f32 + base, dst_f32 + base,
                             rsp.axis_size, rsp.is_logsoftmax,
-                            is_softmax_inf_as_zero, affine_kernel_.get());
+                            is_softmax_inf_as_zero, affine_kernel_.get(),
+                            jit_exp);
                 });
             } else {
                 auto scratch = ctx.get_scratchpad_grantor().template get<char>(
@@ -217,7 +246,7 @@ status_t rvv_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                         // contiguous kernel (in-place)
                         compute_softmax_f32_rvv(tmp, tmp, rsp.axis_size,
                                 rsp.is_logsoftmax, is_softmax_inf_as_zero,
-                                affine_kernel_.get());
+                                affine_kernel_.get(), jit_exp);
 
                         // write back
                         for (dim_t a = 0; a < rsp.axis_size; ++a)


### PR DESCRIPTION
# Description

This PR vectorizes the `f32` softmax/logsoftmax reduction on RV64, closing the design gap with the `aarch64`/`x64` JIT kernels and with the existing RV64 `f16` path.

Previously the `f32` path computed the per-axis `max` reduction and the `exp(x - max)` / sum reduction with scalar `expf` loops; only the final affine (scale/sub) step was vectorized. The scalar `expf` loop dominated runtime. This PR replaces it with a vectorized polynomial `exp`/sub/sum JIT kernel, reusing the same range-reduced polynomial already validated in the RV64 `f16` softmax kernel (which computes `exp` in `f32` internally), so accuracy is unchanged.

## Key Features

- **Vectorized exp/sub/sum**: a new `jit_rvv_softmax_f32_exp_sub_sum_kernel_t` evaluates `exp(src - max)` over `LMUL=4` `e32` vectors, accumulates the ordered sum with `vfredosum`, and (for softmax) writes the `exp` values for the existing affine scale step. `logsoftmax` requests the sum only (`store_exp=false`), avoiding the result write.
- **Same polynomial as the f16 path**: the `exp` approximation, clamping and `2^n` reconstruction are taken verbatim from `jit_rvv_softmax_f16_exp_sub_sum_kernel_t`; the `f32` variant only loads input as `e32` instead of widening from `f16`. The accumulator is updated with `VTA::tu` so a final short tail folds into the low lanes and the closing `vfredosum` still produces the exact ordered sum (the `tu` choice is load-bearing and documented inline at the `vsetvli`).
- **Dispatch guard**: the vectorized `exp` kernel is selected only when the axis fills at least one `LMUL=4` `e32` vector (`axis_size >= 16`, i.e. 16 elements at `VLEN=128`; on larger VLEN the kernel still runs a correct partial vector) and, for a strided axis, the stride is moderate (`inner_size <= 8192`). Very short or memory-bound (large-stride) reductions keep the scalar `exp` path, where the kernel setup cost or the gather/scatter traffic would otherwise dominate. The affine scale step and the strided gather/scatter are unchanged.
- **Data Types**: `f32`.
- **Memory Layouts**: plain dense, any axis (strided axes are gathered into the per-thread scratchpad as before).

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Correctness Evaluation

We ran the benchdnn softmax driver over the test script scope (`--alg=SOFTMAX,LOGSOFTMAX --stag=abx,axb` over `shapes_2d`, `shapes_3d`, `shapes_large`, `shapes_nlp`):

```
./tests/benchdnn/benchdnn --softmax --alg=SOFTMAX,LOGSOFTMAX --stag=abx,axb \
    --sdt=f32 --ddt=f32 --batch=.../softmax/shapes_2d --batch=.../shapes_3d \
    --batch=.../shapes_large --batch=.../shapes_nlp
```

- `f32`: **148/148 passed**, all dispatched to `jit:rvv` (the path this PR changes).
- `f16`: **148/148 passed**, dispatched to `jit:rvv_zvfh` (unchanged path).
- `bf16`: **148/148 passed** (dispatched to the reference softmax `ref:any`, not handled by `rvv_softmax`, unchanged).

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

All experiments are performed on an RV64 `rv64imafdcv` platform (VLEN=128). benchdnn is run in forward mode with `--alg=SOFTMAX,LOGSOFTMAX --stag=abx,axb --sdt=f32 --ddt=f32` over the four batch files, single-core (`taskset -c 27`, `OMP_NUM_THREADS=1`) and 8-core (`taskset -c 20-28`, `OMP_NUM_THREADS=8`, `OMP_PROC_BIND=close`, `OMP_PLACES=cores`). The runs were taken in a low-load window (server load average < 2) to keep the 8-core measurements free of cross-tenant contention. We compare:

1. **baseline**: `upstream/main` — the branch base commit `5fdfa0aef1` (the softmax sources are unchanged on the current upstream tip), `rvv_softmax` with scalar `expf`.
2. **this PR**: `rvv_softmax` with the vectorized `exp`/sub/sum kernel.

Both builds are cross-compiled with GCC 14.2 (`-march=rv64gcv -O3`) and produced from isolated `git worktree` checkouts at the same base commit. `min_time` (ms) is the benchdnn min-latency column. All `f32` shapes dispatch to `jit:rvv`.

### Overall Performance

| Dataset | Baseline 1c (ms) | This PR 1c (ms) | 1c Speedup | Baseline 8c (ms) | This PR 8c (ms) | 8c Speedup |
|---------|------------------|-----------------|-----------|------------------|-----------------|-----------|
| nlp / 2d (dense) | 657.4 | 209.9 | **3.13x** | 82.8 | 25.1 | **3.30x** |
| large (dense) | 174.8 | 47.3 | **3.70x** | 22.4 | 5.9 | **3.79x** |
| 3d/4d/5d axb (dense) | 493.1 | 220.6 | **2.24x** | 62.4 | 25.7 | **2.43x** |
| 3d/4d/5d abx (strided) | 1271.6 | 1030.8 | **1.23x** | 240.9 | 206.9 | **1.16x** |
| **Total** | **2596.9** | **1508.6** | **1.72x** | **408.6** | **263.7** | **1.55x** |

**Dispatch Coverage:**
- All 148 `f32` problems dispatch to `jit:rvv` (100%) in both baseline and this PR.

**Key Observations:**
- Dense reductions (nlp, large, and `axb`-tagged N-D shapes) see **3x-5x** speedups, as the vectorized `exp` removes the scalar `expf` bottleneck directly.
- Strided (`abx`) N-D reductions improve more modestly: the axis is gathered into a scratchpad before the vectorized reduction, so the gather/scatter memory traffic (not `exp`) dominates, and the stride guard keeps the largest-stride cases on the scalar path.
