### PR TITLE
cpu: aarch64: make jit softmax async compatible

### DIFF
--- a/src/cpu/aarch64/jit_uni_softmax.cpp
+++ b/src/cpu/aarch64/jit_uni_softmax.cpp
@@ -20,6 +20,7 @@
 #include <memory>
 
 #include "common/c_types_map.hpp"
+#include "common/compiler_workarounds.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/nstl.hpp"
@@ -981,7 +982,7 @@ status_t jit_uni_softmax_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
     const int nthr = pd()->nthr_;
 
     parallel_nd_ext(nthr, outer_size, inner_size,
-            [&](int ithr, int, dim_t ou, dim_t in) {
+            [= COMPAT_THIS_CAPTURE](int ithr, int, dim_t ou, dim_t in) {
         dim_t offset = (ou * outer_stride + in * inner_stride);
         const char *src_ptr = src + offset * src_data_type_size;
         char *dst_ptr = dst + offset * dst_data_type_size;
@@ -1030,7 +1031,8 @@ status_t jit_uni_softmax_bwd_t<isa>::execute(const exec_ctx_t &ctx) const {
     const auto outer_stride = pd()->axis_size(true) * inner_size;
     const auto outer_size = dst_d.nelems(true) / outer_stride;
 
-    parallel_nd(outer_size, inner_size, [&](dim_t ou, dim_t in) {
+    parallel_nd(outer_size, inner_size,
+            [= COMPAT_THIS_CAPTURE](dim_t ou, dim_t in) {
         dim_t offset = (ou * outer_stride + in * inner_stride);
         char *diff_src_ptr = diff_src + offset * diff_src_data_type_size;
         const char *dst_ptr = dst + offset * dst_data_type_size;


### PR DESCRIPTION
# Description

This PR makes the AArch64 `jit` softmax implementation compatible with asynchronous threadpool execution.

The implementation previously assumed that parallel() completed before returning. With an asynchronous runtime, queued tasks could reference stack-backed scale buffers or locals captured by reference after execute() returned. To avoid this problem and ensure full compatibility with asynchronous mode, this PR captures asynchronous task state by value.

## Validation

Example:

```bash
DNNL_VERBOSE=all OMP_NUM_THREADS=16 ./tests/benchdnn/benchdnn --softmax 256x1000
```

OpenMP:

```bash
onednn_verbose,v1,info,oneDNN v3.14.0 (commit 43b3a68807493401795cfed27f61c8576f0460f1)
onednn_verbose,v1,info,cpu,runtime:OpenMP,nthr:16
onednn_verbose,v1,info,cpu,isa:AArch64 SVE (256 bits)
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,create:cache_miss,cpu,softmax,jit:sve,forward_training,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0,,alg:softmax_accurate axis:1,256x1000,0.146973
onednn_verbose,v1,primitive,create:cache_hit,cpu,softmax,jit:sve,forward_training,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0,,alg:softmax_accurate axis:1,256x1000,0.00219727
onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,256x1000,0.0620117
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,256x1000,0.0229492
onednn_verbose,v1,primitive,exec,cpu,softmax,jit:sve,forward_training,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0,,alg:softmax_accurate axis:1,256x1000,0.0180664
onednn_verbose,v1,primitive,create:cache_hit,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,256x1000,0.00195312
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,256x1000,0.0209961
0:PASSED (9 ms) __REPRO: --softmax --impl=jit:sve 256x1000
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:sve : 1 (100%)                                       |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.01s; create_pd: 0.00s (0%); create_prim: 0.00s (9%); fill: 0.01s (59%); execute: 0.00s (0%); compute_ref: 0.00s (5%); compare: 0.00s (11%);
```

Threadpool (EIGEN_ASYNC) + Asan:

```bash
DNNL_VERBOSE=all OMP_NUM_THREADS=16 ./tests/benchdnn/benchdnn --softmax 256x1000
onednn_verbose,v1,info,oneDNN v3.14.0 (commit 7aca67ce0253b042d9ce530d14654619386b0f32)
onednn_verbose,v1,info,cpu,runtime:threadpool,nthr:16
onednn_verbose,v1,info,cpu,isa:AArch64 SVE (256 bits)
onednn_verbose,v1,info,gpu,runtime:none
onednn_verbose,v1,info,graph,backend,0:dnnl_backend
onednn_verbose,v1,primitive,info,template:operation,engine,primitive,implementation,prop_kind,memory_descriptors,attributes,auxiliary,problem_desc,exec_time
onednn_verbose,v1,graph,info,template:operation,engine,partition_id,partition_kind,op_names,data_formats,logical_tensors,fpmath_mode,implementation,backend,exec_time
onednn_verbose,v1,primitive,create:cache_miss,cpu,softmax,jit:sve,forward_training,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0,,alg:softmax_accurate axis:1,256x1000,1.84595
onednn_verbose,v1,primitive,create:cache_hit,cpu,softmax,jit:sve,forward_training,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0,,alg:softmax_accurate axis:1,256x1000,0.0280762
onednn_verbose,v1,primitive,create:cache_miss,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,256x1000,0.746094
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,256x1000,0.0581055
onednn_verbose,v1,primitive,exec,cpu,softmax,jit:sve,forward_training,src:f32::blocked:ab::f0 dst:f32:a:blocked:ab::f0,,alg:softmax_accurate axis:1,256x1000,0.0649414
onednn_verbose,v1,primitive,create:cache_hit,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,256x1000,0.0380859
onednn_verbose,v1,primitive,exec,cpu,reorder,jit:uni,undef,src:f32::blocked:ab::f0 dst:f32::blocked:ab::f0,,,256x1000,0.0429688
0:PASSED (101 ms) __REPRO: --softmax --impl=jit:sve 256x1000
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:sve : 1 (100%)                                       |
============================================================
tests:1 passed:1 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 0.10s; create_pd: 0.00s (0%); create_prim: 0.00s (2%); fill: 0.08s (75%); execute: 0.00s (0%); compute_ref: 0.01s (7%); compare: 0.01s (10%);
```

Threadpool (EIGEN_ASYNC) + Asan:

```bash
OMP_NUM_THREADS=64  ./tests/benchdnn/benchdnn --softmax --mode=c --global-impl=jit:sve --batch=./tests/benchdnn/inputs/softmax/test_softmax_all

============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
| jit:sve : 5519 (100%)                                    |
============================================================
tests:39519 passed:5403 skipped:34000 mistrusted:116 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 1095.14s; create_pd: 3.46s (0%); create_prim: 5.00s (0%); fill: 987.32s (90%); execute: 1.94s (0%); compute_ref: 26.40s (2%); compare: 43.10s (4%);
```

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?


