### PR TITLE
cpu: gemm: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.cpp
+++ b/src/cpu/gemm/s8x8s32/ref_gemm_s8x8s32.cpp
@@ -98,7 +98,8 @@ dnnl_status_t ref_gemm_s8x8s32(const char *transa, const char *transb,
         double coffset = OCisR ? i2d(co[j]) : OCisC ? i2d(co[i]) : i2d(co[0]);
         double val = ((*beta == 0.0f) ? 0.0 : f2d(*beta) * i2d(C[i + j * ldc]))
                 + f2d(*alpha) * dC[i + j * ldc] + coffset;
-        C[i + j * ldc] = q10n::out_round<int32_t>(q10n::saturate<int32_t>(val));
+        C[i + j * ldc] = q10n::out_round<int32_t>(
+                static_cast<float>(q10n::saturate<int32_t>(val)));
     });
 
     free(dA);

--- a/src/cpu/gemm/s8x8s32/simple_gemm_s8s8s32.cpp
+++ b/src/cpu/gemm/s8x8s32/simple_gemm_s8s8s32.cpp
@@ -65,8 +65,8 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                 val += a[(i + j * blocking_factor * lda) + jb * lda];
             }
             if (alpha != 1.0f) {
-                val = q10n::out_round<int32_t>(
-                        q10n::saturate<int32_t>((double)val * alpha * -128.0));
+                val = q10n::out_round<int32_t>(static_cast<float>(
+                        q10n::saturate<int32_t>((double)val * alpha * -128.0)));
             } else {
                 val *= -128;
             }
@@ -80,8 +80,9 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                     val += a[i + j * lda];
                 }
                 if (alpha != 1.0f) {
-                    val = q10n::out_round<int32_t>(q10n::saturate<int32_t>(
-                            (double)val * alpha * -128.0));
+                    val = q10n::out_round<int32_t>(
+                            static_cast<float>(q10n::saturate<int32_t>(
+                                    (double)val * alpha * -128.0)));
                 } else {
                     val *= -128;
                 }
@@ -95,8 +96,8 @@ void compensation_compute(bool transa, dim_t m, dim_t k, float alpha,
                 val += a[j + i * lda];
             }
             if (alpha != 1.0f) {
-                val = q10n::out_round<int32_t>(
-                        q10n::saturate<int32_t>((double)val * alpha * -128.0));
+                val = q10n::out_round<int32_t>(static_cast<float>(
+                        q10n::saturate<int32_t>((double)val * alpha * -128.0)));
             } else {
                 val *= -128;
             }

--- a/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
+++ b/src/cpu/x64/gemm/amx/jit_avx512_core_amx_gemm_kern.cpp
@@ -63,13 +63,13 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
 
     int kerneltype = ((typea << 1) | typeb);
 
-    dim_t SHIFT_UNROLL_M = 4, SHIFT_UNROLL_N = 4, SHIFT_UNROLL_K = 2;
-    dim_t SHIFT_UNROLL_MM = 5, SHIFT_UNROLL_NN = 5, SHIFT_UNROLL_KK = 6;
-    dim_t SHIFT_A = 0, SHIFT_B = 0, SHIFT_C = 2;
+    int SHIFT_UNROLL_M = 4, SHIFT_UNROLL_N = 4, SHIFT_UNROLL_K = 2;
+    int SHIFT_UNROLL_MM = 5, SHIFT_UNROLL_NN = 5, SHIFT_UNROLL_KK = 6;
+    int SHIFT_A = 0, SHIFT_B = 0, SHIFT_C = 2;
 
-    dim_t UNROLL_M = 0, UNROLL_N = 0, UNROLL_K = 0;
-    dim_t UNROLL_MM = 0, UNROLL_NN = 0, UNROLL_KK = 0;
-    dim_t SIZE_A = 0, SIZE_B = 0, SIZE_C = 0;
+    int UNROLL_M = 0, UNROLL_N = 0, UNROLL_K = 0;
+    int UNROLL_MM = 0, UNROLL_NN = 0, UNROLL_KK = 0;
+    int SIZE_A = 0, SIZE_B = 0, SIZE_C = 0;
 
     if (typec == 0) {
         // Floatingpoint Operation
@@ -81,17 +81,17 @@ void jit_avx512_core_amx_gemm_kern_t::generate() {
         kerneltype = 4;
     }
 
-    UNROLL_M = (((dim_t)1) << SHIFT_UNROLL_M);
-    UNROLL_N = (((dim_t)1) << SHIFT_UNROLL_N);
-    UNROLL_K = (((dim_t)1) << SHIFT_UNROLL_K);
+    UNROLL_M = (1 << SHIFT_UNROLL_M);
+    UNROLL_N = (1 << SHIFT_UNROLL_N);
+    UNROLL_K = (1 << SHIFT_UNROLL_K);
 
-    UNROLL_MM = (((dim_t)1) << SHIFT_UNROLL_MM);
-    UNROLL_NN = (((dim_t)1) << SHIFT_UNROLL_NN);
-    UNROLL_KK = (((dim_t)1) << SHIFT_UNROLL_KK);
+    UNROLL_MM = (1 << SHIFT_UNROLL_MM);
+    UNROLL_NN = (1 << SHIFT_UNROLL_NN);
+    UNROLL_KK = (1 << SHIFT_UNROLL_KK);
 
-    SIZE_A = (((dim_t)1) << SHIFT_A);
-    SIZE_B = (((dim_t)1) << SHIFT_B);
-    SIZE_C = (((dim_t)1) << SHIFT_C);
+    SIZE_A = (1 << SHIFT_A);
+    SIZE_B = (1 << SHIFT_B);
+    SIZE_C = (1 << SHIFT_C);
 
     Xbyak::Label loopE, loopM, loopN, loopK;
     Xbyak::Label l0, l1, l2, l3, l4, l5, l6, l7, l8, l9, la, lb;

--- a/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx512_core_gemm_smalln_tn_f32_kern.cpp
@@ -731,7 +731,7 @@ dnnl_status_t sgemm_smalln_tn(const dim_t m, const dim_t n, const dim_t k,
 
     static dnnl_status_t st = dnnl_success;
     std::call_once(initialized, [&] {
-        for (dim_t N : {1, 2, 3, 4}) {
+        for (int N : {1, 2, 3, 4}) {
             for (float al : {0.0f, 1.0f, 2.0f}) {
                 for (float be : {0.0f, 1.0f, 2.0f}) {
                     auto &kern = kernels[N - 1][(dim_t)al][(dim_t)be];
@@ -761,7 +761,7 @@ dnnl_status_t sgemm_smalln_tn(const dim_t m, const dim_t n, const dim_t k,
 #define MROW_ALIGN 1
 #define MINROWS 16 // Min rows each thread should process
 
-static dim_t smalln_set_num_threads(dim_t m, dim_t k, dim_t nthr_to_use) {
+static int smalln_set_num_threads(dim_t m, dim_t k, int nthr_to_use) {
     /**
      * Simple heuristics for determining num threads to use
      */
@@ -773,7 +773,7 @@ static dim_t smalln_set_num_threads(dim_t m, dim_t k, dim_t nthr_to_use) {
     if ((m & 15) == 0) { // Special handling if m is multiple of 16
         // nthr_16: number of threads such that each thread works on
         // 2^n * 16 number of rows.
-        nthr_16 = m >> 4;
+        nthr_16 = static_cast<int>(m >> 4);
         while (nthr_16 > nthr_to_use && (nthr_16 & 1) == 0)
             nthr_16 = nthr_16 >> 1;
         // Ideal number of threads is more than what we can use.

--- a/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
@@ -1445,7 +1445,7 @@ struct xbyak_gemm_t : public jit_generator_t {
                             = AO1 + (ld_step + section * 4 - OFFSET) * SIZE;
                     for (int off = 0; off < 4; ++off)
                         pextrd(ptr[dst_addr + unroll_m * off * SIZE],
-                                Xmm(ld_step % 2), off);
+                                Xmm(ld_step % 2), static_cast<uint8_t>(off));
                 };
 
                 el_cp(0, 0);
@@ -2133,7 +2133,7 @@ private:
 #else
     const Reg64 ARG_A = r8;
     const Reg64 ARG_LDA = r9;
-    const int stackOffset = STACKSIZE;
+    const int stackOffset = static_cast<int>(STACKSIZE);
     const Reg64 A = ARG_A;
     const Reg64 LDA = ARG_LDA;
 #endif

--- a/src/cpu/x64/gemm/gemm_driver.cpp
+++ b/src/cpu/x64/gemm/gemm_driver.cpp
@@ -135,7 +135,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         c_float += (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                c_data[i + j * ldc] * beta);
                         c_data[i + j * ldc] += ctemp;
                     }
                 }
@@ -149,7 +150,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         c_float -= (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                c_data[i + j * ldc] * beta);
                         c_data[i + j * ldc] -= ctemp;
                     }
                 }
@@ -159,7 +161,8 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                         double c_float = alpha * (double)ctemp;
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] = alpha * ctemp;
+                        c_data[i + j * ldc]
+                                = static_cast<c_type>(alpha * ctemp);
                     }
 
                 } else {
@@ -168,8 +171,10 @@ static inline void add_results(const dim_t m, const dim_t n, const float alpha,
                                 + beta * (double)c_data[i + j * ldc];
                         round_to_nearest(&c_data[i + j * ldc], c_float);
                     } else {
-                        c_data[i + j * ldc] *= beta;
-                        c_data[i + j * ldc] += alpha * ctemp;
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                c_data[i + j * ldc] * beta);
+                        c_data[i + j * ldc] = static_cast<c_type>(
+                                c_data[i + j * ldc] + alpha * ctemp);
                     }
                 }
             }
@@ -1281,11 +1286,11 @@ static inline void set_thread_opts_pack(int nthrs,
         block_z = utils::rnd_up(block_z, block_align);
         thread_z = num_blk * block_z;
         if (thread_z * nthr_z > size_z)
-            nthr_z = utils::div_up(size_z, thread_z);
+            nthr_z = static_cast<int>(utils::div_up(size_z, thread_z));
     };
 
     auto choose_m_blocking = [&]() {
-        auto align = get_vector_length<c_type>();
+        dim_t align = get_vector_length<c_type>();
         align = do_m_blocking_only ? arg->um : align;
         choose_blocking(m, thread_m, nthr_m, arg->bm, block_m, align);
     };
@@ -1623,7 +1628,7 @@ static inline void adjust_thread_count(dim_t m, dim_t n, dim_t k, int *nthrs) {
     if (is_only_avx2)
         if (m > 10 * n && n < *nthrs)
             if (m / *nthrs < veclen * 3)
-                *nthrs = nstl::max(m / veclen / 3, dim_t(1));
+                *nthrs = static_cast<int>(nstl::max(m / veclen / 3, dim_t(1)));
 
     double gemm_cycles = m * n * k / fp_per_cycle;
     gemm_cycles *= is_f32 ? 2.0 : 8.0;

--- a/src/cpu/x64/gemm/gemm_info.cpp
+++ b/src/cpu/x64/gemm/gemm_info.cpp
@@ -378,7 +378,7 @@ void gemm_info_t<a_t, b_t, c_t>::jit_init(void) {
     }
 
     // Note: um is fixed for a given set of data types and ISA.
-    const int um = this->um;
+    const int um = static_cast<int>(this->um);
 
     static std::once_flag initialized;
     static std::atomic<dnnl_status_t> st(dnnl_success);

--- a/src/cpu/x64/gemm/gemm_utils.hpp
+++ b/src/cpu/x64/gemm/gemm_utils.hpp
@@ -192,7 +192,7 @@ dnnl_status_t pack_no_copy(const T *src, dim_t ld_src, dim_t nrows, dim_t ncols,
             if (is_f32) {
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < nrows_dst; i++)
-                    dst_col[i] = alpha * src_col[i];
+                    dst_col[i] = static_cast<T>(alpha * src_col[i]);
             } else {
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < nrows_dst; i++)
@@ -208,7 +208,7 @@ dnnl_status_t pack_no_copy(const T *src, dim_t ld_src, dim_t nrows, dim_t ncols,
             if (is_f32) {
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < nrows_dst; i++)
-                    dst_col[i] = alpha * src_col[i * ld_src];
+                    dst_col[i] = static_cast<T>(alpha * src_col[i * ld_src]);
             } else {
                 PRAGMA_OMP_SIMD()
                 for (dim_t i = 0; i < nrows_dst; i++)

--- a/src/cpu/x64/gemm/gemv_driver.cpp
+++ b/src/cpu/x64/gemm/gemv_driver.cpp
@@ -404,8 +404,8 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
     // Quick return if possible.
     if (m <= 0 || n <= 0) return;
 
-    dim_t nthr_max = dnnl_get_current_num_threads();
-    dim_t nthr_goal = thread_checker<a_t>(nthr_max, m, n, trans);
+    int nthr_max = dnnl_get_current_num_threads();
+    int nthr_goal = thread_checker<a_t>(nthr_max, m, n, trans);
 
     if (nthr_goal == 1) {
         gemv_kernel_driver(
@@ -425,10 +425,10 @@ static inline void gemv_threading_driver(const int trans, const dim_t m,
 
     // Always use the maximum number of threads to avoid OMP overhead that can
     // occur due to change thread counts.
-    auto nthr_spawn = dnnl_thr_syncable() ? nthr_max : nthr_goal;
+    const int nthr_spawn = dnnl_thr_syncable() ? nthr_max : nthr_goal;
     int nbufs_used = 0;
     parallel(nthr_spawn, [&](int ithr, int nthr) {
-        int nthr_eff = nstl::min(nthr_goal, static_cast<dim_t>(nthr));
+        int nthr_eff = nstl::min(nthr_goal, nthr);
 
         dim_t thread_m = m, off_m = 0;
         dim_t thread_n = n, off_n = 0;


### PR DESCRIPTION
It's a gemm(PR Nr.6) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
Total number of warnings after this PR: 1514 => 1474.
Added unavoidable casts and changed local variables to `int` to avoid implicit conversions.