### PR TITLE
cpu:aarch64: add async threadpool runtime support

### DIFF
--- a/src/cpu/aarch64/acl_deconvolution.hpp
+++ b/src/cpu/aarch64/acl_deconvolution.hpp
@@ -18,6 +18,8 @@
 #ifndef CPU_AARCH64_ACL_DECONVOLUTION_HPP
 #define CPU_AARCH64_ACL_DECONVOLUTION_HPP
 
+#include "common/dnnl_thread.hpp"
+
 #include "cpu/aarch64/acl_utils.hpp"
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 #include "cpu/aarch64/post_ops_fallback.hpp"
@@ -104,6 +106,10 @@ struct acl_deconvolution_fwd_t : public primitive_t {
             const auto wei_data_t = wei_d.data_type();
             const auto dst_data_t = dst_d.data_type();
             const auto bia_data_t = bia_d.data_type();
+
+            VDISPATCH_DECONVOLUTION(
+                    DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+                    VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
 
             const bool ok = is_fwd() // Only forward deconvolutions
                     && utils::one_of(

--- a/src/cpu/aarch64/acl_depthwise_convolution.cpp
+++ b/src/cpu/aarch64/acl_depthwise_convolution.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023-2024 Arm Ltd. and affiliates
+* Copyright 2023-2024, 2026 Arm Ltd. and affiliates
 * Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,6 +16,8 @@
 *******************************************************************************/
 
 #include "cpu/aarch64/acl_depthwise_convolution.hpp"
+
+#include "common/dnnl_thread.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -49,6 +51,9 @@ status_t acl_depthwise_convolution_fwd_t::pd_t::init(const engine_t *engine) {
     const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
             && attr()->has_default_values(
                     primitive_attr_t::skip_mask_t::post_ops, f32);
+    VDISPATCH_CONV(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
     bool ok = is_fwd() && set_default_alg_kind(alg_kind::convolution_direct)
             && utils::one_of(true, is_fp16_ok, is_fp32_ok)
             && !has_zero_dim_memory()

--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
@@ -17,6 +17,7 @@
 
 #include "acl_gemm_convolution.hpp"
 #include "acl_convolution_utils.hpp"
+#include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
 #include "cpu/aarch64/cpu_isa_traits.hpp"
 
@@ -55,6 +56,9 @@ status_t acl_gemm_convolution_fwd_t<src_t, wei_t, dst_t, bia_t>::pd_t::init(
         const engine_t *engine) {
     using namespace data_type;
     using smask_t = primitive_attr_t::skip_mask_t;
+
+    VDISPATCH_CONV(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
 
     bool ok = is_fwd() && set_default_alg_kind(alg_kind::convolution_direct)
             && expect_data_types(src_t, wei_t, bia_t, dst_t, undef)

--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
@@ -17,6 +17,7 @@
 
 #include "acl_indirect_gemm_convolution.hpp"
 #include "acl_convolution_utils.hpp"
+#include "common/dnnl_thread.hpp"
 #include "common/memory_tracking.hpp"
 #include "common/utils.hpp"
 #include "cpu/aarch64/cpu_isa_traits.hpp"
@@ -101,6 +102,9 @@ status_t acl_indirect_gemm_convolution_fwd_t::pd_t::init(
     const bool is_fp32_ok = expect_data_types(f32, f32, f32, f32, undef)
             && attr()->has_default_values(
                     smask_t::post_ops | smask_t::fpmath_mode, f32);
+    VDISPATCH_CONV(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
     bool ok = is_fwd() && set_default_alg_kind(alg_kind::convolution_direct)
             && utils::one_of(true, is_fp16_ok, is_bf16_ok, is_fp32_ok)
             && !has_zero_dim_memory()

--- a/src/cpu/aarch64/acl_inner_product.cpp
+++ b/src/cpu/aarch64/acl_inner_product.cpp
@@ -17,6 +17,8 @@
 
 #include "cpu/aarch64/acl_inner_product.hpp"
 
+#include "common/dnnl_thread.hpp"
+
 namespace dnnl {
 namespace impl {
 namespace cpu {
@@ -109,6 +111,10 @@ status_t acl_inner_product_fwd_t::pd_t::init(const engine_t *engine) {
     const bool is_weights_md_format_ok
             = utils::one_of(weights_format_kind_received, format_kind::any,
                     format_kind::blocked);
+    VDISPATCH_INNER_PRODUCT(
+            DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
     const bool ok = is_fwd() && !has_zero_dim_memory()
             && utils::one_of(true, is_fp16_ok, is_fp32_ok, is_bf16_ok)
             && is_weights_md_format_ok

--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
+++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
@@ -88,7 +88,9 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
                     && utils::one_of(true, is_fp16_ok, is_fp32_ok)
                     && !has_zero_dim_memory();
 
-            ok = ok && DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL;
+            VDISPATCH_CONV(
+                    DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+                    VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
             if (!ok) return status::unimplemented;
 
             CHECK(acl_convolution_utils::init_conf_wino(acp_, src_md_,

--- a/src/cpu/aarch64/eltwise_lut.cpp
+++ b/src/cpu/aarch64/eltwise_lut.cpp
@@ -62,7 +62,7 @@ status_t eltwise_lut_fwd_t::execute(const exec_ctx_t &ctx) const {
     src += data_d.offset0();
     dst += data_d.offset0();
 
-    dnnl::impl::parallel(0, [&](int ithr, int nthr) {
+    dnnl::impl::parallel(0, [=](int ithr, int nthr) {
         dim_t begin = 0, end = 0;
         dnnl::impl::balance211(n, nthr, ithr, begin, end);
         if (begin == end) return;

--- a/src/cpu/aarch64/jit_brgemm_conv_bwd.cpp
+++ b/src/cpu/aarch64/jit_brgemm_conv_bwd.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2025 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 * Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,6 +105,8 @@ status_t brgemm_convolution_bwd_t<isa>::pd_t::init(const engine_t *engine) {
     using namespace data_type;
     using namespace utils;
 
+    VDISPATCH_CONV(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
     VDISPATCH_CONV(is_bwd_d(), VERBOSE_BAD_PROPKIND);
     VDISPATCH_CONV(set_default_alg_kind(alg_kind::convolution_direct),
             VERBOSE_BAD_ALGORITHM);

--- a/src/cpu/aarch64/jit_brgemm_deconv.cpp
+++ b/src/cpu/aarch64/jit_brgemm_deconv.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Copyright 2022 Intel Corporation
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -104,6 +104,9 @@ status_t brgemm_deconvolution_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     auto skip_mask = smask_t::post_ops | smask_t::sum_dt;
     if (is_int8) skip_mask |= smask_t::scales | smask_t::zero_points;
 
+    VDISPATCH_DECONVOLUTION(
+            DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
     VDISPATCH_DECONVOLUTION(is_fwd(), VERBOSE_BAD_PROPKIND);
     VDISPATCH_DECONVOLUTION((desc()->alg_kind & alg_kind::deconvolution_direct),
             VERBOSE_BAD_ALGORITHM);

--- a/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2022 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -280,6 +280,10 @@ struct jit_sve_512_core_x8s8s32x_deconvolution_fwd_t : public primitive_t {
         status_t init(const engine_t *engine) {
             using namespace data_type;
             using skip_mask_t = primitive_attr_t::skip_mask_t;
+            VDISPATCH_DECONVOLUTION(
+                    DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+                    VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
             const bool ok = mayiuse(sve_512) && is_fwd()
                     && (desc()->alg_kind & alg_kind::deconvolution_direct)
                     && utils::one_of(src_md(0)->data_type, s8, u8)

--- a/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_512_x8s8s32x_convolution.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -44,6 +44,10 @@ struct jit_sve_512_x8s8s32x_convolution_fwd_t : public primitive_t {
 
         status_t init(const engine_t *engine) {
             using smask_t = primitive_attr_t::skip_mask_t;
+            VDISPATCH_CONV(
+                    DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+                    VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
             bool ok = true && is_fwd()
                     && set_default_alg_kind(alg_kind::convolution_direct)
                     && expect_data_types(src_type, data_type::s8,

--- a/src/cpu/aarch64/jit_uni_batch_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization.cpp
@@ -2206,6 +2206,8 @@ using namespace utils;
 template <cpu_isa_t isa>
 status_t jit_uni_batch_normalization_fwd_t<isa>::pd_t::init(
         const engine_t *engine) {
+    VDISPATCH_BNORM(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
     VDISPATCH_BNORM(is_fwd(), VERBOSE_BAD_PROPKIND);
     VDISPATCH_BNORM(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
     VDISPATCH_BNORM(!has_zero_dim_memory(), "zero dims are not supported");
@@ -2330,6 +2332,8 @@ jit_uni_batch_normalization_fwd_t<isa>::~jit_uni_batch_normalization_fwd_t() {
 template <cpu_isa_t isa>
 status_t jit_uni_batch_normalization_bwd_t<isa>::pd_t::init(
         const engine_t *engine) {
+    VDISPATCH_BNORM(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
     VDISPATCH_BNORM(!is_fwd(), VERBOSE_BAD_PROPKIND);
     VDISPATCH_BNORM(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
     VDISPATCH_BNORM(!has_zero_dim_memory(), "zero dims are not supported");

--- a/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
+++ b/src/cpu/aarch64/jit_uni_batch_normalization_s8.cpp
@@ -414,6 +414,9 @@ status_t jit_uni_batch_normalization_s8_fwd_t<isa>::pd_t::init(
         const engine_t *engine) {
     auto desired_fmt_tag = (ndims() == 4) ? nhwc : ndhwc;
 
+    VDISPATCH_BNORM(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
     bool ok = true && mayiuse(isa) && is_fwd() && !has_zero_dim_memory()
             && one_of(ndims(), 4, 5) && stats_is_src()
             && src_md()->data_type == s8 && check_scale_shift_data_type()

--- a/src/cpu/aarch64/jit_uni_binary.cpp
+++ b/src/cpu/aarch64/jit_uni_binary.cpp
@@ -636,7 +636,7 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
         // Divide number of threads by batch size and limiting it by a number
         // of outer_dims nelems to parallel over it when needed.
         parallel_nd_ext(nthr, batch, thr_per_nelems_group,
-                [&](int, int, dim_t b, dim_t nelems_group) {
+                [=](int, int, dim_t b, dim_t nelems_group) {
             dim_t start = 0, end = 0;
             balance211(nelems0_simd + has_tail, thr_per_nelems_group,
                     nelems_group, start, end);
@@ -680,7 +680,7 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
         // Compute number of vectors, divide it equally between all threads.
         // Last one will also handle a tail if present.
         const int nthr = get_exec_num_of_threads(dst_d);
-        parallel(nthr, [&](const int ithr, const int nthr) {
+        parallel(nthr, [=](const int ithr, const int nthr) {
             dim_t start = 0, end = 0;
             balance211(nelems0_simd + has_tail, nthr, ithr, start, end);
             if (start >= end) return;
@@ -732,7 +732,7 @@ void jit_uni_binary_t::execute_bcast_per_batch_strategy(const data_t *src0,
     const int nthr = get_exec_num_of_threads(dst_d);
     const dim_t thr_per_batch = nstl::min(nelems0_simd + has_tail, (dim_t)nthr);
     parallel_nd_ext(
-            nthr, MB, thr_per_batch, [&](int, int, dim_t b, dim_t ithr) {
+            nthr, MB, thr_per_batch, [=](int, int, dim_t b, dim_t ithr) {
         dim_t start = 0, end = 0;
         balance211(nelems0_simd + has_tail, thr_per_batch, ithr, start, end);
         if (start >= end) return;
@@ -797,10 +797,10 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
 
         const std::function<void(jit_uni_binary_args_t *, dim_t)>
                 kernel_blocked_no_tail
-                = [&](jit_uni_binary_args_t *p, dim_t C_blk) { (*kernel)(p); };
+                = [=](jit_uni_binary_args_t *p, dim_t C_blk) { (*kernel)(p); };
         const std::function<void(jit_uni_binary_args_t *, dim_t)>
                 kernel_blocked_tail
-                = [&](jit_uni_binary_args_t *p, dim_t C_blk) {
+                = [=](jit_uni_binary_args_t *p, dim_t C_blk) {
             if (C_blk == (C_blocks - 1))
                 (*kernel_tail)(p);
             else
@@ -808,7 +808,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
         };
         const auto &kernel_blocked = blocked_oc_tail ? kernel_blocked_tail
                                                      : kernel_blocked_no_tail;
-        const auto src1_off = [&](dim_t mb, dim_t C_blk, dim_t off) -> dim_t {
+        const auto src1_off = [=](dim_t mb, dim_t C_blk, dim_t off) -> dim_t {
             switch (bcast_type) {
                 case bcast_t::scalar: return mb * nelems_slice_src1;
                 case bcast_t::per_batch: return C_blk * SP * simd_w;
@@ -818,7 +818,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
         };
 
         parallel_nd_ext(
-                nthr, MB, C_blocks, [&](int, int, dim_t mb, dim_t C_blk) {
+                nthr, MB, C_blocks, [=](int, int, dim_t mb, dim_t C_blk) {
             jit_uni_binary_args_t p;
             p.spat_offt_count = SP * simd_w * dst_type_size;
             const dim_t off = mb * nelems_slice_src0 + C_blk * SP * simd_w;
@@ -832,7 +832,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
             kernel_blocked(&p, C_blk);
         });
     } else if (op_type == op_t::n_spatial_c) {
-        const auto src1_off = [&](dim_t mb, dim_t sp, dim_t off) -> dim_t {
+        const auto src1_off = [=](dim_t mb, dim_t sp, dim_t off) -> dim_t {
             switch (bcast_type) {
                 case bcast_t::per_batch: return sp * C;
                 case bcast_t::none: return off;
@@ -842,7 +842,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
 
         // Compute strategy:
         // Each line of channels is individual, parallel over MB and spatial.
-        parallel_nd_ext(nthr, MB, SP, [&](int, int, dim_t mb, dim_t sp) {
+        parallel_nd_ext(nthr, MB, SP, [=](int, int, dim_t mb, dim_t sp) {
             jit_uni_binary_args_t p;
             p.spat_offt_count = C * dst_type_size;
             const auto off = mb * nelems_slice_src0 + sp * C;
@@ -856,7 +856,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
             (*kernel)(&p);
         });
     } else if (op_type == op_t::n_c_spatial) {
-        const auto src1_off = [&](dim_t mb, dim_t c, dim_t off) -> dim_t {
+        const auto src1_off = [=](dim_t mb, dim_t c, dim_t off) -> dim_t {
             switch (bcast_type) {
                 case bcast_t::scalar: return mb * nelems_slice_src1;
                 case bcast_t::per_batch: return c * SP;
@@ -867,7 +867,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
 
         // Compute strategy:
         // Each line of spatial is individual, parallel over MB and C.
-        parallel_nd_ext(nthr, MB, C, [&](int, int, dim_t mb, dim_t c) {
+        parallel_nd_ext(nthr, MB, C, [=](int, int, dim_t mb, dim_t c) {
             jit_uni_binary_args_t p;
             p.spat_offt_count = SP * dst_type_size;
             const auto off = mb * nelems_slice_src0 + c * SP;
@@ -928,10 +928,10 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
 
         const std::function<void(jit_uni_binary_args_t *, dim_t)>
                 kernel_blocked_no_tail
-                = [&](jit_uni_binary_args_t *p, dim_t C_blk) { (*kernel)(p); };
+                = [=](jit_uni_binary_args_t *p, dim_t C_blk) { (*kernel)(p); };
         const std::function<void(jit_uni_binary_args_t *, dim_t)>
                 kernel_blocked_tail
-                = [&](jit_uni_binary_args_t *p, dim_t C_blk) {
+                = [=](jit_uni_binary_args_t *p, dim_t C_blk) {
             if (C_blk == (C_blocks - 1))
                 (*kernel_tail)(p);
             else
@@ -941,7 +941,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
                                                      : kernel_blocked_no_tail;
 
         parallel_nd_ext(nthr, MB, C_blocks, N, SP_no_bcast,
-                [&](int, int, dim_t mb, dim_t C_blk, dim_t n, dim_t sp) {
+                [=](int, int, dim_t mb, dim_t C_blk, dim_t n, dim_t sp) {
             jit_uni_binary_args_t p;
             p.spat_offt_count = simd_w * dst_type_size;
             const auto off = mb * nelems_slice_src0
@@ -965,7 +965,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
         // (broadcasted and not broadcasted spatial dims separately).
 
         parallel_nd_ext(nthr, MB, N, SP_no_bcast,
-                [&](int, int, dim_t mb, dim_t n, dim_t sp) {
+                [=](int, int, dim_t mb, dim_t n, dim_t sp) {
             jit_uni_binary_args_t p;
             p.spat_offt_count = C * dst_type_size;
             const auto off
@@ -988,7 +988,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
         // value into a vector register.
 
         parallel_nd_ext(
-                nthr, MB, C, N, [&](int, int, dim_t mb, dim_t c, dim_t n) {
+                nthr, MB, C, N, [=](int, int, dim_t mb, dim_t c, dim_t n) {
             jit_uni_binary_args_t p;
             p.spat_offt_count = SP_no_bcast * dst_type_size;
             const auto off = mb * nelems_slice_src0 + c * N * SP_no_bcast

--- a/src/cpu/aarch64/jit_uni_eltwise.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2017 Intel Corporation
 * Copyright 2021-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@
 
 #include "common/bfloat16.hpp"
 #include "common/c_types_map.hpp"
+#include "common/compiler_workarounds.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
@@ -560,7 +561,7 @@ status_t jit_uni_eltwise_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
     src += offset_bytes;
     dst += offset_bytes;
 
-    parallel(0, [&](const int ithr, const int nthr) {
+    parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         dim_t start {0}, end {0};
 
         balance211(
@@ -657,7 +658,7 @@ status_t jit_uni_eltwise_bwd_t<isa>::execute(const exec_ctx_t &ctx) const {
     diff_dst += diff_off_bytes;
     diff_src += diff_off_bytes;
 
-    parallel(0, [&](const int ithr, const int nthr) {
+    parallel(0, [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         dim_t start {0}, end {0};
 
         balance211(

--- a/src/cpu/aarch64/jit_uni_eltwise_int.cpp
+++ b/src/cpu/aarch64/jit_uni_eltwise_int.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2021 Intel Corporation
 * Copyright 2021 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -349,6 +349,9 @@ void jit_uni_subkernel_int_t<sve_512>::store_8bit(const bool vectorize,
 template <cpu_isa_t isa, data_type_t d_type>
 status_t jit_uni_eltwise_int_fwd_t<isa, d_type>::pd_t::init(
         const engine_t *engine) {
+    VDISPATCH_ELTWISE(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
     bool ok = is_fwd() && mayiuse(isa)
             && utils::everyone_is(
                     d_type, src_md()->data_type, dst_md()->data_type)

--- a/src/cpu/aarch64/jit_uni_i8i8_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_i8i8_pooling.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2020-2021 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -45,6 +45,10 @@ struct jit_uni_i8i8_pooling_fwd_t : public primitive_t {
                 jit_uni_i8i8_pooling_fwd_t);
 
         status_t init(const engine_t *engine) {
+            VDISPATCH_POOLING(
+                    DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+                    VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
             bool ok = true && mayiuse(isa) && utils::one_of(ndims(), 3, 4, 5)
                     && set_default_params() == status::success
                     && desc()->prop_kind == prop_kind::forward_inference

--- a/src/cpu/aarch64/jit_uni_layer_normalization.cpp
+++ b/src/cpu/aarch64/jit_uni_layer_normalization.cpp
@@ -19,6 +19,7 @@
 #include <cmath>
 
 #include "common/c_types_map.hpp"
+#include "common/compiler_workarounds.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/reorder.hpp"
 #include "common/stream.hpp"
@@ -631,7 +632,7 @@ status_t jit_uni_layer_normalization_fwd_t<isa>::execute_forward(
     const dim_t C_padded = src_d.padded_dims()[pd()->ndims() - 1];
     const dim_t C = src_d.dims()[pd()->ndims() - 1];
 
-    parallel(pd()->nthr_, [&](int ithr, int nthr) {
+    parallel(pd()->nthr_, [= COMPAT_THIS_CAPTURE](int ithr, int nthr) {
         dim_t N_start_idx = 0, N_end_idx = 0;
         balance211(N, nthr, ithr, N_start_idx, N_end_idx);
         const char *const src_ptr = reinterpret_cast<const char *>(src)

--- a/src/cpu/aarch64/jit_uni_pooling.hpp
+++ b/src/cpu/aarch64/jit_uni_pooling.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
 #include "common/primitive.hpp"
 #include "common/utils.hpp"
 
@@ -52,6 +53,10 @@ struct jit_uni_pooling_fwd_t : public primitive_t {
 
         status_t init(const engine_t *engine) {
             using namespace utils;
+
+            VDISPATCH_POOLING(
+                    DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+                    VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
 
             const bool ok = mayiuse(isa) && is_fwd() && !has_zero_dim_memory()
                     && everyone_is(
@@ -124,6 +129,10 @@ struct jit_uni_pooling_bwd_t : public primitive_t {
 
         status_t init(const engine_t *engine) {
             using namespace utils;
+
+            VDISPATCH_POOLING(
+                    DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+                    VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
 
             const bool ok = mayiuse(isa)
                     && set_default_params() == status::success && !is_fwd()

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul.cpp
@@ -16,6 +16,7 @@
 *******************************************************************************/
 
 #include "cpu/aarch64/matmul/acl_lowp_matmul.hpp"
+#include "common/dnnl_thread.hpp"
 #include "cpu/cpu_primitive.hpp"
 
 namespace dnnl {
@@ -42,6 +43,9 @@ const std::vector<lowp_matmul_key_t> lowp_matmul_keys = {
 };
 } // namespace
 status_t acl_lowp_matmul_t::pd_t::init(const engine_t *engine) {
+    VDISPATCH_MATMUL(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
     VDISPATCH_MATMUL(set_default_formats(), "failed to set default formats");
     using smask_t = primitive_attr_t::skip_mask_t;
     VDISPATCH_MATMUL(attr()->has_default_values(smask_t::scales

--- a/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
+++ b/src/cpu/aarch64/matmul/acl_lowp_matmul_sq.cpp
@@ -19,6 +19,8 @@
 
 #include "arm_compute/core/utils/quantization/AsymmHelpers.h"
 
+#include "common/dnnl_thread.hpp"
+
 #include "cpu/aarch64/acl_utils.hpp"
 
 namespace dnnl {
@@ -64,6 +66,8 @@ status_t acl_lowp_matmul_sq_t::init(engine_t *engine) {
 }
 
 status_t acl_lowp_matmul_sq_t::pd_t::init(const engine_t *engine) {
+    VDISPATCH_MATMUL(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
 
     VDISPATCH_MATMUL(set_default_formats(), "failed to set default formats");
     using smask_t = primitive_attr_t::skip_mask_t;

--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
+++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
@@ -18,6 +18,8 @@
 #include "cpu/aarch64/matmul/acl_matmul.hpp"
 #include "cpu/aarch64/acl_utils.hpp"
 
+#include "common/dnnl_thread.hpp"
+
 #include <mutex>
 
 namespace dnnl {
@@ -90,6 +92,9 @@ status_t acl_matmul_t::pd_t::init(const engine_t *engine) {
             && platform::has_data_type_support(data_type::bf16);
     const bool is_gemv = utils::everyone_is(2, src_md()->ndims, dst_md()->ndims)
             && (src_md()->dims[0] == 1 || weights_md()->dims[1] == 1);
+
+    VDISPATCH_MATMUL(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
 
     // in case of gemv and we have SVE, we leave BRGeMM to handle it
     VDISPATCH_MATMUL(!(is_gemv && arm_compute::CPUInfo::get().has_sve()),

--- a/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_bf16_matmul.cpp
@@ -287,6 +287,8 @@ status_t jit_bf16_matmul_t::pd_t::init(const engine_t *engine) {
 
     VDISPATCH_MATMUL(
             no_runtime_dims_or_strides, VERBOSE_RUNTIMEDIM_UNSUPPORTED);
+    VDISPATCH_MATMUL(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
 
     const auto src_type = src_md(0)->data_type;
     const auto wei_type = weights_md(0)->data_type;

--- a/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
+++ b/src/cpu/aarch64/matmul/jit_int8_matmul.cpp
@@ -882,6 +882,8 @@ status_t jit_int8_matmul_t<isa>::pd_t::init(const engine_t *engine) {
 
     VDISPATCH_MATMUL(
             no_runtime_dims_or_strides, VERBOSE_RUNTIMEDIM_UNSUPPORTED);
+    VDISPATCH_MATMUL(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
     VDISPATCH_MATMUL(is_dense_format_kind(), VERBOSE_UNSUPPORTED_SPARSE_CFG);
 
     bool is_u8 = utils::everyone_is(u8, src_type, wei_type);

--- a/src/cpu/aarch64/reorder/acl_reorder.cpp
+++ b/src/cpu/aarch64/reorder/acl_reorder.cpp
@@ -1,5 +1,5 @@
 /*******************************************************************************
-* Copyright 2023, 2025 Arm Ltd. and affiliates
+* Copyright 2023, 2025-2026 Arm Ltd. and affiliates
 * Copyright 2026 Intel Corporation
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,6 +17,8 @@
 
 #include "cpu/aarch64/reorder/acl_reorder.hpp"
 #include "cpu/aarch64/cpu_isa_traits.hpp"
+
+#include "common/dnnl_thread.hpp"
 
 namespace {
 /*
@@ -71,6 +73,9 @@ status_t acl_reorder_fwd_t::pd_t::create(reorder_pd_t **reorder_pd,
     using namespace dnnl::impl;
 
     // ComputeLibrary reorders support f32->f32 and f32->bf16
+    VDISPATCH_REORDER_IC(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
     bool ok = src_md->data_type == data_type::f32
             && utils::one_of(dst_md->data_type, data_type::f32, data_type::bf16)
             && attr->has_default_values();

--- a/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/aarch64/shuffle/jit_uni_shuffle.cpp
@@ -48,6 +48,9 @@ status_t jit_uni_shuffle_t<isa>::pd_t::init(const engine_t *engine) {
 
     conf_.data_type = src_d.data_type();
 
+    VDISPATCH_SHUFFLE(DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL,
+            VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME);
+
     const bool ok = is_superset(get_max_cpu_isa(), isa)
             && utils::one_of(conf_.data_type, f32, s32, bf16)
             && src_d.data_type() == dst_d.data_type()


### PR DESCRIPTION
## Description

This PR extends AArch64 asynchronous Eigen threadpool support.

It enables simple capture-safe AArch64 JIT implementations by following the existing async pattern from https://github.com/uxlfoundation/oneDNN/pull/4297.

Enabled for asynchronous THREADPOOL execution:

  - `jit_uni_binary`
  - `eltwise_lut`
  - `jit_uni_eltwise`
  - `jit_uni_layer_normalization`
  - `jit_uni_prelu`

The PR also disables AArch64 implementations that are not yet async-safe or need broader lifetime review when built with THREADPOOL, using `VERBOSE_UNSUPPORTED_THREADPOOL_RUNTIME`.

Disabled for THREADPOOL:

  - `ACL primitives`
  - `jit_brgemm_conv_bwd`
  - `jit_brgemm_deconv`
  - `jit_sve_512_x8s8s32x_convolution`
  - `jit_sve_512_x8s8s32x_deconvolution`
  - `jit_uni_batch_normalization`
  - `jit_uni_batch_normalization_s8`
  - `jit_uni_pooling`
  - `jit_uni_i8i8_pooling`
  - `jit_uni_shuffle`
  - `jit_bf16_matmul`
  - `jit_int8_matmul`
  - `jit_uni_eltwise_int`
  
  Depends on #5789 
Related PRs #5828, #5790

  ## Validation

  Validated on AArch64 SVE 128-bit.

Builds:
 ```
cmake -S ${ONEDNN_SRC} -B ${BUILD_DIR} \
    -DCMAKE_BUILD_TYPE=Release \
    -DONEDNN_CPU_RUNTIME=THREADPOOL \
    -D_DNNL_TEST_THREADPOOL_IMPL=EIGEN_ASYNC \
    -DONEDNN_XLA_SOURCE_DIR=${XLA_SRC} \
    -DONEDNN_USE_CLANG_SANITIZER=Address \
    -DONEDNN_BUILD_TESTS=ON \
    -DONEDNN_BUILD_EXAMPLES=OFF \
    -DONEDNN_BUILD_GRAPH=ON \
    -DONEDNN_ENABLE_GRAPH_DUMP=ON \
    -DONEDNN_CODE_COVERAGE=NONE \
    -DONEDNN_GPU_RUNTIME=NONE \
    -DONEDNN_GPU_VENDOR=GENERIC \
    -DEigen3_DIR=${EIGEN_INSTALL}/share/eigen3/cmake \
    -Dabsl_DIR=${ABSL_INSTALL}/lib/cmake/absl

  cmake --build ${BUILD_DIR} -j16
```
Tested for EIGEN_ASYNC with Address sanitzer and OMP runtime builds


  ## Checklist

  ### General

  - [X] Do all unit and benchdnn tests (make test and make test_benchdnn_*) pass locally for each commit?
```
Full `ctest` was run for OMP release and THREADPOOL + EIGEN_ASYNC release.

  binary/test_binary_all
    EIGEN_ASYNC release: PASS
      selected: ref:any 17116, jit:uni 3373
      tests: 22913 total, 19950 passed, 2424 skipped, 539 mistrusted, 0 failed
    EIGEN_ASYNC ASan: PASS
      selected: same family coverage
      0 failed
    OMP release: PASS
      selected: ref:any 17116, jit:uni 3373
      tests: 22913 total, 19950 passed, 2424 skipped, 539 mistrusted, 0 failed

  eltwise/test_eltwise_all
    EIGEN_ASYNC release: PASS
      selected: ref:any 14768, jit:sve 11115, lut 460
      tests: 75713 total, 26259 passed, 49370 skipped, 84 mistrusted, 0 failed
    EIGEN_ASYNC ASan: PASS
      selected: same family coverage
      0 failed
    OMP release: PASS
      selected: ref:any 14768, jit:sve 11115, lut 460
      tests: 75713 total, 26259 passed, 49370 skipped, 84 mistrusted, 0 failed

  lnorm/test_lnorm_all
    EIGEN_ASYNC release: PASS
      selected: simple:any 11266, jit_lnorm:sve 9288, ref:any 1548
      tests: 25886 total, 21113 passed, 3784 skipped, 989 mistrusted, 0 failed
    EIGEN_ASYNC ASan: PASS
      selected: same family coverage
      tests: 25886 total, 21113 passed, 3784 skipped, 989 mistrusted, 0 failed
    OMP release: PASS
      selected: simple:any 11266, jit_lnorm:sve 9288, ref:any 1548
      tests: 25886 total, 21113 passed, 3784 skipped, 989 mistrusted, 0 failed

  prelu/test_prelu_all
    EIGEN_ASYNC release: PASS
      selected: ref:any 12414, jit:sve 962
      tests: 13376 total, 12870 passed, 0 skipped, 506 mistrusted, 0 failed
    EIGEN_ASYNC ASan: PASS
      selected: ref:any 12414, jit:sve 962
      tests: 13376 total, 12870 passed, 0 skipped, 506 mistrusted, 0 failed
    OMP release: PASS
      selected: same family coverage
      0 failed

  deconv/test_deconv_all
    EIGEN_ASYNC release: PASS
      selected: conv:any+brgconv:sve_128 273, conv:any+brgconv_1x1:sve_128 71, conv:any+ref:any 12
      tests: 5766 total, 356 passed, 5410 skipped, 0 failed
    EIGEN_ASYNC ASan: PASS
      tests: 5766 total, 356 passed, 5410 skipped, 0 failed
    OMP release: PASS
      0 failed

  bnorm/test_bnorm_all_plain
    EIGEN_ASYNC release: PASS
      selected: nspc_bnorm:any 902, ncsp_bnorm:any 778
      tests: 2504 total, 1190 passed, 824 skipped, 490 mistrusted, 0 failed
    EIGEN_ASYNC ASan: PASS
      tests: 2504 total, 1190 passed, 824 skipped, 490 mistrusted, 0 failed
    OMP release: PASS
      selected: ncsp_bnorm:any 762, nspc_bnorm:any 478, bnorm_jit:sve 440
      tests: 2504 total, 1189 passed, 824 skipped, 491 mistrusted, 0 failed

  bnorm/test_bnorm_all_blocked
    EIGEN_ASYNC release: PASS
      selected: none; guarded JIT path skipped
      tests: 1728 total, 0 passed, 1728 skipped, 0 failed
    EIGEN_ASYNC ASan: PASS
      tests: 1728 total, 0 passed, 1728 skipped, 0 failed
    OMP release: PASS
      selected: bnorm_jit:sve 194
      tests: 1728 total, 188 passed, 1534 skipped, 6 mistrusted, 0 failed

  pool/test_pool_all
    EIGEN_ASYNC release: PASS
      selected: ref:any 9705, simple_nhwc:any 6040, simple_nchw:any 3678
      tests: 30697 total, 19423 passed, 11274 skipped, 0 failed
    EIGEN_ASYNC ASan: PASS
      tests: 30697 total, 19423 passed, 11274 skipped, 0 failed
    OMP release: PASS
      selected: ref:any 9705, simple_nhwc:any 4293, simple_nchw:any 2772, jit:sve 2653
      tests: 30697 total, 19423 passed, 11274 skipped, 0 failed

  shuffle/test_shuffle_all
    EIGEN_ASYNC release: PASS
      selected: ref:any 1750
      tests: 1750 total, 1750 passed, 0 skipped, 0 failed
    EIGEN_ASYNC ASan: PASS
      tests: 1750 total, 1750 passed, 0 skipped, 0 failed
    OMP release: PASS
      selected: ref:any 1519, jit:sve 231
      tests: 1750 total, 1750 passed, 0 skipped, 0 failed



```
  - [x] Have you formatted the code using clang-format?
  - [x] clang-tidy passed for changed non-ACL .cpp files available in the local compile database.

  ### Performance improvements

  - [ ] Have you submitted performance data that demonstrates performance improvements?
      - Not applicable.

  ### New features

  - [ ] Have you published an RFC for the new feature?
      - Not applicable. This extends existing async threadpool support.
  - [ ] Was the RFC approved?
      - Not applicable.
  - [ ] Have you added relevant tests?
      - Existing benchdnn coverage was used for focused validation. No new test file is added in this PR.

  ### Bug fixes

  - [x] Have you included information on how to reproduce the issue?
  - [ ] Have you added relevant regression tests?

  ### RFC PR

  - [ ] Does RFC document follow the template?
      - Not applicable.
  - [ ] Have you added a link to the rendered document?
      - Not applicable.