### PR TITLE
cpu: rnn: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/rnn/brgemm_cell_common.cpp
+++ b/src/cpu/rnn/brgemm_cell_common.cpp
@@ -90,9 +90,9 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     typename brgemm_dst_layer_iter_t::postgemm_fused_t fused_postgemm;
 
     if (!rnn.unfused_post_gemm) {
-        fused_postgemm
-                = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
-                          scratch_t *C_n, scratch_t *C_cell_n, int block_step) {
+        fused_postgemm = [&](dim_t m, dim_t n, dim_t nb_i,
+                                 const src_iter_t *Ai_m, scratch_t *C_n,
+                                 scratch_t *C_cell_n, dim_t block_step) {
             const auto Dpg_n = (dst_postgemm != nullptr)
                     ? dst_postgemm + m * LDDl + n
                     : nullptr;
@@ -130,7 +130,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
             fused_postgemm_gru_part1
                     = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
                               scratch_t *C_gates_n, scratch_t *C_cell_n,
-                              int block_step) {
+                              dim_t block_step) {
                 const auto Dpg_n = (dst_postgemm != nullptr)
                         ? dst_postgemm + m * LDDl + n
                         : nullptr;
@@ -157,7 +157,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
             fused_postgemm_gru_part2
                     = [&](dim_t m, dim_t n, dim_t nb_i, const src_iter_t *Ai_m,
                               scratch_t *C_gates_n, scratch_t *C_cell_n,
-                              int block_step) {
+                              dim_t block_step) {
                 const auto Dpg_n = (dst_postgemm != nullptr)
                         ? dst_postgemm + m * LDDl + n
                         : nullptr;
@@ -219,7 +219,7 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         gemm_acc_t *const Cp = (rnn.dt_conf == all_f32)
                 ? reinterpret_cast<gemm_acc_t *>(dst_layer_)
                 : scratch_gates_;
-        const int pLDDl = rnn.dst_layer_ld(cell_position, true);
+        const dim_t pLDDl = rnn.dst_layer_ld(cell_position, true);
         const int pmask
                 = this->pd_->attr()->rnn_weights_projection_qparams_.mask_;
 
@@ -228,8 +228,8 @@ rnn_cell_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
         typename brgemm_dst_proj_t::postgemm_fused_t fused_postgemm_proj;
 
         if (!rnn.unfused_post_gemm) {
-            fused_postgemm_proj
-                    = [&](dim_t m, dim_t n, gemm_acc_t *Cp_n, int block_step) {
+            fused_postgemm_proj = [&](dim_t m, dim_t n, gemm_acc_t *Cp_n,
+                                          dim_t block_step) {
                 const auto weights_scales_n
                         = wscales_proj_postgemm + (pmask ? n : 0);
                 const auto Di_n = (dst_iter_ != nullptr)

--- a/src/cpu/rnn/cell_common.cpp
+++ b/src/cpu/rnn/cell_common.cpp
@@ -80,7 +80,7 @@ rnn_cell_execution_sig(
         assert(rnn.scratch_gates_ld >= rnn.dlc);
         gemm_acc_t *dst_proj = rnn.dt_conf == all_f32 ? (gemm_acc_t *)dst_layer_
                                                       : scratch_gates_;
-        const int dst_proj_ld
+        const dim_t dst_proj_ld
                 = rnn.dt_conf == all_f32 ? dst_layer_ld : rnn.scratch_gates_ld;
 
         CHECK((this->*gemm_projection_func)('N', 'N', rnn.dic, rnn.mb, rnn.dhc,
@@ -109,8 +109,8 @@ void lstm_bwd_weights_peephole_and_bias(const rnn_utils::rnn_conf_t &rnn,
         cell_position_t cell_position, const void *src_iter_c_,
         const void *dst_iter_c_, const scratch_data_t *scratch_gates_,
         float *diff_weights_peephole_, acc_data_t *diff_bias_) {
-    const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
-    const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+    const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+    const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
 
     const auto dst_iter_c = rnn_utils::make_raw_aoc(dst_iter_c_,
             types::data_type_size(rnn.dst_iter_c_dt), rnn.ws_states_iter_c_nld,
@@ -125,13 +125,13 @@ void lstm_bwd_weights_peephole_and_bias(const rnn_utils::rnn_conf_t &rnn,
             rnn, diff_weights_peephole_);
 
     parallel(0, [&](int ithr, int nthr) {
-        int g_dhc_start {}, g_dhc_stop {};
+        dim_t g_dhc_start {}, g_dhc_stop {};
         const int gates_to_process = 5; // 3 -- weights peephole +
                 // 2 -- bias (process a pair at once)
         balance211(gates_to_process * rnn.dhc, nthr, ithr, g_dhc_start,
                 g_dhc_stop);
-        int g = g_dhc_start / rnn.dhc;
-        int dhc = g_dhc_start % rnn.dhc;
+        int g = static_cast<int>(g_dhc_start / rnn.dhc);
+        dim_t dhc = g_dhc_start % rnn.dhc;
         while (g_dhc_start++ < g_dhc_stop) {
             if (g < 3) {
                 // weights peephole
@@ -142,7 +142,7 @@ void lstm_bwd_weights_peephole_and_bias(const rnn_utils::rnn_conf_t &rnn,
                 const int scratch_g = g < 2 ? g : 3;
                 if (rnn.diff_weights_overwrite && (cell_position & last_iter))
                     diff_weights_peephole(g, dhc) = 0;
-                for (int mb = 0; mb < rnn.mb; ++mb) {
+                for (dim_t mb = 0; mb < rnn.mb; ++mb) {
                     diff_weights_peephole(g, dhc)
                             += to_float(c_states(mb, dhc), c_states_dt)
                             * scratch_gates(mb, scratch_g, dhc);
@@ -194,7 +194,7 @@ dnnl_status_t common_bwd_cell_exec_template(T1 gemm_layer_f, T2 gemm_iter_f,
     if (rnn.is_lstm_projection) {
         parallel_nd(rnn.mb, [&](dim_t i) {
             PRAGMA_OMP_SIMD()
-            for (int j = 0; j < rnn.dlc; j++)
+            for (dim_t j = 0; j < rnn.dlc; j++)
                 scratch_diff_ht_[i * rnn.scratch_diff_ht_ld + j]
                         = diff_dst_layer_[i * rnn.ws_diff_states_layer_ld + j]
                         + diff_dst_iter_[i * rnn.ws_diff_states_iter_ld + j];
@@ -315,7 +315,7 @@ rnn_merged_layer_execution_sig((ref_rnn_fwd_t<src_type, weights_type,
     // hence we cannot merge all iterations.
     // This is not applicable for the first layer though, since
     // all the states come from user's `src_layer_`.
-    const int n_iter
+    const dim_t n_iter
             = (cell_position & first_layer) && rnn.skip_src_layer_copy()
             ? rnn.n_iter
             : rnn.n_iter - (rnn.skip_dst_iter_copy() ? 1 : 0);
@@ -338,7 +338,7 @@ rnn_merged_layer_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
     // hence we cannot merge all iterations.
     // This is not applicable for the first layer though, since
     // all the states come from user's `src_layer_`.
-    const int n_iter
+    const dim_t n_iter
             = (cell_position & first_layer) && rnn.skip_src_layer_copy()
             ? rnn.n_iter
             : rnn.n_iter - (rnn.skip_dst_iter_copy() ? 1 : 0);

--- a/src/cpu/rnn/cell_gru.cpp
+++ b/src/cpu/rnn/cell_gru.cpp
@@ -190,8 +190,8 @@ template <data_type_t src_type, data_type_t weights_type, data_type_t acc_type>
 rnn_cell_execution_sig(
         (ref_rnn_bwd_t<src_type, weights_type, acc_type>::cell_execution_gru)) {
     auto gemm_iter_f
-            = [&](int m, int n, int k, const weights_t *A, const gemm_data_t *B,
-                      float beta, gemm_acc_t *C) {
+            = [&](dim_t m, dim_t n, dim_t k, const weights_t *A,
+                      const gemm_data_t *B, float beta, gemm_acc_t *C) {
         return (this->*gemm_iter_func)('N', 'N', m, n, k, 1.0f, A,
                 rnn.weights_iter_ld, B, rnn.scratch_gates_ld, beta, C,
                 rnn.ws_diff_states_iter_ld);
@@ -203,15 +203,15 @@ rnn_cell_execution_sig(
                 rnn.scratch_gates_ld, 0.0, C, rnn.ws_diff_states_layer_ld);
     };
     auto gemm_weights_layer_f = [&](const gemm_data_t *A, const weights_t *B,
-                                        int ldb, gemm_acc_t *C) {
+                                        dim_t ldb, gemm_acc_t *C) {
         const float beta = rnn.diff_weights_beta(cell_position);
         return gemm('N', 'T', rnn.n_gates * rnn.dhc, rnn.slc, rnn.mb, 1.0, A,
                 rnn.scratch_gates_ld, B, ldb, beta, C,
                 rnn.diff_weights_layer_ld);
     };
     auto gemm_weights_iter_f
-            = [&](int m, int n, int k, const weights_t *A, const gemm_data_t *B,
-                      int ldb, gemm_acc_t *C) {
+            = [&](dim_t m, dim_t n, dim_t k, const weights_t *A,
+                      const gemm_data_t *B, dim_t ldb, gemm_acc_t *C) {
         const float beta = rnn.diff_weights_beta(cell_position);
         return gemm('N', 'T', m, n, k, 1.0f, A, rnn.ws_gates_ld, B, ldb, beta,
                 C, rnn.diff_weights_iter_ld);

--- a/src/cpu/rnn/cell_gru_lbr.cpp
+++ b/src/cpu/rnn/cell_gru_lbr.cpp
@@ -160,15 +160,15 @@ rnn_cell_execution_sig((ref_rnn_bwd_t<src_type, weights_type,
                 rnn.n_gates * rnn.dhc, 1.0f, A, rnn.weights_iter_ld, B,
                 rnn.ws_gates_ld, 1.0f, C, rnn.ws_diff_states_iter_ld);
     };
-    const auto gemm_weights_layer
-            = [&](const scratch_t *A, const src_layer_t *B, int ldb, float *C) {
+    const auto gemm_weights_layer =
+            [&](const scratch_t *A, const src_layer_t *B, dim_t ldb, float *C) {
         const float beta = rnn.diff_weights_beta(cell_position);
         return gemm('N', 'T', rnn.n_gates * rnn.dhc, rnn.slc, rnn.mb, 1.0f, A,
                 rnn.scratch_gates_ld, B, ldb, beta, C,
                 rnn.diff_weights_layer_ld);
     };
-    const auto gemm_weights_iter
-            = [&](const scratch_t *A, const src_iter_t *B, int ldb, float *C) {
+    const auto gemm_weights_iter = [&](const scratch_t *A, const src_iter_t *B,
+                                           dim_t ldb, float *C) {
         const float beta = rnn.diff_weights_beta(cell_position);
         return gemm('N', 'T', rnn.n_gates * rnn.dhc, rnn.sic, rnn.mb, 1.0f, A,
                 rnn.ws_gates_ld, B, ldb, beta, C, rnn.diff_weights_iter_ld);

--- a/src/cpu/rnn/ref_postgemm_gru.cpp
+++ b/src/cpu/rnn/ref_postgemm_gru.cpp
@@ -43,13 +43,13 @@ void gru_fwd_part1_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
         rnn_utils::cell_position_t cell_position, src_data_t *ws_gates_,
         scratch_data_t *scratch_gates_, const src_data_t *augru_attention_,
         src_data_t *dst_layer_, src_data_t *dst_iter_,
-        const src_data_t *src_iter_, const void *bias_, int block_step) {
+        const src_data_t *src_iter_, const void *bias_, dim_t block_step) {
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
     const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
 
@@ -66,10 +66,10 @@ void gru_fwd_part1_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
 
     const float *scales_G1 = scales ? scales + 1 : nullptr;
 
-    const auto postgemm_call = [&](int i) {
-        const int n_elem = block_step;
+    const auto postgemm_call = [&](dim_t i) {
+        const dim_t n_elem = block_step;
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             const auto G0 // default func1 is sigmoid
                     = func1(scales,
                             acc_to_float(scratch_gates(i, 0, j), 0, j)
@@ -107,13 +107,13 @@ void gru_fwd_part2_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
         rnn_utils::cell_position_t cell_position, src_data_t *ws_gates_,
         scratch_data_t *scratch_gates_, const src_data_t *augru_attention_,
         src_data_t *dst_layer_, src_data_t *dst_iter_,
-        const src_data_t *src_iter_, const void *bias_, int block_step) {
+        const src_data_t *src_iter_, const void *bias_, dim_t block_step) {
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
     const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
 
@@ -131,10 +131,10 @@ void gru_fwd_part2_postgemm_template(T1 func1, T2 to_src, T3 acc_to_float,
 
     const float *scales_G2 = scales ? scales + 2 : nullptr;
 
-    const auto postgemm_call = [&](int i) {
-        const int n_elem = block_step;
+    const auto postgemm_call = [&](dim_t i) {
+        const dim_t n_elem = block_step;
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             auto G0 = reinterpret_as_float(scratch_gates(i, 0, j));
             const auto G2 // default func1 is tanh
                     = func1(scales_G2,
@@ -175,7 +175,7 @@ rnn_postgemm_sig((rnn_postgemm_fwd_t<src_type, scratch_type,
 
     const auto cvt_from_f32 = [](float f) { return static_cast<gates_t>(f); };
     const auto cvt_to_f32 = [](gates_t b) { return float(b); };
-    const auto deq_id = [](float f, int i, int j) { return f; };
+    const auto deq_id = [](float f, int i, dim_t j) { return f; };
     const auto id = [](float f) { return f; };
 
     if (!this->pd_->attr()->rnn_tparams_.test_mode_)
@@ -201,7 +201,7 @@ rnn_postgemm_sig((rnn_postgemm_fwd_t<src_type, scratch_type,
 
     const auto cvt_from_f32 = [](float f) { return static_cast<gates_t>(f); };
     const auto cvt_to_f32 = [](gates_t b) { return float(b); };
-    const auto deq_id = [](float f, int i, int j) { return f; };
+    const auto deq_id = [](float f, int i, dim_t j) { return f; };
     const auto id = [](float f) { return f; };
 
     if (!this->pd_->attr()->rnn_tparams_.test_mode_)
@@ -242,7 +242,7 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::gru_part1_postgemm) {
         return (dst_layer_t)mxcsr_cvt(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, dim_t j) {
         const float wscale = pd_->attr()->rnn_weights_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[gate * rnn.dhc + j];
@@ -288,7 +288,7 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::gru_part2_postgemm) {
         return (dst_layer_t)mxcsr_cvt(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, dim_t j) {
         const float wscale = pd_->attr()->rnn_weights_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[gate * rnn.dhc + j];
@@ -359,7 +359,7 @@ void gru_bwd_part1_postgemm_template(T to_src, const rnn_utils::rnn_conf_t &rnn,
     parallel_nd(rnn.mb, [&](dim_t i) {
         acc_data_t diff_attention = 0.0f;
         PRAGMA_OMP_SIMD(reduction(+ : diff_attention))
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float h = src_iter(i, j);
             const float dHt = diff_dst_iter(i, j) + diff_dst_layer(i, j);
             const float dG2 = (1.0f - ws_gates(i, 0, j)) * dHt
@@ -412,7 +412,7 @@ void gru_bwd_part2_postgemm_template(T to_src, const rnn_utils::rnn_conf_t &rnn,
     // h * G1 (required for dWh)
     parallel_nd(rnn.mb, [&](dim_t i) {
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float h = src_iter(i, j);
             const float G1 = ws_gates(i, 1, j);
             diff_src_iter(i, j) += dhG1(i, j) * G1;

--- a/src/cpu/rnn/ref_postgemm_gru_lbr.cpp
+++ b/src/cpu/rnn/ref_postgemm_gru_lbr.cpp
@@ -40,7 +40,7 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
         scratch_data_t *scratch_gates_, const src_data_t *augru_attention_,
         src_data_t *dst_layer_, src_data_t *dst_iter_,
         const src_data_t *src_iter_, const void *bias_, src_data_t *ws_grid_,
-        scratch_data_t *scratch_cell_, int block_step) {
+        scratch_data_t *scratch_cell_, dim_t block_step) {
 
     const auto src_iter_ld = rnn.src_iter_ld(cell_position);
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
@@ -60,7 +60,7 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
 
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
     const scratch_gates_aoc_t<scratch_data_t> scratch_cell(rnn, scratch_cell_);
@@ -74,7 +74,7 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
 
     const auto postgemm = [&](dim_t i) {
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float Wh_b = scratch_cell(i, 2, j) + bias(3, j);
             auto G0 = func1(scales, // default func1 is sigmoid
                     scratch_gates(i, 0, j) + scratch_cell(i, 0, j)
@@ -101,9 +101,9 @@ void gru_lbr_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src,
     };
 
     const auto postgemm_brgemm = [&](dim_t i) {
-        const int n_elem = block_step;
+        const dim_t n_elem = block_step;
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             const float Wh_b = scratch_cell(i, 0, j) + bias(3, j);
             auto G0 = func1(scales, // default func1 is sigmoid
                     scratch_gates(i, 0, j) + bias(0, j));
@@ -213,7 +213,7 @@ void gru_lbr_bwd_postgemm_template(T1 to_src, const rnn_utils::rnn_conf_t &rnn,
     parallel_nd(rnn.mb, [&](dim_t i) {
         acc_data_t diff_attention = 0.0f;
         PRAGMA_OMP_SIMD(reduction(+ : diff_attention))
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float h = src_iter(i, j);
             const float dHt = diff_dst_iter(i, j) + diff_dst_layer(i, j);
             float dG0 = (h - ws_gates(i, 2, j)) * dHt

--- a/src/cpu/rnn/ref_postgemm_lstm.cpp
+++ b/src/cpu/rnn/ref_postgemm_lstm.cpp
@@ -42,7 +42,7 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
         scratch_data_t *scratch_gates_, src_data_t *dst_layer_,
         src_data_t *dst_iter_, void *dst_iter_c_, const src_data_t *src_iter_,
         const void *src_iter_c_, const float *weights_peephole_,
-        const void *bias_, int block_step) {
+        const void *bias_, dim_t block_step) {
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
     const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
@@ -50,7 +50,7 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
             rnn, weights_peephole_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return rnn_utils::to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
     // If lstmp, instead of dst_layer, we use scratch_ht if inference or ws_ht if training
@@ -58,8 +58,8 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
             ? rnn.scratch_ht_ld
             : rnn.dst_layer_ld(cell_position);
     const auto dst_iter_ld = rnn.dst_iter_ld(cell_position);
-    const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
-    const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+    const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+    const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
 
     const ws_states_layer_aoc_t<src_data_t> dst_layer(
             rnn, dst_layer_, dst_layer_ld);
@@ -74,11 +74,12 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
             types::data_type_size(rnn.src_iter_c_dt), rnn.ws_states_iter_c_nld,
             src_iter_c_ld);
 
-    const auto src_iter_c = [&](int mb_id, int dhc_id) {
+    const auto src_iter_c = [&](dim_t mb_id, dim_t dhc_id) {
         return rnn_utils::to_float(
                 src_iter_c_aoc(mb_id, dhc_id), rnn.src_iter_c_dt);
     };
-    const auto dst_iter_c_assign = [&](int mb_id, int dhc_id, float c_state) {
+    const auto dst_iter_c_assign
+            = [&](dim_t mb_id, dim_t dhc_id, float c_state) {
         const auto dst_iter_c_ptr
                 = const_cast<void *>(dst_iter_c(mb_id, dhc_id));
 
@@ -92,10 +93,10 @@ void lstm_fwd_postgemm_template(T1 func1, T2 func2, T3 to_src_dt, T4 to_float,
                     = cpu::q10n::saturate_and_round<float16_t>(c_state);
     };
 
-    const auto postgemm_call = [&](int i) {
-        const int n_elem = block_step / (int)sizeof(scratch_data_t);
+    const auto postgemm_call = [&](dim_t i) {
+        const dim_t n_elem = block_step / sizeof(scratch_data_t);
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             float gate_i_arg
                     = to_float(scratch_gates(i, 0, j), 0, j) + bias(0, j);
             if (rnn.is_lstm_peephole)
@@ -154,7 +155,7 @@ rnn_postgemm_sig(
     const float *scales = this->pd_->attr()->rnn_tparams_.scales_;
     const float *cscale = &(this->pd_->attr()->rnn_tparams_.cscale_);
     const auto to_src_dt = [&](float f) { return gates_t(f); };
-    const auto deq_id = [&](float f, int i, int j) { return f; };
+    const auto deq_id = [&](float f, int i, dim_t j) { return f; };
 
     const auto linear_f
             = [](const float *scale, float a) { return *scale * a; };
@@ -193,7 +194,7 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::lstm_postgemm) {
         return q10n::qz_a1b0_t<float, dst_layer_t>()(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, dim_t j) {
         const float wscale = pd_->attr()->rnn_weights_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[gate * rnn.dhc + j];
@@ -234,7 +235,7 @@ rnn_postgemm_sig(rnn_postgemm_fwd_s8_t::lstm_postgemm) {
         return q10n::qz_a1b0_t<float, dst_layer_t>()(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int gate, dim_t j) {
         float wscale = pd_->attr()->rnn_weights_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[gate * rnn.dhc + j];
@@ -276,19 +277,19 @@ void lstm_bwd_postgemm_template(T1 func1, T2 to_src_dt, const float *cscale,
             rnn, scratch_gates_);
     const weights_peephole_aoc_t<const float> weights_peephole(
             rnn, weights_peephole_);
-    const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
-    const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+    const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+    const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
     const auto src_iter_c_aoc = rnn_utils::make_raw_aoc(src_iter_c_,
             types::data_type_size(rnn.src_iter_c_dt), rnn.ws_states_iter_c_nld,
             src_iter_c_ld);
-    const auto src_iter_c = [&](int mb_id, int dhc_id) {
+    const auto src_iter_c = [&](dim_t mb_id, dim_t dhc_id) {
         return rnn_utils::to_float(
                 src_iter_c_aoc(mb_id, dhc_id), rnn.src_iter_c_dt);
     };
     const auto dst_iter_c_aoc = rnn_utils::make_raw_aoc(dst_iter_c_,
             types::data_type_size(rnn.dst_iter_c_dt), rnn.ws_states_iter_c_nld,
             dst_iter_c_ld);
-    const auto dst_iter_c = [&](int mb_id, int dhc_id) {
+    const auto dst_iter_c = [&](dim_t mb_id, dim_t dhc_id) {
         return rnn_utils::to_float(
                 dst_iter_c_aoc(mb_id, dhc_id), rnn.dst_iter_c_dt);
     };
@@ -304,7 +305,7 @@ void lstm_bwd_postgemm_template(T1 func1, T2 to_src_dt, const float *cscale,
 
     parallel_nd(rnn.mb, [&](dim_t i) {
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < rnn.dhc; j++) {
+        for (dim_t j = 0; j < rnn.dhc; j++) {
             const float Ct = dst_iter_c(i, j);
             /// @todo save it in the workspace in fwd pass or recompute it to
             /// save bw

--- a/src/cpu/rnn/ref_postgemm_lstm_projection.cpp
+++ b/src/cpu/rnn/ref_postgemm_lstm_projection.cpp
@@ -37,7 +37,7 @@ namespace {
 template <typename dst_layer_t, typename dst_iter_t>
 void proj_dst_copy(const rnn_utils::rnn_conf_t &rnn,
         rnn_utils::cell_position_t cell_position, dst_iter_t *dst_iter_,
-        const dst_layer_t *dst_layer_, int block_step) {
+        const dst_layer_t *dst_layer_, dim_t block_step) {
     assert(rnn.dic == rnn.dlc);
     static_assert(sizeof(dst_layer_t) == sizeof(dst_iter_t),
             "memcpy requires the same data type size for src and dst");
@@ -72,9 +72,9 @@ rnn_postgemm_sig((rnn_postgemm_fwd_t<src_type, scratch_type,
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position, true);
 
     // Currently, scratch_gates_ contains the output of the projection
-    const int n_elem = block_step / (int)sizeof(dst_layer_t);
+    const dim_t n_elem = block_step / sizeof(dst_layer_t);
 
-    const int m_block
+    const dim_t m_block
             = (rnn.is_brgemm && !rnn.unfused_post_gemm) ? rnn.m_block : rnn.mb;
 
     for (int i = 0; i < m_block; i++)
@@ -107,7 +107,7 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::lstm_projection_postgemm) {
         return q10n::qz_a1b0_t<float, dst_layer_t>()(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, dim_t j) {
         const float wscale
                 = pd_->attr()->rnn_weights_projection_qparams_.mask_ == 0
                 ? weights_scales_[0]
@@ -117,12 +117,12 @@ rnn_postgemm_sig(rnn_postgemm_fwd_u8_t::lstm_projection_postgemm) {
         return (q10n::saturate<float>(s) - wcomp) / (wscale * data_scale);
     };
 
-    auto postgemm_call = [&](int i) {
-        const int n_elem = block_step / (int)sizeof(dst_layer_t);
+    auto postgemm_call = [&](dim_t i) {
+        const dim_t n_elem = block_step / sizeof(dst_layer_t);
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
-            const int scratch_off = i * rnn.scratch_gates_ld + j;
-            const int dst_off = i * dst_layer_ld + j;
+        for (dim_t j = 0; j < n_elem; j++) {
+            const dim_t scratch_off = i * rnn.scratch_gates_ld + j;
+            const dim_t dst_off = i * dst_layer_ld + j;
             const float tmp
                     = dequantize_s32_f32(scratch_gates_[scratch_off], j);
             dst_layer_[dst_off] = quantize_f32_u8(tmp);
@@ -152,21 +152,21 @@ rnn_postgemm_sig(rnn_postgemm_fwd_s8_t::lstm_projection_postgemm) {
         return q10n::qz_a1b0_t<float, dst_layer_t>()(qf);
     };
 
-    const auto dequantize_s32_f32 = [&](gemm_acc_t s, int j) {
+    const auto dequantize_s32_f32 = [&](gemm_acc_t s, dim_t j) {
         const float wscale
                 = pd_->attr()->rnn_weights_projection_qparams_.mask_ == 0
                 ? weights_scales_[0]
                 : weights_scales_[j];
 
-        return (q10n::saturate<float>(s)) / (wscale * data_scale);
+        return q10n::saturate<float>(s) / (wscale * data_scale);
     };
 
     const auto postgemm_call = [&](dim_t i) {
-        const int n_elem = block_step / (int)sizeof(dst_layer_t);
+        const dim_t n_elem = block_step / sizeof(dst_layer_t);
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < n_elem; j++) {
-            const int scratch_off = i * rnn.scratch_gates_ld + j;
-            const int dst_off = i * dst_layer_ld + j;
+        for (dim_t j = 0; j < n_elem; j++) {
+            const dim_t scratch_off = i * rnn.scratch_gates_ld + j;
+            const dim_t dst_off = i * dst_layer_ld + j;
             const float tmp
                     = dequantize_s32_f32(scratch_gates_[scratch_off], j);
             dst_layer_[dst_off] = quantize_f32_s8(tmp);

--- a/src/cpu/rnn/ref_postgemm_rnn.cpp
+++ b/src/cpu/rnn/ref_postgemm_rnn.cpp
@@ -66,14 +66,14 @@ void rnn_fwd_postgemm_template(T func1, const float *scales, float alpha,
         rnn_utils::cell_position_t cell_position, src_data_t *ws_gates_,
         scratch_data_t *scratch_gates_, src_data_t *dst_layer_,
         src_data_t *dst_iter_, const src_data_t *src_iter_, const void *bias_,
-        int block_step) {
+        dim_t block_step) {
 
     const ws_gates_aoc_t<src_data_t> ws_gates(rnn, ws_gates_);
     const scratch_gates_aoc_t<scratch_data_t> scratch_gates(
             rnn, scratch_gates_);
     const auto bias_aoc = rnn_utils::make_raw_aoc(
             bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
-    const auto bias = [&](int gate_id, int dhc_id) {
+    const auto bias = [&](int gate_id, dim_t dhc_id) {
         return to_float(bias_aoc(gate_id, dhc_id), rnn.bias_dt);
     };
     const auto dst_layer_ld = rnn.dst_layer_ld(cell_position);
@@ -85,10 +85,10 @@ void rnn_fwd_postgemm_template(T func1, const float *scales, float alpha,
 
     if (scales != nullptr) alpha = scales[0];
 
-    const int n_elem = block_step / sizeof(scratch_data_t);
+    const dim_t n_elem = block_step / sizeof(scratch_data_t);
 
     const auto postgemm_call = [&](dim_t i) {
-        for (int j = 0; j < n_elem; j++) {
+        for (dim_t j = 0; j < n_elem; j++) {
             const float h
                     = func1(scratch_gates(i, 0, j) + bias(0, j), alpha, 0);
             if (dst_layer_ != nullptr) dst_layer(i, j) = h;

--- a/src/cpu/rnn/ref_rnn.cpp
+++ b/src/cpu/rnn/ref_rnn.cpp
@@ -618,7 +618,7 @@ void ref_rnn_common_t<aprop, src_type, weights_type,
                       alg_kind::vanilla_augru)
             ? 2
             : 1;
-    const int ptr_wei_sz = rnn_.n_layer * rnn_.n_dir * max_nparts;
+    const dim_t ptr_wei_sz = rnn_.n_layer * rnn_.n_dir * max_nparts;
     scratchpad.template book<float *>(key_rnn_ptrs_wei_layer, ptr_wei_sz);
     scratchpad.template book<float *>(key_rnn_ptrs_wei_iter, ptr_wei_sz);
     scratchpad.template book<float *>(key_rnn_ptrs_wei_projection, ptr_wei_sz);
@@ -1076,7 +1076,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
     // We run the grid of computation
     for_(int dir = 0; dir < rnn.n_dir; dir++)
     for (int j = 0; j < rnn.n_layer; j++) {
-        const int lay = (aprop == prop_kind::forward) ? j : rnn.n_layer - j - 1;
+        const int lay = static_cast<int>(
+                (aprop == prop_kind::forward) ? j : rnn.n_layer - j - 1);
 
         CHECK(compute_merged_layer_part_if_applicable(
                 prop_kind::forward, dir, lay));
@@ -1084,8 +1085,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
         // TODO: enable merging projection gemm in bwd lstm projection
 
         for (int i = 0; i < rnn.n_iter; i++) {
-            const int iter
-                    = (aprop == prop_kind::forward) ? i : rnn.n_iter - i - 1;
+            const int iter = static_cast<int>(
+                    (aprop == prop_kind::forward) ? i : rnn.n_iter - i - 1);
 
             // We set parameters to the cell execution call
 
@@ -1244,8 +1245,8 @@ rnn_grid_execution_sig((ref_rnn_common_t<aprop, src_type, weights_type,
             // Note 1: here we assume no change in datatypes for src_iter, ws_iter and dst_iter
 
             const dst_iter_t *states_iter = nullptr;
-            int states_iter_ld = 0;
-            int niter_merge_gemm_iter = 0;
+            dim_t states_iter_ld = 0;
+            dim_t niter_merge_gemm_iter = 0;
 
             states_iter = &(
                     ws_states_iter(lay + 1, dir, rnn.skip_src_iter_copy(), 0));
@@ -1308,8 +1309,8 @@ void copy_init_layer_fwd_template(const rnn_conf_t &rnn,
                         (bfloat16_t *)ws_l2r_ptr, (const float *)xxt, rnn.slc);
             } else {
                 PRAGMA_OMP_SIMD()
-                for (int c = 0; c < rnn.slc; c++)
-                    ws_l2r_ptr[c] = xxt[c];
+                for (dim_t c = 0; c < rnn.slc; c++)
+                    ws_l2r_ptr[c] = static_cast<src_data_t>(xxt[c]);
             }
         }
         if (rnn.exec_dir != l2r) {
@@ -1318,8 +1319,8 @@ void copy_init_layer_fwd_template(const rnn_conf_t &rnn,
                         (bfloat16_t *)ws_r2l_ptr, (const float *)xxt, rnn.slc);
             } else {
                 PRAGMA_OMP_SIMD()
-                for (int c = 0; c < rnn.slc; c++)
-                    ws_r2l_ptr[c] = xxt[c];
+                for (dim_t c = 0; c < rnn.slc; c++)
+                    ws_r2l_ptr[c] = static_cast<src_data_t>(xxt[c]);
             }
         }
     });
@@ -1449,7 +1450,8 @@ void copy_init_iter_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
             return (src_data_t)f;
     };
     const src_data_t zero = maybe_q(0.f);
-    const auto zero_ws_iter_c = [&](int lay, int dir, int mb_id, int sic_id) {
+    const auto zero_ws_iter_c
+            = [&](dim_t lay, dim_t dir, dim_t mb_id, dim_t sic_id) {
         void *ws_states_iter_c = const_cast<void *>(
                 ws_states_iter_c_aoc(lay, dir, 0, mb_id, sic_id));
         if (rnn.src_iter_c_dt == data_type::f32)
@@ -1466,7 +1468,7 @@ void copy_init_iter_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
             const auto *ss = &src_iter_[src_iter_d.blk_off(lay, dir, b, 0)];
             auto *dd = &ws_states_iter(lay + 1, dir, 0, b, 0);
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.sic; s++)
+            for (dim_t s = 0; s < rnn.sic; s++)
                 dd[s] = maybe_q(ss[s]);
         });
     } else {
@@ -1590,11 +1592,11 @@ void copy_res_layer_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
     const auto copy_vec = [&](dst_layer_dt *dd, const src_data_t *ss) {
         if (dequantize_at_copy) {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++)
+            for (dim_t s = 0; s < rnn.dlc; s++)
                 dd[s] = (dst_layer_dt)(((float)ss[s] - shift) / scale);
         } else {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++)
+            for (dim_t s = 0; s < rnn.dlc; s++)
                 dd[s] = (dst_layer_dt)ss[s];
         }
     };
@@ -1602,7 +1604,7 @@ void copy_res_layer_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
     const auto acc_vec = [&](dst_layer_dt *dd, const src_data_t *ss) {
         if (dequantize) {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++) {
+            for (dim_t s = 0; s < rnn.dlc; s++) {
                 float val = (float)ss[s] + dd[s];
                 val = q10n::qz_a1b0_t<float, src_data_t>()(val);
                 dd[s] = (dst_layer_dt)((val - 2 * shift) / scale);
@@ -1610,12 +1612,13 @@ void copy_res_layer_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
         } else if (rnn_u8u8_case
                 || rnn_s8s8_case) { // instead of checking for rnn.is_int8()
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++)
-                dd[s] = q10n::saturate<dst_layer_dt, int16_t>(
-                        (int16_t)dd[s] + (int16_t)ss[s]);
+            for (dim_t s = 0; s < rnn.dlc; s++)
+                dd[s] = static_cast<dst_layer_dt>(
+                        q10n::saturate<dst_layer_dt, int16_t>(
+                                (int16_t)dd[s] + (int16_t)ss[s]));
         } else {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dlc; s++)
+            for (dim_t s = 0; s < rnn.dlc; s++)
                 dd[s] += (dst_layer_dt)ss[s];
         }
     };
@@ -1646,7 +1649,7 @@ void copy_res_layer_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
     });
     if (rnn.skip_dst_iter_copy()) {
         parallel_nd(rnn.mb, [&](dim_t b) {
-            const int it = rnn.n_iter - 1;
+            const dim_t it = rnn.n_iter - 1;
             int dir = 0;
             if (rnn.exec_dir != r2l) {
                 const auto *ss = dst_iter_
@@ -1750,11 +1753,11 @@ void copy_res_iter_fwd_template(const rnn_conf_t &rnn, const rnn_pd_t *pd,
     const auto copy_vec = [&](dst_iter_dt *dd, const src_data_t *ss) {
         if (dequantize) {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dic; s++)
+            for (dim_t s = 0; s < rnn.dic; s++)
                 dd[s] = (dst_iter_dt)(((float)ss[s] - data_shift) / data_scale);
         } else {
             PRAGMA_OMP_SIMD()
-            for (int s = 0; s < rnn.dic; s++)
+            for (dim_t s = 0; s < rnn.dic; s++)
                 dd[s] = (dst_iter_dt)ss[s];
         }
     };
@@ -1859,9 +1862,9 @@ rnn_bias_prepare_sig_templ(copy_bias_to_scratch) {
             scratch_bias_, rnn.n_layer, rnn.n_dir, rnn.n_bias * rnn.dhc);
 
     parallel_nd(static_cast<dim_t>(rnn.n_layer) * rnn.n_dir, [&](dim_t i) {
-        const int off = i * rnn.n_bias * rnn.dhc;
+        const dim_t off = i * rnn.n_bias * rnn.dhc;
         PRAGMA_OMP_SIMD()
-        for (int j = 0; j < rnn.n_bias * rnn.dhc; j++)
+        for (dim_t j = 0; j < rnn.n_bias * rnn.dhc; j++)
             scratch_bias_[off + j] = b_[off + j];
     });
 }

--- a/src/cpu/rnn/rnn_utils.cpp
+++ b/src/cpu/rnn/rnn_utils.cpp
@@ -93,10 +93,10 @@ bool rnn_utils::is_ldio_blocked(const memory_desc_wrapper &mdw) {
     return md_format_tag != format_tag::undef;
 }
 
-int rnn_utils::get_good_ld(int dim, int sizeof_dt) {
+dim_t rnn_utils::get_good_ld(dim_t dim, int sizeof_dt) {
     // we want matrices leading dimentions to be 64-byte aligned,
     // and not divisible by 256 to avoid 4K aliasing effects
-    const int ld = rnd_up(dim, 64 / sizeof_dt);
+    const dim_t ld = rnd_up(dim, 64 / sizeof_dt);
     return (ld % 256 == 0) ? ld + 64 / sizeof_dt : ld;
 }
 
@@ -229,8 +229,8 @@ status_t rnn_utils::set_expected_desc(rnn_conf_t &rnn,
                 rnn_pdata.format = rnn.is_fwd
                         ? rnn_packed_memory_format_t::ldigo_p
                         : rnn_packed_memory_format_t::ldgoi_p;
-                rnn_pdata.ldb = rnn.ws_states_iter_ld;
-                rnn_pdata.n = rnn.mb;
+                rnn_pdata.ldb = static_cast<int>(rnn.ws_states_iter_ld);
+                rnn_pdata.n = static_cast<int>(rnn.mb);
                 rnn_pdata.n_parts = rnn.n_parts_weights_iter;
                 array_copy(rnn_pdata.parts, rnn.parts_weights_iter,
                         DNNL_RNN_MAX_N_PARTS);
@@ -243,9 +243,9 @@ status_t rnn_utils::set_expected_desc(rnn_conf_t &rnn,
                 rnn_pdata.format = rnn.is_fwd
                         ? rnn_packed_memory_format_t::ldigo_p
                         : rnn_packed_memory_format_t::ldgoi_p;
-                rnn_pdata.ldb = rnn.ws_states_layer_ld;
-                rnn_pdata.n
-                        = rnn.merge_gemm_layer ? rnn.n_iter * rnn.mb : rnn.mb;
+                rnn_pdata.ldb = static_cast<int>(rnn.ws_states_layer_ld);
+                rnn_pdata.n = static_cast<int>(
+                        rnn.merge_gemm_layer ? rnn.n_iter * rnn.mb : rnn.mb);
                 rnn_pdata.n_parts = rnn.n_parts_weights_layer;
                 array_copy(rnn_pdata.parts, rnn.parts_weights_layer,
                         DNNL_RNN_MAX_N_PARTS);
@@ -257,8 +257,8 @@ status_t rnn_utils::set_expected_desc(rnn_conf_t &rnn,
             case weights_type_t::projection:
                 // TODO: add ldoi_p for bwd?
                 rnn_pdata.format = rnn_packed_memory_format_t::ldio_p;
-                rnn_pdata.ldb = rnn.proj_ht_ld;
-                rnn_pdata.n = rnn.mb;
+                rnn_pdata.ldb = static_cast<int>(rnn.proj_ht_ld);
+                rnn_pdata.n = static_cast<int>(rnn.mb);
                 rnn_pdata.n_parts = rnn.n_parts_weights_projection;
                 array_copy(rnn_pdata.parts, rnn.parts_weights_projection,
                         DNNL_RNN_MAX_N_PARTS);
@@ -279,7 +279,7 @@ status_t rnn_utils::set_expected_desc(rnn_conf_t &rnn,
     } else {
         using namespace format_tag;
         if (rnn.is_brgemm) {
-            const int n_block = rnn.n_block;
+            const int n_block = static_cast<int>(rnn.n_block);
             format_tag_t tag = format_tag::undef;
 
             if (weights_type == weights_type_t::projection) {
@@ -353,7 +353,7 @@ float rnn_utils::to_float(const void *data, const data_type_t dt) {
 }
 
 const void *rnn_utils::inc_ptr(
-        const void *data, data_type_t data_type, int offset) {
+        const void *data, data_type_t data_type, dim_t offset) {
     if (data_type == data_type::f32)
         return static_cast<const float *>(data) + offset;
     else if (data_type == data_type::bf16)
@@ -364,7 +364,7 @@ const void *rnn_utils::inc_ptr(
         return data;
 }
 
-void *rnn_utils::inc_ptr(void *data, data_type_t data_type, int offset) {
+void *rnn_utils::inc_ptr(void *data, data_type_t data_type, dim_t offset) {
     return const_cast<void *>(
             inc_ptr(static_cast<const void *>(data), data_type, offset));
 }

--- a/src/cpu/rnn/rnn_utils.hpp
+++ b/src/cpu/rnn/rnn_utils.hpp
@@ -48,7 +48,7 @@
             gemm_acc_t *diff_dst_layer_, gemm_acc_t *diff_dst_iter_, \
             gemm_acc_t *diff_dst_iter_c_, const float *weights_peephole_, \
             const void *bias_, gates_t *ws_grid_, scratch_t *scratch_cell_, \
-            dst_iter_t *dst_iter_, float *weights_scales_, int block_step
+            dst_iter_t *dst_iter_, float *weights_scales_, dim_t block_step
 
 #define rnn_postgemm_sig(f) void f(rnn_postgemm_sig_args) const
 
@@ -296,7 +296,7 @@ struct diff_src_brgemm_conf_t {
 
     brgemm_rnn_execute_loop_order_t loop_order
             = brgemm_rnn_execute_loop_order_t::undefined;
-    int gates_block;
+    dim_t gates_block;
 };
 
 struct diff_wei_brgemm_conf_t {
@@ -327,9 +327,9 @@ struct rnn_conf_t {
     data_type_t src_iter_c_dt = data_type::undef;
     data_type_t dst_iter_c_dt = data_type::undef;
 
-    int n_layer = 0, n_iter = 0, n_dir = 0, n_gates = 0, n_states = 0;
-    int mb = 0;
-    int slc = 0, sic = 0, dhc = 0, dic = 0, dlc = 0;
+    dim_t n_layer = 0, n_iter = 0, n_dir = 0, n_gates = 0, n_states = 0;
+    dim_t mb = 0;
+    dim_t slc = 0, sic = 0, dhc = 0, dic = 0, dlc = 0;
     //int gates_ld, gates_nld, gates_ws_ld;
 
     int n_parts_weights_layer = 0;
@@ -344,7 +344,9 @@ struct rnn_conf_t {
     int parts_weights_projection[DNNL_RNN_MAX_N_PARTS];
     size_t part_weights_projection_pack_size[DNNL_RNN_MAX_N_PARTS];
 
-    int n_bias = 0, n_parts_bias = 0, parts_bias[DNNL_RNN_MAX_N_PARTS];
+    dim_t n_bias = 0;
+    int n_parts_bias = 0;
+    int parts_bias[DNNL_RNN_MAX_N_PARTS];
 
     /* Size of packed data in bytes */
     size_t weights_layer_comp_offset = 0, weights_layer_pack_size = 0;
@@ -352,36 +354,37 @@ struct rnn_conf_t {
     size_t weights_projection_comp_offset = 0, weights_projection_pack_size = 0;
 
     bool copy_bias = false;
-    int weights_layer_ld = 0, weights_layer_nld = 0;
-    int diff_weights_layer_ld = 0, diff_weights_layer_nld = 0;
-    int weights_iter_ld = 0, weights_iter_nld = 0;
-    int diff_weights_iter_ld = 0, diff_weights_iter_nld = 0;
-    int weights_projection_ld = 0, weights_projection_nld = 0;
-    int diff_weights_projection_ld = 0, diff_weights_projection_nld = 0;
+    dim_t weights_layer_ld = 0, weights_layer_nld = 0;
+    dim_t diff_weights_layer_ld = 0, diff_weights_layer_nld = 0;
+    dim_t weights_iter_ld = 0, weights_iter_nld = 0;
+    dim_t diff_weights_iter_ld = 0, diff_weights_iter_nld = 0;
+    dim_t weights_projection_ld = 0, weights_projection_nld = 0;
+    dim_t diff_weights_projection_ld = 0, diff_weights_projection_nld = 0;
 
-    int proj_ht_ld = 0, proj_ht_nld = 0;
+    dim_t proj_ht_ld = 0, proj_ht_nld = 0;
 
-    int ws_gates_ld = 0, ws_gates_nld = 0;
-    int ws_ht_ld = 0, ws_ht_nld = 0;
-    int ws_states_layer_ld = 0, ws_states_layer_nld = 0;
-    int ws_states_iter_ld = 0, ws_states_iter_nld = 0;
-    int ws_states_iter_c_ld = 0, ws_states_iter_c_nld = 0;
-    int ws_diff_states_layer_ld = 0, ws_diff_states_layer_nld = 0;
-    int ws_diff_states_iter_ld = 0, ws_diff_states_iter_nld = 0;
-    int ws_diff_states_iter_c_ld = 0, ws_diff_states_iter_c_nld = 0;
+    dim_t ws_gates_ld = 0, ws_gates_nld = 0;
+    dim_t ws_ht_ld = 0, ws_ht_nld = 0;
+    dim_t ws_states_layer_ld = 0, ws_states_layer_nld = 0;
+    dim_t ws_states_iter_ld = 0, ws_states_iter_nld = 0;
+    dim_t ws_states_iter_c_ld = 0, ws_states_iter_c_nld = 0;
+    dim_t ws_diff_states_layer_ld = 0, ws_diff_states_layer_nld = 0;
+    dim_t ws_diff_states_iter_ld = 0, ws_diff_states_iter_nld = 0;
+    dim_t ws_diff_states_iter_c_ld = 0, ws_diff_states_iter_c_nld = 0;
 
-    int scratch_gates_ld = 0, scratch_gates_nld = 0;
-    int scratch_ht_ld = 0, scratch_ht_nld = 0;
-    int scratch_diff_ht_ld = 0, scratch_diff_ht_nld = 0;
+    dim_t scratch_gates_ld = 0, scratch_gates_nld = 0;
+    dim_t scratch_ht_ld = 0, scratch_ht_nld = 0;
+    dim_t scratch_diff_ht_ld = 0, scratch_diff_ht_nld = 0;
 
-    int src_layer_ld_ = 0, src_layer_nld_ = 0;
-    int src_iter_ld_ = 0, src_iter_nld_ = 0;
-    int src_iter_c_ld_ = 0, src_iter_c_nld_ = 0;
-    int dst_layer_ld_ = 0, dst_layer_nld_ = 0;
-    int dst_iter_ld_ = 0, dst_iter_nld_ = 0;
-    int dst_iter_c_ld_ = 0, dst_iter_c_nld_ = 0;
+    dim_t src_layer_ld_ = 0, src_layer_nld_ = 0;
+    dim_t src_iter_ld_ = 0, src_iter_nld_ = 0;
+    dim_t src_iter_c_ld_ = 0, src_iter_c_nld_ = 0;
+    dim_t dst_layer_ld_ = 0, dst_layer_nld_ = 0;
+    dim_t dst_iter_ld_ = 0, dst_iter_nld_ = 0;
+    dim_t dst_iter_c_ld_ = 0, dst_iter_c_nld_ = 0;
 
-    int weights_iter_compensation_size = 0, weights_layer_compensation_size = 0;
+    dim_t weights_iter_compensation_size = 0,
+          weights_layer_compensation_size = 0;
     bool is_fwd = false, is_training = false, is_lbr = false,
          is_lstm_peephole = false, is_lstm_projection = false, is_augru = false,
          is_orig_gru = false;
@@ -420,7 +423,7 @@ struct rnn_conf_t {
     bool merge_gemm_iter = false, merge_gemm_layer = false,
          force_nocopy = false, use_layer_packed_gemm = false,
          use_iter_packed_gemm = false, use_projection_packed_gemm = false;
-    int n_iter_scratch_gates = 0;
+    dim_t n_iter_scratch_gates = 0;
 
     bool diff_weights_overwrite = false;
     bool use_matmul = false;
@@ -664,7 +667,7 @@ struct rnn_conf_t {
 
     dim_t Nproj, Nproj_blocks, nproj_tail;
     dim_t LDAproj, LDBproj, LDCproj[4];
-    int dhc_block_peephole, dhc_tail_peephole, dhc_blocks_peephole;
+    dim_t dhc_block_peephole, dhc_tail_peephole, dhc_blocks_peephole;
     bool brgemm_fwd_iter_layer_fuse_possible = false;
 
     int nthr;
@@ -691,7 +694,7 @@ bool is_ldgoi_blocked(const memory_desc_wrapper &md);
 bool is_ldio_blocked(const memory_desc_wrapper &md);
 bool is_ldoi_blocked(const memory_desc_wrapper &md);
 
-int get_good_ld(int dim, int sizeof_dt);
+dim_t get_good_ld(dim_t dim, int sizeof_dt);
 
 template <typename T>
 bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
@@ -882,18 +885,19 @@ bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
     rnn.is_orig_gru = utils::one_of(
             rd.cell_kind, alg_kind::vanilla_gru, alg_kind::vanilla_augru);
     rnn.n_parts_weights_layer = 1;
-    rnn.parts_weights_layer[0] = rnn.n_gates;
+    rnn.parts_weights_layer[0] = static_cast<int>(rnn.n_gates);
     rnn.parts_weights_layer[1] = 0;
 
     rnn.n_parts_weights_iter = rnn.is_orig_gru ? 2 : 1;
-    rnn.parts_weights_iter[0] = rnn.is_orig_gru ? 2 : rnn.n_gates;
+    rnn.parts_weights_iter[0]
+            = rnn.is_orig_gru ? 2 : static_cast<int>(rnn.n_gates);
     rnn.parts_weights_iter[1] = rnn.is_orig_gru ? 1 : 0;
 
     rnn.n_parts_weights_projection = 1;
     rnn.parts_weights_projection[0] = 1;
 
     rnn.n_parts_bias = 1;
-    rnn.parts_bias[0] = rnn.n_bias;
+    rnn.parts_bias[0] = static_cast<int>(rnn.n_bias);
     rnn.parts_bias[1] = 0;
 
     rnn.use_matmul = !rnn.is_brgemm && rnn.is_fwd // TODO: Enable BWD
@@ -992,7 +996,7 @@ bool init_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
     const auto set_pack_sizes
             = [&](bool merge, bool &do_pack, size_t &weights_pack_size,
                       int &n_parts, int *parts, size_t *parts_pack_size,
-                      size_t &comp_offset, int ic, int oc, int weights_oc,
+                      size_t &comp_offset, dim_t ic, dim_t oc, dim_t weights_oc,
                       dim_t data_ld) -> bool {
         bool pack = true;
         weights_pack_size = 0;
@@ -1091,21 +1095,21 @@ void set_conf(rnn_conf_t &rnn, const rnn_desc_t &rd,
 
     // Set leading dimensions for input weights arrays depending on input format
     const auto set_dims
-            = [&](const memory_desc_wrapper &md, int &ld, int &nld) {
+            = [&](const memory_desc_wrapper &md, dim_t &ld, dim_t &nld) {
         ld = 0;
         nld = 0;
         if (md.is_blocking_desc()) {
             if (is_ldigo(md)) {
-                ld = (int)md.blocking_desc().strides[2];
+                ld = md.blocking_desc().strides[2];
                 nld = md.dims()[2];
             } else if (is_ldgoi(md)) {
-                ld = (int)md.blocking_desc().strides[4];
+                ld = md.blocking_desc().strides[4];
                 nld = md.dims()[3] * md.dims()[4];
             } else if (is_ldoi(md)) {
-                ld = (int)md.blocking_desc().strides[3];
+                ld = md.blocking_desc().strides[3];
                 nld = md.dims()[3];
             } else if (is_ldio(md)) {
-                ld = (int)md.blocking_desc().strides[2];
+                ld = md.blocking_desc().strides[2];
                 nld = md.dims()[2];
             } else
                 assert(!"unsupported weights format");
@@ -1262,7 +1266,7 @@ private:
 
     const byte *const base_ptr_;
     const size_t dt_size_;
-    const int dims_[Tdims];
+    const dim_t dims_[Tdims];
 };
 
 template <typename... Targs>
@@ -1277,13 +1281,13 @@ template <typename T>
 struct ws_gates_aoc_t {
     ws_gates_aoc_t(const rnn_conf_t &rnn, T *data)
         : gates_(data, rnn.ws_gates_nld, rnn.ws_gates_ld), DHC_(rnn.dhc) {}
-    T &operator()(int batch, int gate, int dhc) const {
+    T &operator()(dim_t batch, dim_t gate, dim_t dhc) const {
         return gates_(batch, gate * DHC_ + dhc);
     }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> gates_;
-    const int DHC_;
+    const dim_t DHC_;
 };
 
 template <typename T>
@@ -1291,20 +1295,22 @@ struct scratch_gates_aoc_t {
     scratch_gates_aoc_t(const rnn_conf_t &rnn, T *data)
         : gates_(data, rnn.scratch_gates_nld, rnn.scratch_gates_ld)
         , DHC_(rnn.dhc) {}
-    T &operator()(int batch, int gate, int dhc) const {
+    T &operator()(dim_t batch, dim_t gate, dim_t dhc) const {
         return gates_(batch, gate * DHC_ + dhc);
     }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> gates_;
-    const int DHC_;
+    const dim_t DHC_;
 };
 
 template <typename T>
 struct weights_peephole_aoc_t {
     weights_peephole_aoc_t(const rnn_conf_t &rnn, T *data)
         : weights_peephole_(data, 3, rnn.dhc) {}
-    T &operator()(int g, int dhc) const { return weights_peephole_(g, dhc); }
+    T &operator()(dim_t g, dim_t dhc) const {
+        return weights_peephole_(g, dhc);
+    }
 
 private:
     const utils::array_offset_calculator<T, 2> weights_peephole_;
@@ -1335,7 +1341,7 @@ struct bias_linear_exec_aoc_t {
             assert(!"unsupported data type");
     }
 
-    void **operator()(int layer, int dir) const {
+    void **operator()(dim_t layer, dim_t dir) const {
         if (bias_present_) {
             if (bias_dt_ == data_type::f32)
                 return reinterpret_cast<void **>(
@@ -1380,11 +1386,11 @@ private:
 
 template <typename T>
 struct ws_states_layer_aoc_t {
-    ws_states_layer_aoc_t(const rnn_conf_t &rnn, T *data, int leading_dim)
+    ws_states_layer_aoc_t(const rnn_conf_t &rnn, T *data, dim_t leading_dim)
         : state_(data, rnn.ws_states_layer_nld, leading_dim) {}
     ws_states_layer_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.ws_states_layer_nld, rnn.ws_states_layer_ld) {}
-    T &operator()(int batch, int dhc) const { return state_(batch, dhc); }
+    T &operator()(dim_t batch, dim_t dhc) const { return state_(batch, dhc); }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> state_;
@@ -1392,11 +1398,11 @@ private:
 
 template <typename T>
 struct ws_states_iter_aoc_t {
-    ws_states_iter_aoc_t(const rnn_conf_t &rnn, T *data, int leading_dim)
+    ws_states_iter_aoc_t(const rnn_conf_t &rnn, T *data, dim_t leading_dim)
         : state_(data, rnn.ws_states_iter_nld, leading_dim) {}
     ws_states_iter_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.ws_states_iter_nld, rnn.ws_states_iter_ld) {}
-    T &operator()(int batch, int dhc) const { return state_(batch, dhc); }
+    T &operator()(dim_t batch, dim_t dhc) const { return state_(batch, dhc); }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 2> state_;
@@ -1406,7 +1412,7 @@ template <typename T>
 struct augru_attention_aoc_t {
     augru_attention_aoc_t(const rnn_conf_t &rnn, T *data)
         : state_(data, rnn.mb) {}
-    T &operator()(int batch) const { return state_(batch); }
+    T &operator()(dim_t batch) const { return state_(batch); }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<T, 1> state_;
@@ -1417,7 +1423,7 @@ struct ws_diff_states_layer_aoc_t {
     ws_diff_states_layer_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_layer_(data, rnn.ws_diff_states_layer_nld,
                   rnn.ws_diff_states_layer_ld) {}
-    T &operator()(int batch, int dhc) const {
+    T &operator()(dim_t batch, dim_t dhc) const {
         return diff_states_layer_(batch, dhc);
     }
 
@@ -1430,7 +1436,7 @@ struct ws_diff_states_iter_aoc_t {
     ws_diff_states_iter_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_iter_(data, rnn.ws_diff_states_iter_nld,
                   rnn.ws_diff_states_iter_ld) {}
-    T &operator()(int batch, int dhc) const {
+    T &operator()(dim_t batch, dim_t dhc) const {
         return diff_states_iter_(batch, dhc);
     }
 
@@ -1443,7 +1449,7 @@ struct ws_diff_states_iter_c_aoc_t {
     ws_diff_states_iter_c_aoc_t(const rnn_conf_t &rnn, T *data)
         : diff_states_iter_c_(data, rnn.ws_diff_states_iter_c_nld,
                   rnn.ws_diff_states_iter_c_ld) {}
-    T &operator()(int batch, int dhc) const {
+    T &operator()(dim_t batch, dim_t dhc) const {
         return diff_states_iter_c_(batch, dhc);
     }
 
@@ -1456,18 +1462,18 @@ struct ws_diff_w_iter_aoc_t {
         : diff_weights_iter_(
                   data, rnn.diff_weights_iter_nld, rnn.diff_weights_iter_ld)
         , DHC_(rnn.dhc) {}
-    float &operator()(int sic, int gate, int dhc) const {
+    float &operator()(dim_t sic, dim_t gate, dim_t dhc) const {
         return diff_weights_iter_(sic, gate * DHC_ + dhc);
     }
 
 private:
     const dnnl::impl::utils::array_offset_calculator<float, 2>
             diff_weights_iter_;
-    const int DHC_;
+    const dim_t DHC_;
 };
 
-const void *inc_ptr(const void *data, data_type_t data_type, int offset);
-void *inc_ptr(void *data, data_type_t data_type, int offset);
+const void *inc_ptr(const void *data, data_type_t data_type, dim_t offset);
+void *inc_ptr(void *data, data_type_t data_type, dim_t offset);
 
 } // namespace rnn_utils
 } // namespace cpu

--- a/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_bwd.cpp
@@ -111,12 +111,12 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::execute()
 
 template <typename weights_t, typename scratch_t, typename gemm_acc_t>
 void brgemm_diff_src_layer_iter_t<weights_t, scratch_t,
-        gemm_acc_t>::kernel_amx_compute_iter(const int m_block_id,
-        const int n_block_id, const int gates_start, const int gates_end,
+        gemm_acc_t>::kernel_amx_compute_iter(const dim_t m_block_id,
+        const dim_t n_block_id, const int gates_start, const int gates_end,
         thread_exec_ctx_t &ctx) const {
 
-    const int m = m_block_id * rnn_.diff_src_brgemm.m_block;
-    const int n = n_block_id * rnn_.diff_src_brgemm.n_block;
+    const dim_t m = m_block_id * rnn_.diff_src_brgemm.m_block;
+    const dim_t n = n_block_id * rnn_.diff_src_brgemm.n_block;
     const int num_gates = gates_end - gates_start;
     const scratch_t *const A_m = A_ + m * LDA_;
     const auto B_n_offset = n_block_id * B_nb_offset_;
@@ -253,21 +253,22 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel_amx(
         const int ithr, const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int mn_start = 0, mn_end = 0;
+    dim_t mn_start = 0, mn_end = 0;
     balance211(work_amount_, nthr, ithr, mn_start, mn_end);
 
-    int n_block_id = 0, m_block_id = 0;
+    dim_t n_block_id = 0, m_block_id = 0;
     const auto n_gates = rnn_.n_gates;
-    const int gates_block_size = rnn_.diff_src_brgemm.gates_block;
+    const dim_t gates_block_size = rnn_.diff_src_brgemm.gates_block;
     thread_exec_ctx_t ctx;
     ctx.addr_batch = addr_batch_global_ + ithr * (k_blocks_n_gates_ + 1);
     ctx.amx_buffer = amx_scratchpad_
             + rnn_.diff_src_brgemm.m_block * rnn_.diff_src_brgemm.n_block
                     * ithr;
 
-    for (int gate_idx = 0; gate_idx < n_gates; gate_idx += gates_block_size) {
-        const int gates_start = gate_idx;
-        const int gates_end = nstl::min(gate_idx + gates_block_size, n_gates);
+    for (dim_t gate_idx = 0; gate_idx < n_gates; gate_idx += gates_block_size) {
+        const int gates_start = static_cast<int>(gate_idx);
+        const int gates_end = static_cast<int>(
+                nstl::min<dim_t>(gate_idx + gates_block_size, n_gates));
 
         switch (rnn_.diff_src_brgemm.loop_order) {
             case brgemm_rnn_execute_loop_order_t::mblk_nblk:
@@ -280,7 +281,7 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel_amx(
                 break;
             default: assert(!"unsupported loop order");
         }
-        int mn_idx = mn_start;
+        dim_t mn_idx = mn_start;
         while (mn_idx < mn_end) {
             kernel_amx_compute_iter(
                     m_block_id, n_block_id, gates_start, gates_end, ctx);
@@ -303,10 +304,10 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel_amx(
 template <typename weights_t, typename scratch_t, typename gemm_acc_t>
 void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
-    int n_block_id = 0, m_block_id = 0;
+    dim_t n_block_id = 0, m_block_id = 0;
     nd_iterator_init(start, n_block_id, n_blocking_, m_block_id, m_blocking_);
 
     x64::brgemm_batch_element_t *const addr_batch
@@ -314,8 +315,8 @@ void brgemm_diff_src_layer_iter_t<weights_t, scratch_t, gemm_acc_t>::kernel(
     const auto n_gates = rnn_.n_gates;
 
     while (start < end) {
-        const int m = m_block_id * rnn_.diff_src_brgemm.m_block;
-        const int n = n_block_id * rnn_.diff_src_brgemm.n_block;
+        const dim_t m = m_block_id * rnn_.diff_src_brgemm.m_block;
+        const dim_t n = n_block_id * rnn_.diff_src_brgemm.n_block;
         const scratch_t *const A_m = A_ + m * LDA_;
         const auto B_n_offset = n_block_id * B_nb_offset_;
         const weights_t *const B_wei_iter_n = B_wei_iter_ + B_n_offset;
@@ -537,11 +538,11 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
             : A_layer_transposed_scratch_
                     + ithr * rnn_.diff_wei_brgemm.Kpadded * m_layer_block_;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
-    int n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
-        last_m_block_id = -1;
+    dim_t n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
+          last_m_block_id = -1;
 
     nd_iterator_init(start, n_block_id, n_blocking_, m_block_id, m_blocking_);
 
@@ -555,8 +556,8 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
         const bool should_transpose_src = transpose_needed && !global_transpose
                 && (last_m_block_id != m_block_id);
 
-        const int m_iter = m_block_id * m_iter_block_;
-        const int m_layer = m_block_id * m_layer_block_;
+        const dim_t m_iter = m_block_id * m_iter_block_;
+        const dim_t m_layer = m_block_id * m_layer_block_;
         const src_iter_t *const A_iter_m = global_transpose
                 ? A_iter_transposed_ithr + m_iter * LDA_iter_
                 : A_iter_ + m_iter;
@@ -573,7 +574,7 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
                 ? const_cast<src_layer_t *>(A_layer_m)
                 : A_layer_transposed_ithr;
 
-        const int n = n_block_id * rnn_.diff_wei_brgemm.n_block;
+        const dim_t n = n_block_id * rnn_.diff_wei_brgemm.n_block;
         const scratch_t *const B_n = B_ + n;
         const auto C_iter_offset = m_iter * LDC_iter_ + n;
         const auto C_layer_offset = m_layer * LDC_layer_ + n;
@@ -670,11 +671,11 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
 
     const bool global_transpose = rnn_.diff_wei_brgemm.global_transpose;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
-    int n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
-        last_m_block_id = -1;
+    dim_t n_block_id = 0, m_block_id = 0, last_n_block_id = -1,
+          last_m_block_id = -1;
     switch (rnn_.diff_wei_brgemm.loop_order) {
         case brgemm_rnn_execute_loop_order_t::mblk_nblk:
             nd_iterator_init(
@@ -713,8 +714,8 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
         const bool should_transpose_src
                 = !global_transpose && last_m_block_id != m_block_id;
 
-        const int m_iter = m_block_id * m_iter_block_;
-        const int m_layer = m_block_id * m_layer_block_;
+        const dim_t m_iter = m_block_id * m_iter_block_;
+        const dim_t m_layer = m_block_id * m_layer_block_;
         const src_iter_t *const A_iter_m = global_transpose
                 ? A_iter_transposed_ithr + m_iter * LDA_iter_
                 : A_iter_ + m_iter;
@@ -729,7 +730,7 @@ void brgemm_diff_weights_layer_iter_t<src_layer_t, src_iter_t, scratch_t,
                 ? const_cast<src_layer_t *>(A_layer_m)
                 : A_layer_transposed_ithr;
 
-        const int n = n_block_id * rnn_.diff_wei_brgemm.n_block;
+        const dim_t n = n_block_id * rnn_.diff_wei_brgemm.n_block;
         const scratch_t *const B_n = B_ + n;
         const auto C_iter_offset = m_iter * LDC_iter_ + n;
         const auto C_layer_offset = m_layer * LDC_layer_ + n;
@@ -885,10 +886,10 @@ template <typename scratch_t>
 void brgemm_diff_wei_peep_t<scratch_t>::kernel(
         const int ithr, const int nthr) const {
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
-    int g = 0, dhc_block_id = 0;
+    dim_t g = 0, dhc_block_id = 0;
 
     nd_iterator_init(
             start, g, n_gates_, dhc_block_id, rnn_.dhc_blocks_peephole);

--- a/src/cpu/x64/rnn/brgemm_cell_common_bwd.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_bwd.hpp
@@ -70,7 +70,7 @@ private:
     };
 
     void kernel_amx(const int ithr, const int nthr) const;
-    void kernel_amx_compute_iter(const int m_block_id, const int n_block_id,
+    void kernel_amx_compute_iter(const dim_t m_block_id, const dim_t n_block_id,
             const int gates_start, const int gates_end,
             thread_exec_ctx_t &ctx) const;
     void kernel(const int ithr, const int nthr) const;
@@ -94,10 +94,10 @@ private:
     const dim_t B_gb_layer_offset_;
     const dim_t LDA_;
     const dim_t LDC_;
-    const dim_t max_nthr_;
+    const int max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const dim_t max_n_layer_blocks_;
     const dim_t max_n_iter_blocks_;
     const bool gemm_layer_needed_;
@@ -182,7 +182,7 @@ private:
     const dim_t LDA_layer_;
     const dim_t LDC_iter_;
     const dim_t LDC_layer_;
-    const dim_t max_nthr_;
+    const int max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
     const dim_t k_blocks_;
@@ -195,7 +195,7 @@ private:
     const dim_t B_kb_offset_;
     const dim_t B_k_tail_offset_;
     const dim_t B_k_tail_offset_blocked_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const brgemm_kernel_t *const kernel_iter_full_blocks_;
     const brgemm_kernel_t *const kernel_iter_n_tail_;
     const brgemm_kernel_t *const kernel_iter_k_tail_;
@@ -241,9 +241,9 @@ private:
     const void *src_iter_c_;
     const void *dst_iter_c_;
     float *diff_weights_peephole_;
-    const int work_amount_;
-    const int dst_iter_c_ld_;
-    const int src_iter_c_ld_;
+    const dim_t work_amount_;
+    const dim_t dst_iter_c_ld_;
+    const dim_t src_iter_c_ld_;
     const jit_diff_weights_peephole_t *const kernel_;
     const jit_diff_weights_peephole_t *const kernel_tail_;
 };

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.cpp
@@ -158,14 +158,14 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+    const dim_t max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
             nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * max_K_Block;
@@ -245,7 +245,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         }
 
         for (int g = 0; g < n_gates_; g++) {
-            const int lg = g + g_unfused;
+            const dim_t lg = g + g_unfused;
             const auto *const Bl_g = Bl_n + lg * Bl_g_offset_;
             const auto *const Bi_g = Bi_n + lg * Bi_g_offset_;
             auto *C_g = C_n + lg * rnn_.N;
@@ -274,7 +274,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             if (is_amx) load_cfg_if_needed(pallete_buff_layer_k_tail);
 
             for (int g = 0; g < n_gates_; g++) {
-                const int lg = g + g_unfused;
+                const dim_t lg = g + g_unfused;
                 const auto *const Bl_g = Bl_n + lg * Bl_g_offset_;
                 auto *const C_g = C_n + lg * rnn_.N;
 
@@ -289,7 +289,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
             if (is_amx) load_cfg_if_needed(pallete_buff_iter_k_tail);
 
             for (int g = 0; g < n_gates_; g++) {
-                const int lg = g + g_unfused;
+                const dim_t lg = g + g_unfused;
                 const auto *const Bi_g = Bi_n + lg * Bi_g_offset_;
                 auto *C_g = C_n + lg * rnn_.N;
                 if (rnn_.is_lbr && g == n_gates_ - 1) C_g = C_cell_i;
@@ -326,14 +326,14 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = 2
+    const dim_t max_K_Block = 2
             * nstl::max(rnn_.KB1_blocks + 1,
                     nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     brgemm_batch_element_t *const addr_batch
@@ -398,7 +398,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
         }
 
         for (int g = 0; g < n_gates_; g++) {
-            const int lg = g + g_unfused;
+            const dim_t lg = g + g_unfused;
             const auto *const Bl_g = Bl_n + lg * B_g_offset;
             const auto *const Bi_g = Bi_n + lg * B_g_offset;
             auto *const C_g = C_n + lg * rnn_.N;
@@ -427,7 +427,7 @@ void brgemm_dst_layer_iter_t<src_t, weights_t, scratch_t,
 
         if (rnn_.k2_tail) {
             for (int g = 0; g < n_gates_; g++) {
-                const int lg = g + g_unfused;
+                const dim_t lg = g + g_unfused;
                 auto *const C_g = C_n + lg * rnn_.N;
 
                 int batch_idx = 0;
@@ -511,10 +511,10 @@ void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_proj_, nthr, ithr, start, end);
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
-    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+    const dim_t max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
             nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     auto *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
@@ -525,7 +525,7 @@ void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::kernel(
 
     if (is_amx) load_cfg_if_needed(rnn_brgemm_.pallete_buff_proj_);
 
-    int nb = 0, mb = 0;
+    dim_t nb = 0, mb = 0;
     switch (rnn_.loop_order) {
         case brgemm_rnn_execute_loop_order_t::mblk_nblk:
             nd_iterator_init(start, mb, rnn_.M_blocks, nb, rnn_.Nproj_blocks);
@@ -537,10 +537,10 @@ void brgemm_dst_proj_t<src_t, weights_t, gemm_acc_t>::kernel(
     }
 
     while (start < end) {
-        const int n = nb * rnn_.n_block;
-        const int m = mb * rnn_.m_block;
+        const dim_t n = nb * rnn_.n_block;
+        const dim_t m = mb * rnn_.m_block;
         const bool do_n_tail = (n + rnn_.n_block) > rnn_.Nproj;
-        const int block_step = ((do_n_tail) ? rnn_.nproj_tail : rnn_.n_block)
+        const dim_t block_step = ((do_n_tail) ? rnn_.nproj_tail : rnn_.n_block)
                 * sizeof(src_t);
 
         const auto *const Ap_m = A_ + m * rnn_.LDAproj;
@@ -713,14 +713,14 @@ template <typename src_t, typename weights_t, typename scratch_t,
         typename gemm_acc_t>
 void brgemm_gru_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + rnn_.m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
+    const dim_t max_K_Block = nstl::max(rnn_.KB1_blocks + 1,
             nstl::max(rnn_.KBproj_blocks + 1, rnn_.KB2_blocks + 1));
     brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * max_K_Block;
@@ -985,7 +985,7 @@ void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
         const int ithr, const int nthr) const {
     using namespace cpu::rnn_utils;
 
-    int start = 0, end = 0;
+    dim_t start = 0, end = 0;
     balance211(work_amount_, nthr, ithr, start, end);
 
     const bool is_amx = is_superset(rnn_.brgemm_isa, x64::avx512_core_amx);
@@ -993,7 +993,7 @@ void brgemm_merged_layer_t<src_t, weights_t, scratch_t, gemm_acc_t>::kernel(
     gemm_acc_t *const amx_buffer = is_amx
             ? amx_scratchpad_ + m_block * rnn_.n_block * ithr
             : nullptr;
-    const int max_K_Block = rnn_.KB1_blocks + 1;
+    const dim_t max_K_Block = rnn_.KB1_blocks + 1;
     brgemm_batch_element_t *const addr_batch
             = addr_batch_global_ + ithr * max_K_Block;
 

--- a/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_fwd.hpp
@@ -32,8 +32,8 @@ template <typename src_t, typename weights_t, typename scratch_t,
 class brgemm_dst_layer_iter_t {
 public:
     using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
-    using postgemm_fused_t = std::function<void(
-            dim_t, dim_t, dim_t, const src_t *, scratch_t *, scratch_t *, int)>;
+    using postgemm_fused_t = std::function<void(dim_t, dim_t, dim_t,
+            const src_t *, scratch_t *, scratch_t *, dim_t)>;
     brgemm_dst_layer_iter_t(const ref_rnn_brgemm_t &rnn_brgemm_,
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, const src_t *src_iter,
@@ -64,7 +64,7 @@ private:
     const dim_t LDAi_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const dim_t Bl_n_offset_;
     const dim_t Bi_n_offset_;
     const dim_t Bl_g_offset_;
@@ -108,7 +108,7 @@ class brgemm_dst_proj_t {
 public:
     using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
     using postgemm_fused_t
-            = std::function<void(dim_t, dim_t, gemm_acc_t *, int)>;
+            = std::function<void(dim_t, dim_t, gemm_acc_t *, dim_t)>;
     brgemm_dst_proj_t(const ref_rnn_brgemm_t &rnn_brgemm_,
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, const src_t *proj_ht,
@@ -124,13 +124,13 @@ private:
 
     const ref_rnn_brgemm_t &rnn_brgemm_;
     const rnn_utils::rnn_conf_t &rnn_;
-    const int proj_desc_idx_;
+    const dim_t proj_desc_idx_;
     const src_t *const A_;
     const weights_t *const B_;
     gemm_acc_t *const C_;
     const dim_t LDC_;
-    const dim_t max_nthr_;
-    const int work_amount_proj_;
+    const int max_nthr_;
+    const dim_t work_amount_proj_;
     const dim_t B_n_offset_;
     const dim_t Bp_kb_offset_;
     gemm_acc_t *const amx_scratchpad_;
@@ -148,8 +148,8 @@ template <typename src_t, typename weights_t, typename scratch_t,
 class brgemm_gru_t {
 public:
     using ref_rnn_brgemm_t = rnn_brgemm_utils::rnn_brgemm_t<prop_kind::forward>;
-    using postgemm_fused_t = std::function<void(
-            dim_t, dim_t, dim_t, const src_t *, scratch_t *, scratch_t *, int)>;
+    using postgemm_fused_t = std::function<void(dim_t, dim_t, dim_t,
+            const src_t *, scratch_t *, scratch_t *, dim_t)>;
     brgemm_gru_t(const ref_rnn_brgemm_t &rnn_brgemm_,
             const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, const src_t *src_iter,
@@ -181,10 +181,10 @@ private:
     const dim_t LDAl_;
     const dim_t LDAi_p1_;
     const dim_t LDAi_p2_;
-    const dim_t max_nthr_;
+    const int max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const dim_t Bl_n_offset_;
     const dim_t Bi_n_offset_;
     const dim_t Bl_g_offset_;
@@ -250,10 +250,10 @@ private:
     const weights_t *const Bl_;
     scratch_t *const C_;
     const dim_t LDAl_;
-    const dim_t max_nthr_;
+    const int max_nthr_;
     const dim_t n_blocking_;
     const dim_t m_blocking_;
-    const int work_amount_;
+    const dim_t work_amount_;
     const dim_t Bl_n_offset_;
     const dim_t Bl_g_offset_;
     const dim_t Al_k_tail_offset_;

--- a/src/cpu/x64/rnn/brgemm_cell_common_reorders.cpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_reorders.cpp
@@ -23,18 +23,18 @@ namespace impl {
 namespace cpu {
 namespace x64 {
 
-src_layer_iter_transpose_t::src_layer_iter_transpose_t(const int src_ld,
-        const int dst_ld, const int rows, const int cols,
+src_layer_iter_transpose_t::src_layer_iter_transpose_t(const dim_t src_ld,
+        const dim_t dst_ld, const dim_t rows, const dim_t cols,
         jit_brgemm_trans_src_t *const kernel_transpose)
     : src_ld_(src_ld)
     , dst_ld_(dst_ld)
     , src_rows_(rows)
     , src_cols_(cols)
-    , kernel_transpose_(kernel_transpose) {};
+    , kernel_transpose_(kernel_transpose) {}
 
 template <typename Dt>
 void src_layer_iter_transpose_t::execute(const Dt *src, Dt *dst) const {
-    static constexpr int block_size = 16;
+    static constexpr dim_t block_size = 16;
     const auto rows_div = std::div(src_rows_, block_size);
     const auto rows_tail = rows_div.rem;
     const auto rows_blks = rows_div.quot + (rows_tail > 0 ? 1 : 0);

--- a/src/cpu/x64/rnn/brgemm_cell_common_reorders.hpp
+++ b/src/cpu/x64/rnn/brgemm_cell_common_reorders.hpp
@@ -29,18 +29,18 @@ struct rnn_conf_t;
 }
 namespace x64 {
 struct src_layer_iter_transpose_t {
-    src_layer_iter_transpose_t(const int src_ld, const int dst_ld,
-            const int rows, const int cols,
+    src_layer_iter_transpose_t(const dim_t src_ld, const dim_t dst_ld,
+            const dim_t rows, const dim_t cols,
             jit_brgemm_trans_src_t *const kernel_transpose);
 
     template <typename Dt>
     void execute(const Dt *src, Dt *dst) const;
 
 private:
-    const int src_ld_;
-    const int dst_ld_;
-    const int src_rows_;
-    const int src_cols_;
+    const dim_t src_ld_;
+    const dim_t dst_ld_;
+    const dim_t src_rows_;
+    const dim_t src_cols_;
     jit_brgemm_trans_src_t *const kernel_transpose_;
 };
 

--- a/src/cpu/x64/rnn/jit_brgemm_transpose_single_row.cpp
+++ b/src/cpu/x64/rnn/jit_brgemm_transpose_single_row.cpp
@@ -48,24 +48,24 @@ void jit_brgemm_transpose_single_row_t::load_addresses() {
 #undef PARAM
 
 void jit_brgemm_transpose_single_row_t::compute(
-        const dim_t unrolling, const bool is_tail) {
+        const int unrolling, const bool is_tail) {
 
     if (is_tail) {
-        mov(reg_tmp_.cvt32(), std::pow(2, tail_) - 1);
+        mov(reg_tmp_.cvt32(), (1u << tail_) - 1);
         kmovd(tail_mask_, reg_tmp_.cvt32());
     }
 
     for (int k = unrolling - 1; k >= 0; k--) {
         const auto read_vmm
                 = is_tail ? Xbyak::Zmm(k) | tail_mask_ | T_z : Xbyak::Zmm(k);
-        const auto src_off = k * simd_w_ * sizeof(bfloat16_t);
+        const int src_off = k * simd_w_ * src_dt_size_;
         vpmovzxwd(read_vmm, ptr[reg_src_ + src_off]);
     }
 
     for (int k = unrolling - 1; k >= 0; k--) {
         const auto store_vmm
                 = is_tail ? Xbyak::Zmm(k) | tail_mask_ : Xbyak::Zmm(k);
-        const auto dst_off = k * simd_w_ * sizeof(float);
+        const int dst_off = k * simd_w_ * dst_dt_size_;
         uni_vmovups(ptr[reg_dst_ + dst_off], store_vmm);
     }
 }
@@ -75,8 +75,8 @@ void jit_brgemm_transpose_single_row_t::compute_loop() {
 
     if (full_loop_iters_ > 0) {
         const auto loop_l_off = vmms_available_ * simd_w_;
-        const auto loop_src_off = loop_l_off * sizeof(bfloat16_t);
-        const auto loop_dst_off = loop_l_off * sizeof(float);
+        const auto loop_src_off = loop_l_off * src_dt_size_;
+        const auto loop_dst_off = loop_l_off * dst_dt_size_;
 
         mov(reg_full_loop_, full_loop_iters_);
         L(unroll_full_loop);
@@ -98,8 +98,8 @@ void jit_brgemm_transpose_single_row_t::compute_loop() {
     const int k_blocks_left = k_blocks_nb_ - full_loop_iters_ * vmms_available_;
     if (k_blocks_left > 0) {
         const auto off = k_blocks_left * simd_w_;
-        const auto src_off = off * sizeof(bfloat16_t);
-        const auto dst_off = off * sizeof(float);
+        const auto src_off = off * src_dt_size_;
+        const auto dst_off = off * dst_dt_size_;
 
         compute(k_blocks_left, false);
         add(reg_src_, src_off);

--- a/src/cpu/x64/rnn/jit_brgemm_transpose_single_row.hpp
+++ b/src/cpu/x64/rnn/jit_brgemm_transpose_single_row.hpp
@@ -54,13 +54,15 @@ private:
     void generate() override;
     void load_addresses();
     void compute_loop();
-    void compute(const dim_t unrolling, const bool is_tail);
+    void compute(const int unrolling, const bool is_tail);
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_transpose_single_row_t)
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_brgemm_transpose_single_row_t);
 
-    static constexpr dim_t simd_w_ = 16;
-    static constexpr dim_t vmms_available_ = 32;
+    static constexpr int simd_w_ = 16;
+    static constexpr int vmms_available_ = 32;
+    static constexpr int src_dt_size_ = sizeof(bfloat16_t);
+    static constexpr int dst_dt_size_ = sizeof(float);
 
     const int m_block_;
     const int full_loop_iters_;

--- a/src/cpu/x64/rnn/jit_brgemm_transpose_src.cpp
+++ b/src/cpu/x64/rnn/jit_brgemm_transpose_src.cpp
@@ -379,7 +379,7 @@ void jit_brgemm_trans_m_k_f32_t::generate() {
     // rows -> sp, cols -> ic
     // M -> ic, K -> sp
     assert(conf_->ic_block % transpose_size == 0);
-    const int os_block = conf_->os_block;
+    const int os_block = static_cast<int>(conf_->os_block);
     const int last_os_block_tail = conf_->K_tail % os_block;
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize;
@@ -708,9 +708,9 @@ void jit_brgemm_trans_m_k_bf16_t::generate() {
     constexpr int amx_xf16_granularity = 2;
     const bool last_row_padded = is_superset(conf_->isa, avx512_core_amx)
             && conf_->os % amx_xf16_granularity != 0;
-    const int eff_K_tail = conf_->K_tail - (last_row_padded ? 1 : 0);
+    const dim_t eff_K_tail = conf_->K_tail - (last_row_padded ? 1 : 0);
 
-    const int os_block = conf_->os_block;
+    const int os_block = static_cast<int>(conf_->os_block);
     const int last_os_block_tail = eff_K_tail % transpose_size;
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize;
@@ -1036,7 +1036,7 @@ void jit_brgemm_trans_m_k_f16_t::transpose_16x16(int nrows, int ncolumns) {
 void jit_brgemm_trans_m_k_f16_t::generate() {
     preamble();
     assert(conf_->ic_block % transpose_size == 0);
-    const int os_block = conf_->os_block;
+    const int os_block = static_cast<int>(conf_->os_block);
     const int last_os_block_tail = conf_->K_tail % transpose_size;
     const int ic_tail = conf_->M_tail % transpose_size;
     src_stride = static_cast<dim_t>(conf_->ic) * conf_->ks() * typesize_in;

--- a/src/cpu/x64/rnn/jit_diff_weights_peephole.cpp
+++ b/src/cpu/x64/rnn/jit_diff_weights_peephole.cpp
@@ -69,8 +69,8 @@ void jit_diff_weights_peephole_t::compute_loop() {
     mov(loop_cnt_, compute_block_size_);
     xor_(reg_offset_, reg_offset_);
 
-    const size_t offt_max = max_unrolling * simd_w_;
-    const size_t full_unroling_steps = compute_block_size_ / offt_max;
+    const dim_t offt_max = max_unrolling * simd_w_;
+    const dim_t full_unroling_steps = compute_block_size_ / offt_max;
 
     if (full_unroling_steps) {
         L(unroll_loop);
@@ -85,16 +85,16 @@ void jit_diff_weights_peephole_t::compute_loop() {
         }
     }
 
-    const size_t full_blocks_left = (compute_block_size_ - tail_size_
-                                            - (full_unroling_steps * offt_max))
+    const dim_t full_blocks_left = (compute_block_size_ - tail_size_
+                                           - (full_unroling_steps * offt_max))
             / simd_w_;
 
     L(unroll_loop_tail);
     {
         if (full_blocks_left) {
-            compute_dst(full_blocks_left, false /*tail*/);
+            compute_dst(static_cast<int>(full_blocks_left), false /*tail*/);
             if (tail_size_) {
-                const size_t offt = full_blocks_left * simd_w_;
+                const dim_t offt = full_blocks_left * simd_w_;
                 add(reg_offset_, offt);
             }
         }
@@ -102,30 +102,30 @@ void jit_diff_weights_peephole_t::compute_loop() {
     }
 }
 
-void jit_diff_weights_peephole_t::compute_dst(
-        size_t unrolling_factor, bool tail) {
+void jit_diff_weights_peephole_t::compute_dst(int unrolling_factor, bool tail) {
 
-    static constexpr dim_t number_vmm_single_compute = 3;
+    static constexpr int number_vmm_single_compute = 3;
 
-    const auto get_compute_zmm = [=](size_t base_idx, size_t unroll_group) {
+    const auto get_compute_zmm = [=](int base_idx, int unroll_group) {
         return Xbyak::Zmm(base_idx + unroll_group * number_vmm_single_compute);
     };
 
     const auto get_addr = [&](const Xbyak::Reg64 &reg_base, const dim_t offt,
                                   const data_type_t dt) {
-        const auto dt_size = types::data_type_size(dt);
-        return ptr[reg_base + reg_offset_ * dt_size + offt * dt_size];
+        const int dt_size = static_cast<int>(types::data_type_size(dt));
+        return ptr[reg_base + reg_offset_ * dt_size
+                + static_cast<uint32_t>(offt * dt_size)];
     };
 
-    static constexpr size_t dst_idx = 0;
-    static constexpr size_t scratch_idx = 1;
-    static constexpr size_t c_states_idx = 2;
+    static constexpr int dst_idx = 0;
+    static constexpr int scratch_idx = 1;
+    static constexpr int c_states_idx = 2;
 
     const auto io_dst = io_.at(dst_dt_);
     const auto io_scratch = io_.at(scratch_dt_);
     const auto io_c_states = io_.at(c_states_dt_);
 
-    for (size_t unroll_group = 0; unroll_group < unrolling_factor;
+    for (int unroll_group = 0; unroll_group < unrolling_factor;
             ++unroll_group) {
 
         const auto dst_zmm = get_compute_zmm(dst_idx, unroll_group);

--- a/src/cpu/x64/rnn/jit_diff_weights_peephole.hpp
+++ b/src/cpu/x64/rnn/jit_diff_weights_peephole.hpp
@@ -52,7 +52,7 @@ private:
     void load_addresses();
     void init();
     void compute_loop();
-    void compute_dst(size_t unrolling, bool tail);
+    void compute_dst(int unrolling, bool tail);
 
     static constexpr int simd_w_ = 16;
     static constexpr dim_t max_unrolling = 10;

--- a/src/cpu/x64/rnn/jit_gates_reduction.cpp
+++ b/src/cpu/x64/rnn/jit_gates_reduction.cpp
@@ -58,7 +58,7 @@ void jit_gates_reduction_t::generate() {
 
 #define PARAM_OFF(x) offsetof(jit_gates_reduction_t::call_params_t, x)
 
-size_t jit_gates_reduction_t::reserve_vmm() {
+int jit_gates_reduction_t::reserve_vmm() {
     return number_reserved_vmms_++;
 }
 
@@ -148,17 +148,18 @@ void jit_gates_reduction_t::compute_step(
 
 void jit_gates_reduction_t::compute(dim_t unrolling) {
 
-    const int n_block_off = rnn_.diff_wei_brgemm.n_block * sizeof(float);
+    const size_t n_block_off = rnn_.diff_wei_brgemm.n_block * sizeof(float);
 
     for (dim_t k = 0; k < unrolling; ++k) {
-        const int k_offset = -1 * (k + 1) * n_block_off;
-        const int first_reversed_block = acc_regs_.size() - 1;
+        const dim_t k_offset = -1 * (k + 1) * n_block_off;
+        const dim_t first_reversed_block = acc_regs_.size() - 1;
 
-        for (int n_block = first_reversed_block; n_block >= 0; --n_block) {
+        for (dim_t n_block = first_reversed_block; n_block >= 0; --n_block) {
             const bool tail = static_cast<bool>(n_tail_)
                     && n_block == first_reversed_block;
             const auto &acc_zmm = acc_regs_[n_block];
-            const int nk_offset = k_offset + n_block * simd_w_ * sizeof(float);
+            const dim_t nk_offset
+                    = k_offset + n_block * simd_w_ * sizeof(float);
             compute_step(acc_zmm, ptr[reg_src_ + reg_loop_ + nk_offset], tail);
         }
     }
@@ -169,7 +170,7 @@ void jit_gates_reduction_t::compute_loop() {
     const dim_t k_pack = rnn_.is_xf16_conf() ? 2 : 1;
     const dim_t k = rnn_.diff_wei_brgemm.Kpadded;
     const auto res = std::div(k, k_block);
-    const int n_block_off = rnn_.diff_wei_brgemm.n_block
+    const size_t n_block_off = rnn_.diff_wei_brgemm.n_block
             * (rnn_.is_xf16_conf() ? sizeof(bfloat16_t) : sizeof(float));
     const auto &num_k_blks = res.quot;
     const auto &k_tail = res.rem;

--- a/src/cpu/x64/rnn/jit_gates_reduction.hpp
+++ b/src/cpu/x64/rnn/jit_gates_reduction.hpp
@@ -62,14 +62,14 @@ private:
     void compute(dim_t unrolling);
     void compute_step(
             const Xbyak::Zmm &acc, const Xbyak::Address &addr, bool tail);
-    size_t reserve_vmm();
+    int reserve_vmm();
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_gates_reduction_t)
     DNNL_DISALLOW_COPY_AND_ASSIGN(jit_gates_reduction_t);
 
     static constexpr dim_t simd_w_ = 16;
 
-    size_t number_reserved_vmms_ = 0;
+    int number_reserved_vmms_ = 0;
     const rnn_utils::rnn_conf_t &rnn_;
     const bool is_n_tail_;
     const dim_t n_block_;

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
@@ -43,12 +43,16 @@ struct jit_uni_gru_cell_postgemm_part1_bwd : public jit_uni_rnn_postgemm_t {
 protected:
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    const size_t vlen_scratch
-            = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
-    static constexpr size_t hstate_dt_size = sizeof(float);
-    const size_t gate_dt_size = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
+    const int vlen_scratch = vlen
+            / (sizeof(float)
+                    / static_cast<dim_t>(
+                            types::data_type_size(scratch_data_t)));
+    static constexpr int hstate_dt_size = sizeof(float);
+    const int gate_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
+    const int scratch_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;
@@ -100,10 +104,10 @@ protected:
 #endif
 
         // helper lambda to address the gates and biases
-        const auto sg_addr = [&](int i) {
+        const auto sg_addr = [&](dim_t i) {
             return ptr[addr_scratch_gates_reg + i * rnn_.dhc * scratch_dt_size];
         };
-        const auto wg_addr = [&](int i) {
+        const auto wg_addr = [&](dim_t i) {
             return ptr[addr_ws_gates_reg + i * rnn_.dhc * gate_dt_size];
         };
 

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
@@ -55,16 +55,19 @@ protected:
 
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t qscale_dt_size = sizeof(float);
-    const size_t vlen_dst
+    static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int qscale_dt_size = sizeof(float);
+    const int vlen_dst
             = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias_ = vlen / (sizeof(float) / bias_dt_size_);
-    const size_t hstate_dt_size = types::data_type_size(src_data_t);
-    const size_t gate_dt_size = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
-    const size_t vlen_qscale = vlen / qscale_dt_size;
-    const size_t vlen_elems = vlen / scratch_dt_size;
+    const int vlen_bias_ = vlen / (sizeof(float) / bias_dt_size_);
+    const int hstate_dt_size
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int gate_dt_size
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int scratch_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
+    const int vlen_qscale = vlen / qscale_dt_size;
+    const int vlen_elems = vlen / scratch_dt_size;
 
     const int loop_ur_max = 4;
     // We skip vmm0 as it can be used by the injector for masks on sse4.1
@@ -126,16 +129,16 @@ protected:
             return ptr[addr_bias_reg + i * rnn_.dhc * bias_dt_size_ + j * vlen];
         };
 
-        const size_t loop_len = rnn_.dhc;
-        const size_t loop_tail = loop_len % vlen_elems;
+        const dim_t loop_len = rnn_.dhc;
+        const int loop_tail = static_cast<int>(loop_len % vlen_elems);
         // initialize registers with addresses and constants
         init_regs(weights_scales, vlen, loop_tail);
 
         // both sigmoid and tanh use the same table so load address just once in rax
         sigmoid_injector_->load_table_addr();
 
-        const size_t nb_loop_len = loop_len / vlen_elems;
-        size_t loop_ur_val = 1;
+        const dim_t nb_loop_len = loop_len / vlen_elems;
+        int loop_ur_val = 1;
         const bool is_brgemm = rnn_.is_brgemm && !rnn_.unfused_post_gemm;
         if (is_brgemm) {
 #ifdef _WIN32
@@ -153,15 +156,15 @@ protected:
 
             mov(loop_cnt, loop_len);
         }
-        const size_t loop_ur = loop_ur_val;
+        const int loop_ur = loop_ur_val;
 
         auto compute_loop
-                = [&](size_t current_vlen_elem, size_t current_loop_unroll) {
+                = [&](int current_vlen_elem, int current_loop_unroll) {
             const auto current_vlen = current_vlen_elem * scratch_dt_size;
             Label loop_start_label;
             L(loop_start_label);
             {
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (int loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     const Vmm G0(G0_idx(loop_ur_idx));
                     const Vmm G1(G1_idx(loop_ur_idx));
@@ -195,14 +198,14 @@ protected:
                 // Compute sigmoid of unrolled G0 and G1 regs together
                 // (this allows to not save any registers during eltwise)
                 injector_utils::vmm_index_set_t vmm_idxs;
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (int loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     vmm_idxs.emplace(G0_idx(loop_ur_idx));
                     vmm_idxs.emplace(G1_idx(loop_ur_idx));
                 }
                 sigmoid_injector_->compute_vector_range(vmm_idxs);
 
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (int loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     const Vmm G0(G0_idx(loop_ur_idx));
                     const Vmm G1(G1_idx(loop_ur_idx));
@@ -258,10 +261,10 @@ protected:
                     add(addr_states_t_l_copy_reg, current_states_size);
                     add(addr_states_tm1_l_reg, current_states_size);
                     if (is_training) add(addr_ws_gates_reg, current_gate_size);
-                    inc_regs(mask,
-                            current_vlen == vlen
-                                    ? current_vlen * current_loop_unroll
-                                    : qscale_dt_size);
+                    const int qscale_shift = current_vlen == vlen
+                            ? current_vlen * current_loop_unroll
+                            : qscale_dt_size;
+                    inc_regs(mask, qscale_shift);
 
                     // increment loop counter
                     sub(loop_cnt, current_vlen_elem * current_loop_unroll);

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
@@ -43,12 +43,16 @@ struct jit_uni_gru_cell_postgemm_part2_bwd : public jit_uni_rnn_postgemm_t {
 protected:
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t hstate_dt_size = sizeof(float);
-    const size_t vlen_scratch
-            = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
-    const size_t gate_dt_size = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int hstate_dt_size = sizeof(float);
+    const int vlen_scratch = vlen
+            / (sizeof(float)
+                    / static_cast<dim_t>(
+                            types::data_type_size(scratch_data_t)));
+    const int gate_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
+    const int scratch_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;
@@ -105,10 +109,10 @@ protected:
 #endif
 
         // helper lambda to address the gates and biases
-        const auto sg_addr = [&](int i) {
+        const auto sg_addr = [&](dim_t i) {
             return ptr[addr_scratch_gates_reg + i * rnn_.dhc * scratch_dt_size];
         };
-        const auto wg_addr = [&](int i) {
+        const auto wg_addr = [&](dim_t i) {
             return ptr[addr_ws_gates_reg + i * rnn_.dhc * gate_dt_size];
         };
 

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
@@ -55,16 +55,19 @@ protected:
 
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t qscale_dt_size = sizeof(float);
-    const size_t vlen_dst
+    static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int qscale_dt_size = sizeof(float);
+    const int vlen_dst
             = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
-    const size_t hstate_dt_size = types::data_type_size(src_data_t);
-    const size_t gate_dt_size = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
-    const size_t vlen_qscale = vlen / qscale_dt_size;
-    const size_t vlen_elems = vlen / scratch_dt_size;
+    const int vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
+    const int hstate_dt_size
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int gate_dt_size
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int scratch_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
+    const int vlen_qscale = vlen / qscale_dt_size;
+    const int vlen_elems = vlen / scratch_dt_size;
 
     const int loop_ur_max = 4;
     // We skip vmm0 as it can be used by the injector for masks on sse4.1
@@ -142,16 +145,16 @@ protected:
                     + j * vlen_bias];
         };
 
-        const size_t loop_len = rnn_.dhc;
-        const size_t loop_tail = loop_len % vlen_elems;
+        const dim_t loop_len = rnn_.dhc;
+        const int loop_tail = static_cast<int>(loop_len % vlen_elems);
 
         // initialize registers with addresses and constants
         mov(table_reg, table_label);
         tanh_injector_->load_table_addr();
         init_regs(weights_scales, vlen, loop_tail);
 
-        const size_t nb_loop_len = loop_len / vlen_elems;
-        size_t loop_ur_val = 1;
+        const dim_t nb_loop_len = loop_len / vlen_elems;
+        int loop_ur_val = 1;
         const bool is_brgemm = rnn_.is_brgemm && !rnn_.unfused_post_gemm;
         if (is_brgemm) {
 #ifdef _WIN32
@@ -169,15 +172,15 @@ protected:
 
             mov(loop_cnt, loop_len);
         }
-        const size_t loop_ur = loop_ur_val;
+        const int loop_ur = loop_ur_val;
 
         auto compute_loop
-                = [&](size_t current_vlen_elem, size_t current_loop_unroll) {
+                = [&](int current_vlen_elem, int current_loop_unroll) {
             const auto current_vlen = current_vlen_elem * scratch_dt_size;
             Label loop_start_label;
             L(loop_start_label);
             {
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (int loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     // Compute gate 2: G2 = tanh(G2 + b2)
                     load(G2(loop_ur_idx), sg_addr(2, loop_ur_idx),
@@ -195,13 +198,13 @@ protected:
                 // Compute tanh of unrolled G2 regs together
                 // (this allows to not save any registers during eltwise)
                 injector_utils::vmm_index_set_t vmm_idxs;
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (int loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     vmm_idxs.emplace(G2(loop_ur_idx).getIdx());
                 }
                 tanh_injector_->compute_vector_range(vmm_idxs);
 
-                for (size_t loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
+                for (int loop_ur_idx = 0; loop_ur_idx < current_loop_unroll;
                         ++loop_ur_idx) {
                     // if training we write back the gates
                     if (is_training)
@@ -267,10 +270,10 @@ protected:
 
                 if (current_vlen_elem != loop_tail) {
                     // increment address pointers
-                    const auto current_gate_size = current_vlen == vlen
+                    const dim_t current_gate_size = current_vlen == vlen
                             ? vlen_dst * current_loop_unroll
                             : gate_dt_size;
-                    const auto current_states_size = current_vlen == vlen
+                    const dim_t current_states_size = current_vlen == vlen
                             ? vlen_dst * current_loop_unroll
                             : hstate_dt_size;
 
@@ -326,7 +329,7 @@ protected:
         init_table(vlen);
         L(table_label);
         {
-            for (size_t i = 0; i < vlen / sizeof(float); i++)
+            for (int i = 0; i < vlen / qscale_dt_size; i++)
                 dd(float2int(1.0f));
         }
     }

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_bwd.hpp
@@ -43,12 +43,15 @@ struct jit_uni_gru_lbr_cell_postgemm_bwd : public jit_uni_rnn_postgemm_t {
 protected:
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t hstate_dt_size = sizeof(float);
-    const size_t vlen_scratch
-            = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
-    const size_t gate_dt_size = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int hstate_dt_size = sizeof(float);
+    const int vlen_scratch = vlen
+            / (hstate_dt_size
+                    / static_cast<int>(types::data_type_size(scratch_data_t)));
+    const int gate_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
+    const int scratch_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;

--- a/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_lbr_cell_postgemm_fwd.hpp
@@ -56,17 +56,23 @@ protected:
 
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int f32_dt_size = sizeof(float);
 
-    const size_t vlen_dst
-            = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias_ = vlen / (sizeof(float) / bias_dt_size_);
-    const size_t hstate_dt_size = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
-    const size_t gate_dt_size = types::data_type_size(src_data_t);
-    const size_t vlen_elems = vlen / scratch_dt_size;
-    const size_t loop_len = rnn_.dhc;
-    const size_t loop_tail = loop_len % nstl::max(size_t(1), vlen_elems);
+    const int vlen_dst = vlen
+            / (f32_dt_size
+                    / static_cast<int>(types::data_type_size(src_data_t)));
+    const int vlen_bias_ = vlen / (f32_dt_size / bias_dt_size_);
+    const int hstate_dt_size
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int scratch_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
+    const int gate_dt_size
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int vlen_elems = vlen / scratch_dt_size;
+    const dim_t loop_len = rnn_.dhc;
+    const int loop_tail
+            = static_cast<int>(loop_len % nstl::max<dim_t>(1, vlen_elems));
 
     void generate() override {
         using namespace Xbyak;
@@ -137,8 +143,8 @@ protected:
             return ptr[addr_scratch_cell_reg + i * rnn_.dhc * scratch_dt_size];
         };
 
-        auto compute_loop = [&](size_t current_vlen_elems) {
-            const auto current_vlen = current_vlen_elems * scratch_dt_size;
+        auto compute_loop = [&](int current_vlen_elems) {
+            const int current_vlen = current_vlen_elems * scratch_dt_size;
             Label loop_start_label, loop_inc_regs_or_finish;
             L(loop_start_label);
             {
@@ -234,7 +240,7 @@ protected:
                 if (current_vlen_elems != loop_tail) {
                     const auto current_gate_size
                             = current_vlen == vlen ? vlen_dst : gate_dt_size;
-                    const auto current_states_size
+                    const dim_t current_states_size
                             = current_vlen == vlen ? vlen_dst : hstate_dt_size;
                     add(addr_scratch_gates_reg, current_vlen);
                     add(addr_ws_h_reg, current_gate_size);

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
@@ -64,17 +64,19 @@ protected:
     std::unique_ptr<injector_t> tanh_injector_;
 
     // register size in bytes
-    static constexpr size_t vlen_ = cpu_isa_traits_t<isa>::vlen;
-    const size_t vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
+    static constexpr int vlen_ = cpu_isa_traits_t<isa>::vlen;
+    const int vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
 
-    static constexpr size_t diff_cstate_dt_size_ = sizeof(float);
-    static constexpr size_t hstate_dt_size_ = sizeof(float);
-    static constexpr size_t weights_peephole_dt_size_ = sizeof(float);
+    static constexpr int diff_cstate_dt_size_ = sizeof(float);
+    static constexpr int hstate_dt_size_ = sizeof(float);
+    static constexpr int weights_peephole_dt_size_ = sizeof(float);
 
-    const size_t vlen_scratch_
+    const int vlen_scratch_
             = vlen_ / (sizeof(float) / types::data_type_size(scratch_data_t));
-    const size_t gate_dt_size_ = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size_ = types::data_type_size(scratch_data_t);
+    const int gate_dt_size_
+            = static_cast<int>(types::data_type_size(scratch_data_t));
+    const int scratch_dt_size_
+            = static_cast<int>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
@@ -69,16 +69,19 @@ protected:
     std::unique_ptr<injector_t> tanh_injector_;
 
     // register size in bytes
-    static constexpr size_t vlen_ = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t qscale_dt_size = sizeof(float);
-    static constexpr size_t weights_peephole_dt_size_ = sizeof(float);
-    const size_t vlen_dst_
+    static constexpr int vlen_ = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int qscale_dt_size = sizeof(float);
+    static constexpr int weights_peephole_dt_size_ = sizeof(float);
+    const int vlen_dst_
             = vlen_ / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias_ = vlen_ / (sizeof(float) / bias_dt_size_);
-    const size_t vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
-    const size_t hstate_dt_size_ = types::data_type_size(src_data_t);
-    const size_t gate_dt_size_ = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size_ = types::data_type_size(scratch_data_t);
+    const int vlen_bias_ = vlen_ / (sizeof(float) / bias_dt_size_);
+    const int vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
+    const int hstate_dt_size_
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int gate_dt_size_
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int scratch_dt_size_
+            = static_cast<int>(types::data_type_size(scratch_data_t));
     int get_vmm_idx(int unroll_idx, int type_shift) const {
         const int preserved_vmm_start_idx = 1;
         // G0, G1, G2, G3, c_states;
@@ -101,7 +104,7 @@ protected:
     }
 
     dim_t scale_off(int gate_idx, int unroll_idx) const {
-        const size_t vlen_qscale_elem = vlen_ / qscale_dt_size;
+        const int vlen_qscale_elem = vlen_ / qscale_dt_size;
         return gate_idx * rnn_.dhc + unroll_idx * vlen_qscale_elem;
     }
 
@@ -172,8 +175,8 @@ protected:
                     + i * rnn_.dhc * weights_peephole_dt_size_ + j * vlen_];
         };
 
-        const auto loop_len = rnn_.dhc * scratch_dt_size_;
-        const auto loop_tail = loop_len % vlen_;
+        const dim_t loop_len = rnn_.dhc * scratch_dt_size_;
+        const int loop_tail = static_cast<int>(loop_len % vlen_);
 
         // initialize registers with addresses and constants
         init_regs(weights_scales, vlen_, loop_tail / scratch_dt_size_);
@@ -207,7 +210,7 @@ protected:
                 loop_unroll_tail = 1;
         }
 
-        auto compute_loop = [&](size_t current_vlen, int current_unroll_len) {
+        auto compute_loop = [&](int current_vlen, int current_unroll_len) {
             this->reset_tmp_vmm_idx_range(
                     get_last_preserved_vmm_idx(current_unroll_len) + 1,
                     this->get_max_allowed_tmp_vmm_allowed_idx());
@@ -217,7 +220,7 @@ protected:
             const bool single_tail_loop_iter
                     = current_vlen < vlen_ && current_vlen == loop_tail;
             const bool need_increment_regs = !single_tail_loop_iter;
-            const auto iter_size = current_unroll_len * current_vlen;
+            const int iter_size = current_unroll_len * current_vlen;
 
             Label loop_start_label, loop_skip_label;
             cmp(loop_cnt, iter_size);
@@ -387,7 +390,7 @@ protected:
                     to_src(ptr[addr_states_t_l_copy_reg + ur_idx * vlen_dst_],
                             tmp_c_states, src_data_t, current_vlen, true);
                 }
-                const size_t hstate_shift = current_vlen < vlen_
+                const dim_t hstate_shift = current_vlen < vlen_
                         ? hstate_dt_size_
                         : current_unroll_len * vlen_dst_;
                 if (need_increment_regs)
@@ -404,33 +407,33 @@ protected:
                 // increment address pointers
                 L_aligned(loop_inc_regs_label);
                 if (need_increment_regs) {
-                    const size_t scratch_shift = current_vlen < vlen_
+                    const dim_t scratch_shift = current_vlen < vlen_
                             ? scratch_dt_size_
                             : current_unroll_len * vlen_;
                     add(addr_scratch_gates_reg, scratch_shift);
                     if (rnn_.is_lstm_peephole) {
-                        const size_t wpeephole_shift = current_vlen < vlen_
+                        const dim_t wpeephole_shift = current_vlen < vlen_
                                 ? weights_peephole_dt_size_
                                 : current_unroll_len * vlen_;
                         add(addr_weights_peephole_reg, wpeephole_shift);
                     }
-                    const size_t bias_shift = current_vlen < vlen_
+                    const dim_t bias_shift = current_vlen < vlen_
                             ? bias_dt_size_
                             : current_unroll_len * vlen_bias_;
                     add(addr_bias_reg, bias_shift);
                     add(addr_states_t_l_reg, hstate_shift);
-                    const size_t cstate_shift = current_vlen < vlen_
+                    const dim_t cstate_shift = current_vlen < vlen_
                             ? cstate_dt_size_
                             : current_unroll_len * vlen_c_states_;
                     add(addr_c_states_tm1_l_reg, cstate_shift);
                     add(addr_c_states_t_l_reg, cstate_shift);
                     if (is_training) {
-                        const size_t gate_shift = current_vlen < vlen_
+                        const dim_t gate_shift = current_vlen < vlen_
                                 ? gate_dt_size_
                                 : current_unroll_len * vlen_dst_;
                         add(addr_ws_gates_reg, gate_shift);
                     }
-                    const size_t qscale_shift = current_vlen < vlen_
+                    const int qscale_shift = current_vlen < vlen_
                             ? qscale_dt_size
                             : current_unroll_len * vlen_;
                     inc_regs(mask, qscale_shift);

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
@@ -43,12 +43,14 @@ struct jit_uni_rnn_cell_postgemm_bwd : public jit_uni_rnn_postgemm_t {
 protected:
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t hstate_dt_size = sizeof(float);
-    const size_t vlen_scratch
+    static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int hstate_dt_size = sizeof(float);
+    const int vlen_scratch
             = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
-    const size_t gate_dt_size = types::data_type_size(scratch_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    const int gate_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
+    const int scratch_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
@@ -51,16 +51,19 @@ protected:
 
     // register size in bytes
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
-    static constexpr size_t vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr size_t cstate_dt_size = sizeof(float);
-    static constexpr size_t qscale_dt_size = sizeof(float);
+    static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
+    static constexpr int cstate_dt_size = sizeof(float);
+    static constexpr int qscale_dt_size = sizeof(float);
 
-    const size_t vlen_dst
+    const int vlen_dst
             = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const size_t vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
-    const size_t hstate_dt_size = types::data_type_size(src_data_t);
-    const size_t gate_dt_size = types::data_type_size(src_data_t);
-    const size_t scratch_dt_size = types::data_type_size(scratch_data_t);
+    const int vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
+    const int hstate_dt_size
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int gate_dt_size
+            = static_cast<int>(types::data_type_size(src_data_t));
+    const int scratch_dt_size
+            = static_cast<int>(types::data_type_size(scratch_data_t));
 
     void generate() override {
         using namespace Xbyak;
@@ -187,7 +190,8 @@ protected:
             deq_w(src_data_t, G, tmp1_vmm, tmp2_vmm, 0, mask, scratch_dt_size);
 
             // add biases
-            to_float(tmp1_vmm, B_addr, rnn_.bias_dt, sizeof(float));
+            to_float(tmp1_vmm, B_addr, rnn_.bias_dt,
+                    static_cast<int>(sizeof(float)));
             uni_vaddps(Gs, Gs, tmp1s_vmm);
 
             // inject eltwise code

--- a/src/cpu/x64/rnn/jit_uni_rnn_common_postgemm.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_common_postgemm.hpp
@@ -42,8 +42,9 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
         , rnn_(rnn)
         , pd_(pd)
         , projection_(false)
-        , bias_dt_size_(types::data_type_size(rnn.bias_dt))
-        , cstate_dt_size_(types::data_type_size(rnn.src_iter_c_dt))
+        , bias_dt_size_(static_cast<int>(types::data_type_size(rnn.bias_dt)))
+        , cstate_dt_size_(
+                  static_cast<int>(types::data_type_size(rnn.src_iter_c_dt)))
         , is_avx512(mayiuse(avx512_core))
         , is_avx2(mayiuse(avx2))
         , weights_scales_reg(r13)
@@ -126,14 +127,14 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
 
     template <typename dst_layer_t, typename dst_iter_t, typename src_iter_t,
             typename gates_t, typename scratch_t>
-    inline void postgemm_fwd_call(int m, const rnn_utils::rnn_conf_t &rnn,
+    inline void postgemm_fwd_call(dim_t m, const rnn_utils::rnn_conf_t &rnn,
             rnn_utils::cell_position_t cell_position, gates_t *ws_gates_,
             scratch_t *scratch_gates_, const dst_layer_t *augru_attention_,
             dst_layer_t *dst_layer_, void *dst_iter_c_,
             const src_iter_t *src_iter_, const void *src_iter_c_,
             const float *weights_peephole_, const void *bias_,
             gates_t *ws_grid_, scratch_t *scratch_cell_, dst_iter_t *dst_iter_,
-            float *weights_scales_, int block_step) const {
+            float *weights_scales_, dim_t block_step) const {
         const rnn_utils::ws_gates_aoc_t<gates_t> ws_gates(rnn, ws_gates_);
         const rnn_utils::scratch_gates_aoc_t<scratch_t> scratch_gates(
                 rnn, scratch_gates_);
@@ -143,11 +144,11 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
                 bias_, types::data_type_size(rnn.bias_dt), rnn.n_bias, rnn.dhc);
 
         const auto src_iter_ld = rnn.src_iter_ld(cell_position);
-        const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+        const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
         const auto dst_layer_ld
                 = rnn.dst_layer_ld(cell_position, is_projection());
         const auto dst_iter_ld = rnn.dst_iter_ld(cell_position);
-        const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+        const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
 
         const rnn_utils::ws_states_layer_aoc_t<dst_layer_t> dst_layer(
                 rnn, dst_layer_, dst_layer_ld);
@@ -227,8 +228,8 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
             typename gemm_acc_t, typename gates_t, typename scratch_t>
     rnn_postgemm_sig(execute_bwd) {
         using namespace rnn_utils;
-        const int dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
-        const int src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
+        const dim_t dst_iter_c_ld = rnn.dst_iter_c_ld(cell_position);
+        const dim_t src_iter_c_ld = rnn.src_iter_c_ld(cell_position);
         const auto src_iter_ld = rnn.src_iter_ld(cell_position);
 
         const rnn_utils::weights_peephole_aoc_t<const float> weights_peephole(
@@ -371,8 +372,7 @@ struct jit_uni_rnn_postgemm_t : public jit_generator_t {
     }
 
 protected:
-    void init_regs(
-            float *weights_scales, size_t vlen, size_t tail_elements = 0) {
+    void init_regs(float *weights_scales, int vlen, int tail_elements = 0) {
         if (is_avx512 && tail_elements > 0) {
             mov(tmp_reg, size_t((1 << tail_elements) - 1));
             kmovq(zmm_tail_k_mask, tmp_reg);
@@ -422,12 +422,12 @@ protected:
         }
     }
 
-    void init_regs(size_t vlen, size_t tail_elements = 0) {
+    void init_regs(int vlen, int tail_elements = 0) {
         assert(pd_->weights_md()->data_type != data_type::s8);
         return init_regs(nullptr, vlen, tail_elements);
     }
 
-    void init_table(size_t vlen) {
+    void init_table(int vlen) {
         if (pd_->weights_md()->data_type != data_type::s8) return;
         /* int8 (de)quantization init*/
         const primitive_attr_t *attr = pd_->attr();
@@ -473,12 +473,12 @@ protected:
         }
     }
 
-    void inc_regs(int mask, size_t vlen) {
+    void inc_regs(int mask, int vlen) {
         if (pd_->weights_md()->data_type == data_type::s8) {
             if (mask != 0) add(weights_scales_reg, vlen);
         }
     }
-    void inc_regs(size_t vlen) {
+    void inc_regs(int vlen) {
         assert(pd_->weights_md()->data_type != data_type::s8);
         inc_regs(0, vlen);
     }
@@ -884,8 +884,8 @@ protected:
     const rnn_pd_t *pd_;
     bool projection_;
     bf16_emulation_t *bf16_emu_ = nullptr;
-    const size_t bias_dt_size_;
-    const size_t cstate_dt_size_;
+    const int bias_dt_size_;
+    const int cstate_dt_size_;
     const bool is_avx512;
     const bool is_avx2;
 

--- a/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
+++ b/src/cpu/x64/rnn/rnn_brgemm_utils.cpp
@@ -153,8 +153,8 @@ std::pair<dim_t, dim_t> brgemm_calc_k_block_vanilla_rnn(dim_t K1, dim_t K2,
     dim_t k2_block = K2;
 
     if (should_adjust_by_l2) {
-        int block_size = (l2_cache_size * l2_occupancy)
-                / ((M + n_block) * src_layer_type_size);
+        int block_size = static_cast<int>((l2_cache_size * l2_occupancy)
+                / ((M + n_block) * src_layer_type_size));
 
         if (is_xf16) {
             // due to weights format ldgOI32o2i block_size should be even
@@ -357,7 +357,7 @@ void rnn_brgemm_base_t::init_scratchpad(const cpu::rnn_utils::rnn_conf_t &rnn,
                 rnn.n_iter * rnn.mb * sizeof(bfloat16_t), 64);
     }
 
-    const int max_K_Block
+    const dim_t max_K_Block
             = nstl::max(rnn.KB1_blocks + 1,
                       nstl::max(rnn.KBproj_blocks + 1, rnn.KB2_blocks + 1))
             * (rnn.brgemm_fwd_iter_layer_fuse_possible ? 2 : 1);
@@ -550,7 +550,7 @@ status_t rnn_brgemm_t<prop_kind::forward>::configure_brgemm(
         rnn.merge_gemm_layer = true;
 
         // required adjustment if mlc_m_dim_adjustment_not_required = false
-        const int n_iters_to_merge = rnn.n_iter;
+        const dim_t n_iters_to_merge = rnn.n_iter;
         rnn.Mlayermerged = rnn.mb * n_iters_to_merge;
         rnn.mlayermerged_block = brgemm_calc_m_block(cell_kind,
                 prop_kind::forward, rnn.nthr, rnn.Mlayermerged, rnn.N_blocks,
@@ -638,8 +638,8 @@ status_t rnn_brgemm_t<prop_kind::forward>::init_kernels(
                 K, LDA, LDB, LDC, beta, max_bs);
     };
 
-    const int brgemm_n = nstl::min(rnn.N, rnn.n_block);
-    const int brgemm_n_tail = nstl::min(rnn.N, rnn.n_tail);
+    const dim_t brgemm_n = nstl::min(rnn.N, rnn.n_block);
+    const dim_t brgemm_n_tail = nstl::min(rnn.N, rnn.n_tail);
     const int max_bs_factor = rnn.brgemm_fwd_iter_layer_fuse_possible ? 2 : 1;
 
     for (int i = 0; i < num_base_kernels_; i++) {
@@ -1141,10 +1141,10 @@ static status_t init_kernels_diff_src(rnn_diff_src_brgemm_t &diff_src,
     };
 
     const auto &diff_src_conf = rnn.diff_src_brgemm;
-    const int n_diff_src = nstl::min(diff_src_conf.N, diff_src_conf.n_block);
-    const int n_diff_src_iter_tail
+    const dim_t n_diff_src = nstl::min(diff_src_conf.N, diff_src_conf.n_block);
+    const dim_t n_diff_src_iter_tail
             = nstl::min(diff_src_conf.N_iter, diff_src_conf.n_iter_tail);
-    const int n_diff_src_layer_tail
+    const dim_t n_diff_src_layer_tail
             = nstl::min(diff_src_conf.N_layer, diff_src_conf.n_layer_tail);
     const auto K_batch_size = rnn.n_gates * diff_src_conf.K_blocks;
     const auto split_gates_computation
@@ -1364,8 +1364,9 @@ static status_t init_kernels_diff_wei(rnn_diff_wei_brgemm_t &diff_wei,
     tmp_matmul_conf_for_reorder.wei_tag = format_tag::ab;
     tmp_matmul_conf_for_reorder.N = rnn.scratch_gates_ld;
     tmp_matmul_conf_for_reorder.K = rnn.mb;
-    tmp_matmul_conf_for_reorder.wei_n_blk = tmp_matmul_conf_for_reorder.N_blk
-            = diff_wei_conf.n_block;
+    tmp_matmul_conf_for_reorder.N_blk = diff_wei_conf.n_block;
+    tmp_matmul_conf_for_reorder.wei_n_blk
+            = static_cast<int>(diff_wei_conf.n_block);
     tmp_matmul_conf_for_reorder.N_tail = diff_wei_conf.n_tail;
     tmp_matmul_conf_for_reorder.LDB = diff_wei_conf.LDB;
     tmp_matmul_conf_for_reorder.src_dt = tmp_matmul_conf_for_reorder.wei_dt
@@ -1417,14 +1418,14 @@ status_t rnn_brgemm_t<prop_kind::backward>::init_kernels(
 
             kernel_transpose_single_row_iter_
                     = utils::make_unique<jit_brgemm_transpose_single_row_t>(
-                            m_block_iter);
+                            static_cast<int>(m_block_iter));
             CHECK(kernel_transpose_single_row_iter_->create_kernel());
 
             if (!is_m_block_equal) {
                 const auto m_block_layer = rnn.diff_wei_brgemm.M_layer;
                 kernel_transpose_single_row_layer_
                         = utils::make_unique<jit_brgemm_transpose_single_row_t>(
-                                m_block_layer);
+                                static_cast<int>(m_block_layer));
                 CHECK(kernel_transpose_single_row_layer_->create_kernel());
             }
         }
@@ -1441,24 +1442,24 @@ status_t rnn_brgemm_t<prop_kind::backward>::init_kernels(
         trans_conf.M = 0;
         const auto rnd_up_size = data_type_vnni_granularity(src_type);
         const auto os_padded = utils::rnd_up(rnn.mb, rnd_up_size);
-        trans_conf.os = os_padded;
+        trans_conf.os = static_cast<int>(os_padded);
         trans_conf.LDA = os_padded; // dst's leading dim
         trans_conf.K_tail = rnn.mb % blk_size; // src's rows tail
 
-        const int LDA_iter[]
+        const dim_t LDA_iter[]
                 = {rnn.src_iter_ld_, rnn.dst_layer_ld_, rnn.ws_states_iter_ld};
         trans_conf.M_tail = rnn.sic % blk_size; // src's cols tail
         for (int i = 0; i < num_base_kernels_; i++) {
-            trans_conf.ic = LDA_iter[i];
+            trans_conf.ic = static_cast<int>(LDA_iter[i]);
             CHECK(create_brgemm_trans_src(
                     kernel_transpose_iter_[i], &trans_conf));
         }
 
-        const int LDA_layer[]
+        const dim_t LDA_layer[]
                 = {rnn.src_layer_ld_, rnn.dst_iter_ld_, rnn.ws_states_layer_ld};
         trans_conf.M_tail = rnn.slc % blk_size; // src's cols tail
         for (int i = 0; i < num_base_kernels_; i++) {
-            trans_conf.ic = LDA_layer[i];
+            trans_conf.ic = static_cast<int>(LDA_layer[i]);
             CHECK(create_brgemm_trans_src(
                     kernel_transpose_layer_[i], &trans_conf));
         }


### PR DESCRIPTION
It's a RNN (PR Nr.9) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
C4244 warnings eliminated: 556.
Tried to replicate all code suggestions in previous PR to meet the minimal changes eliminating C4244.