### PR TITLE
cpu: reorder: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/reorder/simple_reorder.hpp
+++ b/src/cpu/reorder/simple_reorder.hpp
@@ -1145,10 +1145,10 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 auto i = &input[get_blk_off(
                         input_d, batch, D0_blksize * D0, D1_blksize * D1)];
                 auto o = &output[get_blk_off(output_d, batch, D0, D1)];
-                const dim_t d0_block
-                        = nstl::min(D0_blksize, D0dim - D0 * D0_blksize);
-                const dim_t d1_block
-                        = nstl::min(D1_blksize, D1dim - D1 * D1_blksize);
+                const int d0_block = static_cast<int>(
+                        nstl::min(D0_blksize, D0dim - D0 * D0_blksize));
+                const int d1_block = static_cast<int>(
+                        nstl::min(D1_blksize, D1dim - D1 * D1_blksize));
                 dim_t _offset = batch * NB_D1dim * D1_blksize + D1 * D1_blksize;
                 int32_t *zp_ptr = (order_keep && has_asymmetric_comp)
                         ? &zp[_offset]
@@ -2413,8 +2413,8 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 const dim_t src_zps_off
                         = get_quant_off(input_idx, ndims, src_zps_mask,
                                 src_zps_group0, src_zps_group1, src_zps_md);
-                src_zp_val = io::load_float_value(
-                        src_zps_d.data_type(), src_zero_points, src_zps_off);
+                src_zp_val = static_cast<int>(io::load_float_value(
+                        src_zps_d.data_type(), src_zero_points, src_zps_off));
             }
 
             const auto o_off = output_d.off_l(idx);
@@ -2650,8 +2650,8 @@ struct simple_reorder_impl_t<SIMPLE_REORDER_TEMPL_CALL,
                 const dim_t src_zps_off
                         = get_quant_off(input_idx, ndims, src_zps_mask,
                                 src_zps_group0, src_zps_group1, src_zps_md);
-                src_zp_val = io::load_float_value(
-                        src_zps_d.data_type(), src_zero_points, src_zps_off);
+                src_zp_val = static_cast<int>(io::load_float_value(
+                        src_zps_d.data_type(), src_zero_points, src_zps_off));
             }
 
             const auto i_off = input_d.off_l(idx);

--- a/src/cpu/rnn/rnn_reorders.hpp
+++ b/src/cpu/rnn/rnn_reorders.hpp
@@ -77,7 +77,8 @@ static inline void quantize_igo(int8_t *scratch_quantized,
                 const float s = scales[(mask == 0) ? 0 : go];
                 scratch_quantized[ldi * G * O + go]
                         = q10n::qz_b0_t<in_data_t, int8_t>()(
-                                src[ldi * G * O + go], s);
+                                static_cast<in_data_t>(src[ldi * G * O + go]),
+                                s);
             }
         }
     });
@@ -101,7 +102,9 @@ static inline void quantize_goi(int8_t *scratch_quantized,
         for (dim_t i = 0; i < I; i++) {
             scratch_quantized[ld * I * G * O + i * G * O + go]
                     = q10n::qz_b0_t<in_data_t, int8_t>()(
-                            src[ld * G * O * I + go * I + i], s);
+                            static_cast<in_data_t>(
+                                    src[ld * G * O * I + go * I + i]),
+                            s);
         }
     });
 }
@@ -117,8 +120,9 @@ static inline void compensate_igo(float *compensation,
     // We parallelize on LD and GO
     // TODO: maybe restrict parallelism as we might have large
     // parallelisation overhead if dimensions are small
-    const int LD_nthr = nstl::min(L * D, dim_t(nthr));
-    const int GO_nthr = nstl::min(G * O, dim_t(nthr / LD_nthr));
+    const int LD_nthr = static_cast<int>(nstl::min<dim_t>(L * D, nthr));
+    const int GO_nthr
+            = static_cast<int>(nstl::min<dim_t>(G * O, nthr / LD_nthr));
     parallel(nthr, [=](const int ithr, const int nthr) {
         int LD_ithr = -1;
         int GO_ithr = -1;
@@ -857,7 +861,8 @@ private:
             return status::success;
         }
 
-        const int o_block = dst_d.blocking_desc().inner_blks[0];
+        const int o_block
+                = static_cast<int>(dst_d.blocking_desc().inner_blks[0]);
         static constexpr int i_block = 4;
 
         dim_t L, D, I, G, O;
@@ -925,7 +930,8 @@ private:
             return row + col;
         };
         const auto kernel_plain_to_blocked
-                = [=](const out_data_t *inp, out_data_t *out, int ib, int ob) {
+                = [=](const out_data_t *inp, out_data_t *out, dim_t ib,
+                          dim_t ob) {
             PRAGMA_OMP_SIMD()
             for (int i = 0; i < i_block * o_block; i++)
                 out[i] = 0;

--- a/src/cpu/x64/jit_uni_reorder.cpp
+++ b/src/cpu/x64/jit_uni_reorder.cpp
@@ -113,9 +113,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
 
     struct simple_impl_desc_t {
         int ndims_full_unroll = 0;
-        int len_last_dim_unroll = 0;
-        int tail_len_unroll = 0;
-        int len_unroll = 0;
+        dim_t len_last_dim_unroll = 0;
+        dim_t tail_len_unroll = 0;
+        dim_t len_unroll = 0;
     };
 
 #define PARAM(x) \
@@ -130,9 +130,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         const int ndims = prb.ndims;
 
         int ndims_full_unroll = 0;
-        int len_last_dim_unroll = 1;
-        int tail_len_unroll = 0;
-        int len_unroll = 1;
+        dim_t len_last_dim_unroll = 1;
+        dim_t tail_len_unroll = 0;
+        dim_t len_unroll = 1;
 
         // It is responsible for finding as many values as kernel can unroll.
         // If tail is present, then kernel will unroll only last node.
@@ -145,7 +145,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             len_unroll = prb.nodes[0].n;
             tail_len_unroll = prb.nodes[0].is_zero_pad_needed
                     ? 0
-                    : static_cast<int>(prb.nodes[0].tail_size);
+                    : prb.nodes[0].tail_size;
         } else {
             for (int d = 0; d < ndims; ++d) {
                 const auto &node = prb.nodes[d];
@@ -212,26 +212,26 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         return is_superset(isa, avx512_core_fp16) || is_superset(isa, avx10_2);
     }
 
-    Address i_addr(int i_off) {
+    Address i_addr(dim_t i_off) {
         return ptr[reg_ptr_in_ + reg_off_in_ + i_off * itype_sz_];
     }
 
-    Address o_addr(int o_off, bool with_type_multiplier = true) {
+    Address o_addr(dim_t o_off, bool with_type_multiplier = true) {
         if (with_type_multiplier)
             return ptr[reg_ptr_out_ + reg_off_out_ + o_off * otype_sz_];
         else
             return ptr[reg_ptr_out_ + reg_off_out_ + o_off];
     }
 
-    Address src_s_addr(int s_off) {
+    Address src_s_addr(dim_t s_off) {
         return ptr[reg_ptr_src_scales_ + reg_off_scale_ + s_off * stype_sz_];
     }
 
-    Address dst_s_addr(int s_off) {
+    Address dst_s_addr(dim_t s_off) {
         return ptr[reg_ptr_dst_scales_ + reg_off_scale_ + s_off * stype_sz_];
     }
 
-    Address c_addr(int c_off) {
+    Address c_addr(dim_t c_off) {
         return ptr[reg_ptr_comp_ + reg_off_comp_ + c_off * sizeof(int32_t)];
     }
 
@@ -240,9 +240,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 + sizeof(int64_t) * (node_id)];
     }
 
-    void step(int off, int prev_i_off, int prev_o_off, int prev_s_off,
-            int prev_c_off, int &i_off, int &o_off, int &s_off, int &c_off,
-            int step_size = 1) {
+    void step(dim_t off, dim_t prev_i_off, dim_t prev_o_off, dim_t prev_s_off,
+            dim_t prev_c_off, dim_t &i_off, dim_t &o_off, dim_t &s_off,
+            dim_t &c_off, dim_t step_size = 1) {
         i_off = prev_i_off;
         o_off = prev_o_off;
         s_off = prev_s_off;
@@ -250,7 +250,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
 
         if (off == 0) return;
 
-        int start_dim = 0, dims_prod = 1;
+        int start_dim = 0;
+        dim_t dims_prod = 1;
         for (; start_dim < prb_.ndims && dims_prod != step_size; ++start_dim)
             dims_prod *= prb_.n(start_dim);
         assert(start_dim < prb_.ndims);
@@ -275,14 +276,14 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         }
     }
 
-    void step(int off, int prev_i_off, int prev_o_off, int &i_off, int &o_off,
-            int step_size = 1) {
-        int dummy = 0;
+    void step(dim_t off, dim_t prev_i_off, dim_t prev_o_off, dim_t &i_off,
+            dim_t &o_off, dim_t step_size = 1) {
+        dim_t dummy = 0;
         step(off, prev_i_off, prev_o_off, dummy, dummy, i_off, o_off, dummy,
                 dummy, step_size);
     }
 
-    void tr8x8_avx2(int i_off, int o_off) {
+    void tr8x8_avx2(dim_t i_off, dim_t o_off) {
         using namespace data_type;
 
         const auto cvt2ps
@@ -509,7 +510,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 = (utils::one_of(prb_.otype, u8, s8, s32) && interim_f32);
 
         for (int i = 0; i < unroll; i++) {
-            const int node_0_input_stride = prb_.is(0);
+            const ptrdiff_t node_0_input_stride = prb_.is(0);
             load(Ymm(i), i_addr(i_off + i * node_0_input_stride),
                     unroll * itype_sz_);
 
@@ -548,7 +549,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         }
 
         for (int i = 0; i < unroll; i++) {
-            const int node_1_output_stride = prb_.os(1);
+            const ptrdiff_t node_1_output_stride = prb_.os(1);
             if (prb_.otype != f32)
                 cvt2odt(Ymm(i), prb_.otype,
                         need_saturation       ? s32
@@ -563,7 +564,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     bool can_do_tr8x8() {
         using namespace data_type;
 
-        static constexpr size_t desirable_node_size = 8;
+        static constexpr dim_t desirable_node_size = 8;
         static constexpr ptrdiff_t desirable_stride = 1;
 
         // This process relies on swapping the two innermost dimensions.
@@ -582,12 +583,12 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 && !compensation_needed_;
     }
 
-    bool process_unroll_tr8x8(const int ndims, const int len) {
+    bool process_unroll_tr8x8(const int ndims, const dim_t len) {
         if (!can_do_tr8x8()) return false;
 
-        const int step_size = prb_.n(0) * prb_.n(1);
-        int i_off = 0, o_off = 0;
-        for (int off = 0; off < len; off += step_size) {
+        const dim_t step_size = prb_.n(0) * prb_.n(1);
+        dim_t i_off = 0, o_off = 0;
+        for (dim_t off = 0; off < len; off += step_size) {
             step(off, i_off, o_off, i_off, o_off, step_size);
             tr8x8_avx2(i_off, o_off);
         }
@@ -595,8 +596,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         return true;
     }
 
-    void process_unroll_generic_step(int reg_unroll, const int *i_off,
-            const int *o_off, const int *s_off, const int *c_off,
+    void process_unroll_generic_step(int reg_unroll, const dim_t *i_off,
+            const dim_t *o_off, const dim_t *s_off, const dim_t *c_off,
             const int *zero_padding, const bool tail_processing) {
         using namespace data_type;
 
@@ -927,14 +928,15 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             if (itype_sz_ == 4 || interim_f32) {
                 for (int ur = 0; ur < reg_unroll; ur += load_step)
                     for (int r = 1; r < load_step; ++r) {
-                        uni_vshufps(Xmm(ur + r), Xmm(ur), Xmm(ur), r);
+                        uni_vshufps(Xmm(ur + r), Xmm(ur), Xmm(ur),
+                                static_cast<uint8_t>(r));
                     }
             } else {
                 for (int ur = 0; ur < reg_unroll; ur += load_step)
                     for (int r = 1; r < load_step; ++r) {
                         if (mayiuse(avx))
                             vpalignr(Xmm(ur + r), Xmm(ur), Xmm(ur),
-                                    itype_sz_ * r);
+                                    static_cast<uint8_t>(itype_sz_ * r));
                         else {
                             movups(Xmm(ur + r), Xmm(ur));
                             palignr(Xmm(ur + r), Xmm(ur), itype_sz_ * r);
@@ -1202,7 +1204,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                     for (int r = ur; r < ur + ur_step; ++r) {
                         if (zero_padding[r] == 0 || !tail_processing) {
                             uni_vshufps(xmm_tmp_, xmm_compensation,
-                                    xmm_compensation, r);
+                                    xmm_compensation, static_cast<uint8_t>(r));
                             const Reg32 reg_tmp_32 = reg_tmp_.cvt32();
                             uni_vmovd(reg_tmp_32, xmm_tmp_);
                             const auto comp_addr = c_addr(c_off[r]);
@@ -1255,17 +1257,16 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     }
 
     void process_unroll_generic(
-            const int ndims, int len, const bool tail_processing) {
+            const int ndims, dim_t len, const bool tail_processing) {
         assert(IMPLICATION(prb_.nodes[0].tail_size > 0,
-                len == static_cast<int>(prb_.nodes[0].n)
-                        || len == static_cast<int>(prb_.nodes[0].tail_size)));
+                len == prb_.nodes[0].n || len == prb_.nodes[0].tail_size));
 
         const int blk = 8;
 
-        int i_off[2 * blk] = {0};
-        int o_off[2 * blk] = {0};
-        int s_off[2 * blk] = {0};
-        int c_off[2 * blk] = {0};
+        dim_t i_off[2 * blk] = {0};
+        dim_t o_off[2 * blk] = {0};
+        dim_t s_off[2 * blk] = {0};
+        dim_t c_off[2 * blk] = {0};
 
         int curr = 0; // will switch between 0 and 1
 
@@ -1280,8 +1281,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             if (interim_f32) uni_vcvtdq2ps(xmm_dst_zp_, xmm_dst_zp_);
         }
 
-        for (int off = 0; off < len; off += blk) {
-            const int reg_unroll = nstl::min(off + blk, len) - off;
+        for (dim_t off = 0; off < len; off += blk) {
+            const int reg_unroll
+                    = static_cast<int>(nstl::min<dim_t>(off + blk, len) - off);
             int zero_padding[blk] = {0};
             const auto curr_blk = curr * blk;
 
@@ -1289,8 +1291,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             for (int ur = off != 0 ? 0 : 1; ur < reg_unroll; ++ur) {
                 const int ur_c = curr_blk + ur;
                 const int ur_p = (ur_c - 1 + 2 * blk) % (2 * blk); // prev ur
-                const bool is_tail
-                        = off + ur >= static_cast<int>(prb_.nodes[0].tail_size);
+                const bool is_tail = off + ur >= prb_.nodes[0].tail_size;
                 step(off + ur, i_off[ur_p], o_off[ur_p], s_off[ur_p],
                         c_off[ur_p], i_off[ur_c], o_off[ur_c], s_off[ur_c],
                         c_off[ur_c]);
@@ -1305,14 +1306,14 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         }
     }
 
-    void compute_ker(
-            const int ndims, const int len_unroll, const bool tail_processing) {
+    void compute_ker(const int ndims, const dim_t len_unroll,
+            const bool tail_processing) {
         bool optimized = process_unroll_tr8x8(ndims, len_unroll);
         if (!optimized)
             process_unroll_generic(ndims, len_unroll, tail_processing);
     }
 
-    void loop_begin(Label &l, Reg64 reg_cnt, int len) {
+    void loop_begin(Label &l, Reg64 reg_cnt, dim_t len) {
         mov(reg_cnt, len);
         L(l);
     }
@@ -1331,13 +1332,12 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         cmp(reg_curr_chunk, last_chunk);
     }
 
-    void zero_dst_memory(const int bytes_to_zeroing) {
+    void zero_dst_memory(const dim_t bytes_to_zeroing) {
         static constexpr int num_of_bytes_in_xmm = 128 / 8;
 
-        const int xmms_to_zeroing
-                = std::div(bytes_to_zeroing, num_of_bytes_in_xmm).quot;
+        const dim_t xmms_to_zeroing = bytes_to_zeroing / num_of_bytes_in_xmm;
         const int tail_to_zeroing
-                = std::div(bytes_to_zeroing, num_of_bytes_in_xmm).rem;
+                = static_cast<int>(bytes_to_zeroing % num_of_bytes_in_xmm);
 
         uni_vpxor(xmm_tmp_, xmm_tmp_, xmm_tmp_);
 
@@ -1360,23 +1360,24 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             sub(reg_off_out_, num_of_bytes_in_xmm * xmms_to_zeroing);
     }
 
-    void finalize_tail_loop(int i_step, int o_step, int s_step, int c_step,
-            const int curr_node_id) {
+    void finalize_tail_loop(dim_t i_step, dim_t o_step, dim_t s_step,
+            dim_t c_step, const int curr_node_id) {
         static constexpr int empty_chunk_info = -1;
 
         mov(reg_tmp_, empty_chunk_info);
         mov(data_chunk_addr(curr_node_id), reg_tmp_);
 
-        const int padded_area = prb_.nodes[curr_node_id].n
+        const dim_t padded_area = prb_.nodes[curr_node_id].n
                 - prb_.nodes[curr_node_id].tail_size;
 
         if (prb_.nodes[curr_node_id].is_zero_pad_needed) {
-            int num_of_zero_padded_values = padded_area;
+            dim_t num_of_zero_padded_values = padded_area;
             for (int i = curr_node_id - 1; i >= 0; i--) {
                 num_of_zero_padded_values *= prb_.nodes[i].n;
             }
 
-            const int bytes_to_zeroing = num_of_zero_padded_values * otype_sz_;
+            const dim_t bytes_to_zeroing
+                    = num_of_zero_padded_values * otype_sz_;
             zero_dst_memory(bytes_to_zeroing);
         }
 
@@ -1394,17 +1395,17 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 || prb_.dst_scale_type == scale_type_t::MANY)
             add(reg_off_scale_, padded_area * s_step * stype_sz_);
         if (compensation_needed_)
-            add(reg_off_comp_, padded_area * c_step * sizeof(int32_t));
+            add(reg_off_comp_, padded_area * c_step * ctype_sz_);
     }
 
-    void loop_end(Label &l, const Reg64 reg_cnt, int len, int i_step,
-            int o_step, int s_step, int c_step, const int curr_node_id) {
+    void loop_end(Label &l, const Reg64 reg_cnt, dim_t len, dim_t i_step,
+            dim_t o_step, dim_t s_step, dim_t c_step, const int curr_node_id) {
         add(reg_off_in_, i_step * itype_sz_);
         add(reg_off_out_, o_step * otype_sz_);
         if (prb_.src_scale_type == scale_type_t::MANY
                 || prb_.dst_scale_type == scale_type_t::MANY)
             add(reg_off_scale_, s_step * stype_sz_);
-        if (compensation_needed_) add(reg_off_comp_, c_step * sizeof(int32_t));
+        if (compensation_needed_) add(reg_off_comp_, c_step * ctype_sz_);
 
         dec(reg_cnt);
         jnz(l);
@@ -1429,8 +1430,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         if (prb_.src_scale_type == scale_type_t::MANY
                 || prb_.dst_scale_type == scale_type_t::MANY)
             sub(reg_off_scale_, len * s_step * stype_sz_);
-        if (compensation_needed_)
-            sub(reg_off_comp_, len * c_step * sizeof(int32_t));
+        if (compensation_needed_) sub(reg_off_comp_, len * c_step * ctype_sz_);
     }
 
     void compute_blk_ker(const simple_impl_desc_t &desc) {
@@ -1446,7 +1446,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
                 jne(no_last_chunk, T_NEAR);
             }
 
-            const int len_unroll = desc.tail_len_unroll > 0
+            const dim_t len_unroll = desc.tail_len_unroll > 0
                     ? desc.tail_len_unroll
                     : desc.len_unroll;
             compute_ker(omp_ndims, len_unroll, with_tail_processing);
@@ -1464,12 +1464,12 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
 
         if (jit_loop > 0) {
             const int nfu = desc.ndims_full_unroll;
-            const int unroll_factor
+            const dim_t unroll_factor
                     = jit_loop == 1 ? desc.len_last_dim_unroll : 1;
             const int curr_node_id = nfu + (jit_loop - 1);
             const int parent_node_id = prb_.nodes[curr_node_id].parent_node_id;
-            const int tail_size = prb_.tail(curr_node_id) / unroll_factor;
-            const auto node_size = prb_.n(curr_node_id) / unroll_factor;
+            const dim_t tail_size = prb_.tail(curr_node_id) / unroll_factor;
+            const dim_t node_size = prb_.n(curr_node_id) / unroll_factor;
             const Reg64 reg_loop_cnt = reg_cnt[jit_loop - 1];
             const bool curr_node_has_tail = prb_.tail(curr_node_id) != 0;
             Label loop, if_no_tail, if_end;
@@ -1565,8 +1565,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
         , f8_e5m2_cvt_(nullptr)
         , f8_e4m3_cvt_(nullptr) {
         assert(!utils::one_of(isa_, isa_undef, isa_all));
-        itype_sz_ = data_type_size(prb_.itype);
-        otype_sz_ = data_type_size(prb_.otype);
+        itype_sz_ = static_cast<int>(data_type_size(prb_.itype));
+        otype_sz_ = static_cast<int>(data_type_size(prb_.otype));
         stype_sz_ = sizeof(float);
         if (prb_.otype == data_type::bf16 && !mayiuse(avx512_core_bf16)
                 && !mayiuse(avx2_vnni_2)) {
@@ -1655,7 +1655,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
             je(reorder_kernel, T_NEAR);
             // If zeroing data is set then all dst memory
             // will be zeroed and nothing more will be done.
-            int bytes_to_zeroing = otype_sz_;
+            dim_t bytes_to_zeroing = otype_sz_;
             for (int i = 0; i < prb_.ndims; i++) {
                 bytes_to_zeroing *= prb_.nodes[i].n;
             }
@@ -1708,6 +1708,7 @@ private:
     int itype_sz_;
     int otype_sz_;
     int stype_sz_;
+    static constexpr int ctype_sz_ = sizeof(int32_t);
 
     const cpu_isa_t isa_;
 
@@ -1822,15 +1823,15 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
     jit_single_blk_kernel_t(const tr::prb_t &prb)
         : jit_generator_t(jit_name())
         , prb_(prb)
-        , itype_sz_(data_type_size(prb_.itype))
-        , otype_sz_(data_type_size(prb_.otype))
-        , block_sz(prb.nodes[0].n) {}
+        , itype_sz_(static_cast<int>(data_type_size(prb_.itype)))
+        , otype_sz_(static_cast<int>(data_type_size(prb_.otype)))
+        , block_sz(static_cast<int>(prb.nodes[0].n)) {}
 
     void generate() override {
-        auto input_stride
-                = prb_.nodes[0].is != 1 ? prb_.nodes[0].is : prb_.nodes[1].is;
-        auto output_stride
-                = prb_.nodes[0].os != 1 ? prb_.nodes[0].os : prb_.nodes[1].os;
+        const int input_stride = static_cast<int>(
+                prb_.nodes[0].is != 1 ? prb_.nodes[0].is : prb_.nodes[1].is);
+        const int output_stride = static_cast<int>(
+                prb_.nodes[0].os != 1 ? prb_.nodes[0].os : prb_.nodes[1].os);
 
         Label tail_processing;
 
@@ -1950,7 +1951,7 @@ struct jit_single_blk_kernel_t : public jit_generator_t {
         vxorps(ymm_tmp, ymm_tmp, ymm_tmp);
         vpcmpeqd(ymm_mask, ymm_mask, ymm_mask);
         // shift by mask to have tail nelems in ymm_mask
-        const uint8_t in_mask = 0xFF << mask;
+        const uint8_t in_mask = static_cast<uint8_t>(0xFF << mask);
         vpblendd(ymm_mask, ymm_mask, ymm_tmp, in_mask);
     }
 
@@ -2202,7 +2203,8 @@ static void prb_block_for_cache(tr::prb_t &prb) {
                     [](const tr::node_t &lhs, const tr::node_t &rhs) {
                 return lhs.n < rhs.n;
             });
-            const auto min_idx = std::distance(dim_beg_it, min_n_node_it);
+            const int min_idx = static_cast<int>(
+                    std::distance(dim_beg_it, min_n_node_it));
             // check if min_idx node is parent of node with tail processing which
             // is currently unsupported (i.e. tail processing can only be handled
             // at the inner-most dimension)
@@ -2271,8 +2273,8 @@ static void prb_thread_kernel_balance(
          *  In the worst case the minimal size_want_borrow is equal
          *  to the innermost driver dimension itself. In that case
          *  we will sacrifice it in favor of kernel (is it fine?). */
-        size_t size_want_borrow
-                = utils::div_up(tr::ker_prb_size_min, size_ker_cur);
+        dim_t size_want_borrow
+                = utils::div_up<dim_t>(tr::ker_prb_size_min, size_ker_cur);
         for (; prb.nodes[kdims].n % size_want_borrow; ++size_want_borrow)
             ;
 
@@ -2296,7 +2298,8 @@ static void prb_thread_kernel_balance(
             want_borrow_ker_from_drv, want_borrow_drv_from_ker);
 
     if (want_borrow_drv_from_ker) {
-        size_t size_want_borrow = utils::div_up(size_drv_min, size_drv_cur);
+        dim_t size_want_borrow
+                = utils::div_up<dim_t>(size_drv_min, size_drv_cur);
         for (; prb.nodes[kdims - 1].n % size_want_borrow; ++size_want_borrow)
             ;
 
@@ -2448,7 +2451,7 @@ void jit_uni_reorder_t::omp_driver_1d(int ithr, int nthr, int off,
         int32_t *compensation_scratch) const {
     const tr::prb_t &prb = pd()->prb_;
     const tr::node_t *ns = prb.nodes + off;
-    for_nd(ithr, nthr, (ptrdiff_t)ns[0].n, [&](ptrdiff_t d0) {
+    for_nd(ithr, nthr, ns[0].n, [&](dim_t d0) {
         tr::call_param_t base_params;
         base_params.in = in + d0 * ns[0].is * data_type_size(prb.itype);
         base_params.out = out + d0 * ns[0].os * data_type_size(prb.otype);
@@ -2467,7 +2470,7 @@ void jit_uni_reorder_t::omp_driver_1d(int ithr, int nthr, int off,
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 1;
-            const ptrdiff_t omp_data_chunks[omp_ndims] = {d0};
+            const dim_t omp_data_chunks[omp_ndims] = {d0};
             fill_curr_data_chunks(
                     prb, off, omp_data_chunks, omp_ndims, tail_params);
 
@@ -2484,8 +2487,7 @@ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
         int32_t *compensation_scratch) const {
     const tr::prb_t &prb = pd()->prb_;
     const tr::node_t *ns = prb.nodes + off;
-    for_nd(ithr, nthr, (ptrdiff_t)ns[1].n, (ptrdiff_t)ns[0].n,
-            [&](ptrdiff_t d1, ptrdiff_t d0) {
+    for_nd(ithr, nthr, ns[1].n, ns[0].n, [&](dim_t d1, dim_t d0) {
         tr::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is) * data_type_size(prb.itype);
@@ -2507,7 +2509,7 @@ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 2;
-            const ptrdiff_t omp_data_chunks[omp_ndims] = {d0, d1};
+            const dim_t omp_data_chunks[omp_ndims] = {d0, d1};
             fill_curr_data_chunks(
                     prb, off, omp_data_chunks, omp_ndims, tail_params);
 
@@ -2524,8 +2526,8 @@ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
         int32_t *compensation_scratch) const {
     const tr::prb_t &prb = pd()->prb_;
     const tr::node_t *ns = prb.nodes + off;
-    for_nd(ithr, nthr, (ptrdiff_t)ns[2].n, (ptrdiff_t)ns[1].n,
-            (ptrdiff_t)ns[0].n, [&](ptrdiff_t d2, ptrdiff_t d1, ptrdiff_t d0) {
+    for_nd(ithr, nthr, ns[2].n, ns[1].n, ns[0].n,
+            [&](dim_t d2, dim_t d1, dim_t d0) {
         tr::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is + d2 * ns[2].is)
@@ -2549,7 +2551,7 @@ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 3;
-            const ptrdiff_t omp_data_chunks[omp_ndims] = {d0, d1, d2};
+            const dim_t omp_data_chunks[omp_ndims] = {d0, d1, d2};
             fill_curr_data_chunks(
                     prb, off, omp_data_chunks, omp_ndims, tail_params);
 
@@ -2566,9 +2568,8 @@ void jit_uni_reorder_t::omp_driver_4d(int ithr, int nthr, int off,
         int32_t *compensation_scratch) const {
     const tr::prb_t &prb = pd()->prb_;
     const tr::node_t *ns = prb.nodes + off;
-    for_nd(ithr, nthr, (ptrdiff_t)ns[3].n, (ptrdiff_t)ns[2].n,
-            (ptrdiff_t)ns[1].n, (ptrdiff_t)ns[0].n,
-            [&](ptrdiff_t d3, ptrdiff_t d2, ptrdiff_t d1, ptrdiff_t d0) {
+    for_nd(ithr, nthr, ns[3].n, ns[2].n, ns[1].n, ns[0].n,
+            [&](dim_t d3, dim_t d2, dim_t d1, dim_t d0) {
         tr::call_param_t base_params;
         base_params.in = in
                 + (d0 * ns[0].is + d1 * ns[1].is + d2 * ns[2].is
@@ -2596,7 +2597,7 @@ void jit_uni_reorder_t::omp_driver_4d(int ithr, int nthr, int off,
             tail_params.base_params = base_params;
 
             static constexpr int omp_ndims = 4;
-            const ptrdiff_t omp_data_chunks[omp_ndims] = {d0, d1, d2, d3};
+            const dim_t omp_data_chunks[omp_ndims] = {d0, d1, d2, d3};
             fill_curr_data_chunks(
                     prb, off, omp_data_chunks, omp_ndims, tail_params);
 
@@ -2646,7 +2647,7 @@ void jit_uni_reorder_t::reduce_compensation(char *out,
 }
 
 void jit_uni_reorder_t::fill_curr_data_chunks(const tr::prb_t &prb,
-        const int off, const ptrdiff_t *omp_data_chunks, const int omp_ndims,
+        const int off, const dim_t *omp_data_chunks, const int omp_ndims,
         tr::tail_call_param_t &c) const {
     // Chunks are backwards numered i.e:
     // [0] -> [node_size]
@@ -2852,8 +2853,8 @@ status_t jit_blk_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
 }
 
 void jit_blk_reorder_t::pd_t::prb_tile_normalize(tr::prb_t &p) {
-    if (!utils::one_of(p.nodes[0].n, 8ul, 16ul)
-            && utils::one_of(p.nodes[1].n, 8ul, 16ul)) {
+    if (!utils::one_of(p.nodes[0].n, 8, 16)
+            && utils::one_of(p.nodes[1].n, 8, 16)) {
         nstl::swap(p.nodes[0], p.nodes[1]);
     }
 }
@@ -2872,7 +2873,7 @@ status_t jit_blk_reorder_t::execute(const exec_ctx_t &ctx) const {
 
     // kernel handle 2-dimension tiles, a tail is possible
     auto &prb = this->pd()->prb_;
-    ptrdiff_t BH = 1;
+    dim_t BH = 1;
     for (int i = 2; i < prb.ndims; ++i) {
         BH *= prb.nodes[i].n;
     }

--- a/src/cpu/x64/jit_uni_reorder.hpp
+++ b/src/cpu/x64/jit_uni_reorder.hpp
@@ -36,8 +36,8 @@ constexpr int max_ndims = DNNL_MAX_NDIMS;
 struct node_t {
     static constexpr int64_t empty_field = -1;
 
-    size_t n = 0;
-    size_t tail_size = 0;
+    dim_t n = 0;
+    dim_t tail_size = 0;
     int dim_id = empty_field;
     int parent_node_id = empty_field;
     bool is_zero_pad_needed = false;
@@ -77,12 +77,12 @@ struct prb_t {
         return false;
     }
 
-    size_t tail(int d) const {
+    dim_t tail(int d) const {
         assert(d < ndims);
         return nodes[d].tail_size;
     }
 
-    size_t n(int d) const {
+    dim_t n(int d) const {
         assert(d < ndims);
         return nodes[d].n;
     }
@@ -137,7 +137,7 @@ void prb_simplify(prb_t &p);
 
 /** splits the node dim into two of sizes n1 and n / n1
  * @warning n must be multiple of n1 */
-void prb_node_split(prb_t &p, int dim, size_t n1);
+void prb_node_split(prb_t &p, int dim, dim_t n1);
 
 /** swaps d0 and d1 nodes */
 void prb_node_swap(prb_t &p, int d0, int d1);
@@ -259,7 +259,7 @@ private:
             int dst_zp, int32_t *compensation_scratch) const;
 
     void fill_curr_data_chunks(const tr::prb_t &prb, const int off,
-            const ptrdiff_t *omp_data_chunks, const int omp_ndims,
+            const dim_t *omp_data_chunks, const int omp_ndims,
             tr::tail_call_param_t &c) const;
 
     void reduce_compensation(char *out,

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.cpp
@@ -70,7 +70,7 @@ struct direct_copy_kernel_t
     int get_max_unroll() const override { return unroll_12_; }
 
     void operator()(
-            const void *src, void *dst, size_t work_amount) const override {
+            const void *src, void *dst, dim_t work_amount) const override {
         ker_args_t args;
         args.src = src;
         args.dst = dst;
@@ -82,9 +82,9 @@ struct direct_copy_kernel_t
         return jit_generator_t::create_kernel();
     }
 
-    Address src_ptr(size_t offt = 0) { return ptr[reg_src + offt]; }
+    Address src_ptr(int offt = 0) { return ptr[reg_src + offt]; }
 
-    Address dst_ptr(size_t offt = 0) { return ptr[reg_dst + offt]; }
+    Address dst_ptr(int offt = 0) { return ptr[reg_dst + offt]; }
 
     Vmm vmm_src(int idx) const {
         // Incorporate `+ 1` here as `0th` index is used for tail on AVX2.
@@ -92,47 +92,45 @@ struct direct_copy_kernel_t
     }
 
     void copy(const int unroll, const bool tail) {
+        const int src_dt_size
+                = static_cast<int>(types::data_type_size(src_dt_));
+        const int dst_dt_size
+                = static_cast<int>(types::data_type_size(dst_dt_));
+
         // Copy two simdw at once in vectorized loop first when `ne_convert`
         // instructions are available for xf16.
         if (isa_ == avx2_vnni_2
                 && (utils::one_of(src_dt_, data_type::bf16, data_type::f16))
                 && (unroll % 2 == 0)) {
-            for (size_t i = 0; i < static_cast<size_t>(unroll) / 2; i++) {
+            for (int i = 0; i < unroll / 2; i++) {
                 const Vmm &vmm_src_even = vmm_src(2 * i);
                 const Vmm &vmm_src_odd = vmm_src(2 * i + 1);
                 Vmm vmm_tmp(vmm_tmp_idx_);
                 io_[src_dt_]->load_two_simdw_xf16(
-                        src_ptr(2 * i * types::data_type_size(src_dt_)
-                                * simd_w_),
-                        vmm_src_even, vmm_src_odd);
+                        src_ptr(2 * i * src_dt_size * simd_w_), vmm_src_even,
+                        vmm_src_odd);
                 io_[src_dt_]->merge_interleaved_to_plain(
                         vmm_src_even, vmm_src_odd, vmm_tmp);
                 io_[dst_dt_]->store(vmm_src_even,
-                        dst_ptr(2 * i * types::data_type_size(dst_dt_)
-                                * simd_w_),
-                        tail);
+                        dst_ptr(2 * i * dst_dt_size * simd_w_), tail);
                 io_[dst_dt_]->store(vmm_src_odd,
-                        dst_ptr((2 * i + 1) * types::data_type_size(dst_dt_)
-                                * simd_w_),
-                        tail);
+                        dst_ptr((2 * i + 1) * dst_dt_size * simd_w_), tail);
             }
         } else {
             for (int i = 0; i < unroll; i++) {
                 io_[src_dt_]->load(
-                        src_ptr(i * types::data_type_size(src_dt_) * simd_w_),
-                        vmm_src(i), tail);
+                        src_ptr(i * src_dt_size * simd_w_), vmm_src(i), tail);
             }
             for (int i = 0; i < unroll; i++) {
-                io_[dst_dt_]->store(vmm_src(i),
-                        dst_ptr(i * types::data_type_size(dst_dt_) * simd_w_),
-                        tail);
+                io_[dst_dt_]->store(
+                        vmm_src(i), dst_ptr(i * dst_dt_size * simd_w_), tail);
             }
         }
 
         if (tail) return;
 
-        add(reg_src, unroll * types::data_type_size(src_dt_) * simd_w_);
-        add(reg_dst, unroll * types::data_type_size(dst_dt_) * simd_w_);
+        add(reg_src, unroll * src_dt_size * simd_w_);
+        add(reg_dst, unroll * dst_dt_size * simd_w_);
         sub(reg_work_amount, unroll * simd_w_);
     }
 
@@ -201,7 +199,7 @@ private:
     struct ker_args_t {
         const void *src;
         void *dst;
-        size_t work_amount;
+        dim_t work_amount;
     };
 
     bool is_bf16() const {

--- a/src/cpu/x64/jit_uni_reorder_direct_copy.hpp
+++ b/src/cpu/x64/jit_uni_reorder_direct_copy.hpp
@@ -55,7 +55,7 @@ struct jit_uni_reorder_direct_copy_t : public primitive_t {
 
     struct kernel_base_t {
         virtual void operator()(
-                const void *src, void *dst, size_t work_amount) const
+                const void *src, void *dst, dim_t work_amount) const
                 = 0;
         static kernel_base_t *create(const reorder_pd_t *pd, cpu_isa_t isa);
         virtual status_t create_kernel() = 0;

--- a/src/cpu/x64/jit_uni_reorder_utils.cpp
+++ b/src/cpu/x64/jit_uni_reorder_utils.cpp
@@ -59,7 +59,7 @@ struct layout_desc_t {
         , strides {0} {}
     data_type_t dt;
     int ndims;
-    dims_t id;
+    int id[DNNL_MAX_NDIMS];
     dims_t dims;
     dims_t tails;
     bool is_blk[DNNL_MAX_NDIMS];
@@ -161,11 +161,11 @@ static void prb_set_compensation_strides(prb_t &p) {
         const int parent = get_next_parent_node(p.nodes, p.ndims, cur_node);
         if (parent < 0) return false;
 
-        const size_t p_n = p.nodes[parent].n;
+        const dim_t p_n = p.nodes[parent].n;
 
         // if 'parent_node.n' is larger than 1, then cur_node stride
         // is 'cur_node.n'
-        return p_n > size_t(1);
+        return p_n > 1;
     };
 
     const auto compensation_needed = p.req_s8s8_comp || p.req_asymmetric_comp;
@@ -389,11 +389,11 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
 
             dim_t factor = old.dims[o_pos] / ild.dims[i_pos];
 
-            const size_t tail_of_upper_dim
+            const dim_t tail_of_upper_dim
                     = utils::div_up(old.tails[o_pos], factor) == ild.dims[i_pos]
                     ? 0
                     : utils::div_up(old.tails[o_pos], factor);
-            const size_t tail_of_lower_dim = old.tails[o_pos] % factor;
+            const dim_t tail_of_lower_dim = old.tails[o_pos] % factor;
 
             p.nodes[ndims].n = ild.dims[i_pos];
             p.nodes[ndims].dim_id = old.id[o_pos];
@@ -514,15 +514,11 @@ void prb_simplify(prb_t &p) {
                 = skip_dim_combining(d) || skip_dim_combining(d + 1);
         if (skip_dims_combining) continue;
 
-        const bool trivial_fold = next_node.n == static_cast<size_t>(1);
-        const bool real_fold = next_node.is
-                        == static_cast<ptrdiff_t>(this_node.n * this_node.is)
-                && next_node.os
-                        == static_cast<ptrdiff_t>(this_node.n * this_node.os)
-                && next_node.ss
-                        == static_cast<ptrdiff_t>(this_node.n * this_node.ss)
-                && next_node.cs
-                        == static_cast<ptrdiff_t>(this_node.n * this_node.cs);
+        const bool trivial_fold = next_node.n == 1;
+        const bool real_fold = next_node.is == this_node.n * this_node.is
+                && next_node.os == this_node.n * this_node.os
+                && next_node.ss == this_node.n * this_node.ss
+                && next_node.cs == this_node.n * this_node.cs;
         if (trivial_fold || real_fold) {
             this_node.n *= next_node.n;
             this_node.dim_id = node_t::empty_field;
@@ -540,7 +536,7 @@ void prb_simplify(prb_t &p) {
 #endif
 }
 
-void prb_node_split(prb_t &p, int dim, size_t new_node_size) {
+void prb_node_split(prb_t &p, int dim, dim_t new_node_size) {
     assert(dim < p.ndims);
     assert(p.ndims < max_ndims);
     assert(p.nodes[dim].n % new_node_size == 0);
@@ -551,18 +547,18 @@ void prb_node_split(prb_t &p, int dim, size_t new_node_size) {
     for (int d = p.ndims; d > dim + 1; --d)
         p.nodes[d] = p.nodes[d - 1];
 
-    const size_t upper_node_size = p.nodes[dim].n / new_node_size;
-    const size_t lower_node_size = new_node_size;
+    const dim_t upper_node_size = p.nodes[dim].n / new_node_size;
+    const dim_t lower_node_size = new_node_size;
     p.nodes[dim + 1].n = upper_node_size;
     p.nodes[dim].n = lower_node_size;
 
     const bool is_tail = p.nodes[dim].tail_size > 0;
-    const size_t upper_node_tail
+    const dim_t upper_node_tail
             = utils::div_up(p.nodes[dim].tail_size, lower_node_size)
                     == upper_node_size
             ? 0
             : utils::div_up(p.nodes[dim].tail_size, lower_node_size);
-    const size_t lower_node_tail = p.nodes[dim].tail_size % lower_node_size;
+    const dim_t lower_node_tail = p.nodes[dim].tail_size % lower_node_size;
     p.nodes[dim].tail_size = is_tail ? lower_node_tail : 0;
     p.nodes[dim + 1].tail_size = is_tail ? upper_node_tail : 0;
 


### PR DESCRIPTION
It's a reordering (PR Nr.10) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
C4244 warnings eliminated: 55.
Tried to replicate all code suggestions in previous PR to meet the minimal changes eliminating C4244.