### PR TITLE
[GPU][GEMM] apply modifyStrategy to env gemm kernels

### DIFF
--- a/src/gpu/intel/gemm/jit/gen_kernel.cpp
+++ b/src/gpu/intel/gemm/jit/gen_kernel.cpp
@@ -189,10 +189,10 @@ status_t gen_desc_t::finalize(const char *tags) {
         strategy_.unroll[LoopM] = entry_->driverInfo.unroll[LoopM];
         strategy_.unroll[LoopN] = entry_->driverInfo.unroll[LoopN];
         parseStrategy(entry_->strategy, hw_, problem_, strategy_);
-        modifyStrategy(strategy_, aux_params_);
 #ifdef DNNL_DEV_MODE
     }
 #endif
+    modifyStrategy(strategy_, aux_params_);
     strategy_.panelCheck
             |= (isPacked(problem_.A.layout) || isPacked(problem_.B.layout));
 


### PR DESCRIPTION
# Description

This call was skipped for strategies specified in env, this caused different behavior than when the same strategy was selected from the db, and crashed: 

```
 --> GEMM_KERNEL="gemm QQ[SQ] N@8N@8N 32 16 1 0 av32+m32@48 am32+S32@64 aB wg 4x8 xaf st vav hi pt sb32 bk0 sn grf256 sys sr br kv afb rr pab"  DNNL_JIT_DUMP=1 ./tests/benchdnn/benchdnn --engine=gpu --allow-enum-tags-only=false --matmul --impl=jit:gemm:any --dt=f8_e5m2:f8_e5m2:f8_e5m2 --stag=abx --wtag=abx --dtag=abx --attr-scales=dst:mx:e8m0:1x32 --impl=jit:gemm:any 32x32:32x32
benchdnn: /nfs/site/proj/mkl/hal9000/kealanba/dnn-ws/dnn-master/src/gpu/intel/jit/eltwise_injector.cpp:326: void dnnl::impl::gpu::intel::jit::eltwise_injector_f32_t<ngen_generator_t>::mx_scale_compute_fwd(int, const ngen::GRF&, int, const ngen::Subregister&, int, ngen::DataType, int) [with ngen_generator_t = ngen::BinaryCodeGenerator<ngen::Core::XeHPC>]: Assertion `utils::one_of(dst_dt, ngen::DataType::bf8, ngen::DataType::hf8, static_cast<ngen::DataType>(0x5A))' failed.
Aborted (core dumped)
```

The same testcase executed on XeHPC will succesfully run the same strategy.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?