### PR TITLE
graph: fix a few issues under async threadpool runtime

### DIFF
--- a/src/common/stream_impl.hpp
+++ b/src/common/stream_impl.hpp
@@ -32,7 +32,9 @@ public:
         : use_verbose_profiler_(false), flags_(flags) {}
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     stream_impl_t(threadpool_interop::threadpool_iface *threadpool)
-        : flags_(stream_flags::in_order), threadpool_(threadpool) {}
+        : use_verbose_profiler_(false)
+        , flags_(stream_flags::in_order)
+        , threadpool_(threadpool) {}
 #endif
 
     virtual ~stream_impl_t() = default;

--- a/src/graph/backend/dnnl/executables/gen_index.cpp
+++ b/src/graph/backend/dnnl/executables/gen_index.cpp
@@ -89,10 +89,19 @@ void genindex_executable_t::execute(const stream &stream,
         const std::unordered_map<int, memory> &args) const {
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
-        stream.get()->wait();
+        bool block_on_wait = true;
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+        dnnl::threadpool_interop::threadpool_iface *tp = nullptr;
+        auto st = stream.get()->get_threadpool(&tp);
+        block_on_wait = st == dnnl::impl::status::success && tp
+                && !(tp->get_flags()
+                        & dnnl::threadpool_interop::threadpool_iface::
+                                ASYNCHRONOUS);
+#endif
+        if (block_on_wait) stream.get()->wait();
         double start_ms = dnnl::impl::get_msec();
         execute_impl(stream, args);
-        stream.get()->wait();
+        if (block_on_wait) stream.get()->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
         VPROF(start_ms, graph, exec, VERBOSE_profile, info_.c_str(),
                 duration_ms);

--- a/src/graph/backend/dnnl/executables/host_scalar.cpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.cpp
@@ -37,10 +37,24 @@ void host_scalar_executable_t::execute_impl(const stream &stream,
     const memory &src_mem = it_src->second;
     const memory &dst_mem = it_dst->second;
 
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    // Chain through TP so async execution order is preserved.
+    // Capture by value since the lambda may outlive this scope.
+    stream.get()->before_exec_hook();
+    dnnl::impl::parallel(1, [src_mem, dst_mem](int, int) {
+        DNNL_HOST_SCALAR_TYPE_SWITCH(
+                src_mem.get_desc().get_data_type(), DType, {
+                    const DType val = src_mem.get_host_scalar_value<DType>();
+                    std::memcpy(dst_mem.get_data_handle(), &val, sizeof(DType));
+                });
+    });
+    stream.get()->after_exec_hook();
+#else
     DNNL_HOST_SCALAR_TYPE_SWITCH(src_mem.get_desc().get_data_type(), DType, {
         const DType val = src_mem.get_host_scalar_value<DType>();
         std::memcpy(dst_mem.get_data_handle(), &val, sizeof(DType));
     });
+#endif
 }
 
 void host_scalar_executable_t::execute(const stream &stream,

--- a/src/graph/backend/dnnl/executables/host_scalar.cpp
+++ b/src/graph/backend/dnnl/executables/host_scalar.cpp
@@ -16,6 +16,7 @@
 
 #include "graph/backend/dnnl/executables/host_scalar.hpp"
 
+#include "common/dnnl_thread.hpp"
 #include "common/stream.hpp"
 
 namespace dnnl {
@@ -35,6 +36,7 @@ void host_scalar_executable_t::execute_impl(const stream &stream,
 
     const memory &src_mem = it_src->second;
     const memory &dst_mem = it_dst->second;
+
     DNNL_HOST_SCALAR_TYPE_SWITCH(src_mem.get_desc().get_data_type(), DType, {
         const DType val = src_mem.get_host_scalar_value<DType>();
         std::memcpy(dst_mem.get_data_handle(), &val, sizeof(DType));
@@ -45,10 +47,19 @@ void host_scalar_executable_t::execute(const stream &stream,
         const std::unordered_map<int, memory> &args) const {
     if (get_verbose(dnnl::impl::verbose_t::exec_profile,
                 dnnl::impl::component_t::graph)) {
-        stream.get()->wait();
+        bool block_on_wait = true;
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+        dnnl::threadpool_interop::threadpool_iface *tp = nullptr;
+        auto st = stream.get()->get_threadpool(&tp);
+        block_on_wait = st == dnnl::impl::status::success && tp
+                && !(tp->get_flags()
+                        & dnnl::threadpool_interop::threadpool_iface::
+                                ASYNCHRONOUS);
+#endif
+        if (block_on_wait) stream.get()->wait();
         double start_ms = dnnl::impl::get_msec();
         execute_impl(stream, args);
-        stream.get()->wait();
+        if (block_on_wait) stream.get()->wait();
         double duration_ms = dnnl::impl::get_msec() - start_ms;
         VPROF(start_ms, graph, exec, VERBOSE_profile, info_.c_str(),
                 duration_ms);


### PR DESCRIPTION
1. Fix an uninitialized variable in `stream_impl_t`. Async verbose profiler is not supported at this moment. I noticed segfault or hang when turning on verbose print under async threadpool runtime which seems relate to this.
2. Make `host_scalar` and `gen_index` to not wait when verbose is enabled under async threadpool runtime. The approached is adopted from https://github.com/uxlfoundation/oneDNN/blob/main/src/graph/interface/partition.cpp#L333 .
3. Submit `host_scalar`'s memcpy task to the threadpool to make it async.