### PR TITLE
x64: cvt: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp8cvt.cpp
@@ -37,9 +37,9 @@ void fp8_conversion_e5m2_t::prepare_table() {
     host_->align(64);
     host_->L(label_vnni_permute_index_table_);
     // Data for f16
-    for (size_t i = 0; i < 64; ++i) {
+    for (int i = 0; i < 64; ++i) {
         // 2, 0, 3, 1, ...
-        size_t index = i;
+        int index = i;
         switch (i % 4) {
             case 0: index = i + 2; break;
             case 1: index = i - 1; break;
@@ -49,12 +49,12 @@ void fp8_conversion_e5m2_t::prepare_table() {
         host_->db(index);
     }
     // Data for bf16
-    for (size_t i = 0; i < 32; ++i) {
-        size_t index = 4 * (i / 2) + (i % 2);
+    for (int i = 0; i < 32; ++i) {
+        int index = 4 * (i / 2) + (i % 2);
         host_->db(index);
     }
-    for (size_t i = 32; i < 64; ++i) {
-        size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
+    for (int i = 32; i < 64; ++i) {
+        int index = 4 * ((i - 32) / 2) + (i % 2) + 2;
         host_->db(index);
     }
 
@@ -85,12 +85,12 @@ void fp8_conversion_e5m2_t::prepare_table() {
 void fp8_conversion_e4m3_t::prepare_table() {
     host_->align(64);
     host_->L(label_vnni_permute_index_table_);
-    for (size_t i = 0; i < 32; ++i) {
-        size_t index = 4 * (i / 2) + (i % 2);
+    for (int i = 0; i < 32; ++i) {
+        int index = 4 * (i / 2) + (i % 2);
         host_->db(index);
     }
-    for (size_t i = 32; i < 64; ++i) {
-        size_t index = 4 * ((i - 32) / 2) + (i % 2) + 2;
+    for (int i = 32; i < 64; ++i) {
+        int index = 4 * ((i - 32) / 2) + (i % 2) + 2;
         host_->db(index);
     }
 

--- a/src/cpu/x64/jit_uni_convert_xf16.cpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.cpp
@@ -72,29 +72,31 @@ void jit_uni_cvt_ps_to_xf16_t<isa>::generate() {
 
         L(l_simd_notail);
     } else {
-        const size_t blocked_size = (nelems_ / simd_w_) * simd_w_;
-        constexpr size_t unroll_length = 1024;
-        const size_t number_of_loops = blocked_size / unroll_length;
-        const size_t loop_tail = blocked_size % unroll_length;
+        const dim_t blocked_size = (nelems_ / simd_w_) * simd_w_;
+        constexpr int unroll_length = 1024;
+        constexpr int src_dt_size = sizeof(float);
+        constexpr int dst_dt_size = sizeof(float16_t);
+        const dim_t number_of_loops = blocked_size / unroll_length;
+        const int loop_tail = static_cast<int>(blocked_size % unroll_length);
 
         if (number_of_loops > 0) {
             Xbyak::Label l_number_of_loops;
             mov(reg_nelems, number_of_loops);
             L(l_number_of_loops);
-            for (size_t i = 0; i < unroll_length; i += simd_w_)
+            for (int i = 0; i < unroll_length; i += simd_w_)
                 cvt_ps_to_xf16(i, false);
-            add(reg_input, sizeof(float) * unroll_length);
-            add(reg_output, sizeof(float16_t) * unroll_length);
+            add(reg_input, src_dt_size * unroll_length);
+            add(reg_output, dst_dt_size * unroll_length);
 
             dec(reg_nelems);
             cmp(reg_nelems, 0);
             jg(l_number_of_loops, T_NEAR);
         }
         if (loop_tail > 0) {
-            for (size_t i = 0; i < loop_tail; i += simd_w_)
+            for (int i = 0; i < loop_tail; i += simd_w_)
                 cvt_ps_to_xf16(i, false);
-            add(reg_input, sizeof(float) * loop_tail);
-            add(reg_output, sizeof(float16_t) * loop_tail);
+            add(reg_input, src_dt_size * loop_tail);
+            add(reg_output, dst_dt_size * loop_tail);
         }
         if (tail_size_ != 0) {
             setup_mask();

--- a/src/cpu/x64/jit_uni_convert_xf16.hpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.hpp
@@ -55,18 +55,18 @@ struct jit_uni_cvt_ps_to_xf16_t : public jit_generator_t {
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_cvt_ps_to_xf16_t)
 
-    jit_uni_cvt_ps_to_xf16_t(impl::data_type_t dt, size_t nelems = 0)
+    jit_uni_cvt_ps_to_xf16_t(impl::data_type_t dt, dim_t nelems = 0)
         : jit_generator_t(jit_name())
         , output_dt_(dt)
         , nelems_(nelems)
         , is_dynamic_size_(nelems_ == 0)
-        , tail_size_(nelems_ % simd_w_) {}
+        , tail_size_(static_cast<int>(nelems_ % simd_w_)) {}
 
     void generate() override;
 
 protected:
     const impl::data_type_t output_dt_; // bf16 or f16
-    const size_t nelems_;
+    const dim_t nelems_;
     const bool is_dynamic_size_;
     const int tail_size_;
 
@@ -104,7 +104,7 @@ protected:
 struct jit_avx512_core_cvt_ps_to_bf16_t
     : public jit_uni_cvt_ps_to_xf16_t<avx512_core> {
 
-    jit_avx512_core_cvt_ps_to_bf16_t(impl::data_type_t dt, size_t nelems = 0)
+    jit_avx512_core_cvt_ps_to_bf16_t(impl::data_type_t dt, dim_t nelems = 0)
         : jit_uni_cvt_ps_to_xf16_t<avx512_core>(dt, nelems)
         , use_bf16_emu_(!mayiuse(avx512_core_bf16))
         , bf16_emu_(use_bf16_emu_ ? utils::make_unique<bf16_emulation_t>(this,
@@ -126,7 +126,7 @@ private:
 
 struct jit_cvt_ps_to_xf16_t {
 
-    jit_cvt_ps_to_xf16_t(impl::data_type_t data_type, size_t nelems = 0)
+    jit_cvt_ps_to_xf16_t(impl::data_type_t data_type, dim_t nelems = 0)
         : nelems_(nelems) {
         if (data_type == data_type::f16 && mayiuse(avx512_core_fp16))
             kernel_ = utils::make_unique<
@@ -153,7 +153,7 @@ struct jit_cvt_ps_to_xf16_t {
 
 private:
     std::unique_ptr<jit_generator_t> kernel_;
-    const size_t nelems_;
+    const dim_t nelems_;
 };
 
 template <cpu_isa_t isa>


### PR DESCRIPTION
It's a conversion utils (PR Nr.11) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
C4244 warnings eliminated: 9.