### PR TITLE
cpu: softmax: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/ref_softmax.cpp
+++ b/src/cpu/ref_softmax.cpp
@@ -120,11 +120,11 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
         // The code below makes the compiler generate maxps instruction.
         // rather than maxss, which is generated for the 'else' code path
         auto max_wrapper = [](float a, float b) { return nstl::max(a, b); };
-        auto min_wrapper = [](int a, int b) { return nstl::min(a, b); };
+        auto min_wrapper = [](dim_t a, dim_t b) { return nstl::min(a, b); };
 
         if (channels_ < unroll_factor) {
             float max_val = -FLT_MAX;
-            for (int i = 0; i < channels_; i++) {
+            for (dim_t i = 0; i < channels_; i++) {
                 max_val = max_wrapper(max_val,
                         io::load_float_value(src_d.data_type(), src_data, i));
             }
@@ -136,8 +136,8 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
                 max_values[i]
                         = io::load_float_value(src_d.data_type(), src_data, i);
             }
-            for (int i = unroll_factor; i < channels_; i += unroll_factor) {
-                int offset = min_wrapper(i, channels_ - unroll_factor);
+            for (dim_t i = unroll_factor; i < channels_; i += unroll_factor) {
+                dim_t offset = min_wrapper(i, channels_ - unroll_factor);
                 for (int j = 0; j < unroll_factor; j++) {
                     max_values[j] = max_wrapper(max_values[j],
                             io::load_float_value(
@@ -151,14 +151,14 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
             space_max = max_val;
         }
 #else
-        for (int c = 0; c < channels_; ++c)
+        for (dim_t c = 0; c < channels_; ++c)
             space_max = nstl::max(space_max,
                     io::load_float_value(src_d.data_type(), src_data, c));
 #endif
 
         // sub + exp + sum
         int tail = channels_ % unroll_factor;
-        for (int i = 0; i < channels_ - tail; i += unroll_factor) {
+        for (dim_t i = 0; i < channels_ - tail; i += unroll_factor) {
             PRAGMA_OMP_SIMD(reduction(+ : space_denom))
             for (int j = 0; j < unroll_factor; j++) {
                 float s = io::load_float_value(
@@ -174,7 +174,7 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
                 io::store_float_value(interim_dt, d, interim_ptr, i + j);
             }
         }
-        for (int i = channels_ - tail; i < channels_; i++) {
+        for (dim_t i = channels_ - tail; i < channels_; i++) {
             float s = io::load_float_value(src_d.data_type(), src_data, i);
             float d = s - space_max;
             if (pd()->is_softmax()) {
@@ -192,7 +192,7 @@ status_t ref_softmax_fwd_t::execute_forward_dense(const exec_ctx_t &ctx) const {
         } else if (pd()->is_logsoftmax()) {
             space_denom = logf(space_denom);
         }
-        for (int c = 0; c < channels_; ++c) {
+        for (dim_t c = 0; c < channels_; ++c) {
             float d = io::load_float_value(interim_dt, interim_ptr, c);
             float val = 0;
             if (pd()->is_softmax()) {
@@ -316,16 +316,16 @@ status_t ref_softmax_fwd_t::execute_forward_generic(
         utils::array_set(space_max, -FLT_MAX, inner_size_);
         utils::array_set(space_denom, 0, inner_size_);
 
-        for (int in = 0; in < inner_size_; in++) {
+        for (dim_t in = 0; in < inner_size_; in++) {
             dim_t ou_in_offset = ou * channels_ * inner_size_ + in;
 
-            for (int c = 0; c < channels_; c++) {
+            for (dim_t c = 0; c < channels_; c++) {
                 size_t off = src_d.off_l(ou_in_offset + c * inner_size_);
                 float s = io::load_float_value(src_d.data_type(), src, off);
                 space_max[in] = nstl::max(space_max[in], s);
             }
 
-            for (int c = 0; c < channels_; c++) {
+            for (dim_t c = 0; c < channels_; c++) {
                 size_t src_off = src_d.off_l(ou_in_offset + c * inner_size_);
                 float s = io::load_float_value(src_d.data_type(), src, src_off);
                 float d = s - space_max[in];
@@ -346,7 +346,7 @@ status_t ref_softmax_fwd_t::execute_forward_generic(
                 space_denom[in] = logf(space_denom[in]);
             }
 
-            for (int c = 0; c < channels_; c++) {
+            for (dim_t c = 0; c < channels_; c++) {
                 size_t dst_off = dst_d.off_l(ou_in_offset + c * inner_size_);
                 size_t interim_off = pd()->need_intermediate_scratchpad()
                         ? thr_shift + c
@@ -472,7 +472,7 @@ status_t ref_softmax_bwd_t::execute_backward_generic(
             [= COMPAT_THIS_CAPTURE](dim_t ou, dim_t in) {
         dim_t ou_in_offset = ou * channels_ * inner_size_ + in;
         float sbr = 0;
-        for (int c = 0; c < channels_; ++c) {
+        for (dim_t c = 0; c < channels_; ++c) {
             auto diff_dst_off
                     = diff_dst_d.off_l(ou_in_offset + c * inner_size_);
             float dd = io::load_float_value(
@@ -486,7 +486,7 @@ status_t ref_softmax_bwd_t::execute_backward_generic(
             }
         }
 
-        for (int c = 0; c < channels_; ++c) {
+        for (dim_t c = 0; c < channels_; ++c) {
             auto diff_dst_off
                     = diff_dst_d.off_l(ou_in_offset + c * inner_size_);
             auto dst_off = dst_d.off_l(ou_in_offset + c * inner_size_);

--- a/src/cpu/ref_softmax.hpp
+++ b/src/cpu/ref_softmax.hpp
@@ -183,7 +183,7 @@ private:
 
     std::unique_ptr<ref_post_ops_t> ref_post_ops;
     bool use_dense_;
-    int outer_size_, channels_, inner_size_;
+    dim_t outer_size_, channels_, inner_size_;
 };
 
 struct ref_softmax_bwd_t : public primitive_t {
@@ -245,7 +245,7 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
 
     bool use_dense_;
-    int outer_size_, channels_, inner_size_;
+    dim_t outer_size_, channels_, inner_size_;
 };
 
 } // namespace cpu

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -119,17 +119,17 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     bool with_dst_scales_ = false;
     bool use_ext_aux_vmms_ = false;
 
-    size_t unroll_regs_ = 4;
+    int unroll_regs_ = 4;
 
-    size_t axis_simd_full_;
+    dim_t axis_simd_full_;
     int axis_simd_tail_;
-    size_t n_loops_;
-    size_t loop_tail_;
-    size_t process_n_elems_;
-    size_t src_next_vreg_stride_;
-    size_t interim_next_vreg_stride_;
-    size_t dst_next_vreg_stride_;
-    size_t diff_dst_next_vreg_stride_;
+    dim_t n_loops_;
+    int loop_tail_;
+    dim_t process_n_elems_;
+    dim_t src_next_vreg_stride_;
+    dim_t interim_next_vreg_stride_;
+    dim_t dst_next_vreg_stride_;
+    dim_t diff_dst_next_vreg_stride_;
 
     const int bf16_emu_zmm_1_idx_ = 23;
     const int bf16_emu_zmm_2_idx_ = 24;
@@ -160,7 +160,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
 
     void compute_predefined_variables() {
         n_loops_ = axis_simd_full_ / unroll_regs_;
-        loop_tail_ = axis_simd_full_ - n_loops_ * unroll_regs_;
+        loop_tail_
+                = static_cast<int>(axis_simd_full_ - n_loops_ * unroll_regs_);
         process_n_elems_ = compute_process_n_elems(dst_d_);
         src_next_vreg_stride_ = compute_next_vreg_stride(src_d_);
         interim_next_vreg_stride_ = simd_w_ * sizeof(float);
@@ -281,9 +282,10 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         // `pre_body` and `post_body` functions are called with the maximum
         // unroll value of a `body` function as they operate over vmms,
         // which numeration depends on that value.
-        const auto max_body_unroll = n_loops_ ? unroll_regs_
-                : loop_tail_                  ? loop_tail_
-                                              : 1;
+        // `loop_tail_` is bounded by `unroll_regs_`.
+        const int max_body_unroll = n_loops_ ? unroll_regs_
+                : loop_tail_                 ? loop_tail_
+                                             : 1;
         pre_body(max_body_unroll);
 
         L(body_unroll_loop);
@@ -640,9 +642,9 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                                     0.f);
                     for (int j = 0; j < exp_vmm_aux_count; j++) {
                         // Insert the next idx starting after `vreg_tmp_sum`.
-                        exp_aux_indices.insert(static_cast<size_t>(
+                        exp_aux_indices.insert(
                                 get_aux_vmm(vreg_tmp_sum, (j + 1) * max_unroll)
-                                        .getIdx()));
+                                        .getIdx());
                     }
                     exp_injector_->compute_vector(
                             vreg_tmp_src.getIdx(), exp_aux_indices);
@@ -1052,7 +1054,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
             : is_superset(isa, avx)                             ? yword
                                                                 : xword;
     static constexpr auto vlen = cpu_isa_traits_t<isa>::vlen;
-    static constexpr auto simd_w_ = vlen / sizeof(float); // bf16 works on ymms
+    static constexpr int simd_w_ = vlen / sizeof(float); // bf16 works on ymms
 
     const memory_desc_wrapper src_d_, dst_d_;
     io::jit_io_multi_dt_helper_t<Vmm> io_;
@@ -1101,19 +1103,19 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     bool with_src_scales_ = false;
     bool with_dst_scales_ = false;
 
-    size_t unroll_inner_size_ = 4;
-    size_t unroll_axis_size_ = 8;
+    int unroll_inner_size_ = 4;
+    int unroll_axis_size_ = 8;
 
-    size_t axis_size_;
-    size_t axis_size_unroll_tail_;
-    size_t axis_stride_;
-    size_t axis_simd_full_;
+    dim_t axis_size_;
+    int axis_size_unroll_tail_;
+    dim_t axis_stride_;
+    dim_t axis_simd_full_;
     int axis_simd_tail_;
-    size_t n_loops_;
-    size_t loop_tail_;
-    size_t src_next_vreg_stride_;
-    size_t interim_next_vreg_stride_;
-    size_t dst_next_vreg_stride_;
+    dim_t n_loops_;
+    int loop_tail_;
+    dim_t src_next_vreg_stride_;
+    dim_t interim_next_vreg_stride_;
+    dim_t dst_next_vreg_stride_;
 
     const int bf16_emu_zmm_1_idx_ = 23;
     const int bf16_emu_zmm_2_idx_ = 24;
@@ -1141,9 +1143,11 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     void compute_predefined_variables() {
         // `axis_simd_full_` is actually `inner_simd_full_`.
         n_loops_ = axis_simd_full_ / unroll_inner_size_;
-        loop_tail_ = axis_simd_full_ - n_loops_ * unroll_inner_size_;
+        loop_tail_ = static_cast<int>(
+                axis_simd_full_ - n_loops_ * unroll_inner_size_);
 
-        axis_size_unroll_tail_ = axis_size_ % unroll_axis_size_;
+        axis_size_unroll_tail_
+                = static_cast<int>(axis_size_ % unroll_axis_size_);
 
         src_next_vreg_stride_ = compute_next_vreg_stride(src_d_);
         interim_next_vreg_stride_ = vlen;
@@ -1442,10 +1446,10 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
 
         axis_size_loop_unroll(store_body, unroll_inner, tail);
 
-        add(reg_src_spat_offt,
-                unroll_inner * simd_w_ * src_d_.data_type_size());
-        add(reg_dst_spat_offt,
-                unroll_inner * simd_w_ * dst_d_.data_type_size());
+        const dim_t src_dt_size = src_d_.data_type_size();
+        const dim_t dst_dt_size = dst_d_.data_type_size();
+        add(reg_src_spat_offt, unroll_inner * simd_w_ * src_dt_size);
+        add(reg_dst_spat_offt, unroll_inner * simd_w_ * dst_dt_size);
     }
 
     // The function provides unrolling over inner size. A single compute block


### PR DESCRIPTION
It's a softmax (PR Nr.12) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
C4244 warnings eliminated: 47.