### PR TITLE
cpu: resampling: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/simple_resampling.cpp
+++ b/src/cpu/simple_resampling.cpp
@@ -82,13 +82,13 @@ status_t simple_resampling_kernel_t::init() {
 }
 
 status_t simple_resampling_kernel_t::execute(const exec_ctx_t &ctx) const {
-    const int OD = pd_->OD();
-    const int OH = pd_->OH();
-    const int OW = pd_->OW();
-    const int ID = pd_->ID();
-    const int IH = pd_->IH();
-    const int IW = pd_->IW();
-    const int NB_CH = utils::div_up(pd_->C(), inner_stride_);
+    const dim_t OD = pd_->OD();
+    const dim_t OH = pd_->OH();
+    const dim_t OW = pd_->OW();
+    const dim_t ID = pd_->ID();
+    const dim_t IH = pd_->IH();
+    const dim_t IW = pd_->IW();
+    const dim_t NB_CH = utils::div_up(pd_->C(), inner_stride_);
 
     if (pd_->is_fwd()) {
         const auto src = CTX_IN_MEM(const char *, DNNL_ARG_SRC);

--- a/src/cpu/x64/jit_avx512_core_resampling.cpp
+++ b/src/cpu/x64/jit_avx512_core_resampling.cpp
@@ -461,7 +461,8 @@ private:
         }
 
         add(reg_offset, channel_offset);
-        imul(reg_offset, reg_offset, types::data_type_size(src_data_type()));
+        const dim_t src_dt_size = types::data_type_size(src_data_type());
+        imul(reg_offset, reg_offset, src_dt_size);
 
         // read src
         io_->at(src_data_type())
@@ -513,7 +514,7 @@ private:
             io_->at(dst_data_type())->store(zmm_dst, address, is_tail);
         });
 
-        for (unsigned i = 0; i < number_of_loops_;
+        for (dim_t i = 0; i < number_of_loops_;
                 i++, number_of_processed_points += simd_w())
             resample_linear(false);
 
@@ -577,7 +578,7 @@ private:
             io_->at(dst_data_type())->store(zmm_dst, address, is_tail);
         });
 
-        for (unsigned i = 0; i < number_of_loops_;
+        for (dim_t i = 0; i < number_of_loops_;
                 i++, number_of_processed_points += simd_w())
             resample_linear(false);
 
@@ -655,7 +656,7 @@ private:
             io_->at(dst_data_type())->store(zmm_dst, address, is_tail);
         });
 
-        for (unsigned i = 0; i < number_of_loops_;
+        for (dim_t i = 0; i < number_of_loops_;
                 i++, number_of_processed_points += simd_w())
             resample_linear(false);
 
@@ -692,9 +693,9 @@ private:
 
         add(reg_offset,
                 channel_offset); // iw * stride_w_ + ih * stride_h_ + id * stride_d_ + channel_offset
+        const dim_t src_dt_size = types::data_type_size(src_data_type());
         imul(reg_offset, reg_offset,
-                types::data_type_size(
-                        src_data_type())); // (iw * stride_w_ + ih * stride_h_ + id * stride_d_ + channel_offset)*dt_size
+                src_dt_size); // (iw * stride_w_ + ih * stride_h_ + id * stride_d_ + channel_offset)*dt_size
 
         if (pd_->is_fwd()) {
             // read nearest to dst
@@ -744,7 +745,7 @@ private:
             io_->at(dst_data_type())->store(zmm_dst, address, is_tail);
         });
 
-        for (unsigned i = 0; i < number_of_loops_;
+        for (dim_t i = 0; i < number_of_loops_;
                 i++, number_of_processed_points += simd_w())
             resample_nearest(false);
 
@@ -790,7 +791,7 @@ private:
     dim_t stride_h_ = 0;
     dim_t stride_w_ = 0;
     dim_t inner_stride_ = 0;
-    unsigned number_of_loops_ = 0;
+    dim_t number_of_loops_ = 0;
     int tail_size_ = 0;
     bool is_saturation_needed_ = false;
     unsigned stack_size_needed_ = 0;

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -630,14 +630,14 @@ struct jit_uni_pooling_args_t {
 struct jit_resampling_conf_t {
     unsigned ndims = 0;
 
-    unsigned c = 0;
-    unsigned id = 0, ih = 0, iw = 0;
-    unsigned od = 0, oh = 0, ow = 0;
+    dim_t c = 0;
+    dim_t id = 0, ih = 0, iw = 0;
+    dim_t od = 0, oh = 0, ow = 0;
 
-    unsigned stride_d = 0;
-    unsigned stride_h = 0;
-    unsigned stride_w = 0;
-    unsigned inner_stride = 0;
+    dim_t stride_d = 0;
+    dim_t stride_h = 0;
+    dim_t stride_w = 0;
+    dim_t inner_stride = 0;
 
     // The linear algorithm is an approximation of the point
     // value based on the limit values. For one dimension,
@@ -651,10 +651,10 @@ struct jit_resampling_conf_t {
     bool is_saturation_needed = false;
     data_type_t src_data_type = data_type::undef;
     data_type_t dst_data_type = data_type::undef;
-    size_t src_dt_size = 0;
-    size_t dst_dt_size = 0;
+    int src_dt_size = 0;
+    int dst_dt_size = 0;
     size_t output_data_size = 0;
-    size_t el_size_of_indices = 0;
+    int el_size_of_indices = 0;
 
     bool is_blocked_8_format = false;
     format_tag_t src_tag = format_tag::undef;

--- a/src/cpu/x64/jit_uni_resampling.cpp
+++ b/src/cpu/x64/jit_uni_resampling.cpp
@@ -109,10 +109,12 @@ status_t jit_uni_resampling_fwd_t::pd_t::init(const engine_t *engine) {
     conf_.ndims = ndims();
 
     if (conf_.alg == alg_kind::resampling_linear)
-        conf_.number_of_corners = pow(2, conf_.ndims - 2);
+        conf_.number_of_corners = 1u << (conf_.ndims - 2);
 
-    conf_.src_dt_size = types::data_type_size(conf_.src_data_type);
-    conf_.dst_dt_size = types::data_type_size(conf_.dst_data_type);
+    conf_.src_dt_size
+            = static_cast<int>(types::data_type_size(conf_.src_data_type));
+    conf_.dst_dt_size
+            = static_cast<int>(types::data_type_size(conf_.dst_data_type));
 
     conf_.is_saturation_needed
             = utils::one_of(conf_.dst_data_type, s32, s8, u8);
@@ -300,18 +302,21 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_nearest() {
             + utils::rnd_up(pd()->OW(), kernel_->get_simd_w()));
 
     for (dim_t od = 0; od < pd()->OD(); od++) {
-        const int offset_id = nearest_idx(od, pd()->OD(), pd()->ID())
-                * pd()->get_conf().stride_d;
+        const unsigned offset_id
+                = static_cast<unsigned>(nearest_idx(od, pd()->OD(), pd()->ID())
+                        * pd()->get_conf().stride_d);
         indices_.emplace_back(offset_id);
     }
     for (dim_t oh = 0; oh < pd()->OH(); oh++) {
-        const int offset_ih = nearest_idx(oh, pd()->OH(), pd()->IH())
-                * pd()->get_conf().stride_h;
+        const unsigned offset_ih
+                = static_cast<unsigned>(nearest_idx(oh, pd()->OH(), pd()->IH())
+                        * pd()->get_conf().stride_h);
         indices_.emplace_back(offset_ih);
     }
     for (dim_t ow = 0; ow < pd()->OW(); ow++) {
-        const int offset_iw = nearest_idx(ow, pd()->OW(), pd()->IW())
-                * pd()->get_conf().stride_w;
+        const unsigned offset_iw
+                = static_cast<unsigned>(nearest_idx(ow, pd()->OW(), pd()->IW())
+                        * pd()->get_conf().stride_w);
         indices_.emplace_back(offset_iw);
     }
 
@@ -322,11 +327,11 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
     using namespace resampling_utils;
 
     const unsigned number_of_corners = pd()->get_conf().number_of_corners;
-    const unsigned stride_w = pd()->get_conf().stride_w;
-    const unsigned stride_h = pd()->get_conf().stride_h;
-    const unsigned stride_d = pd()->get_conf().stride_d;
+    const dim_t stride_w = pd()->get_conf().stride_w;
+    const dim_t stride_h = pd()->get_conf().stride_h;
+    const dim_t stride_d = pd()->get_conf().stride_d;
 
-    unsigned num_of_elements = 0;
+    dim_t num_of_elements = 0;
     if (pd()->get_conf().tag_kind == jit_memory_tag_kind_t::ncsp) {
         // In kernel is used vmovdqu to get indices. This instruction don't have
         // tail processing possibilities on sse41 and avx. To avoid problems
@@ -356,9 +361,11 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
                 for (unsigned i = 0; i < number_of_corners; i++) {
                     std::bitset<3> corners(i);
                     indices_[i * indices_stride + offset]
-                            = coeffs_id.idx[corners.test(2)] * stride_d
-                            + coeffs_ih.idx[corners.test(1)] * stride_h
-                            + coeffs_iw.idx[corners.test(0)] * stride_w;
+                            = static_cast<unsigned>(
+                                    coeffs_id.idx[corners.test(2)] * stride_d
+                                    + coeffs_ih.idx[corners.test(1)] * stride_h
+                                    + coeffs_iw.idx[corners.test(0)]
+                                            * stride_w);
                     weights_[i * weights_stride + offset]
                             = coeffs_id.wei[corners.test(2)]
                             * coeffs_ih.wei[corners.test(1)]
@@ -389,8 +396,10 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
             // to read and makes the operation faster.
             weights_w[2 * ow] = coeffs_iw.wei[0];
             weights_w[2 * ow + 1] = coeffs_iw.wei[1];
-            indices_w[2 * ow] = coeffs_iw.idx[0] * stride_w;
-            indices_w[2 * ow + 1] = coeffs_iw.idx[1] * stride_w;
+            indices_w[2 * ow]
+                    = static_cast<unsigned>(coeffs_iw.idx[0] * stride_w);
+            indices_w[2 * ow + 1]
+                    = static_cast<unsigned>(coeffs_iw.idx[1] * stride_w);
         }
 
         for (dim_t oh = 0; oh < pd()->OH(); oh++) {
@@ -398,8 +407,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
             weights_h[oh] = coeffs_ih.wei[0];
             weights_h[pd()->OH() + oh] = coeffs_ih.wei[1];
-            indices_h[oh] = coeffs_ih.idx[0] * stride_h;
-            indices_h[pd()->OH() + oh] = coeffs_ih.idx[1] * stride_h;
+            indices_h[oh] = static_cast<unsigned>(coeffs_ih.idx[0] * stride_h);
+            indices_h[pd()->OH() + oh]
+                    = static_cast<unsigned>(coeffs_ih.idx[1] * stride_h);
         }
 
         for (dim_t od = 0; od < pd()->OD(); od++) {
@@ -407,8 +417,9 @@ status_t jit_uni_resampling_fwd_t::fill_data_for_linear() {
 
             weights_d[od] = coeffs_id.wei[0];
             weights_d[pd()->OD() + od] = coeffs_id.wei[1];
-            indices_d[od] = coeffs_id.idx[0] * stride_d;
-            indices_d[pd()->OD() + od] = coeffs_id.idx[1] * stride_d;
+            indices_d[od] = static_cast<unsigned>(coeffs_id.idx[0] * stride_d);
+            indices_d[pd()->OD() + od]
+                    = static_cast<unsigned>(coeffs_id.idx[1] * stride_d);
         }
     } else {
         assert(!"Invalid memory format kind.");
@@ -439,8 +450,8 @@ status_t jit_uni_resampling_fwd_t::execute(const exec_ctx_t &ctx) const {
 
 status_t jit_uni_resampling_fwd_t::interpolate_nearest(const uint8_t *src,
         uint8_t *dst, const std::vector<const void *> &post_ops_args) const {
-    const size_t src_dt_size = pd()->get_conf().src_dt_size;
-    const size_t dst_dt_size = pd()->get_conf().dst_dt_size;
+    const int src_dt_size = pd()->get_conf().src_dt_size;
+    const int dst_dt_size = pd()->get_conf().dst_dt_size;
     const size_t inner_stride = pd()->get_conf().inner_stride;
 
     const dim_t MB = pd()->MB();
@@ -509,8 +520,8 @@ status_t jit_uni_resampling_fwd_t::interpolate_nearest(const uint8_t *src,
 
 status_t jit_uni_resampling_fwd_t::interpolate_linear(const uint8_t *src,
         uint8_t *dst, const std::vector<const void *> &post_ops_args) const {
-    const size_t src_dt_size = pd()->get_conf().src_dt_size;
-    const size_t dst_dt_size = pd()->get_conf().dst_dt_size;
+    const int src_dt_size = pd()->get_conf().src_dt_size;
+    const int dst_dt_size = pd()->get_conf().dst_dt_size;
     const size_t inner_stride = pd()->get_conf().inner_stride;
 
     const dim_t MB = pd()->MB();

--- a/src/cpu/x64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.cpp
@@ -129,8 +129,8 @@ bool jit_uni_resampling_kernel_t<isa, Vmm>::can_movntps_be_used() const {
 }
 
 template <cpu_isa_t isa, typename Vmm>
-std::size_t jit_uni_resampling_kernel_t<isa, Vmm>::calculate_tail_size() const {
-    std::size_t tail_size = 0;
+int jit_uni_resampling_kernel_t<isa, Vmm>::calculate_tail_size() const {
+    dim_t tail_size = 0;
 
     if (conf_.tag_kind == tag_kind::nspc
             || conf_.tag_kind == tag_kind::blocked) {
@@ -143,16 +143,17 @@ std::size_t jit_uni_resampling_kernel_t<isa, Vmm>::calculate_tail_size() const {
     } else
         assert(!"Incorrect memory tag passed to resampling primitive.");
 
-    return tail_size;
+    return static_cast<int>(tail_size);
 }
 
 template <cpu_isa_t isa, typename Vmm>
-int jit_uni_resampling_kernel_t<isa, Vmm>::get_channels_to_compute_without_tail(
-        const bool is_tail_in_blocked_format) const {
+dim_t jit_uni_resampling_kernel_t<isa,
+        Vmm>::get_channels_to_compute_without_tail(const bool
+                is_tail_in_blocked_format) const {
     assert(utils::one_of(conf_.tag_kind, tag_kind::blocked, tag_kind::nspc)
             && "Incorrect memory tag.");
 
-    int c_to_compute_without_tail = 0;
+    dim_t c_to_compute_without_tail = 0;
 
     if (conf_.tag_kind == tag_kind::blocked && is_tail_in_blocked_format) {
         // Example:
@@ -226,7 +227,8 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding_in_post_ops(
     else {
         std::bitset<8> tail_mask((1 << tail_size_) - 1);
         tail_mask.flip();
-        uni_vblendps(vmm_data, vmm_data, vmm_zeros, tail_mask.to_ulong());
+        uni_vblendps(vmm_data, vmm_data, vmm_zeros,
+                static_cast<int>(tail_mask.to_ulong()));
     }
 }
 
@@ -255,17 +257,17 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::apply_postops(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding(
-        const int c_to_compute_without_tail, const bool is_tail) {
-    const int c_to_compute_with_tail
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
+    const dim_t c_to_compute_with_tail
             = is_tail ? utils::rnd_up(tail_size_, simd_w_) : 0;
-    const int c_to_zeroing = conf_.inner_stride - c_to_compute_without_tail
+    const dim_t c_to_zeroing = conf_.inner_stride - c_to_compute_without_tail
             - c_to_compute_with_tail;
 
     if (c_to_zeroing > 0) {
         assert(c_to_zeroing % simd_w_ == 0);
         const Vmm vmm_zeros(vmm_tmp_.getIdx());
 
-        for (int c = 0; c < c_to_zeroing; c += simd_w_) {
+        for (dim_t c = 0; c < c_to_zeroing; c += simd_w_) {
             uni_vxorps(vmm_zeros, vmm_zeros, vmm_zeros);
             const auto dst_address = ptr[reg_dst_ + c * conf_.dst_dt_size];
             io_.at(conf_.dst_data_type)->store(vmm_zeros, dst_address, false);
@@ -278,8 +280,8 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::preserve_zero_padding(
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::interpolate_c_oriented_format(
         const c_oriented_generation_fn_t &generation_fn) {
-    const unsigned c_with_padding = utils::rnd_up(conf_.c, conf_.inner_stride);
-    const unsigned padding_size_to_preserve = c_with_padding - conf_.c;
+    const dim_t c_with_padding = utils::rnd_up(conf_.c, conf_.inner_stride);
+    const dim_t padding_size_to_preserve = c_with_padding - conf_.c;
 
     if (padding_size_to_preserve > 0 && conf_.tag_kind == tag_kind::blocked) {
         Label tail_label;
@@ -364,7 +366,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_ncsp_format() {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::compute_nearest_c_interpolate(
-        const int c_to_compute_without_tail, const bool is_tail) {
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
     const Reg64 &reg_c = reg_tmp_;
     const Reg64 &reg_src_shifted = reg_aux_src_0_;
 
@@ -408,7 +410,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::compute_nearest_c_interpolate(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa,
-        Vmm>::compute_ne_xf16_nearest_c_interpolate(const int
+        Vmm>::compute_ne_xf16_nearest_c_interpolate(const dim_t
                 c_to_compute_without_tail) {
     const Reg64 &reg_c = reg_tmp_;
     const Reg64 &reg_src_shifted = reg_aux_src_0_;
@@ -455,12 +457,12 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_c_oriented_format(
     const bool has_ne_xf16_supported = isa == avx2_vnni_2
             && utils::one_of(
                     conf_.src_data_type, data_type::bf16, data_type::f16);
-    const int total_c_to_compute_without_tail
+    const dim_t total_c_to_compute_without_tail
             = get_channels_to_compute_without_tail(is_tail_in_blocked_format);
-    const int c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
+    const dim_t c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
             ? utils::rnd_dn(total_c_to_compute_without_tail, 2 * simd_w_)
             : 0;
-    const int c_to_compute_without_tail = total_c_to_compute_without_tail
+    const dim_t c_to_compute_without_tail = total_c_to_compute_without_tail
             - c_to_compute_ne_xf16_without_tail;
     const bool insert_tail_processsing_code
             = (conf_.tag_kind == tag_kind::nspc && tail_size_ > 0)
@@ -503,10 +505,9 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::nearest_c_oriented_format(
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::linear_ncsp_format() {
-    const unsigned indices_stride
+    const dim_t indices_stride
             = conf_.ow * conf_.oh * conf_.od * conf_.el_size_of_indices;
-    const unsigned weights_stride
-            = conf_.ow * conf_.oh * conf_.od * sizeof(float);
+    const dim_t weights_stride = conf_.ow * conf_.oh * conf_.od * sizeof(float);
 
     auto linear_interpolation = [&](const bool is_tail) {
         const Vmm vmm_dst(vmm_idx(0));
@@ -562,7 +563,7 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::linear_ncsp_format() {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa,
-        Vmm>::compute_ne_xf16_linear_c_interpolate(const int
+        Vmm>::compute_ne_xf16_linear_c_interpolate(const dim_t
                 c_to_compute_without_tail) {
     const Reg64 &reg_c = reg_tmp_;
 
@@ -646,7 +647,7 @@ void jit_uni_resampling_kernel_t<isa,
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_resampling_kernel_t<isa, Vmm>::compute_linear_c_interpolate(
-        const int c_to_compute_without_tail, const bool is_tail) {
+        const dim_t c_to_compute_without_tail, const bool is_tail) {
     const Reg64 &reg_c = reg_tmp_;
 
     const std::vector<std::reference_wrapper<const Vmm>> src_vmms
@@ -740,12 +741,12 @@ void jit_uni_resampling_kernel_t<isa, Vmm>::linear_c_oriented_format(
     const bool has_ne_xf16_supported = isa == avx2_vnni_2 && conf_.ndims <= 4
             && utils::one_of(
                     conf_.src_data_type, data_type::bf16, data_type::f16);
-    const int total_c_to_compute_without_tail
+    const dim_t total_c_to_compute_without_tail
             = get_channels_to_compute_without_tail(is_tail_in_blocked_format);
-    const int c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
+    const dim_t c_to_compute_ne_xf16_without_tail = has_ne_xf16_supported
             ? utils::rnd_dn(total_c_to_compute_without_tail, 2 * simd_w_)
             : 0;
-    const int c_to_compute_without_tail = total_c_to_compute_without_tail
+    const dim_t c_to_compute_without_tail = total_c_to_compute_without_tail
             - c_to_compute_ne_xf16_without_tail;
     const bool insert_tail_processsing_code
             = (conf_.tag_kind == tag_kind::nspc && tail_size_ > 0)

--- a/src/cpu/x64/jit_uni_resampling_kernel.hpp
+++ b/src/cpu/x64/jit_uni_resampling_kernel.hpp
@@ -71,8 +71,8 @@ private:
     }
 
     bool can_movntps_be_used() const;
-    std::size_t calculate_tail_size() const;
-    int get_channels_to_compute_without_tail(
+    int calculate_tail_size() const;
+    dim_t get_channels_to_compute_without_tail(
             bool is_tail_in_blocked_format) const;
 
     std::map<data_type_t, io::io_saturation_conf_t>
@@ -85,7 +85,7 @@ private:
             const int data_idx, const bool is_tail, const size_t offset = 0);
 
     void preserve_zero_padding(
-            int c_to_compute_without_tail, const bool is_tail);
+            dim_t c_to_compute_without_tail, const bool is_tail);
 
     void interpolate_c_oriented_format(
             const c_oriented_generation_fn_t &generation_fn);
@@ -94,13 +94,13 @@ private:
     void linear_ncsp_format();
     void linear_c_oriented_format(const bool is_tail_in_blocked_format);
     void compute_nearest_c_interpolate(
-            const int c_to_compute_without_tail, const bool is_tail);
+            const dim_t c_to_compute_without_tail, const bool is_tail);
     void compute_ne_xf16_nearest_c_interpolate(
-            const int c_to_compute_without_tail);
+            const dim_t c_to_compute_without_tail);
     void compute_linear_c_interpolate(
-            const int c_to_compute_without_tail, const bool is_tail);
+            const dim_t c_to_compute_without_tail, const bool is_tail);
     void compute_ne_xf16_linear_c_interpolate(
-            const int c_to_compute_without_tail);
+            const dim_t c_to_compute_without_tail);
 
     void generate() override;
 


### PR DESCRIPTION
It's a resampling(PR Nr.13) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
C4244 warnings eliminated: 59.