### PR TITLE
cpu: binary: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -970,7 +970,7 @@ struct jit_binary_conf_t {
     bool is_ternary_op = false;
     bool is_src_different_layouts = false;
     dim_t outer_dims = 1;
-    int src1_stride = 1;
+    dim_t src1_stride = 1;
     int not_bcasted_sp_dims = 0;
     cpu_isa_t isa = isa_undef;
 

--- a/src/cpu/x64/jit_uni_binary.cpp
+++ b/src/cpu/x64/jit_uni_binary.cpp
@@ -782,12 +782,15 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
     const memory_desc_wrapper src2_d(pd()->src_md(2));
     const memory_desc_wrapper dst_d(pd()->dst_md(0));
 
-    const int src0_type_size = types::data_type_size(src0_d.data_type());
-    const int src1_type_size = types::data_type_size(src1_d.data_type());
+    const int src0_type_size
+            = static_cast<int>(types::data_type_size(src0_d.data_type()));
+    const int src1_type_size
+            = static_cast<int>(types::data_type_size(src1_d.data_type()));
     const int src2_type_size = pd()->is_ternary_op()
-            ? types::data_type_size(src2_d.data_type())
+            ? static_cast<int>(types::data_type_size(src2_d.data_type()))
             : 0;
-    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const int dst_type_size
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     const auto &conf = pd()->get_conf();
     const bool is_src_different_layouts = conf.is_src_different_layouts;
@@ -797,7 +800,8 @@ void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
 
         const dim_t src1_different_layout_stride = conf.src1_stride;
         for (int i = 0; i < simd_w; i++)
-            indices[i] = i * src1_different_layout_stride * src1_type_size;
+            indices[i] = static_cast<unsigned>(
+                    i * src1_different_layout_stride * src1_type_size);
 
         const dim_t batch = src0_d.dims()[0];
         const dim_t batch_stride = src1_d.blocking_desc().strides[0];
@@ -903,12 +907,15 @@ void jit_uni_binary_t::execute_bcast_per_batch_strategy(const data_t *src0,
     const memory_desc_wrapper src2_d(pd()->src_md(2));
     const memory_desc_wrapper dst_d(pd()->dst_md(0));
 
-    const int src0_type_size = types::data_type_size(src0_d.data_type());
-    const int src1_type_size = types::data_type_size(src1_d.data_type());
+    const int src0_type_size
+            = static_cast<int>(types::data_type_size(src0_d.data_type()));
+    const int src1_type_size
+            = static_cast<int>(types::data_type_size(src1_d.data_type()));
     const int src2_type_size = pd()->is_ternary_op()
-            ? types::data_type_size(src2_d.data_type())
+            ? static_cast<int>(types::data_type_size(src2_d.data_type()))
             : 0;
-    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const int dst_type_size
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     const dim_t MB = src0_d.dims()[0];
     const dim_t nelems0_per_b = src0_d.nelems(true) / MB;
@@ -958,12 +965,15 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
     const memory_desc_wrapper src2_d(pd()->src_md(2));
     const memory_desc_wrapper dst_d(pd()->dst_md(0));
 
-    const int src0_type_size = types::data_type_size(src0_d.data_type());
-    const int src1_type_size = types::data_type_size(src1_d.data_type());
+    const int src0_type_size
+            = static_cast<int>(types::data_type_size(src0_d.data_type()));
+    const int src1_type_size
+            = static_cast<int>(types::data_type_size(src1_d.data_type()));
     const int src2_type_size = pd()->is_ternary_op()
-            ? types::data_type_size(src2_d.data_type())
+            ? static_cast<int>(types::data_type_size(src2_d.data_type()))
             : 0;
-    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const int dst_type_size
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     const auto ndims = src0_d.ndims();
     const auto &dims = src0_d.dims();
@@ -983,8 +993,7 @@ void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
                               : 0);
 
     if (op_type == op_t::c_blocked) {
-        const dim_t C_blocks = std::ceil(
-                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        const dim_t C_blocks = utils::div_up(src0_d.padded_dims()[1], simd_w);
         // Compute strategy:
         // Each block is individual - parallel over MB and C_blocks safely.
 
@@ -1082,12 +1091,15 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
     const memory_desc_wrapper src2_d(pd()->src_md(2));
     const memory_desc_wrapper dst_d(pd()->dst_md(0));
 
-    const int src0_type_size = types::data_type_size(src0_d.data_type());
-    const int src1_type_size = types::data_type_size(src1_d.data_type());
+    const int src0_type_size
+            = static_cast<int>(types::data_type_size(src0_d.data_type()));
+    const int src1_type_size
+            = static_cast<int>(types::data_type_size(src1_d.data_type()));
     const int src2_type_size = pd()->is_ternary_op()
-            ? types::data_type_size(src2_d.data_type())
+            ? static_cast<int>(types::data_type_size(src2_d.data_type()))
             : 0;
-    const int dst_type_size = types::data_type_size(dst_d.data_type());
+    const int dst_type_size
+            = static_cast<int>(types::data_type_size(dst_d.data_type()));
 
     const auto ndims = src0_d.ndims();
     const auto &dims = src0_d.dims();
@@ -1109,8 +1121,7 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
             = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
 
     if (op_type == op_t::c_blocked) {
-        const dim_t C_blocks = std::ceil(
-                static_cast<float>(src0_d.padded_dims()[1]) / simd_w);
+        const dim_t C_blocks = utils::div_up(src0_d.padded_dims()[1], simd_w);
         // Compute strategy:
         // Each line of channels is individual, parallel over MB, C_blocks
         // and spatial (broadcasted and not broadcasted spatial dims

--- a/src/cpu/x64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.cpp
@@ -40,7 +40,7 @@ static bool is_ne_xf16_supported(cpu_isa_t isa, const data_type_t dtype) {
     return isa == avx2_vnni_2 && is_xf16(dtype);
 }
 
-binary_kernel_t::binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
+binary_kernel_t::binary_kernel_t(const int vlen, const binary_pd_t *pd,
         const jit_binary_conf_t &conf, const char *name, bool tail_kernel)
     : jit_generator_t(name, conf.isa)
     , vlen_(vlen)
@@ -51,8 +51,8 @@ binary_kernel_t::binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
     , is_src1_outer_dims_tail_(
               conf_.is_src_different_layouts && conf_.outer_dims % simd_w_)
     , tail_size_(get_tail_size())
-    , padding_tail_size_(
-              pd->src_md(0)->padded_dims[1] - pd->src_md(0)->dims[1]) {}
+    , padding_tail_size_(static_cast<int>(
+              pd->src_md(0)->padded_dims[1] - pd->src_md(0)->dims[1])) {}
 
 int binary_kernel_t::get_tail_size() const {
     memory_desc_wrapper src0_d(pd_->src_md(0));
@@ -172,7 +172,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::apply_postops(int unroll, bool tail) {
 
         for (int vmm_idx = 1; vmm_idx < unroll + vmm_start_idx_; vmm_idx++) {
             const auto vmm_l_off = (vmm_idx - vmm_start_idx_) * simd_w_;
-            const auto dst_dt_size = types::data_type_size(conf_.dst_type);
+            const int dst_dt_size
+                    = static_cast<int>(types::data_type_size(conf_.dst_type));
             rhs_arg_params.vmm_idx_to_out_reg.emplace(vmm_idx, reg_tmp1_);
             rhs_arg_params.vmm_idx_to_out_elem_off_val.emplace(
                     vmm_idx, vmm_l_off * dst_dt_size);
@@ -216,7 +217,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::load_kernel_params() {
 // `reg_offt_src0_` in the header file for more details.
 template <cpu_isa_t isa, typename Vmm>
 Address jit_uni_binary_kernel_t<isa, Vmm>::src0_ptr(size_t offt) {
-    const auto src0_type_size = types::data_type_size(conf_.src0_type);
+    const int src0_type_size
+            = static_cast<int>(types::data_type_size(conf_.src0_type));
     return vmmword[reg_src0_ + reg_offt_src0_ * src0_type_size
             + offt * src0_type_size];
 }
@@ -228,14 +230,16 @@ Address jit_uni_binary_kernel_t<isa, Vmm>::src1_ptr(size_t offt) {
 
 template <cpu_isa_t isa, typename Vmm>
 Address jit_uni_binary_kernel_t<isa, Vmm>::src2_ptr(size_t offt) {
-    const auto src2_type_size = types::data_type_size(conf_.src2_type);
+    const int src2_type_size
+            = static_cast<int>(types::data_type_size(conf_.src2_type));
     return vmmword[reg_src2_ + reg_offt_src0_ * src2_type_size
             + offt * src2_type_size];
 }
 
 template <cpu_isa_t isa, typename Vmm>
 Address jit_uni_binary_kernel_t<isa, Vmm>::dst_ptr(size_t offt) {
-    const auto src0_type_size = types::data_type_size(conf_.src0_type);
+    const int src0_type_size
+            = static_cast<int>(types::data_type_size(conf_.src0_type));
     const auto &reg_offt_dst
             = conf_.is_i8 ? reg_offt_dst_ : (reg_offt_src0_ * src0_type_size);
     return vmmword[reg_dst_ + reg_offt_dst + offt];
@@ -281,7 +285,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::perform_op(
     else if (alg == binary_sub)
         uni_vsubps(v0, v0, v1);
     else if (cmp_op) {
-        const unsigned int predicate = cmp_predicate(alg);
+        const uint8_t predicate = static_cast<uint8_t>(cmp_predicate(alg));
         if (is_avx512) {
             vcmpps(cmp_mask, v0, v1, predicate);
             vmovups(v0 | cmp_mask | T_z, vreg_one_);
@@ -379,12 +383,11 @@ void jit_uni_binary_kernel_t<isa, Vmm>::load_src1(
         // gather is using register instead of operand to read address
         // use reg_src1_ directly, without offset stored in second
         // register
-        add(reg_src1_,
-                types::data_type_size(conf_.src1_type) * conf_.src1_stride
-                        * simd_w_);
+        const int src1_type_size
+                = static_cast<int>(types::data_type_size(conf_.src1_type));
+        add(reg_src1_, src1_type_size * conf_.src1_stride * simd_w_);
         sub(reg_reverse_src1_stride_range_,
-                types::data_type_size(conf_.src1_type) * conf_.src1_stride
-                        * simd_w_);
+                src1_type_size * conf_.src1_stride * simd_w_);
 
         Label src1_stride_range_not_exceed, src1_C_tail_end;
 
@@ -392,7 +395,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::load_src1(
         jg(src1_stride_range_not_exceed, T_NEAR);
         {
             pop(reg_src1_);
-            add(reg_src1_, types::data_type_size(conf_.src1_type));
+            add(reg_src1_, src1_type_size);
             push(reg_src1_);
             mov(reg_reverse_src1_stride_range_, reg_src1_stride_range_);
         }
@@ -408,7 +411,8 @@ void jit_uni_binary_kernel_t<isa, Vmm>::store(int unroll, bool tail) {
     for (int i = 0; i < unroll; i++) {
         const Vmm vreg_tmp_src0 = Vmm(i + vmm_start_idx_);
         const int offt = simd_w_ * i;
-        const auto dt_size = types::data_type_size(conf_.dst_type);
+        const int dt_size
+                = static_cast<int>(types::data_type_size(conf_.dst_type));
 
         if (is_tail_kernel_ && padding_tail_size_) {
             // apply zero-padding
@@ -568,8 +572,10 @@ template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_kernel_t<isa, Vmm>::forward() {
     Label unroll_loop, unroll_loop_tail, nelems_tail, end;
 
-    const auto src1_type_size = types::data_type_size(conf_.src1_type);
-    const auto dst_type_size = types::data_type_size(conf_.dst_type);
+    const int src1_type_size
+            = static_cast<int>(types::data_type_size(conf_.src1_type));
+    const int dst_type_size
+            = static_cast<int>(types::data_type_size(conf_.dst_type));
 
     if (conf_.is_src_different_layouts) push(reg_src1_);
 
@@ -617,7 +623,7 @@ void jit_uni_binary_kernel_t<isa, Vmm>::forward() {
 
     L(unroll_loop);
     {
-        const size_t offt = unroll_regs_ * simd_w_;
+        const int offt = unroll_regs_ * simd_w_;
         cmp(reg_reverse_spat_offt_, offt * dst_type_size);
         jl(unroll_loop_tail, T_NEAR);
 
@@ -683,8 +689,9 @@ void jit_uni_binary_kernel_t<isa, Vmm>::forward() {
 
 template <cpu_isa_t isa, typename Vmm>
 void jit_uni_binary_kernel_t<isa, Vmm>::forward_over_outer_dims() {
-    const auto outer_dims_size
-            = conf_.outer_dims * types::data_type_size(conf_.dst_type);
+    const int dst_type_size
+            = static_cast<int>(types::data_type_size(conf_.dst_type));
+    const dim_t outer_dims_size = conf_.outer_dims * dst_type_size;
 
     if (conf_.is_i8 || conf_.dst_type == data_type::s32) {
         uni_vpxor(vreg_zero_, vreg_zero_, vreg_zero_);

--- a/src/cpu/x64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/x64/jit_uni_binary_kernel.hpp
@@ -42,7 +42,7 @@ struct binary_kernel_t : public jit_generator_t {
     using op_t = binary_op_t;
     using bcast_t = binary_bcast_t;
 
-    binary_kernel_t(const size_t vlen, const binary_pd_t *pd,
+    binary_kernel_t(const int vlen, const binary_pd_t *pd,
             const jit_binary_conf_t &conf, const char *name,
             bool tail_kernel = false);
     ~binary_kernel_t() override = default;
@@ -52,12 +52,12 @@ struct binary_kernel_t : public jit_generator_t {
     }
 
     int simd_w() const noexcept { return simd_w_; }
-    size_t vlen() const noexcept { return vlen_; }
+    int vlen() const noexcept { return vlen_; }
 
 protected:
     int get_tail_size() const;
 
-    const size_t vlen_;
+    const int vlen_;
     const int simd_w_;
     constexpr static int vmm_start_idx_ = 1;
     const binary_pd_t *pd_;
@@ -129,11 +129,11 @@ struct jit_uni_binary_kernel_t : public binary_kernel_t {
     // For the ternary select operation, a conditional value is required
     // for computation in addition to src0 and src1. The number of unroll
     // registers are adjusted to accomodate for the extra input.
-    const size_t unroll_regs_ = is_avx512 ? (conf_.is_ternary_op ? 3 : 8)
-                                          : (conf_.is_ternary_op ? 1 : 4);
-    const size_t offt_src0_;
-    const size_t offt_src1_;
-    const size_t offt_src2_;
+    const int unroll_regs_ = is_avx512 ? (conf_.is_ternary_op ? 3 : 8)
+                                       : (conf_.is_ternary_op ? 1 : 4);
+    const int offt_src0_;
+    const int offt_src1_;
+    const int offt_src2_;
 
     io::jit_io_multi_dt_helper_t<Vmm> io_;
     std::unique_ptr<injector::jit_uni_postops_injector_t<Vmm>>


### PR DESCRIPTION
It's a binary (PR Nr.14) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
C4244 warnings eliminated: 44.
Mostly done via casting and changing local variables/attributes to `int` dt.