### PR TITLE
cpu: reduction: eliminate implicit narrowing conversions

### DIFF
--- a/src/cpu/ref_reduction.cpp
+++ b/src/cpu/ref_reduction.cpp
@@ -63,7 +63,7 @@ void accumulate(T &acc, const T &src, alg_kind_t alg, float p) {
         case reduction_norm_lp_sum:
         case reduction_norm_lp_power_p_max:
         case reduction_norm_lp_power_p_sum:
-            acc += powf(nstl::abs(src), p);
+            acc += static_cast<T>(powf(nstl::abs(src), p));
             break;
         default: assert(!"unknown alg");
     }

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -1000,9 +1000,9 @@ struct jit_reduction_conf_t {
     data_type_t dst_type = data_type::undef;
     data_type_t acc_type = data_type::undef;
 
-    std::size_t src_dt_size = 0;
-    std::size_t dst_dt_size = 0;
-    std::size_t acc_dt_size = 0;
+    int src_dt_size = 0;
+    int dst_dt_size = 0;
+    int acc_dt_size = 0;
 
     alg_kind_t alg = alg_kind::undef;
     cpu_isa_t isa = isa_undef;

--- a/src/cpu/x64/jit_uni_reduction.cpp
+++ b/src/cpu/x64/jit_uni_reduction.cpp
@@ -61,9 +61,9 @@ status_t jit_uni_reduction_t::pd_t::init(const engine_t *engine) {
     conf_.dst_type = dst_md()->data_type;
     conf_.acc_type
             = types::default_accum_data_type(conf_.src_type, conf_.dst_type);
-    conf_.src_dt_size = types::data_type_size(conf_.src_type);
-    conf_.dst_dt_size = types::data_type_size(conf_.dst_type);
-    conf_.acc_dt_size = types::data_type_size(conf_.acc_type);
+    conf_.src_dt_size = static_cast<int>(types::data_type_size(conf_.src_type));
+    conf_.dst_dt_size = static_cast<int>(types::data_type_size(conf_.dst_type));
+    conf_.acc_dt_size = static_cast<int>(types::data_type_size(conf_.acc_type));
 
     VDISPATCH_REDUCTION(
             impl_supports_datatype(conf_.src_type), VERBOSE_UNSUPPORTED_DT);
@@ -172,8 +172,8 @@ status_t jit_uni_reduction_t::execute(const exec_ctx_t &ctx) const {
 
     const dim_t idle_size = pd()->get_conf().idle_size;
     const dim_t reduce_size = pd()->get_conf().reduce_size;
-    const std::size_t src_dt_size = pd()->get_conf().src_dt_size;
-    const std::size_t dst_dt_size = pd()->get_conf().dst_dt_size;
+    const int src_dt_size = pd()->get_conf().src_dt_size;
+    const int dst_dt_size = pd()->get_conf().dst_dt_size;
     const auto &post_ops = pd()->attr()->post_ops_;
     const auto &post_ops_binary_rhs_arg_vec
             = binary_injector::prepare_binary_args(post_ops, ctx);


### PR DESCRIPTION
It's a reduction(PR Nr.15) part of [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
C4244 warnings eliminated: 4.
Minor changes: casting and changing dt to `int`.