### PR TITLE
[GPU] Fixup GEMM C repack

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -1695,6 +1695,12 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
         if (strategy.kInterleave)
             period = gcd(period, strategy.kInterleaveChunk);
 
+        // C is repacked (and late scales applied) every `period` k-elements, but
+        // advances in units of opCountAB. If opCountAB does not divide period,
+        // scale groups can be silently skipped.
+        if (period % opCountAB != 0)
+            stub("C repack period incompatible with outer product count");
+
         state.Cr_layout = RegisterLayout(hw, Tc_compute, Cr_unrollM * mx, Cr_unrollN * nx, globalCM, 1, strategy.C.tileR, strategy.C.tileC, true);
     }
 

--- a/src/gpu/intel/gemm/jit/generator/strategy.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy.cpp
@@ -252,6 +252,18 @@ void GEMMStrategy::preflight(HW hw, const GEMMProblem &problem)
 
     if (!systolic && AccumulatorRegister::count(hw, GRFs, problem.Tc.real().ngen()) == 0)
         kChain = 1;
+    // Late 2D scales are only read once per C repack, which occurs every
+    // gcd(aqGroupK, bqGroupK) k-elements. A k-chain spanning more than that would
+    // skip scale groups, so trim it to fit.
+    int minOPC = minOuterProductCount(problem, *this);
+    if (kChain > 1 && problem.forceLateQuant(minOPC)) {
+        int period = problem.aScale2D() ? problem.aqGroupK : 0;
+        if (problem.bScale2D())
+            period = period ? gcd(period, problem.bqGroupK) : problem.bqGroupK;
+        if (kInterleave) period = gcd(period, kInterleaveChunk);
+        if (period % minOPC == 0)
+            kChain = gcd(kChain, period / minOPC);
+    }
     cAccumulators &= (kChain == 1);
 
     // Accumulator usage: 64-bit emulation, or k chaining, or extra C registers, or storage for r0 header.


### PR DESCRIPTION
# Description

Fixup repack C issue causing grouped gemm fails on CRI. Trim kchain when required to make sure period and quantization groups align for C repack. Enforce requirement in gemm setup.

Fixes # [MFDNN-15441](https://jira.devtools.intel.com/browse/MFDNN-15441)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?