### PR TITLE
[benchdnn] Fixup sparse testing inputs

### DIFF
--- a/tests/benchdnn/inputs/matmul/test_matmul_gpu
+++ b/tests/benchdnn/inputs/matmul/test_matmul_gpu
@@ -136,12 +136,10 @@
 --reset
 --batch=option_set_fwks_ext_gpu
 
-# Test tf32 configuration
---reset
---batch=option_set_fwks_key_gpu_tf32
-
 # precomputed reductions for zero points
 --reset
 --batch=harness_matmul_precomp_reductions
 
---batch=harness_matmul_sparse
+# Test tf32 configuration
+--reset
+--batch=option_set_fwks_key_gpu_tf32


### PR DESCRIPTION
# Description

Fixes large number of fails in nightly by dropping double inclusion of `harness_matmul_sparse` already included in `test_matmul_ci` which is included in `test_matmul_gpu` already. The second set was also picking up a `--check-impl=ref` flag that caused mass fails since sparse matmuls are only supported by ref on GPU. 

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?
