### PR TITLE
scripts: verbose converter: add missing sparse encoding support

### DIFF
--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -16,6 +16,7 @@
 
 import functools
 import logging
+import math
 from collections import defaultdict
 from typing import Dict, List, Mapping, Optional, Set, cast
 
@@ -90,6 +91,10 @@ class Converter(metaclass=ConverterMeta):
             if not md.tag:
                 continue
             return f"--tag={md.tag}"  # XXX: Don't use maybe_make_any_tag
+        return ""
+
+    @property
+    def encoding(self) -> str:
         return ""
 
     @property
@@ -375,9 +380,10 @@ class StridesMixin(TagTripletMixin):
         tags = []
         strides = []
 
-        def add_strides_or_tag(arg, md):
-            if md.grouped is not None:
-                return  # grouped MDs go through --grouped
+        def add_strides_or_tag(arg, md: ir.MemoryDescriptor):
+            if md.format_kind == "sparse":
+                strides.append(md.strides)
+                return
             tag = maybe_make_any_tag(md)
             if arg == "wei" and str(md.flags.value) != "f0":
                 tag = "any"
@@ -622,6 +628,34 @@ class MatmulConverter(StridesMixin, MultiDataTypeWithBiasMixin, Converter):
                 mask = md.flags.value.split("_")[1][4:]
                 return f"--bia_mask={mask}"
         return ""
+
+    @property
+    def encoding(self):
+        src, wei = self.entry.shapes.split(":", 2)[:2]
+        *sb, m, sk = map(int, src.split("x"))
+        *wb, wk, n = map(int, wei.split("x"))
+        b = tuple(max(s, w) for s, w in zip(sb, wb))
+
+        counts = {
+            "src": math.prod(sb) * m * sk,
+            "wei": math.prod(wb) * wk * n,
+            "dst": math.prod(b) * m * n,
+        }
+
+        encodings: Dict[str, str] = {}
+        for md in self.entry.mds:
+            if md.arg not in counts:
+                continue
+            if md.format_kind != "sparse" or md.grouped:
+                continue
+            count = counts[md.arg]
+            nnz = max(200, count // 100)
+            sparsity = 1.00 - min(nnz / count, 1.00)
+            encodings[md.arg] = f"{md.tag}+{sparsity:.2f}"
+        if not encodings:
+            return ""
+        encoding = ":".join(encodings.get(arg, "") for arg in counts)
+        return f"--encoding={encoding}"
 
     @property
     def grouped(self) -> str:
@@ -1028,6 +1062,7 @@ class InputGenerator:
             converter.aux,
             converter.bias_mask,
             converter.dts,
+            converter.encoding,
             converter.tags,
             converter.flags,
             converter.attrs,

--- a/scripts/verbose_converter/src/parse.py
+++ b/scripts/verbose_converter/src/parse.py
@@ -373,7 +373,10 @@ class ParserImpl:
         post_op.mask = spec.read_uint()
         if spec.read_literal(":"):
             post_op.tag = spec.read_str()
-        # benchdnn can't do anything with src2 info yet.
+        if spec.read_literal(":"):
+            post_op.src2_mask = spec.read_uint()
+        if spec.read_literal(":"):
+            post_op.src2_tag = spec.read_str()
         return post_op
 
     @staticmethod

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -804,31 +804,38 @@ std::ostream &operator<<(std::ostream &ss, const primitive_attr_t *attr) {
                 case primitive_kind::binary: {
                     const post_ops_t::entry_t::binary_t &eb = e.binary;
                     const auto &md = eb.user_src1_desc;
-                    int mask = 0;
-                    for (int d = 0; d < md.ndims; ++d)
-                        mask += md.dims[d] != 1 ? (1 << d) : 0;
-                    ss << delim << eb.alg << ":" << md.data_type << ":" << mask;
-                    const memory_desc_wrapper mdw(md);
-                    switch (mdw.format_kind()) {
-                        case format_kind::blocked:
-                            if (!mdw.count_non_unit_dims(1)) {
-                                ss << ":" << md2fmt_tag_str(&eb.src1_desc);
-                                const auto &strides_str
-                                        = md2fmt_strides_str(&eb.src1_desc);
-                                if (!strides_str.empty())
-                                    ss << ":" << strides_str;
-                            }
-                            break;
-                        case format_kind::sparse:
-                            if (mdw.is_grouped_desc()) {
-                                ss << ":grouped";
+                    ss << delim << eb.alg << ":" << md.data_type;
+
+                    auto dump = [&](const memory_desc_t &md) {
+                        int mask = 0;
+                        for (int d = 0; d < md.ndims; ++d)
+                            mask += md.dims[d] != 1 ? (1 << d) : 0;
+                        ss << ":" << mask;
+                        const memory_desc_wrapper mdw(md);
+                        switch (mdw.format_kind()) {
+                            case format_kind::blocked:
+                                if (!mdw.count_non_unit_dims(1)) {
+                                    ss << ":" << md2fmt_tag_str(&eb.src1_desc);
+                                    const auto &strides_str
+                                            = md2fmt_strides_str(&eb.src1_desc);
+                                    if (!strides_str.empty())
+                                        ss << ":" << strides_str;
+                                }
                                 break;
-                            }
-                            assert(!"unsupported sparse encoding");
-                            break;
-                        case format_kind::any: ss << ":any"; break;
-                        default: assert(!"unsupported format_kind");
-                    }
+                            case format_kind::sparse:
+                                if (mdw.is_grouped_desc()) {
+                                    ss << ":grouped";
+                                    break;
+                                }
+                                assert(!"unsupported sparse encoding");
+                                break;
+                            case format_kind::any: ss << ":any"; break;
+                            default: assert(!"unsupported format_kind");
+                        }
+                    };
+
+                    dump(md);
+                    if (e.is_binary_with_ternary_op()) dump(eb.user_src2_desc);
                 } break;
                 case primitive_kind::prelu: {
                     const auto &ep = e.prelu;


### PR DESCRIPTION
Addresses [MFDNN-15452](https://jira.devtools.intel.com/browse/MFDNN-15452).

Sparsity encoding was missing from the benchdnn generator.