### PR TITLE
Add ACE support for bf16 and int8 in brgemm kernels and dispatch

### DIFF
--- a/src/cpu/cpu_convolution_list.cpp
+++ b/src/cpu/cpu_convolution_list.cpp
@@ -148,6 +148,8 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
         {{forward, "bf16:bf16:*"}, {
             CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_X64(ip_convolution_fwd_t)
+            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_ace>)
+            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_ace>)
             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
             CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx512_core_amx>)
             CPU_INSTANCE_AMX(jit_avx512_core_amx_1x1_convolution_fwd_t)
@@ -246,6 +248,8 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
         })},
         {{backward_data, "*:bf16:bf16"}, REG_BWD_D_PK({
             CPU_INSTANCE_X64(ip_convolution_bwd_data_t)
+            CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx10_2_ace>)
+            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx10_2_ace>)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_t<avx512_core_amx>)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
             CPU_INSTANCE_AMX(jit_avx512_core_amx_convolution_bwd_data_t)
@@ -339,6 +343,8 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
         {{forward, "xi8:s8:*"}, {
             CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
             CPU_INSTANCE_X64(ip_convolution_fwd_t)
+            CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_ace>)
+            CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_ace>)
             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>)
             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
             CPU_INSTANCE_AMX(brgemm_convolution_fwd_t<avx10_2_amx_2>)
@@ -383,6 +389,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
         }},
         // BWD int8
         {{backward_data, "*:s8:xi8"}, REG_BWD_D_PK({
+            CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx10_2_ace>)
             CPU_INSTANCE_AMX(brgemm_convolution_bwd_strided_t<avx512_core_amx>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core_vnni>)
             CPU_INSTANCE_AVX512(brgemm_convolution_bwd_strided_t<avx512_core>)

--- a/src/cpu/cpu_deconvolution_list.cpp
+++ b/src/cpu/cpu_deconvolution_list.cpp
@@ -48,6 +48,7 @@ using namespace dnnl::impl::prop_kind;
 const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
     static const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> the_map = REG_DECONV_P({
         {{forward}, {
+            CPU_INSTANCE_AMX(brgemm_deconvolution_fwd_t<avx10_2_ace>)
             CPU_INSTANCE_AMX(brgemm_deconvolution_fwd_t<avx10_2_amx_2>)
             CPU_INSTANCE_AMX(brgemm_deconvolution_fwd_t<avx512_core_amx_fp16>)
             CPU_INSTANCE_AMX(brgemm_deconvolution_fwd_t<avx512_core_amx>)

--- a/src/cpu/matmul/cpu_matmul_list.cpp
+++ b/src/cpu/matmul/cpu_matmul_list.cpp
@@ -81,6 +81,7 @@ constexpr impl_list_item_t impl_list[] = REG_MATMUL_P({
         CPU_INSTANCE_AARCH64(brgemm_matmul_t<sve_256>)
         CPU_INSTANCE_AARCH64(brgemm_matmul_t<sve_128>)
         CPU_INSTANCE_X64_ZEN(zen_matmul_t)
+        CPU_INSTANCE_AMX(brgemm_matmul_t<avx10_2_ace>)
         CPU_INSTANCE_AMX(brgemm_matmul_t<avx10_2_amx_2>)
         CPU_INSTANCE_AMX(brgemm_matmul_t<avx512_core_amx_fp16>)
         CPU_INSTANCE_AMX(brgemm_matmul_t<avx512_core_amx>)

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -272,9 +272,12 @@ status_t brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
             || (max_c_stride >= max_stride && !brg->is_runtime_ldc))
         return status::unimplemented;
 
-    // Only amx_int8 kernel supports u8 weights.
-    if (!IMPLICATION(
-                brg->dt_b == u8, is_superset(brg->isa_impl, avx512_core_amx)))
+    // u8 weights need an outer product taking an unsigned second operand,
+    // which only the tile ISAs have. This is an early ISA screen; whether a
+    // tile kernel is really used is re-checked in brgemm_desc_finalize().
+    if (!IMPLICATION(brg->dt_b == u8,
+                is_superset(brg->isa_impl, avx512_core_amx)
+                        || is_superset(brg->isa_impl, avx10_2_ace)))
         return status::unimplemented;
 
     return status::success;
@@ -585,7 +588,7 @@ status_t brgemm_desc_set_attr(
 
     // virtual padding is not supported for "amx"
     if ((brgattr.max_top_vpad > 0 || brgattr.max_bottom_vpad > 0)
-            && (brg->is_tmm))
+            && (brg->is_tmm || brg->is_ace()))
         return status::unimplemented;
 
     // Sprinkled prefetch is supported for brgemm_batch_size is 1
@@ -629,6 +632,15 @@ status_t brgemm_desc_set_attr(
                     is_superset(brg->isa_impl, avx10_2)))
         return status::unimplemented;
 
+    if (!IMPLICATION(brgattr.use_ace, brg->is_ace()))
+        return status::unimplemented;
+
+    // The ACE kernels cover bf16 and int8 only, see set_isa_impl(). Reject the
+    // remaining types so that dispatch falls through to an implementation that
+    // supports them.
+    if (brgattr.use_ace && (brg->is_f16 || brg->is_fp8))
+        return status::unimplemented;
+
     return status::success;
 }
 
@@ -650,6 +662,11 @@ status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
                 = brg->bdb_tail > 0 ? brg->bdb_tail : brg->bd_block;
         if ((max_vpad > min_bd_block)) return status::unimplemented;
     }
+
+    // Tile paths take unsigned B (TMUL under AMX-INT8, TOP4BUUD/TOP4BSUD
+    // under ACE); vector kernels read B as signed. is_tmm is final here.
+    if (!IMPLICATION(brg->dt_b == u8, brg->is_tmm))
+        return status::unimplemented;
 
     // Required for EVEX encoding for offsets
     // The kernel brgemm_amx_uker_t has support of large offsets in post-ops
@@ -725,13 +742,7 @@ status_t brgemm_kernel_destroy(brgemm_kernel_t *brg_kernel) {
 }
 
 status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
-    if (!brg.is_tmm) return status::unimplemented;
-
-    auto rd_block = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
-    if (brg.is_input_convert())
-        rd_block = utils::rnd_up(rd_block, 2 /*vnni_granularity*/);
-    else
-        rd_block = utils::rnd_up(rd_block, brg.rd_step);
+    if (!brg.is_tmm && !brg.is_ace()) return status::unimplemented;
 
     palette_config_t *buff = (palette_config_t *)(palette);
 
@@ -739,6 +750,19 @@ status_t brgemm_init_tiles(const brgemm_desc_t &brg, char palette[64]) {
     static constexpr int max_palette_size_in_bytes = 64;
     for (int i = 0; i < max_palette_size_in_bytes; i++)
         _tc[i] = 0;
+
+    // ACE uses a fixed 8x16x64 tile geometry; bytes 1-63 are zero.
+    // The descriptor was already cleared, so only the palette ID is set here.
+    if (brg.is_ace()) {
+        buff->palette_id = amx_palette_ace;
+        return status::success;
+    }
+
+    auto rd_block = (!brg.rdb && brg.rdb_tail) ? brg.rdb_tail : brg.rd_block;
+    if (brg.is_input_convert())
+        rd_block = utils::rnd_up(rd_block, 2 /*vnni_granularity*/);
+    else
+        rd_block = utils::rnd_up(rd_block, brg.rd_step);
 
     const int typesize_A = brg.is_input_convert()
             ? static_cast<int>(sizeof(int16_t))
@@ -912,6 +936,7 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(brgattr.hint_load_nt_A);
     CMP_BRGEMM_FIELD(brgattr.hint_load_nt_B);
     CMP_BRGEMM_FIELD(brgattr.K_koef);
+    CMP_BRGEMM_FIELD(brgattr.use_ace);
 
     if (lhs.brgattr.bd_mask_level > 0)
         for (int i = 0; i < lhs.bcast_dim; i++) {

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -252,6 +252,9 @@ struct DNNL_API brgemm_attr_t {
     const brgemm_batch_element_t *static_offsets;
     // hint whether to use on the fly copy of A due to unaligned accesses
     bool hint_fused_copy_a = false;
+    // request the ACE compute path; honored only when the descriptor resolves
+    // to an ACE ISA, see brgemm_desc_t::is_ace()
+    bool use_ace = false;
 };
 
 struct brgemm_desc_t {
@@ -532,14 +535,18 @@ struct brgemm_desc_t {
     }
 
     // Tile register decomposition
+    // TMUL tails need their own tile because the tail geometry is baked into
+    // the palette. ACE tiles are fixed-size, so a tail reuses the last tile.
     int get_bd_block2() const noexcept {
-        return static_cast<int>(
-                (bdb <= bd_block2) ? bdb : (bd_block2 + (bdb_tail ? 1 : 0)));
+        return static_cast<int>((bdb <= bd_block2)
+                        ? bdb
+                        : (bd_block2 + ((bdb_tail && !is_ace()) ? 1 : 0)));
     }
 
     int get_ld_block2() const noexcept {
-        return static_cast<int>(
-                (ldb <= ld_block2) ? ldb : (ld_block2 + (ldb_tail ? 1 : 0)));
+        return static_cast<int>((ldb <= ld_block2)
+                        ? ldb
+                        : (ld_block2 + ((ldb_tail && !is_ace()) ? 1 : 0)));
     }
 
     int get_num_C_tiles() const noexcept {
@@ -553,6 +560,7 @@ struct brgemm_desc_t {
     }
 
     int get_num_A_tiles() const noexcept {
+        if (is_ace()) return 0;
         const auto req_tiles = (bdb_tail && bdb > 1) ? 2 : 1;
         const auto max_tiles = AMX_TILES_NUM - get_num_C_tiles() - 1;
         const auto n_tiles = nstl::min(get_bd_block2(), max_tiles);
@@ -568,6 +576,7 @@ struct brgemm_desc_t {
     }
 
     int get_num_B_tiles() const noexcept {
+        if (is_ace()) return 0;
         const auto req_tiles = (ldb_tail && ldb > 1) ? 2 : 1;
         const auto max_tiles
                 = AMX_TILES_NUM - get_num_C_tiles() - get_num_A_tiles();
@@ -581,6 +590,22 @@ struct brgemm_desc_t {
         auto N = (n_tail || full_B_tiles == 0) ? get_num_B_tiles() - 1
                                                : n % full_B_tiles;
         return (get_num_C_tiles() + get_num_A_tiles() + N);
+    }
+
+    bool can_reuse_input_transform() const noexcept {
+        // FP8 conversion and transform caching share temporary workspace, so
+        // caching would allow converted data to overwrite a saved transform.
+        return !is_fp8_via_convert();
+    }
+
+    bool save_transform_A() const noexcept {
+        return can_reuse_input_transform() && ldb2 > 1;
+    }
+
+    bool save_transform_B() const noexcept {
+        // ACE never caches B: it loads B straight from memory with vmovups,
+        // so no transform buffer is reserved for it.
+        return !is_ace() && can_reuse_input_transform() && bdb2 > 1;
     }
 
     dim_t get_convert_wsp_buffer_size() const noexcept {
@@ -600,9 +625,34 @@ struct brgemm_desc_t {
         return 0;
     }
 
+    int all_rdb() const noexcept {
+        return static_cast<int>(rdb + (rdb_tail != 0));
+    }
+
+    int rd_block_A_size() const noexcept { return rd_block * typesize_A; }
+    int rd_block_B_size() const noexcept { return rd_block * typesize_B; }
+
+    // ACE A transform stores each bd_block in 4 ZMM registers.
+    // It packs 16 rows into 4 ZMMs and transposes to one ZMM per rd_step.
+    static constexpr int ace_zmms_per_bd_block = 4;
+    int ace_transformed_A_bd_block_size() const noexcept {
+        return ace_zmms_per_bd_block
+                * static_cast<int>(cpu_isa_traits_t<avx512_core>::vlen);
+    }
+    int ace_transformed_A_bd_block2_size() const noexcept {
+        return bd_block2 * ace_transformed_A_bd_block_size();
+    }
+
     dim_t get_wsp_buffer_size() const noexcept {
         dim_t sz = 0;
-        if (is_tmm) {
+        if (is_ace()) {
+            // ACE transforms and caches A only; B is consumed directly from
+            // its source matrix by the ZMM load path. No C tile area is
+            // reserved either, ACE reads accumulators out with tilemovrow.
+            if (save_transform_A())
+                sz = static_cast<dim_t>(ace_transformed_A_bd_block2_size())
+                        * brgattr.max_bs * all_rdb();
+        } else if (is_tmm) {
             sz = get_num_C_tiles() * tilesize; // postops buffer
             sz += get_convert_wsp_buffer_size();
             if (amx_wary_k_tail()) sz += tilesize;
@@ -676,6 +726,10 @@ struct brgemm_desc_t {
                 && brgattr.use_uker
                 && everyone_is(false, is_runtime_lda, is_runtime_ldb,
                         is_runtime_ldc, is_runtime_ldd);
+    }
+
+    bool is_ace() const noexcept {
+        return brgattr.use_ace && is_superset(isa_impl, cpu_isa_t::avx10_2_ace);
     }
 
     bool is_xf16() const noexcept { return is_bf16 || is_f16; }

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -159,14 +159,17 @@ void set_isa_impl(brgemm_desc_t *brg) {
                     is_isa_ok(avx512_core), avx512_core, is_isa_ok(avx2_vnni_2),
                     avx2_vnni_2, is_isa_ok(avx2), avx2);
         } else {
-            brg->isa_impl = utils::map(true, isa_undef,
-                    is_isa_ok(avx10_2_amx_2), avx10_2_amx_2,
+            brg->isa_impl = utils::map(true, isa_undef, is_isa_ok(avx10_2_ace),
+                    avx10_2_ace, is_isa_ok(avx10_2_amx_2), avx10_2_amx_2,
                     is_isa_ok(avx512_core_amx), avx512_core_amx,
                     is_isa_ok(avx10_2), avx10_2, is_isa_ok(avx512_core_bf16),
                     avx512_core_bf16, is_isa_ok(avx2_vnni_2), avx2_vnni_2);
         }
     } else if (brg->is_f16) {
         if (everyone_is(data_type::f16, brg->dt_a, brg->dt_b)) {
+            // ACE is deliberately absent: ACE defines no FP16 outer product,
+            // so a descriptor resolving to the ACE ISA could not be computed
+            // and would only lose the TMUL FP16 path.
             brg->isa_impl = utils::map(true, isa_undef,
                     is_isa_ok(avx10_2_amx_2), avx10_2_amx_2,
                     is_isa_ok(avx512_core_amx_fp16), avx512_core_amx_fp16,
@@ -183,16 +186,21 @@ void set_isa_impl(brgemm_desc_t *brg) {
                     is_isa_ok(avx512_core_fp16), avx512_core_fp16);
         }
     } else if (brg->is_int8) {
-        brg->isa_impl = utils::map(true, isa_undef, is_isa_ok(avx10_2_amx_2),
-                avx10_2_amx_2, is_isa_ok(avx512_core_amx_fp16),
-                avx512_core_amx_fp16, is_isa_ok(avx512_core_amx),
-                avx512_core_amx, is_isa_ok(avx10_2), avx10_2,
-                is_isa_ok(avx512_core_fp16), avx512_core_fp16,
+        // ACE is listed first, matching the bf16 branch above: utils::map
+        // returns the first match, so the ACE entry has to precede the TMUL
+        // ones for an ACE descriptor to win whenever both are usable.
+        brg->isa_impl = utils::map(true, isa_undef, is_isa_ok(avx10_2_ace),
+                avx10_2_ace, is_isa_ok(avx10_2_amx_2), avx10_2_amx_2,
+                is_isa_ok(avx512_core_amx_fp16), avx512_core_amx_fp16,
+                is_isa_ok(avx512_core_amx), avx512_core_amx, is_isa_ok(avx10_2),
+                avx10_2, is_isa_ok(avx512_core_fp16), avx512_core_fp16,
                 is_isa_ok(avx512_core_vnni), avx512_core_vnni,
                 is_isa_ok(avx512_core), avx512_core, is_isa_ok(avx2_vnni_2),
                 avx2_vnni_2, is_isa_ok(avx2_vnni), avx2_vnni, is_isa_ok(avx2),
                 avx2);
     } else if (brg->is_fp8) {
+        // ACE omits fp8 outer products; its kernels do not emit MX-block
+        // scaled TOP4MX*PS forms.
         brg->isa_impl = utils::map(true, isa_undef, is_isa_ok(avx10_2_amx_2),
                 avx10_2_amx_2, is_isa_ok(avx10_1_512_amx_fp16),
                 avx10_1_512_amx_fp16, is_isa_ok(avx10_2), avx10_2);
@@ -200,8 +208,11 @@ void set_isa_impl(brgemm_desc_t *brg) {
 }
 
 void set_brg_vmm(brgemm_desc_t *brg) {
+    // is_tmm means "accumulates into tile registers", which ACE does as well,
+    // so it is listed here next to the TMUL (is_*_tmm) flags. See the note on
+    // avx10_2_ace in cpu_isa_traits.hpp.
     brg->is_tmm = brg->is_int8_tmm || brg->is_bf16_tmm || brg->is_f16_tmm
-            || brg->is_bf32 || brg->is_fp8_tmm;
+            || brg->is_bf32 || brg->is_fp8_tmm || brg->is_ace();
     brg->is_zmm = !brg->is_tmm && mayiuse(avx512_core)
             && is_superset(brg->isa_impl, avx512_core);
     brg->is_ymm
@@ -303,6 +314,79 @@ int calculate_max_bcast_block(brgemm_desc_t *brg, const int adj_ld_block2) {
     return max_bcast_block;
 }
 
+// Helper function to find bdb and bdb_tail given bd_block and taking into
+// account bd_mask
+static void find_bdb_bd_mask(
+        const brgemm_desc_t *brg, int bd_block, dim_t &bdb, int &bdb_tail) {
+    const auto BD = brg->bcast_dim;
+
+    if (brg->brgattr.bd_mask_level != 2 || BD == 0) {
+        bdb = div_up(BD, bd_block);
+        bdb_tail = BD % bd_block;
+        return;
+    }
+
+    bdb = 0;
+    bdb_tail = 0;
+    for (int i = 0; i < BD;) {
+        if (brg->brgattr.bd_mask_level == 2 && brg->brgattr.bd_mask[i] == 0) {
+            i++;
+        } else {
+            i += bd_block;
+            if (i > BD) {
+                // Remainder bounded by bd_block, safe to narrow.
+                bdb_tail = static_cast<int>(BD - i + bd_block);
+                if (brg->brgattr.use_uker) bdb++;
+            } else
+                bdb++;
+        }
+    }
+}
+
+// Helper function to find bdb2 and ldb2 by given blocking
+static void recalc_blocking(brgemm_desc_t *brg, int new_bd_block,
+        int new_ld_block, int new_bd_block2, int new_ld_block2) {
+    const auto LD = brg->load_dim;
+
+    if (new_bd_block != 0) {
+        brg->bd_block = new_bd_block;
+        find_bdb_bd_mask(brg, brg->bd_block, brg->bdb, brg->bdb_tail);
+        brg->is_M_tail = (brg->bdb_tail != 0);
+    }
+
+    if (new_ld_block != 0) {
+        brg->ld_block = new_ld_block;
+        brg->ldb = div_up(LD, brg->ld_block);
+        brg->ldb_tail = LD % brg->ld_block;
+    }
+
+    if (new_bd_block2 != 0) {
+        brg->bd_block2 = new_bd_block2;
+        if (brg->can_dispatch_uker()) {
+            brg->bdb2 = div_up(brg->bdb, brg->bd_block2);
+            brg->bdb2_tail = 0;
+        } else {
+            if (brg->bdb_tail && brg->bd_block2 > 1) brg->bd_block2--;
+            auto full_bd_blocks = brg->bdb - (brg->bdb_tail != 0 ? 1 : 0);
+            brg->bdb2 = full_bd_blocks / brg->bd_block2;
+            brg->bdb2_tail = full_bd_blocks % brg->bd_block2;
+        }
+    }
+
+    if (new_ld_block2 != 0) {
+        brg->ld_block2 = new_ld_block2;
+        if (brg->can_dispatch_uker()) {
+            brg->ldb2 = div_up(brg->ldb, brg->ld_block2);
+            brg->ldb2_tail = 0;
+        } else {
+            if (brg->ldb_tail && brg->ld_block2 > 1) brg->ld_block2--;
+            auto full_ld_blocks = brg->ldb - (brg->ldb_tail != 0 ? 1 : 0);
+            brg->ldb2 = full_ld_blocks / brg->ld_block2;
+            brg->ldb2_tail = full_ld_blocks % brg->ld_block2;
+        }
+    }
+}
+
 status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     const auto L1 = platform::get_per_core_cache_size(1);
 
@@ -317,31 +401,6 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     brg->ldb = LD / brg->ld_block;
     brg->ldb_tail = LD % brg->ld_block;
 
-    auto find_bdb_bd_mask = [&](int bd_block, dim_t &bdb, int &bdb_tail) {
-        if (brg->brgattr.bd_mask_level != 2 || BD == 0) {
-            bdb = div_up(BD, bd_block);
-            bdb_tail = BD % bd_block;
-            return;
-        }
-
-        bdb = 0;
-        bdb_tail = 0;
-        for (int i = 0; i < BD;) {
-            if (brg->brgattr.bd_mask_level == 2
-                    && brg->brgattr.bd_mask[i] == 0) {
-                i++;
-            } else {
-                i += bd_block;
-                if (i > BD) {
-                    // Remainder bounded by bd_block, safe to narrow.
-                    bdb_tail = static_cast<int>(BD - i + bd_block);
-                    if (brg->brgattr.use_uker) bdb++;
-                } else
-                    bdb++;
-            }
-        }
-    };
-
     auto find_bd_block_for_bd_mask = [&]() {
         if (brg->brgattr.bd_mask_level != 2 || BD == 0) return false;
 
@@ -352,7 +411,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
         for (auto bd_block = start_bd_block; bd_block > 0; bd_block--) {
             dim_t bdb = 0;
             int bdb_tail = 0;
-            find_bdb_bd_mask(bd_block, bdb, bdb_tail);
+            find_bdb_bd_mask(brg, bd_block, bdb, bdb_tail);
             // bcast_dim should be divided by bd_block
             if (bdb < min_bdb && bdb_tail == 0) {
                 min_bdb = bdb;
@@ -450,53 +509,12 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
                 || brg->bd_block < 8);
     };
 
-    auto recalc_blocking = [&](int new_bd_block, int new_ld_block,
-                                   int new_bd_block2, int new_ld_block2) {
-        if (new_bd_block != 0) {
-            brg->bd_block = new_bd_block;
-            find_bdb_bd_mask(brg->bd_block, brg->bdb, brg->bdb_tail);
-            brg->is_M_tail = (brg->bdb_tail != 0);
-        }
-
-        if (new_ld_block != 0) {
-            brg->ld_block = new_ld_block;
-            brg->ldb = div_up(LD, brg->ld_block);
-            brg->ldb_tail = LD % brg->ld_block;
-        }
-
-        if (new_bd_block2 != 0) {
-            brg->bd_block2 = new_bd_block2;
-            if (brg->can_dispatch_uker()) {
-                brg->bdb2 = div_up(brg->bdb, brg->bd_block2);
-                brg->bdb2_tail = 0;
-            } else {
-                if (brg->bdb_tail && brg->bd_block2 > 1) brg->bd_block2--;
-                auto full_bd_blocks = brg->bdb - (brg->bdb_tail != 0 ? 1 : 0);
-                brg->bdb2 = full_bd_blocks / brg->bd_block2;
-                brg->bdb2_tail = full_bd_blocks % brg->bd_block2;
-            }
-        }
-
-        if (new_ld_block2 != 0) {
-            brg->ld_block2 = new_ld_block2;
-            if (brg->can_dispatch_uker()) {
-                brg->ldb2 = div_up(brg->ldb, brg->ld_block2);
-                brg->ldb2_tail = 0;
-            } else {
-                if (brg->ldb_tail && brg->ld_block2 > 1) brg->ld_block2--;
-                auto full_ld_blocks = brg->ldb - (brg->ldb_tail != 0 ? 1 : 0);
-                brg->ldb2 = full_ld_blocks / brg->ld_block2;
-                brg->ldb2_tail = full_ld_blocks % brg->ld_block2;
-            }
-        }
-    };
-
     auto recalc_blocking_ext
             = [&](int new_bd_block, int new_ld_block, int new_bd_block2,
                       int new_ld_block2, bool load_nt_A, bool load_nt_B,
                       brgemm_kernel_innermost_loop_t innermost_loop) {
         recalc_blocking(
-                new_bd_block, new_ld_block, new_bd_block2, new_ld_block2);
+                brg, new_bd_block, new_ld_block, new_bd_block2, new_ld_block2);
         brg->load_nt_A = load_nt_A;
         brg->load_nt_B = load_nt_B;
         brg->innermost_loop = innermost_loop;
@@ -536,7 +554,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     brg->load_nt_B = try_load_nt_B && try_load_nt;
 
     recalc_blocking(
-            brg->bd_block, brg->ld_block, brg->bd_block2, brg->ld_block2);
+            brg, brg->bd_block, brg->ld_block, brg->bd_block2, brg->ld_block2);
 
     if (brg->can_dispatch_uker()) {
         // Blocking heuristics for some shapes
@@ -589,41 +607,41 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
         const bool ldb_tail_only = ldb_tail_16 && !bdb_block_tail;
         const bool bdb_tail_only = bdb_block_tail && !ldb_tail_16;
         if (ldb_tail_only && LD > 64 && brg->ld_block < 8) {
-            recalc_blocking(0, 16, 2, 1);
+            recalc_blocking(brg, 0, 16, 2, 1);
         } else if (ldb_tail_only && weak_ldb && LD_R16 == 64) {
-            recalc_blocking(0, 16, 1, 4);
+            recalc_blocking(brg, 0, 16, 1, 4);
         } else if (ldb_tail_only && weak_ldb && LD_R16 == 48) {
-            recalc_blocking(0, 16, 1, 3);
+            recalc_blocking(brg, 0, 16, 1, 3);
         } else if (ldb_tail_only && weak_ldb && LD_R16 == 32) {
-            recalc_blocking(0, 16, 2, 2);
+            recalc_blocking(brg, 0, 16, 2, 2);
         } else if (BD <= 16) {
             // Have to call recalc_blocking twice to calculate ldb
             // BD <= 16 here, safe to narrow into the bd_block parameter.
-            recalc_blocking(static_cast<int>(BD), 16, 0, 0);
+            recalc_blocking(brg, static_cast<int>(BD), 16, 0, 0);
             const int ld_block2 = static_cast<int>(
                     nstl::min<dim_t>(ldb_tail_16 ? ((brg->ldb > 4) ? 3 : 4) : 5,
                             div_up(LD, 16)));
-            recalc_blocking(0, 0, 1, ld_block2);
+            recalc_blocking(brg, 0, 0, 1, ld_block2);
         } else if (bdb_tail_only && weak_bdb && BD > 64) {
-            recalc_blocking(16, 16, 1, 2);
+            recalc_blocking(brg, 16, 16, 1, 2);
         } else if (bdb_tail_only && weak_bdb && BD_R16 == 64) {
-            recalc_blocking(16, 16, 4, 1);
+            recalc_blocking(brg, 16, 16, 4, 1);
         } else if (bdb_tail_only && weak_bdb && BD_R16 == 48) {
-            recalc_blocking(16, 16, 3, 1);
+            recalc_blocking(brg, 16, 16, 3, 1);
         } else if (bdb_tail_only && weak_bdb && BD_R16 == 32
                 && (LD % 32 == 0)) {
-            recalc_blocking(16, 16, 2, 2);
+            recalc_blocking(brg, 16, 16, 2, 2);
         } else if (LD <= 16) {
             // Have to call recalc_blocking twice to calculate bdb
             // we can't use ld_block other than 16
-            recalc_blocking(16, 16, 0, 0);
+            recalc_blocking(brg, 16, 16, 0, 0);
             const int bd_block2 = static_cast<int>(
                     nstl::min<dim_t>(brg->bdb_tail ? (brg->bdb > 4 ? 3 : 4) : 5,
                             div_up(BD, 16)));
-            recalc_blocking(0, 0, bd_block2, 1);
+            recalc_blocking(brg, 0, 0, bd_block2, 1);
         } else if (bdb_block_tail && ldb_tail_16 && BD_R16 == 32 && LD_R16 == 32
                 && (weak_ldb || weak_bdb)) {
-            recalc_blocking(16, 16, 2, 2);
+            recalc_blocking(brg, 16, 16, 2, 2);
         }
 
         // The code below is a draft for the future optimization of interleave
@@ -650,7 +668,7 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
     }
 
     // check hints for blocking parameters
-    recalc_blocking(brg->brgattr.hint_bd_block, brg->brgattr.hint_ld_block,
+    recalc_blocking(brg, brg->brgattr.hint_bd_block, brg->brgattr.hint_ld_block,
             brg->brgattr.hint_bd_block2 ? brg->brgattr.hint_bd_block2
                                         : brg->bd_block2,
             brg->brgattr.hint_ld_block2 ? brg->brgattr.hint_ld_block2
@@ -852,6 +870,80 @@ status_t brgemm_blocking_vmm_gemv(brgemm_desc_t *brg) {
     return status::success;
 }
 
+status_t brgemm_blocking_ace(brgemm_desc_t *brg) {
+    const auto LD = brg->load_dim;
+    const auto BD = brg->bcast_dim;
+
+    brg->ld_block = 16;
+    // Use actual M as bd_block for M < 16.
+    brg->bd_block = static_cast<int>(nstl::min<dim_t>(BD, 16));
+
+    // recalc_blocking() below recomputes ldb/bdb and the tails; use the same
+    // convention here so that the search picks the block2 values for the
+    // blocking the kernel is actually built with.
+    const auto ldb = div_up(LD, brg->ld_block);
+    dim_t bdb = 0;
+    int bdb_tail = 0;
+    find_bdb_bd_mask(brg, brg->bd_block, bdb, bdb_tail);
+
+    const auto ntiles = brgemm_desc_t::AMX_TILES_NUM;
+
+    // ACE post-op zmm layout: bias uses zmm10-17, scales use zmm18-23.
+    // Active scales cap ld_block2 at 6 to avoid overlap with accm zmm24-31.
+    const bool needs_scales = brg->with_src_scales || brg->with_wei_scales;
+    const int max_postop_ld_block2 = needs_scales ? 6 : 8;
+
+    dim_t best_loads_number = LLONG_MAX;
+    auto best_bd_block2 = 1;
+    auto best_ld_block2 = 1;
+    const int max_bd_block2 = static_cast<int>(nstl::min<dim_t>(ntiles, bdb));
+    for (int bd_block2 = 1; bd_block2 <= max_bd_block2; bd_block2++) {
+        const int ld_block2 = static_cast<int>(nstl::min<dim_t>(
+                nstl::min<dim_t>(nstl::max<dim_t>(1, ldb), ntiles / bd_block2),
+                max_postop_ld_block2));
+
+        // Calculate the number of loads for one iteration by reduce_dim
+        const auto loads_number
+                = static_cast<dim_t>(ldb) * div_up(bdb, bd_block2)
+                + bdb * div_up(ldb, ld_block2);
+        if (loads_number < best_loads_number) {
+            best_loads_number = loads_number;
+            best_bd_block2 = bd_block2;
+            best_ld_block2 = ld_block2;
+        }
+    }
+    brg->bd_block2 = best_bd_block2;
+    brg->ld_block2 = best_ld_block2;
+
+    recalc_blocking(
+            brg, brg->bd_block, brg->ld_block, brg->bd_block2, brg->ld_block2);
+
+    // check hints for blocking parameters
+    recalc_blocking(brg, brg->brgattr.hint_bd_block, brg->brgattr.hint_ld_block,
+            brg->brgattr.hint_bd_block2 ? brg->brgattr.hint_bd_block2
+                                        : brg->bd_block2,
+            brg->brgattr.hint_ld_block2 ? brg->brgattr.hint_ld_block2
+                                        : brg->ld_block2);
+
+    // The hints above are unclamped, and brgemm_init_tiles() returns early on
+    // the ACE palette without reaching its AMX_TILES_NUM check, so the budget
+    // has to be enforced here. ACE keeps A and B in zmms, only C is tiled.
+    if (brg->get_num_C_tiles() > brgemm_desc_t::AMX_TILES_NUM)
+        return status::unimplemented;
+
+    // A reduction block fills the four ZMMs used by the ACE A transform.
+    brg->rd_block = brg->rd_step * brgemm_desc_t::ace_zmms_per_bd_block;
+    brg->rdb = brg->reduce_dim / brg->rd_block;
+    brg->rdb_tail = brg->reduce_dim % brg->rd_block;
+
+    // To use fewer registers in the ACE micro-kernel: load several blocks of A
+    // and keep them in registers if bd_block2 < ld_block2, otherwise load
+    // several blocks of B and keep them in registers.
+    brg->n_bcast_1_load = brg->bd_block2 < brg->ld_block2;
+
+    return status::success;
+}
+
 status_t brgemm_blocking_vmm(brgemm_desc_t *brg) {
     if (brg->is_gemv) return brgemm_blocking_vmm_gemv(brg);
     const auto L1 = platform::get_per_core_cache_size(1);
@@ -955,7 +1047,9 @@ status_t brgemm_blocking(brgemm_desc_t *brg) {
     if (!(brg->is_tmm || brg->is_zmm || brg->is_ymm))
         return status::unimplemented;
 
-    if (brg->is_tmm)
+    if (brg->is_ace())
+        CHECK(brgemm_blocking_ace(brg));
+    else if (brg->is_tmm)
         CHECK(brgemm_blocking_tmm(brg));
     else
         CHECK(brgemm_blocking_vmm(brg));
@@ -1094,14 +1188,17 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
             && mayiuse(avx512_core_amx);
 
     set_isa_impl(brg);
-    brg->is_int8_tmm
-            = brg->is_int8 && is_superset(brg->isa_impl, avx512_core_amx);
-    brg->is_bf16_tmm
-            = brg->is_bf16 && is_superset(brg->isa_impl, avx512_core_amx);
-    brg->is_f16_tmm
-            = brg->is_f16 && is_superset(brg->isa_impl, avx512_core_amx_fp16);
-    brg->is_fp8_tmm
-            = brg->is_fp8 && is_superset(brg->isa_impl, avx512_core_amx_fp16);
+    // ACE hardware can resolve bf16/int8 to ACE even without TMUL.
+    // Query the hardware instead of assuming ACE implies no TMUL.
+    const auto has_tmul = [&](cpu_isa_t amx_isa) {
+        return is_superset(brg->isa_impl, amx_isa)
+                || (is_superset(brg->isa_impl, avx10_2_ace)
+                        && mayiuse(amx_isa));
+    };
+    brg->is_int8_tmm = brg->is_int8 && has_tmul(avx512_core_amx);
+    brg->is_bf16_tmm = brg->is_bf16 && has_tmul(avx512_core_amx);
+    brg->is_f16_tmm = brg->is_f16 && has_tmul(avx512_core_amx_fp16);
+    brg->is_fp8_tmm = brg->is_fp8 && has_tmul(avx512_core_amx_fp16);
 
     brg->has_int8_vnni = isa_has_int8_vnni(brg->isa_impl);
 

--- a/src/cpu/x64/brgemm/brgemm_utils.hpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.hpp
@@ -22,6 +22,7 @@
 #include "cpu/x64/cpu_isa_traits.hpp"
 
 #include "common/c_types_map.hpp"
+#include "common/utils.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -40,6 +41,22 @@ void set_isa_impl(brgemm_desc_t *brg);
 status_t brgemm_blocking(brgemm_desc_t *brg);
 
 status_t brdgmm_blocking(brgemm_desc_t *brg);
+
+/* The ACE kernels compute bf16 and int8 only, see set_isa_impl(). */
+inline bool ace_dt_ok(data_type_t dt_a, data_type_t dt_b) {
+    using namespace data_type;
+    return utils::everyone_is(bf16, dt_a, dt_b)
+            || (utils::one_of(dt_a, u8, s8) && utils::one_of(dt_b, u8, s8));
+}
+
+/* ACE picks the unrolled kernel by default; it is usually fastest, but its
+ * per-bd/ld block expansion can bloat code. TODO: when M*N*K*max_bs grows,
+ * switch from the unconditional `true` to a size-based criterion that falls
+ * back to the base kernel. Some needed dimensions are not available everywhere,
+ * so they must be threaded through with the criterion. */
+inline bool ace_prefer_uker() {
+    return true;
+}
 
 /* The purpose of this function is to enable initialization of brgemm values
  * and then call additional functions like blocking heuristics without

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -134,7 +134,7 @@ struct jit_brgemm_amx_uker_base_t : public jit_base_brgemm_kernel_t {
                     || with_binary_batch_bcast_ || with_binary_spatial_bcast_
                     || with_binary_no_bcast_;
         }
-        use_ils_ = brg.brgattr.use_interleave_stores;
+        use_ils_ = brg.brgattr.use_interleave_stores && !brg.is_ace();
     }
 
     DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_brgemm_amx_uker_base_t)
@@ -167,19 +167,22 @@ private:
     const reg64_t reg_addr_batch = r13;
     const reg64_savable_t reg_aux1_batch {
             regscratchpad_, rbx, rbp, may_use_rbp()};
-    const reg64_t reg_A = r11;
-    const reg64_t reg_B = r10;
+    const reg64_savable_t reg_A {regscratchpad_, r11};
+    const reg64_savable_t reg_B {regscratchpad_, r10};
     const reg64_t reg_stride_lda = r14;
     const reg64_t reg_stride_ldb = abi_not_param1;
-    const reg64_t reg_C = r15;
-    const reg64_t reg_D = r12;
+    const reg64_savable_t reg_C {regscratchpad_, r15};
+    const reg64_savable_t reg_D {regscratchpad_, r12};
 
-    const reg64_t reg_buf = r8;
+    const reg64_savable_t reg_buf {regscratchpad_, r8};
     const reg64_t reg_BS = rbx;
     const reg64_t reg_BS_loop = r9;
-    const reg64_t reg_bias = rbx;
-    const reg64_t reg_scales = rbx;
-    const reg64_t reg_dst_scales = rbx;
+    const reg64_savable_t reg_bias {regscratchpad_, rbx};
+    const reg64_savable_t reg_bias_backup {regscratchpad_, rbx};
+    const reg64_savable_t reg_src_scales {regscratchpad_, rbx};
+    const reg64_savable_t reg_wei_scales {regscratchpad_, rbx};
+    const reg64_savable_t reg_wei_scales_backup {regscratchpad_, rbx};
+    const reg64_savable_t reg_dst_scales {regscratchpad_, rbx};
 
     const reg64_t reg_stride_ld_block = rdx;
     const reg64_t reg_do_post_ops = rbx;
@@ -405,7 +408,6 @@ private:
     brgemm_iteration_t prev_bi_;
     // current storing coordinates
     int ils_vec_ = 0, ils_bdb_ = 0, ils_ldb_ = 0, ils_bd_start_ = 0;
-    int ils_bd_step_ = 3; // heuristic value
     prf_t prf0A, prf1A, prf2A, prfntaA, prf0B, prf1B, prf2B, prfntaB, prf0C,
             prf1C;
 
@@ -413,11 +415,28 @@ private:
     bool use_sat_cvt_ = false;
 
     bool ununroll_bd_loop = false;
+    // Number of ZMM registers per bd block for ACE microkernel.
+    static constexpr int ace_zmms_per_bd_block
+            = brgemm_desc_t::ace_zmms_per_bd_block;
 
-    Xbyak::Opmask ld_full_mask = Xbyak::Opmask(2);
-    Xbyak::Opmask ld_tail_mask = Xbyak::Opmask(3);
-    Xbyak::Opmask fp_col_mask = Xbyak::Opmask(4);
-    Xbyak::Opmask rd_tail_mask = Xbyak::Opmask(5);
+    Xbyak::Opmask ld_full_mask = Xbyak::Opmask(0);
+    // Post-ops may use and clobber Opmask(1), so it is not allocated here.
+    // TODO: check whether post-ops can be made to preserve it.
+    Xbyak::Opmask ld_tail_mask = Xbyak::Opmask(7);
+    Xbyak::Opmask fp_col_mask = Xbyak::Opmask(2);
+    Xbyak::Opmask rd_tail_mask = Xbyak::Opmask(3);
+    Xbyak::Opmask fp8_tmp_mask = Xbyak::Opmask(4);
+
+    // The four constant masks below are set up once in generate(), so they
+    // must avoid k4: the fp8 converters clobber it and are instantiated for
+    // f8 binary post-ops even when ACE itself computes bf16/int8. k2 and k3
+    // are only written by fp8 convert and AMX k-tail paths ACE never takes.
+    // ace_load_A_mask is rewritten before every use, so k4 is safe for it.
+    Xbyak::Opmask ace_load_A_mask = Xbyak::Opmask(4);
+    Xbyak::Opmask ace_load_A_mask_f = Xbyak::Opmask(2);
+    Xbyak::Opmask ace_load_A_mask_f0 = Xbyak::Opmask(3);
+    Xbyak::Opmask ace_load_A_mask_f00 = Xbyak::Opmask(5);
+    Xbyak::Opmask ace_load_A_mask_f000 = Xbyak::Opmask(6);
 
     // Zmm map below
     const Xbyak::Zmm &zmm_tmp_1() const noexcept { return this->zmm0; }
@@ -430,7 +449,6 @@ private:
     Xmm fp8_emu_xmm_3() const noexcept { return Xmm(3); }
     Xmm fp8_emu_xmm_4() const noexcept { return Xmm(6); }
     Xmm fp8_emu_xmm_5() const noexcept { return Xmm(7); }
-    Xbyak::Opmask fp8_tmp_mask = Xbyak::Opmask(6);
     const reg64_t fp8_tmp_reg = rax;
 
     const Xbyak::Zmm zmm_bf32_permute = zmm6;
@@ -439,23 +457,77 @@ private:
     const Xbyak::Zmm zmm_lbound = zmm8;
     const Xbyak::Zmm zmm_ubound = zmm9;
 
+    int store_bd_step() const {
+        return brg.is_ace() ? 8 : 3; /*heuristic values*/
+    }
+
     // zmm_bias, zmm_bias and accm shouldn't be overlapped
     Xbyak::Zmm accm(int bd) const {
         assert(bd < 16);
-        return Xbyak::Zmm(31 - (bd % ils_bd_step_));
+        return Xbyak::Zmm(31 - (bd % store_bd_step()));
     }
 
+    int ace_reserved_zmms() { return 5; }
+
     Xbyak::Zmm zmm_bias(int ldb) const {
-        assert(ldb < 5);
-        // zmm10 - zmm14
-        return Xbyak::Zmm(10 + ldb);
+        if (brg.is_ace()) {
+            // ACE: zmm10 - zmm17 (avoids zmm6=zmm_zp_comp_a,
+            // zmm7=zmm_zp_c, zmm8=zmm_lbound, zmm9=zmm_ubound)
+            assert(ldb < 8); // ld_block2 capped at 8 (no-scales) in blocking
+            return Xbyak::Zmm(10 + ldb);
+        } else {
+            assert(ldb < 5);
+            // zmm10 - zmm14
+            return Xbyak::Zmm(10 + ldb);
+        }
     }
 
     Xbyak::Zmm zmm_scales(int ldb) const {
-        assert(ldb < 5);
-        assert(ils_bd_step_ < 10);
-        // zmm15 - zmm19
-        return Xbyak::Zmm(15 + ldb);
+        if (brg.is_ace()) {
+            // ACE: zmm18 - zmm23 (safe below accm zmm24-31)
+            // ld_block2 capped at 6 when scales active in blocking
+            assert(ldb < 6); // max safe: zmm18+5=zmm23 < zmm24(accm)
+            assert(store_bd_step() < 10);
+            return Xbyak::Zmm(18 + ldb);
+        } else {
+            assert(ldb < 5);
+            assert(store_bd_step() < 10);
+            // zmm15 - zmm19
+            return Xbyak::Zmm(15 + ldb);
+        }
+    }
+
+    // ACE rd steps = ZMM count used per A/B block in the micro-kernel.
+    // This is the number of rd steps for each block.
+    int ace_rd_steps(int rd_block) const noexcept {
+        return div_up(rd_block, brg.rd_step);
+    }
+
+    Xbyak::Zmm ace_zmm_tmp(int i) {
+        assert(1 <= i && i <= 4);
+        return Xbyak::Zmm(i);
+    }
+
+    // ACE A register: bdb block index, rds register index.
+    // Returns the ZMM for the ACE micro-kernel A matrix.
+    Xbyak::Zmm ace_zmm_A(int bdb, int rds) {
+        const int base_idx
+                = ace_rd_steps(brg.rd_block) * (brg.n_bcast_1_load ? bdb : 0);
+        const int idx = ace_reserved_zmms() + base_idx + rds;
+        assert(idx < 32 && "ZMM register index overflow in ace_zmm_A");
+        return Xbyak::Zmm(idx);
+    }
+
+    // ACE B register: ldb block index, rds register index.
+    // Returns the ZMM for the ACE micro-kernel B matrix.
+    Xbyak::Zmm ace_zmm_B(int ldb, int rds) {
+        // n_bcast_1_load reuses one B register; only rds 0 is valid.
+        assert(IMPLICATION(brg.n_bcast_1_load, rds == 0));
+        const int base_idx = ace_rd_steps(brg.rd_block)
+                * (brg.n_bcast_1_load ? brg.bd_block2 : (1 + ldb));
+        const int idx = ace_reserved_zmms() + base_idx + rds;
+        assert(idx < 32 && "ZMM register index overflow in ace_zmm_B");
+        return Xbyak::Zmm(idx);
     }
 
     template <typename U>
@@ -549,12 +621,20 @@ private:
     void maybe_fused_copy_A_nt_load(brgemm_iteration_t &bi, int bdb);
 
     void maybe_sprinkle_prefetches();
+    void ace_load_A_4x16bytes(
+            const Zmm &zmm, size_t mask, const Reg64 &reg_A, dim_t offset);
+
+    void ace_load_A(brgemm_iteration_t &bi, int bdb, dim_t offset);
+    void ace_load_B(brgemm_iteration_t &bi, int ldb, dim_t offset, int rdstep);
+    void outer_product(const Zmm &zmm_a, const Zmm &zmm_b, const Tmm &accm);
 
     void tdpbxxd(brgemm_iteration_t &bi, int bdb_idx, int ldb_idx,
             bool do_pre_tilestore, bool do_post_tilestore);
 
     void gemm_microkernel_amx(brgemm_iteration_t &bi);
+    void gemm_microkernel_ace(brgemm_iteration_t &bi);
 
+    void rdb_loop_body(brgemm_iteration_t &bi);
     void rdb_loop(brgemm_iteration_t &bi);
 
     void bs_loop_body(brgemm_iteration_t &bi);
@@ -607,6 +687,9 @@ private:
             int rd_elem_idx = 0) const noexcept;
 
     dim_t C_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
+            dim_t ldb) const noexcept;
+
+    dim_t C_offset_row(const brgemm_iteration_t &bi, int bdb, int inp_bd,
             dim_t ldb) const noexcept;
 
     dim_t D_offset(const brgemm_iteration_t &bi, int bdb, int inp_bd,
@@ -759,9 +842,9 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset_wsp(
     const auto bs_offs = bi.bsi->pos * brg.bcast_dim
             * rnd_up(brg.reduce_dim, brg.max_rd_block()) * brg.typesize_A;
 
-    const auto bdb_offs = bi.bdi->pos(bdb) * brg.rd_block * brg.typesize_A;
+    const auto bdb_offs = bi.bdi->pos(bdb) * brg.rd_block_A_size();
     const auto rdb_offs
-            = bi.rdi->pos(rdb) * brg.bcast_dim * brg.rd_block * brg.typesize_A;
+            = bi.rdi->pos(rdb) * brg.bcast_dim * brg.rd_block_A_size();
 
     return transform_offset + bs_offs + bdb_offs + rdb_offs;
 }
@@ -774,7 +857,7 @@ dim_t jit_brgemm_amx_uker_base_t::A_offset(
     const auto bdb_offs
             = ununroll_bd_loop ? bi.bdi->rel_pos(bdb) : bi.bdi->pos(bdb);
     return bdb_offs * LDA2_size_ + bs_offs
-            + bi.rdi->pos(rdb) * brg.rd_block * brg.typesize_A;
+            + bi.rdi->pos(rdb) * brg.rd_block_A_size();
 }
 
 dim_t jit_brgemm_amx_uker_base_t::A_offset_line(const brgemm_iteration_t &bi,
@@ -814,6 +897,23 @@ dim_t jit_brgemm_amx_uker_base_t::C_offset(const brgemm_iteration_t &bi,
 
     return (dim_t)bd_shift * LDC2_size_M_ + (dim_t)bloc_idx * LDC2_size_N_
             + in_block * brg.typesize_C;
+}
+
+// ACE stores accumulators one row at a time, so the bd stride within a block is
+// LDC_size_ and not LDC2_size_M_, which matters when LDC2_M != LDC. The offset
+// between bdb blocks still uses LDC2_size_M_, as legacy AMX tilestored does.
+dim_t jit_brgemm_amx_uker_base_t::C_offset_row(const brgemm_iteration_t &bi,
+        int bdb, int inp_bd, dim_t ldb) const noexcept {
+    const auto bi_bd_start = get_out_bd(bi.bdi, 0, 0);
+    const auto bdb_start = get_out_bd(bi.bdi, bdb, 0);
+    const auto bdb_start_shift
+            = bdb_start - (ununroll_bd_loop ? bi_bd_start : 0);
+    dim_t ldc_elem = (dim_t)ldb * brg.ld_block;
+    dim_t bloc_idx = ldc_elem / brg.LDC;
+    dim_t in_block = ldc_elem % brg.LDC;
+
+    return (dim_t)bdb_start_shift * LDC2_size_M_ + (dim_t)inp_bd * LDC_size_
+            + (dim_t)bloc_idx * LDC2_size_N_ + in_block * brg.typesize_C;
 }
 
 dim_t jit_brgemm_amx_uker_base_t::D_offset(const brgemm_iteration_t &bi,
@@ -967,6 +1067,40 @@ void jit_brgemm_amx_uker_base_t::read_params() {
         mov(reg_per_mn_comp, ptr[param1 + GET_OFF(ptr_per_mn_compensation)]);
         reg_per_mn_comp.save();
     }
+
+    if (brg.with_bias) {
+        mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
+        reg_bias.save();
+    }
+    if (brg.with_src_scales) {
+        mov(reg_src_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
+        reg_src_scales.save();
+    }
+    if (brg.with_wei_scales) {
+        mov(reg_wei_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
+        reg_wei_scales.save();
+    }
+    if (brg.with_dst_scales) {
+        mov(reg_dst_scales, ptr[param1 + GET_OFF(ptr_dst_scales)]);
+        reg_dst_scales.save();
+    }
+
+    if (brg.type == brgemm_offs || brg.type == brgemm_static_offs) {
+        if (brg.layout == brgemm_row_major) {
+            mov(reg_A, ptr[param1 + GET_OFF(ptr_A)]);
+            mov(reg_B, ptr[param1 + GET_OFF(ptr_B)]);
+        } else {
+            mov(reg_A, ptr[param1 + GET_OFF(ptr_B)]);
+            mov(reg_B, ptr[param1 + GET_OFF(ptr_A)]);
+        }
+        reg_A.save();
+        reg_B.save();
+    }
+
+    mov(reg_C, ptr[param1 + GET_OFF(ptr_C)]);
+    reg_C.save();
+    mov(reg_D, ptr[param1 + GET_OFF(ptr_D)]);
+    reg_D.save();
 }
 
 void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
@@ -984,6 +1118,11 @@ void jit_brgemm_amx_uker_base_t::load_accumulators(brgemm_iteration_t &bi) {
     for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
     for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
         if (may_load_accumulators_) {
+            // TILELOADD is not supported under the ACE palette and raises
+            // #UD. may_load_accumulators_ is therefore never set for ACE;
+            // see init().
+            assert(!brg.is_ace()
+                    && "TILELOADD is illegal under the ACE palette");
             auto c_offset = C_offset(bi, bdb, 0, bi.ldi->pos(ldb)) + ils_shift;
             tileloadd(Tmm(get_C_tensor(bi, bdb, ldb)),
                     ptr[reg_C + c_offset + reg_stride_ld_block]);
@@ -1081,6 +1220,12 @@ void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
 
 void jit_brgemm_amx_uker_base_t::maybe_saturation(Xbyak::Zmm &zmm) {
     if (!dt_requires_saturation_) return;
+    // For ACE, zmm_lbound/zmm_ubound (zmm8/zmm9) are reused as ace_zmm_B
+    // registers and clobbered during computation, so restore the saturation
+    // state before converting.
+    if (brg.is_ace())
+        init_saturate_f32(zmm_lbound, zmm_ubound, reg_tmp_gpr, data_type::f32,
+                brg.dt_d, false, use_sat_cvt_);
     saturate_cvt_f32(
             zmm, zmm_lbound, zmm_ubound, brg.dt_d, false, use_sat_cvt_);
 }
@@ -1126,10 +1271,10 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     // Load wei_scales for per K-block application (is_per_k_wei_scales).
     // This must happen for both apply_postops and non-apply_postops paths.
     if (brg.with_wei_scales && brg.is_per_k_wei_scales) {
-        mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
+        reg_wei_scales.restore();
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
-                    reg_scales, scales_offset(ldi->pos(ldb)));
+                    reg_wei_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
             if (brg.is_single_wei_scale) {
                 // Broadcast a single scale value — handle non-f32 types.
@@ -1156,9 +1301,9 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
         }
 
         if (brg.with_src_scales && !brg.is_per_k_src_scales) {
-            mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
+            reg_src_scales.restore();
             auto zmm_src_sc = zmm_tmp_1();
-            auto src_sc_addr = EVEX_compress_addr(reg_scales, 0);
+            auto src_sc_addr = EVEX_compress_addr(reg_src_scales, 0);
             switch (brg.dt_src_scales) {
                 case data_type::bf16:
                     vpbroadcastw(zmm_src_sc, src_sc_addr);
@@ -1179,7 +1324,7 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     if (!bi.apply_postops) return;
 
     if (brg.with_bias) {
-        mov(reg_bias, ptr[param1 + GET_OFF(ptr_bias)]);
+        reg_bias.restore();
 
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto ptr_bias
@@ -1191,11 +1336,12 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
 
     if (brg.with_src_scales && !brg.is_per_k_src_scales
             && !brg.is_per_k_wei_scales) {
-        mov(reg_scales, ptr[param1 + GET_OFF(ptr_src_scales)]);
+        reg_src_scales.restore();
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             // Hard-coded assumption for a single src scale value being
             // supported, thus, offset is 0.
-            auto scales_ptr = EVEX_compress_addr(reg_scales, /* offset = */ 0);
+            auto scales_ptr
+                    = EVEX_compress_addr(reg_src_scales, /* offset = */ 0);
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
             const auto zmm_scale = zmm_scales(ldb);
             const auto zmm_scale_masked = zmm_scales(ldb) | k_mask | T_z;
@@ -1219,10 +1365,10 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
     }
 
     if (brg.with_wei_scales && !brg.is_per_k_wei_scales) {
-        mov(reg_scales, ptr[param1 + GET_OFF(ptr_wei_scales)]);
+        reg_wei_scales.restore();
         for (int ldb = 0; ldb < ldi->block2(); ldb++) {
             auto scales_ptr = EVEX_compress_addr(
-                    reg_scales, scales_offset(ldi->pos(ldb)));
+                    reg_wei_scales, scales_offset(ldi->pos(ldb)));
             auto k_mask = ldi->is_tail(ldb) ? ld_tail_mask : ld_full_mask;
 
             const auto zmm_scale = zmm_scales(ldb);
@@ -1234,8 +1380,9 @@ void jit_brgemm_amx_uker_base_t::prepare_post_ops_registers(
                     // when both scales are defined.
                     assert(brg.dt_wei_scales == data_type::f32);
                     // Src scales are set, need to multiply by their value.
-                    auto scales_bcast_ptr = EVEX_compress_addr(reg_scales,
-                            scales_offset(ldi->pos(ldb)), /* bcast = */ true);
+                    auto scales_bcast_ptr = EVEX_compress_addr(reg_wei_scales,
+                            scales_offset(ldi->pos(ldb)),
+                            /* bcast = */ true);
                     vmulps(zmm_scale_masked, zmm_scale, scales_bcast_ptr);
                 } else {
                     switch (brg.dt_wei_scales) {
@@ -1503,13 +1650,17 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         auto zmm = accm(bd);
         if (!is_out_bd(bi.bdi, bdb, bd)) continue;
 
-        auto vreg_acc = bi.ldi->is_tail(ldb) ? accm(bd) | ld_tail_mask | T_z
-                                             : accm(bd);
         some_bd_mask = true;
 
+        auto vreg_acc = accm(bd);
+        // fill accumulator vector by data
         if (bi.skip_accumulation) {
             vpxord(vreg_acc, vreg_acc, vreg_acc);
+        } else if (brg.is_ace()) {
+            tilemovrow(vreg_acc, Tmm(get_C_tensor(bi, bdb, ldb)), bd);
         } else {
+            vreg_acc = bi.ldi->is_tail(ldb) ? vreg_acc | ld_tail_mask | T_z
+                                            : vreg_acc;
             const auto wsp_offset = (use_ils_ || brg.interleave_tilestores_)
                     ? (bdb * prev_bi_.ldi->block2() + ldb)
                             * prev_bi_.bdi->block(0) * ld_block_C_size_
@@ -1572,10 +1723,18 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
             }
         }
 
+        // For ACE with LDC2 layout: use LDC_size_ per row (not LDC2_size_M_
+        // which is the tile-block stride). For other cases, use C_offset as-is.
+        const bool ace_ldc2 = brg.is_ace() && brg.brgattr.LDC2_M > 0;
+        const auto c_offset = ace_ldc2
+                ? C_offset_row(bi, bdb, bd, bi.ldi->pos(ldb))
+                : C_offset(bi, bdb, bd, bi.ldi->pos(ldb));
+        if (ace_ldc2) lea(reg_long_offt, ptr[reg_C + c_offset]);
+        const auto ptr_C = ace_ldc2
+                ? zword[reg_long_offt]
+                : EVEX_compress_addr_safe(reg_C, c_offset, reg_tmp_gpr);
+
         if (need_to_apply_alpha_beta_ || bi.skip_accumulation) {
-            const auto c_offset = C_offset(bi, bdb, bd, bi.ldi->pos(ldb));
-            const auto ptr_C
-                    = EVEX_compress_addr_safe(reg_C, c_offset, reg_long_offt);
             apply_alpha_beta_to_vector(
                     zmm.getIdx(), ptr_C, bi.ldi->is_tail(ldb));
         }
@@ -1658,7 +1817,7 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
     }
 
     if (brg.with_dst_scales) {
-        mov(reg_dst_scales, ptr[param1 + GET_OFF(ptr_dst_scales)]);
+        reg_dst_scales.restore();
         auto zmm_dst_scales = zmm_tmp_1();
         vbroadcastss(zmm_dst_scales, ptr[reg_dst_scales]);
         for (auto bd = bd_start; bd < bd_finish; bd++) {
@@ -1754,8 +1913,7 @@ void jit_brgemm_amx_uker_base_t::store_vector(
 
     if (!is_out_bd(bi.bdi, bdb, inp_bd)) return;
 
-    auto vreg_acc = bi.ldi->is_tail(ldb) ? accm(inp_bd) | ld_tail_mask | T_z
-                                         : accm(inp_bd);
+    auto acc_idx = accm(inp_bd).getIdx();
 
     auto ldb_pos = bi.ldi->pos(ldb);
     auto is_ld_tail = bi.ldi->is_tail(ldb);
@@ -1764,17 +1922,20 @@ void jit_brgemm_amx_uker_base_t::store_vector(
 
     if (bi.apply_postops) {
         auto ptr_D = EVEX_compress_addr_safe(reg_D, d_offset, reg_tmp_gpr);
-        store_vector_with_post_ops(vreg_acc.getIdx(), ptr_D, is_ld_tail);
+        store_vector_with_post_ops(acc_idx, ptr_D, is_ld_tail);
     } else if (are_post_ops_applicable_) {
         // Intermediate C-buffer store; dtype may be narrower than the
         // accumulator (e.g. bf16/f16) under dst-dtype C-buffer mode.
         auto ptr_C = EVEX_compress_addr_safe(reg_C, c_offset, reg_tmp_gpr);
+        store_vector_without_post_ops(acc_idx, ptr_C, is_ld_tail, brg.dt_c);
+    } else if (brg.is_ace() && brg.brgattr.LDC2_M > 0) {
+        const auto row_offset = C_offset_row(bi, bdb, inp_bd, ldb_pos);
+        lea(reg_long_offt, ptr[reg_C + row_offset]);
         store_vector_without_post_ops(
-                vreg_acc.getIdx(), ptr_C, is_ld_tail, brg.dt_c);
+                acc_idx, zword[reg_long_offt], is_ld_tail, brg.dt_c);
     } else {
         auto ptr_D = EVEX_compress_addr_safe(reg_D, d_offset, reg_tmp_gpr);
-        store_vector_without_post_ops(
-                vreg_acc.getIdx(), ptr_D, is_ld_tail, brg.dt_d);
+        store_vector_without_post_ops(acc_idx, ptr_D, is_ld_tail, brg.dt_d);
     }
 }
 
@@ -1797,7 +1958,7 @@ void jit_brgemm_amx_uker_base_t::interleave_store(
         }
         prepare_post_ops_registers_ldb(prev_bi_, 0);
         ils_bd_start_ = 0;
-        auto bd_finish = nstl::min(ils_bd_step_, prev_bi_.bdi->block(0));
+        auto bd_finish = nstl::min(store_bd_step(), prev_bi_.bdi->block(0));
         process_output_range(prev_bi_, 0, bd_finish, cur_bdb, cur_ldb);
     }
 
@@ -1823,10 +1984,10 @@ void jit_brgemm_amx_uker_base_t::interleave_store(
         if (ldb != cur_ldb) prepare_post_ops_registers_ldb(prev_bi_, ldb);
 
         if (bdb != cur_bdb || ldb != cur_ldb
-                || rnd_dn(bd, ils_bd_step_) != ils_bd_start_) {
-            ils_bd_start_ = rnd_dn(bd, ils_bd_step_);
+                || rnd_dn(bd, store_bd_step()) != ils_bd_start_) {
+            ils_bd_start_ = rnd_dn(bd, store_bd_step());
             auto bd_finish = nstl::min(
-                    ils_bd_start_ + ils_bd_step_, prev_bi_.bdi->block(bdb));
+                    ils_bd_start_ + store_bd_step(), prev_bi_.bdi->block(bdb));
             process_output_range(prev_bi_, ils_bd_start_, bd_finish, bdb, ldb);
         }
 
@@ -1865,8 +2026,13 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
 
     for_(int bdb = 0; bdb < bi.bdi->block2(); bdb++)
     for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
-        if (store_by_vectors) {
-            if (!brg.interleave_tilestores_ && !bi.skip_accumulation) {
+
+        // ACE palette does not support tilestored, so always use
+        // vector store path (tilemovrow + vmovups) for ACE.
+        const bool tile_store_by_vectors = store_by_vectors || brg.is_ace();
+        if (tile_store_by_vectors) {
+            if (!brg.interleave_tilestores_ && !bi.skip_accumulation
+                    && !brg.is_ace()) {
                 const auto wsp_offset = use_ils_
                         ? (bdb * bi.ldi->block2() + ldb) * bi.bdi->block(0)
                                 * ld_block_C_size_
@@ -1879,9 +2045,9 @@ void jit_brgemm_amx_uker_base_t::store_accumulators(brgemm_iteration_t &bi) {
             prepare_post_ops_registers_ldb(bi, ldb);
 
             for (int bd_step = 0; bd_step < bi.bdi->block(bdb);
-                    bd_step += ils_bd_step_) {
-                auto bd_finish
-                        = nstl::min(bd_step + ils_bd_step_, bi.bdi->block(bdb));
+                    bd_step += store_bd_step()) {
+                auto bd_finish = nstl::min(
+                        bd_step + store_bd_step(), bi.bdi->block(bdb));
                 process_output_range(bi, bd_step, bd_finish, bdb, ldb);
 
                 for (auto bd = bd_step; bd < bd_finish; bd++)
@@ -1917,9 +2083,9 @@ void jit_brgemm_amx_uker_base_t::set_A_B_matrices(dim_t bs) {
                             batch_offset + GET_OFF_BATCH_ELEMENT(ptr.A)));
         }
     } else if (brg.type == brgemm_offs) {
+        reg_A.restore();
+        reg_B.restore();
         if (brg.layout == brgemm_row_major) {
-            mov(reg_A, ptr[param1 + GET_OFF(ptr_A)]);
-            mov(reg_B, ptr[param1 + GET_OFF(ptr_B)]);
             add(reg_A,
                     EVEX_compress_addr(reg_addr_batch,
                             batch_offset + GET_OFF_BATCH_ELEMENT(offset.A)));
@@ -1927,8 +2093,6 @@ void jit_brgemm_amx_uker_base_t::set_A_B_matrices(dim_t bs) {
                     EVEX_compress_addr(reg_addr_batch,
                             batch_offset + GET_OFF_BATCH_ELEMENT(offset.B)));
         } else {
-            mov(reg_A, ptr[param1 + GET_OFF(ptr_B)]);
-            mov(reg_B, ptr[param1 + GET_OFF(ptr_A)]);
             add(reg_A,
                     EVEX_compress_addr(reg_addr_batch,
                             batch_offset + GET_OFF_BATCH_ELEMENT(offset.B)));
@@ -1956,14 +2120,14 @@ void jit_brgemm_amx_uker_base_t::set_A_B_matrices() {
         }
     } else if (brg.type == brgemm_offs) {
         reg_aux1_batch.restore();
+        // The offsets are relative to the original matrix pointers, so the
+        // base pointers have to be reloaded before every batch element.
+        reg_A.restore();
+        reg_B.restore();
         if (brg.layout == brgemm_row_major) {
-            mov(reg_A, ptr[param1 + GET_OFF(ptr_A)]);
-            mov(reg_B, ptr[param1 + GET_OFF(ptr_B)]);
             add(reg_A, ptr[reg_aux1_batch + GET_OFF_BATCH_ELEMENT(offset.A)]);
             add(reg_B, ptr[reg_aux1_batch + GET_OFF_BATCH_ELEMENT(offset.B)]);
         } else {
-            mov(reg_A, ptr[param1 + GET_OFF(ptr_B)]);
-            mov(reg_B, ptr[param1 + GET_OFF(ptr_A)]);
             add(reg_A, ptr[reg_aux1_batch + GET_OFF_BATCH_ELEMENT(offset.B)]);
             add(reg_B, ptr[reg_aux1_batch + GET_OFF_BATCH_ELEMENT(offset.A)]);
         }
@@ -2010,7 +2174,7 @@ void jit_brgemm_amx_uker_base_t::maybe_tileloadd_nt(
 
     auto t1 = Tmm(is_A ? brg.get_A_tensor(xdb, bi.bdi->is_tail(xdb))
                        : brg.get_B_tensor(xdb, bi.ldi->is_tail(xdb)));
-    auto reg_base = is_A ? reg_A : reg_B;
+    auto &reg_base = is_A ? reg_A : reg_B;
     auto reg_stride = is_A ? reg_stride_lda : reg_stride_ldb;
 
     const bool mem_advice_A = utils::one_of(brg.brgattr.mem_advice,
@@ -2355,16 +2519,10 @@ void jit_brgemm_amx_uker_base_t::maybe_pre_process_data(brgemm_iteration_t &bi,
 
     const auto &tloop = imap_[bi.apply_postops];
     auto should_save_transform = [&](matrix_kind_t mk) {
-        // For fp8 via conversion we use temporal buffer heavily for conversion.
-        // Therefore saved data may be overwritten
-        // TODO: remove this restriction
-        if (brg.is_fp8_via_convert()) return false;
-        // save if there is a reuse
-        if (mk == matrix_A) {
-            return tloop.ldis.size() > 1;
-        } else {
-            return tloop.bdis.size() > 1;
-        }
+        if (mk == matrix_A)
+            return brg.save_transform_A();
+        else
+            return brg.save_transform_B();
     };
 
     const auto dt = mk == matrix_A ? brg.dt_a : brg.dt_b;
@@ -2523,6 +2681,224 @@ void jit_brgemm_amx_uker_base_t::copy_k_tail_to_wsp(const Tmm &t1,
     }
 }
 
+void jit_brgemm_amx_uker_base_t::ace_load_A_4x16bytes(
+        const Zmm &zmm, size_t mask, const Reg64 &reg_A, dim_t offset) {
+    constexpr size_t full_mask = 0xFFFF;
+    constexpr size_t all_full_mask = 0xFFFFFFFFFFFFFFFF;
+
+    const auto zmm_tmp1 = ace_zmm_tmp(1);
+    const auto xmm_tmp = Xmm(zmm_tmp1.getIdx());
+    if (mask != all_full_mask) vpxord(zmm, zmm, zmm);
+
+    for (int i = 0; i < 4; ++i) {
+        const auto cur_offset = offset + i * lda() * ace_zmms_per_bd_block;
+        const size_t cur_mask = (mask >> (16 * i)) & full_mask;
+        if (cur_mask == 0) continue;
+
+        if (cur_mask != full_mask) {
+            // Partial mask: load bytes and insert into ZMM.
+            // vbroadcasti32x4 is unsafe because it reads the full 128-bit block first.
+            mov(reg_tmp_gpr, cur_mask);
+            kmovq(ace_load_A_mask, reg_tmp_gpr);
+            vmovdqu8(xmm_tmp | ace_load_A_mask | T_z, ptr[reg_A + cur_offset]);
+            vinserti64x2(zmm, zmm, xmm_tmp, i);
+        } else {
+            // Note: bind by value; assigning through a reference to
+            // ace_load_A_mask would clobber the member used above.
+            const Xbyak::Opmask bcst_mask
+                    = utils::pick(i, ace_load_A_mask_f, ace_load_A_mask_f0,
+                            ace_load_A_mask_f00, ace_load_A_mask_f000);
+            vbroadcasti32x4(zmm | bcst_mask, ptr[reg_A + cur_offset]);
+        }
+    }
+}
+
+void jit_brgemm_amx_uker_base_t::ace_load_A(
+        brgemm_iteration_t &bi, int bdb, dim_t offset) {
+
+    // ACE inputs are fetched through ZMMs rather than TILELOADD/TILELOADDT1.
+    // ACE also does not imply MOVRS, so NT and memory-advice hints do not
+    // affect the ACE A/B load paths.
+
+    const auto bd_block = bi.bdi->block(bdb);
+    const auto rd_block = bi.rdi->block(0);
+    const auto base_zmm_idx = ace_zmm_A(bdb, 0).getIdx();
+    const auto a_zmm1 = Zmm(base_zmm_idx + 0);
+    const auto a_zmm2 = Zmm(base_zmm_idx + 1);
+    const auto a_zmm3 = Zmm(base_zmm_idx + 2);
+    const auto a_zmm4 = Zmm(base_zmm_idx + 3);
+
+    const auto transformed_data_base
+            = (bi.bsi->idx * brg.all_rdb() + bi.rdi->pos(0))
+                    * brg.ace_transformed_A_bd_block2_size()
+            + bdb * brg.ace_transformed_A_bd_block_size();
+    const auto transf_addr = [&](int i) {
+        const auto transformed_data_offset
+                = transformed_data_base + i * zmm_width_in_bytes;
+        return ptr[reg_buf + transformed_data_offset];
+    };
+
+    if (brg.save_transform_A() && bi.ldi->idx > 0) {
+
+        vmovups(a_zmm1, transf_addr(0));
+        vmovups(a_zmm2, transf_addr(1));
+        vmovups(a_zmm3, transf_addr(2));
+        vmovups(a_zmm4, transf_addr(3));
+        return; // done
+    }
+
+    // Load 4 zmm registers with 16 rows, 4 bytes per each row: each register
+    // holds 16 x rd_step elements (2 for bf16, 4 for int8).
+
+    const int mask_stride = 16; // 16 bytes per row
+    const auto rd_block2 = rd_block;
+    for (int rb = 0; rb < ace_zmms_per_bd_block; ++rb) {
+        auto zmm = ace_zmm_A(bdb, rb);
+        if (rb >= bd_block) {
+            vpxord(zmm, zmm, zmm);
+            continue;
+        }
+        size_t mask = 0;
+        int mask_row_offs = 0;
+        for (int row = rb; row < bd_block; row += ace_zmms_per_bd_block) {
+            for (int col = 0; col < rd_block2; ++col) {
+                if (brg.typesize_A == 2) {
+                    // bf16, f16
+                    mask |= (size_t)0b11 << (mask_row_offs + col * 2);
+                } else if (brg.typesize_A == 1) {
+                    // f8_e5m2, f8_e4m3, s8, u8
+                    mask |= (size_t)0b1 << (mask_row_offs + col);
+                } else {
+                    assert(!"Unsupported data type for ace_load_A");
+                }
+            }
+            mask_row_offs += mask_stride;
+        }
+        ace_load_A_4x16bytes(zmm, mask, reg_A, offset + rb * lda());
+    }
+    // transpose four 4x4 blocks
+    const auto tmp_zmm1 = ace_zmm_tmp(1);
+    const auto tmp_zmm2 = ace_zmm_tmp(2);
+    const auto tmp_zmm3 = ace_zmm_tmp(3);
+    const auto tmp_zmm4 = ace_zmm_tmp(4);
+    vpunpckldq(tmp_zmm1, a_zmm1, a_zmm2);
+    vpunpckhdq(tmp_zmm2, a_zmm1, a_zmm2);
+    vpunpckldq(tmp_zmm3, a_zmm3, a_zmm4);
+    vpunpckhdq(tmp_zmm4, a_zmm3, a_zmm4);
+    vpunpcklqdq(a_zmm1, tmp_zmm1, tmp_zmm3);
+    vpunpckhqdq(a_zmm2, tmp_zmm1, tmp_zmm3);
+    vpunpcklqdq(a_zmm3, tmp_zmm2, tmp_zmm4);
+    vpunpckhqdq(a_zmm4, tmp_zmm2, tmp_zmm4);
+
+    if (brg.save_transform_A() && bi.ldi->idx == 0) {
+
+        vmovups(transf_addr(0), a_zmm1);
+        vmovups(transf_addr(1), a_zmm2);
+        vmovups(transf_addr(2), a_zmm3);
+        vmovups(transf_addr(3), a_zmm4);
+    }
+}
+
+void jit_brgemm_amx_uker_base_t::ace_load_B(
+        brgemm_iteration_t &bi, int ldb, dim_t offset, int rdstep) {
+    // if rdstep is -1, then we load all registers for this ldb
+    const auto start_rdstep = (rdstep == -1) ? 0 : rdstep;
+    const auto finish_rdstep
+            = (rdstep == -1) ? ace_rd_steps(bi.rdi->block(0)) : rdstep + 1;
+    // EVEX_compress_addr uses rbp (= reg_aux1_batch) as a scale multiplier
+    // for offsets >= 0x200. Since rbp holds a live batch pointer during the
+    // microkernel, we must not let it be used as an address component.
+    // Pre-add the base offset to reg_tmp_gpr and use small per-rds offsets.
+    const dim_t rds_stride = brg.rd_step * LDB_size_;
+    // When called with a specific rdstep (n_bcast_1_load=true path), the
+    // caller passes B_offset for the ldb block but does not advance for the
+    // K-step. We must add rdstep * rds_stride so that each K-step reads from
+    // the correct row of B (not always row 0).
+    const dim_t effective_offset
+            = offset + (rdstep == -1 ? 0 : rdstep * rds_stride);
+    const bool needs_base_fixup = (effective_offset >= EVEX_max_8b_offt);
+    if (needs_base_fixup) { lea(reg_tmp_gpr, ptr[reg_B + effective_offset]); }
+    for (int rds = start_rdstep; rds < finish_rdstep; rds++) {
+        // if rdstep != -1 , then (rds - start_rdstep) should be 0
+        auto zmm = ace_zmm_B(ldb, rds - start_rdstep);
+        auto k_mask = (!bi.ldi->is_tail(ldb)) ? ld_full_mask : ld_tail_mask;
+        const dim_t rds_off = (rds - start_rdstep) * rds_stride;
+        // Use dword-granular vmovups: each ld element occupies one dword of
+        // the B register, and ld_tail_mask has one bit per element. A
+        // qword-granular load would fetch twice the tail bytes and can read
+        // past the end of B.
+        if (needs_base_fixup) {
+            vmovups(zmm | k_mask | T_z,
+                    EVEX_compress_addr(reg_tmp_gpr, rds_off));
+        } else {
+            vmovups(zmm | k_mask | T_z,
+                    EVEX_compress_addr(reg_B, effective_offset + rds_off));
+        }
+    }
+}
+
+void jit_brgemm_amx_uker_base_t::outer_product(
+        const Zmm &zmm_a, const Zmm &zmm_b, const Tmm &accm) {
+    using namespace data_type;
+    if (brg.dt_a == bf16 && brg.dt_b == bf16) {
+        top2bf16ps(accm, zmm_a, zmm_b);
+    } else if (brg.dt_a == u8 && brg.dt_b == u8) {
+        top4buud(accm, zmm_a, zmm_b);
+    } else if (brg.dt_a == u8 && brg.dt_b == s8) {
+        top4busd(accm, zmm_a, zmm_b);
+    } else if (brg.dt_a == s8 && brg.dt_b == u8) {
+        top4bsud(accm, zmm_a, zmm_b);
+    } else if (brg.dt_a == s8 && brg.dt_b == s8) {
+        top4bssd(accm, zmm_a, zmm_b);
+    } else {
+        assert(!"Unsupported data type for outer product");
+    }
+}
+
+void jit_brgemm_amx_uker_base_t::gemm_microkernel_ace(brgemm_iteration_t &bi) {
+    prf0A.reset();
+    prf1A.reset();
+    prf2A.reset();
+    prfntaA.reset();
+    prf0B.reset();
+    prf1B.reset();
+    prf2B.reset();
+    prfntaB.reset();
+
+    if (brg.n_bcast_1_load) {
+        for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+            ace_load_A(bi, bdb, A_offset(bi, bdb));
+        }
+
+        for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+            for (int rds = 0; rds < ace_rd_steps(bi.rdi->block(0)); rds++) {
+                // Load one line from B for the current ldb and rds into
+                // ace_zmm_B(ldb, 0).
+                ace_load_B(bi, ldb, B_offset(bi, ldb), rds);
+                for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+                    const auto &accm = Tmm(get_C_tensor(bi, bdb, ldb));
+                    outer_product(ace_zmm_A(bdb, rds), ace_zmm_B(ldb, 0), accm);
+                }
+            }
+        }
+    } else {
+        for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+            // load several registers for each ldb
+            ace_load_B(bi, ldb, B_offset(bi, ldb), -1);
+        }
+
+        for (int bdb = 0; bdb < bi.bdi->block2(); bdb++) {
+            ace_load_A(bi, bdb, A_offset(bi, bdb));
+            for (int ldb = 0; ldb < bi.ldi->block2(); ldb++) {
+                const auto &accm = Tmm(get_C_tensor(bi, bdb, ldb));
+                for (int rds = 0; rds < ace_rd_steps(bi.rdi->block(0)); rds++)
+                    outer_product(
+                            ace_zmm_A(bdb, rds), ace_zmm_B(ldb, rds), accm);
+            }
+        }
+    }
+}
+
 void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
     prf0A.reset();
     prf1A.reset();
@@ -2571,11 +2947,18 @@ void jit_brgemm_amx_uker_base_t::gemm_microkernel_amx(brgemm_iteration_t &bi) {
             do_post_tilestore);
 }
 
+void jit_brgemm_amx_uker_base_t::rdb_loop_body(brgemm_iteration_t &bi) {
+    if (brg.is_ace())
+        gemm_microkernel_ace(bi);
+    else
+        gemm_microkernel_amx(bi);
+}
+
 void jit_brgemm_amx_uker_base_t::rdb_loop(brgemm_iteration_t &bi) {
     const auto &tloop = imap_[bi.apply_postops];
     for (auto &rdi : tloop.rdis) {
         bi.rdi = &rdi;
-        gemm_microkernel_amx(bi);
+        rdb_loop_body(bi);
     }
 }
 
@@ -2787,8 +3170,8 @@ void jit_brgemm_amx_uker_base_t::bdb_loop(brgemm_iteration_t &bi) {
 }
 
 void jit_brgemm_amx_uker_base_t::top_loop(brgemm_iteration_t &bi) {
-    mov(reg_C, ptr[param1 + GET_OFF(ptr_C)]);
-    mov(reg_D, ptr[param1 + GET_OFF(ptr_D)]);
+    reg_C.restore();
+    reg_D.restore();
     init(bi);
     if (brg.innermost_loop == brgemm_ld_loop_innermost)
         bdb_loop(bi);
@@ -3019,13 +3402,8 @@ void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
                     (brg.brgattr.max_bs == 1 || brg.type == brgemm_static_offs)
                             && !brg.brgattr.var_bs);
     if (brg.type == brgemm_static_offs && !bi.skip_accumulation) {
-        if (brg.layout == brgemm_row_major) {
-            mov(reg_A, ptr[param1 + GET_OFF(ptr_A)]);
-            mov(reg_B, ptr[param1 + GET_OFF(ptr_B)]);
-        } else {
-            mov(reg_A, ptr[param1 + GET_OFF(ptr_B)]);
-            mov(reg_B, ptr[param1 + GET_OFF(ptr_A)]);
-        }
+        reg_A.restore();
+        reg_B.restore();
     } else if (brg.brgattr.max_bs == 1 && !bi.skip_accumulation) {
         assert(one_of(brg.type, brgemm_addr, brgemm_offs));
         if (brg.type == brgemm_addr) {
@@ -3045,13 +3423,8 @@ void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
                                 reg_addr_batch, GET_OFF_BATCH_ELEMENT(ptr.A)));
             }
         } else if (brg.type == brgemm_offs) {
-            if (brg.layout == brgemm_row_major) {
-                mov(reg_A, ptr[param1 + GET_OFF(ptr_A)]);
-                mov(reg_B, ptr[param1 + GET_OFF(ptr_B)]);
-            } else {
-                mov(reg_A, ptr[param1 + GET_OFF(ptr_B)]);
-                mov(reg_B, ptr[param1 + GET_OFF(ptr_A)]);
-            }
+            reg_A.restore();
+            reg_B.restore();
         }
     }
 
@@ -3059,8 +3432,9 @@ void jit_brgemm_amx_uker_base_t::init(brgemm_iteration_t &bi) {
 
     // for many primitives which use brgemm the brg.ldb2 is equal or less than 1
     // so we can read post ops data only once per brgemm call
-
-    if (brg.ldb2 > 1) {
+    // For ACE the ZMM registers are used intensively to load data from A and
+    // B, which prevents keeping the post-ops data until post-processing.
+    if (brg.ldb2 > 1 || brg.is_ace()) {
         prepare_post_ops_registers_once_ = false;
     } else if (brg.ldb2 == 1) {
         if (brg.ldb2_tail == 0 && brg.ldb_tail == 0) {
@@ -3119,14 +3493,26 @@ void jit_brgemm_amx_uker_base_t::generate() {
 
     sub(rsp, regscratchpad_.Size());
 
-    const auto full_mask = size_t {0xffffffffffffffff};
     const auto tail_mask = size_t((1 << brg.ldb_tail) - 1);
     reg64_t reg_mask = rbx;
 
-    mov(reg_mask, full_mask);
-    kmovq(ld_full_mask, reg_mask);
+    // ld_full_mask is k0, which encodes as "no masking", so it is never read.
     mov(reg_mask, tail_mask);
     kmovq(ld_tail_mask, reg_mask);
+
+    if (brg.is_ace()) {
+        // Constant row masks of the ACE A load. ACE emits bf16 and int8 only,
+        // so the fp8 paths that would clobber these opmasks are never taken.
+        assert(!brg.is_fp8);
+        mov(reg_mask, 0xf);
+        kmovq(ace_load_A_mask_f, reg_mask);
+        mov(reg_mask, 0xf0);
+        kmovq(ace_load_A_mask_f0, reg_mask);
+        mov(reg_mask, 0xf00);
+        kmovq(ace_load_A_mask_f00, reg_mask);
+        mov(reg_mask, 0xf000);
+        kmovq(ace_load_A_mask_f000, reg_mask);
+    }
 
     LDA_size_ = static_cast<dim_t>(brg.typesize_A) * brg.LDA;
     LDB_size_ = static_cast<dim_t>(brg.typesize_B) * brg.LDB;
@@ -3159,8 +3545,9 @@ void jit_brgemm_amx_uker_base_t::generate() {
 
     // if beta == 1 and C datatype is f32 it is better to perform addition by
     // reading tiles directly from C instead of by reading/writing by vectors
+    // ACE palette does not support tileloadd, so we must use vector path
     may_load_accumulators_ = one_of(brg.alpha, 0.f, 1.f) && brg.beta == 1.f
-            && brg.dt_c == brg.dt_d
+            && !brg.is_ace() && brg.dt_c == brg.dt_d
             && IMPLICATION(brg.is_input_convert(), brg.is_fp8_via_convert())
             && IMPLICATION(
                     brg.is_f32 || brg.is_bf16, brg.dt_c == data_type::f32)
@@ -3186,7 +3573,7 @@ void jit_brgemm_amx_uker_base_t::generate() {
             vmovups(zmm_bf32_permute, ptr[rip + permute_index_table]);
     }
 
-    mov(reg_stride_lda, lda());
+    mov(reg_stride_lda, lda() * (brg.is_ace() ? ace_zmms_per_bd_block : 1));
     mov(reg_stride_ldb, ldb());
 
     bool non_postops_generate

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -148,6 +148,12 @@ struct jit_brgemm_kernel_t : public jit_base_brgemm_kernel_t {
 private:
     brgemm_desc_t brg;
 
+    // The packed ACE B tensor is a sequence of N panels of brg.LDB columns,
+    // consecutive panels being brgattr.LDB2 elements apart.
+    bool ace_has_b_panels() const {
+        return brg.is_ace() && brg.brgattr.LDB2 != 0 && brg.load_dim > brg.LDB;
+    }
+
     enum matrix_kind_t { matrix_A, matrix_B };
     static constexpr int zmm_width_in_bytes_
             = cpu_isa_traits_t<avx512_core>::vlen;
@@ -250,6 +256,11 @@ private:
     const reg64_savable_backup_t reg_aux_D_bdb_loop_backup {reg_aux_D, r19};
     const reg64_savable_t reg_D_bdb_loop_shift {regscratchpad_, rbx, r21};
 
+    // ld columns already consumed in the current N panel of packed ACE B.
+    // Only used when the ld loop can cross a panel, see ldb_regs_shift().
+    const reg64_savable_t reg_ace_ldb_pos {
+            regscratchpad_, rbx, ace_has_b_panels()};
+
     /* bf16 emulation */
     const reg64_t bf16_emu_scratch = rbx;
 
@@ -264,16 +275,22 @@ private:
     bool with_binary_non_scalar_bcast_ = false;
     const int max_effective_vregs;
 
-    // Opmask(2) and Opmask(3) have slightly different semantics in the GEMM
-    // and GEMV code paths. This is why we have GEMV-specific aliases.
+    // Number of ZMM registers per bd block for ACE microkernel.
+    static constexpr int ace_zmms_per_bd_block
+            = brgemm_desc_t::ace_zmms_per_bd_block;
+
+    // Mask register allocation:
+    // k1: ld_full_mask (B matrix full blocks)
+    // k2: ace_load_A_mask (A matrix loading)
+    // k7: ld_tail_mask (B matrix tail blocks)
     //
     // GEMM:
     //   ld_full_mask - all bits in the mask are set; used along the load
     //                  dimension.
     //   ld_tail_mask - only bits corresponding to the load dimension tail
     //                  are set.
-    Xbyak::Opmask ld_full_mask = Xbyak::Opmask(2);
-    Xbyak::Opmask ld_tail_mask = Xbyak::Opmask(3);
+    Xbyak::Opmask ld_full_mask = Xbyak::Opmask(1);
+    Xbyak::Opmask ld_tail_mask = Xbyak::Opmask(7);
 
     // GEMV:
     //   gemv_full_mask    - all bits in the mask are set; used along the
@@ -290,6 +307,10 @@ private:
     // Used for both AMX GEMM and GEMV code paths.
     Xbyak::Opmask rd_tail_mask = Xbyak::Opmask(6);
     Xbyak::Opmask fp8_tail_mask = Xbyak::Opmask(7);
+
+    // Aliases gemv_full_mask. That is only safe because ACE implements GEMM
+    // only, so the gemv path is never generated together with it.
+    Xbyak::Opmask ace_load_A_mask = Xbyak::Opmask(2);
 
     static int get_max_effective_vregs(const brgemm_desc_t &brg) {
         auto used_vregs = 0;
@@ -351,6 +372,44 @@ private:
     Vmm vmm_beta() const noexcept { return vmm_tmp(1); }
     Vmm vmm_lbound() const noexcept { return vmm_tmp(1); }
     Vmm vmm_ubound() const noexcept { return vmm_tmp(0); }
+
+    // ace_rd_steps is the number of rd steps in the ACE micro-kernel loop.
+    // It is the number of ZMM registers used for each block of the A and B
+    // matrices.
+    int ace_rd_steps(int rd_block) const noexcept {
+        return div_up(rd_block, brg.rd_step);
+    }
+
+    Xbyak::Zmm ace_zmm_tmp(int i) {
+        assert(1 <= i && i <= 4);
+        return Xbyak::Zmm(i);
+    }
+
+    // Returns the Zmm register for matrix A for ACE microkernel.
+    // bdb: block index in bd dimension
+    // rds: register index within the block
+    Xbyak::Zmm ace_zmm_A(int bdb, int rds) {
+        const int base_idx
+                = ace_rd_steps(brg.rd_block) * (brg.n_bcast_1_load ? bdb : 0);
+        const int idx = 5 + base_idx + rds;
+        assert(idx < 32 && "ZMM register index overflow in ace_zmm_A");
+        return Xbyak::Zmm(idx);
+    }
+
+    // Returns the Zmm register for matrix B for ACE microkernel.
+    // bd_block2: number of bd blocks the caller is currently generating for
+    // ldb: block index in ld dimension
+    // rds: register index within the block
+    Xbyak::Zmm ace_zmm_B(int bd_block2, int ldb, int rds) {
+        // With n_bcast_1_load the A blocks sit below and every ldb is loaded
+        // and consumed before the next one, so all ldb reuse one B slot.
+        // Indexing by ldb here would run past zmm31 once ld_block2 >= 6.
+        const int base_idx = ace_rd_steps(brg.rd_block)
+                * (brg.n_bcast_1_load ? bd_block2 : (1 + ldb));
+        const int idx = 5 + base_idx + rds;
+        assert(idx < 32 && "ZMM register index overflow in ace_zmm_B");
+        return Xbyak::Zmm(idx);
+    }
 
     Vmm vmm_one_bytes() const noexcept { return Vmm(3); }
     Vmm vmm_zp_a_shift() const noexcept { return Vmm(2); }
@@ -419,7 +478,7 @@ private:
     void advance_bdb_post_op_regs(int adj_bd_block);
     void restore_bdb_post_op_regs(int bd_block2);
     void ldb_regs_shift(int ld_block2, bool is_tail = false);
-    void advance_bd_block2_post_op_regs(int bd_block2);
+    void advance_bd_block2_post_op_regs(int bd_block2, bool is_tail = false);
 
     void copy_post_ops_stack_values_to_aux(bool is_reg_tail);
     void read_params();
@@ -481,6 +540,16 @@ private:
     void gemv_microkernel(bool is_bdb_tail, int ld_block, bool is_rd_tail);
     void gemm_microkernel_amx(int bd_block2, bool is_bdb_tail, int ld_block2,
             bool is_rd_tail, bool is_ld_tail);
+    void gemm_microkernel_ace(int bd_block2, bool is_bdb_tail, int ld_block2,
+            bool is_rd_tail, bool is_ld_tail);
+
+    void ace_load_A_4x16bytes(
+            const Zmm &zmm, size_t mask, const Reg64 &reg_A, dim_t offset);
+    void ace_load_A(int bdb, dim_t offset, bool is_bdb_tail, int bd_block,
+            bool is_rd_tail = false);
+    void ace_load_B(int ldb, dim_t offset, int rdstep, bool is_ld_tail,
+            int rd_block, int bd_block2);
+    void outer_product(const Zmm &zmm_a, const Zmm &zmm_b, const Tmm &accm);
 
     void bs_loop(int bd_block2, bool is_bdb_tail, int ld_block, bool is_ld_tail,
             bool first_bdb, bool last_bdb, int rows_for_rd_tail,
@@ -510,23 +579,26 @@ private:
     dim_t ldb_D_offset(int ld_block2, bool is_tail = false) const noexcept;
     dim_t ldb_po_offset(int ld_block2, bool is_tail = false) const noexcept;
 
-    dim_t bdb_A_offset(int bd_block2) const noexcept;
-    dim_t bdb_C_offset(int bd_block2) const noexcept;
-    dim_t bdb_D_offset(int bd_block2) const noexcept;
-    dim_t bdb_po_offset(int bd_block2) const noexcept;
+    dim_t bdb_A_offset(int bd_block2, bool is_tail = false) const noexcept;
+    dim_t bdb_C_offset(int bd_block2, bool is_tail = false) const noexcept;
+    dim_t bdb_D_offset(int bd_block2, bool is_tail = false) const noexcept;
+    dim_t bdb_po_offset(int bd_block2, bool is_tail = false) const noexcept;
 
     dim_t bias_offset(int ld, bool is_tail = false) const noexcept;
     dim_t oc_logical_offset(int ld, bool is_tail = false) const noexcept;
 
     dim_t compensations_offset(int ld, bool is_tail = false) const noexcept;
-    dim_t bdb_compensation_offset(int bd_block2) const noexcept;
+    dim_t bdb_compensation_offset(
+            int bd_block2, bool is_tail = false) const noexcept;
     dim_t bd_compensation_offset(int ld, int bd) const noexcept;
     dim_t wei_scales_offset(int ld, bool is_tail = false) const noexcept;
     dim_t zp_comp_a_offset(int ld, bool is_tail = false) const noexcept;
     dim_t bd_zp_comp_a_offset(int ld, int bd) const noexcept;
-    dim_t bdb_zp_comp_a_offset(int bd_block2) const noexcept;
+    dim_t bdb_zp_comp_a_offset(
+            int bd_block2, bool is_tail = false) const noexcept;
     dim_t zp_comp_b_offset(int bd) const noexcept;
-    dim_t bdb_zp_comp_b_offset(int bd_block2) const noexcept;
+    dim_t bdb_zp_comp_b_offset(
+            int bd_block2, bool is_tail = false) const noexcept;
     dim_t zp_c_values_offset(int ld, bool is_tail = false) const noexcept;
 
     // Offsets into the per-(M,N) f32 compensation buffer. The buffer mirrors
@@ -627,21 +699,23 @@ template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::rdb_A_offset() const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return static_cast<dim_t>(brg.rd_block) * brg.LDA * brg.typesize_A;
-    return static_cast<dim_t>(brg.typesize_A) * brg.rd_block;
+    return brg.rd_block_A_size();
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::rdb_B_offset() const noexcept {
     if (brg.is_gemv && brg.gemv_acc_is_vector())
         return static_cast<dim_t>(brg.rd_block) * brg.typesize_B;
-    return static_cast<dim_t>(brg.typesize_B) * brg.rd_block * brg.LDB;
+    return brg.rd_block_B_size() * brg.LDB;
 }
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::ldb_B_offset(
         int ld_block2, bool is_tail) const noexcept {
-    return (is_tail) ? brg.typesize_B * brg.ldb_tail * brg.ld_step
-                     : brg.typesize_B * ld_block2 * brg.ld_block * brg.ld_step;
+    // For TMM/AMX with blocked format, use rd_step instead of ld_step
+    const auto step = brg.is_tmm ? brg.rd_step : brg.ld_step;
+    return (is_tail) ? brg.typesize_B * brg.ldb_tail * step
+                     : brg.typesize_B * ld_block2 * brg.ld_block * step;
 }
 
 template <typename Wmm>
@@ -665,31 +739,39 @@ dim_t jit_brgemm_kernel_t<Wmm>::ldb_po_offset(
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_A_offset(int bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_A_offset(
+        int bd_block2, bool is_tail) const noexcept {
+    const auto bd_block = is_tail ? brg.bdb_tail : brg.bd_block;
     if (brg.is_gemv && brg.gemv_acc_is_vector())
-        return brg.typesize_A * bd_block2 * brg.bd_block;
-    return brg.typesize_A * bd_block2 * brg.bd_block * brg.LDA;
+        return brg.typesize_A * bd_block2 * bd_block;
+    return brg.typesize_A * bd_block2 * bd_block * brg.LDA;
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_C_offset(int bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_C_offset(
+        int bd_block2, bool is_tail) const noexcept {
+    const auto bd_block = is_tail ? brg.bdb_tail : brg.bd_block;
     if (brg.is_gemv && brg.gemv_acc_is_vector())
-        return brg.typesize_C * bd_block2 * brg.bd_block * brg.LDC;
-    return bd_block2 * brg.bd_block
+        return brg.typesize_C * bd_block2 * bd_block * brg.LDC;
+    return bd_block2 * bd_block
             * (brg.is_runtime_ldc ? 1 : brg.typesize_C * brg.LDC);
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_D_offset(int bd_block2) const noexcept {
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_D_offset(
+        int bd_block2, bool is_tail) const noexcept {
+    const auto bd_block = is_tail ? brg.bdb_tail : brg.bd_block;
     if (brg.is_gemv && brg.gemv_acc_is_vector())
-        return brg.typesize_D * bd_block2 * brg.bd_block * brg.LDD;
-    return bd_block2 * brg.bd_block
+        return brg.typesize_D * bd_block2 * bd_block * brg.LDD;
+    return bd_block2 * bd_block
             * (brg.is_runtime_ldd ? 1 : brg.typesize_D * brg.LDD);
 }
 
 template <typename Wmm>
-dim_t jit_brgemm_kernel_t<Wmm>::bdb_po_offset(int bd_block2) const noexcept {
-    return bd_block2 * brg.bd_block * brg.LDD;
+dim_t jit_brgemm_kernel_t<Wmm>::bdb_po_offset(
+        int bd_block2, bool is_tail) const noexcept {
+    const auto bd_block = is_tail ? brg.bdb_tail : brg.bd_block;
+    return bd_block2 * bd_block * brg.LDD;
 }
 
 template <typename Wmm>
@@ -717,8 +799,9 @@ dim_t jit_brgemm_kernel_t<Wmm>::compensations_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_compensation_offset(
-        int bd_block2) const noexcept {
-    return sizeof(int32_t) * bd_block2 * brg.bd_block * brg.LDB;
+        int bd_block2, bool is_tail) const noexcept {
+    const auto bd_block = is_tail ? brg.bdb_tail : brg.bd_block;
+    return sizeof(int32_t) * bd_block2 * bd_block * brg.LDB;
 }
 
 template <typename Wmm>
@@ -749,8 +832,9 @@ dim_t jit_brgemm_kernel_t<Wmm>::zp_comp_a_offset(
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_zp_comp_a_offset(
-        int bd_block2) const noexcept {
-    return sizeof(int32_t) * bd_block2 * brg.bd_block * brg.LDB;
+        int bd_block2, bool is_tail) const noexcept {
+    const auto bd_block = is_tail ? brg.bdb_tail : brg.bd_block;
+    return sizeof(int32_t) * bd_block2 * bd_block * brg.LDB;
 }
 
 template <typename Wmm>
@@ -766,8 +850,9 @@ dim_t jit_brgemm_kernel_t<Wmm>::zp_comp_b_offset(int bd) const noexcept {
 
 template <typename Wmm>
 dim_t jit_brgemm_kernel_t<Wmm>::bdb_zp_comp_b_offset(
-        int bd_block2) const noexcept {
-    return zp_comp_b_offset(bd_block2 * brg.bd_block);
+        int bd_block2, bool is_tail) const noexcept {
+    const auto bd_block = is_tail ? brg.bdb_tail : brg.bd_block;
+    return zp_comp_b_offset(bd_block2 * bd_block);
 }
 
 template <typename Wmm>
@@ -958,8 +1043,37 @@ void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(int ld_block2, bool is_tail) {
     add(reg_aux_C, C_offset);
     add(reg_aux_D, D_offset);
 
-    add(reg_b_offset,
-            (is_tail) ? ldb_B_offset(0, true) : ldb_B_offset(ld_block2));
+    // Packed ACE B shifts non-linearly: N panels of brg.LDB columns sit
+    // brgattr.LDB2 elements apart, columns inside a panel brg.rd_step apart.
+    // The ld tail shift is unused, so only full blocks need the panel jump.
+    if (ace_has_b_panels() && !is_tail) {
+        const dim_t col_bytes = brg.typesize_B * brg.rd_step;
+        const dim_t ld_cols = ld_block2 * brg.ld_block;
+        const dim_t panel_cols = brg.LDB;
+        const dim_t panel_bytes = brg.typesize_B * brg.brgattr.LDB2;
+
+        if (ld_cols % panel_cols == 0) {
+            // Whole panels per step: the position in the panel never changes.
+            add(reg_b_offset, (ld_cols / panel_cols) * panel_bytes);
+        } else {
+            assert(panel_cols % ld_cols == 0);
+            Xbyak::Label ld_no_panel_crossing, ld_shift_done;
+            reg_ace_ldb_pos.restore();
+            add(reg_ace_ldb_pos, ld_cols);
+            cmp(reg_ace_ldb_pos, panel_cols);
+            jl(ld_no_panel_crossing, T_NEAR);
+            sub(reg_ace_ldb_pos, panel_cols);
+            add(reg_b_offset, panel_bytes - (panel_cols - ld_cols) * col_bytes);
+            jmp(ld_shift_done, T_NEAR);
+            L(ld_no_panel_crossing);
+            add(reg_b_offset, ld_cols * col_bytes);
+            L(ld_shift_done);
+            reg_ace_ldb_pos.save();
+        }
+    } else {
+        add(reg_b_offset,
+                (is_tail) ? ldb_B_offset(0, true) : ldb_B_offset(ld_block2));
+    }
 
     if (brg.with_bias) {
         reg_aux_bias.restore();
@@ -1005,23 +1119,24 @@ void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(int ld_block2, bool is_tail) {
 }
 
 template <typename Wmm>
-void jit_brgemm_kernel_t<Wmm>::advance_bd_block2_post_op_regs(int bd_block2) {
+void jit_brgemm_kernel_t<Wmm>::advance_bd_block2_post_op_regs(
+        int bd_block2, bool is_tail) {
     if (brg.req_comp_pads_with_bcast && brg.req_s8s8_compensation) {
         reg_buf.restore();
-        add(reg_buf, bdb_compensation_offset(bd_block2));
+        add(reg_buf, bdb_compensation_offset(bd_block2, is_tail));
         reg_buf.save();
     }
 
     if (brg.req_comp_pads_with_bcast
             && brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_zp_comp_a.restore();
-        add(reg_zp_comp_a, bdb_zp_comp_a_offset(bd_block2));
+        add(reg_zp_comp_a, bdb_zp_comp_a_offset(bd_block2, is_tail));
         reg_zp_comp_a.save();
     }
 
     if (brg.zp_type_b != brgemm_broadcast_t::none) {
         reg_zp_comp_b.restore();
-        add(reg_zp_comp_b, bdb_zp_comp_b_offset(bd_block2));
+        add(reg_zp_comp_b, bdb_zp_comp_b_offset(bd_block2, is_tail));
         reg_zp_comp_b.save();
     }
     if (brg.with_per_mn_compensation) {
@@ -1038,6 +1153,10 @@ void jit_brgemm_kernel_t<Wmm>::copy_post_ops_stack_values_to_aux(
         mov(reg_aux_C, reg_C);
         mov(reg_aux_D, reg_D);
         xor_(reg_b_offset, reg_b_offset);
+        if (ace_has_b_panels()) {
+            xor_(reg_ace_ldb_pos, reg_ace_ldb_pos);
+            reg_ace_ldb_pos.save();
+        }
         if (brg.with_bias) {
             reg_bias.restore();
             reg_bias.saveTo(reg_aux_bias);
@@ -2385,6 +2504,14 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
                                 auto vreg_acc = accm(1, bd, 0);
                                 uni_vpxor(vreg_acc, vreg_acc, vreg_acc);
                             }
+                        } else if (brg.is_ace()) {
+                            // For ACE, extract the rows directly from the
+                            // tile with tilemovrow.
+                            for (int bd = 0; bd < adj_bd_block; bd++) {
+                                const auto vreg_idx = accm(1, bd, 0).getIdx();
+                                const auto vreg_zmm = Zmm(vreg_idx);
+                                tilemovrow(vreg_zmm, Tmm(c_tensor), bd);
+                            }
                         } else {
                             tilestored(ptr[reg_buf + reg_stride_ld_block],
                                     Tmm(c_tensor));
@@ -2429,12 +2556,42 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
                     } else {
                         auto tmm = Tmm(c_tensor);
                         if (skip_accumulation) tilezero(tmm);
-                        tilestored(ptr[reg_aux_C + reg_stride_ld_block], tmm);
-                        if (ldb < ld_block2 - 1)
-                            add(reg_aux_C, ldb_C_offset(1));
+                        if (brg.is_ace()) {
+                            // For ACE, extract and store rows using tilemovrow.
+                            // tilemovrow returns one dword per element (f32 for
+                            // bf16, s32 for int8), so a dword-granular vmovups
+                            // stores a full row; the tail uses ld_tail_mask.
+                            const size_t ldb_offset = ldb * ldb_C_offset(1);
+                            for (int bd = 0; bd < adj_bd_block; bd++) {
+                                const size_t c_offset = ldb_offset
+                                        + (bd * brg.LDC) * brg.typesize_C;
+                                const auto vreg_zmm
+                                        = Zmm(31); // Use temp register
+                                tilemovrow(vreg_zmm, tmm, bd);
+                                if (is_ld_tail) {
+                                    uni_vmovups(ptr[reg_aux_C + c_offset]
+                                                    | ld_tail_mask | T_z,
+                                            vreg_zmm);
+                                } else {
+                                    uni_vmovups(ptr[reg_aux_C + c_offset],
+                                            vreg_zmm);
+                                }
+                            }
+                        } else {
+                            tilestored(
+                                    ptr[reg_aux_C + reg_stride_ld_block], tmm);
+                            if (ldb < ld_block2 - 1)
+                                add(reg_aux_C, ldb_C_offset(1));
+                        }
                     }
                 }
-                if (ld_block2 > 1) sub(reg_aux_C, ldb_C_offset(ld_block2 - 1));
+                // Reset reg_aux_C back to column 0 after ldb loop.
+                // The do_accum_ops path and the non-ACE tilestored path
+                // advance reg_aux_C by ldb_C_offset(1) per ldb iteration.
+                // The ACE do_accum_ops=false path uses compile-time offsets
+                // and does not modify reg_aux_C.
+                if (ld_block2 > 1 && (do_accum_ops || !brg.is_ace()))
+                    sub(reg_aux_C, ldb_C_offset(ld_block2 - 1));
                 if (bdb < bd_block2 - 1) {
                     if (brg.is_runtime_ldc)
                         reg_dynamic_C_offset.addTo(reg_aux_C);
@@ -2885,6 +3042,230 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_amx(int bd_block2,
 }
 
 template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::ace_load_A_4x16bytes(
+        const Zmm &zmm, size_t mask, const Reg64 &reg_A, dim_t offset) {
+    constexpr size_t full_mask = 0xFFFF;
+    constexpr size_t all_full_mask = 0xFFFFFFFFFFFFFFFF;
+
+    const auto zmm_tmp1 = ace_zmm_tmp(1);
+    const auto xmm_tmp = Xmm(zmm_tmp1.getIdx());
+    if (mask != all_full_mask) vpxord(zmm, zmm, zmm);
+
+    for (int i = 0; i < 4; ++i) {
+        const auto cur_offset
+                = offset + i * brg.LDA * ace_zmms_per_bd_block * brg.typesize_A;
+        const size_t cur_mask = (mask >> (16 * i)) & full_mask;
+        if (cur_mask == 0) continue;
+
+        // Always use masked load to handle M < 16 safely
+        mov(reg_tmp_gpr, cur_mask);
+        kmovq(ace_load_A_mask, reg_tmp_gpr);
+        vmovdqu8(xmm_tmp | ace_load_A_mask | T_z, ptr[reg_A + cur_offset]);
+        vinserti64x2(zmm, zmm, xmm_tmp, i);
+    }
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::ace_load_A(int bdb, dim_t offset,
+        bool is_bdb_tail, int bd_block, bool is_rd_tail) {
+    const auto rd_block = is_rd_tail ? brg.rdb_tail : brg.rd_block;
+    const int mask_stride = 16; // 16 bytes per row
+
+    for (int rb = 0; rb < ace_zmms_per_bd_block; ++rb) {
+        auto zmm = ace_zmm_A(bdb, rb);
+        if (rb >= bd_block) {
+            vpxord(zmm, zmm, zmm);
+            continue;
+        }
+        size_t mask = 0;
+        int mask_row_offs = 0;
+        for (int row = rb; row < bd_block; row += ace_zmms_per_bd_block) {
+            for (int col = 0; col < rd_block; ++col) {
+                if (brg.typesize_A == 2) {
+                    // bf16, f16
+                    mask |= (size_t)0b11 << (mask_row_offs + col * 2);
+                } else if (brg.typesize_A == 1) {
+                    // f8_e5m2, f8_e4m3, s8, u8
+                    mask |= (size_t)0b1 << (mask_row_offs + col);
+                } else {
+                    assert(!"Unsupported data type for ace_load_A");
+                }
+            }
+            mask_row_offs += mask_stride;
+        }
+        ace_load_A_4x16bytes(
+                zmm, mask, reg_aux_A, offset + rb * brg.LDA * brg.typesize_A);
+    }
+    // transpose four 4x4 blocks
+    const auto base_zmm_idx = ace_zmm_A(bdb, 0).getIdx();
+    const auto a_zmm1 = Zmm(base_zmm_idx + 0);
+    const auto a_zmm2 = Zmm(base_zmm_idx + 1);
+    const auto a_zmm3 = Zmm(base_zmm_idx + 2);
+    const auto a_zmm4 = Zmm(base_zmm_idx + 3);
+    const auto tmp_zmm1 = ace_zmm_tmp(1);
+    const auto tmp_zmm2 = ace_zmm_tmp(2);
+    const auto tmp_zmm3 = ace_zmm_tmp(3);
+    const auto tmp_zmm4 = ace_zmm_tmp(4);
+    vpunpckldq(tmp_zmm1, a_zmm1, a_zmm2);
+    vpunpckhdq(tmp_zmm2, a_zmm1, a_zmm2);
+    vpunpckldq(tmp_zmm3, a_zmm3, a_zmm4);
+    vpunpckhdq(tmp_zmm4, a_zmm3, a_zmm4);
+    vpunpcklqdq(a_zmm1, tmp_zmm1, tmp_zmm3);
+    vpunpckhqdq(a_zmm2, tmp_zmm1, tmp_zmm3);
+    vpunpcklqdq(a_zmm3, tmp_zmm2, tmp_zmm4);
+    vpunpckhqdq(a_zmm4, tmp_zmm2, tmp_zmm4);
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::ace_load_B(int ldb, dim_t offset, int rdstep,
+        bool is_ld_tail, int rd_block, int bd_block2) {
+    const auto start_rdstep = (rdstep == -1) ? 0 : rdstep;
+    const auto finish_rdstep
+            = (rdstep == -1) ? ace_rd_steps(rd_block) : rdstep + 1;
+
+    // Use ukernel formula: rd_step * LDB * typesize
+    const auto rds_stride = brg.rd_step * brg.LDB * brg.typesize_B;
+
+    for (int rds = start_rdstep; rds < finish_rdstep; rds++) {
+        auto zmm = ace_zmm_B(bd_block2, ldb, rds);
+        const auto total_offset = offset + rds * rds_stride;
+        const auto zmm_B = is_ld_tail ? (zmm | ld_tail_mask | T_z) : zmm;
+        // Use dword-granular vmovups: each ld element occupies one dword of
+        // the B register, and ld_tail_mask has one bit per element. A
+        // qword-granular load would fetch twice the tail bytes and can read
+        // past the end of B.
+        vmovups(zmm_B, ptr[reg_aux_B + total_offset]);
+    }
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::outer_product(
+        const Zmm &zmm_a, const Zmm &zmm_b, const Tmm &accm) {
+    using namespace data_type;
+    if (brg.dt_a == bf16 && brg.dt_b == bf16) {
+        top2bf16ps(accm, zmm_a, zmm_b);
+    } else if (brg.dt_a == u8 && brg.dt_b == u8) {
+        top4buud(accm, zmm_a, zmm_b);
+    } else if (brg.dt_a == u8 && brg.dt_b == s8) {
+        top4busd(accm, zmm_a, zmm_b);
+    } else if (brg.dt_a == s8 && brg.dt_b == u8) {
+        top4bsud(accm, zmm_a, zmm_b);
+    } else if (brg.dt_a == s8 && brg.dt_b == s8) {
+        top4bssd(accm, zmm_a, zmm_b);
+    } else {
+        assert(!"Unsupported data type for outer product");
+    }
+}
+
+template <typename Wmm>
+void jit_brgemm_kernel_t<Wmm>::gemm_microkernel_ace(int bd_block2,
+        bool is_bdb_tail, int ld_block2, bool is_rd_tail, bool is_ld_tail) {
+    dim_t rbd_block = (is_rd_tail) ? 1 : brg.rdb;
+    for (dim_t rdb = 0; rdb < rbd_block; rdb++) {
+        if (brg.n_bcast_1_load) {
+            // Load A once for all bdb
+            for (int bdb = 0; bdb < bd_block2; bdb++) {
+                int bd_block = (is_bdb_tail && bdb == bd_block2 - 1)
+                        ? brg.bdb_tail
+                        : brg.bd_block;
+                // The tail uses rdb=0, and reg_aux_A has already
+                // advanced past the full blocks.
+                const auto rd_offset = rdb * rdb_A_offset();
+                ace_load_A(bdb, rd_offset + A_offset(bdb, 0, true),
+                        is_bdb_tail && bdb == bd_block2 - 1, bd_block,
+                        is_rd_tail);
+            }
+
+            // Load B one rds at a time, compute with all bdb
+            for (int ldb = 0; ldb < ld_block2; ldb++) {
+                // The offset is relative to reg_aux_B, which has already
+                // been advanced for the tail.
+                const auto rd_pos = rdb;
+                const auto ldb_offs = ldb * brg.ld_block;
+                auto b_offset_base
+                        = rd_pos * brg.rd_block * brg.LDB * brg.typesize_B
+                        + brg.typesize_B
+                                * ((ldb_offs / brg.LDB) * brg.brgattr.LDB2
+                                        + (ldb_offs % brg.LDB) * brg.rd_step);
+
+                const auto rd_block_cur
+                        = is_rd_tail ? brg.rdb_tail : brg.rd_block;
+                for (int rds = 0; rds < ace_rd_steps(rd_block_cur); rds++) {
+                    // Load one rds line from B into ace_zmm_B(bd_block2, ldb,
+                    // rds); ace_load_B adds rds * rds_stride internally.
+                    ace_load_B(ldb, b_offset_base, rds, is_ld_tail,
+                            rd_block_cur, bd_block2);
+
+                    // Compute with all bdb
+                    for (int bdb = 0; bdb < bd_block2; bdb++) {
+                        const int idx = (is_ld_tail) ? brg.ld_block2 : ldb;
+                        const auto &accm = Tmm(brg.get_C_tensor(
+                                bdb, idx, is_bdb_tail, is_ld_tail));
+                        outer_product(ace_zmm_A(bdb, rds),
+                                ace_zmm_B(bd_block2, ldb, rds), accm);
+                    }
+                }
+            }
+        } else {
+            // For the non-n_bcast path, load all the B matrices first and
+            // then compute with A.
+            for (int ldb = 0; ldb < ld_block2; ldb++) {
+                // The offset is relative to reg_aux_B, which has already
+                // been advanced for the tail.
+                const auto rd_pos = rdb;
+                const auto ldb_offs = ldb * brg.ld_block;
+                const auto b_offset
+                        = rd_pos * brg.rd_block * brg.LDB * brg.typesize_B
+                        + brg.typesize_B
+                                * ((ldb_offs / brg.LDB) * brg.brgattr.LDB2
+                                        + (ldb_offs % brg.LDB) * brg.rd_step);
+                const auto rd_block_cur
+                        = is_rd_tail ? brg.rdb_tail : brg.rd_block;
+                ace_load_B(
+                        ldb, b_offset, -1, is_ld_tail, rd_block_cur, bd_block2);
+            }
+
+            // Compute with loaded B
+            for (int bdb = 0; bdb < bd_block2; bdb++) {
+                int bd_block = (is_bdb_tail && bdb == bd_block2 - 1)
+                        ? brg.bdb_tail
+                        : brg.bd_block;
+                // The tail uses rdb=0, and reg_aux_A has already
+                // advanced past the full blocks.
+                const auto rd_offset = rdb * rdb_A_offset();
+                ace_load_A(bdb, rd_offset + A_offset(bdb, 0, true),
+                        is_bdb_tail && bdb == bd_block2 - 1, bd_block,
+                        is_rd_tail);
+                for (int ldb = 0; ldb < ld_block2; ldb++) {
+                    const int idx = (is_ld_tail) ? brg.ld_block2 : ldb;
+                    const auto &accm = Tmm(brg.get_C_tensor(
+                            bdb, idx, is_bdb_tail, is_ld_tail));
+                    const auto rd_block_cur
+                            = is_rd_tail ? brg.rdb_tail : brg.rd_block;
+                    for (int rds = 0; rds < ace_rd_steps(rd_block_cur); rds++) {
+                        outer_product(ace_zmm_A(bdb, rds),
+                                ace_zmm_B(bd_block2, ldb, rds), accm);
+                    }
+                }
+            }
+        }
+    }
+    if (!is_rd_tail) {
+        add(reg_aux_A, brg.rdb * rdb_A_offset());
+        // For ACE with BA16a64b2a: The rdb loop runs brg.rdb times,
+        // each iteration processes rd_block elements.
+        // So advance by brg.rdb * rd_block * LDB * typesize
+        if (brg.is_ace()) {
+            const auto rdb_B_stride
+                    = brg.rdb * brg.rd_block * brg.LDB * brg.typesize_B;
+            add(reg_aux_B, rdb_B_stride);
+        } else {
+            add(reg_aux_B, brg.rdb * rdb_B_offset());
+        }
+    }
+}
+
+template <typename Wmm>
 void jit_brgemm_kernel_t<Wmm>::dot_product(Vmm v1, Vmm v2, Vmm v3) {
     if (brg.is_f16 && brg.isa_impl == avx10_2)
         vdpphps(v1, v2, v3);
@@ -3287,7 +3668,7 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
     // `reg_aux_C` and `reg_tmp_microkernel` are aliases for `r14` so we need to
     // save its content.
     const dim_t max_prefetch_offset = B_offset(ld_block2 - 1, rd_loop - 1)
-            + static_cast<dim_t>(brg.LDB) * brg.rd_block * brg.typesize_B;
+            + static_cast<dim_t>(brg.LDB) * brg.rd_block_B_size();
     if (max_prefetch_offset > INT_MAX) reg_aux_C.save();
 
     if (brg.is_fp8_via_convert()) reg64_fp8_aux.save();
@@ -3337,8 +3718,8 @@ void jit_brgemm_kernel_t<Wmm>::gemm_microkernel(int bd_block2, bool is_bdb_tail,
                 if (prefetch_count_B < ld_block2) {
                     const dim_t prefetch_offset
                             = B_offset(prefetch_count_B++, rd)
-                            + static_cast<dim_t>(brg.LDB) * brg.rd_block
-                                    * brg.typesize_B;
+                            + static_cast<dim_t>(brg.LDB)
+                                    * brg.rd_block_B_size();
                     // Only use EVEX_compress_addr_safe/make_safe_addr
                     // when prefetch_offset > INT_MAX forr perf purpose
                     if (prefetch_offset <= INT_MAX) {
@@ -3396,8 +3777,12 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(int bd_block2, bool is_bdb_tail,
 
         if (brg.is_tmm) {
             const bool is_rd_tail = false;
-            gemm_microkernel_amx(
-                    bd_block2, is_bdb_tail, ld_block2, is_rd_tail, is_ld_tail);
+            if (brg.is_ace())
+                gemm_microkernel_ace(bd_block2, is_bdb_tail, ld_block2,
+                        is_rd_tail, is_ld_tail);
+            else
+                gemm_microkernel_amx(bd_block2, is_bdb_tail, ld_block2,
+                        is_rd_tail, is_ld_tail);
         } else {
             if (brg.rdb > 0) {
                 Label rdb_loop_label;
@@ -3423,8 +3808,12 @@ void jit_brgemm_kernel_t<Wmm>::bs_loop(int bd_block2, bool is_bdb_tail,
         if (brg.rdb_tail != 0) {
             const bool is_rd_tail = true;
             if (brg.is_tmm) {
-                gemm_microkernel_amx(bd_block2, is_bdb_tail, ld_block2,
-                        is_rd_tail, is_ld_tail);
+                if (brg.is_ace())
+                    gemm_microkernel_ace(bd_block2, is_bdb_tail, ld_block2,
+                            is_rd_tail, is_ld_tail);
+                else
+                    gemm_microkernel_amx(bd_block2, is_bdb_tail, ld_block2,
+                            is_rd_tail, is_ld_tail);
             } else {
                 if (brg.is_gemv)
                     gemv_microkernel(is_bdb_tail, ld_block2, is_rd_tail);
@@ -3575,6 +3964,10 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
     auto do_ldb_loop = [this](int bd_block2, bool is_bdb_tail, bool first_bdb,
                                bool last_bdb, int rows_for_rd_tail,
                                bool skip_accumulation) {
+        // For the ACE rd tail every bdb iteration starts fresh with
+        // reg_b_offset = 0. No restore is needed here because
+        // copy_post_ops_stack_values_to_aux already zeroes it.
+
         if (brg.ldb2 > 0) {
             const bool is_ld_reg_tail = false;
             const bool is_ld_tail = false;
@@ -3607,20 +4000,22 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
         if (brg.is_runtime_ldc) {
             reg_C.saveTo(reg_C_backup);
             xor_(reg_C, reg_C);
-            reg_stride_ld_block.imulTo(reg_C, bdb_C_offset(bd_block2));
+            reg_stride_ld_block.imulTo(
+                    reg_C, bdb_C_offset(bd_block2, is_bdb_tail));
             reg_C_backup.addTo(reg_C);
         } else {
-            add(reg_C, bdb_C_offset(bd_block2));
+            add(reg_C, bdb_C_offset(bd_block2, is_bdb_tail));
         }
         if (brg.is_runtime_ldd) {
             reg_D.saveTo(reg_aux_D_backup);
             xor_(reg_D, reg_D);
-            reg_D_shift_bytes.imulTo(reg_D, bdb_D_offset(bd_block2));
+            reg_D_shift_bytes.imulTo(
+                    reg_D, bdb_D_offset(bd_block2, is_bdb_tail));
             reg_aux_D_backup.addTo(reg_D);
         } else {
-            add(reg_D, bdb_D_offset(bd_block2));
+            add(reg_D, bdb_D_offset(bd_block2, is_bdb_tail));
         }
-        add(reg_a_offset, bdb_A_offset(bd_block2));
+        add(reg_a_offset, bdb_A_offset(bd_block2, is_bdb_tail));
 
         if (brg.is_per_k_src_scales) {
             const auto adj_bd_block = is_bdb_tail ? brg.bdb_tail : brg.bd_block;
@@ -3647,7 +4042,7 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
             }
         }
 
-        advance_bd_block2_post_op_regs(bd_block2);
+        advance_bd_block2_post_op_regs(bd_block2, is_bdb_tail);
     };
 
     int rows_for_rd_tail, bd_blocks_for_rd_tail;
@@ -3859,9 +4254,10 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
     if (is_superset(brg.isa_impl, avx512_core)) {
         const auto full_mask = size_t {0xffffffffffffffff};
 
+        reg64_t reg_mask = rax;
+
         if (!brg.is_gemv) {
             const auto tail_mask = size_t((1 << brg.ldb_tail) - 1);
-            reg64_t reg_mask = rax;
 
             mov(reg_mask, full_mask);
             kmovq(ld_full_mask, reg_mask);
@@ -3876,7 +4272,6 @@ void jit_brgemm_kernel_t<Wmm>::generate() {
         } else {
             const auto partial_mask
                     = brg.transA ? size_t((1 << brg.gemv_tail) - 1) : 1;
-            reg64_t reg_mask = rax;
 
             mov(reg_mask, full_mask);
             kmovq(gemv_full_mask, reg_mask);

--- a/src/cpu/x64/jit_brgemm_1x1_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_1x1_conv.cpp
@@ -221,6 +221,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::pd_t::init_brgemm_desc() {
         // brgemm kernel
         if (need_postwork_ && ic_chunks_ == 1 && (!jcp_.is_reduced_rtus))
             brgattr.postops_only = true;
+        brgattr.use_ace = jcp_.is_ace;
 
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
         auto LDD = jcp_.oc_without_padding;
@@ -297,7 +298,7 @@ status_t brgemm_1x1_convolution_fwd_t<isa>::init(engine_t *engine) {
                 && brg->reduce_dim > 0 && !brg_kernels_[brg_idx]) {
             CHECK(brg_kernels_.insert(brg_idx, brg));
             const bool is_amx = brgemm_convolution_utils::is_amx(isa);
-            if (is_amx) brgemm_palettes_.insert(brg_idx, brg);
+            if (is_amx && brg->is_tmm) brgemm_palettes_.insert(brg_idx, brg);
         }
     }
     return status::success;
@@ -828,6 +829,7 @@ template struct brgemm_1x1_convolution_fwd_t<avx512_core_amx>;
 template struct brgemm_1x1_convolution_fwd_t<avx512_core_amx_fp16>;
 template struct brgemm_1x1_convolution_fwd_t<avx10_2>;
 template struct brgemm_1x1_convolution_fwd_t<avx10_2_amx_2>;
+template struct brgemm_1x1_convolution_fwd_t<avx10_2_ace>;
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -316,6 +316,7 @@ status_t brgemm_convolution_fwd_t<isa>::pd_t::add_brg_descriptor(dim_t vM,
     }
     brgattr.fpmath_mode = attr()->fpmath_.mode_;
     brgattr.K_koef = (float)bs / static_cast<float>(KW);
+    brgattr.use_ace = jcp_.is_ace;
 
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
 
@@ -722,7 +723,7 @@ status_t brgemm_convolution_fwd_t<isa>::add_brg_kernel(int brg_idx) {
     if (!brgemm_kernels_[brg_idx] && brg && brg->bcast_dim > 0
             && brg->load_dim > 0 && brg->reduce_dim > 0) {
         CHECK(brgemm_kernels_.insert(brg_idx, brg));
-        if (is_amx) brgemm_palettes_.insert(brg_idx, brg);
+        if (is_amx && brg->is_tmm) brgemm_palettes_.insert(brg_idx, brg);
     }
     return status::success;
 }
@@ -2553,6 +2554,7 @@ template struct brgemm_convolution_fwd_t<avx512_core_amx>;
 template struct brgemm_convolution_fwd_t<avx512_core_amx_fp16>;
 template struct brgemm_convolution_fwd_t<avx10_2>;
 template struct brgemm_convolution_fwd_t<avx10_2_amx_2>;
+template struct brgemm_convolution_fwd_t<avx10_2_ace>;
 } // namespace x64
 
 } // namespace cpu

--- a/src/cpu/x64/jit_brgemm_conv_bwd.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd.cpp
@@ -184,6 +184,7 @@ template struct brgemm_convolution_bwd_t<avx10_2>;
 template struct brgemm_convolution_bwd_t<avx512_core_amx>;
 template struct brgemm_convolution_bwd_t<avx512_core_amx_fp16>;
 template struct brgemm_convolution_bwd_t<avx10_2_amx_2>;
+template struct brgemm_convolution_bwd_t<avx10_2_ace>;
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_strided.cpp
@@ -371,6 +371,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::pd_t::add_brg_descriptor(
         brgattr.max_bottom_vpad = jcp_.max_vpad;
     }
     brgattr.generate_skip_accumulation = true;
+    brgattr.use_ace = jcp_.is_ace;
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
 
     auto LDD = jcp_.stride_w * jcp_.ic_without_padding;
@@ -422,7 +423,7 @@ status_t brgemm_convolution_bwd_strided_t<isa>::add_brg_kernel(int brg_idx) {
     if (!brg_kernels_[brg_idx] && brg && brg->bcast_dim > 0 && brg->load_dim > 0
             && brg->reduce_dim > 0) {
         CHECK(brg_kernels_.insert(brg_idx, brg));
-        if (is_amx) brgemm_palettes_.insert(brg_idx, brg);
+        if (is_amx && brg->is_tmm) brgemm_palettes_.insert(brg_idx, brg);
     }
     return status::success;
 }
@@ -1918,6 +1919,7 @@ template struct brgemm_convolution_bwd_strided_t<avx512_core_bf16>;
 template struct brgemm_convolution_bwd_strided_t<avx512_core_fp16>;
 template struct brgemm_convolution_bwd_strided_t<avx10_2>;
 template struct brgemm_convolution_bwd_strided_t<avx10_2_amx_2>;
+template struct brgemm_convolution_bwd_strided_t<avx10_2_ace>;
 
 } // namespace x64
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -60,7 +60,9 @@ inline status_t init_tag(format_tag_t &tag, memory_desc_t &md,
 }
 
 bool is_amx(cpu_isa_t isa) {
-    return is_superset(isa, avx512_core_amx);
+    // See the note on the forward is_amx(): this asks whether accumulators
+    // live in tile registers, which is true for ACE as well as for TMUL.
+    return isa_has_tile_accumulators(isa);
 }
 
 bool post_ops_ok(jit_brgemm_conv_conf_t &jcp, primitive_attr_t &attr,
@@ -413,10 +415,7 @@ struct brg_blocking_t : public jit_brgemm_conv_conf_t {
     };
 
     brg_blocking_t() {
-        // TODO: This is a broken form of initialization for a base class.
-        // Either set default values in a base class, or provide a proper
-        // default ctor, or take a `jit_brgemm_conv_conf_t` object to initialize
-        // a base class object.
+        // TODO: base-class init is wrong here; use default values or a real ctor.
         jit_brgemm_conv_conf_t *base
                 = static_cast<jit_brgemm_conv_conf_t *>(this);
         *base = jit_brgemm_conv_conf_t();
@@ -599,6 +598,13 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
     CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brgemm_addr, src_dt, wei_dt,
             brgemm_row_major, alpha, beta, LDA, LDB, LDC, vM, vN, vK, nullptr,
             is_bf32));
+    // Blocking dispatches on use_ace, so the attribute has to reach the
+    // descriptor before brgemm_blocking(), otherwise this simulation would
+    // estimate VMM/TMUL blocks for an ACE kernel.
+    brgemm_attr_t brgattr;
+    brgattr.use_ace = is_ace;
+    brgattr.use_uker = use_uker;
+    CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
     ur = brg.bd_block * nstl::max<dim_t>(1, brg.bd_block2);
@@ -609,6 +615,7 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
         CHECK(brgemm_utils::init_brgemm_conf(&brg_sp_tail, isa, brgemm_addr,
                 src_dt, wei_dt, brgemm_row_major, alpha, beta, LDA, LDB, LDC,
                 M_tail, vN, vK, nullptr, is_bf32));
+        CHECK(brgemm_desc_set_attr(&brg_sp_tail, brgattr));
         CHECK(brgemm_utils::brgemm_blocking(&brg_sp_tail));
         ur_block_tail = brg_sp_tail.bd_block;
     } else {
@@ -656,9 +663,15 @@ status_t brg_blocking_t::get_brgemm_ur(
                     CHECK(brgemm_utils::init_brgemm_conf(&brg, isa, brg_type,
                             src_dt, wei_dt, brgemm_row_major, alpha, vbeta, LDA,
                             LDB, LDC, vM, vN, vK, strides_ptr, is_bf32));
-                    CHECK(brgemm_utils::brgemm_blocking(&brg));
 
                     brgemm_attr_t brgattr;
+                    // Blocking dispatches on use_ace, so this pair has to be
+                    // applied before brgemm_blocking() rather than after it.
+                    brgattr.use_ace = is_ace;
+                    brgattr.use_uker = use_uker;
+                    CHECK(brgemm_desc_set_attr(&brg, brgattr));
+                    CHECK(brgemm_utils::brgemm_blocking(&brg));
+
                     brgattr.max_bs = max_batch;
                     const int max_vpad = (exec_type == exec_vpad)
                             ? static_cast<int>(nstl::max(l_pad, r_pad))
@@ -1566,6 +1579,9 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.vnni_block
             = static_cast<int>(data_type_vnni_granularity(last_oc_block_dt));
 
+    jcp.is_ace = is_superset(isa, avx10_2_ace)
+            && brgemm_utils::ace_dt_ok(jcp.src_dt, jcp.wei_dt);
+
     // TODO: optimize grouped convolutions with small oc
     const bool is_grouped_small_oc
             = jcp.prop_kind != prop_kind::backward_weights && with_groups
@@ -1725,8 +1741,15 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.use_M_mask = 0;
     jcp.is_is_blocking = false;
     jcp.oskip = 0;
-    jcp.use_uker = is_amx(isa) && !jcp.is_1x1;
-    jcp.use_interleave_stores = jcp.use_uker;
+    if (jcp.is_ace) {
+        jcp.use_uker = brgemm_utils::ace_prefer_uker();
+        // The unrolled kernel already disables interleaved stores on ACE,
+        // setting it here keeps the blocking search on the same value.
+        jcp.use_interleave_stores = false;
+    } else {
+        jcp.use_uker = is_amx(isa) && !jcp.is_1x1;
+        jcp.use_interleave_stores = jcp.use_uker;
+    }
     jcp.hint_prefetching = brgemm_kernel_prefetching_t::brgemm_prf_default;
     jcp.brgemm_bd_loop_innermost = false;
 

--- a/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_w.cpp
@@ -131,6 +131,7 @@ status_t brgemm_convolution_bwd_weights_t::pd_t::init(const engine_t *engine) {
                 brgattr.hint_innermost_loop = jcp_.brgemm_bd_loop_innermost
                         ? brgemm_bd_loop_innermost
                         : brgemm_innermost_undef;
+                brgattr.use_ace = jcp_.is_ace;
 
                 brgattr.hint_expected_A_size = 0;
                 brgattr.hint_expected_B_size = 0;
@@ -862,7 +863,9 @@ void brgemm_convolution_bwd_weights_t::call_brgemm_kernel(
     const auto brg_ker = brg_kernels_[brg_idx];
     assert(brg_ker != nullptr);
 
-    brgemm_palettes_.maybe_tile_configure(true, btc.cur_brg_idx, brg_idx);
+    const auto &jcp = pd()->jcp_;
+    const bool is_amx = brgemm_convolution_utils::is_amx(jcp.isa);
+    brgemm_palettes_.maybe_tile_configure(is_amx, btc.cur_brg_idx, brg_idx);
 
     brgemm_kernel_execute(brg_ker, batch_size, btc.brg_batch, ptr_C,
             static_cast<void *>(btc.wsp_tile));

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -266,13 +266,13 @@ inline status_t init_tag(format_tag_t &tag, memory_desc_t &md,
 }
 
 bool is_amx(cpu_isa_t isa) {
-    return is_superset(isa, avx512_core_amx);
+    // Tile accumulators drive blocking and kernel choice; ACE uses them too.
+    return isa_has_tile_accumulators(isa);
 }
 
 bool uses_batch_elements(
         brgemm_batch_kind_t brg_type, conv_brgemm_exec_type_t exec_type) {
-    // Batch elements are required for all batch kinds except fixed strides.
-    // Batch elements are also required for virtual padding.
+    // Batch elements are required except for fixed-stride batches and virtual padding.
     return IMPLICATION(brg_type == brgemm_strd, exec_type == exec_vpad);
 }
 
@@ -292,11 +292,9 @@ bool post_ops_ok(jit_brgemm_conv_conf_t &jcp, primitive_attr_t &attr,
 }
 
 bool is_groups_ok(jit_brgemm_conv_conf_t &jcp) {
-    // Enable grouped convs for the shapes not supported in direct convs
-    // direct approach only supports int8/bf16 grouped conv
-    // when channels per groups is at least multiple of 4
-    // and bf16 grouped conv with layout nxc on jit_bf16 impl
-    // TODO: remove this condition after the restriction on small ic is removed
+    // Grouped convs are allowed where direct convs reject them.
+    // This is limited to int8/bf16 groups with IC/OC multiples of 4.
+    // TODO: drop this once the small-IC restriction is removed.
     return jcp.ngroups > 1
             && IMPLICATION(one_of(jcp.src_dt, u8, s8, bf16),
                     jcp.ic % 4 == 0 && jcp.oc % 4 == 0);
@@ -668,6 +666,8 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
             : 0;
     brgattr.max_top_vpad = max_vpad;
     brgattr.max_bottom_vpad = max_vpad;
+    brgattr.use_ace = is_ace;
+    brgattr.use_uker = use_uker;
     CHECK(brgemm_desc_set_attr(&brg, brgattr));
     CHECK(brgemm_utils::brgemm_blocking(&brg));
     // AMX kernel may fall back to VMM, in which case bd_block2 == 0
@@ -686,6 +686,8 @@ status_t brg_blocking_t::estimate_brgemm_ur() {
                     ? brgemm_broadcast_t::per_tensor
                     : brgemm_broadcast_t::none;
         }
+        brgattr.use_ace = is_ace;
+        brgattr.use_uker = use_uker;
         CHECK(brgemm_desc_set_attr(&brg_sp_tail, brgattr));
         CHECK(brgemm_utils::brgemm_blocking(&brg_sp_tail));
         ur_block_tail = brg_sp_tail.bd_block;
@@ -774,6 +776,8 @@ status_t brg_blocking_t::get_brgemm_ur(
         brgattr.max_top_vpad = max_vpad;
         brgattr.max_bottom_vpad = max_vpad;
         brgattr.fpmath_mode = attr->fpmath_.mode_;
+        brgattr.use_ace = is_ace;
+        brgattr.use_uker = use_uker;
         CHECK(brgemm_desc_set_attr(&brg, brgattr));
 
         brg.with_sum = with_sum;
@@ -1322,9 +1326,15 @@ bool brg_blocking_t::fast_check_oc_block_1x1() const {
 float brg_blocking_t::est_eff_1x1() {
 
     auto calc_ave_blk = [&](dim_t dim, dim_t block, bool use_ave) -> float {
+        if (block <= 0) return 0.f;
         const dim_t nb = dim / block;
-        constexpr int max_nb = 2; // only consider 2x2 tile blocking
+        // only consider 2x2 tile blocking
+        // TODO: ACE selects bd_block2/ld_block2 by search (ld_block2 can
+        // reach 6 or 8), so this estimate does not model ACE blocking
+        // correctly.
+        constexpr int max_nb = 2;
         const dim_t block2 = nstl::min<dim_t>(max_nb, nb);
+        if (block2 == 0) return 0.f;
         const dim_t nb2 = nb / block2;
         const dim_t nb2_tail = nb % block2;
         if (!use_ave) return static_cast<float>(block2);
@@ -1339,6 +1349,7 @@ float brg_blocking_t::est_eff_1x1() {
     const auto M_n_sp_blks = ur_block > 0 ? nstl::max(M, M_tail) / ur_block : 0;
     const auto M_tail_n_sp_blks
             = ur_block_tail > 0 ? M_tail / ur_block_tail : 0;
+    const auto n_sp_blks = nstl::max<dim_t>(1, M_n_sp_blks + M_tail_n_sp_blks);
 
     // heuristic for maskrcnn workaround: use old blocking for some convolutions
     // TODO: remove this condition
@@ -1347,9 +1358,9 @@ float brg_blocking_t::est_eff_1x1() {
             || (ic == 512 && oc == 1024) || (ic == 512 && oc == 2048);
     const auto amx_fac = maskrcnn_cond
             ? (static_cast<float>(div_up(M + M_tail, 16))
-                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks))
+                      / static_cast<float>(n_sp_blks))
             : (static_cast<float>(div_up(M + M_tail, 16))
-                      / static_cast<float>(M_n_sp_blks + M_tail_n_sp_blks));
+                      / static_cast<float>(n_sp_blks));
 
     const auto brgemm_microkernel_eff = is_amx(isa)
             ? amx_fac * (static_cast<float>(ocb_ave) * spb_ave)
@@ -1360,7 +1371,7 @@ float brg_blocking_t::est_eff_1x1() {
             / static_cast<float>(rnd_up(sp_block, ur));
 
     // heuristic sp_block: for reduced rtus, prioritize a smaller sp_block
-    const auto heur_sp_block = is_reduced_rtus
+    const auto heur_sp_block = is_reduced_rtus && sp_block != 0
             ? 1.f / static_cast<float>(sp_block)
             : static_cast<float>(sp_block);
     const auto brgemm_eff = squeeze_val(static_cast<float>(ur)
@@ -1569,12 +1580,12 @@ void brg_blocking_t::calc_blocks_1x1() {
     is_rtus = is_ic_zero_padded || (!is_os_blocking_ok && is_amx(isa));
     const bool is_int8_convolution = everyone_is(true, one_of(src_dt, u8, s8),
             wei_dt == s8, one_of(dst_dt, f32, s32, s8, u8, bf16));
-    // reduced_rtus zero-pads the input-channel when IC is not in a
-    // vnni-friendly block size. It decreases the footprint of RTUS by using a
-    // reduced copy-buffer size i.e. it is only used for the last os_spatial
-    // block and the last ic_channel computation of size '16 * vnni_block'.
+    // reduced_rtus shrinks the RTUS copy buffer for the last OS/IC block.
+    // It assumes non-grouped layout and AMX tile geometry; ACE loads A via ZMMs,
+    // so the AMX assumption is invalid and we must fall back to regular RTUS.
     is_reduced_rtus = is_rtus && is_int8_convolution && ic > ic_without_padding
-            && everyone_is(1, stride_d, stride_h, stride_w);
+            && everyone_is(1, stride_d, stride_h, stride_w) && ngroups == 1
+            && !is_ace;
 
     if (is_os_blocking_ok || is_rtus) {
         sp = os;
@@ -1593,7 +1604,7 @@ void brg_blocking_t::calc_blocks_1x1() {
     const auto thr_eff_threshold = 0.9f;
 
     const auto max_sp_block_L2 = os;
-    // TODO: nb_os_blocking always is 1 for now. Update this code
+    // TODO: nb_os_blocking is currently hard-coded to 1.
     nb_os_blocking = 1;
     dim_t start_sp_block = 0;
 
@@ -1817,10 +1828,15 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     if (jcp.wei_plain)
         CHECK(pick_tags(jcp, src_md, weights_md, dst_md, bias_md));
 
-    const auto vnni_dt = jcp.prop_kind == prop_kind::backward_weights
-            ? jcp.dst_dt
+    const bool is_bwd_w = jcp.prop_kind == prop_kind::backward_weights;
+
+    const auto vnni_dt = is_bwd_w                                  ? jcp.dst_dt
             : utils::one_of(true, jcp.is_f32_bf16, jcp.is_f32_f16) ? jcp.src_dt
                                                                    : jcp.wei_dt;
+    jcp.is_ace = is_superset(isa, avx10_2_ace)
+            && brgemm_utils::ace_dt_ok(
+                    jcp.src_dt, is_bwd_w ? jcp.dst_dt : jcp.wei_dt);
+
     const bool req_emulation = utils::one_of(isa, avx10_1_512, avx10_2);
     const data_type_t vnni_block_dt
             = get_mac_emu_data_type(vnni_dt, isa, req_emulation);
@@ -2575,6 +2591,15 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
         const bool use_loop_ngcdhw = max_size < static_cast<float>(wei_size)
                 || (jcp.mb == 1 && os < os_cutoff);
         jcp.loop_order = use_loop_ngcdhw ? loop_ngcdhw : loop_ndhwgc;
+
+        // The blocking search below dispatches on both flags, so for ACE they
+        // have to be set before the search rather than after it.
+        if (jcp.is_ace) {
+            jcp.use_uker = brgemm_utils::ace_prefer_uker();
+            // The unrolled kernel already disables interleaved stores on ACE,
+            // setting it here keeps the blocking search on the same value.
+            jcp.use_interleave_stores = false;
+        }
     }
 
     const auto min_oc_block = jcp.acc_simd_w;
@@ -2651,7 +2676,7 @@ status_t init_1x1_conf(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.adjusted_batch_size
             = div_up(rnd_up(jcp.gemm_batch_size * sc_size, P4K), sc_size);
 
-    if (is_amx(isa)) {
+    if (is_amx(isa) && !jcp.is_ace) {
         // heuristic for small mb
         const bool is_small_mb = jcp.nthr > 1 && jcp.mb == 1
                 && jcp.ic * jcp.oh <= 28 * 1024 && jcp.oc * jcp.oh <= 14 * 1024;
@@ -3213,9 +3238,17 @@ status_t init_conf_bwd_w(jit_brgemm_conv_conf_t &jcp,
             && one_of(diff_weights_d.data_type(), f32, f16, f8_e5m2, f8_e4m3)
             && one_of(diff_dst_d.data_type(), f8_e5m2, f8_e4m3);
 
-    jcp.isa = is_fp8
-            ? (mayiuse(avx10_2_amx_2) ? avx10_2_amx_2 : avx512_core_amx_fp16)
-            : (is_f16 ? avx512_core_amx_fp16 : avx512_core_amx);
+    // The ACE kernels compute bf16 and int8 only, so every other datatype has
+    // to keep its existing AMX flavor. This mirrors the jcp.is_ace condition in
+    // init_jcp().
+    const bool is_ace_dt = brgemm_utils::ace_dt_ok(
+            src_d.data_type(), diff_dst_d.data_type());
+
+    jcp.isa = (is_ace_dt && mayiuse(avx10_2_ace))
+            ? avx10_2_ace
+            : (is_fp8 ? (mayiuse(avx10_2_amx_2) ? avx10_2_amx_2
+                                                : avx512_core_amx_fp16)
+                      : (is_f16 ? avx512_core_amx_fp16 : avx512_core_amx));
 
     // disabling verbose dispatch messages for unsupported isa for better readability
     if (!mayiuse(jcp.isa)) return status::unimplemented;

--- a/src/cpu/x64/jit_brgemm_deconv.cpp
+++ b/src/cpu/x64/jit_brgemm_deconv.cpp
@@ -311,6 +311,7 @@ template struct brgemm_deconvolution_fwd_t<avx10_2>;
 template struct brgemm_deconvolution_fwd_t<avx512_core_amx>;
 template struct brgemm_deconvolution_fwd_t<avx512_core_amx_fp16>;
 template struct brgemm_deconvolution_fwd_t<avx10_2_amx_2>;
+template struct brgemm_deconvolution_fwd_t<avx10_2_ace>;
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -906,6 +906,7 @@ struct jit_brgemm_conv_conf_t {
     int nthr_mb, nthr_g, nthr_oc_b, nthr_ic_b, nthr_oh;
     bool transform_to_vnni;
     bool has_int8_vnni;
+    bool is_ace {false};
     float scale_adjust_factor;
     int ic_tail, oc_tail;
     size_t tr_src_block_size, tr_src_buf_size, tr_src_buf_count;

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -373,7 +373,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
     const int max_n_ker_idx
             = bgmmc_.is_runtime_N ? max_num_dynamic_n_tails + 1 : 2;
 
-    const bool is_amx = is_superset(isa, avx512_core_amx);
+    const bool is_amx = isa_has_tile_accumulators(isa);
     const bool is_s8s8 = src_dt == s8 && wei_dt == s8;
     // In the case of dynamic M for amx the last tail kernel generate using
     // non-amx isa. s8s8 proplem type is exception to avoid compensations
@@ -491,9 +491,13 @@ status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
         brgattr.mem_advice = bgmmc_.mem_advice;
         brgattr.max_bs = bs;
         brgattr.hint_prefetchw = bgmmc_.hint_prefetchw;
-        if (is_superset(kernel_isa, avx512_core_amx)) {
-            brgattr.use_uker = true;
-            brgattr.use_interleave_stores = true;
+        if (is_superset(kernel_isa, avx512_core_amx)
+                || is_superset(kernel_isa, avx10_2_ace)) {
+            // For ACE the kernel flavor comes from a single policy helper.
+            brgattr.use_uker = IMPLICATION(
+                    bgmmc_.is_ace, brgemm_utils::ace_prefer_uker());
+            brgattr.use_ace = bgmmc_.is_ace;
+            brgattr.use_interleave_stores = !bgmmc_.is_ace;
             brgattr.max_bs = bs;
             brgattr.wary_A_k_tail_read = bgmmc_.extendable_k;
             brgattr.extendable_k = bgmmc_.extendable_k;
@@ -563,7 +567,7 @@ status_t brgemm_matmul_t<isa>::init(engine_t *engine) {
         brgemm_kernel_t *ker = nullptr;
         CHECK(brgemm_kernel_create(&ker, pd()->get_brg_desc(idx)));
         CHECK(safe_ptr_assign(brg_kernels_[idx], ker));
-        if (is_superset(pd()->get_brg_desc(idx).isa_impl, avx512_core_amx))
+        if (isa_has_tile_accumulators(pd()->get_brg_desc(idx).isa_impl))
             brgemm_palettes_.insert(idx, pd()->get_brg_desc(idx));
 
         if (pd()->with_reduce()) {
@@ -673,7 +677,7 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
         const auto &bgmmc = pd()->get_brgemm_matmul_conf();
         const bool use_buffer_a
                 = bgmmc.use_buffer_a || bgmmc.use_buffer_a_tail_only;
-        const bool is_amx = is_superset(isa, avx512_core_amx);
+        const bool is_amx = isa_has_tile_accumulators(isa);
         const dim_t M_chunks = brgmm_ctx.get_M_chunks();
         const int M_chunk_size = brgmm_ctx.get_M_chunk_size();
         const dim_t M_chunk_tail = brgmm_ctx.get_M_chunk_tail();
@@ -876,8 +880,9 @@ void brgemm_matmul_t<isa>::compute_kernel(
             ithr, b_idx, m_blk_idx, n_blk_idx);
 
     auto is_brg_amx = [&](const int brg_idx) {
-        return is_superset(
-                pd()->get_brg_desc(brg_idx).isa_impl, avx512_core_amx);
+        // Tile accumulators (and therefore the tile workspace) are used by
+        // both AMX and ACE, so this must not test for TMUL support alone.
+        return isa_has_tile_accumulators(pd()->get_brg_desc(brg_idx).isa_impl);
     };
 
     // Execute the kernel for one K-block. Pure accumulation into C goes through
@@ -1749,7 +1754,7 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                           key_brgemm_primitive_buffer_reduce)
                 : nullptr;
 
-        is_amx_ = is_superset(isa, avx512_core_amx);
+        is_amx_ = isa_has_tile_accumulators(isa);
         wsp_tile_ptr_ = is_amx_
                 ? ctx.get_scratchpad_grantor().template get<char>(
                           key_conv_amx_tile_buffer)
@@ -2997,6 +3002,7 @@ template struct brgemm_matmul_t<avx10_2_amx_2>;
 template struct brgemm_matmul_t<avx512_core_amx_fp16>;
 template struct brgemm_matmul_t<avx512_core_amx>;
 template struct brgemm_matmul_t<avx10_2>;
+template struct brgemm_matmul_t<avx10_2_ace>;
 template struct brgemm_matmul_t<avx512_core_fp16>;
 template struct brgemm_matmul_t<avx512_core_bf16>;
 template struct brgemm_matmul_t<avx512_core_vnni>;

--- a/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_copy_utils.cpp
@@ -7164,7 +7164,10 @@ status_t create_brgemm_matmul_copy_b(
             CHECK(safe_ptr_assign(copy_ker,
                     new jit_brgemm_matmul_copy_cvt_fp8_to_xf16_t(conf)));
         } else {
-            if (mayiuse(avx512_core_amx))
+            // No AMX here: this path uses vpermi2b. AVX10.2 ACE gets VBMI explicitly.
+            const bool has_vbmi_copy_b = mayiuse(avx512_core_amx)
+                    || is_superset(conf->isa, avx10_2_ace);
+            if (has_vbmi_copy_b)
                 CHECK(safe_ptr_assign(copy_ker,
                         new jit_amx_brgemm_matmul_copy_b_int8_t(conf)));
             else if (is_superset(conf->isa, avx512_core))

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -22,6 +22,7 @@
 #include "cpu/matmul/gemm_based_common.hpp"
 #include "cpu/matmul/matmul_utils.hpp"
 #include "cpu/platform.hpp"
+#include "cpu/x64/brgemm/brgemm_utils.hpp"
 #include "cpu/x64/injectors/jit_uni_postops_injector.hpp"
 #include "cpu/x64/matmul/amx_blocking_heuristics.hpp"
 #include "cpu/x64/matmul/brgemm_matmul_utils.hpp"
@@ -226,8 +227,7 @@ bool is_batch_layout_trivial(const memory_desc_wrapper &mdw) {
     dim_t expected_stride = strides[innermost_batch_idx];
     if (expected_stride == 0) return false;
     for (int d = innermost_batch_idx; d >= 0; --d) {
-        // Dimensions of size 1 do not contribute to the batch offset and
-        // their stride is irrelevant.
+        // Size-1 dims do not affect the batch offset; stride is irrelevant.
         if (dims[d] == 1) continue;
         if (strides[d] != expected_stride) return false;
         expected_stride *= dims[d];
@@ -254,7 +254,8 @@ status_t check_isa_with_datatype(
                     is_superset(isa, avx512_core)
                             || is_superset(isa, avx2_vnni))
             && IMPLICATION(bm_conf_utils.is_bf16(),
-                    one_of(isa, avx512_core_amx, avx512_core_bf16, avx2_vnni_2))
+                    one_of(isa, avx512_core_amx, avx512_core_bf16, avx2_vnni_2,
+                            avx10_2_ace))
             && IMPLICATION(bm_conf_utils.is_f16(),
                     one_of(isa, avx10_2, avx10_2_amx_2, avx512_core_amx_fp16,
                             avx512_core_fp16, avx2_vnni_2))
@@ -1848,6 +1849,9 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     const bool is_wei_any = weights_d.format_kind() == format_kind::any
             || weights_d.is_sparse_packed_desc();
+    bgmmc.is_ace = is_superset(isa, avx10_2_ace)
+            && brgemm_utils::ace_dt_ok(bgmmc.src_dt, bgmmc.wei_dt);
+
     brgemm_matmul_conf_utils_t bm_conf_utils(bgmmc, isa, attr,
             src_d.format_kind() == format_kind::any, is_wei_any,
             dst_d.format_kind() == format_kind::any,
@@ -1877,7 +1881,13 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             one_of(status::success, check_isa_dt_st, gemv_check_isa_dt_st),
             VERBOSE_ISA_DT_MISMATCH);
 
-    bgmmc.is_amx = is_superset(isa, avx512_core_amx);
+    // When the resolved ISA is ACE, TMUL is not reachable through it, so there
+    // is no fallback for data type combinations ACE cannot compute. Reject them
+    // here instead of generating an AMX kernel.
+    VCONDCHECK_BG(IMPLICATION(is_superset(isa, avx10_2_ace), bgmmc.is_ace),
+            VERBOSE_ISA_DT_MISMATCH);
+
+    bgmmc.is_amx = isa_has_tile_accumulators(isa);
     bgmmc.a_dt_sz = bgmmc.tr_a_dt_sz = types::data_type_size(bgmmc.src_dt);
     bgmmc.b_dt_sz = bgmmc.tr_b_dt_sz = types::data_type_size(bgmmc.wei_dt);
 
@@ -2574,8 +2584,8 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     // Disable 'small_shape' heuristic for amx_fp16 until it is validated with
     // performance measurements.
-    allow_small_shape_fallback
-            = allow_small_shape_fallback && (bgmmc.isa != avx512_core_amx_fp16);
+    allow_small_shape_fallback = allow_small_shape_fallback
+            && (bgmmc.isa != avx512_core_amx_fp16) && !bgmmc.is_ace;
     // This is the only implementation that support the packed_sparse_weights
     // case therefore there is no fallback for it.
     allow_small_shape_fallback
@@ -3001,7 +3011,7 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
                 types::data_type_size(f32));
     }
 
-    if (is_superset(bgmmc.isa, avx512_core_amx))
+    if (isa_has_tile_accumulators(bgmmc.isa))
         scratchpad.book(key_conv_amx_tile_buffer,
                 static_cast<size_t>(bgmmc.nthr) * bgmmc.wsp_tile_per_thr_bytes,
                 default_data_align);

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -146,6 +146,7 @@ struct brgemm_matmul_conf_t {
     bool packed_sparse_weights;
     bool with_wei_decompression;
     int postops_inst_count;
+    bool is_ace {false};
 
     bool use_buffer_a;
     bool use_buffer_a_tail_only;

--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -143,6 +143,10 @@ dnnl_status_t brgemm_attr_init(
         // PROCESS_KEY_VAL(bd_mask_level);
         PROCESS_KEY_VAL(use_uker);
         PROCESS_KEY_VAL(use_interleave_stores);
+#if defined(brg_x64)
+        // ACE is an x64-only compute path.
+        PROCESS_KEY_VAL(use_ace);
+#endif
         PROCESS_KEY_VAL(b_is_vnni);
         PROCESS_KEY_VAL(postops_only);
         PROCESS_KEY_VAL(hint_bd_block);


### PR DESCRIPTION
This PR adds support for the AVX10.2 ACE (Advanced Matrix Extensions) instruction set to the brgemm kernels and related convolution, deconvolution, and matmul kernels. The changes introduce new ACE-specific implementations, update ISA selection logic, and adjust data structure logic and buffer management to accommodate ACE's unique features. 