### PR TITLE
Revert "gpu: intel: sdpa: fix fwd micro kernel with argument packing"

### DIFF
--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -487,7 +487,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #else
         const global SCALE_DATA_T *scale_ptr,
 #endif
-        int d_qkv, int k, int q, const global KEY_ATTR_SCALES_DATA_T *K_scales,
+        int d_qk, int d_v, int k, int q,
+        const global KEY_ATTR_SCALES_DATA_T *K_scales,
         const global KEY_ATTR_ZP_DATA_T *K_zp,
         const global VAL_ATTR_SCALES_DATA_T *V_scales,
         const global VAL_ATTR_ZP_DATA_T *V_zp, const int attn_mask_type
@@ -516,11 +517,6 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 ) {
 
     uint sg_ij = sub_group_broadcast(get_local_id(1), 0);
-    /* d_qk and d_v are packed into a single scalar argument to work around a
-     * GPU compiler miscompilation triggered when they are passed as two
-     * separate kernel arguments. Each head size fits in 16 bits (max 1024). */
-    const int d_qk = d_qkv & 0xFFFF;
-    const int d_v = (d_qkv >> 16) & 0xFFFF;
     uint b1 = get_group_id(2);
 
     uint b0, b0_kv;

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -1662,7 +1662,8 @@ status_t micro_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
     } else {
         arg_list.append(scale);
     }
-    arg_list.append((int)((D_qk & 0xFFFF) | ((D_v & 0xFFFF) << 16)));
+    arg_list.append((int)D_qk);
+    arg_list.append((int)D_v);
     arg_list.append((int)K);
     arg_list.append((int)Q);
     arg_list.append(key_scales);


### PR DESCRIPTION
PR reverts the workaround from #5636. My local testing shows that the original issue now fails with diagnostics introduced in https://github.com/uxlfoundation/oneDNN/pull/5767. This indicates argument overlap rather than an IGC miscompilation.

#5767 addressed the argument overlap so the issue is not reproducible with the latest main.