### PR TITLE
cpu: aarch64: fix jit_sve_convolution memory leak

### DIFF
--- a/src/cpu/aarch64/jit_sve_convolution.cpp
+++ b/src/cpu/aarch64/jit_sve_convolution.cpp
@@ -21,6 +21,7 @@
 #include "common/type_helpers.hpp"
 #include "common/utils.hpp"
 
+#include "cpu/aarch64/cpu_barrier.hpp"
 #include "cpu/aarch64/jit_sve_convolution.hpp"
 
 namespace dnnl {
@@ -1660,7 +1661,7 @@ void jit_sve_convolution_bwd_weights_t<src_type, diff_dst_type,
         const {
     const memory_desc_wrapper diff_dst_d(pd()->diff_dst_md());
 
-    auto rb = this->reducer_bias_;
+    const auto &rb = reducer_bias_;
     assert(nthr_ == rb->balancer().nthr_);
 
     memory_tracking::grantor_t reducer_bia_scratchpad(
@@ -1756,7 +1757,7 @@ void jit_sve_convolution_bwd_weights_t<src_type, diff_dst_type,
 
     memory_tracking::grantor_t reducer_bia_scratchpad(
             scratchpad, prefix_reducer_bia);
-    auto rb = this->reducer_bias_;
+    const auto &rb = reducer_bias_;
     rb->init(reducer_bia_scratchpad);
 }
 
@@ -1833,7 +1834,7 @@ void jit_sve_convolution_bwd_weights_t<src_type, diff_dst_type,
                     break;
                 case harness_nxc:
                 case harness_mb_reduction: {
-                    auto rb = this->reducer_bias_;
+                    const auto &rb = reducer_bias_;
                     assert(nthr == rb->balancer().nthr_);
                     if (rb->balancer().ithr_njobs(ithr) == 0) return;
                     memory_tracking::grantor_t reducer_bia_scratchpad(

--- a/src/cpu/aarch64/jit_sve_convolution.hpp
+++ b/src/cpu/aarch64/jit_sve_convolution.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2020 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2025 Arm Ltd. and affiliates
+* Copyright 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@
 #include "common/primitive.hpp"
 #include "common/utils.hpp"
 
-#include "cpu/aarch64/cpu_barrier.hpp"
 #include "cpu/aarch64/cpu_reducer.hpp"
 #include "cpu/cpu_convolution_pd.hpp"
 
@@ -267,9 +266,9 @@ private:
 
     int nthr_, nthr_mb_, nthr_g_, nthr_oc_b_, nthr_ic_b_;
 
-    jit_sve_conv_bwd_weights_kernel_f32_t<isa> *kernel_;
-    cpu_accumulator_1d_t<diff_weights_type, isa> *acc_ker_;
-    cpu_reducer_t<diff_weights_type, isa> *reducer_bias_;
+    std::unique_ptr<jit_sve_conv_bwd_weights_kernel_f32_t<isa>> kernel_;
+    std::unique_ptr<cpu_accumulator_1d_t<diff_weights_type, isa>> acc_ker_;
+    std::unique_ptr<cpu_reducer_t<diff_weights_type, isa>> reducer_bias_;
 };
 
 } // namespace aarch64


### PR DESCRIPTION
# Description

Fix a memory leak in `jit_sve_convolution` by switching to `std::unique_ptr`.

With `LeakSanitizer`:
```
# The following leaks are fixed by this patch:
$ ./build-main/tests/benchdnn/benchdnn --conv --global-impl='jit:sve' --batch=test_conv_smoke
...
SUMMARY: LeakSanitizer: 585180 byte(s) leaked in 207 allocation(s). 
```

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?