### PR TITLE
cpu: rv64: use scratchpad for f16 softmax

### DIFF
--- a/src/cpu/rv64/rvv_softmax.cpp
+++ b/src/cpu/rv64/rvv_softmax.cpp
@@ -131,7 +131,7 @@ void compute_softmax_f16_scalar(const dnnl::impl::float16_t *src,
 // f16 compute kernel
 void compute_softmax_f16_rvv(const dnnl::impl::float16_t *src,
         dnnl::impl::float16_t *dst, dim_t len, bool is_logsoftmax,
-        bool is_softmax_inf_as_zero) {
+        bool is_softmax_inf_as_zero, float *scratchpad) {
 
     float max_val
             = (float)nstl::numeric_limits<dnnl::impl::float16_t>::lowest();
@@ -154,7 +154,6 @@ void compute_softmax_f16_rvv(const dnnl::impl::float16_t *src,
     }
 
     if (is_logsoftmax) {
-        float *scratchpad = new float[len];
         float sum_exp = 0.f;
 
         jit_rvv_softmax_f16_exp_sub_sum(
@@ -163,24 +162,22 @@ void compute_softmax_f16_rvv(const dnnl::impl::float16_t *src,
 
         const float sub = max_val + log_sum;
         jit_rvv_softmax_f16_affine_from_f16(src, dst, len, sub, 1.0f);
-        delete[] scratchpad;
     } else {
-        float *tmp_dst = new float[len];
         float sum_exp = 0.f;
         const bool all_minus_inf
                 = is_softmax_inf_as_zero && (max_val == -INFINITY);
 
         if (all_minus_inf) {
             for (dim_t i = 0; i < len; ++i)
-                tmp_dst[i] = 0.f;
+                scratchpad[i] = 0.f;
         } else {
             jit_rvv_softmax_f16_exp_sub_sum(
-                    src, tmp_dst, len, max_val, &sum_exp);
+                    src, scratchpad, len, max_val, &sum_exp);
         }
         const float inv_sum = sum_exp ? (1.0f / sum_exp) : 1.0f;
 
-        jit_rvv_softmax_f16_affine_from_f32(tmp_dst, dst, len, 0.0f, inv_sum);
-        delete[] tmp_dst;
+        jit_rvv_softmax_f16_affine_from_f32(
+                scratchpad, dst, len, 0.0f, inv_sum);
     }
 }
 #endif
@@ -263,13 +260,22 @@ status_t rvv_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
 
             const dim_t outer_stride = pd()->axis_size(true) * rsp.inner_size;
             const int nthr = pd()->nthr_;
+            auto reduction = ctx.get_scratchpad_grantor().template get<float>(
+                    memory_tracking::names::key_softmax_reduction);
 
             if (rsp.inner_size == 1) {
-                parallel_nd(rsp.outer_size, [&](dim_t outer) {
-                    const dim_t base = outer * outer_stride;
-                    compute_softmax_f16_rvv(src_f16 + base, dst_f16 + base,
-                            rsp.axis_size, rsp.is_logsoftmax,
-                            is_softmax_inf_as_zero);
+                parallel(nthr, [&](int ithr, int nthr) {
+                    float *tmp = reduction
+                            + static_cast<size_t>(ithr)
+                                    * static_cast<size_t>(rsp.axis_size);
+                    dim_t start {0}, end {0};
+                    balance211(rsp.outer_size, nthr, ithr, start, end);
+                    for (dim_t outer = start; outer < end; ++outer) {
+                        const dim_t base = outer * outer_stride;
+                        compute_softmax_f16_rvv(src_f16 + base, dst_f16 + base,
+                                rsp.axis_size, rsp.is_logsoftmax,
+                                is_softmax_inf_as_zero, tmp);
+                    }
                 });
             } else {
                 auto scratch = ctx.get_scratchpad_grantor().template get<char>(
@@ -278,6 +284,9 @@ status_t rvv_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                 parallel(nthr, [&](int ithr, int nthr) {
                     auto *tmp
                             = reinterpret_cast<dnnl::impl::float16_t *>(scratch)
+                            + static_cast<size_t>(ithr)
+                                    * static_cast<size_t>(rsp.axis_size);
+                    float *reduction_tmp = reduction
                             + static_cast<size_t>(ithr)
                                     * static_cast<size_t>(rsp.axis_size);
 
@@ -297,7 +306,8 @@ status_t rvv_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                                 rsp.axis_size, stride_bytes);
 
                         compute_softmax_f16_rvv(tmp, tmp, rsp.axis_size,
-                                rsp.is_logsoftmax, is_softmax_inf_as_zero);
+                                rsp.is_logsoftmax, is_softmax_inf_as_zero,
+                                reduction_tmp);
 
                         jit_rvv_softmax_f16_scatter(tmp, dst_f16 + base,
                                 rsp.axis_size, stride_bytes);

--- a/src/cpu/rv64/rvv_softmax.hpp
+++ b/src/cpu/rv64/rvv_softmax.hpp
@@ -113,12 +113,25 @@ struct rvv_softmax_fwd_t : public primitive_t {
 
         void init_scratchpad() {
             auto scratchpad = scratchpad_registry().registrar();
-            nthr_ = rsp_.inner_size > 1 ? dnnl_get_max_threads() : 1;
+            const bool is_f16 = rsp_.data_type == data_type::f16;
+            const dim_t work_amount = rsp_.inner_size > 1
+                    ? rsp_.outer_size * rsp_.inner_size
+                    : rsp_.outer_size;
+            nthr_ = rsp_.inner_size > 1 || is_f16
+                    ? static_cast<int>(nstl::min<dim_t>(dnnl_get_max_threads(),
+                              nstl::max<dim_t>(work_amount, 1)))
+                    : 1;
             const size_t dt_size = types::data_type_size(rsp_.data_type);
             if (rsp_.inner_size > 1) {
                 scratchpad.template book<char>(
                         memory_tracking::names::key_softmax_interim_store,
                         static_cast<size_t>(axis_size(true)) * dt_size
+                                * static_cast<size_t>(nthr_));
+            }
+            if (is_f16) {
+                scratchpad.template book<float>(
+                        memory_tracking::names::key_softmax_reduction,
+                        static_cast<size_t>(axis_size(true))
                                 * static_cast<size_t>(nthr_));
             }
         }


### PR DESCRIPTION
## Summary

This PR optimizes the RV64 f16 softmax path by replacing per-call temporary heap allocation with primitive scratchpad storage.

The existing f16 RVV softmax implementation allocates a temporary `float[len]` buffer inside `compute_softmax_f16_rvv()` for each softmax slice. This introduces noticeable overhead for workloads with many small or medium softmax problems. The PR moves this temporary buffer to oneDNN scratchpad and reuses one buffer per worker thread.

## Changes

- Pass a preallocated f32 scratchpad buffer into `compute_softmax_f16_rvv()`.
- Replace `new float[len]` / `delete[]` in both softmax and logsoftmax f16 paths.
- Book `key_softmax_reduction` scratchpad storage for RV64 f16 softmax.
- Use per-thread scratchpad regions to keep the implementation thread-safe.
- Keep the existing numerical flow unchanged:
  - max reduction remains unchanged;
  - NaN / +inf fallback remains unchanged;
  - -inf handling for `softmax_accurate_inf_as_zero` remains unchanged;
  - RVV exp/sub/sum and affine kernels are reused as before.

## Performance

Tested on RV64 hardware with benchdnn.

### Representative NLP softmax shapes

Input file: `benchdnn/inputs/softmax/shapes_nlp`  
Data type: `f16`

| Build | Total avg time |
| --- | ---: |
| Baseline | 32.8672 ms |
| This PR | 24.6485 ms |

Overall speedup: **1.33x**

### CI softmax shapes

Input file: `benchdnn/inputs/softmax/shapes_ci`  
Data type: `f16`

| Build | Total avg time |
| --- | ---: |
| Baseline | 6.13306 ms |
| This PR | 0.178548 ms |

Overall speedup: **34.35x**

Per-shape results:

| Shape | Baseline | This PR | Speedup |
| --- | ---: | ---: | ---: |
| `16x16` | 1.59766 ms | 0.020752 ms | 76.99x |
| `255x10` | 1.35368 ms | 0.029948 ms | 45.20x |
| `2x19x17x13` | 1.56624 ms | 0.109212 ms | 14.34x |
| `1x16x2x12` | 1.61548 ms | 0.018636 ms | 86.69x |

## Notes

The large improvement on small CI shapes comes from removing repeated heap allocation from the hot path. The computation itself is intentionally unchanged.

## Validation

- Rebased on latest `upstream/main`
- `clang-format-18` applied
- `ctest` passed