### PR TITLE
cpu: x64: zen64: add inner product support

### DIFF
--- a/src/common/memory_desc.hpp
+++ b/src/common/memory_desc.hpp
@@ -181,6 +181,11 @@ struct zen_packed_desc_t {
     // for different GEMM source types stay distinct in the primitive cache and
     // so the reorder can pick the matching packer variant.
     dnnl_data_type_t gemm_src_dt;
+    // Source weights orientation: false => [K, N] (matmul); true => [N, K] =
+    // [OC, IC] (inner product). Packed bytes are orientation-normalized, so this
+    // only tells zen_reorder how to read the source; stored explicitly since the
+    // opaque format has no strides.
+    bool weights_transposed;
 };
 
 struct sparse_desc_t {

--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -175,6 +175,9 @@ size_t get_md_hash(const memory_desc_t &md) {
             seed = hash_combine(seed,
                     static_cast<size_t>(
                             md.format_desc.zen_packed_desc.gemm_src_dt));
+            seed = hash_combine(seed,
+                    static_cast<size_t>(
+                            md.format_desc.zen_packed_desc.weights_transposed));
             break;
         case format_kind::rnn_packed:
             seed = hash_combine(seed,

--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -123,6 +123,7 @@ void serialize(serialization_stream_t &sstream, const memory_desc_t &md) {
             sstream.append(md.format_desc.zen_packed_desc.size);
             sstream.append(md.format_desc.zen_packed_desc.per_slice_size);
             sstream.append(md.format_desc.zen_packed_desc.gemm_src_dt);
+            sstream.append(md.format_desc.zen_packed_desc.weights_transposed);
             break;
         case format_kind::rnn_packed:
             sstream.append(md.format_desc.rnn_packed_desc.format);

--- a/src/common/type_helpers.hpp
+++ b/src/common/type_helpers.hpp
@@ -664,7 +664,9 @@ inline bool operator==(const memory_desc_t &lhs, const memory_desc_t &rhs) {
                 && lhs.format_desc.zen_packed_desc.per_slice_size
                 == rhs.format_desc.zen_packed_desc.per_slice_size
                 && lhs.format_desc.zen_packed_desc.gemm_src_dt
-                == rhs.format_desc.zen_packed_desc.gemm_src_dt;
+                == rhs.format_desc.zen_packed_desc.gemm_src_dt
+                && lhs.format_desc.zen_packed_desc.weights_transposed
+                == rhs.format_desc.zen_packed_desc.weights_transposed;
     return true;
 }
 

--- a/src/cpu/cpu_inner_product_list.cpp
+++ b/src/cpu/cpu_inner_product_list.cpp
@@ -25,7 +25,13 @@
 #if DNNL_X64
 #include "cpu/x64/gemm_bf16_inner_product.hpp"
 #include "cpu/x64/matmul_inner_product.hpp"
+#if DNNL_X64_USE_ZEN
+#include "cpu/x64/zen64/inner_product/zen_inner_product.hpp"
+#endif
 using namespace dnnl::impl::cpu::x64;
+#if DNNL_X64_USE_ZEN
+using namespace dnnl::impl::cpu::x64::zen::inner_product;
+#endif
 #elif DNNL_AARCH64
 #if defined(DNNL_AARCH64_USE_ACL)
 #include "cpu/aarch64/acl_inner_product.hpp"
@@ -50,6 +56,7 @@ using namespace dnnl::impl::prop_kind;
 const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
     static const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> the_map = REG_IP_P({
         {{forward, "f32:xf:*"}, {
+            CPU_INSTANCE_X64_ZEN(zen_inner_product_fwd_t)
             CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
             CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
             CPU_INSTANCE_RV64(rvv_brgemm_inner_product_fwd_t)
@@ -59,6 +66,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
             nullptr,
         }},
         {{forward, "bf16:bf16:*"}, {
+            CPU_INSTANCE_X64_ZEN(zen_inner_product_fwd_t)
             CPU_INSTANCE_X64(matmul_inner_product_fwd_t)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_fwd_t<f32>)
             CPU_INSTANCE_AVX512(gemm_bf16_inner_product_fwd_t<bf16>)

--- a/src/cpu/x64/zen64/common/zen_format_tag.hpp
+++ b/src/cpu/x64/zen64/common/zen_format_tag.hpp
@@ -138,8 +138,13 @@ inline bool is_zen_packed(const memory_desc_t &md) {
 // configs (uniform f32, uniform bf16, bf16 src/wei -> f32 dst) it equals the
 // weights compute type; it is recorded so packed descriptors for different
 // GEMM source types stay distinct in the primitive cache.
+// K and N are the GEMM dimensions (contraction, output). weights_transposed
+// tells how the md's dims map to them: false => [K, N] (matmul); true =>
+// [N, K] = [OC, IC] (inner product). It only affects how zen_reorder reads the
+// source -- packed bytes are normalized either way. Default false = matmul.
 inline status_t init_zen_packed_md(memory_desc_t &weights_md,
-        data_type_t gemm_src_dt, dim_t K, dim_t N, dim_t batch = 1) {
+        data_type_t gemm_src_dt, dim_t K, dim_t N, dim_t batch = 1,
+        bool weights_transposed = false) {
     const dim_t per_slice = zen_packed_bytes(K, N, weights_md.data_type);
     if (per_slice <= 0) return status::unimplemented;
 
@@ -156,6 +161,8 @@ inline status_t init_zen_packed_md(memory_desc_t &weights_md,
     weights_md.format_desc.zen_packed_desc.per_slice_size = per_slice_sz;
     weights_md.format_desc.zen_packed_desc.size = per_slice_sz * batch_sz;
     weights_md.format_desc.zen_packed_desc.gemm_src_dt = gemm_src_dt;
+    weights_md.format_desc.zen_packed_desc.weights_transposed
+            = weights_transposed;
     return status::success;
 }
 

--- a/src/cpu/x64/zen64/inner_product/zen_inner_product.cpp
+++ b/src/cpu/x64/zen64/inner_product/zen_inner_product.cpp
@@ -1,0 +1,237 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/x64/zen64/inner_product/zen_inner_product.hpp"
+
+#include <string>
+
+#include "common/primitive_exec_types.hpp"
+#include "common/utils.hpp"
+#include "common/verbose.hpp"
+
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/matmul_inner_product.hpp" // init_matmul_md + matmul_desc machinery
+#include "cpu/x64/zen64/common/zen_format_tag.hpp" // init_zen_packed_md
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace zen {
+namespace inner_product {
+
+using namespace data_type;
+
+namespace {
+
+// Like matmul_inner_product's create_matmul_pd, but stops at the first impl
+// whose name identifies zen_matmul (the shared helper only accepts brg_matmul).
+status_t create_zen_matmul_pd(std::shared_ptr<primitive_desc_t> &matmul_pd,
+        const engine_t *engine, const memory_desc_t *src_md,
+        const memory_desc_t *wei_md, const memory_desc_t *dst_md,
+        const memory_desc_t *bia_md, const primitive_attr_t *attr) {
+    auto matmul_desc = matmul_desc_t();
+    CHECK(matmul_desc_init(&matmul_desc, src_md, wei_md, bia_md, dst_md,
+            /*reduce_md=*/nullptr, matmul_reduce_kind::src));
+
+    primitive_desc_iterator_t it(
+            engine, (op_desc_t *)&matmul_desc, attr, nullptr);
+    while (it != it.end()) {
+        matmul_pd = *(++it);
+        if (!matmul_pd) return status::unimplemented;
+        if (std::string(matmul_pd->name()).find("zen") != std::string::npos)
+            return status::success;
+    }
+    return status::unimplemented;
+}
+
+} // namespace
+
+status_t zen_inner_product_fwd_t::pd_t::init(const engine_t *engine) {
+    using namespace utils;
+    using smask_t = primitive_attr_t::skip_mask_t;
+
+    // IP-specific gates only; the nested zen_matmul validates dtypes/post-ops.
+    // Both fwd prop_kinds are accepted; init_matmul_params picks the weights path.
+    VDISPATCH_INNER_PRODUCT(is_fwd(), VERBOSE_BAD_PROPKIND);
+    VDISPATCH_INNER_PRODUCT(
+            ::dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAMD),
+            "This implementation only supports AMD CPUs");
+    VDISPATCH_INNER_PRODUCT(mayiuse(avx512_core), VERBOSE_UNSUPPORTED_ISA);
+    VDISPATCH_INNER_PRODUCT(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+    // 2D only (plain Linear); spatial IP declines to matmul_inner_product/brgemm.
+    VDISPATCH_INNER_PRODUCT(ndims() == 2, VERBOSE_BAD_NDIMS, "src", ndims());
+    VDISPATCH_INNER_PRODUCT(
+            !has_runtime_dims_or_strides(), VERBOSE_RUNTIMEDIM_UNSUPPORTED);
+
+    VDISPATCH_INNER_PRODUCT(one_of(weights_md(0)->data_type, f32, bf16),
+            VERBOSE_UNSUPPORTED_DT);
+
+    // Only post-ops (+sum_dt) may deviate; the nested matmul checks the exact set.
+    VDISPATCH_INNER_PRODUCT(
+            attr()->has_default_values(
+                    smask_t::post_ops | smask_t::sum_dt, dst_md(0)->data_type),
+            VERBOSE_UNSUPPORTED_ATTR);
+
+    VDISPATCH_INNER_PRODUCT_SC(
+            init_matmul_params(engine), "init_matmul_params");
+
+    init_scratchpad();
+    return status::success;
+}
+
+status_t zen_inner_product_fwd_t::pd_t::set_training_formats() {
+    using namespace format_tag;
+    assert(desc()->prop_kind != prop_kind::forward_inference);
+    // Backward shares src/weights, so resolve open descriptors to the plain
+    // layout it expects (never zen_packed, nor the ba transpose). 2D: tag == ab.
+    if (memory_desc_wrapper(src_md_).format_any())
+        CHECK(memory_desc_init_by_tag(src_md_, ab));
+    if (memory_desc_wrapper(weights_md_).format_any())
+        CHECK(memory_desc_init_by_tag(weights_md_, ab));
+    if (memory_desc_wrapper(dst_md_).format_any())
+        CHECK(memory_desc_init_by_tag(dst_md_, ab));
+    if (with_bias() && memory_desc_wrapper(bias_md_).format_any())
+        CHECK(memory_desc_init_by_tag(bias_md_, x));
+    return status::success;
+}
+
+status_t zen_inner_product_fwd_t::pd_t::init_matmul_params(
+        const engine_t *engine) {
+    using namespace format_tag;
+    const auto src_dt = src_md(0)->data_type;
+    const auto wei_dt = weights_md(0)->data_type;
+
+    // Prepack (zen_packed) needs inference weights, either open (we advertise,
+    // framework reorders once) or already packed from a prior query.
+    const bool inference = desc()->prop_kind == prop_kind::forward_inference;
+    const bool wei_format_any = memory_desc_wrapper(weights_md(0)).format_any();
+    const bool wei_already_packed = zen::is_zen_packed(*weights_md(0));
+
+    // Inference may pick the zen_packed prepack layout; training must expose
+    // plain layouts the backward primitives can consume.
+    if (inference) {
+        VDISPATCH_INNER_PRODUCT(set_default_params() == status::success,
+                VERBOSE_UNSUPPORTED_TAG);
+    } else {
+        VDISPATCH_INNER_PRODUCT_SC(
+                set_training_formats(), VERBOSE_UNSUPPORTED_TAG);
+    }
+
+    // Unpadded IC so the matmul (K=IC) never over-reads; plain 2D src/dst.
+    VDISPATCH_INNER_PRODUCT(
+            IC_total() == IC_total_padded(), VERBOSE_UNSUPPORTED_TAG_S, "src");
+    VDISPATCH_INNER_PRODUCT(memory_desc_wrapper(src_md(0)).matches_tag(ab),
+            VERBOSE_UNSUPPORTED_TAG_S, "src");
+    VDISPATCH_INNER_PRODUCT(memory_desc_wrapper(dst_md(0)).matches_tag(ab),
+            VERBOSE_UNSUPPORTED_TAG_S, "dst");
+
+    const dim_t K = IC_total();
+    const dim_t N = OC();
+
+    // 2D matmul descriptors: src [MB, IC] ab, dst [MB, OC] ab, bias [1, OC] ab.
+    memory_desc_t mm_src_md {}, mm_wei_md {}, mm_dst_md {}, mm_bia_md {};
+    VDISPATCH_INNER_PRODUCT_SC(
+            init_matmul_md(mm_src_md, *src_md(), ab), VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_INNER_PRODUCT_SC(
+            init_matmul_md(mm_dst_md, *dst_md(), ab), VERBOSE_UNSUPPORTED_TAG);
+
+    const bool use_zen_packed
+            = inference && (wei_format_any || wei_already_packed);
+    if (use_zen_packed) {
+        // matmul weights = zen_packed [IC, OC]. The packed bytes are normalized
+        // [K=IC, N=OC], so this md is identical whether advertised or pre-packed.
+        dims_t wei_2d = {K, N};
+        VDISPATCH_INNER_PRODUCT_SC(
+                memory_desc_init_by_tag(mm_wei_md, 2, wei_2d, wei_dt, ab),
+                VERBOSE_UNSUPPORTED_TAG);
+        VDISPATCH_INNER_PRODUCT_SC(
+                zen::init_zen_packed_md(mm_wei_md, src_dt, K, N, /*batch=*/1,
+                        /*weights_transposed=*/false),
+                VERBOSE_UNSUPPORTED_TAG);
+        // Advertise zen_packed [OC, IC] only for open weights, so the framework
+        // reorders once. A pre-packed md is kept as-is (no second reorder).
+        if (wei_format_any) {
+            VDISPATCH_INNER_PRODUCT_SC(
+                    zen::init_zen_packed_md(weights_md_, src_dt, K, N,
+                            /*batch=*/1, /*weights_transposed=*/true),
+                    VERBOSE_UNSUPPORTED_TAG);
+        }
+    } else {
+        // Plain path: hand the matmul the IP weights [OC, IC] as an [IC, OC] view
+        // of the same bytes. oi -> ba (transposed view); io -> ab (direct view).
+        // A concrete tag keeps zen_matmul on its plain path (packs each call).
+        const memory_desc_wrapper wd(weights_md(0));
+        format_tag_t mm_wei_tag = format_tag::undef;
+        if (wd.matches_tag(ab))
+            mm_wei_tag = ba;
+        else if (wd.matches_tag(ba))
+            mm_wei_tag = ab;
+        VDISPATCH_INNER_PRODUCT(mm_wei_tag != format_tag::undef,
+                VERBOSE_UNSUPPORTED_TAG_S, "weights");
+        VDISPATCH_INNER_PRODUCT_SC(init_matmul_md(mm_wei_md, *weights_md(),
+                                           mm_wei_tag, /*swap_dims=*/true),
+                VERBOSE_UNSUPPORTED_TAG);
+    }
+
+    if (with_bias()) {
+        dims_t bia_2d = {1, N};
+        VDISPATCH_INNER_PRODUCT_SC(
+                memory_desc_init_by_tag(mm_bia_md, 2, bia_2d,
+                        weights_md(1)->data_type, format_tag::ab),
+                VERBOSE_UNSUPPORTED_TAG);
+    }
+
+    // Resolve format_any on binary post-op src1 so the IP pd advertises a
+    // concrete layout and rejects unplaceable post-ops (nested matmul no-ops it).
+    VDISPATCH_INNER_PRODUCT_SC(
+            attr_.set_default_formats(dst_md(0)), VERBOSE_UNSUPPORTED_POSTOP);
+
+    // Nested matmul pd (must resolve to zen_matmul); it owns validation,
+    // post-ops, and compute.
+    primitive_attr_t matmul_attr = *attr();
+    VDISPATCH_INNER_PRODUCT_SC(
+            create_zen_matmul_pd(matmul_pd_, engine, &mm_src_md, &mm_wei_md,
+                    &mm_dst_md, with_bias() ? &mm_bia_md : nullptr,
+                    &matmul_attr),
+            VERBOSE_PRIMITIVE_CREATION_FAIL, "matmul");
+    VDISPATCH_INNER_PRODUCT(
+            matmul_pd_ != nullptr, VERBOSE_PRIMITIVE_CREATION_FAIL, "matmul");
+
+    return status::success;
+}
+
+status_t zen_inner_product_fwd_t::execute(const exec_ctx_t &ctx) const {
+    using namespace memory_tracking::names;
+
+    // Reuse the DNNL_ARG_* memories as-is: src/dst/bias flatten to the 2D mds and
+    // the IP weights buffer is read as the matmul's [IC,OC] view (packed or ba).
+    exec_args_t matmul_args = ctx.args();
+    exec_ctx_t matmul_ctx(ctx, std::move(matmul_args));
+
+    auto *nested_grantor = create_nested_grantor(ctx.get_scratchpad_grantor(),
+            key_nested, matmul_->pd()->scratchpad_registry());
+    matmul_ctx.set_scratchpad_grantor(nested_grantor);
+
+    return matmul_->execute(matmul_ctx);
+}
+
+} // namespace inner_product
+} // namespace zen
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/zen64/inner_product/zen_inner_product.hpp
+++ b/src/cpu/x64/zen64/inner_product/zen_inner_product.hpp
@@ -1,0 +1,92 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_ZEN64_INNER_PRODUCT_ZEN_INNER_PRODUCT_HPP
+#define CPU_X64_ZEN64_INNER_PRODUCT_ZEN_INNER_PRODUCT_HPP
+
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive.hpp"
+#include "common/primitive_desc.hpp"
+
+#include "cpu/cpu_inner_product_pd.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace zen {
+namespace inner_product {
+
+// Zen inner product = a thin 2D adapter mapping the IP problem onto a nested
+// zen_matmul (no duplication of its validation / post-ops / launcher). The
+// weights path is chosen per prop_kind:
+//   - forward_inference w/ open weights: advertise the opaque zen_packed format
+//     so the framework prepacks [OC,IC] weights once into [K=IC, N=OC]; matmul
+//     reads [IC,OC]. Constant weights => packed only once.
+//   - otherwise (training, or pre-resolved plain weights): hand matmul the plain
+//     [OC,IC] weights as an [IC,OC] view (same bytes); zen_matmul packs each call.
+struct zen_inner_product_fwd_t : public primitive_t {
+    using primitive_t::primitive_t;
+
+    struct pd_t : public ::dnnl::impl::cpu::cpu_inner_product_fwd_pd_t {
+        using ::dnnl::impl::cpu::cpu_inner_product_fwd_pd_t::
+                cpu_inner_product_fwd_pd_t;
+
+        DECLARE_COMMON_PD_T("zen:ip:f32|bf16:amd", zen_inner_product_fwd_t);
+
+        status_t init(const engine_t *engine);
+
+        std::shared_ptr<primitive_desc_t> matmul_pd_;
+
+    private:
+        // Reshape the IP problem to 2D, advertise zen_packed weights, and
+        // create the nested zen_matmul pd (mirrors matmul_inner_product).
+        status_t init_matmul_params(const engine_t *engine);
+
+        // Resolve open descriptors to plain (backward-suitable) layouts for
+        // training
+        status_t set_training_formats();
+
+        void init_scratchpad() {
+            auto scratchpad = scratchpad_registry().registrar();
+            scratchpad.book(memory_tracking::names::key_nested,
+                    matmul_pd_->scratchpad_registry());
+        }
+    };
+
+    status_t init(engine_t *engine) override {
+        CHECK(pd()->matmul_pd_->create_primitive(matmul_, engine));
+        return status::success;
+    }
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::shared_ptr<primitive_t> matmul_;
+};
+
+} // namespace inner_product
+} // namespace zen
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/zen64/reorder/zen_reorder.cpp
+++ b/src/cpu/x64/zen64/reorder/zen_reorder.cpp
@@ -191,18 +191,21 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
         VDISPATCH_REORDER_IC(id.dims()[i] == od.dims()[i],
                 VERBOSE_INCONSISTENT_DIM, "src", i, "dst", i);
 
-    // Logical (K, N) of one slice and the batch count.
-    const dim_t K = od.dims()[ndims - 2];
-    const dim_t N = od.dims()[ndims - 1];
+    // Logical (K, N) of one slice and the batch count. The packed dst records
+    // the weights orientation: the last two dims are [.., K, N] for matmul and
+    // [.., N, K] for inner product (weights_transposed), so pick K/N accordingly.
+    const bool nk = od.zen_packed_desc().weights_transposed;
+    const int kdim = nk ? ndims - 1 : ndims - 2;
+    const int ndim = nk ? ndims - 2 : ndims - 1;
+    const dim_t K = od.dims()[kdim];
+    const dim_t N = od.dims()[ndim];
     const dim_t batch = batched ? od.dims()[0] : 1;
 
-    // execute() collapses a K==1 slice to contiguous row-major (`ab`) since a
-    // dense single row is layout-agnostic. A padded col-major (`acb`/`ba`) row
-    // (N stride != 1) is *not* contiguous, so that assumption would misread it;
-    // decline it here and let the reference reorder serve the (pathological)
-    // case instead.
-    VDISPATCH_REORDER_IC(K != 1 || src_strides[ndims - 1] == 1,
-            VERBOSE_UNSUPPORTED_TAG_S, "src");
+    // execute() collapses a K==1 slice to contiguous row-major since a dense
+    // single row is layout-agnostic; that assumption needs the N axis
+    // contiguous. A padded (non-contiguous) K==1 row is declined here.
+    VDISPATCH_REORDER_IC(
+            K != 1 || src_strides[ndim] == 1, VERBOSE_UNSUPPORTED_TAG_S, "src");
 
     // zen_weight_prepack takes int64_t K/N/ldb but the matmul that consumes the
     // packed buffer drives them through the int Zen API; reject oversized slices
@@ -277,30 +280,39 @@ status_t zen_reorder_t::execute(const exec_ctx_t &ctx) const {
     // are always (K, N); the batch dim (if any) is outermost.
     const int ndims = src_d.ndims();
     const bool batched = ndims == 3;
-    const int64_t K = src_d.dims()[ndims - 2];
-    const int64_t N = src_d.dims()[ndims - 1];
+    // The packed dst records the weights orientation: the last two dims are
+    // [.., K, N] for matmul and [.., N, K] for inner product (weights_transposed).
+    // Map K/N onto the right physical axes.
+    const bool nk = dst_d.zen_packed_desc().weights_transposed;
+    const int kdim = nk ? ndims - 1 : ndims - 2;
+    const int ndim = nk ? ndims - 2 : ndims - 1;
+    const int64_t K = src_d.dims()[kdim];
+    const int64_t N = src_d.dims()[ndim];
     const int64_t batch = batched ? src_d.dims()[0] : 1;
 
-    // Detect transpose from the slice's last-two-dim strides:
-    //   ab -> strides[..]={ldb, 1}  -> trans='n', ldb = row stride
-    //   ba -> strides[..]={1, ldb}  -> trans='t', ldb = col stride
-    // When K==1 (degenerate row) and the row is contiguous (N stride == 1),
-    // both layouts coincide, so treat the src as `ab` (trans='n'); the byte
-    // stream is identical. A padded (non-contiguous) K==1 row is rejected in
-    // pd_t::init(), so it never reaches here.
+    // Describe the logical (K, N) matrix's physical layout to the packer via
+    // transposed + ldb, read from the actual strides so a padded leading dim is
+    // honored (pd_t::init guarantees one of the last two axes is unit-stride):
+    //   N axis contiguous -> row-major [K,N] -> trans='n', ldb = K-axis stride
+    //   K axis contiguous -> col-major [K,N] -> trans='t', ldb = N-axis stride
+    //   K==1 degenerate row -> both coincide -> row-major, ldb = N.
+    // For matmul (nk=false) this reduces to the plain ab/ba test.
     const auto &src_strides = src_d.blocking_desc().strides;
-    const bool src_is_ab = (src_strides[ndims - 1] == 1) || (K == 1);
-    const bool transposed = !src_is_ab;
-
-    // The leading dim is read from the actual inner stride (not the logical
-    // extent), so a padded leading dim is honored: ab -> row stride
-    // (strides[ndims-2]); ba -> col stride (strides[ndims-1]).
-    // Exception: when K==1 the slice is a single row and both layouts coincide
-    // (src_is_ab is forced true above), but the K-dimension stride is then
-    // degenerate (can be 1 for an `acb` source) rather than the row length, so
-    // fall back to the logical N -- the packer requires ldb >= N.
-    const int64_t ldb = src_is_ab ? (K == 1 ? N : src_strides[ndims - 2])
-                                  : src_strides[ndims - 1];
+    const int64_t k_stride = src_strides[kdim];
+    const int64_t n_stride = src_strides[ndim];
+    bool transposed;
+    int64_t ldb;
+    if (K == 1) {
+        transposed = false;
+        ldb = N;
+    } else if (n_stride == 1) {
+        transposed = false;
+        ldb = k_stride;
+    } else {
+        transposed = true;
+        ldb = n_stride;
+    }
+    const bool src_is_ab = !transposed;
 
     const auto src_dt = src_d.data_type();
     const auto dst_dt = dst_d.data_type();


### PR DESCRIPTION


# Description

Adds a Zen (AMD) x64 forward inner product implementation by adapting the 2D inner product problem onto the existing zen_matmul path


# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
