### PR TITLE
xe: gemm: restore transitional selectGEMM overload for legacy callers

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -115,16 +115,17 @@ InterfaceHandler GEMMOptions::generateInterface(HW hw, HostPayload host) const {
     /* Set up arguments for microkernel */
     InterfaceHandler interface(hw);
 
-    if (host.simd <= 0 || host.argumentBytes <= 0)
-        stub("Invalid host kernel thread payload");
-
-    /* Place microkernel arguments above the host kernel's thread payload:
-       r0, the local IDs, then the cross-thread arguments. */
-    interface.requireLocalID(3);
-    /* SIMD fixes the local-ID register stride, hence the cross-thread base. */
-    interface.requireSIMD(host.simd);
-    interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
-                                  + GRF::bytesToGRFs(hw, host.argumentBytes)));
+    if (host.simd <= 0 || host.argumentBytes <= 0) {
+        interface.setArgumentBase(ngen::GRF(8));
+    } else {
+        /* Place microkernel arguments above the host kernel's thread payload:
+           r0, the local IDs, then the cross-thread arguments. */
+        interface.requireLocalID(3);
+        /* SIMD fixes the local-ID register stride, hence the cross-thread base. */
+        interface.requireSIMD(host.simd);
+        interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
+                                      + GRF::bytesToGRFs(hw, host.argumentBytes)));
+    }
     interface.newArgument("A", localA ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
     interface.newArgument("lda", DataType::d);
     interface.newArgument("B", localB ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
@@ -408,6 +409,14 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
         }
     }
     throw std::runtime_error("No matching kernel");
+}
+
+Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+                   const GEMMProblem &problem, const std::vector<StrategyRequirement> &reqs,
+                   StrategyAdjuster strategyAdjuster, SelectionObserver *observer)
+{
+    return selectGEMM(options, HostPayload(0, 0), hwInfo, sizes, problem, reqs,
+                      strategyAdjuster, observer);
 }
 
 static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool localA, bool localB,

--- a/src/gpu/intel/gemm/jit/include/gemmstone/config.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/config.hpp
@@ -55,4 +55,12 @@ inline int getVerbose(GEMMVerbose v) { return 0; }
 #define GEMMSTONE_NAMESPACE_END }
 #endif
 
+#ifndef GEMMSTONE_DEPRECATED
+#if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#define GEMMSTONE_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#define GEMMSTONE_DEPRECATED(msg)
+#endif
+#endif
+
 #endif /* header guard */

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -65,6 +65,13 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                      StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
 
+/* Transitional overload for callers that do not yet pass a HostPayload. */
+GEMMSTONE_DEPRECATED("Defaults host payload base to r8, which may mismatch the host kernel and clobber the OpenCL kernel arguments. Use selectGEMM overload with HostPayload")
+Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+                                     const GEMMProblem &problem,
+                                     const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
+                                     StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
+
 /* Helpers */
 static inline int alignmentForLD(int ld)
 {


### PR DESCRIPTION
This a fixup for https://github.com/uxlfoundation/oneDNN/pull/5767. OpenVINO uses the API without `HostPayload` argument so let's keep it to avoid build breakage.