### PR TITLE
cpu: rv64: matmul: add f16/bf16 jit kernel

### DIFF
--- a/src/cpu/rv64/gemm/jit_rvv_gemm_f16_kernel.cpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_f16_kernel.cpp
@@ -1,0 +1,250 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/rv64/gemm/jit_rvv_gemm_f16_kernel.hpp"
+
+#include <memory>
+#include <mutex>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+namespace gemm_utils {
+
+using namespace Xbyak_riscv;
+using namespace dnnl::impl::utils;
+
+jit_rvv_gemm_f16_kernel_t::jit_rvv_gemm_f16_kernel_t(
+        dim_t n_cols, bool isTransA, data_type_t in_dt)
+    : jit_generator_t("rv64_gemm_kernel_f16_jit")
+    , n_cols_(n_cols)
+    , isTransA_(isTransA)
+    , is_bf16_(in_dt == data_type::bf16) {
+    assert(utils::one_of(in_dt, data_type::f16, data_type::bf16));
+    create_kernel();
+}
+
+void jit_rvv_gemm_f16_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+
+    const Reg reg_A_ptr = a1; // running pointer into A
+    const Reg reg_m = a2; // tile height (used for vsetvli)
+    const Reg reg_C_base = a3; // base pointer to C(:, 0)
+
+    const Reg reg_lda_bytes = t0;
+    const Reg reg_ldb_bytes = t1;
+    const Reg reg_ldc_bytes = t2;
+    const Reg reg_K = t3;
+
+    const Reg reg_k = a4; // current k counter
+    const Reg reg_B0_ptr = a6; // running pointer into B
+    const Reg reg_tmp0 = a7;
+    const FReg freg_b[6] = {fa2, fa3, fa4, fa5, fa6, fa7};
+
+    const VReg v_c[6]
+            = {VReg(0), VReg(4), VReg(8), VReg(12), VReg(16), VReg(20)};
+    const VReg v_a0(24); // e16/m2: v24-v25
+    const VReg v_a1(28); // e16/m2: v28-v29
+
+    // Layout of call_params_t:
+    //   0  : const void *A
+    //   8  : const void *B
+    //   16 : void *C
+    //   24 : dim_t lda
+    //   32 : dim_t ldb
+    //   40 : dim_t ldc
+    //   48 : dim_t K
+    //   56 : dim_t m
+    ld(reg_A_ptr, reg_param, 0);
+    ld(reg_B0_ptr, reg_param, 8);
+    ld(reg_C_base, reg_param, 16);
+    ld(reg_lda_bytes, reg_param, 24);
+    ld(reg_ldb_bytes, reg_param, 32);
+    ld(reg_ldc_bytes, reg_param, 40);
+    ld(reg_K, reg_param, 48);
+    ld(reg_m, reg_param, 56);
+
+    // A, B and C elements are 2 bytes.
+    slli(reg_lda_bytes, reg_lda_bytes, 1);
+    slli(reg_ldb_bytes, reg_ldb_bytes, 1);
+    slli(reg_ldc_bytes, reg_ldc_bytes, 1);
+
+    const Reg &reg_tmp3 = reg_param;
+
+    // f32 accumulators: e32/m4. Zero the full groups before switching to the
+    // e16/m2 configuration of the K loop.
+    vsetvli(x0, reg_m, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    for (dim_t c = 0; c < n_cols_; c++)
+        vmv_v_i(v_c[c], 0);
+
+    // A rows and the widening FMA run at e16/m2 (same VLMAX as e32/m4).
+    vsetvli(x0, reg_m, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
+
+    auto emit_load_a = [&](const VReg &v_a) {
+        if (isTransA_) {
+            vlse16_v(v_a, reg_A_ptr, reg_lda_bytes);
+        } else {
+            vle16_v(v_a, reg_A_ptr);
+        }
+    };
+
+    auto emit_advance_a = [&]() {
+        if (isTransA_) {
+            addi(reg_A_ptr, reg_A_ptr, 2);
+        } else {
+            add(reg_A_ptr, reg_A_ptr, reg_lda_bytes);
+        }
+    };
+
+    auto emit_advance_b = [&]() { addi(reg_B0_ptr, reg_B0_ptr, 2); };
+
+    auto emit_fma = [&](dim_t col, const VReg &v_a) {
+        if (is_bf16_) {
+            vfwmaccbf16_vf(v_c[col], freg_b[col], v_a);
+        } else {
+            vfwmacc_vf(v_c[col], freg_b[col], v_a);
+        }
+    };
+
+    // Load the n_cols B scalars (stride ldb apart), interleaving each flh with
+    // the FMA of the previously loaded scalar to hide the load latency.
+    auto emit_load_b_scattered_compute = [&](const VReg &v_a) {
+        flh(freg_b[0], reg_B0_ptr, 0);
+        if (n_cols_ == 1) {
+            emit_fma(0, v_a);
+        } else {
+            add(reg_tmp0, reg_B0_ptr, reg_ldb_bytes);
+            flh(freg_b[1], reg_tmp0, 0);
+            emit_fma(0, v_a);
+            for (dim_t c = 2; c < n_cols_; c++) {
+                add(reg_tmp0, reg_tmp0, reg_ldb_bytes);
+                flh(freg_b[c], reg_tmp0, 0);
+                emit_fma(c - 1, v_a);
+            }
+            emit_fma(n_cols_ - 1, v_a);
+        }
+    };
+
+    mv(reg_k, x0);
+
+    Label label_k_done;
+    Label label_loop_a0, label_loop_a1;
+    Label label_drain_a0, label_drain_a1;
+
+    bge(reg_k, reg_K, label_k_done);
+
+    emit_load_a(v_a0);
+    addi(reg_k, reg_k, 1);
+    bge(reg_k, reg_K, label_drain_a0);
+
+    L(label_loop_a0);
+    emit_advance_a();
+    emit_load_a(v_a1);
+    emit_load_b_scattered_compute(v_a0);
+    emit_advance_b();
+    addi(reg_k, reg_k, 1);
+    bge(reg_k, reg_K, label_drain_a1);
+
+    L(label_loop_a1);
+    emit_advance_a();
+    emit_load_a(v_a0);
+    emit_load_b_scattered_compute(v_a1);
+    emit_advance_b();
+    addi(reg_k, reg_k, 1);
+    bge(reg_k, reg_K, label_drain_a0);
+    j_(label_loop_a0);
+
+    L(label_drain_a0);
+    emit_load_b_scattered_compute(v_a0);
+    j_(label_k_done);
+
+    L(label_drain_a1);
+    emit_load_b_scattered_compute(v_a1);
+    j_(label_k_done);
+
+    L(label_k_done);
+
+    // C store: narrow the f32 accumulators in place to the input data type and
+    // store (overwrite-only; the driver rejects beta != 0). Stays at e16/m2,
+    // the configuration of the narrowing destination.
+    for (dim_t c = 0; c < n_cols_; c++) {
+        if (c == 0) {
+            mv(reg_tmp3, reg_C_base);
+        } else {
+            li(reg_tmp0, c);
+            mul(reg_tmp3, reg_ldc_bytes, reg_tmp0);
+            add(reg_tmp3, reg_C_base, reg_tmp3);
+        }
+        if (is_bf16_) {
+            vfncvtbf16_f_f_w(v_c[c], v_c[c]);
+        } else {
+            vfncvt_f_f_w(v_c[c], v_c[c]);
+        }
+        vse16_v(v_c[c], reg_tmp3);
+    }
+
+    ret();
+#else
+    ret();
+#endif
+}
+
+namespace {
+
+template <bool isTransA, bool isBf16>
+struct jit_rvv_gemm_f16_kernel_storage_t {
+    std::array<std::unique_ptr<jit_rvv_gemm_f16_kernel_t>, 8> nb;
+    jit_rvv_gemm_f16_kernel_table_t table;
+};
+
+template <bool isTransA, bool isBf16>
+jit_rvv_gemm_f16_kernel_storage_t<isTransA, isBf16> &
+get_jit_rvv_gemm_f16_kernel_storage() {
+    static jit_rvv_gemm_f16_kernel_storage_t<isTransA, isBf16> storage;
+    static std::once_flag initialized;
+
+    std::call_once(initialized, [] {
+        for (dim_t n_cols = 1; n_cols <= 6; n_cols++) {
+            storage.nb[n_cols].reset(new jit_rvv_gemm_f16_kernel_t(n_cols,
+                    isTransA, isBf16 ? data_type::bf16 : data_type::f16));
+            storage.table.nb[n_cols] = storage.nb[n_cols].get();
+        }
+    });
+
+    return storage;
+}
+
+} // namespace
+
+const jit_rvv_gemm_f16_kernel_table_t &get_jit_rvv_gemm_f16_kernel_table(
+        bool isTransA, data_type_t in_dt) {
+    if (isTransA) {
+        return in_dt == data_type::bf16
+                ? get_jit_rvv_gemm_f16_kernel_storage<true, true>().table
+                : get_jit_rvv_gemm_f16_kernel_storage<true, false>().table;
+    }
+    return in_dt == data_type::bf16
+            ? get_jit_rvv_gemm_f16_kernel_storage<false, true>().table
+            : get_jit_rvv_gemm_f16_kernel_storage<false, false>().table;
+}
+
+} // namespace gemm_utils
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/gemm/jit_rvv_gemm_f16_kernel.hpp
+++ b/src/cpu/rv64/gemm/jit_rvv_gemm_f16_kernel.hpp
@@ -1,0 +1,94 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_GEMM_JIT_RVV_GEMM_F16_KERNEL_HPP
+#define CPU_RV64_GEMM_JIT_RVV_GEMM_F16_KERNEL_HPP
+
+#include "common/c_types_map.hpp"
+
+#include "cpu/rv64/jit_generator.hpp"
+
+#include <array>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+namespace gemm_utils {
+
+// RVV JIT micro-kernel for half-precision GEMM (f16 or bf16 inputs, dst of the
+// same type) on RV64.
+//
+// Computes an m x n_cols tile of:
+//   C[0:m, 0:n_cols] = A[0:m, 0:K] * B[0:K, 0:n_cols]
+// with f32 accumulation; the accumulators are narrowed to the input data type
+// once at the C store (overwrite-only, matching the epilogue contract of the
+// s8 GEMM kernel for narrow dst types — the driver rejects beta != 0).
+//
+// Design mirrors jit_rvv_gemm_kernel_t (f32): outer-product micro-kernel with
+// LMUL=m4 f32 accumulators and n_cols (1..6) broadcast B scalars; A rows are
+// loaded at SEW=e16 LMUL=m2 (vfwmacc.vf for f16 / vfwmaccbf16.vf for bf16,
+// gated by the caller), double-buffered to overlap the A load with FMAs.
+//
+// Vector register layout:
+//   v0..v23  : six f32 accumulator groups (LMUL=m4, one per column)
+//   v24..v25 : A double-buffer 0 (e16/m2; also reused as epilogue temporary)
+//   v28..v29 : A double-buffer 1 (e16/m2)
+struct jit_rvv_gemm_f16_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const void *A; // f16/bf16 elements
+        const void *B; // f16/bf16 elements
+        void *C; // same data type as A/B
+        dim_t lda;
+        dim_t ldb;
+        dim_t ldc;
+        dim_t K;
+        dim_t m;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_gemm_f16_kernel_t)
+
+    // Construct a JIT kernel for a specific n_cols (1..6) and A access pattern.
+    // in_dt selects f16 (Zvfh) vs bf16 (Zvfbfwma); the caller gates the ISA.
+    jit_rvv_gemm_f16_kernel_t(dim_t n_cols, bool isTransA, data_type_t in_dt);
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+
+private:
+    dim_t n_cols_;
+    bool isTransA_;
+    bool is_bf16_;
+};
+
+struct jit_rvv_gemm_f16_kernel_table_t {
+    std::array<const jit_rvv_gemm_f16_kernel_t *, 8> nb {};
+};
+
+const jit_rvv_gemm_f16_kernel_table_t &get_jit_rvv_gemm_f16_kernel_table(
+        bool isTransA, data_type_t in_dt);
+
+} // namespace gemm_utils
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/rv64/gemm/rvv_gemm_f16.cpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f16.cpp
@@ -1,0 +1,280 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cstring>
+
+#include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/platform.hpp"
+
+#include "cpu/rv64/gemm/jit_rvv_gemm_f16_kernel.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_f16.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace dnnl::impl::utils;
+using namespace gemm_utils;
+// e16/m2 A rows hold the same number of elements as the f32 kernel's e32/m4
+// rows, so the f32 unroll factors apply unchanged.
+using gemm_f16_traits = gemm_utils::gemm_utils_traits<float>;
+
+namespace {
+
+// Scalar copy of A into workspace for cache-friendly access. Elements are
+// 2 bytes (f16/bf16); after copy, ws is laid out as K blocks of m contiguous
+// elements:
+//   ws[k * m + i] = A_logical[i, k]
+void copy_A_f16(
+        bool isTransA, dim_t K, const char *A, dim_t lda, char *ws, dim_t m) {
+    for (dim_t k = 0; k < K; k++) {
+        if (isTransA) {
+            for (dim_t i = 0; i < m; i++)
+                std::memcpy(ws + i * 2, A + (i * lda + k) * 2, 2);
+        } else {
+            std::memcpy(ws, A + k * lda * 2, m * 2);
+        }
+        ws += m * 2;
+    }
+}
+
+template <bool isTransA>
+void block_ker_f16(const dim_t M, const dim_t N, const dim_t K, const char *A,
+        const dim_t lda, const char *B, const dim_t ldb, char *C,
+        const dim_t ldc, char *ws, bool do_copy, const dim_t m_unroll,
+        const jit_rvv_gemm_f16_kernel_table_t &trans_a_table,
+        const jit_rvv_gemm_f16_kernel_table_t &nontrans_a_table) {
+
+    const dim_t n_unroll = gemm_f16_traits::get_n_unroll_factor();
+
+    const dim_t Nu = rnd_dn(N, n_unroll);
+    const dim_t Mu = rnd_dn(M, m_unroll);
+    const dim_t n_tail = N - Nu;
+    const dim_t m_tail = M - Mu;
+
+    auto call_kernel = [&](const jit_rvv_gemm_f16_kernel_table_t &kernel_table,
+                               const void *a, const void *b, void *c,
+                               dim_t lda_eff, dim_t tile_m, dim_t tile_n) {
+        jit_rvv_gemm_f16_kernel_t::call_params_t p;
+        p.A = a;
+        p.B = b;
+        p.C = c;
+        p.lda = lda_eff;
+        p.ldb = ldb;
+        p.ldc = ldc;
+        p.K = K;
+        p.m = tile_m;
+
+        (*kernel_table.nb[tile_n])(&p);
+    };
+
+    auto invoke_kernel = [&](const char *a_orig, const void *b, void *c,
+                                 dim_t tile_m, dim_t tile_n, dim_t j_col) {
+        const void *a_eff;
+        dim_t lda_eff;
+        bool trans_a_eff;
+
+        if (do_copy && tile_m == m_unroll) {
+            if (j_col == 0) {
+                copy_A_f16(isTransA, K, a_orig, lda, ws, m_unroll);
+            }
+            a_eff = ws;
+            lda_eff = m_unroll;
+            trans_a_eff = false;
+        } else {
+            a_eff = a_orig;
+            lda_eff = lda;
+            trans_a_eff = isTransA;
+        }
+
+        const auto &kernel_table
+                = trans_a_eff ? trans_a_table : nontrans_a_table;
+        call_kernel(kernel_table, a_eff, b, c, lda_eff, tile_m, tile_n);
+    };
+
+    for (dim_t i = 0; i < Mu; i += m_unroll) {
+        const char *a = isTransA ? &A[i * lda * 2] : &A[i * 2];
+        for (dim_t j = 0; j < Nu; j += n_unroll) {
+            const char *b = &B[j * ldb * 2];
+            invoke_kernel(a, b, &C[(i + j * ldc) * 2], m_unroll, n_unroll, j);
+        }
+
+        if (n_tail > 0) {
+            const char *b = &B[Nu * ldb * 2];
+            invoke_kernel(a, b, &C[(i + Nu * ldc) * 2], m_unroll, n_tail, Nu);
+        }
+    }
+
+    if (m_tail > 0) {
+        const char *a_tail = isTransA ? &A[Mu * lda * 2] : &A[Mu * 2];
+
+        for (dim_t j = 0; j < Nu; j += n_unroll) {
+            const char *b = &B[j * ldb * 2];
+            const auto &kernel_table
+                    = isTransA ? trans_a_table : nontrans_a_table;
+            call_kernel(kernel_table, a_tail, b, &C[(Mu + j * ldc) * 2], lda,
+                    m_tail, n_unroll);
+        }
+
+        if (n_tail > 0) {
+            const char *b = &B[Nu * ldb * 2];
+            const auto &kernel_table
+                    = isTransA ? trans_a_table : nontrans_a_table;
+            call_kernel(kernel_table, a_tail, b, &C[(Mu + Nu * ldc) * 2], lda,
+                    m_tail, n_tail);
+        }
+    }
+}
+
+template <bool isTransA>
+void gemm_ithr_f16(const dim_t M, const dim_t N, const dim_t K, const char *A,
+        const dim_t lda, const char *B, const dim_t ldb, char *C,
+        const dim_t ldc, bool do_copy, char *ws, const dim_t m_unroll,
+        const jit_rvv_gemm_f16_kernel_table_t &trans_a_table,
+        const jit_rvv_gemm_f16_kernel_table_t &nontrans_a_table) {
+
+    constexpr dim_t BM = gemm_traits_t<float, isTransA, false>::BM;
+    constexpr dim_t BN = gemm_traits_t<float, isTransA, false>::BN;
+
+    if ((M <= 0) || (N <= 0)) return;
+
+    // The JIT epilogue is overwrite-only, so the whole reduction runs in a
+    // single K pass (no K blocking).
+    for (dim_t Bm = 0; Bm < M; Bm += BM) {
+        dim_t mb = nstl::min(M - Bm, BM);
+        for (dim_t Bn = 0; Bn < N; Bn += BN) {
+            dim_t nb = nstl::min(N - Bn, BN);
+            const char *curA = isTransA ? A + Bm * lda * 2 : A + Bm * 2;
+            const char *curB = B + Bn * ldb * 2;
+            char *curC = C + (Bm + Bn * ldc) * 2;
+            block_ker_f16<isTransA>(mb, nb, K, curA, lda, curB, ldb, curC, ldc,
+                    ws, do_copy, m_unroll, trans_a_table, nontrans_a_table);
+        }
+    }
+}
+} // namespace
+
+status_t rvv_gemm_f16(const char *transa_, const char *transb_, const dim_t *M_,
+        const dim_t *N_, const dim_t *K_, const float *alpha_, const void *A,
+        const dim_t *lda_, const void *B, const dim_t *ldb_, const float *beta_,
+        void *C, const dim_t *ldc_, data_type_t dt, char *ws_buffers_in,
+        const gemm_partition_t *part) {
+
+    if (!(utils::one_of(*transa_, 'n', 'N', 't', 'T')
+                && utils::one_of(*transb_, 'n', 'N')))
+        return status::unimplemented;
+
+    // Overwrite-only epilogue contract (see the kernel header).
+    if (*alpha_ != 1.0f || *beta_ != 0.0f) return status::unimplemented;
+    if (!utils::one_of(dt, data_type::f16, data_type::bf16))
+        return status::unimplemented;
+
+    bool isTransA = (*transa_ == 'T' || *transa_ == 't');
+
+    const dim_t M = *M_, N = *N_, K = *K_;
+    const dim_t lda = *lda_, ldb = *ldb_, ldc = *ldc_;
+
+    // early out and avoid division by zero in partitioning
+    if (utils::one_of(0, M, N)) return status::success;
+
+    if (K <= 0) {
+        auto *C_bytes = static_cast<char *>(C);
+        for (dim_t j = 0; j < N; j++)
+            std::memset(C_bytes + j * ldc * 2, 0, M * 2);
+        return status::success;
+    }
+
+    int nthr_m, nthr_n, nthr_k;
+    dim_t MB, NB, KB;
+    if (part) {
+        nthr_m = part->nthr_m;
+        nthr_n = part->nthr_n;
+        MB = part->MB;
+        NB = part->NB;
+    } else {
+        int nthr = dnnl_get_current_num_threads();
+        calc_nthr_nocopy_rvv(
+                M, N, K, nthr, &nthr_m, &nthr_n, &nthr_k, &MB, &NB, &KB);
+    }
+    // The K axis is never split: the kernel stores the narrowed result once.
+    const int nthr_mn = nthr_m * nthr_n;
+
+    bool do_copy = (NB / gemm_f16_traits::get_n_unroll_factor() > 3);
+    const dim_t m_unroll = gemm_f16_traits::get_m_unroll_factor();
+    const size_t ws_elems_per_thr = K * m_unroll * 2;
+    const size_t ws_size_per_thr = rnd_up(ws_elems_per_thr, PAGE_4K);
+
+    // The per-thread A-copy workspace must be booked in the caller's
+    // scratchpad (the matmul primitive books via pd_t::init_scratchpad()
+    // whenever the copy can trigger).
+    char *ws_buffers = ws_buffers_in;
+    if (do_copy && !ws_buffers) return status::unimplemented;
+
+    const auto &trans_a_table = get_jit_rvv_gemm_f16_kernel_table(true, dt);
+    const auto &nontrans_a_table = get_jit_rvv_gemm_f16_kernel_table(false, dt);
+
+    auto get_thr_block = [&](dim_t &from, dim_t &to, dim_t &myN, dim_t NB_,
+                                 dim_t N_, int ithr) {
+        from = NB_ * (ithr);
+        to = NB_ * (ithr + 1);
+        if (to > N_) to = N_;
+        myN = to - from;
+    };
+
+    parallel(nthr_mn, [&](int ithr, int nthr) {
+        assert(nthr_mn == nthr);
+        MAYBE_UNUSED(nthr);
+
+        int ithr_m = ithr % nthr_m;
+        int ithr_n = ithr / nthr_m;
+
+        char *ws = do_copy ? ws_buffers + ithr * ws_size_per_thr : nullptr;
+
+        dim_t m_from = 0, m_to = 0, myM = 0, n_from = 0, n_to = 0, myN = 0;
+
+        get_thr_block(m_from, m_to, myM, MB, M, ithr_m);
+        get_thr_block(n_from, n_to, myN, NB, N, ithr_n);
+
+        if (myM > 0 && myN > 0) {
+            const char *A_bytes = static_cast<const char *>(A);
+            const char *B_bytes = static_cast<const char *>(B);
+            char *C_bytes = static_cast<char *>(C);
+            const char *myA = isTransA ? &A_bytes[m_from * lda * 2]
+                                       : &A_bytes[m_from * 2];
+            const char *myB = B_bytes + n_from * ldb * 2;
+            char *myC = C_bytes + (m_from + n_from * ldc) * 2;
+
+            if (!isTransA) {
+                gemm_ithr_f16<false>(myM, myN, K, myA, lda, myB, ldb, myC, ldc,
+                        do_copy, ws, m_unroll, trans_a_table, nontrans_a_table);
+            } else {
+                gemm_ithr_f16<true>(myM, myN, K, myA, lda, myB, ldb, myC, ldc,
+                        do_copy, ws, m_unroll, trans_a_table, nontrans_a_table);
+            }
+        }
+    });
+
+    return status::success;
+}
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/gemm/rvv_gemm_f16.hpp
+++ b/src/cpu/rv64/gemm/rvv_gemm_f16.hpp
@@ -1,0 +1,55 @@
+/*******************************************************************************
+* Copyright 2026 ZTE Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_GEMM_RVV_GEMM_F16_HPP
+#define CPU_RV64_GEMM_RVV_GEMM_F16_HPP
+
+#include "common/c_types_map.hpp"
+
+#include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+// rvv_gemm_f16 computes C = A * B with f32 accumulation, where A, B and C all
+// hold `dt` elements (f16 or bf16); the accumulators are narrowed to `dt` once
+// at the store. The JIT epilogue is overwrite-only, so alpha must be 1 and
+// beta must be 0 (unimplemented is returned otherwise), and K is never split
+// across threads or blocks — the kernel accumulates the full reduction before
+// the single store.
+//
+// transb must be 'N'/'n' (the matmul mapping never transposes the src side);
+// transa may be 'N' (row-major weights) or 'T' (col-major weights).
+//
+// `part` optionally supplies the thread partition computed at primitive
+// initialization (see gemm_utils::gemm_partition_t); nthr_k is forced to 1.
+// `ws_buffers` holds the per-thread A-copy workspace (char elements) booked
+// in the caller's scratchpad; unimplemented is returned when the A copy is
+// active for the computed partition and no workspace is provided.
+status_t rvv_gemm_f16(const char *transa, const char *transb, const dim_t *M,
+        const dim_t *N, const dim_t *K, const float *alpha, const void *A,
+        const dim_t *lda, const void *B, const dim_t *ldb, const float *beta,
+        void *C, const dim_t *ldc, data_type_t dt, char *ws_buffers = nullptr,
+        const gemm_utils::gemm_partition_t *part = nullptr);
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_GEMM_RVV_GEMM_F16_HPP

--- a/src/cpu/rv64/rvv_matmul.cpp
+++ b/src/cpu/rv64/rvv_matmul.cpp
@@ -18,8 +18,10 @@
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/memory_desc_wrapper.hpp"
+#include "common/nstl.hpp"
 #include "common/utils.hpp"
 #include "cpu/platform.hpp"
+#include "cpu/rv64/gemm/rvv_gemm_f16.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_s8s8s32.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_utils_f32.hpp"
@@ -48,9 +50,11 @@ void rvv_matmul_t::pd_t::init_scratchpad() {
     calc_nthr_nocopy_rvv(gemm_M, gemm_N, K_, max_nthr, &nthr_m_, &nthr_n_,
             &nthr_k_, &MB_, &NB_, &KB_);
 
-    // Pick the path's own m_unroll: f32 and int8 derive the factor independently
-    m_unroll_ = is_f32_path_ ? gemm_utils_traits<float>::get_m_unroll_factor()
-                             : gemm_utils_traits<int8_t>::get_m_unroll_factor();
+    // Pick the path's own m_unroll: f32 and int8 derive the factor
+    // independently; the half-precision kernel loads A at e16/m2, which holds
+    // the same element count as the f32 kernel's e32/m4.
+    m_unroll_ = is_int8_path_ ? gemm_utils_traits<int8_t>::get_m_unroll_factor()
+                              : gemm_utils_traits<float>::get_m_unroll_factor();
     do_copy_ = (NB_ / gemm_utils_traits<float>::get_n_unroll_factor() > 3);
 
     const int nthr_mn = nthr_m_ * nthr_n_;
@@ -60,33 +64,43 @@ void rvv_matmul_t::pd_t::init_scratchpad() {
 
     // K-split reduction buffer. Both f32 and s32 dst use 4-byte elements;
     // book<char> + byte count keeps the contract type-agnostic. Only needed
-    // when the K axis is split across threads.
-    if (nthr_k_ > 1) {
+    // when the K axis is split across threads; the half-precision GEMM never
+    // splits K (overwrite-only epilogue).
+    if (nthr_k_ > 1 && !is_hp_path_) {
         const size_t c_elems
                 = (size_t)nthr_m_ * nthr_n_ * (nthr_k_ - 1) * MB_ * NB_;
         scratchpad.template book<char>(key_gemm_accumulator, c_elems * 4);
     }
 
-    // Per-thread A-copy workspace. Size mirrors what rvv_gemm_f32 /
-    // rvv_gemm_s8s8s32 malloc in the fallback path: rnd_up(K*m_unroll*elem_size,
-    // PAGE_4K) bytes per thread.
-    if (do_copy_) {
-        const size_t elem_size = is_f32_path_ ? sizeof(float) : sizeof(int8_t);
-        const size_t ws_size_per_thr
+    // Per-thread A-copy workspace. Size mirrors what the GEMM drivers malloc
+    // in the fallback path: rnd_up(K*m_unroll*elem_size, PAGE_4K) bytes per
+    // thread. With per-batch weights, execute() may split the batch loop
+    // across workers, each driving a single-thread GEMM partition whose NB is
+    // the full gemm_N — the copy may trigger there even when the full
+    // partition's NB_ says otherwise, so cover both thread counts.
+    const dim_t batch_workers
+            = weights_are_broadcast_ ? 0 : nstl::min(batch_, (dim_t)max_nthr);
+    ws_thr_slices_
+            = static_cast<int>(nstl::max<dim_t>(nthr_to_use, batch_workers));
+    const bool per_batch_copy
+            = M_ / gemm_utils_traits<float>::get_n_unroll_factor() > 3;
+    if (do_copy_ || (batch_workers > 0 && per_batch_copy)) {
+        const size_t elem_size = is_int8_path_ ? sizeof(int8_t)
+                : is_hp_path_                  ? 2 // f16/bf16 elements
+                                               : sizeof(float);
+        ws_slice_bytes_
                 = utils::rnd_up((size_t)K_ * m_unroll_ * elem_size, PAGE_4K);
         scratchpad.template book<char>(
-                key_gemm_tmp_buffer, (size_t)nthr_to_use * ws_size_per_thr);
+                key_gemm_tmp_buffer, (size_t)ws_thr_slices_ * ws_slice_bytes_);
     }
 }
 
 status_t rvv_matmul_t::init(engine_t *engine) {
     UNUSED(engine);
-    // The int8 path has no post-op kernel yet; only build the per-row
-    // "bias + post-op chain" kernel for the f32 dispatch.
-    if (!pd()->is_int8_path_) {
-        // The post-ops kernel below hardcodes f32 dst_dt; gating it on
-        // is_f32_path_ ensures the f32-only invariant stays explicit.
-        assert(pd()->is_f32_path_);
+    // Only the f32 dispatch applies the per-row "bias + post-op chain"
+    // kernel (it hardcodes an f32 dst); the int8 path fuses bias inside its
+    // GEMM kernel and the half-precision path has no bias / post-ops yet.
+    if (pd()->is_f32_path_) {
         const memory_desc_wrapper bias_d(pd()->desc()->bias_desc);
         jit_uni_postops_kernel_t::conf_t conf;
         conf.dst_dt = data_type::f32;
@@ -133,6 +147,30 @@ gemm_axes_t make_gemm_axes(dim_t M, dim_t N, dim_t K, bool weights_col_major) {
     g.ldc = N;
     return g;
 }
+
+// Runs `call_one(b, ws, part)` for every batch element. With enough batch
+// entries the loop runs in parallel, each worker driving a single-thread GEMM
+// partition over its entries with its own A-copy workspace slice; otherwise
+// the batch is walked sequentially with the full partition. This makes the
+// batch dimension part of the parallel work for per-batch weights, like the
+// aarch64/x64 brgemm matmuls do, instead of an outer serial loop.
+template <typename F>
+void run_batch_gemm(dim_t batch, int ws_thr_slices, size_t ws_slice_bytes,
+        char *ws_base, const gemm_utils::gemm_partition_t *part_full,
+        const gemm_utils::gemm_partition_t *part_single, F call_one) {
+    dim_t nworkers = nstl::min(batch, (dim_t)dnnl_get_current_num_threads());
+    nworkers = nstl::min(nworkers, (dim_t)ws_thr_slices);
+    if (nworkers > 1) {
+        parallel(static_cast<int>(nworkers), [&](int ithr, int nthr) {
+            char *ws = ws_base ? ws_base + ithr * ws_slice_bytes : nullptr;
+            for (dim_t b = ithr; b < batch; b += nthr)
+                call_one(b, ws, part_single);
+        });
+    } else {
+        for (dim_t b = 0; b < batch; ++b)
+            call_one(b, ws_base, part_full);
+    }
+}
 } // namespace
 
 status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
@@ -162,6 +200,9 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     // different threadpool contexts.
     const gemm_utils::gemm_partition_t part {pd()->nthr_m_, pd()->nthr_n_,
             pd()->nthr_k_, pd()->MB_, pd()->NB_, pd()->KB_};
+    // Single-thread partition for the parallel batch loop (run_batch_gemm).
+    const gemm_utils::gemm_partition_t part_single {
+            1, 1, 1, g.M_gemm, g.N_gemm, g.K_gemm};
 
     const int src_batch_ndims = ndims > 2 ? ndims - 2 : 0;
     const int wei_batch_ndims = wei_ndims > 2 ? wei_ndims - 2 : 0;
@@ -170,14 +211,49 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     const dim_t N_dim = wei_dims[wei_ndims - 1];
     const dim_t wei_matrix_stride = K_dim * N_dim;
 
+    // Byte views of the operands so the per-dtype dispatches share one batch
+    // addressing scheme (strides in bytes, per-dtype element sizes).
+    const char *src_bytes
+            = static_cast<const char *>(CTX_IN_MEM(const void *, DNNL_ARG_SRC));
+    const char *wei_bytes = static_cast<const char *>(
+            CTX_IN_MEM(const void *, DNNL_ARG_WEIGHTS));
+    char *dst_bytes = static_cast<char *>(CTX_OUT_MEM(void *, DNNL_ARG_DST));
+    const dim_t src_batch_stride_bytes
+            = M * K * types::data_type_size(src_d.data_type());
+    const dim_t dst_batch_stride_bytes
+            = M * N * types::data_type_size(dst_d.data_type());
+
+    // Weights base for batch element b, honoring broadcast (size-1) batch
+    // dims. Local scratch: called from parallel workers.
+    auto wei_base = [&](dim_t b) -> const char * {
+        if (wei_batch_ndims == 0) return wei_bytes;
+        dim_t batch_indices[DNNL_MAX_NDIMS] = {};
+        utils::l_dims_by_l_offset(batch_indices, b, src_dims, src_batch_ndims);
+        dim_t weight_batch_index = 0;
+        for (int d = 0; d < wei_batch_ndims; ++d) {
+            const int src_dim_idx = d + batch_dim_shift;
+            dim_t idx = (src_dim_idx >= 0) ? batch_indices[src_dim_idx]
+                                           : dim_t(0);
+            const dim_t wei_dim = wei_dims[d];
+            idx = (wei_dim == 1) ? dim_t(0) : idx;
+            weight_batch_index = weight_batch_index * wei_dim + idx;
+        }
+        return wei_bytes
+                + weight_batch_index * wei_matrix_stride
+                * types::data_type_size(weights_d.data_type());
+    };
+
+    auto &grantor = ctx.get_scratchpad_grantor();
+    char *ws_bytes = pd()->ws_slice_bytes_
+            ? grantor.template get<char>(
+                      memory_tracking::names::key_gemm_tmp_buffer)
+            : nullptr;
+
     if (pd()->is_int8_path_) {
         // Int8 dispatch: (s8|u8) weights * (s8|u8) src ->
         // (s32|f32|s8|u8|f16|bf16) dst. No post-ops or scales (those attrs are
         // rejected in pd_t::init), so the only epilogue work is the optional
         // fused bias inside the GEMM kernel itself.
-        const void *weights = CTX_IN_MEM(const void *, DNNL_ARG_WEIGHTS);
-        const void *src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
-        void *dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
         const float *bias = bias_d.is_zero()
                 ? nullptr
                 : CTX_IN_MEM(const float *, DNNL_ARG_BIAS);
@@ -191,18 +267,9 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
         const bool b_signed = src_d.data_type() == data_type::s8;
         const data_type_t dst_dt = dst_d.data_type();
 
-        const dim_t src_batch_stride = M * K;
-        const dim_t dst_batch_stride = M * N;
-
-        // Scratchpad buffers booked in pd_t::init_scratchpad().
-        auto &grantor = ctx.get_scratchpad_grantor();
         int32_t *c_buffer = pd()->nthr_k_ > 1
                 ? grantor.template get<int32_t>(
                           memory_tracking::names::key_gemm_accumulator)
-                : nullptr;
-        int8_t *ws_buffer = pd()->do_copy_
-                ? grantor.template get<int8_t>(
-                          memory_tracking::names::key_gemm_tmp_buffer)
                 : nullptr;
 
         if (pd()->weights_are_broadcast_) {
@@ -211,51 +278,61 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
             const dim_t N_gemm_all = batch * g.N_gemm; // batch * M
 
             status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &M_gemm_all,
-                    &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src,
-                    &g.ldb, &beta, dst, &g.ldc, /*bias=*/bias, a_signed,
-                    b_signed, dst_dt, c_buffer, ws_buffer, bias_is_scalar,
+                    &N_gemm_all, &g.K_gemm, &alpha, wei_bytes, &g.lda,
+                    src_bytes, &g.ldb, &beta, dst_bytes, &g.ldc,
+                    /*bias=*/bias, a_signed, b_signed, dst_dt, c_buffer,
+                    reinterpret_cast<int8_t *>(ws_bytes), bias_is_scalar,
                     &part);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);
         } else {
-            for (dim_t b = 0; b < batch; ++b) {
-                const char *src_base = static_cast<const char *>(src)
-                        + b * src_batch_stride
-                                * types::data_type_size(src_d.data_type());
-                char *dst_base = static_cast<char *>(dst)
-                        + b * dst_batch_stride
-                                * types::data_type_size(dst_d.data_type());
-
-                dim_t batch_indices[DNNL_MAX_NDIMS] = {};
-                if (src_batch_ndims > 0) {
-                    utils::l_dims_by_l_offset(
-                            batch_indices, b, src_dims, src_batch_ndims);
-                }
-
-                dim_t weight_batch_index = 0;
-                if (wei_batch_ndims > 0) {
-                    for (int d = 0; d < wei_batch_ndims; ++d) {
-                        const int src_dim_idx = d + batch_dim_shift;
-                        dim_t idx = (src_dim_idx >= 0)
-                                ? batch_indices[src_dim_idx]
-                                : dim_t(0);
-                        const dim_t wei_dim = wei_dims[d];
-                        idx = (wei_dim == 1) ? dim_t(0) : idx;
-                        weight_batch_index = weight_batch_index * wei_dim + idx;
-                    }
-                }
-
-                const char *wei_base = static_cast<const char *>(weights)
-                        + weight_batch_index * wei_matrix_stride;
-
+            run_batch_gemm(batch, pd()->ws_thr_slices_, pd()->ws_slice_bytes_,
+                    ws_bytes, &part, &part_single,
+                    [&](dim_t b, char *ws,
+                            const gemm_utils::gemm_partition_t *p) {
                 status_t st = rvv_gemm_s8s8s32(&g.transa, &g.transb, &g.M_gemm,
-                        &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda,
-                        src_base, &g.ldb, &beta, dst_base, &g.ldc,
+                        &g.N_gemm, &g.K_gemm, &alpha, wei_base(b), &g.lda,
+                        src_bytes + b * src_batch_stride_bytes, &g.ldb, &beta,
+                        dst_bytes + b * dst_batch_stride_bytes, &g.ldc,
                         /*bias=*/bias, a_signed, b_signed, dst_dt, c_buffer,
-                        ws_buffer, bias_is_scalar, &part);
+                        reinterpret_cast<int8_t *>(ws), bias_is_scalar, p);
                 assert(st == status::success || st == status::unimplemented);
                 MAYBE_UNUSED(st);
-            }
+            });
+        }
+        return status::success;
+    }
+
+    if (pd()->is_hp_path_) {
+        // Half-precision dispatch: (f16|bf16) weights * (f16|bf16) src ->
+        // same-dtype dst with f32 accumulation inside the GEMM kernel. No
+        // bias / post-ops on this path (rejected in pd_t::init).
+        const data_type_t hp_dt = src_d.data_type();
+
+        if (pd()->weights_are_broadcast_) {
+            //   C(N x (batch * M)) = A(N x K) * B(K x (batch * M))
+            const dim_t M_gemm_all = g.M_gemm; // N
+            const dim_t N_gemm_all = batch * g.N_gemm; // batch * M
+
+            status_t st = rvv_gemm_f16(&g.transa, &g.transb, &M_gemm_all,
+                    &N_gemm_all, &g.K_gemm, &alpha, wei_bytes, &g.lda,
+                    src_bytes, &g.ldb, &beta, dst_bytes, &g.ldc, hp_dt,
+                    ws_bytes, &part);
+            assert(st == status::success || st == status::unimplemented);
+            MAYBE_UNUSED(st);
+        } else {
+            run_batch_gemm(batch, pd()->ws_thr_slices_, pd()->ws_slice_bytes_,
+                    ws_bytes, &part, &part_single,
+                    [&](dim_t b, char *ws,
+                            const gemm_utils::gemm_partition_t *p) {
+                status_t st = rvv_gemm_f16(&g.transa, &g.transb, &g.M_gemm,
+                        &g.N_gemm, &g.K_gemm, &alpha, wei_base(b), &g.lda,
+                        src_bytes + b * src_batch_stride_bytes, &g.ldb, &beta,
+                        dst_bytes + b * dst_batch_stride_bytes, &g.ldc, hp_dt,
+                        ws, p);
+                assert(st == status::success || st == status::unimplemented);
+                MAYBE_UNUSED(st);
+            });
         }
         return status::success;
     }
@@ -263,7 +340,6 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     // f32 dispatch (unchanged): bias + post-op chain is applied per output row
     // after the GEMM by jit_uni_postops_kernel_t.
     auto src = CTX_IN_MEM(const float *, DNNL_ARG_SRC);
-    auto weights = CTX_IN_MEM(const float *, DNNL_ARG_WEIGHTS);
     auto dst = CTX_OUT_MEM(float *, DNNL_ARG_DST);
 
     const post_ops_t &post_ops = pd()->attr()->post_ops_;
@@ -280,17 +356,11 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
     //     column-major [K, M] with leading dim K, so transb = 'N', ldb = K.
     //   - C is viewed as column-major [N, M] with leading dim N, which matches
     //     row-major [M, N] in memory.
-    const dim_t src_batch_stride = M * K;
     const dim_t dst_batch_stride = M * N;
 
-    auto &grantor = ctx.get_scratchpad_grantor();
     float *c_buffer = pd()->nthr_k_ > 1
             ? grantor.template get<float>(
                       memory_tracking::names::key_gemm_accumulator)
-            : nullptr;
-    float *ws_buffer = pd()->do_copy_
-            ? grantor.template get<float>(
-                      memory_tracking::names::key_gemm_tmp_buffer)
             : nullptr;
 
     if (pd()->weights_are_broadcast_) {
@@ -299,45 +369,32 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
         dim_t N_gemm_all = batch * g.N_gemm; // batch * M
 
         status_t st = rvv_gemm_f32(&g.transa, &g.transb, &M_gemm_all,
-                &N_gemm_all, &g.K_gemm, &alpha, weights, &g.lda, src, &g.ldb,
+                &N_gemm_all, &g.K_gemm, &alpha,
+                reinterpret_cast<const float *>(wei_bytes), &g.lda, src, &g.ldb,
                 &beta, dst, &g.ldc,
-                /*bias=*/nullptr, c_buffer, ws_buffer, &part);
+                /*bias=*/nullptr, c_buffer, reinterpret_cast<float *>(ws_bytes),
+                &part);
         assert(st == status::success || st == status::unimplemented);
         MAYBE_UNUSED(st);
 
     } else {
-        for (dim_t b = 0; b < batch; ++b) {
-            const float *src_base = src + b * src_batch_stride;
-            float *dst_base = dst + b * dst_batch_stride;
-
-            dim_t batch_indices[DNNL_MAX_NDIMS] = {};
-            if (src_batch_ndims > 0) {
-                utils::l_dims_by_l_offset(
-                        batch_indices, b, src_dims, src_batch_ndims);
-            }
-
-            dim_t weight_batch_index = 0;
-            if (wei_batch_ndims > 0) {
-                for (int d = 0; d < wei_batch_ndims; ++d) {
-                    const int src_dim_idx = d + batch_dim_shift;
-                    dim_t idx = (src_dim_idx >= 0) ? batch_indices[src_dim_idx]
-                                                   : dim_t(0);
-                    const dim_t wei_dim = wei_dims[d];
-                    idx = (wei_dim == 1) ? dim_t(0) : idx;
-                    weight_batch_index = weight_batch_index * wei_dim + idx;
-                }
-            }
-
-            const float *wei_base
-                    = weights + weight_batch_index * wei_matrix_stride;
-
+        run_batch_gemm(batch, pd()->ws_thr_slices_, pd()->ws_slice_bytes_,
+                ws_bytes, &part, &part_single,
+                [&](dim_t b, char *ws, const gemm_utils::gemm_partition_t *p) {
             status_t st = rvv_gemm_f32(&g.transa, &g.transb, &g.M_gemm,
-                    &g.N_gemm, &g.K_gemm, &alpha, wei_base, &g.lda, src_base,
-                    &g.ldb, &beta, dst_base, &g.ldc,
-                    /*bias=*/nullptr, c_buffer, ws_buffer, &part);
+                    &g.N_gemm, &g.K_gemm, &alpha,
+                    reinterpret_cast<const float *>(wei_base(b)), &g.lda,
+                    reinterpret_cast<const float *>(
+                            src_bytes + b * src_batch_stride_bytes),
+                    &g.ldb, &beta,
+                    reinterpret_cast<float *>(
+                            dst_bytes + b * dst_batch_stride_bytes),
+                    &g.ldc,
+                    /*bias=*/nullptr, c_buffer, reinterpret_cast<float *>(ws),
+                    p);
             assert(st == status::success || st == status::unimplemented);
             MAYBE_UNUSED(st);
-        }
+        });
     }
 
     if (!bias && post_ops.len() == 0) return status::success;

--- a/src/cpu/rv64/rvv_matmul.hpp
+++ b/src/cpu/rv64/rvv_matmul.hpp
@@ -66,7 +66,9 @@ struct rvv_matmul_t : public primitive_t {
             // Determine which dispatch path this pd serves. f32 stays on the
             // existing f32 GEMM kernel; (s8|u8) src + (s8|u8) weights + a dst
             // in the int8-supported set (s32|f32|s8|u8|f16|bf16) runs through
-            // the int8 GEMM kernel. f16 and bf16 additionally require Zvfh /
+            // the int8 GEMM kernel. f16/bf16 src and weights with a dst of
+            // the same type runs through the half-precision GEMM kernel
+            // (f32 accumulation). f16 and bf16 additionally require Zvfh /
             // Zvfbfwma, which we gate below.
             const auto src_dt = src_mdw.data_type();
             const auto wei_dt = weights_mdw.data_type();
@@ -79,8 +81,10 @@ struct rvv_matmul_t : public primitive_t {
             is_int8_path_ = utils::one_of(src_dt, s8, u8)
                     && utils::one_of(wei_dt, s8, u8) && dst_in_int8_set
                     && acc_dt == s32;
-            VDISPATCH_MATMUL(
-                    is_f32_path_ || is_int8_path_, VERBOSE_UNSUPPORTED_DT);
+            is_hp_path_ = utils::one_of(src_dt, f16, bf16) && wei_dt == src_dt
+                    && dst_dt == src_dt && acc_dt == f32;
+            VDISPATCH_MATMUL(is_f32_path_ || is_int8_path_ || is_hp_path_,
+                    VERBOSE_UNSUPPORTED_DT);
             // Half-precision dst requires the corresponding vector fp
             // extension. The CPU is probed once in init() so this is cheap.
             if (is_int8_path_ && dst_dt == f16) {
@@ -88,6 +92,14 @@ struct rvv_matmul_t : public primitive_t {
             }
             if (is_int8_path_ && dst_dt == bf16) {
                 VDISPATCH_MATMUL(mayiuse(zvfbfwma), VERBOSE_UNSUPPORTED_ISA);
+            }
+            if (is_hp_path_) {
+                VDISPATCH_MATMUL(mayiuse(src_dt == f16 ? zvfh : zvfbfwma),
+                        VERBOSE_UNSUPPORTED_ISA);
+                // The half-precision GEMM kernel has no fused bias / post-ops
+                // yet.
+                VDISPATCH_MATMUL(
+                        bias_mdw.is_zero(), VERBOSE_UNSUPPORTED_BIAS_CFG);
             }
             // The int8 path rejects per-oc / per-tensor scales, zero-points,
             // and post-ops in this MVP; only optional f32 bias is supported.
@@ -251,9 +263,12 @@ struct rvv_matmul_t : public primitive_t {
         // Dispatch path selected in init(). is_f32_path_ keeps the historical
         // behavior; is_int8_path_ routes (s8|u8):(s8|u8):(s32|f32|s8|u8|f16|bf16)
         // through the int8 GEMM kernel and rejects non-default attrs except
-        // bias (and scales/zero-points/post-ops).
+        // bias (and scales/zero-points/post-ops); is_hp_path_ routes
+        // f16:f16:f16 / bf16:bf16:bf16 through the half-precision GEMM kernel
+        // and rejects all attrs including bias.
         bool is_f32_path_ = false;
         bool is_int8_path_ = false;
+        bool is_hp_path_ = false;
 
         int nthr_m_ = 1;
         int nthr_n_ = 1;
@@ -263,6 +278,11 @@ struct rvv_matmul_t : public primitive_t {
         dim_t KB_ = 0;
         dim_t m_unroll_ = 0;
         bool do_copy_ = false;
+        // A-copy workspace booked in the scratchpad: number of per-thread
+        // slices (0 = not booked) and the byte size of one slice. Covers both
+        // the full GEMM partition and the parallel batch loop in execute().
+        int ws_thr_slices_ = 0;
+        size_t ws_slice_bytes_ = 0;
 
     private:
         void init_scratchpad();


### PR DESCRIPTION
# Description

This change implements half-precision matmul for RV64 and aligns the per-batch-weights execution with the aarch64/x64 brgemm matmul threading model.

It introduces:

1. A JIT micro-kernel (`jit_rvv_gemm_f16_kernel_t`) computing `C = A * B` with f16 or bf16 inputs, f32 accumulation and a same-dtype dst: A rows are loaded at `SEW=e16 LMUL=m2` and double-buffered, B scalars arrive via `flh` and FMA through `vfwmacc.vf` (f16, Zvfh) or `vfwmaccbf16.vf` (bf16, Zvfbfwma) into six `e32/m4` accumulator groups, mirroring the f32 GEMM kernel's outer-product structure. The epilogue narrows the accumulators in place (`vfncvt.f.f.w` / `vfncvtbf16.f.f.w`) and stores once (overwrite-only, the same epilogue contract the s8 GEMM kernel uses for narrow dst types, so K is never split).
2. A GEMM driver (`rvv_gemm_f16`) mirroring `rvv_gemm_f32`: M/N threading with the init-time `gemm_partition_t`, per-thread A-copy workspace and `alpha == 1, beta == 0` enforcement.
3. `rvv_matmul_t` dispatch for `f16:f16:f16` and `bf16:bf16:bf16` (accum f32), gated on `mayiuse(zvfh)` / `mayiuse(zvfbfwma)`; bias and post-ops are rejected on this path and fall back to the reference, matching how the int8 path started out.
4. A parallel batch loop (`run_batch_gemm`) for the per-batch-weights (3D non-broadcast) case: with enough batch entries the loop runs one single-thread GEMM partition per worker over its batch entries, each with its own workspace slice — the batch dimension becomes part of the parallel work like in the aarch64/x64 brgemm matmuls, instead of a serial outer loop that used at most `nthr_m * nthr_n` threads on shapes like `2048x40x64:2048x64x40`.

Baseline dispatch for the test scope: f16 went to `ref:any` (scalar reference) and bf16 to `gemm:jit:bf16` (scalar fallback of the BLAS-driver matmul, no RV64 driver); f32, s8 and u8 already ran on `jit:rvv` and keep their existing kernels — the 2D f32/s8/u8 execution path is unchanged.

## Key Features

- **Data Types**: new `f16:f16:f16` (Zvfh) and `bf16:bf16:bf16` (Zvfbfwma); existing `f32`, `s8`, `u8` paths untouched
- **Memory Layouts**: dense row-major src/dst; weights row-major or col-major (both A access patterns JIT-specialized)
- **Post-Ops**: none on the half-precision path yet (attrs rejected → reference fallback); f32 post-ops unchanged
- **Threading**: batch dimension parallelized for per-batch weights; M/N threading as before

# Checklist

## General

- [x] Do all unit and benchdnn tests pass? — yes: all 55 test-scope runs (5 dtypes × 11 problems from `shapes_converted_ip_inf_lb_{gmnt,googlenet,resnet}` + `shapes_transformer`) pass in benchdnn correctness mode (default mode; `--mode=f` perf runs skip verification)
- [x] Have you formatted the code using clang-format? — clang-format-18 applied to all changed files

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on SG2044 (VLEN=128, `rv64imafdcv` incl. `zvfh`) with GCC 14.2 `-march=rv64gcv -O3`, `RelWithAssert`. Comparison is between:

1. **upstream/main** (commit 443bee1e3f): f16 baseline dispatches to `ref:any` (scalar reference), bf16 to `gemm:jit:bf16` (scalar fallback)
2. **this branch**: upstream/main + `jit:rvv` half-precision matmul + parallel batch loop

Single-core runs use `taskset -c 27, OMP_NUM_THREADS=1`; multi-core runs use `taskset -c 20-28, OMP_NUM_THREADS=8`. For every dtype the upstream and branch binaries are invoked back-to-back on the same shape file inside one quiet server window (1-min loadavg tracked around every run; the only load above ~1.6 was the measured run's own threads). Latency is the benchdnn `--mode=f` `min_time` column. The 2D f32/s8/u8 problems exercise identical code in both builds, so their deltas bound the measurement noise floor.

### Single-Core Performance (taskset -c 27, OMP_NUM_THREADS=1, min_time ms)

f16 (baseline `ref:any` → `jit:rvv`):

| Problem | upstream (ms) | this PR (ms) | Speedup |
|---------|---------------|--------------|---------|
| GNMT:0*1 (64x512:512x512) | 543.46 | 1.57 | **345.8x** |
| GNMT:1*1 (64x1024:1024x1024) | 3352.11 | 10.79 | **310.8x** |
| googlenet_v1:ip1 (128x2048:2048x1024) | 67053.30 | 57.11 | **1174.2x** |
| googlenet_v1:ip2 (128x1024:1024x1000) | 4552.57 | 13.24 | **343.9x** |
| inceptionv3:ip1 (224x2048:2048x1000) | 15143.20 | 51.16 | **296.0x** |
| resnet:ip1 (112x2048:2048x1000) | 7574.61 | 27.29 | **277.6x** |
| resnet_sparse:ip1 (64x2048:2048x1000) | 4318.11 | 17.14 | **251.9x** |
| shapes_transformer | 19140.78 | 56.80 | **337.0x** |

bf16 (baseline `gemm:jit:bf16` → `jit:rvv`):

| Problem | upstream (ms) | this PR (ms) | Speedup |
|---------|---------------|--------------|---------|
| GNMT:0*1 | 156.13 | 1.58 | **99.0x** |
| GNMT:1*1 | 637.31 | 12.21 | **52.2x** |
| googlenet_v1:ip1 | 2489.61 | 56.86 | **43.8x** |
| googlenet_v1:ip2 | 1209.33 | 12.10 | **100.0x** |
| inceptionv3:ip1 | 4225.35 | 53.83 | **78.5x** |
| resnet:ip1 | 2113.12 | 27.17 | **77.8x** |
| resnet_sparse:ip1 | 1207.89 | 16.94 | **71.3x** |
| shapes_transformer | 4257.85 | 56.88 | **74.9x** |


### Multi-Core Performance (taskset -c 20-28, OMP_NUM_THREADS=8, min_time ms)

f16 (baseline `ref:any` → `jit:rvv`):

| Problem | upstream (ms) | this PR (ms) | Speedup |
|---------|---------------|--------------|---------|
| GNMT:0*1 | 70.29 | 0.25 | **280.1x** |
| GNMT:1*1 | 438.80 | 1.77 | **247.8x** |
| googlenet_v1:ip1 | 4168.29 | 13.95 | **298.8x** |
| googlenet_v1:ip2 | 590.89 | 2.20 | **269.1x** |
| inceptionv3:ip1 | 1923.68 | 8.29 | **232.0x** |
| resnet:ip1 | 963.39 | 5.10 | **188.9x** |
| resnet_sparse:ip1 | 550.91 | 2.87 | **191.9x** |
| shapes_transformer | 2391.43 | 9.19 | **260.2x** |

bf16 (baseline `gemm:jit:bf16` → `jit:rvv`):

| Problem | upstream (ms) | this PR (ms) | Speedup |
|---------|---------------|--------------|---------|
| GNMT:0*1 | 23.50 | 0.25 | **93.4x** |
| GNMT:1*1 | 106.47 | 1.83 | **58.3x** |
| googlenet_v1:ip1 | 415.85 | 10.14 | **41.0x** |
| googlenet_v1:ip2 | 151.69 | 2.43 | **62.4x** |
| inceptionv3:ip1 | 530.46 | 8.54 | **62.2x** |
| resnet:ip1 | 264.90 | 5.11 | **51.9x** |
| resnet_sparse:ip1 | 151.91 | 2.87 | **52.9x** |
| shapes_transformer | 533.18 | 8.99 | **59.3x** |