### PR TITLE
cpu: rv64: add RVV JIT shuffle primitive

### DIFF
--- a/.github/.licenserc.yml
+++ b/.github/.licenserc.yml
@@ -14,6 +14,7 @@ header:
       |ZTE Corporation
       |Institute of Software, Chinese Academy of Sciences
       |openKylin community
+      |Léandre Le Duc
       |SpacemiT Corporation)\.?\s*)+
       ?(?:SPDX-License-Identifier: Apache-2\.0\s+)?Licensed under the Apache License, Version 2\.0 \(the .License.\);
       you may not use this file except in compliance with the License\.

--- a/src/cpu/cpu_shuffle_list.cpp
+++ b/src/cpu/cpu_shuffle_list.cpp
@@ -18,7 +18,6 @@
 
 #include "cpu/cpu_engine.hpp"
 
-#include "common/bfloat16.hpp"
 #include "cpu/ref_shuffle.hpp"
 
 #if DNNL_X64
@@ -27,6 +26,9 @@ using namespace dnnl::impl::cpu::x64;
 #elif DNNL_AARCH64
 #include "cpu/aarch64/shuffle/jit_uni_shuffle.hpp"
 using namespace dnnl::impl::cpu::aarch64;
+#elif DNNL_RV64
+#include "cpu/rv64/shuffle/jit_uni_shuffle.hpp"
+using namespace dnnl::impl::cpu::rv64;
 #endif
 
 namespace dnnl {
@@ -43,6 +45,7 @@ constexpr impl_list_item_t impl_list[] = REG_SHUFFLE_P({
         CPU_INSTANCE_X64(jit_uni_shuffle_t<sse41>)
         CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<sve>)
         CPU_INSTANCE_AARCH64(jit_uni_shuffle_t<asimd>)
+        CPU_INSTANCE_RV64(jit_uni_shuffle_t)
         CPU_INSTANCE(ref_shuffle_t)
         /* eol */
         nullptr,

--- a/src/cpu/rv64/shuffle/jit_uni_shuffle.cpp
+++ b/src/cpu/rv64/shuffle/jit_uni_shuffle.cpp
@@ -1,0 +1,225 @@
+/*******************************************************************************
+* Copyright 2026 Léandre Le Duc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "common/c_types_map.hpp"
+#include "common/compiler_workarounds.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/nstl.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "common/z_magic.hpp"
+#include "cpu/platform.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+#include "cpu/rv64/shuffle/jit_uni_shuffle.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+// Gathers `cb_loop_size` elements per spatial position and repeats over
+// `sp_loop_size` consecutive positions. The channel permutation itself never
+// reaches the kernel: it was folded into a table of byte offsets at init, so
+// this is a plain gather-and-pack loop that knows nothing about layouts,
+// dimensionality, or propagation direction.
+struct jit_uni_shuffle_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const void *src = nullptr;
+        void *dst = nullptr;
+        const void *input_off = nullptr;
+        size_t sp_stride = 0;
+        size_t sp_loop_size = 0;
+        size_t cb_loop_size = 0;
+    };
+#define GET_OFF(field) offsetof(call_params_t, field)
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_shuffle_kernel_t);
+    jit_uni_shuffle_kernel_t(size_t dt_size)
+        : jit_generator_t("jit_uni_shuffle"), dt_size(dt_size) {}
+
+    // Register layout. a0 holds call_params_t*, per the LP64D convention; every
+    // register below is caller-saved, so there is no prologue or stack frame.
+    //
+    //   a1 in      gather base ; fixed inside a run, += stride between runs
+    //   a2 out     destination cursor ;  never reset, one contiguous stream
+    //   a3 off     table base           a4 stride   bytes between runs
+    //   a5 runs    positions left       a6          elements per run
+    //   t0 vl      t1 bytes (scratch)   t2 cb       elements left in the run
+    //   t3 cursor  table cursor ; reset to a3 at the start of every run
+    //   v8-v11     offsets, always e32/m4
+    //   v16+       gathered data, m4 for 32-bit and m2 for 16-bit
+    void generate() override {
+        ld(a1, a0, GET_OFF(src));
+        ld(a2, a0, GET_OFF(dst));
+        ld(a3, a0, GET_OFF(input_off));
+        ld(a4, a0, GET_OFF(sp_stride));
+        ld(a5, a0, GET_OFF(sp_loop_size));
+        ld(a6, a0, GET_OFF(cb_loop_size));
+
+        const Reg in = a1, out = a2, off = a3, stride = a4, runs = a5,
+                  cb_loop_size = a6, vl = t0, bytes = t1, cb = t2, cursor = t3;
+        const VReg voff(8), vout(16);
+        const bool is16 = dt_size == 2;
+
+        Label sploop, spdone;
+        Label cloop, cdone;
+
+        L(sploop);
+        beqz(runs, spdone);
+
+        // A run re-reads the table from its start and gathers relative to a
+        // fixed base, so both cursors reset here; only `in` walks between runs.
+        mv(cb, cb_loop_size);
+        mv(cursor, off);
+
+        L(cloop);
+        beqz(cb, cdone);
+
+        // Index vtype first, so vl is sized for the offsets we are about to
+        // load; the data vtype then reuses that same vl (x0 destination).
+        vsetvli(vl, cb, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+        vle32_v(voff, cursor);
+        if (is16) vsetvli(x0, vl, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
+
+        // `in` stays put: the table holds absolute byte offsets from it.
+        vluxei32_v(vout, in, voff);
+        if (is16)
+            vse16_v(vout, out);
+        else
+            vse32_v(vout, out);
+
+        // The destination advances by the element width, the table cursor
+        // always by 4. Indices are uint32_t whatever the data type is.
+        slli(bytes, vl, is16 ? 1 : 2);
+        add(out, out, bytes);
+        slli(bytes, vl, 2);
+        add(cursor, cursor, bytes);
+        sub(cb, cb, vl);
+        j_(cloop);
+        L(cdone);
+
+        add(in, in, stride);
+        addi(runs, runs, -1);
+        j_(sploop);
+        L(spdone);
+        ret();
+    }
+    void operator()(const call_params_t *args) const {
+        jit_generator_t::operator()(args);
+    }
+
+    const size_t dt_size;
+};
+
+status_t jit_uni_shuffle_t::precompute_offsets() {
+    const auto conf = pd()->get_conf();
+    const dim_t axis_size = pd()->axis_size();
+    const dim_t group_size = pd()->group_size();
+    const dim_t transpose_row
+            = pd()->is_fwd() ? group_size : axis_size / group_size;
+    const dim_t transpose_col
+            = pd()->is_fwd() ? axis_size / group_size : group_size;
+    std::vector<dim_t> rev_transposed(axis_size);
+
+    // Precompute transposed axis helper array
+    parallel_nd(transpose_col, transpose_row, [&](dim_t i, dim_t j) {
+        rev_transposed[j * transpose_col + i] = i * transpose_row + j;
+    });
+    const dim_t C = conf.c;
+    input_off_ = (uint32_t *)malloc(
+            C * sizeof(uint32_t), platform::get_cache_line_size());
+    if (input_off_ == nullptr) return status::out_of_memory;
+
+    const dim_t SP = conf.sp, es = conf.dt_size, blk = conf.blk_size;
+    parallel_nd(C, [&](dim_t c) {
+        const dim_t ic = rev_transposed[c];
+        // We get the proper lane index in the corresponding block.
+        // Then if we need a specific spatial point, we just need to add sp * blk.
+        input_off_[c] = (uint32_t)((ic / blk * SP * blk + ic % blk) * es);
+    });
+
+    return status::success;
+}
+
+status_t jit_uni_shuffle_t::init(engine_t *engine) {
+    UNUSED(engine);
+    CHECK(precompute_offsets());
+    CHECK(safe_ptr_assign(
+            kernel_, new jit_uni_shuffle_kernel_t(pd()->get_conf().dt_size)));
+    CHECK(kernel_->create_kernel());
+    return status::success;
+}
+
+status_t jit_uni_shuffle_t::execute(const exec_ctx_t &ctx) const {
+    using namespace utils;
+    using kparams_t = jit_uni_shuffle_kernel_t::call_params_t;
+
+    const auto i_arg = pd()->is_fwd() ? DNNL_ARG_SRC : DNNL_ARG_DIFF_DST;
+    const auto o_arg = pd()->is_fwd() ? DNNL_ARG_DST : DNNL_ARG_DIFF_SRC;
+
+    auto input = CTX_IN_MEM(const char *, i_arg);
+    auto output = CTX_OUT_MEM(char *, o_arg);
+    const auto conf = pd()->get_conf();
+
+    const dim_t MB = conf.mb;
+    const dim_t nb_c = conf.nb_blk;
+
+    // If we already use all the threads, no tiling on spatial dim.
+    // Otherwise we balance the remaining tasks between all the threads.
+    const int nthr = dnnl_get_current_num_threads();
+    const dim_t tasks = MB * nb_c;
+    const dim_t sp_split_size = (tasks >= nthr)
+            ? conf.sp
+            : nstl::max<dim_t>(1, div_up(conf.sp, div_up((dim_t)nthr, tasks)));
+    const dim_t nb_sp = div_up(conf.sp, sp_split_size);
+
+    parallel_nd(MB, nb_c, nb_sp,
+            [= COMPAT_THIS_CAPTURE](dim_t mb, dim_t cb, dim_t spb) {
+        const dim_t c_curr = cb * conf.blk_size;
+        const dim_t sp0 = spb * sp_split_size;
+        const dim_t sp_blk_size = nstl::min(sp_split_size, conf.sp - sp0);
+        const dim_t base = mb * conf.stride_mb + sp0 * conf.blk_size;
+
+        kparams_t args;
+        args.src = input + base * conf.dt_size;
+        args.dst = output + (base + conf.sp * c_curr) * conf.dt_size;
+        args.input_off = input_off_ + c_curr;
+        args.sp_stride = conf.blk_size * conf.dt_size;
+        args.sp_loop_size = sp_blk_size;
+        args.cb_loop_size = conf.blk_size;
+
+        (*kernel_)(&args);
+    });
+    return status::success;
+}
+jit_uni_shuffle_t::jit_uni_shuffle_t(const pd_t *apd) : primitive_t(apd) {}
+jit_uni_shuffle_t::~jit_uni_shuffle_t() {
+    free(input_off_);
+}
+
+#undef GET_OFF
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/shuffle/jit_uni_shuffle.hpp
+++ b/src/cpu/rv64/shuffle/jit_uni_shuffle.hpp
@@ -1,0 +1,149 @@
+/*******************************************************************************
+* Copyright 2026 Léandre Le Duc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_SHUFFLE_JIT_UNI_SHUFFLE_HPP
+#define CPU_RV64_SHUFFLE_JIT_UNI_SHUFFLE_HPP
+
+#include <cstdint>
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/memory.hpp"
+#include "common/primitive.hpp"
+#include "common/primitive_desc.hpp"
+#include "common/primitive_exec_types.hpp"
+
+#include "common/shuffle_pd.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "cpu/cpu_shuffle_pd.hpp"
+#include "cpu/platform.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+struct jit_shuffle_conf_t {
+    dim_t mb = 0, c = 0, sp = 0;
+    dim_t stride_mb = 0;
+    dim_t dt_size = 0;
+    dim_t blk_size = 0;
+    dim_t nb_blk = 0;
+};
+
+struct jit_uni_shuffle_kernel_t;
+
+struct jit_uni_shuffle_t : public primitive_t {
+    struct pd_t : public cpu_shuffle_pd_t {
+        using cpu_shuffle_pd_t::cpu_shuffle_pd_t;
+
+        DECLARE_COMMON_PD_T("jit:rvv", jit_uni_shuffle_t);
+
+        status_t init(const engine_t *engine) {
+            UNUSED(engine);
+            using namespace dnnl::impl::data_type;
+            using namespace format_tag;
+
+            const memory_desc_wrapper src_d(
+                    is_fwd() ? src_md() : diff_src_md());
+            const memory_desc_wrapper dst_d(
+                    is_fwd() ? dst_md() : diff_dst_md());
+
+            const data_type_t dt = src_d.data_type();
+
+            // All datatype are supported, since it's only memory move
+            // However, at least the  vector extension is needed
+            VDISPATCH_SHUFFLE(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
+            VDISPATCH_SHUFFLE(dt == dst_d.data_type(), VERBOSE_INCONSISTENT_DT,
+                    "src", "dst");
+            VDISPATCH_SHUFFLE(
+                    attr()->has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
+
+            // We do not make compute op on the elements, only memory manipulation
+            // so we support all the data 32/16 sized types.
+            VDISPATCH_SHUFFLE(utils::one_of(dt, f32, s32, f16, bf16),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_SHUFFLE(platform::has_data_type_support(dt),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_SHUFFLE(axis() == 1, VERBOSE_BAD_AXIS);
+            VDISPATCH_SHUFFLE(
+                    set_default_formats_common(), VERBOSE_UNSUPPORTED_TAG);
+            VDISPATCH_SHUFFLE(
+                    src_d == dst_d, VERBOSE_INCONSISTENT_MDS, "src", "dst");
+            VDISPATCH_SHUFFLE(
+                    impl::is_dense_format_kind({src_d.md_, dst_d.md_}),
+                    VERBOSE_UNSUPPORTED_SPARSE_CFG);
+            conf_.mb = MB();
+            conf_.c = C();
+            conf_.sp = D() * H() * W();
+            conf_.dt_size = types::data_type_size(dt);
+            conf_.stride_mb = src_d.blocking_desc().strides[0];
+            const format_tag_t blocked_tag = memory_desc_matches_one_of_tag(
+                    *src_d.md_, nCw4c, nCw8c, nCw16c, nChw4c, nChw8c, nChw16c,
+                    nCdhw4c, nCdhw8c, nCdhw16c);
+            const format_tag_t nspc_tag = memory_desc_matches_one_of_tag(
+                    *src_d.md_, nc, nwc, nhwc, ndhwc);
+
+            VDISPATCH_SHUFFLE(blocked_tag != format_tag::undef
+                            || nspc_tag != format_tag::undef,
+                    VERBOSE_UNSUPPORTED_TAG);
+
+            if (blocked_tag != format_tag::undef) {
+                conf_.blk_size = src_d.blocking_desc().inner_blks[0];
+                VDISPATCH_SHUFFLE(
+                        conf_.c % conf_.blk_size == 0, VERBOSE_UNSUPPORTED_TAG);
+                conf_.nb_blk = conf_.c / conf_.blk_size;
+            } else {
+                // nspc
+                conf_.blk_size = conf_.c;
+                conf_.nb_blk = 1;
+            }
+            // Since offset are uint32_t, we need to ensure they are smaller than UINT32_MAX.
+            const dim_t max_off
+                    = ((conf_.nb_blk - 1) * conf_.sp * conf_.blk_size
+                              + conf_.blk_size - 1)
+                    * conf_.dt_size;
+            VDISPATCH_SHUFFLE(
+                    max_off <= (dim_t)UINT32_MAX, VERBOSE_UNSUPPORTED_TAG);
+            return status::success;
+        }
+
+        const jit_shuffle_conf_t &get_conf() const { return conf_; }
+
+    private:
+        jit_shuffle_conf_t conf_;
+    };
+
+    jit_uni_shuffle_t(const pd_t *apd);
+    ~jit_uni_shuffle_t() override;
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    std::unique_ptr<jit_uni_shuffle_kernel_t> kernel_;
+    status_t precompute_offsets();
+    uint32_t *input_off_ = nullptr;
+};
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // CPU_RV64_SHUFFLE_JIT_UNI_SHUFFLE_HPP


### PR DESCRIPTION
# Description

Adds a JIT (xbyak_riscv) shuffle primitive for RV64. The channel permutation is resolved once at primitive creation into a table of 32-bit byte offsets, so the kernel is a vector-length-agnostic gather-and-pack loop on `vluxei32.v` that knows nothing about the layout, the dimensionality or the propagation direction, all of it lives in the table. NSPC is modelled as a blocked layout with `blk = C` and a single block, which collapses the blocked offset formula (`ic / blk * SP * blk + ic % blk`) to `ic` and cancels the block term in the destination address, so one kernel serves both layouts with no branch past `pd_t::init()`. Backward is the same transposition with the group factors swapped, absorbed when the table is built.

Baseline dispatch for the test scope: every supported case went to `ref:any` (scalar reference). This is the first JIT shuffle implementation to cover channels-last; x64 and aarch64 match blocked formats only.

## Key Features

- **Data Types**: f32, s32 (`e32`) and f16, bf16 (`e16`): shuffle does no arithmetic, so only the element width matters. `LMUL` is derived from `SEW` to pin the index group at `e32/m4`, giving the index and data vtypes the same `VLMAX`, which is what lets the data `vsetvli` reuse `vl` instead of recomputing it. The kernel needs no FP extension of its own (`SEW` is a width, not a type); dispatch still gates f16/bf16 on Zvfh/Zvfbfwma via `platform::has_data_type_support`, as `ref_shuffle` does.
- **Memory Layouts**: NSPC (`nc`/`nwc`/`nhwc`/`ndhwc`) and channel-blocked (`nCw/hw/dhw{4,8,16}c`), 2D through 5D, one kernel for both
- **Directions**: forward and backward
- **Post-Ops**: none : shuffle takes no attributes
- **Reference fallback**: 8-bit types; a partial trailing channel block (`C % blk != 0`, which would need a masked gather); offset spans exceeding 32 bits, since `vluxei32` zero-extends its indices; and `axis != 1` or plain layouts, where the permuted axis is not innermost and the operation degenerates into contiguous block copies : the same restriction x64 and aarch64 apply

# Checklist

## General

- [x] Do all unit and benchdnn tests pass? yes: `test_shuffle` 52/52 under QEMU (`rv64,v=true,zvfh=true,zvfbfwma=true,vext_spec=v1.0`), at **VLEN=128 and VLEN=256 from the same binary**. Of the 9 configurations per dtype, the 5 supported ones (`acb`, `acdb`, `aBcd8b`, `aBcd16b`, `aBcde16b`) dispatch to `jit:rvv` for both forward and backward; the other 4 are plain layouts or `axis != 1` and route to reference by design, with no unintended fallbacks.
- [x] Have you formatted the code using clang-format?  yes

## Performance improvements

- [x] Have you submitted performance data?

Kendryte K230 (T-Head C908, RVV 1.0, VLEN=128), `DNNL_CPU_RUNTIME=SEQ`, single thread. Both builds use the default `-march=rv64gc`, so the reference is scalar exactly as oneDNN ships it and neither side is favoured. Latency is the benchdnn `--mode=P` `min_time` column with `--group=2`; the two binaries were invoked back-to-back on each shape and run-to-run variation stayed under 1%.

| tag | problem | upstream (ms) | this PR (ms) | Speedup |
|-----|---------|--------------:|-------------:|--------:|
| axb | 1x116x56x56 | 1.820 | 0.796 | **2.29x** |
| axb | 1x232x28x28 | 0.900 | 0.361 | **2.49x** |
| axb | 1x464x14x14 | 0.455 | 0.179 | **2.54x** |
| axb | 1x1024x7x7 | 0.269 | 0.103 | **2.61x** |
| axb | 4x2048x7x7 | 2.051 | 0.926 | **2.21x** |
| aBx16b | 1x128x28x28 | 1.801 | 0.211 | **8.54x** |
| aBx16b | 1x256x14x14 | 0.927 | 0.123 | **7.55x** |
| aBx16b | 1x512x7x7 | 0.483 | 0.078 | **6.16x** |

The blocked path gains about three times more than channels-last, and not from vectorization: `ref_shuffle` recomputes `input_c / blksize * SP * blksize + input_c % blksize` per element with a `blksize` the compiler cannot strength-reduce, so precomputing the table also removes an integer division and a modulo per element. The channels-last gain grows as the spatial extent shrinks (2.21x at 4x2048x7x7 against 2.61x at 1x1024x7x7), reflecting the other structural difference: `ref_shuffle` rebuilds its permutation table on every `execute`, this implementation builds it once. Memory-bound throughout, as expected for pure data movement.

Note on backward coverage: the benchdnn shuffle driver creates both backward descriptors with `tag::any` and passes no forward hint, so `set_default_formats_common()` resolves them to a plain layout and `--dir=BWD_D` routes to reference for every JIT implementation, x64 and aarch64 included. Backward is exercised through the gtest, which does propagate the hint.
