### PR TITLE
oneDNN v3.13.1 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.13.0")
+set(PROJECT_VERSION "3.13.1")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.13:
* Fixed correctness issue in matmul with non-`f32` common scales on x64 CPUs (8649862e7ffed19ada8f5da214970e7c14bb4741)
* Fixed an `unimplemented` error in grouped matmul with post-ops on Intel GPUs (168ccaf573225b53402afdd982fdf3eccb7a0463)
* Fixed correctness issue in `f8` grouped matmul on Intel GPUs based on Xe-LPG architecture (0a2644a08ee70fe521bc2325d7b8ba8d15ff53a2)
* Fixed matmul correctness issue for non-trivial source strides on x64 CPUs (6e5689d1fc15a8156211d616ec1b22b28dad2f78, 21ed470fb3f7e5b7f7f9fa0971dc090e9b78d212)
* Extended grouped matmul post-ops to support all eltwise algorithms on Intel GPUs (1b5607ce061ce50b2cb6f53c0aade6b2adc14867, b24a1db4a8ae5c261f22dc5ea54062a3c594a27f, 3829e476b5c7e5f3ddab2b590c8b272df4b80012, 879d412c2b5d904cdcae5954d8e404fdea88aaff, 678f4199e36ffa86d3714582d7f5e36a34184213)
* Fixed performance regression in `f16` matmul with `N = 1` and binary post-op on x64 CPUs (0b9ccf7ac1d8a917ed5510c2ee8f6fc3cef146e8)
* Fixed a performance regression in `f64` matmul with large K on Intel GPUs (4a44f5f64df5417dd2e6dbbec7a8142ea8454a56) 
* Fixed an `unimplemented` error in grouped matmul with `u8` weights and zero points on Intel GPUs based on Xe-HPG architecture (f9d64d081d36d835224b339196c9967bc0974e23, 347e3f41ade0d27dbbcbfe2b18a8bf95d9e1f3d3)
* Cleaned up implicit narrowing conversions and removed suppression of MSVC compiler warning C4244 on Intel CPUs (af6fc5e4720522cd4f4abcf8ff56b60d54800770, 2a1e6af73c62b40aa29be198f93e6a3c72f005c6, d7b4acd996c409a023082f67bcffe4544a3900c1, 428ab1970ae9e281e8552156851b511d8f015a70, 21ebf76f046a98020e668e4c285ed028eeaf350b, 9392d8bcb84da2f8335e4524ea17266eb65c62eb, f0172dcd1f9ccb3ecfa7f5cab135a8f079f2679f, 43454140cf7a36071a07440b8df6e5956e08d8ab, 6203120749478b4ae1a6b1055716baa080066503, 29c3bb3851f025209f378060ebde04b1c3726bc4, ca64e8735ab66f72e6dd7ab63f814beef882bdd5, 554c09fc67bae7b3419c4e0e70376e1d4841b588, 514dc231a8dd835c2a4d464a650fc5cb23498f5d, 4afe4b214d8d3dd1e605fc5d9a90818a58133e1b, c92aa9d17a67c17c655cb92df8915805a5a46588, 800de484aa1fac61a1abb15b6750704801a330a3, 4f681cb1b515711861b31b73777b75049f0c291f, 82192d635aad8ad5290c7229230010e88608fcce, f28a821ea11c3263bbe761dd98f3d572d99e5e4a, 764729fdbabeece612e15a664b1be37a8fb1c4f2, 71e5cc3dcce6faf094b3c7c51201a3141265fcc6, 48e72041f29bddc1d7beb35a8f9f9c707f0e7e7b, cdedd44acc396bec58f725a19eda0c697c7a3de6, 23b98badba52a9a9576bdcd23a879551b14c354b, 6375c24c714d3dbe371bedb2aca8f93cbc9d780d, 0929f31b7bf9af34eaedf180a950b824f19348b0, d36e03ab3365ccdbb3dda46520b7d67424f6621e, 39dbfc5f24c5e63161d532578753bba4d56c012b, 1dc80b58f6b3389061b7613fee895c95f8ae19c4, 3508778d62fe2c2cbfcf10a8bf789b4d5faae69e)
 * Reduced convolution and deconvolution primitives creation time on Intel GPUs (9be3cfe43c2fe08d70059e50c77f8db5fad8a735, 521463af0220a9f5c337282257d9f6d283dd7e35, 251a8d6a08c347f5cd029785e3b4d60e55108496, dcc10e62f66571d0e9ec60ca168c2d444f776f53, 4c2a7d753882154f1367547e8ed3e9cbf653eb9c, 3a78962ce1782274a748adeac61b769c324ffbb5, da8af993e0590ea9ad8f784cf3f85eb6c06dcd5a, 268bafeae99e36cefd29e66830353d59cf51009a)
 * Extended set of supported algorithms in eltwise post-op in grouped matmul primitive on Intel GPUs (99b824e864d763d3f05e030961504d33f8ff5c63, b6fa78719996c697ffa34b1d94b551f65b59decc, b0c8687c600323c85bb893554a3021a104c34cb9, d46a6cb4be430f3bddb5f2bb13b88404570c1ff2, 2e3e918f15efb10738c8c2c771d192c128f4da7a, 226a0da7ff1425e754dad321a67f35a32ee78602, dd0f425582fd53b05dca885cbc8ae40792b379d6, 44391fc9789c246418c01a187057bb9045b434a8, e7b8ab878d4d9bfa738a5843ac320795b57fa5c5, 281167bee1834af6bf7b1abef6975c940f5c0530, e09f4741cf6f934848bb77cff1bfb09f2a3a2460, 2be907b867e465d8f58cd0146deb1bcb8917d371, a209014932b432d5c2ad8fb6c72f0c01481915ef, 82200ce4e177cbfda71fda4c1965c86d3ca7f0b5)
* Fixed crash during convolution primitive creation with large shapes on x64 CPUs (a3d459721b72c3a9d2685b46c03dafee7af0f25c)
