### PR TITLE
[GPU] Fix microkernels with ONEDNN_EXPERIMENTAL_SYCL_KERNEL_COMPILER

### DIFF
--- a/src/gpu/intel/sycl/engine.cpp
+++ b/src/gpu/intel/sycl/engine.cpp
@@ -19,6 +19,8 @@
 #include "xpu/sycl/memory_storage.hpp"
 
 #include "gemmstone/dsl/runtime.hpp"
+#include "gemmstone/microkernel/fuser.hpp"
+#include "gpu/intel/compute/ukernels.hpp"
 #include "gpu/intel/jit/generator_base.hpp"
 #include "gpu/intel/sycl/compat.hpp"
 #include "gpu/intel/sycl/device_info.hpp"
@@ -135,6 +137,23 @@ status_t engine_t::create_kernels(
     auto kb_exe = syclex::build(
             kb_src, syclex::properties {syclex::build_options(build_options)});
     *kernels = std::vector<compute::kernel_t>(kernel_names.size());
+
+    if (kernel_ctx.has_custom_headers()
+            && gemmstone::microkernel::hasMicrokernels(code_str.c_str())) {
+        xpu::binary_t binary;
+        CHECK(get_kernel_bundle_binary(this, kb_exe, binary));
+        CHECK(compute::fuse_microkernels(
+                binary, code_str.c_str(), device_info()->grf_size()));
+
+        std::vector<std::unique_ptr<::sycl::kernel>> sycl_kernels;
+        CHECK(compat::make_kernels(sycl_kernels, kernel_names, this, binary));
+        for (size_t i = 0; i < kernel_names.size(); ++i) {
+            if (!sycl_kernels[i]) continue;
+            CHECK(interop_kernel_t::make((*kernels)[i], *sycl_kernels[i], src));
+        }
+        return status::success;
+    }
+
     for (size_t i = 0; i < kernel_names.size(); ++i) {
         if (!kernel_names[i]) continue;
 

--- a/src/gpu/intel/sycl/utils.cpp
+++ b/src/gpu/intel/sycl/utils.cpp
@@ -319,6 +319,33 @@ status_t get_kernel_binary(
     return status::success;
 }
 
+status_t get_kernel_bundle_binary(const gpu::intel::sycl::engine_t *engine,
+        const ::sycl::kernel_bundle<::sycl::bundle_state::executable> &bundle,
+        xpu::binary_t &binary) {
+    switch (xpu::sycl::get_backend(engine->device())) {
+        case xpu::sycl::backend_t::ze: {
+            auto ze_modules = ::sycl::get_native<
+                    ::sycl::backend::ext_oneapi_level_zero>(bundle);
+            if (ze_modules.empty()) return status::runtime_error;
+            CHECK(ze::get_module_binary(ze_modules[0], binary));
+            break;
+        }
+        case xpu::sycl::backend_t::opencl: {
+            auto ocl_programs
+                    = ::sycl::get_native<::sycl::backend::opencl>(bundle);
+            std::vector<xpu::ocl::wrapper_t<cl_program>> programs;
+            for (auto p : ocl_programs)
+                programs.push_back(xpu::ocl::make_wrapper(p));
+            if (programs.empty()) return status::runtime_error;
+            CHECK(ocl::get_ocl_program_binary(
+                    programs[0], engine->ocl_device(), binary));
+            break;
+        }
+        default: return status::runtime_error;
+    }
+    return status::success;
+}
+
 gpu_utils::device_id_t device_id(const ::sycl::device &dev) {
     if (xpu::sycl::is_host(dev))
         return std::make_tuple(

--- a/src/gpu/intel/sycl/utils.hpp
+++ b/src/gpu/intel/sycl/utils.hpp
@@ -58,6 +58,10 @@ status_t create_ocl_engine(
 
 status_t get_kernel_binary(const ::sycl::kernel &kernel, xpu::binary_t &binary);
 
+status_t get_kernel_bundle_binary(const gpu::intel::sycl::engine_t *engine,
+        const ::sycl::kernel_bundle<::sycl::bundle_state::executable> &bundle,
+        xpu::binary_t &binary);
+
 gpu_utils::device_id_t device_id(const ::sycl::device &dev);
 
 bool mayiuse_microkernels(const gpu::intel::sycl::engine_t *engine);


### PR DESCRIPTION
PR adds microkernel fusion step after `syclex::build()`. Otherwise microkernels are broken in builds with `-DONEDNN_EXPERIMENTAL_SYCL_KERNEL_COMPILER=ON`.