### PR TITLE
[rls-v3.13] Backport PRs from main

### DIFF
--- a/cmake/gen_gpu_kernel.cmake
+++ b/cmake/gen_gpu_kernel.cmake
@@ -56,7 +56,7 @@ string(REGEX REPLACE "\n" ")==\"\"\\\\n\"\nR\"==(" cl_file_lines "${cl_file_line
 
 if(cl_file_ext STREQUAL ".cl")
     set(cl_file_contents  "const char *${cl_file_name}_kernel = R\"==(${cl_file_lines})==\";")
-elseif(cl_file_ext STREQUAL ".h")
+elseif(cl_file_ext STREQUAL ".h" OR cl_file_ext STREQUAL ".hxx")
     set(cl_file_contents  "const char *${cl_file_name}_header = R\"==(${cl_file_lines})==\";")
 else()
     message(FATAL_ERROR "Unknown file extensions: ${cl_file_ext}")

--- a/src/gpu/gpu_reorder_pd.hpp
+++ b/src/gpu/gpu_reorder_pd.hpp
@@ -30,8 +30,8 @@ struct gpu_reorder_pd_t : public reorder_pd_t {
 protected:
     bool attr_ok() const {
         using sm = dnnl_primitive_attr::skip_mask_t;
-        return attr()->has_default_values(
-                       sm::zero_points | sm::scales | sm::post_ops)
+        return attr()->has_default_values(sm::zero_points | sm::scales
+                       | sm::post_ops | sm::gpu_attr)
                 && post_ops_ok() && zero_points_ok();
     }
 

--- a/src/gpu/intel/CMakeLists.txt
+++ b/src/gpu/intel/CMakeLists.txt
@@ -35,7 +35,12 @@ add_subdirectory(gemm/jit)
 include("${PROJECT_SOURCE_DIR}/cmake/gen_gpu_kernel_list.cmake")
 
 file(GLOB_RECURSE CL_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cl)
-file(GLOB_RECURSE CL_HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+file(GLOB_RECURSE CL_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.hxx
+    )
+# gemm/jit headers are C++, not OpenCL
+list(FILTER CL_HEADERS EXCLUDE REGEX "/gemm/jit/")
 
 set(kernel_list_templ "${PROJECT_SOURCE_DIR}/src/gpu/intel/ocl_kernel_list.cpp.in")
 set(kernel_list_src "${PROJECT_BINARY_DIR}/src/gpu/intel/ocl_kernel_list.cpp")

--- a/src/gpu/intel/compute/ukernels.cpp
+++ b/src/gpu/intel/compute/ukernels.cpp
@@ -16,8 +16,13 @@
 
 #include "gpu/intel/compute/ukernels.hpp"
 
+#include <exception>
+#include <string>
+
 #include "common/verbose.hpp"
+#include "gemmstone/microkernel/fuser.hpp"
 #include "gemmstone/microkernel/shim.hpp"
+#include "gpu/intel/utils.hpp"
 
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include "gpu/intel/ocl/engine.hpp"
@@ -133,6 +138,20 @@ void microkernel_shims_t::finalize() {
         kernel_ctx_.add_option("-cl-intel-512-GRF-per-thread");
     else if (grf_min_ > 128)
         kernel_ctx_.add_option("-cl-intel-256-GRF-per-thread");
+}
+
+status_t fuse_microkernels(
+        xpu::binary_t &binary, const char *code, int grf_size) {
+    try {
+        if (!gemmstone::microkernel::fuse(binary, code, grf_size))
+            VWARN(common, runtime,
+                    "could not check microkernel registers against the host "
+                    "kernel thread payload");
+    } catch (const std::exception &e) {
+        VERROR(common, runtime, "microkernel fusion failed: %s", e.what());
+        return status::runtime_error;
+    } catch (...) { return status::runtime_error; }
+    return status::success;
 }
 
 } // namespace compute

--- a/src/gpu/intel/compute/ukernels.cpp
+++ b/src/gpu/intel/compute/ukernels.cpp
@@ -16,6 +16,9 @@
 
 #include "gpu/intel/compute/ukernels.hpp"
 
+#include "common/verbose.hpp"
+#include "gemmstone/microkernel/shim.hpp"
+
 #if DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
 #include "gpu/intel/ocl/engine.hpp"
 #include "gpu/intel/ocl/utils.hpp"
@@ -88,6 +91,48 @@ bool mayiuse_microkernels(const engine_t *engine) {
     auto it = engine_microkernel_map.find(engine->engine_id());
     if (it != std::end(engine_microkernel_map)) return it->second;
     return engine_microkernel_map[engine->engine_id()] = mayiuse_mk(engine);
+}
+
+status_t validate_microkernel(const gemmstone::microkernel::Package &package,
+        const char *kernel_name) {
+    using Status = gemmstone::microkernel::Package::Status;
+    const char *reason = nullptr;
+    switch (package.status) {
+        case Status::Success: return status::success;
+        case Status::Pending:
+            reason = "was not finalized before validation";
+            break;
+        case Status::UncertainClobbers:
+            reason = "has uncertain register clobbers and is not supported";
+            break;
+        case Status::UnsupportedHW:
+            reason = "is incompatible with the current hardware";
+            break;
+    }
+    VCONDCHECK(primitive, create, check, gpu, reason == nullptr,
+            status::unimplemented, "%s microkernel %s", kernel_name, reason);
+    return status::runtime_error;
+}
+
+void microkernel_shims_t::add(const char *header_name, const char *decorator,
+        const gemmstone::microkernel::Package &package) {
+    gemmstone::microkernel::ShimOptions options;
+    options.subgroupSize = subgroup_size_;
+    options.useTileOps = true;
+    options.decorator = decorator;
+    options.microkernelID = next_id_++;
+
+    kernel_ctx_.add_custom_header(header_name,
+            generateShim(package,
+                    gemmstone::microkernel::HostLanguage::OpenCL_C, options));
+    require_grfs(package.grfMin);
+}
+
+void microkernel_shims_t::finalize() {
+    if (arch_ >= gpu_arch_t::xe3p && grf_min_ > 256)
+        kernel_ctx_.add_option("-cl-intel-512-GRF-per-thread");
+    else if (grf_min_ > 128)
+        kernel_ctx_.add_option("-cl-intel-256-GRF-per-thread");
 }
 
 } // namespace compute

--- a/src/gpu/intel/compute/ukernels.hpp
+++ b/src/gpu/intel/compute/ukernels.hpp
@@ -23,6 +23,7 @@
 #include "gpu/intel/compute/device_info.hpp"
 #include "gpu/intel/compute/kernel_ctx.hpp"
 #include "gpu/intel/engine.hpp"
+#include "xpu/utils.hpp"
 
 namespace gemmstone {
 namespace microkernel {
@@ -66,6 +67,11 @@ private:
     uint32_t next_id_ = 0;
     int grf_min_ = 0;
 };
+
+// Splices microkernel machine code embedded in `code` into the IGC-compiled
+// binary. Callers check hasMicrokernels() first.
+status_t fuse_microkernels(
+        xpu::binary_t &binary, const char *code, int grf_size);
 
 } // namespace compute
 } // namespace intel

--- a/src/gpu/intel/compute/ukernels.hpp
+++ b/src/gpu/intel/compute/ukernels.hpp
@@ -17,8 +17,18 @@
 #ifndef GPU_INTEL_COMPUTE_UKERNELS_HPP
 #define GPU_INTEL_COMPUTE_UKERNELS_HPP
 
+#include <algorithm>
+
 #include "common/engine.hpp"
+#include "gpu/intel/compute/device_info.hpp"
+#include "gpu/intel/compute/kernel_ctx.hpp"
 #include "gpu/intel/engine.hpp"
+
+namespace gemmstone {
+namespace microkernel {
+struct Package; // NOLINT(readability-identifier-naming)
+} // namespace microkernel
+} // namespace gemmstone
 
 namespace dnnl {
 namespace impl {
@@ -28,6 +38,34 @@ namespace compute {
 
 extern const char *cl_microkernels_check_kernel_code;
 bool mayiuse_microkernels(const engine_t *engine);
+
+// Validates a finalized microkernel package, emitting a verbose message and
+// returning a non-success status if it cannot be used.
+status_t validate_microkernel(const gemmstone::microkernel::Package &package,
+        const char *kernel_name);
+
+// Embeds microkernel shims, assigning IDs and requesting the needed GRF mode.
+class microkernel_shims_t {
+public:
+    microkernel_shims_t(
+            kernel_ctx_t &kernel_ctx, int subgroup_size, gpu_arch_t arch)
+        : kernel_ctx_(kernel_ctx), subgroup_size_(subgroup_size), arch_(arch) {}
+
+    void add(const char *header_name, const char *decorator,
+            const gemmstone::microkernel::Package &package);
+
+    void require_grfs(int grf_min) { grf_min_ = std::max(grf_min_, grf_min); }
+
+    // Applies the GRF mode required by the packages added so far.
+    void finalize();
+
+private:
+    kernel_ctx_t &kernel_ctx_;
+    int subgroup_size_;
+    gpu_arch_t arch_;
+    uint32_t next_id_ = 0;
+    int grf_min_ = 0;
+};
 
 } // namespace compute
 } // namespace intel

--- a/src/gpu/intel/conv/jit.cpp
+++ b/src/gpu/intel/conv/jit.cpp
@@ -18,6 +18,7 @@
 
 #include <utility>
 
+#include "common/reorder.hpp"
 #include "common/utils.hpp"
 #include "common/verbose.hpp"
 #include "gpu/gpu_zero_points_conv.hpp"
@@ -28,8 +29,7 @@
 #include "gpu/intel/jit/ir/kernel_info.hpp"
 #include "gpu/intel/jit/utils/utils.hpp"
 #include "gpu/intel/logging.hpp"
-#include "gpu/intel/reorder/jit/config.hpp"
-#include "gpu/intel/reorder/jit/kernel.hpp"
+#include "gpu/intel/primitive_attr.hpp"
 
 namespace dnnl {
 namespace impl {
@@ -39,12 +39,45 @@ namespace conv {
 
 using namespace jit;
 
+// Nested reorder between the user layout and the scratchpad compute layout.
+struct reorder_data_t {
+    std::shared_ptr<primitive_desc_t> pd;
+    memory_desc_t compute_md;
+    int arg_key = DNNL_ARG_UNDEF;
+    uint32_t scratchpad_key = 0;
+    uint32_t nested_key = 0;
+    bool is_input = false;
+};
+
 struct pd_data_t {
     config_t pd_cfg;
     tensor_config_t tensor_cfg;
     std::vector<kernel_info_t> kernel_infos;
+    // Parallel to kernel_infos, set for pre/post reorder entries only.
+    std::vector<reorder_data_t> reorders;
     std::shared_ptr<primitive_desc_t> zp_pd;
 };
+
+struct tensor_ref_t {
+    const layout_param_t *layout;
+    const memory_desc_t *md;
+};
+
+static tensor_ref_t get_tensor_ref(const config_t &cfg,
+        const convolution_pd_t *pd, const std::string &name) {
+    if (name == "src") return {&cfg.src_layout(), pd->invariant_src_md()};
+    if (name == "wei") return {&cfg.wei_layout(), pd->invariant_wei_md()};
+    if (name == "bia") return {&cfg.bia_layout(), pd->invariant_bia_md()};
+    if (name == "dst") return {&cfg.dst_layout(), pd->invariant_dst_md()};
+    return {};
+}
+
+// GRF mode of the convolution kernel, see init_regs(). The pd-time config has
+// no GRF mode set yet unless it's overridden from the environment.
+static int conv_regs(const config_t &cfg) {
+    if (cfg.options_param().is_overridden("regs")) return cfg.regs();
+    return default_regs(cfg);
+}
 
 #define CONV_CHECK(_st) \
     do { \
@@ -111,7 +144,8 @@ public:
             pd->data->tensor_cfg
                     = get_tensor_config(pd->data->pd_cfg, zp_md_in(*pd->data));
             pd->data->kernel_infos.reserve(max_kernels);
-            CONV_CHECK(init_kernel_infos(pd));
+            pd->data->reorders.reserve(max_kernels);
+            CONV_CHECK(init_kernel_infos(pd, engine));
 
             return status::success;
         } catch (std::exception &err) {
@@ -125,7 +159,6 @@ public:
     status_t init(T *primitive, impl::engine_t *engine) {
         auto *pd = primitive->pd();
         auto &data = *pd->data;
-        auto &tensor_cfg = data.tensor_cfg;
         auto tiler = std::make_shared<tiler_t>(data.pd_cfg);
 
         if (primitive->cache_blob()) {
@@ -168,14 +201,26 @@ public:
                 init_nd_ranges(primitive, cfg);
                 auto &kernel_infos = data.kernel_infos;
 
-                // This absolutely HAS to be executed first if present,
-                // since it adds its own version mark to the cache blob
-                for (int i = 0; i < int(kernel_infos.size()); i++)
-                    if (kernel_infos[i].id() == kernel_id_t::zp_precalc) {
-                        gpu_assert(data.zp_pd);
-                        CONV_CHECK(primitive->create_nested_primitive(
-                                zp_prim_, data.zp_pd, engine));
-                    }
+                // Nested primitives have to be created before the kernels
+                // below: they register their cache blob blocks right away
+                // while the kernels are registered only after the loop.
+                // Does not depend on the tiler, create it once.
+                for (int i = 0; i < int(kernel_infos.size()) && !zp_prim_;
+                        i++) {
+                    if (kernel_infos[i].id() != kernel_id_t::zp_precalc)
+                        continue;
+                    gpu_assert(data.zp_pd);
+                    CONV_CHECK(primitive->create_nested_primitive(
+                            zp_prim_, data.zp_pd, engine));
+                }
+
+                reorder_prims_.resize(kernel_infos.size());
+                for (int i = 0; i < int(kernel_infos.size()); i++) {
+                    auto &pd = data.reorders[i].pd;
+                    if (!pd || reorder_prims_[i]) continue;
+                    CONV_CHECK(primitive->create_nested_primitive(
+                            reorder_prims_[i], pd, engine));
+                }
 
                 std::vector<compute::kernel_t> tmp_kernels;
                 for (int i = 0; i < int(kernel_infos.size()); i++) {
@@ -186,29 +231,6 @@ public:
                                     primitive, /*register_kernel=*/false,
                                     engine, cfg, info,
                                     nd_ranges_[i].local_range(), zp_dst));
-                            break;
-                        }
-                        case kernel_id_t::pre_reorder: {
-                            reorder::jit::config_t reorder_cfg(cfg.options(),
-                                    tensor_cfg.user_layout(info.arg_name(1)),
-                                    tensor_cfg.compute_layout(
-                                            info.arg_name(1)));
-                            tmp_kernels.push_back(
-                                    make_kernel<reorder::jit::kernel_t>(
-                                            primitive,
-                                            /*register_kernel=*/false, engine,
-                                            reorder_cfg, "conv_reorder", info));
-                            break;
-                        }
-                        case kernel_id_t::post_reorder: {
-                            reorder::jit::config_t reorder_cfg(cfg.options(),
-                                    tensor_cfg.compute_layout(info.arg_name(0)),
-                                    tensor_cfg.user_layout(info.arg_name(0)));
-                            tmp_kernels.push_back(
-                                    make_kernel<reorder::jit::kernel_t>(
-                                            primitive,
-                                            /*register_kernel=*/false, engine,
-                                            reorder_cfg, "conv_reorder", info));
                             break;
                         }
                         case kernel_id_t::zero_out:
@@ -222,6 +244,8 @@ public:
                                             cfg.options(), info, engine));
                             break;
 
+                        case kernel_id_t::pre_reorder:
+                        case kernel_id_t::post_reorder:
                         case kernel_id_t::zp_precalc:
                             tmp_kernels.emplace_back();
                             continue;
@@ -310,6 +334,9 @@ public:
                             zp_prim_->pd()->scratchpad_registry());
                     e_ctx.set_scratchpad_grantor(nested_grantor);
                     CONV_CHECK(zp_prim_->execute(e_ctx));
+                } else if (data.reorders[i].pd) {
+                    CONV_CHECK(execute_reorder(
+                            ctx, data.reorders[i], *reorder_prims_[i]));
                 }
                 nsubmitted++;
                 if (nsubmitted == nkernels) break;
@@ -320,6 +347,29 @@ public:
     }
 
 private:
+    static status_t execute_reorder(const exec_ctx_t &ctx,
+            const reorder_data_t &r, const impl::primitive_t &prim) {
+        auto storage = ctx.get_scratchpad_grantor().get_memory_storage(
+                r.scratchpad_key);
+        std::unique_ptr<memory_t, memory_deleter_t> compute_mem;
+        CHECK(safe_ptr_assign(compute_mem,
+                new memory_t(ctx.stream()->engine(), &r.compute_md,
+                        std::move(storage))));
+
+        exec_args_t r_args;
+        auto compute_arg = memory_arg_t {compute_mem.get(), !r.is_input};
+        r_args[DNNL_ARG_FROM]
+                = r.is_input ? ctx.args().at(r.arg_key) : compute_arg;
+        r_args[DNNL_ARG_TO]
+                = r.is_input ? compute_arg : ctx.args().at(r.arg_key);
+        exec_ctx_t r_ctx(ctx, std::move(r_args));
+        auto *nested_grantor
+                = create_nested_grantor(ctx.get_scratchpad_grantor(),
+                        r.nested_key, prim.pd()->scratchpad_registry());
+        r_ctx.set_scratchpad_grantor(nested_grantor);
+        return prim.execute(r_ctx);
+    }
+
     static const memory_desc_t *zp_md_in(const pd_data_t &data) {
         if (!data.zp_pd) return nullptr;
         const bool is_bwd_d
@@ -339,13 +389,56 @@ private:
         auto &infos = pd->data->kernel_infos;
         gpu_assert((int)infos.size() + 1 <= max_kernels);
         infos.emplace_back();
+        pd->data->reorders.emplace_back();
         auto &ret = infos.back();
         ret.set_id(kernel_id);
         return ret;
     }
 
     template <typename T>
-    static status_t init_kernel_infos(T *pd) {
+    static status_t init_reorder(T *pd, const impl::engine_t *engine,
+            kernel_id_t id, const std::string &name, int arg_key,
+            int scratchpad_key, size_t scratchpad_size) {
+        auto &data = *pd->data;
+        auto t = get_tensor_ref(data.pd_cfg, pd, name);
+        VDISPATCH_CONV_IC(
+                t.layout, VERBOSE_UNSUPPORTED_TENSOR_LAYOUT, name.c_str());
+        // Unnormalized layout matches the user memory descriptor ndims.
+        auto &compute_layout = t.layout->compute_unnormalized();
+        // Compensation is handled by the conv, reorder the plain data only.
+        auto user_md = *t.md;
+        user_md.extra = {};
+        auto compute_md = to_md(compute_layout, user_md);
+        VDISPATCH_CONV_IC(
+                memory_desc_wrapper(compute_md).size() <= scratchpad_size,
+                VERBOSE_SCRATCHPAD_LIMIT);
+
+        create_kernel_info(pd, id);
+        auto &r = data.reorders.back();
+        r.compute_md = compute_md;
+        r.arg_key = arg_key;
+        r.scratchpad_key = into<uint32_t>(scratchpad_key);
+        r.nested_key
+                = into<uint32_t>(memory_tracking::names::key_nested_multiple
+                        + data.reorders.size());
+        r.is_input = (id == kernel_id_t::pre_reorder);
+        // Match the conv kernel's GRF and systolic mode to avoid a GPU state
+        // switch between the interleaved reorder and conv dispatches.
+        gpu_primitive_attr_t gpu_attr(
+                conv_regs(data.pd_cfg), data.pd_cfg.options().require_dpas());
+        primitive_attr_t attr;
+        CHECK(attr.set_gpu_attr(gpu_attr));
+        CHECK(reorder_primitive_desc_create(r.pd,
+                const_cast<impl::engine_t *>(engine),
+                r.is_input ? &user_md : &r.compute_md,
+                r.is_input ? &r.compute_md : &user_md, &attr));
+        pd->scratchpad_registry().registrar().book(
+                r.nested_key, r.pd->scratchpad_registry());
+        return status::success;
+    }
+
+    template <typename T>
+    static status_t init_kernel_infos(T *pd, const impl::engine_t *engine) {
         auto &data = *pd->data;
         auto &cfg = data.pd_cfg;
         auto &conv_info = create_kernel_info(pd, kernel_id_t::convolution);
@@ -426,26 +519,14 @@ private:
                 auto user_buf = make_buffer(t.name + "_user");
                 compute_arg_key = ++scratchpad_key;
 
-                if (!src_conv_precalc && t.is_input) {
-                    auto &reorder_info
-                            = create_kernel_info(pd, kernel_id_t::pre_reorder);
-                    reorder_info.register_user_arg(user_buf, user_arg_key,
-                            /*is_input=*/true);
-                    add_compute_arg(reorder_info, compute_buf, false);
-                    reorder::jit::config_t reorder_cfg(
-                            cfg.options(), t.user_layout, t.compute_layout);
-                    reorder_info.set_nd_range(reorder_cfg.nd_range());
-                }
-                if (!src_conv_precalc && t.is_output) {
-                    auto &reorder_info
-                            = create_kernel_info(pd, kernel_id_t::post_reorder);
-                    add_compute_arg(reorder_info, compute_buf, true);
-                    reorder_info.register_user_arg(user_buf, user_arg_key,
-                            /*is_input=*/false);
-                    reorder::jit::config_t reorder_cfg(
-                            cfg.options(), t.compute_layout, t.user_layout);
-                    reorder_info.set_nd_range(reorder_cfg.nd_range());
-                }
+                if (!src_conv_precalc && t.is_input)
+                    CHECK(init_reorder(pd, engine, kernel_id_t::pre_reorder,
+                            t.name, user_arg_key, compute_arg_key,
+                            compute_size));
+                if (!src_conv_precalc && t.is_output)
+                    CHECK(init_reorder(pd, engine, kernel_id_t::post_reorder,
+                            t.name, user_arg_key, compute_arg_key,
+                            compute_size));
                 if (src_conv_precalc) {
                     scratchpad_book(++scratchpad_key);
                     create_zero_out_info().register_scratchpad_arg(compute_buf,
@@ -500,11 +581,11 @@ private:
                     // we need to directly query config here.
                     nd_ranges_[i] = cfg.nd_range();
                     break;
-                case kernel_id_t::pre_reorder:
-                case kernel_id_t::post_reorder:
                 case kernel_id_t::zero_out:
                     nd_ranges_[i] = info.nd_range();
                     break;
+                case kernel_id_t::pre_reorder:
+                case kernel_id_t::post_reorder:
                 case kernel_id_t::zp_precalc: break;
                 default: gpu_error_not_expected();
             }
@@ -533,6 +614,8 @@ private:
     std::vector<compute::kernel_t> kernels_;
     std::vector<compute::nd_range_t> nd_ranges_;
     std::shared_ptr<impl::primitive_t> zp_prim_;
+    // Parallel to kernel_infos.
+    std::vector<std::shared_ptr<impl::primitive_t>> reorder_prims_;
 };
 
 status_t gen_fwd_t::pd_t::init(impl::engine_t *engine) {

--- a/src/gpu/intel/conv/jit/config.cpp
+++ b/src/gpu/intel/conv/jit/config.cpp
@@ -1939,7 +1939,8 @@ status_t init_cfg(config_t &cfg, const primitive_t *prim) {
             cfg = std::move(try_cfg);
             return status::success;
         }
-        cfg.tiler().move_next(cfg);
+        // Pass the tried config: the GRF mode is set on it, not on cfg.
+        cfg.tiler().move_next(try_cfg);
     }
     return status::runtime_error;
 }

--- a/src/gpu/intel/conv/jit/plan_utils.hpp
+++ b/src/gpu/intel/conv/jit/plan_utils.hpp
@@ -33,7 +33,7 @@ namespace jit {
 using namespace intel::jit;
 
 struct base_plan_t {
-    base_plan_t(const dsl::hw_t hw = dsl::hw_t()) : hw(hw) {}
+    base_plan_t(const dsl::hw_t &hw = dsl::hw_t()) : hw(hw) {}
 
     int grf_size() const {
         gpu_assert(hw.ngen_hw() != ngen::HW::Unknown);

--- a/src/gpu/intel/conv/jit/tiler.cpp
+++ b/src/gpu/intel/conv/jit/tiler.cpp
@@ -634,7 +634,7 @@ private:
             return false;
         }
 
-        blocking_t blk;
+        const blocking_t &blk;
         dim_t b_iter;
         dim_t m_iter;
         dim_t n_iter;
@@ -1207,26 +1207,27 @@ dim_t grf_usage_bytes(const config_t &cfg, const blocking_params_t &params) {
 
 void sort_by_model_scores(params_generator_t &params_gen, const config_t &cfg,
         tiler_mode_t mode) {
-    std::unordered_map<int, float> eff_scores;
+    std::vector<float> eff_scores(params_gen.configs());
+    auto shape = cfg.shape(/*pad=*/true);
     for (int i = 0; i < params_gen.configs(); i++) {
         auto &p = params_gen.at(i);
         float score = model::get_score(cfg, p);
-        float eff = p.blocking().get_efficiency(cfg.shape(/*pad=*/true));
-        eff_scores.emplace(p.id(), score * eff);
+        float eff = p.blocking().get_efficiency(shape);
+        eff_scores[p.id()] = score * eff;
     }
     if (mode == tiler_mode_t::lookup) {
         // Give the lookup entry the highest score.
         eff_scores[params_gen.at(0).id()] = 1.0f;
     }
     params_gen.sort(0, params_gen.configs(),
-            [&](const blocking_params_t &p) { return -eff_scores.at(p.id()); });
+            [&](const blocking_params_t &p) { return -eff_scores[p.id()]; });
 
     // Heuristics when model tie is detected
     auto &params_vec = params_gen.params_vec();
     auto &p_best = params_vec[0];
     for (auto &p_next : params_gen.params_vec()) {
         if (&p_best == &p_next) continue;
-        if (eff_scores.at(p_best.id()) != eff_scores.at(p_next.id())) break;
+        if (eff_scores[p_best.id()] != eff_scores[p_next.id()]) break;
 
         if (cfg.prb().is_bwd_w && cfg.allow_global_reduction()) {
             // As the model estimate is the same, prefer fewer atomic reductions
@@ -1246,6 +1247,7 @@ void sort_by_model_scores(params_generator_t &params_gen, const config_t &cfg,
     }
 
 #ifdef DNNL_DEV_MODE
+    if (!logger_t<log_level_t::trace>::is_enabled()) return;
     using namespace ir_utils;
     std::vector<std::string> headers
             = {"Config", "Score", "Eff", "Regs", "SLM size"};

--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -416,18 +416,12 @@ status_t micro_horz_t::init(impl::engine_t *engine) {
     if (lda % 4 == 0 && (pd()->OC() % tile_wgu_m) == 0)
         kernel_ctx.define_int("BLOCK_DST", 1);
 
-    gemmstone::microkernel::ShimOptions shimOptions;
-    shimOptions.subgroupSize = sg_size(engine);
-    shimOptions.useTileOps = true;
-    shimOptions.decorator = "wgu";
-
-    auto header = generateShim(pd()->gemm_gate_up_pkg(),
-            gemmstone::microkernel::HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_gateup.h", std::move(header));
-
-    if (pd()->gemm_gate_up_pkg().grfMin > 128) {
-        kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
-    }
+    compute::microkernel_shims_t shims(kernel_ctx, sg_size(engine),
+            utils::downcast<const intel::engine_t *>(engine)
+                    ->device_info()
+                    ->gpu_arch());
+    shims.add("gemm_gateup.h", "wgu", pd()->gemm_gate_up_pkg());
+    shims.finalize();
 
     CHECK(create_kernel(
             engine, &gemm_gate_up_, "micro_gated_mlp_horz", kernel_ctx));

--- a/src/gpu/intel/gated_mlp/micro_horz.cpp
+++ b/src/gpu/intel/gated_mlp/micro_horz.cpp
@@ -109,6 +109,9 @@ int sg_size(impl::engine_t *engine) {
     return intel_engine->device_info()->min_subgroup_size();
 }
 
+// micro_gated_mlp_horz cross-thread argument bytes, plus headroom.
+constexpr int host_argument_bytes = 320;
+
 } // anonymous namespace
 
 status_t micro_horz_t::pd_t::init(impl::engine_t *engine) {
@@ -262,9 +265,12 @@ status_t micro_horz_t::pd_t::init_microkernels(
     opts_wgu.scaleA = with_wts_gate_scales(this) && !wgu_common_scales;
     opts_wgu.offsetA = with_wts_gate_zp(this);
 
+    const gemmstone::microkernel::HostPayload host {
+            sg_size(engine), host_argument_bytes};
+
     try {
-        gemm_gate_up_pkg_
-                = selectGEMM(opts_wgu, hw_info, sizes, problem_wgu, reqs_wgu);
+        gemm_gate_up_pkg_ = selectGEMM(
+                opts_wgu, host, hw_info, sizes, problem_wgu, reqs_wgu);
     } catch (std::exception &e) {
         VDISPATCH_GATED_MLP(false,
                 "gemm_gateup microkernel generation failed with message: %s",

--- a/src/gpu/intel/gemm/jit/dsl/ir/core.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/core.hpp
@@ -364,7 +364,7 @@ public:
                                 && a.is_equal(other.b)));
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         if (is_commutative_op(op_kind)) {
             size_t a_hash = hash(a);
             size_t b_hash = hash(b);
@@ -400,7 +400,7 @@ public:
         return value == other.value;
     }
 
-    size_t get_hash() const override { return hash(value); }
+    size_t compute_hash() const override { return hash(value); }
 
     bool value;
 
@@ -434,7 +434,7 @@ public:
                 && (saturate == other.saturate);
     }
 
-    size_t get_hash() const override { return hash(type, expr, saturate); }
+    size_t compute_hash() const override { return hash(type, expr, saturate); }
 
     bool is_bool_vec_u16() const {
         if (is_bool_vec(expr.type()) && is_u16_or_u32_scalar(type)) return true;
@@ -472,7 +472,7 @@ public:
 
     bool operator==(const const_var_t &other) const { return this == &other; }
 
-    size_t get_hash() const override { return hash(name); }
+    size_t compute_hash() const override { return hash(name); }
 
     std::string name;
 
@@ -494,7 +494,7 @@ public:
         return type == other.type && (value == other.value);
     }
 
-    size_t get_hash() const override { return hash(value); }
+    size_t compute_hash() const override { return hash(value); }
 
     double value;
 
@@ -517,7 +517,7 @@ public:
         return type == other.type && (value == other.value);
     }
 
-    size_t get_hash() const override { return hash(value); }
+    size_t compute_hash() const override { return hash(value); }
 
     static expr_t shrink_type(const expr_t &e) {
         auto &imm = e.as<int_imm_t>();
@@ -563,7 +563,7 @@ public:
                 && false_expr.is_equal(other.false_expr);
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         return hash(cond, true_expr, false_expr);
     }
 
@@ -609,7 +609,7 @@ public:
                 && utils::is_equal(v_vec, other.v_vec);
     }
 
-    size_t get_hash() const override { return hash(c, u_vec, v_vec); }
+    size_t compute_hash() const override { return hash(c, u_vec, v_vec); }
 
     expr_t c;
     std::vector<expr_t> u_vec;
@@ -648,7 +648,9 @@ public:
                 && off.is_equal(other.off) && (stride == other.stride);
     }
 
-    size_t get_hash() const override { return hash(type, buf, off, stride); }
+    size_t compute_hash() const override {
+        return hash(type, buf, off, stride);
+    }
 
     bool has_default_stride() const { return stride == default_stride; }
 
@@ -680,7 +682,7 @@ public:
         return base.is_equal(other.base) && off.is_equal(other.off);
     }
 
-    size_t get_hash() const override { return hash(base, off); }
+    size_t compute_hash() const override { return hash(base, off); }
 
     // Normalizes (base op off) pointer so that the new base is a variable and
     // off is an offset expression.
@@ -777,7 +779,7 @@ public:
                 && utils::is_equal(idx, other.idx);
     }
 
-    size_t get_hash() const override { return hash(vec, idx); }
+    size_t compute_hash() const override { return hash(vec, idx); }
 
     int elems() const { return int(idx.size()); }
 
@@ -846,7 +848,7 @@ public:
                 && b.is_equal(other.b) && c.is_equal(other.c);
     }
 
-    size_t get_hash() const override { return hash(op_kind, a, b, c); }
+    size_t compute_hash() const override { return hash(op_kind, a, b, c); }
 
     op_kind_t op_kind;
     expr_t a;
@@ -887,7 +889,7 @@ public:
         return (op_kind == other.op_kind) && a.is_equal(other.a);
     }
 
-    size_t get_hash() const override { return hash(op_kind, a); }
+    size_t compute_hash() const override { return hash(op_kind, a); }
 
     op_kind_t op_kind;
     expr_t a;
@@ -909,7 +911,9 @@ public:
         return this == &other;
     }
 
-    size_t get_hash() const override { return std::hash<std::string> {}(name); }
+    size_t compute_hash() const override {
+        return std::hash<std::string> {}(name);
+    }
 
     std::string name;
     bool is_mutable = false;
@@ -948,7 +952,7 @@ public:
         return oss.str();
     }
 
-    size_t get_hash() const override { return hash(var, off, elems); }
+    size_t compute_hash() const override { return hash(var, off, elems); }
 
     expr_t var;
     int off;
@@ -1135,7 +1139,7 @@ public:
         return this == &obj;
     }
 
-    size_t get_hash() const override { return hash(buf_sizes); }
+    size_t compute_hash() const override { return hash(buf_sizes); }
 
     // List of buffers accessed from instructions.
     std::vector<expr_t> bufs;
@@ -1195,7 +1199,7 @@ public:
                 && body.is_equal(other.body);
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         return hash(buf, size, kind, attrs, body);
     }
 
@@ -1257,7 +1261,7 @@ public:
         return var.is_equal(other.var) && value.is_equal(other.value);
     }
 
-    size_t get_hash() const override { return hash(var, value); }
+    size_t compute_hash() const override { return hash(var, value); }
 
     std::string str() const override {
         std::ostringstream oss;
@@ -1314,7 +1318,7 @@ public:
                 && (stride == other.stride) && (fill_mask0 == other.fill_mask0);
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         return hash(buf, off, value, stride, mask, fill_mask0);
     }
 
@@ -1377,7 +1381,7 @@ public:
                 && step.is_equal(other.step) && (unroll == other.unroll);
     }
 
-    size_t get_hash() const override {
+    size_t compute_hash() const override {
         return hash(var, init, bound, body, step, unroll);
     }
 
@@ -1426,7 +1430,7 @@ public:
                 && else_body.is_equal(other.else_body);
     }
 
-    size_t get_hash() const override { return hash(cond, body, else_body); }
+    size_t compute_hash() const override { return hash(cond, body, else_body); }
 
     std::string line_str() const {
         ostringstream_t oss;
@@ -1461,7 +1465,7 @@ public:
                 && body.is_equal(other.body);
     }
 
-    size_t get_hash() const override { return hash(var, value, body); }
+    size_t compute_hash() const override { return hash(var, value, body); }
 
     std::string line_str() const {
         ostringstream_t out;
@@ -1587,7 +1591,7 @@ public:
         return (label == other.label) && body.is_equal(other.body);
     }
 
-    size_t get_hash() const override { return hash(label, body); }
+    size_t compute_hash() const override { return hash(label, body); }
 
     stmt_label_t label;
     stmt_t body;
@@ -1616,7 +1620,7 @@ public:
         return utils::is_equal(vec, other.vec);
     }
 
-    size_t get_hash() const override { return hash(vec); }
+    size_t compute_hash() const override { return hash(vec); }
 
     std::vector<stmt_t> vec;
 
@@ -1639,7 +1643,7 @@ public:
         return cond.is_equal(other.cond) && body.is_equal(other.body);
     }
 
-    size_t get_hash() const override { return hash(cond, body); }
+    size_t compute_hash() const override { return hash(cond, body); }
 
     std::string line_str() const {
         ostringstream_t out;
@@ -1701,7 +1705,7 @@ public:
         return mod.getAll() == other.mod.getAll();
     }
 
-    size_t get_hash() const override { return hash(mod.getAll()); }
+    size_t compute_hash() const override { return hash(mod.getAll()); }
 
     std::string str() const override {
         ostringstream_t oss;
@@ -1748,8 +1752,8 @@ class func_impl_t : public object::impl_t {
 public:
     func_impl_t(object::impl_t::info_t type_info) : object::impl_t(type_info) {}
 
-    size_t get_hash() const override {
-        dsl_error() << "get_hash() is not implemented.";
+    size_t compute_hash() const override {
+        dsl_error() << "compute_hash() is not implemented.";
         return 0;
     }
 
@@ -1813,7 +1817,7 @@ public:
                 && attr.is_equal(other.attr);
     }
 
-    size_t get_hash() const override { return hash(args, attr); }
+    size_t compute_hash() const override { return hash(args, attr); }
 
     std::string line_str() const {
         ostringstream_t out;

--- a/src/gpu/intel/gemm/jit/dsl/ir/grf_permutation.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/grf_permutation.hpp
@@ -80,7 +80,7 @@ public:
         return this == &obj;
     }
 
-    size_t get_hash() const override { return 0; }
+    size_t compute_hash() const override { return 0; }
 
     std::shared_ptr<grf_permutation_t> grf_perm;
 

--- a/src/gpu/intel/gemm/jit/dsl/ir/ir.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/ir.hpp
@@ -823,7 +823,7 @@ public:
     }
 
 private:
-    object_map_t<expr_t, std::vector<relation_t>> relations_;
+    const object_map_t<expr_t, std::vector<relation_t>> &relations_;
 };
 
 // TODO: Add integers check (only integers can be constrained).
@@ -834,6 +834,10 @@ public:
     }
 
     void add_constraint(const expr_t &e);
+
+    bool is_empty() const {
+        return relations_.empty() && modulus_infos_.empty();
+    }
 
     bool can_prove(const expr_t &e, bool try_simplify = true) const {
         auto ret = can_prove_impl(e, /*do_simplify=*/false);

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
@@ -1823,7 +1823,22 @@ private:
     constraint_set_t cset_;
 };
 
+expr_t simplify_expr_impl(const expr_t &_e, const constraint_set_t &cset);
+
 expr_t simplify_expr(const expr_t &_e, const constraint_set_t &cset) {
+    if (!cset.is_empty()) return simplify_expr_impl(_e, cset);
+    if (is_const(_e) || is_var(_e)) return _e;
+    static const size_t max_cache_size = 4096;
+    static thread_local object_eq_map_t<expr_t, expr_t> cache;
+    auto it = cache.find(_e);
+    if (it != cache.end()) return it->second;
+    auto ret = simplify_expr_impl(_e, cset);
+    if (cache.size() >= max_cache_size) cache.clear();
+    cache.emplace(_e, ret);
+    return ret;
+}
+
+expr_t simplify_expr_impl(const expr_t &_e, const constraint_set_t &cset) {
     expr_t e = _e;
 
     if (is_const(e) || is_var(e)) return e;
@@ -2421,7 +2436,6 @@ expr_t nary_op_canonicalize(const expr_t &_e) {
     e = mul_nary_op_expander_t().mutate(e);
 
     dsl_assert(is_nary_op_canonical(e)) << e;
-    maybe_unused(is_nary_op_canonical(e));
 
     return e;
 }

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
@@ -1513,7 +1513,8 @@ public:
         auto _b = nary_op_back_transform(b);
 
         // 0 <= a < b => (a / b) == 0
-        bool abs_a_lt_b = cset.can_prove(_a >= 0) && cset.can_prove(_a < _b);
+        bool abs_a_lt_b = cset.can_prove(_a >= 0, /*try_simplify=*/false)
+                && cset.can_prove(_a < _b, /*try_simplify=*/false);
 
         // 0 <= a < b => (a % b) == a
         if (abs_a_lt_b) {

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/simplify.cpp
@@ -42,7 +42,7 @@ public:
 
     bool operator==(const pexpr_t &other) const { return id == other.id; }
 
-    size_t get_hash() const override { return hash(id); }
+    size_t compute_hash() const override { return hash(id); }
 
     std::string str() const override {
         ostringstream_t oss;
@@ -102,7 +102,7 @@ public:
         return (id == other.id) && (value == other.value);
     }
 
-    size_t get_hash() const override { return hash(id, value); }
+    size_t compute_hash() const override { return hash(id, value); }
 
     std::string str() const override {
         ostringstream_t oss;
@@ -721,7 +721,7 @@ public:
         return (op_kind == other.op_kind) && utils::is_equal(args, other.args);
     }
 
-    size_t get_hash() const override { return hash(op_kind, args); }
+    size_t compute_hash() const override { return hash(op_kind, args); }
 
     std::string str() const override {
         ostringstream_t oss;
@@ -1040,7 +1040,7 @@ public:
         return f_common.factors.size() == factors.size();
     }
 
-    size_t get_hash() const override { return hash(factors); }
+    size_t compute_hash() const override { return hash(factors); }
 
     std::string str() const override {
         ostringstream_t oss;

--- a/src/gpu/intel/gemm/jit/dsl/ir/pass/trace.cpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/pass/trace.cpp
@@ -46,7 +46,7 @@ void trace_stop(const char *pass_name) {
     if (get_trace_profiler()) get_trace_profiler()->stop(pass_name);
 }
 void trace_perf() {
-    dsl_perf() << get_trace_profiler();
+    if (get_trace_profiler()) dsl_perf() << *get_trace_profiler();
 }
 
 void trace_pass(

--- a/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
@@ -15,13 +15,16 @@
 *******************************************************************************/
 
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <fstream>
 #include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
 #include "generator/microkernel/elf.hpp"
+#include "generator/microkernel/payload.hpp"
 #include "gemmstone/microkernel/fuser.hpp"
 
 GEMMSTONE_NAMESPACE_START
@@ -29,8 +32,19 @@ namespace microkernel {
 
 static void fixupJumpTargets(uint8_t *start, size_t len, ptrdiff_t adjust);
 
-void fuse(std::vector<uint8_t> &binary,
-        const std::vector<uint8_t> &microkernel, long id) {
+/* Host payloads, checked against the microkernel's register placement. */
+struct PayloadCheck {
+    const std::vector<KernelInfo> *kernels;
+    uint32_t argumentBase;
+    int grfBytes;
+    bool *validated;
+};
+
+static void checkPayload(const PayloadCheck &check, const char *kernelName);
+
+static void fuse(std::vector<uint8_t> &binary,
+        const std::vector<uint8_t> &microkernel, long id,
+        const PayloadCheck *check) {
     auto base = binary.data();
     auto bytes = binary.size();
 
@@ -106,6 +120,9 @@ void fuse(std::vector<uint8_t> &binary,
 
         if (!spliceStart || !spliceEnd) continue;
 
+        // Validate the argument placement against the selected base.
+        if (check && snames) checkPayload(*check, snames + text->name + 6);
+
         int relSectionID = -1;
         std::string rname = ".rel";
         rname += (snames + text->name);
@@ -172,12 +189,62 @@ void fuse(std::vector<uint8_t> &binary,
         std::swap(binary, newBinary);
 
         // Tail-recurse to handle any further instances of this microkernel
-        fuse(binary, microkernel, id);
+        fuse(binary, microkernel, id, check);
         return;
     }
 }
 
-void fuse(std::vector<uint8_t> &binary, const char *source) {
+static bool findZeInfo(
+        const std::vector<uint8_t> &binary, const char *&text, size_t &length) {
+    auto base = binary.data();
+    auto bytes = binary.size();
+
+    if (bytes < sizeof(FileHeader)) return false;
+    auto *fheader = reinterpret_cast<const FileHeader *>(base);
+    if (fheader->magic != ELFMagic || fheader->elfClass != ELFClass64)
+        return false;
+    if (fheader->sectionHeaderSize != sizeof(SectionHeader)) return false;
+    if (fheader->sectionTableOff > bytes) return false;
+    if ((bytes - fheader->sectionTableOff) / sizeof(SectionHeader)
+            < fheader->sectionCount)
+        return false;
+
+    auto *sheaders = reinterpret_cast<const SectionHeader *>(
+            base + fheader->sectionTableOff);
+    for (int s = 0; s < fheader->sectionCount; s++) {
+        if (sheaders[s].type != SectionHeader::Type::ZeInfo) continue;
+        if (sheaders[s].offset > bytes
+                || sheaders[s].size > bytes - sheaders[s].offset)
+            return false;
+        text = reinterpret_cast<const char *>(base + sheaders[s].offset);
+        length = size_t(sheaders[s].size);
+        return true;
+    }
+    return false;
+}
+
+// vISA does not reserve registers against IGC's thread payload, so a microkernel
+// placed too low silently corrupts the host kernel's arguments.
+static void checkPayload(const PayloadCheck &check, const char *kernelName) {
+    for (auto &kernel : *check.kernels) {
+        if (kernel.name != kernelName) continue;
+        *check.validated = true;
+
+        auto payloadEnd = payloadEndBytes(kernel, check.grfBytes);
+        if (payloadEnd <= check.argumentBase) return;
+
+        auto argumentBytes = payloadEnd - crossthreadBase(kernel, check.grfBytes);
+        throw std::runtime_error("Microkernel registers (r"
+                + std::to_string(check.argumentBase / check.grfBytes)
+                + " and up) overlap the thread payload of kernel "
+                + kernel.name + ", which ends at r"
+                + std::to_string((payloadEnd - 1) / check.grfBytes)
+                + ". Raise HostPayload::argumentBytes to "
+                + std::to_string(argumentBytes) + " or more");
+    }
+}
+
+bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes) {
     std::vector<uint8_t> microkernel;
     const auto sigilLen = strlen(sigilBinary);
 
@@ -185,19 +252,33 @@ void fuse(std::vector<uint8_t> &binary, const char *source) {
         return ((c >= 'A') ? (c - 'A' + 10) : (c - '0')) & 0xF;
     };
 
+    /* Read the payload layout before fusing moves the .ze_info section. */
+    std::vector<KernelInfo> kernels;
+    const char *zeInfo = nullptr;
+    size_t zeInfoLength = 0;
+    bool haveLayout = grfBytes > 0 && findZeInfo(binary, zeInfo, zeInfoLength)
+            && parseZeInfo(zeInfo, zeInfoLength, kernels);
+    bool validated = false;
+
     for (const char *s = std::strstr(source, sigilBinary); s;
             s = std::strstr(s, sigilBinary)) {
         s += sigilLen;
         char *after;
         long id = strtol(s, &after, 10);
+        uint32_t argumentBase = 0;
+        if (*after == ':')
+            argumentBase = uint32_t(strtoul(after + 1, &after, 10));
         microkernel.clear();
         for (s = after + 1; *s != '\n'; s += 2) {
             if (!s[0] || !s[1]) break;
             microkernel.push_back(static_cast<uint8_t>(
                     (toNybble(s[0]) << 4) | toNybble(s[1])));
         }
-        fuse(binary, microkernel, id);
+        PayloadCheck check {&kernels, argumentBase, grfBytes, &validated};
+        fuse(binary, microkernel, id,
+                (haveLayout && argumentBase > 0) ? &check : nullptr);
     }
+    return validated;
 }
 
 static void fixupJumpTargets(uint8_t *start, size_t len, ptrdiff_t adjust) {

--- a/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/fuser.cpp
@@ -26,6 +26,7 @@
 #include "generator/microkernel/elf.hpp"
 #include "generator/microkernel/payload.hpp"
 #include "gemmstone/microkernel/fuser.hpp"
+#include "ngen_elf.hpp"
 
 GEMMSTONE_NAMESPACE_START
 namespace microkernel {
@@ -42,9 +43,33 @@ struct PayloadCheck {
 
 static void checkPayload(const PayloadCheck &check, const char *kernelName);
 
+/* Compacted no-op, used to keep microkernel instructions 16-byte aligned.
+   Encodings are per-arch compaction table entries; verify additions with
+   iga64 (sync.nop {Compacted} / mov (1|M0) null:ud r0.0:ud {Compacted}). */
+static const uint8_t *alignmentFiller(ngen::HW hw) {
+    static const uint8_t syncNop[8] = {0x01, 0, 0, 0xE8, 0x01, 0, 0x11, 0};
+    static const uint8_t movNull[8] = {0x61, 0, 0x84, 0xBC, 0, 0, 0, 0};
+    static const uint8_t movNullXe2[8] = {0x61, 0, 0x84, 0xFC, 0, 0, 0x10, 0};
+    static const uint8_t movNullXe3p[8] = {0x61, 0, 0x84, 0xA4, 0, 0, 0, 0};
+    switch (hw) {
+        case ngen::HW::Unknown:
+        case ngen::HW::Gen9:
+        case ngen::HW::Gen10:
+        case ngen::HW::Gen11:
+        case ngen::HW::XeLP:
+        case ngen::HW::XeHP: return nullptr;
+        case ngen::HW::XeHPG: return syncNop;
+        case ngen::HW::XeHPC: return movNull;
+        case ngen::HW::Xe2:
+        case ngen::HW::Xe3: return movNullXe2;
+        case ngen::HW::Xe3p: return movNullXe3p;
+    }
+    return nullptr;
+}
+
 static void fuse(std::vector<uint8_t> &binary,
         const std::vector<uint8_t> &microkernel, long id,
-        const PayloadCheck *check) {
+        const PayloadCheck *check, const uint8_t *filler) {
     auto base = binary.data();
     auto bytes = binary.size();
 
@@ -139,22 +164,30 @@ static void fuse(std::vector<uint8_t> &binary,
 
         size_t before = spliceStart - base;
         auto after = bytes - before - removeBytes;
-        ptrdiff_t sizeAdjust = microkernel.size() - removeBytes;
 
         auto kbefore = before - text->offset;
+
+        /* Keep the microkernel's (uncompacted) instructions 16-byte aligned
+           so they do not straddle instruction cache lines. */
+        std::vector<uint8_t> blob;
+        if (filler && (kbefore & 8)) blob.assign(filler, filler + 8);
+        blob.insert(blob.end(), microkernel.begin(), microkernel.end());
+
+        ptrdiff_t sizeAdjust = blob.size() - removeBytes;
+
         auto kafter = text->size - kbefore - removeBytes;
 
         std::vector<uint8_t> newBinary(bytes + sizeAdjust);
         auto newBase = newBinary.data();
 
         memmove(newBase, base, before);
-        memmove(newBase + before, microkernel.data(), microkernel.size());
-        memmove(newBase + before + microkernel.size(),
+        memmove(newBase + before, blob.data(), blob.size());
+        memmove(newBase + before + blob.size(),
                 spliceStart + removeBytes, after);
 
         fixupJumpTargets(newBase + text->offset, kbefore, +sizeAdjust);
         fixupJumpTargets(
-                newBase + before + microkernel.size(), kafter, -sizeAdjust);
+                newBase + before + blob.size(), kafter, -sizeAdjust);
 
         fheaderPtr = reinterpret_cast<FileHeader *>(newBase);
 
@@ -189,7 +222,7 @@ static void fuse(std::vector<uint8_t> &binary,
         std::swap(binary, newBinary);
 
         // Tail-recurse to handle any further instances of this microkernel
-        fuse(binary, microkernel, id, check);
+        fuse(binary, microkernel, id, check, filler);
         return;
     }
 }
@@ -248,6 +281,9 @@ bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes) {
     std::vector<uint8_t> microkernel;
     const auto sigilLen = strlen(sigilBinary);
 
+    auto filler = alignmentFiller(
+            ngen::ELFCodeGenerator<ngen::HW::Unknown>::getBinaryArch(binary));
+
     auto toNybble = [](char c) {
         return ((c >= 'A') ? (c - 'A' + 10) : (c - '0')) & 0xF;
     };
@@ -276,7 +312,7 @@ bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes) {
         }
         PayloadCheck check {&kernels, argumentBase, grfBytes, &validated};
         fuse(binary, microkernel, id,
-                (haveLayout && argumentBase > 0) ? &check : nullptr);
+                (haveLayout && argumentBase > 0) ? &check : nullptr, filler);
     }
     return validated;
 }

--- a/src/gpu/intel/gemm/jit/generator/microkernel/payload.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/payload.cpp
@@ -1,0 +1,154 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+
+#include "generator/microkernel/payload.hpp"
+
+GEMMSTONE_NAMESPACE_START
+namespace microkernel {
+
+static std::string unquote(const std::string &s) {
+    if (s.size() >= 2 && (s.front() == '\'' || s.front() == '"')
+            && s.back() == s.front())
+        return s.substr(1, s.size() - 2);
+    return s;
+}
+
+bool parseZeInfo(
+        const char *text, size_t length, std::vector<KernelInfo> &kernels) {
+    kernels.clear();
+
+    bool inKernels = false;
+    enum { None, ExecEnv, Payload, PerThread } section = None;
+    PayloadArgument perThread;
+    auto *end = text + length;
+
+    for (auto *l = text; l < end;) {
+        auto *eol = static_cast<const char *>(
+                std::memchr(l, '\n', size_t(end - l)));
+        if (!eol) eol = end;
+        int indent = 0;
+        while (l + indent < eol && l[indent] == ' ')
+            indent++;
+        std::string line(l + indent, size_t(eol - l - indent));
+        l = (eol < end) ? eol + 1 : end;
+        while (!line.empty() && (line.back() == '\r' || line.back() == ' '))
+            line.pop_back();
+        if (line.empty() || line[0] == '#') continue;
+
+        if (indent == 0) {
+            inKernels = (line == "kernels:");
+            section = None;
+            continue;
+        }
+        if (!inKernels) continue;
+
+        bool item = (line.compare(0, 2, "- ") == 0);
+        if (item) line = line.substr(2);
+
+        /* A list item at kernel level starts a kernel; its first key is inline. */
+        if (indent == 2 && item) {
+            kernels.emplace_back();
+            section = None;
+            indent = 4;
+            item = false;
+        }
+        if (kernels.empty()) return false;
+        auto &kernel = kernels.back();
+
+        auto colon = line.find(':');
+        if (colon == std::string::npos) continue;
+        std::string key = line.substr(0, colon), val;
+        auto v = line.find_first_not_of(' ', colon + 1);
+        if (v != std::string::npos) val = unquote(line.substr(v));
+
+        auto number = [&] {
+            return uint32_t(std::strtoul(val.c_str(), nullptr, 10));
+        };
+
+        if (indent == 4 && !item) {
+            if (key == "name") {
+                kernel.name = val;
+                continue;
+            }
+            if (val.empty()) {
+                section = (key == "execution_env")                ? ExecEnv
+                        : (key == "payload_arguments")            ? Payload
+                        : (key == "per_thread_payload_arguments") ? PerThread
+                                                                  : None;
+                perThread = {};
+                continue;
+            }
+        }
+        if (section == None) continue;
+
+        if (section == ExecEnv) {
+            if (key == "inline_data_payload_size")
+                kernel.inlineDataBytes = number();
+            continue;
+        }
+
+        if (section == PerThread) {
+            /* Only the extent matters; local IDs need no padding fixup. */
+            if (item) perThread = {};
+            if (key == "offset") perThread.offset = number();
+            else if (key == "size") perThread.size = number();
+            kernel.perThreadBytes = std::max(
+                    kernel.perThreadBytes, perThread.offset + perThread.size);
+            continue;
+        }
+
+        if (item) kernel.payload.emplace_back();
+        if (kernel.payload.empty()) { kernels.clear(); return false; }
+        auto &arg = kernel.payload.back();
+        if (key == "offset") arg.offset = number();
+        else if (key == "size") arg.size = number();
+    }
+
+    return !kernels.empty();
+}
+
+static uint32_t alignUp(uint32_t x, uint32_t align) {
+    return (x + align - 1) & ~(align - 1);
+}
+
+uint32_t crossthreadBase(const KernelInfo &kernel, int grfBytes) {
+    auto grf = uint32_t(grfBytes);
+    return grf + alignUp(kernel.perThreadBytes, grf);
+}
+
+uint32_t payloadEndBytes(const KernelInfo &kernel, int grfBytes) {
+    // Inline data occupies a whole GRF regardless of inline_data_payload_size,
+    // so offsets at or past it shift by the padding.
+    auto inlineData = kernel.inlineDataBytes;
+    uint32_t pad = inlineData
+            ? alignUp(inlineData, uint32_t(grfBytes)) - inlineData
+            : 0;
+
+    auto base = crossthreadBase(kernel, grfBytes);
+    auto end = base;
+    for (auto &arg : kernel.payload) {
+        auto offset = base + arg.offset + ((arg.offset >= inlineData) ? pad : 0);
+        end = std::max(end, offset + arg.size);
+    }
+    return end;
+}
+
+}
+GEMMSTONE_NAMESPACE_END

--- a/src/gpu/intel/gemm/jit/generator/microkernel/payload.hpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/payload.hpp
@@ -1,0 +1,57 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef GEMMSTONE_GENERATOR_MICROKERNEL_PAYLOAD_HPP
+#define GEMMSTONE_GENERATOR_MICROKERNEL_PAYLOAD_HPP
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "gemmstone/config.hpp"
+
+GEMMSTONE_NAMESPACE_START
+namespace microkernel {
+
+// A thread payload argument, at a byte offset within its payload block.
+struct PayloadArgument {
+    uint32_t offset = 0;
+    uint32_t size = 0;
+};
+
+struct KernelInfo {
+    std::string name;
+    uint32_t inlineDataBytes = 0;
+    uint32_t perThreadBytes = 0;
+    // Kept per-argument: inline-data padding shifts each offset individually,
+    // and .ze_info may list the arguments before inline_data_payload_size.
+    std::vector<PayloadArgument> payload;
+};
+
+// Reads kernel thread payload layouts from zebin .ze_info metadata.
+// Unrecognized keys are skipped; returns false if no kernel list was found.
+bool parseZeInfo(const char *text, size_t length, std::vector<KernelInfo> &kernels);
+
+// Thread payload geometry, in GRF bytes relative to r0. `grfBytes` must be
+// supplied: .ze_info records grf_count, not the GRF width.
+uint32_t crossthreadBase(const KernelInfo &kernel, int grfBytes);
+uint32_t payloadEndBytes(const KernelInfo &kernel, int grfBytes);
+
+}
+GEMMSTONE_NAMESPACE_END
+
+#endif

--- a/src/gpu/intel/gemm/jit/generator/microkernel/shim.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/shim.cpp
@@ -754,7 +754,8 @@ std::string generateShim(const Package &package, HostLanguage language,
 
     /* Insert binary code in comment for fuser */
     const char hexChars[] = "0123456789abcdef";
-    shim << "    // " << sigilBinary << options.microkernelID << ' ';
+    shim << "    // " << sigilBinary << options.microkernelID << ':'
+         << package.argumentBase << ' ';
     for (auto b : package.binary)
         shim << hexChars[(b >> 4) & 0xF] << hexChars[b & 0xF];
     shim << '\n';

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -111,11 +111,21 @@ Protocol makeProtocol(const GEMMOptions &o) {
     return {"ugemm", arguments(o), settings()};
 }
 
-InterfaceHandler GEMMOptions::generateInterface(HW hw) const {
+InterfaceHandler GEMMOptions::generateInterface(HW hw, HostPayload host) const {
     /* Set up arguments for microkernel */
     InterfaceHandler interface(hw);
 
-    interface.setArgumentBase(ngen::GRF(8));
+    if (host.simd <= 0 || host.argumentBytes <= 0) {
+        /* Transitional: legacy callers keep the fixed base and r0-r9 claim. */
+        interface.setArgumentBase(ngen::GRF(8));
+    } else {
+        /* Place microkernel arguments above the host kernel's thread payload:
+           r0, the local IDs, then the cross-thread arguments. */
+        interface.requireLocalID(3);
+        interface.requireSIMD(host.simd);
+        interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
+                                      + GRF::bytesToGRFs(hw, host.argumentBytes)));
+    }
     interface.newArgument("A", localA ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
     interface.newArgument("lda", DataType::d);
     interface.newArgument("B", localB ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
@@ -160,7 +170,7 @@ std::string strategyToString(HW hw, const GEMMProblem &problem, const GEMMStrate
     return ss.str();
 }
 
-Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation hwInfo, SizeParams sizes,
                    const GEMMProblem &problem_, const std::vector<StrategyRequirement> &reqs_,
                    StrategyAdjuster strategyAdjuster, SelectionObserver *observer)
 {
@@ -240,7 +250,7 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
     evalParams.euCount = hwInfo.euCount;
 
     /* Generate interface */
-    InterfaceHandler interface = effOptions.generateInterface(hw);
+    InterfaceHandler interface = effOptions.generateInterface(hw, host);
 
     kcatalog::Catalog catalog = [&]() {
         if (localA)
@@ -400,6 +410,14 @@ Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams 
         }
     }
     throw std::runtime_error("No matching kernel");
+}
+
+Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+                   const GEMMProblem &problem, const std::vector<StrategyRequirement> &reqs,
+                   StrategyAdjuster strategyAdjuster, SelectionObserver *observer)
+{
+    return selectGEMM(options, HostPayload(0, 0), hwInfo, sizes, problem, reqs,
+                      strategyAdjuster, observer);
 }
 
 static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool localA, bool localB,

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -115,17 +115,16 @@ InterfaceHandler GEMMOptions::generateInterface(HW hw, HostPayload host) const {
     /* Set up arguments for microkernel */
     InterfaceHandler interface(hw);
 
-    if (host.simd <= 0 || host.argumentBytes <= 0) {
-        /* Transitional: legacy callers keep the fixed base and r0-r9 claim. */
-        interface.setArgumentBase(ngen::GRF(8));
-    } else {
-        /* Place microkernel arguments above the host kernel's thread payload:
-           r0, the local IDs, then the cross-thread arguments. */
-        interface.requireLocalID(3);
-        interface.requireSIMD(host.simd);
-        interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
-                                      + GRF::bytesToGRFs(hw, host.argumentBytes)));
-    }
+    if (host.simd <= 0 || host.argumentBytes <= 0)
+        stub("Invalid host kernel thread payload");
+
+    /* Place microkernel arguments above the host kernel's thread payload:
+       r0, the local IDs, then the cross-thread arguments. */
+    interface.requireLocalID(3);
+    /* SIMD fixes the local-ID register stride, hence the cross-thread base. */
+    interface.requireSIMD(host.simd);
+    interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
+                                  + GRF::bytesToGRFs(hw, host.argumentBytes)));
     interface.newArgument("A", localA ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
     interface.newArgument("lda", DataType::d);
     interface.newArgument("B", localB ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
@@ -410,14 +409,6 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
         }
     }
     throw std::runtime_error("No matching kernel");
-}
-
-Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
-                   const GEMMProblem &problem, const std::vector<StrategyRequirement> &reqs,
-                   StrategyAdjuster strategyAdjuster, SelectionObserver *observer)
-{
-    return selectGEMM(options, HostPayload(0, 0), hwInfo, sizes, problem, reqs,
-                      strategyAdjuster, observer);
 }
 
 static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool localA, bool localB,

--- a/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel_selector.cpp
@@ -115,16 +115,17 @@ InterfaceHandler GEMMOptions::generateInterface(HW hw, HostPayload host) const {
     /* Set up arguments for microkernel */
     InterfaceHandler interface(hw);
 
-    if (host.simd <= 0 || host.argumentBytes <= 0)
-        stub("Invalid host kernel thread payload");
-
-    /* Place microkernel arguments above the host kernel's thread payload:
-       r0, the local IDs, then the cross-thread arguments. */
-    interface.requireLocalID(3);
-    /* SIMD fixes the local-ID register stride, hence the cross-thread base. */
-    interface.requireSIMD(host.simd);
-    interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
-                                  + GRF::bytesToGRFs(hw, host.argumentBytes)));
+    if (host.simd <= 0 || host.argumentBytes <= 0) {
+        interface.setArgumentBase(ngen::GRF(8));
+    } else {
+        /* Place microkernel arguments above the host kernel's thread payload:
+           r0, the local IDs, then the cross-thread arguments. */
+        interface.requireLocalID(3);
+        /* SIMD fixes the local-ID register stride, hence the cross-thread base. */
+        interface.requireSIMD(host.simd);
+        interface.setArgumentBase(GRF(interface.getCrossthreadBase().getBase()
+                                      + GRF::bytesToGRFs(hw, host.argumentBytes)));
+    }
     interface.newArgument("A", localA ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
     interface.newArgument("lda", DataType::d);
     interface.newArgument("B", localB ? ExternalArgumentType::LocalPtr : ExternalArgumentType::GlobalPtr);
@@ -409,6 +410,14 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
         }
     }
     throw std::runtime_error("No matching kernel");
+}
+
+Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+                   const GEMMProblem &problem, const std::vector<StrategyRequirement> &reqs,
+                   StrategyAdjuster strategyAdjuster, SelectionObserver *observer)
+{
+    return selectGEMM(options, HostPayload(0, 0), hwInfo, sizes, problem, reqs,
+                      strategyAdjuster, observer);
 }
 
 static inline bool getStrategyByHeuristics(HW hw, GEMMStrategy &strategy, bool localA, bool localB,

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -54,7 +54,12 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
     auto argumentBase = interface.getArgumentBase();
     if (argumentBase.isInvalid() || argumentBase.getBase() < 1)
         stub("Microkernel argument base not set");
-    state.ra.claim(GRFRange(0, argumentBase.getBase()));
+    int claimGRFs = argumentBase.getBase();
+    // XXX: Keep the legacy claim as a workaround for NVL-P to avoid
+    // performance regressions. IGC is sensitive to register range changes.
+    if (getProductFamily() == ngen::ProductFamily::NVLP)
+        claimGRFs = std::max<int>(claimGRFs, 10);
+    state.ra.claim(GRFRange(0, claimGRFs));
 
     moveR0(strategy, state);
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -50,11 +50,11 @@ void Generator<hw>::gemmMicrokernel(GEMMProblem problem, GEMMStrategy strategy, 
 
     state.isNested = true;
 
-    /* Leave some space for host kernel arguments */
-    // The host side arguments with 32 byte size registers (DG2)
-    // use 16 registers include padding bytes (aligned with 128 bytes)
-    // r0, r4 are reserved for system threads
-    state.ra.claim((GRF::bytes(hw) >= 64) ? r0-r9 : r0-r15);
+    /* Reserve the host kernel's thread payload, below the microkernel's arguments. */
+    auto argumentBase = interface.getArgumentBase();
+    if (argumentBase.isInvalid() || argumentBase.getBase() < 1)
+        stub("Microkernel argument base not set");
+    state.ra.claim(GRFRange(0, argumentBase.getBase()));
 
     moveR0(strategy, state);
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_microkernel.cxx
@@ -324,6 +324,7 @@ microkernel::Package Generator<hw>::gemmMicrokernelPackage(const GEMMProblem &pr
     package.settings.push_back({"slm_size", int(slmSize)});
 
     package.barrierCount = interface.getBarrierCount();
+    package.argumentBase = interface.getArgumentBase().getBase() * GRF::bytes(hw);
 
     package.finalize(knownClobbers);
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/config.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/config.hpp
@@ -55,4 +55,12 @@ inline int getVerbose(GEMMVerbose v) { return 0; }
 #define GEMMSTONE_NAMESPACE_END }
 #endif
 
+#ifndef GEMMSTONE_DEPRECATED
+#if __cplusplus >= 201402L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201402L)
+#define GEMMSTONE_DEPRECATED(msg) [[deprecated(msg)]]
+#else
+#define GEMMSTONE_DEPRECATED(msg)
+#endif
+#endif
+
 #endif /* header guard */

--- a/src/gpu/intel/gemm/jit/include/gemmstone/dsl/ir/object.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/dsl/ir/object.hpp
@@ -46,7 +46,15 @@ public:
     // Provides equality semantics.
     virtual bool is_equal(const impl_t &obj) const = 0;
 
-    virtual size_t get_hash() const = 0;
+    // Memoized, the hash is computed at most once per object: IR objects are
+    // immutable once created by design.
+    size_t get_hash() const {
+        if (!hash_) {
+            size_t h = compute_hash();
+            hash_ = h ? h : 1; // 0 marks "not computed yet"
+        }
+        return hash_;
+    }
 
     bool is_expr() const { return info().is_expr; }
     bool is_stmt() const { return info().is_stmt; }
@@ -88,6 +96,8 @@ public:
     virtual void _visit(ir_visitor_t &visitor) const;
 
 protected:
+    virtual size_t compute_hash() const = 0;
+
     friend class gemmstone::dsl::ir::object_t;
     template <typename T>
     friend struct info_t;
@@ -140,6 +150,7 @@ private:
 
     ref_count_t ref_count_;
     info_t info_;
+    mutable size_t hash_ = 0;
 };
 
 template <typename T>
@@ -236,6 +247,7 @@ public:
 
     // Comparison with equality semantics.
     bool is_equal(const object_t &other) const {
+        if (impl_ == other.impl()) return true;
         if (is_empty() || other.is_empty())
             return is_empty() == other.is_empty();
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/dsl/tensor.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/dsl/tensor.hpp
@@ -71,8 +71,9 @@ private:
             return !operator==(other);
         }
 
+        // NUL-padded names: byte-swapped compare matches strncmp() ordering.
         bool operator<(const name_t &other) const {
-            return std::strncmp(data_, other.data_, max_len) < 0;
+            return bswap(numeric_value()) < bswap(other.numeric_value());
         }
 
         size_t index() const {
@@ -89,6 +90,17 @@ private:
         std::string str() const { return data_; }
 
     private:
+        static uint64_t bswap(uint64_t v) {
+#if defined(__GNUC__) || defined(__clang__)
+            return __builtin_bswap64(v);
+#else
+            uint64_t ret = 0;
+            for (int i = 0; i < 8; i++)
+                ret |= ((v >> (8 * i)) & 0xFF) << (8 * (7 - i));
+            return ret;
+#endif
+        }
+
         uint64_t numeric_value() const {
             uint64_t ret;
             static_assert(sizeof(*this) == sizeof(ret),
@@ -283,8 +295,9 @@ public:
     }
 
     const ValueT &operator[](const idx_t &key) const {
-        gemm_assert(has(key), "Key not found: " + key.str());
-        return map_.at(key);
+        auto it = map_.find(key);
+        if (it == map_.end()) stub(("Key not found: " + key.str()).c_str());
+        return it->second;
     }
 
     ValueT &operator[](const idx_t &key) {

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/fuser.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/fuser.hpp
@@ -30,12 +30,11 @@ static constexpr uint32_t sigilStart = 0xCAFEFADE;
 static constexpr uint32_t sigilEnd = 0xFADECAFE;
 static constexpr const char *sigilBinary = "@_u_@";
 
-// Fuse the microkernel machine code into the program binary of a compiled host kernel.
-void fuse(std::vector<uint8_t> &binary,
-        const std::vector<uint8_t> &microkernel, int id = 0);
-
-// Fusing microkernels that were embedded directly in source code.
-void fuse(std::vector<uint8_t> &binary, const char *source);
+// Fuse source-embedded microkernels into the compiled host kernel's binary.
+// Each is checked against the host thread payload; an overlap throws, leaving
+// `binary` partially fused. Returns false if none could be checked (fused but
+// unvalidated).
+bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes);
 bool hasMicrokernels(const char *source);
 
 }

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/fuser.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/fuser.hpp
@@ -37,6 +37,11 @@ static constexpr const char *sigilBinary = "@_u_@";
 bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes);
 bool hasMicrokernels(const char *source);
 
+// Transitional overload for legacy callers: skips payload validation.
+inline bool fuse(std::vector<uint8_t> &binary, const char *source) {
+    return fuse(binary, source, 0);
+}
+
 }
 GEMMSTONE_NAMESPACE_END
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/package.hpp
@@ -83,6 +83,7 @@ struct Package {
     /* Register usage */
     std::vector<Argument> arguments; // Input and output arguments for microkernel
     std::vector<RegisterRange> clobbers; // Registers clobbered by microkernel (includes arguments) [*]
+    uint32_t argumentBase = 0; // First GRF byte used by microkernel; host thread payload lies below
 
     /* Requirements */
     uint32_t gmdidCompat; // Compatible GMDID

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -34,6 +34,14 @@ struct HWInformation {
     bool isEfficient64Bit;
 };
 
+/* Host kernel thread payload. Microkernel registers are placed above it. */
+struct HostPayload {
+    HostPayload(int simd, int argumentBytes) : simd(simd), argumentBytes(argumentBytes) {}
+
+    int simd;             /* host kernel SIMD width */
+    int argumentBytes;    /* cross-thread argument bytes, with headroom */
+};
+
 struct GEMMOptions {
     bool localA = false;
     bool localB = false;
@@ -46,13 +54,20 @@ struct GEMMOptions {
     bool kParallelLocal = false;
 
     GEMMOptions() = default;
-    ngen::InterfaceHandler generateInterface(ngen::HW hw) const;
+    ngen::InterfaceHandler generateInterface(ngen::HW hw, HostPayload host) const;
     GEMMOptions transpose() const;
 };
 
 /* Main entrypoint for microkernel auto-selection */
 using StrategyAdjuster = std::function<void(GEMMStrategy&)>;
-Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes, const GEMMProblem &problem,
+Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation hwInfo, SizeParams sizes,
+                                     const GEMMProblem &problem,
+                                     const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
+                                     StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
+
+/* Transitional overload for callers that do not yet pass a HostPayload. */
+Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+                                     const GEMMProblem &problem,
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                      StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -65,12 +65,6 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                      StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
 
-/* Transitional overload for callers that do not yet pass a HostPayload. */
-Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
-                                     const GEMMProblem &problem,
-                                     const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
-                                     StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
-
 /* Helpers */
 static inline int alignmentForLD(int ld)
 {

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -65,8 +65,10 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                      StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
 
-/* Transitional overload for callers that do not yet pass a HostPayload. */
-GEMMSTONE_DEPRECATED("Defaults host payload base to r8, which may mismatch the host kernel and clobber the OpenCL kernel arguments. Use selectGEMM overload with HostPayload")
+/* Transitional overload for callers that do not yet pass a HostPayload.
+   Defaults the host payload base to r8, which may mismatch the host kernel and
+   clobber the OpenCL kernel arguments. Use selectGEMM with HostPayload.
+*/
 Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
                                      const GEMMProblem &problem,
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -65,6 +65,13 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                      StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
 
+/* Transitional overload for callers that do not yet pass a HostPayload. */
+GEMMSTONE_DEPRECATED("Defaults host payload base to r8, which may mismatch the host kernel and clobber the OpenCL kernel arguments. Use selectGEMM overload with HostPayload")
+Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
+                                     const GEMMProblem &problem,
+                                     const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
+                                     StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
+
 /* Helpers */
 static inline int alignmentForLD(int ld)
 {

--- a/src/gpu/intel/include/eltwise.h
+++ b/src/gpu/intel/include/eltwise.h
@@ -42,272 +42,37 @@
 #define POST_OP_LITERAL(x) x##f
 #endif
 
-POST_OP_DATA_T relu_fwd(POST_OP_DATA_T s, float alpha) {
-    return s > 0 ? s : s * alpha;
-}
-POST_OP_DATA_T relu_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {
-    return s > 0 ? dd : dd * alpha;
-}
-POST_OP_DATA_T relu_bwd_use_dst(
-        POST_OP_DATA_T dd, POST_OP_DATA_T d, float alpha) {
-    return d > 0 ? dd : dd * alpha;
+#define ELT_T POST_OP_DATA_T
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+
+#ifdef ELTWISE_VECTOR_API
+// float1 has no builtin overloads, so it defers to the scalar form.
+#include "gpu/intel/include/generic_vector_ops.h"
+
+float1 __attribute__((overloadable)) fwd_eltwise_common(
+        int eltwise_alg, float1 x, float alpha_, float beta_, float scale_) {
+    x[0] = fwd_eltwise_common(eltwise_alg, x[0], alpha_, beta_, scale_);
+    return x;
 }
 
-POST_OP_DATA_T linear_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    return alpha * s + beta;
-}
-POST_OP_DATA_T linear_bwd(POST_OP_DATA_T dd, float alpha) {
-    return dd * alpha;
-}
+#define ELT_T float2
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+#define ELT_T float4
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+#define ELT_T float8
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+#define ELT_T float16
+#include "gpu/intel/include/eltwise_fwd_body.hxx"
+#undef ELT_T
+#endif
 
-POST_OP_DATA_T soft_relu_fwd(POST_OP_DATA_T s, float alpha) {
-    s = alpha * s;
-    POST_OP_DATA_T v
-            = (s < log(CONVERT_POST_OP_DATA_T(DATA_MAX)) ? log1p(exp(s)) : s);
-    return v / alpha;
-}
-POST_OP_DATA_T soft_relu_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {
-    s = alpha * s;
-    return dd / (POST_OP_LITERAL(1.) + exp(-s));
-}
-
-POST_OP_DATA_T logistic_fwd(POST_OP_DATA_T s) {
-    return (POST_OP_LITERAL(1.)) / (POST_OP_LITERAL(1.) + exp(-s));
-}
-POST_OP_DATA_T logistic_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    POST_OP_DATA_T v = logistic_fwd(s);
-    return dd * v * (POST_OP_LITERAL(1.) - v);
-}
-POST_OP_DATA_T logistic_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
-    return dd * d * (POST_OP_LITERAL(1.) - d);
-}
-
-POST_OP_DATA_T square_fwd(POST_OP_DATA_T s) {
-    return s * s;
-}
-POST_OP_DATA_T square_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return dd * 2 * s;
-}
-
-POST_OP_DATA_T sqrt_fwd(POST_OP_DATA_T s) {
-    return sqrt(s);
-}
-POST_OP_DATA_T sqrt_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return dd / (POST_OP_LITERAL(2.) * sqrt(s));
-}
-POST_OP_DATA_T sqrt_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
-    return dd / (POST_OP_LITERAL(2.) * d);
-}
-
-POST_OP_DATA_T abs_fwd(POST_OP_DATA_T s) {
-    return s > 0 ? s : -s;
-}
-POST_OP_DATA_T abs_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return s > 0 ? dd : s < 0 ? -dd : 0;
-}
-
-POST_OP_DATA_T tanh_fwd(POST_OP_DATA_T s) {
-    return tanh(s);
-}
-POST_OP_DATA_T tanh_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    POST_OP_DATA_T e = tanh_fwd(s);
-    return dd * (POST_OP_LITERAL(1.) - e) * (POST_OP_LITERAL(1.) + e);
-}
-POST_OP_DATA_T tanh_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
-    return dd * (POST_OP_LITERAL(1.) - d) * (POST_OP_LITERAL(1.) + d);
-}
-
-POST_OP_DATA_T mish_fwd(POST_OP_DATA_T s) {
-    return s * tanh_fwd(soft_relu_fwd(s, POST_OP_LITERAL(1.)));
-}
-POST_OP_DATA_T mish_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    const POST_OP_DATA_T tanh = tanh_fwd(soft_relu_fwd(s, POST_OP_LITERAL(1.)));
-    const POST_OP_DATA_T srelu_bwd
-            = soft_relu_bwd(POST_OP_LITERAL(1.), s, POST_OP_LITERAL(1.));
-    const POST_OP_DATA_T derivative = tanh
-            + s * srelu_bwd
-                    * (POST_OP_LITERAL(1.) - pow(tanh, POST_OP_LITERAL(2.)));
-    return dd * derivative;
-}
-
-POST_OP_DATA_T elu_fwd(POST_OP_DATA_T s, float alpha) {
-    return s > 0 ? s : alpha * expm1(s);
-}
-POST_OP_DATA_T elu_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {
-    return dd * (s > 0 ? 1 : alpha * exp(s));
-}
-POST_OP_DATA_T elu_bwd_use_dst(
-        POST_OP_DATA_T dd, POST_OP_DATA_T d, float alpha) {
-    return dd * (d > 0 ? 1 : d + alpha);
-}
-
-POST_OP_DATA_T exp_fwd(POST_OP_DATA_T s) {
-    return exp(s);
-}
-
-POST_OP_DATA_T exp_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return dd * exp_fwd(s);
-}
-POST_OP_DATA_T exp_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
-    return dd * d;
-}
-
-POST_OP_DATA_T gelu_tanh_fwd(POST_OP_DATA_T s) {
-    const POST_OP_DATA_T g = POST_OP_LITERAL(1.5957691669464111328125) * s
-            * (POST_OP_LITERAL(1.) + POST_OP_LITERAL(0.044715) * s * s);
-    return s / (POST_OP_LITERAL(1.) + exp(-g));
-}
-POST_OP_DATA_T gelu_tanh_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    const POST_OP_DATA_T sqrt_2_over_pi
-            = POST_OP_LITERAL(0.79788458347320556640625);
-    const POST_OP_DATA_T fitting_const = POST_OP_LITERAL(0.044715);
-    const POST_OP_DATA_T g = sqrt_2_over_pi * s
-            * (POST_OP_LITERAL(1.) + fitting_const * s * s);
-    const POST_OP_DATA_T dg = sqrt_2_over_pi
-            * (POST_OP_LITERAL(1.)
-                    + POST_OP_LITERAL(3.) * fitting_const * s * s);
-    const POST_OP_DATA_T v = tanh_fwd(g);
-    return dd * POST_OP_LITERAL(0.5) * (POST_OP_LITERAL(1.) + v)
-            * (POST_OP_LITERAL(1.) + s * (POST_OP_LITERAL(1.) - v) * dg);
-}
-
-POST_OP_DATA_T swish_fwd(POST_OP_DATA_T s, float alpha) {
-    POST_OP_DATA_T w = -alpha * s;
-    return s / (POST_OP_LITERAL(1.) + exp(w));
-}
-POST_OP_DATA_T swish_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha) {
-    POST_OP_DATA_T v = logistic_fwd(alpha * s);
-    return dd * (v + s * alpha * v * (POST_OP_LITERAL(1.) - v));
-}
-
-POST_OP_DATA_T log_fwd(POST_OP_DATA_T s) {
-    return log(s);
-}
-POST_OP_DATA_T log_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    return dd / s;
-}
-
-POST_OP_DATA_T clip_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    s = s > alpha ? s : alpha;
-    return s > beta ? beta : s;
-}
-POST_OP_DATA_T clip_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    return dd * (alpha < s && s <= beta ? 1 : 0);
-}
-
-POST_OP_DATA_T clip_v2_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    s = s > alpha ? s : alpha;
-    return s < beta ? s : beta;
-}
-POST_OP_DATA_T clip_v2_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    return dd * (alpha < s && s < beta ? 1 : 0);
-}
-POST_OP_DATA_T clip_v2_bwd_use_dst(
-        POST_OP_DATA_T dd, POST_OP_DATA_T d, float alpha, float beta) {
-    return dd * (alpha < d && d < beta ? 1 : 0);
-}
-
-POST_OP_DATA_T pow_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    return alpha * pow(s, (POST_OP_DATA_T)(beta));
-}
-POST_OP_DATA_T pow_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    if (beta == 0) return 0;
-
-    POST_OP_DATA_T v = pow_fwd(s, alpha * beta, beta - 1);
-    return dd * v;
-}
-
-POST_OP_DATA_T gelu_erf_fwd(POST_OP_DATA_T s) {
-    const POST_OP_DATA_T sqrt_2_over_2
-            = POST_OP_LITERAL(0.707106769084930419921875);
-    POST_OP_DATA_T v = s * sqrt_2_over_2;
-    return POST_OP_LITERAL(0.5) * s * (POST_OP_LITERAL(1.) + erf(v));
-}
-
-POST_OP_DATA_T gelu_erf_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
-    const POST_OP_DATA_T two_over_sqrt_pi
-            = POST_OP_LITERAL(1.12837922573089599609375);
-    const POST_OP_DATA_T sqrt_2_over_2
-            = POST_OP_LITERAL(0.707106769084930419921875);
-    POST_OP_DATA_T v = s * sqrt_2_over_2;
-    return dd * POST_OP_LITERAL(0.5)
-            * (POST_OP_LITERAL(1.) + erf(v)
-                    + v * two_over_sqrt_pi * exp(-v * v));
-}
-
-float round_fwd(POST_OP_DATA_T s) {
-    return (float)rint((float)s);
-}
-
-POST_OP_DATA_T hardsigmoid_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    POST_OP_DATA_T v = (POST_OP_DATA_T)alpha * s + (POST_OP_DATA_T)beta;
-    return v <= POST_OP_LITERAL(0.)    ? POST_OP_LITERAL(0.)
-            : v >= POST_OP_LITERAL(1.) ? POST_OP_LITERAL(1.)
-                                       : v;
-}
-POST_OP_DATA_T hardsigmoid_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    POST_OP_DATA_T v = alpha * s + beta;
-    return v <= 0.f ? 0.f : v >= 1.f ? 0.f : dd * alpha;
-}
-
-POST_OP_DATA_T hardswish_fwd(POST_OP_DATA_T s, float alpha, float beta) {
-    return s * hardsigmoid_fwd(s, alpha, beta);
-}
-POST_OP_DATA_T hardswish_bwd(
-        POST_OP_DATA_T dd, POST_OP_DATA_T s, float alpha, float beta) {
-    POST_OP_DATA_T v = alpha * s + beta;
-    POST_OP_DATA_T w = POST_OP_LITERAL(2.) * alpha * s + beta;
-    return (v <= 0.f ? 0.f : v >= 1.f ? dd : dd * w);
-}
-
-float fwd_eltwise_common(int eltwise_alg, POST_OP_DATA_T x, float alpha_,
-        float beta_, float scale_) {
-    switch (eltwise_alg) {
-        case eltwise_relu: return scale_ * relu_fwd(x, alpha_); break;
-        case eltwise_linear:
-            return scale_ * linear_fwd(x, alpha_, beta_);
-            break;
-        case eltwise_soft_relu: return scale_ * soft_relu_fwd(x, alpha_); break;
-        case eltwise_mish: return scale_ * mish_fwd(x); break;
-        case eltwise_logistic: return scale_ * logistic_fwd(x); break;
-        case eltwise_tanh: return scale_ * tanh_fwd(x); break;
-        case eltwise_elu: return scale_ * elu_fwd(x, alpha_); break;
-        case eltwise_square: return scale_ * square_fwd(x); break;
-        case eltwise_sqrt: return scale_ * sqrt_fwd(x); break;
-        case eltwise_abs: return scale_ * abs_fwd(x); break;
-        case eltwise_exp: return scale_ * exp_fwd(x); break;
-        case eltwise_gelu_tanh: return scale_ * gelu_tanh_fwd(x); break;
-        case eltwise_swish: return scale_ * swish_fwd(x, alpha_); break;
-        case eltwise_log: return scale_ * log_fwd(x); break;
-        case eltwise_clip: return scale_ * clip_fwd(x, alpha_, beta_); break;
-        case eltwise_clip_v2:
-            return scale_ * clip_v2_fwd(x, alpha_, beta_);
-            break;
-        case eltwise_pow: return scale_ * pow_fwd(x, alpha_, beta_); break;
-        case eltwise_gelu_erf: return scale_ * gelu_erf_fwd(x); break;
-        case eltwise_round: return scale_ * round_fwd(x); break;
-        case eltwise_hardswish:
-            return scale_ * hardswish_fwd(x, alpha_, beta_);
-            break;
-        case eltwise_hardsigmoid:
-            return scale_ * hardsigmoid_fwd(x, alpha_, beta_);
-            break;
-        case eltwise_relu_dst: return scale_ * relu_fwd(x, alpha_); break;
-        case eltwise_logistic_dst: return scale_ * logistic_fwd(x); break;
-        case eltwise_tanh_dst: return scale_ * tanh_fwd(x); break;
-        case eltwise_elu_dst: return scale_ * elu_fwd(x, alpha_); break;
-        case eltwise_sqrt_dst: return scale_ * sqrt_fwd(x); break;
-        case eltwise_exp_dst: return scale_ * exp_fwd(x); break;
-        case eltwise_clip_v2_dst:
-            return scale_ * clip_v2_fwd(x, alpha_, beta_);
-            break;
-        default: return x; break;
-    }
-}
+#define ELT_T POST_OP_DATA_T
+#include "gpu/intel/include/eltwise_bwd_body.hxx"
+#undef ELT_T
 
 float fwd_eltwise(POST_OP_DATA_T x, float alpha_, float beta_, float scale_) {
 #ifdef ELTWISE_ALG

--- a/src/gpu/intel/include/eltwise.h
+++ b/src/gpu/intel/include/eltwise.h
@@ -153,12 +153,9 @@ POST_OP_DATA_T exp_bwd_use_dst(POST_OP_DATA_T dd, POST_OP_DATA_T d) {
 }
 
 POST_OP_DATA_T gelu_tanh_fwd(POST_OP_DATA_T s) {
-    const POST_OP_DATA_T sqrt_2_over_pi
-            = POST_OP_LITERAL(0.79788458347320556640625);
-    const POST_OP_DATA_T fitting_const = POST_OP_LITERAL(0.044715);
-    const POST_OP_DATA_T g = sqrt_2_over_pi * s
-            * (POST_OP_LITERAL(1.) + fitting_const * s * s);
-    return (POST_OP_LITERAL(0.5) * s * (POST_OP_LITERAL(1.) + tanh_fwd(g)));
+    const POST_OP_DATA_T g = POST_OP_LITERAL(1.5957691669464111328125) * s
+            * (POST_OP_LITERAL(1.) + POST_OP_LITERAL(0.044715) * s * s);
+    return s / (POST_OP_LITERAL(1.) + exp(-g));
 }
 POST_OP_DATA_T gelu_tanh_bwd(POST_OP_DATA_T dd, POST_OP_DATA_T s) {
     const POST_OP_DATA_T sqrt_2_over_pi

--- a/src/gpu/intel/include/eltwise_bwd_body.hxx
+++ b/src/gpu/intel/include/eltwise_bwd_body.hxx
@@ -1,0 +1,155 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+ELT_T __attribute__((overloadable)) relu_bwd(ELT_T dd, ELT_T s, float alpha) {
+    return s > 0 ? dd : dd * alpha;
+}
+ELT_T __attribute__((overloadable)) relu_bwd_use_dst(
+        ELT_T dd, ELT_T d, float alpha) {
+    return d > 0 ? dd : dd * alpha;
+}
+
+ELT_T __attribute__((overloadable)) linear_bwd(ELT_T dd, float alpha) {
+    return dd * alpha;
+}
+
+ELT_T __attribute__((overloadable)) soft_relu_bwd(
+        ELT_T dd, ELT_T s, float alpha) {
+    s = alpha * s;
+    return dd / (POST_OP_LITERAL(1.) + exp(-s));
+}
+
+ELT_T __attribute__((overloadable)) logistic_bwd(ELT_T dd, ELT_T s) {
+    ELT_T v = logistic_fwd(s);
+    return dd * v * (POST_OP_LITERAL(1.) - v);
+}
+ELT_T __attribute__((overloadable)) logistic_bwd_use_dst(ELT_T dd, ELT_T d) {
+    return dd * d * (POST_OP_LITERAL(1.) - d);
+}
+
+ELT_T __attribute__((overloadable)) square_bwd(ELT_T dd, ELT_T s) {
+    return dd * 2 * s;
+}
+
+ELT_T __attribute__((overloadable)) sqrt_bwd(ELT_T dd, ELT_T s) {
+    return dd / (POST_OP_LITERAL(2.) * sqrt(s));
+}
+ELT_T __attribute__((overloadable)) sqrt_bwd_use_dst(ELT_T dd, ELT_T d) {
+    return dd / (POST_OP_LITERAL(2.) * d);
+}
+
+ELT_T __attribute__((overloadable)) abs_bwd(ELT_T dd, ELT_T s) {
+    return s > 0 ? dd : s < 0 ? -dd : 0;
+}
+
+ELT_T __attribute__((overloadable)) tanh_bwd(ELT_T dd, ELT_T s) {
+    ELT_T e = tanh_fwd(s);
+    return dd * (POST_OP_LITERAL(1.) - e) * (POST_OP_LITERAL(1.) + e);
+}
+ELT_T __attribute__((overloadable)) tanh_bwd_use_dst(ELT_T dd, ELT_T d) {
+    return dd * (POST_OP_LITERAL(1.) - d) * (POST_OP_LITERAL(1.) + d);
+}
+
+ELT_T __attribute__((overloadable)) mish_bwd(ELT_T dd, ELT_T s) {
+    const ELT_T tanh = tanh_fwd(soft_relu_fwd(s, POST_OP_LITERAL(1.)));
+    const ELT_T srelu_bwd
+            = soft_relu_bwd(POST_OP_LITERAL(1.), s, POST_OP_LITERAL(1.));
+    const ELT_T derivative = tanh
+            + s * srelu_bwd
+                    * (POST_OP_LITERAL(1.) - pow(tanh, POST_OP_LITERAL(2.)));
+    return dd * derivative;
+}
+
+ELT_T __attribute__((overloadable)) elu_bwd(ELT_T dd, ELT_T s, float alpha) {
+    return dd * (s > 0 ? 1 : alpha * exp(s));
+}
+ELT_T __attribute__((overloadable)) elu_bwd_use_dst(
+        ELT_T dd, ELT_T d, float alpha) {
+    return dd * (d > 0 ? 1 : d + alpha);
+}
+
+ELT_T __attribute__((overloadable)) exp_bwd(ELT_T dd, ELT_T s) {
+    return dd * exp_fwd(s);
+}
+ELT_T __attribute__((overloadable)) exp_bwd_use_dst(ELT_T dd, ELT_T d) {
+    return dd * d;
+}
+
+ELT_T __attribute__((overloadable)) gelu_tanh_bwd(ELT_T dd, ELT_T s) {
+    const ELT_T sqrt_2_over_pi = POST_OP_LITERAL(0.79788458347320556640625);
+    const ELT_T fitting_const = POST_OP_LITERAL(0.044715);
+    const ELT_T g = sqrt_2_over_pi * s
+            * (POST_OP_LITERAL(1.) + fitting_const * s * s);
+    const ELT_T dg = sqrt_2_over_pi
+            * (POST_OP_LITERAL(1.)
+                    + POST_OP_LITERAL(3.) * fitting_const * s * s);
+    const ELT_T v = tanh_fwd(g);
+    return dd * POST_OP_LITERAL(0.5) * (POST_OP_LITERAL(1.) + v)
+            * (POST_OP_LITERAL(1.) + s * (POST_OP_LITERAL(1.) - v) * dg);
+}
+
+ELT_T __attribute__((overloadable)) swish_bwd(ELT_T dd, ELT_T s, float alpha) {
+    ELT_T v = logistic_fwd(alpha * s);
+    return dd * (v + s * alpha * v * (POST_OP_LITERAL(1.) - v));
+}
+
+ELT_T __attribute__((overloadable)) log_bwd(ELT_T dd, ELT_T s) {
+    return dd / s;
+}
+
+ELT_T __attribute__((overloadable)) clip_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    return dd * (alpha < s && s <= beta ? 1 : 0);
+}
+
+ELT_T __attribute__((overloadable)) clip_v2_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    return dd * (alpha < s && s < beta ? 1 : 0);
+}
+ELT_T __attribute__((overloadable)) clip_v2_bwd_use_dst(
+        ELT_T dd, ELT_T d, float alpha, float beta) {
+    return dd * (alpha < d && d < beta ? 1 : 0);
+}
+
+ELT_T __attribute__((overloadable)) pow_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    if (beta == 0) return 0;
+
+    ELT_T v = pow_fwd(s, alpha * beta, beta - 1);
+    return dd * v;
+}
+
+ELT_T __attribute__((overloadable)) gelu_erf_bwd(ELT_T dd, ELT_T s) {
+    const ELT_T two_over_sqrt_pi = POST_OP_LITERAL(1.12837922573089599609375);
+    const ELT_T sqrt_2_over_2 = POST_OP_LITERAL(0.707106769084930419921875);
+    ELT_T v = s * sqrt_2_over_2;
+    return dd * POST_OP_LITERAL(0.5)
+            * (POST_OP_LITERAL(1.) + erf(v)
+                    + v * two_over_sqrt_pi * exp(-v * v));
+}
+
+ELT_T __attribute__((overloadable)) hardsigmoid_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    ELT_T v = alpha * s + beta;
+    return v <= 0.f ? 0.f : v >= 1.f ? 0.f : dd * alpha;
+}
+
+ELT_T __attribute__((overloadable)) hardswish_bwd(
+        ELT_T dd, ELT_T s, float alpha, float beta) {
+    ELT_T v = alpha * s + beta;
+    ELT_T w = POST_OP_LITERAL(2.) * alpha * s + beta;
+    return (v <= 0.f ? 0.f : v >= 1.f ? dd : dd * w);
+}

--- a/src/gpu/intel/include/eltwise_fwd_body.hxx
+++ b/src/gpu/intel/include/eltwise_fwd_body.hxx
@@ -1,0 +1,149 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+ELT_T __attribute__((overloadable)) relu_fwd(ELT_T s, float alpha) {
+    return s > (ELT_T)0 ? s : s * alpha;
+}
+
+ELT_T __attribute__((overloadable)) linear_fwd(
+        ELT_T s, float alpha, float beta) {
+    return alpha * s + beta;
+}
+
+ELT_T __attribute__((overloadable)) soft_relu_fwd(ELT_T s, float alpha) {
+    s = alpha * s;
+    return (s < (ELT_T)log(CONVERT_POST_OP_DATA_T(DATA_MAX)) ? log1p(exp(s))
+                                                             : s)
+            / alpha;
+}
+
+ELT_T __attribute__((overloadable)) logistic_fwd(ELT_T s) {
+    return (ELT_T)POST_OP_LITERAL(1.) / (POST_OP_LITERAL(1.) + exp(-s));
+}
+
+ELT_T __attribute__((overloadable)) square_fwd(ELT_T s) {
+    return s * s;
+}
+
+ELT_T __attribute__((overloadable)) sqrt_fwd(ELT_T s) {
+    return sqrt(s);
+}
+
+ELT_T __attribute__((overloadable)) abs_fwd(ELT_T s) {
+    return s > (ELT_T)0 ? s : -s;
+}
+
+ELT_T __attribute__((overloadable)) tanh_fwd(ELT_T s) {
+    return tanh(s);
+}
+
+ELT_T __attribute__((overloadable)) mish_fwd(ELT_T s) {
+    return s * tanh_fwd(soft_relu_fwd(s, POST_OP_LITERAL(1.)));
+}
+
+ELT_T __attribute__((overloadable)) elu_fwd(ELT_T s, float alpha) {
+    return s > (ELT_T)0 ? s : alpha * expm1(s);
+}
+
+ELT_T __attribute__((overloadable)) exp_fwd(ELT_T s) {
+    return exp(s);
+}
+
+ELT_T __attribute__((overloadable)) gelu_tanh_fwd(ELT_T s) {
+    const ELT_T g = POST_OP_LITERAL(1.5957691669464111328125) * s
+            * (POST_OP_LITERAL(1.) + POST_OP_LITERAL(0.044715) * s * s);
+    return s / (POST_OP_LITERAL(1.) + exp(-g));
+}
+
+ELT_T __attribute__((overloadable)) swish_fwd(ELT_T s, float alpha) {
+    return s / (POST_OP_LITERAL(1.) + exp(-alpha * s));
+}
+
+ELT_T __attribute__((overloadable)) log_fwd(ELT_T s) {
+    return log(s);
+}
+
+ELT_T __attribute__((overloadable)) clip_fwd(ELT_T s, float alpha, float beta) {
+    return fmin(fmax(s, (ELT_T)alpha), (ELT_T)beta);
+}
+
+ELT_T __attribute__((overloadable)) clip_v2_fwd(
+        ELT_T s, float alpha, float beta) {
+    return clip_fwd(s, alpha, beta);
+}
+
+ELT_T __attribute__((overloadable)) pow_fwd(ELT_T s, float alpha, float beta) {
+    return alpha * pow(s, (ELT_T)beta);
+}
+
+ELT_T __attribute__((overloadable)) gelu_erf_fwd(ELT_T s) {
+    return POST_OP_LITERAL(0.5) * s
+            * (POST_OP_LITERAL(1.)
+                    + erf(s * POST_OP_LITERAL(0.707106769084930419921875)));
+}
+
+ELT_T __attribute__((overloadable)) round_fwd(ELT_T s) {
+    return rint(s);
+}
+
+ELT_T __attribute__((overloadable)) hardsigmoid_fwd(
+        ELT_T s, float alpha, float beta) {
+    const ELT_T v = linear_fwd(s, alpha, beta);
+    return isnan(v)
+            ? v
+            : clamp(v, (ELT_T)POST_OP_LITERAL(0.), (ELT_T)POST_OP_LITERAL(1.));
+}
+
+ELT_T __attribute__((overloadable)) hardswish_fwd(
+        ELT_T s, float alpha, float beta) {
+    return s * hardsigmoid_fwd(s, alpha, beta);
+}
+
+ELT_T __attribute__((overloadable)) fwd_eltwise_common(
+        int eltwise_alg, ELT_T x, float alpha_, float beta_, float scale_) {
+    switch (eltwise_alg) {
+        case eltwise_relu: return scale_ * relu_fwd(x, alpha_);
+        case eltwise_linear: return scale_ * linear_fwd(x, alpha_, beta_);
+        case eltwise_soft_relu: return scale_ * soft_relu_fwd(x, alpha_);
+        case eltwise_mish: return scale_ * mish_fwd(x);
+        case eltwise_logistic: return scale_ * logistic_fwd(x);
+        case eltwise_tanh: return scale_ * tanh_fwd(x);
+        case eltwise_elu: return scale_ * elu_fwd(x, alpha_);
+        case eltwise_square: return scale_ * square_fwd(x);
+        case eltwise_sqrt: return scale_ * sqrt_fwd(x);
+        case eltwise_abs: return scale_ * abs_fwd(x);
+        case eltwise_exp: return scale_ * exp_fwd(x);
+        case eltwise_gelu_tanh: return scale_ * gelu_tanh_fwd(x);
+        case eltwise_swish: return scale_ * swish_fwd(x, alpha_);
+        case eltwise_log: return scale_ * log_fwd(x);
+        case eltwise_clip: return scale_ * clip_fwd(x, alpha_, beta_);
+        case eltwise_clip_v2: return scale_ * clip_v2_fwd(x, alpha_, beta_);
+        case eltwise_pow: return scale_ * pow_fwd(x, alpha_, beta_);
+        case eltwise_gelu_erf: return scale_ * gelu_erf_fwd(x);
+        case eltwise_round: return scale_ * round_fwd(x);
+        case eltwise_hardswish: return scale_ * hardswish_fwd(x, alpha_, beta_);
+        case eltwise_hardsigmoid:
+            return scale_ * hardsigmoid_fwd(x, alpha_, beta_);
+        case eltwise_relu_dst: return scale_ * relu_fwd(x, alpha_);
+        case eltwise_logistic_dst: return scale_ * logistic_fwd(x);
+        case eltwise_tanh_dst: return scale_ * tanh_fwd(x);
+        case eltwise_elu_dst: return scale_ * elu_fwd(x, alpha_);
+        case eltwise_sqrt_dst: return scale_ * sqrt_fwd(x);
+        case eltwise_exp_dst: return scale_ * exp_fwd(x);
+        case eltwise_clip_v2_dst: return scale_ * clip_v2_fwd(x, alpha_, beta_);
+        default: return x;
+    }
+}

--- a/src/gpu/intel/jit/ir/hw.hpp
+++ b/src/gpu/intel/jit/ir/hw.hpp
@@ -58,6 +58,14 @@ inline bool prefer_large_grf(
     return gpu_attr->grf_per_thread() > 128;
 }
 
+inline bool prefer_dpas(
+        const dsl::hw_t &hw, const gpu_primitive_attr_t *gpu_attr) {
+    if (!gpu_attr || !gpu_attr->use_dpas()) return false;
+    gpu_assert(hw.systolic_support())
+            << "dpas requested on hardware without systolic support";
+    return true;
+}
+
 } // namespace jit
 } // namespace intel
 } // namespace gpu

--- a/src/gpu/intel/jit/ir/tensor.hpp
+++ b/src/gpu/intel/jit/ir/tensor.hpp
@@ -374,6 +374,19 @@ private:
     dim_t block_;
 };
 
+// Some complex expressions need more than one simplify() call.
+inline expr_t simplify_repeat(
+        const expr_t &e, const constraint_set_t &cset, int max_tries = 5) {
+    auto ret = e;
+    auto next = ir::simplify(ret, cset);
+    for (int i = 0; i < max_tries; i++) {
+        ret = next;
+        next = ir::simplify(next, cset);
+        if (next.is_equal(ret)) break;
+    }
+    return ret;
+}
+
 class mask_tensor_t {
 public:
     mask_tensor_t() = default;
@@ -416,16 +429,8 @@ public:
     }
 
     void simplify(const constraint_set_t &cset) {
-        for (auto &mask : id2masks_) {
-            auto new_mask = ir::simplify(mask, cset);
-            // Some complex expressions need more than one simplify() call.
-            int max_tries = 5;
-            for (int i = 0; i < max_tries; i++) {
-                mask = new_mask;
-                new_mask = ir::simplify(new_mask, cset);
-                if (new_mask.is_equal(mask)) break;
-            }
-        }
+        for (auto &mask : id2masks_)
+            mask = simplify_repeat(mask, cset);
         mask2ids_.clear();
         for (int i = 0; i < int(id2masks_.size()); i++) {
             auto ret = mask2ids_.insert({id2masks_[i], i});
@@ -930,8 +935,9 @@ public:
         auto _vlayout = create_dense_vlayout();
         mask_tensor_t mask_tensor(_vlayout);
         icoord_t vargs(nvdims());
-        create_mask_tensor(mask_tensor, _vlayout, 0, vargs, tmask);
-        mask_tensor.simplify(cset);
+        // Distinct per-tdim mask factors are far fewer than elements.
+        std::vector<object_eq_map_t<expr_t, expr_t>> memo(ntdims());
+        create_mask_tensor(mask_tensor, _vlayout, 0, vargs, tmask, cset, memo);
         return mask_tensor;
     }
 
@@ -1045,12 +1051,13 @@ private:
 
     void create_mask_tensor(mask_tensor_t &mask_tensor,
             const layout_t &_vlayout, dim_idx_t vidx, icoord_t &vargs,
-            uint32_t tmask) const {
+            uint32_t tmask, const constraint_set_t &cset,
+            std::vector<object_eq_map_t<expr_t, expr_t>> &memo) const {
         if (vidx == _vlayout.ndims()) {
             bool is_init = false;
             coord_t vvalues;
             coord_t targs;
-            expr_t mask = bool_imm_t::make(true);
+            expr_t mask;
             for (dim_idx_t i = 0; i < ntdims(); i++) {
                 auto &tdim = tdims_[i];
                 if ((tmask & (1 << i)) == 0) continue;
@@ -1063,15 +1070,32 @@ private:
                     targs = cvt_vargs_to_targs(vargs);
                     is_init = true;
                 }
-                mask &= tdim.mask(targs[i], vvars_, vvalues);
+                auto f = tdim.mask(targs[i], vvars_, vvalues);
+                expr_t fs;
+                auto it = memo[i].find(f);
+                if (it != memo[i].end()) {
+                    fs = it->second;
+                } else {
+                    fs = simplify_repeat(f, cset);
+                    memo[i].emplace(f, fs);
+                }
+                // Fold the conjunction as simplify_rewrite_and() would.
+                if (auto *imm = fs.as_ptr<bool_imm_t>()) {
+                    if (imm->value) continue;
+                    mask = fs;
+                    break;
+                }
+                mask = mask.is_empty() ? fs : (mask & fs);
             }
+            if (mask.is_empty()) mask = bool_imm_t::make(true);
             mask_tensor.set_mask(_vlayout.offset<dim_t>(vargs), mask);
             return;
         }
 
         for (dim_idx_t i = 0; i < vdims()[vidx]; i++) {
             vargs[vidx] = i;
-            create_mask_tensor(mask_tensor, _vlayout, vidx + 1, vargs, tmask);
+            create_mask_tensor(
+                    mask_tensor, _vlayout, vidx + 1, vargs, tmask, cset, memo);
         }
     }
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cl
@@ -99,11 +99,14 @@ void load_bias(
 
 #if WITH_POST_OP
 #if WITH_BINARY_GROUPED_SCALE
+// One column-block of the [M,N] grouped scale, applied a block at a time.
+DECLARE_2D_TILE(binary_group_chunk_type, float, SUBGROUP_SIZE,
+        ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
+        ugemm_grouped_c_type_nblock0, 1)
 #if !BINARY_SCALE_GROUPED_DT_F32
-// Intermediate tile for loading non-float binary scale data before converting
-DECLARE_2D_TILE(binary_group_in_tile_type, BINARY_SCALE_GROUPED_TILE_DATA_T,
+DECLARE_2D_TILE(binary_group_chunk_in_type, BINARY_SCALE_GROUPED_TILE_DATA_T,
         SUBGROUP_SIZE, ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
-        ugemm_grouped_c_type_nblock0, ugemm_grouped_c_type_nblock1)
+        ugemm_grouped_c_type_nblock0, 1)
 #endif
 #endif
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cl
@@ -98,6 +98,9 @@ void load_bias(
 #endif
 
 #if WITH_POST_OP
+#define ELTWISE_VECTOR_API
+#include "gpu/intel/include/eltwise.h"
+
 #if WITH_BINARY_GROUPED_SCALE
 // One column-block of the [M,N] grouped scale, applied a block at a time.
 DECLARE_2D_TILE(binary_group_chunk_type, float, SUBGROUP_SIZE,

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -42,6 +42,13 @@ namespace gpu {
 namespace intel {
 namespace matmul {
 
+namespace {
+
+// grouped_micro_gemm cross-thread argument bytes, plus headroom.
+constexpr int host_argument_bytes = 256;
+
+} // namespace
+
 status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
     using namespace jit;
     using namespace gemmstone;
@@ -97,6 +104,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
     opts.offsetB = src_quant_.with_zp();
     opts.slmPtr = true;
     opts.kParallelLocal = is_gemv_;
+    const HostPayload host {sg_size_, host_argument_bytes};
 
     if (opts.scaleA) {
         data_type_t wei_scale_dt = wei_quant_.scale_dt();
@@ -218,7 +226,8 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
     };
 
     try {
-        gemm_ = selectGEMM(opts, hw_info, sizes, problem, {}, strat_override);
+        gemm_ = selectGEMM(
+                opts, host, hw_info, sizes, problem, {}, strat_override);
     } catch (const std::runtime_error &) {
         std::vector<StrategyRequirement> reqs;
 
@@ -273,7 +282,7 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
                         std::min((dim_t)(avg_m / reqs[1].value), max_wg_n))));
         try {
             gemm_ = selectGEMM(
-                    opts, hw_info, sizes, problem, reqs, strat_override);
+                    opts, host, hw_info, sizes, problem, reqs, strat_override);
         } catch (const std::runtime_error &ex) {
             VDISPATCH_MATMUL_IC(false,
                     "gemm microkernel generation failure with message: %s",

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -282,14 +282,13 @@ status_t grouped_micro_gemm_t::pd_t::init_microkernels(impl::engine_t *engine) {
     }
 
     /* Generate microkernel shims */
-    ShimOptions shimOptions;
-    shimOptions.subgroupSize = sg_size_;
-    shimOptions.useTileOps = true;
-    shimOptions.decorator = "grouped";
-
     kernel_ctx_.define_int("SUBGROUP_SIZE", sg_size_);
-    kernel_ctx_.add_custom_header("gemm_grouped.h",
-            generateShim(gemm_, HostLanguage::OpenCL_C, shimOptions));
+
+    compute::microkernel_shims_t shims(
+            kernel_ctx_, sg_size_, dev_info->gpu_arch());
+    shims.add("gemm_grouped.h", "grouped", gemm_);
+    shims.require_grfs(strategyGRFs_);
+    shims.finalize();
 
     return status::success;
 }
@@ -477,14 +476,6 @@ status_t grouped_micro_gemm_t::pd_t::init(impl::engine_t *engine) {
     wei_quant_.define_macros(kernel_ctx_, "WEI");
 
     kernel_ctx_.set_data_type(dst_dt);
-
-    const int grf_min = std::max(strategyGRFs_, gemm_.grfMin);
-    const bool is_xe3p = dev_info->gpu_arch() >= compute::gpu_arch_t::xe3p;
-    if (is_xe3p && grf_min > 256) {
-        kernel_ctx_.add_option("-cl-intel-512-GRF-per-thread");
-    } else if (grf_min > 128) {
-        kernel_ctx_.add_option("-cl-intel-256-GRF-per-thread");
-    }
 
     def_data_type(kernel_ctx_, src_dt, "SRC");
     def_data_type(kernel_ctx_, wei_dt, "WEI");

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -157,24 +157,35 @@ inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, l
                     to_ocl_float(e.eltwise.alpha).c_str(), i, i);
         } else if (e.is_binary()) {
             if (po_chain[i] == po_kind_t::binary_grouped_scale) {
-                s += utils::format(R"(
-#define CONCAT_I(var) var##_%d
-    const global BINARY_SCALE_GROUPED_TILE_DATA_T *group_scale_ptr = grouped_scale + src_offset * lddst;
-
-    ugemm_grouped_c_type CONCAT_I(binary_group_tile);
+                s += R"(
+    {
+        const global BINARY_SCALE_GROUPED_TILE_DATA_T *group_scale_ptr
+                = grouped_scale + src_offset * lddst;
+#define GRP_BC ugemm_grouped_c_type_block1
+#define GRP_NBR ugemm_grouped_c_type_nblock0
+#define GRP_NBC ugemm_grouped_c_type_nblock1
+#pragma unroll
+        for (int gcb = 0; gcb < GRP_NBC; gcb++) {
+            binary_group_chunk_type binary_group_chunk;
 #if BINARY_SCALE_GROUPED_DT_F32
-    tile_load(&CONCAT_I(binary_group_tile), group_scale_ptr, n, m, lddst, sg_i0, sg_j0);
+            tile_load(&binary_group_chunk, group_scale_ptr, n, m, lddst, sg_i0,
+                    sg_j0 + gcb * GRP_BC);
 #else
-    binary_group_in_tile_type CONCAT_I(binary_group_in_tile);
-    tile_load(&CONCAT_I(binary_group_in_tile), group_scale_ptr, n, m, lddst, sg_i0, sg_j0);
-    tile_convert(CONCAT_I(binary_group_in_tile), CONCAT_I(binary_group_tile), BINARY_SCALE_GROUPED_TO_FLOAT);
+            binary_group_chunk_in_type binary_group_chunk_in;
+            tile_load(&binary_group_chunk_in, group_scale_ptr, n, m, lddst,
+                    sg_i0, sg_j0 + gcb * GRP_BC);
+            tile_convert(binary_group_chunk_in, binary_group_chunk,
+                    BINARY_SCALE_GROUPED_TO_FLOAT);
 #endif
-#define binary_mul_%d(a, b) ((a) * (b))
-    tile_binary((*c_tile), CONCAT_I(binary_group_tile), CONCAT_I(binary_mul));
-#undef binary_mul_%d
-#undef CONCAT_I
-                         )",
-                        i, i, i);
+#pragma unroll
+            for (int gbb = 0; gbb < GRP_NBR; gbb++)
+                (*c_tile).x[GRP_NBR * gcb + gbb] *= binary_group_chunk.x[gbb];
+        }
+#undef GRP_BC
+#undef GRP_NBR
+#undef GRP_NBC
+    }
+                         )";
             } else if (po_chain[i] == po_kind_t::binary_dense_scale) {
                 s += utils::format(
                         R"(

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -31,6 +31,16 @@ namespace matmul {
     VCONDCHECK(primitive, create, check, matmul, (cond), \
             status::unimplemented, msg, ##__VA_ARGS__);
 
+bool is_eltwise_alg_supported(alg_kind_t alg) {
+    using namespace alg_kind;
+    return utils::one_of(alg, eltwise_relu, eltwise_linear, eltwise_soft_relu,
+            eltwise_mish, eltwise_logistic, eltwise_tanh, eltwise_elu,
+            eltwise_square, eltwise_sqrt, eltwise_abs, eltwise_exp,
+            eltwise_gelu_tanh, eltwise_swish, eltwise_log, eltwise_clip,
+            eltwise_clip_v2, eltwise_pow, eltwise_gelu_erf, eltwise_round,
+            eltwise_hardswish, eltwise_hardsigmoid);
+}
+
 int find_po_in_chain(const po_kind_t *po_chain, po_kind_t kind) {
     for (int i = 0; i < 3; ++i) {
         if (po_chain[i] == kind) return i;
@@ -50,7 +60,7 @@ status_t check_post_op_chain(const primitive_attr_t &attr,
         VCHECK_MATMUL(
                 e.is_eltwise() || e.is_binary(), VERBOSE_UNSUPPORTED_POSTOP);
         if (e.is_eltwise()) {
-            VCHECK_MATMUL(e.eltwise.alg == alg_kind::eltwise_swish,
+            VCHECK_MATMUL(is_eltwise_alg_supported(e.eltwise.alg),
                     VERBOSE_UNSUPPORTED_POSTOP);
             po_chain[i] = po_kind_t::eltwise;
         } else if (e.is_binary()) {
@@ -149,12 +159,14 @@ inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, l
         const auto &e = po.entry_[i];
         if (e.is_eltwise()) {
             s += utils::format(R"(
-#define eltwise_apply_%d(v) ((%s) * ((v) / (1.0f + exp(-(%s) * (v)))))
+#define eltwise_apply_%d(v) fwd_eltwise_common(%d, v, %s, %s, %s)
     tile_elementwise((*c_tile), eltwise_apply_%d);
 #undef eltwise_apply_%d
                      )",
-                    i, to_ocl_float(e.eltwise.scale).c_str(),
-                    to_ocl_float(e.eltwise.alpha).c_str(), i, i);
+                    i, static_cast<int>(e.eltwise.alg),
+                    to_ocl_float(e.eltwise.alpha).c_str(),
+                    to_ocl_float(e.eltwise.beta).c_str(),
+                    to_ocl_float(e.eltwise.scale).c_str(), i, i);
         } else if (e.is_binary()) {
             if (po_chain[i] == po_kind_t::binary_grouped_scale) {
                 s += R"(

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.hpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.hpp
@@ -41,6 +41,8 @@ enum class po_kind_t {
     binary_nvfp4_scale
 };
 
+bool is_eltwise_alg_supported(alg_kind_t alg);
+
 int find_po_in_chain(const po_kind_t *po_chain, po_kind_t kind);
 
 status_t check_post_op_chain(const primitive_attr_t &attr,

--- a/src/gpu/intel/ocl/engine.cpp
+++ b/src/gpu/intel/ocl/engine.cpp
@@ -27,6 +27,7 @@
 
 #include "gemmstone/dsl/runtime.hpp"
 #include "gemmstone/microkernel/fuser.hpp"
+#include "gpu/intel/compute/ukernels.hpp"
 #include "gpu/intel/jit/generator_base.hpp"
 #include "gpu/intel/ocl/device_info.hpp"
 #include "gpu/intel/ocl/kernel.hpp"
@@ -241,7 +242,8 @@ cl_int maybe_print_debug_info(
 }
 
 inline status_t fuse_microkernels(cl_context context, cl_device_id device,
-        xpu::ocl::wrapper_t<cl_program> &program, const char *code) {
+        xpu::ocl::wrapper_t<cl_program> &program, const char *code,
+        int grf_size) {
     if (gemmstone::microkernel::hasMicrokernels(code)) {
         cl_int status = CL_SUCCESS;
         size_t binary_size = 0;
@@ -253,9 +255,7 @@ inline status_t fuse_microkernels(cl_context context, cl_device_id device,
         OCL_CHECK(xpu::ocl::clGetProgramInfo(program, CL_PROGRAM_BINARIES,
                 sizeof(binary_data), &binary_data, nullptr));
 
-        try {
-            gemmstone::microkernel::fuse(binary, code);
-        } catch (...) { return status::runtime_error; }
+        CHECK(compute::fuse_microkernels(binary, code, grf_size));
 
         auto nbinary_size = binary.size();
         auto nbinary_data = const_cast<const uint8_t *>(binary.data());
@@ -325,7 +325,8 @@ status_t engine_t::build_program_from_source(
     OCL_CHECK(maybe_print_debug_info(err, program, dev));
 
     if (kernel_ctx.has_custom_headers())
-        CHECK(fuse_microkernels(ctx, dev, program, pp_code_str_ptr));
+        CHECK(fuse_microkernels(
+                ctx, dev, program, pp_code_str_ptr, dev_info->grf_size()));
 
     return status::success;
 }

--- a/src/gpu/intel/primitive.cpp
+++ b/src/gpu/intel/primitive.cpp
@@ -33,7 +33,7 @@ status_t primitive_t::create_kernel(impl::engine_t *engine,
                 VERBOSE_KERNEL_CREATION_FAIL,
                 jitter ? jitter->kernel_name() : "cached");
         kernel->hash_dump("blob");
-        CHECK(register_kernels({*kernel}));
+        if (register_kernel) CHECK(register_kernels({*kernel}));
         return status::success;
     }
     VCHECK_KERNEL(intel_engine->create_kernel(kernel, jitter),

--- a/src/gpu/intel/primitive_attr.hpp
+++ b/src/gpu/intel/primitive_attr.hpp
@@ -26,30 +26,43 @@ namespace gpu {
 namespace intel {
 
 struct gpu_primitive_attr_t : public primitive_attr_item_t {
-    gpu_primitive_attr_t(int grf_per_thread = 0)
-        : grf_per_thread_(grf_per_thread) {}
+    gpu_primitive_attr_t(int grf_per_thread = 0, bool use_dpas = false)
+        : grf_per_thread_(grf_per_thread), use_dpas_(use_dpas) {}
 
     std::unique_ptr<primitive_attr_item_t> clone() const override {
-        return utils::make_unique<gpu_primitive_attr_t>(grf_per_thread_);
+        return utils::make_unique<gpu_primitive_attr_t>(
+                grf_per_thread_, use_dpas_);
     }
 
-    bool has_default_values() const override { return grf_per_thread_ == 0; }
+    bool has_default_values() const override {
+        return grf_per_thread_ == 0 && !use_dpas_;
+    }
 
     bool is_equal(const primitive_attr_item_t &other) const override {
         auto *other_ptr = utils::downcast<const gpu_primitive_attr_t *>(&other);
-        return grf_per_thread_ == other_ptr->grf_per_thread_;
+        return grf_per_thread_ == other_ptr->grf_per_thread_
+                && use_dpas_ == other_ptr->use_dpas_;
     }
 
-    size_t get_hash() const override { return grf_per_thread_; }
+    size_t get_hash() const override {
+        size_t seed = 0;
+        seed = hash_combine(seed, grf_per_thread_);
+        seed = hash_combine(seed, use_dpas_);
+        return seed;
+    }
 
     void serialize(serialization_stream_t &stream) const override {
         stream.append(grf_per_thread_);
+        stream.append(use_dpas_);
     }
 
     int grf_per_thread() const { return grf_per_thread_; }
+    bool use_dpas() const { return use_dpas_; }
+    void set_use_dpas(bool value) { use_dpas_ = value; }
 
 private:
     int grf_per_thread_;
+    bool use_dpas_ = false;
 };
 
 } // namespace intel

--- a/src/gpu/intel/reorder/jit.cpp
+++ b/src/gpu/intel/reorder/jit.cpp
@@ -78,8 +78,8 @@ status_t gen_t::pd_t::init(impl::engine_t *engine, impl::engine_t *src_engine,
             VERBOSE_UNSUPPORTED_DT_CFG);
 
     using sm = dnnl_primitive_attr::skip_mask_t;
-    auto skip_mask
-            = sm::post_ops | sm::zero_points | sm::scales | sm::rounding_mode;
+    auto skip_mask = sm::post_ops | sm::zero_points | sm::scales
+            | sm::rounding_mode | sm::gpu_attr;
     VDISPATCH_REORDER(
             attr()->has_default_values(skip_mask), VERBOSE_UNSUPPORTED_ATTR);
     VDISPATCH_REORDER(extra_ok(true), VERBOSE_UNSUPPORTED_MD_FLAG, "extra_ok");
@@ -136,6 +136,7 @@ status_t gen_t::pd_t::init(impl::engine_t *engine, impl::engine_t *src_engine,
     dsl::hw_t hw(make_ir_hw(engine));
     dsl::kernel::options_t options(hw);
     options.set_regs(prefer_large_grf(hw, gpu_attr) ? 256 : 128);
+    options.set_require_dpas(prefer_dpas(hw, gpu_attr));
     options.set_simd(16);
     cfg = std::make_shared<config_t>(options, src_layout, dst_layout);
     cfg->set_zp_cfg(zp_cfg);

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -88,12 +88,16 @@ bool with_quantize_common(const quant_entry_t &entry) {
     return !entry.has_default_values() && ((entry.get_mask() & 12) == 0);
 }
 
+// micro_sdpa/micro_sdpa_bwd cross-thread argument bytes, plus headroom.
+constexpr int host_argument_bytes_fwd = 320;
+constexpr int host_argument_bytes_bwd = 256;
+
 compute::gpu_arch_t gpu_arch(const micro::HWInformation &hw_info) {
     return jit::convert_ngen_arch_to_dnnl(
             getCore(ngen::npack::decodeHWIPVersion(hw_info.gmdid).family));
 }
 
-} /* anonymous namespace */
+} // namespace
 
 status_t update_config_from_devenv_values(
         fwd_config_t *config, bool quantized) {
@@ -1181,6 +1185,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
             opts_vs, sizes_kq, sizes_vs, ukernel_config);
 
+    const micro::HostPayload host {subgroup_size, host_argument_bytes_fwd};
     const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs;
@@ -1224,8 +1229,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
         }
     };
     try {
-        gemm_kq = micro::selectGEMM(opts_kq, hw_info, sizes_kq, problem_kq,
-                reqs_kq, kq_strat_override);
+        gemm_kq = micro::selectGEMM(opts_kq, host, hw_info, sizes_kq,
+                problem_kq, reqs_kq, kq_strat_override);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_kq microkernel generation failure with message: %s",
@@ -1259,11 +1264,11 @@ status_t micro_fwd_params_t::get_kernel_ctx(
                 strategy.dpasw |= strategy.fused;
                 vs_strat_override(strategy);
             };
-            gemm_vs = micro::selectGEMM(
-                    opts_vs, hw_info, sizes_vs, problem_vs, reqs_vs, adjust_vs);
+            gemm_vs = micro::selectGEMM(opts_vs, host, hw_info, sizes_vs,
+                    problem_vs, reqs_vs, adjust_vs);
         } else {
-            gemm_vs = micro::selectGEMM(opts_vs, hw_info, sizes_vs, problem_vs,
-                    reqs_vs, vs_strat_override);
+            gemm_vs = micro::selectGEMM(opts_vs, host, hw_info, sizes_vs,
+                    problem_vs, reqs_vs, vs_strat_override);
         }
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
@@ -1347,6 +1352,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
             opts_vtdA, opts_ktq, opts_qdSt, sizes_kq, sizes_vs, sizes_vtdA,
             sizes_ktq, sizes_qdSt, ukernel_config);
 
+    const micro::HostPayload host {subgroup_size, host_argument_bytes_bwd};
     const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs, gemm_vtdA, gemm_ktq, gemm_qdSt;
@@ -1393,7 +1399,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     /* Ask microkernel provider for microkernel */
     try {
         gemm_kq = micro::selectGEMM(
-                opts_kq, hw_info, sizes_kq, problem_kq, reqs_kq);
+                opts_kq, host, hw_info, sizes_kq, problem_kq, reqs_kq);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_kq microkernel generation failure with message: %s",
@@ -1407,11 +1413,11 @@ status_t micro_bwd_params_t::get_kernel_ctx(
                 /* Enable dpasw */
                 strategy.dpasw |= strategy.fused;
             };
-            gemm_vs = micro::selectGEMM(
-                    opts_vs, hw_info, sizes_vs, problem_vs, reqs_vs, adjust_vs);
+            gemm_vs = micro::selectGEMM(opts_vs, host, hw_info, sizes_vs,
+                    problem_vs, reqs_vs, adjust_vs);
         } else {
             gemm_vs = micro::selectGEMM(
-                    opts_vs, hw_info, sizes_vs, problem_vs, reqs_vs);
+                    opts_vs, host, hw_info, sizes_vs, problem_vs, reqs_vs);
         }
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
@@ -1433,7 +1439,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
 
     try {
         gemm_vtdA = micro::selectGEMM(
-                opts_vtdA, hw_info, sizes_vtdA, problem_vtdA, reqs_vtdA);
+                opts_vtdA, host, hw_info, sizes_vtdA, problem_vtdA, reqs_vtdA);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_vtdA microkernel generation failure with message: %s",
@@ -1445,7 +1451,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
 
     try {
         gemm_ktq = micro::selectGEMM(
-                opts_ktq, hw_info, sizes_ktq, problem_ktq, reqs_ktq);
+                opts_ktq, host, hw_info, sizes_ktq, problem_ktq, reqs_ktq);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_ktq microkernel generation failure with message: %s",
@@ -1457,7 +1463,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
 
     try {
         gemm_qdSt = micro::selectGEMM(
-                opts_qdSt, hw_info, sizes_qdSt, problem_qdSt, reqs_qdSt);
+                opts_qdSt, host, hw_info, sizes_qdSt, problem_qdSt, reqs_qdSt);
     } catch (const std::runtime_error &ex) {
         VCHECK_SDPA_COND(false,
                 "gemm_qdSt microkernel generation failure with message: %s",

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -28,6 +28,7 @@
 #include "gpu/intel/compute/ukernels.hpp"
 #include "gpu/intel/compute/utils.hpp"
 #include "gpu/intel/gemm/jit/gen_kernel.hpp"
+#include "gpu/intel/jit/utils/type_bridge.hpp"
 #include "gpu/intel/primitive_conf.hpp"
 #include "gpu/intel/utils.hpp"
 
@@ -85,6 +86,11 @@ status_t validate_microkernel(
 ///   |  8 (0001) | false   |
 bool with_quantize_common(const quant_entry_t &entry) {
     return !entry.has_default_values() && ((entry.get_mask() & 12) == 0);
+}
+
+compute::gpu_arch_t gpu_arch(const micro::HWInformation &hw_info) {
+    return jit::convert_ngen_arch_to_dnnl(
+            getCore(ngen::npack::decodeHWIPVersion(hw_info.gmdid).family));
 }
 
 } /* anonymous namespace */
@@ -1175,6 +1181,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
             opts_vs, sizes_kq, sizes_vs, ukernel_config);
 
+    const auto hw_arch = gpu_arch(hw_info);
+
     micro::Package gemm_kq, gemm_vs;
 
     /* Set up microkernel strategy */
@@ -1268,28 +1276,10 @@ status_t micro_fwd_params_t::get_kernel_ctx(
             problem_kq.toString().c_str(), problem_vs.toString().c_str());
 
     /* Generate microkernel shims */
-    micro::ShimOptions shimOptions;
-    shimOptions.subgroupSize = subgroup_size;
-    shimOptions.useTileOps = true;
-    shimOptions.decorator = "kq";
-
-    kernel_ctx.add_custom_header("gemm_kq.h",
-            micro::generateShim(gemm_kq, HostLanguage::OpenCL_C, shimOptions));
-
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "vs";
-
-    kernel_ctx.add_custom_header("gemm_vs.h",
-            micro::generateShim(gemm_vs, HostLanguage::OpenCL_C, shimOptions));
-
-    const int grf_min = std::max(gemm_kq.grfMin, gemm_vs.grfMin);
-    const auto product = ngen::npack::decodeHWIPVersion(hw_info.gmdid);
-    const bool is_xe3p = getCore(product.family) >= ngen::HW::Xe3p;
-    if (is_xe3p && grf_min > 256) {
-        kernel_ctx.add_option("-cl-intel-512-GRF-per-thread");
-    } else if (grf_min > 128) {
-        kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
-    }
+    compute::microkernel_shims_t shims(kernel_ctx, subgroup_size, hw_arch);
+    shims.add("gemm_kq.h", "kq", gemm_kq);
+    shims.add("gemm_vs.h", "vs", gemm_vs);
+    shims.finalize();
 
     return status::success;
 }
@@ -1356,6 +1346,8 @@ status_t micro_bwd_params_t::get_kernel_ctx(
             problem_vtdA, problem_ktq, problem_qdSt, opts_kq, opts_vs,
             opts_vtdA, opts_ktq, opts_qdSt, sizes_kq, sizes_vs, sizes_vtdA,
             sizes_ktq, sizes_qdSt, ukernel_config);
+
+    const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs, gemm_vtdA, gemm_ktq, gemm_qdSt;
 
@@ -1435,21 +1427,9 @@ status_t micro_bwd_params_t::get_kernel_ctx(
             problem_qdSt.toString().c_str());
 
     /* Generate microkernel shims */
-    micro::ShimOptions shimOptions;
-    shimOptions.subgroupSize = subgroup_size;
-    shimOptions.useTileOps = true;
-    shimOptions.decorator = "kq";
-
-    std::string gemm_kq_header
-            = micro::generateShim(gemm_kq, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_kq.h", std::move(gemm_kq_header));
-
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "vs";
-
-    std::string gemm_vs_header
-            = micro::generateShim(gemm_vs, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_vs.h", std::move(gemm_vs_header));
+    compute::microkernel_shims_t shims(kernel_ctx, subgroup_size, hw_arch);
+    shims.add("gemm_kq.h", "kq", gemm_kq);
+    shims.add("gemm_vs.h", "vs", gemm_vs);
 
     try {
         gemm_vtdA = micro::selectGEMM(
@@ -1461,12 +1441,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     }
     CHECK(validate_microkernel(gemm_vtdA, "gemm_vtdA"));
 
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "vtdA";
-
-    std::string gemm_vtdA_header = micro::generateShim(
-            gemm_vtdA, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_vtdA.h", std::move(gemm_vtdA_header));
+    shims.add("gemm_vtdA.h", "vtdA", gemm_vtdA);
 
     try {
         gemm_ktq = micro::selectGEMM(
@@ -1478,12 +1453,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     }
     CHECK(validate_microkernel(gemm_ktq, "gemm_ktq"));
 
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "ktq";
-
-    std::string gemm_ktq_header = micro::generateShim(
-            gemm_ktq, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_ktq.h", std::move(gemm_ktq_header));
+    shims.add("gemm_ktq.h", "ktq", gemm_ktq);
 
     try {
         gemm_qdSt = micro::selectGEMM(
@@ -1495,22 +1465,9 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     }
     CHECK(validate_microkernel(gemm_qdSt, "gemm_qdSt"));
 
-    shimOptions.microkernelID++;
-    shimOptions.decorator = "qdSt";
+    shims.add("gemm_qdSt.h", "qdSt", gemm_qdSt);
 
-    std::string gemm_qdSt_header = micro::generateShim(
-            gemm_qdSt, HostLanguage::OpenCL_C, shimOptions);
-    kernel_ctx.add_custom_header("gemm_qdSt.h", std::move(gemm_qdSt_header));
-
-    const int grf_min = std::max({gemm_kq.grfMin, gemm_vs.grfMin,
-            gemm_vtdA.grfMin, gemm_ktq.grfMin, gemm_qdSt.grfMin});
-    const auto product = ngen::npack::decodeHWIPVersion(hw_info.gmdid);
-    const bool is_xe3p = getCore(product.family) >= ngen::HW::Xe3p;
-    if (is_xe3p && grf_min > 256) {
-        kernel_ctx.add_option("-cl-intel-512-GRF-per-thread");
-    } else if (grf_min > 128) {
-        kernel_ctx.add_option("-cl-intel-256-GRF-per-thread");
-    }
+    shims.finalize();
 
     return status::success;
 }

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -94,11 +94,9 @@ constexpr int host_argument_bytes_bwd = 256;
 
 // XXX: Use the adjusted argument base as a workaround to avoid performance
 // regressions in some cases.
-int host_argument_bytes_fwd_for(
-        const micro::HWInformation &hw_info, bool systolic) {
+int host_argument_bytes_fwd_for(const micro::HWInformation &hw_info) {
     auto family = ngen::npack::decodeHWIPVersion(hw_info.gmdid).family;
     if (family == ngen::ProductFamily::NVLP) return 256;
-    if (systolic && ngen::getCore(family) == ngen::HW::XeHPG) return 288;
     return host_argument_bytes_fwd;
 }
 
@@ -1195,8 +1193,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
             opts_vs, sizes_kq, sizes_vs, ukernel_config);
 
-    const micro::HostPayload host {subgroup_size,
-            host_argument_bytes_fwd_for(hw_info, use_systolic_ukernel)};
+    const micro::HostPayload host {
+            subgroup_size, host_argument_bytes_fwd_for(hw_info)};
     const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs;

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -92,6 +92,16 @@ bool with_quantize_common(const quant_entry_t &entry) {
 constexpr int host_argument_bytes_fwd = 320;
 constexpr int host_argument_bytes_bwd = 256;
 
+// XXX: Use the adjusted argument base as a workaround to avoid performance
+// regressions in some cases.
+int host_argument_bytes_fwd_for(
+        const micro::HWInformation &hw_info, bool systolic) {
+    auto family = ngen::npack::decodeHWIPVersion(hw_info.gmdid).family;
+    if (family == ngen::ProductFamily::NVLP) return 256;
+    if (systolic && ngen::getCore(family) == ngen::HW::XeHPG) return 288;
+    return host_argument_bytes_fwd;
+}
+
 compute::gpu_arch_t gpu_arch(const micro::HWInformation &hw_info) {
     return jit::convert_ngen_arch_to_dnnl(
             getCore(ngen::npack::decodeHWIPVersion(hw_info.gmdid).family));
@@ -1185,7 +1195,8 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     deserialize_config_to_gemmstone(hw_info, problem_kq, problem_vs, opts_kq,
             opts_vs, sizes_kq, sizes_vs, ukernel_config);
 
-    const micro::HostPayload host {subgroup_size, host_argument_bytes_fwd};
+    const micro::HostPayload host {subgroup_size,
+            host_argument_bytes_fwd_for(hw_info, use_systolic_ukernel)};
     const auto hw_arch = gpu_arch(hw_info);
 
     micro::Package gemm_kq, gemm_vs;

--- a/src/gpu/intel/ze/engine.cpp
+++ b/src/gpu/intel/ze/engine.cpp
@@ -149,11 +149,8 @@ status_t engine_t::create_kernels(std::vector<compute::kernel_t> *kernels,
             device(), context(), code, options, binary));
 
     if (kernel_ctx.has_custom_headers()
-            && gemmstone::microkernel::hasMicrokernels(code_c)) {
-        try {
-            gemmstone::microkernel::fuse(binary, code_c);
-        } catch (...) { return status::runtime_error; }
-    }
+            && gemmstone::microkernel::hasMicrokernels(code_c))
+        CHECK(compute::fuse_microkernels(binary, code_c, dev_info->grf_size()));
 
     CHECK(convert_to_ze(*kernels, kernel_names, binary));
 

--- a/third_party/ngen/ngen_interface.hpp
+++ b/third_party/ngen/ngen_interface.hpp
@@ -139,6 +139,7 @@ public:
                           size_t z = 1)                  { wg[0] = x; wg[1] = y; wg[2] = z; }
 
     void setArgumentBase(RegData base)                   { baseOverride = base; }
+    RegData getArgumentBase() const                      { return baseOverride; }
     void setInlineGRFCount(int grfs)                     { requestedInlineBytes = grfs * GRF::bytes(hw); }
     int32_t getSkipCrossThreadOffset() const             { return offsetSkipCrossThread; }
     std::array<int32_t, 2> getCTPatchOffsets() const     { return offsetCTPatches; }


### PR DESCRIPTION
PR backports four upstream GPU PRs to the v3.13 release branch:

- uxlfoundation/oneDNN#5693 - Reduce JIT conv/deconv primitive creation time
- uxlfoundation/oneDNN#5763 - Convolution: create pre/post reorders as nested primitives
- uxlfoundation/oneDNN#5767 - Validate microkernel registers against host thread payload
- uxlfoundation/oneDNN#5716 - Enable all eltwise algorithms in grouped GEMM
- uxlfoundation/oneDNN#5844 - Restore selectGEMM legacy API (to not break OpenVINO builds)
