### PR TITLE
cpu: rv64: eltwise: add bf16 support

### DIFF
--- a/src/cpu/cpu_eltwise_list.cpp
+++ b/src/cpu/cpu_eltwise_list.cpp
@@ -70,6 +70,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_AARCH64_ACL(acl_eltwise_fwd_t)
             CPU_INSTANCE_RV64(jit_uni_eltwise_fwd_t<v>)
             CPU_INSTANCE_RV64(jit_uni_eltwise_fwd_t<zvfh>)
+            CPU_INSTANCE_RV64(jit_uni_eltwise_fwd_t<zvfbfwma>)
             CPU_INSTANCE(ref_eltwise_fwd_t)
             nullptr,
         }},
@@ -85,6 +86,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_AARCH64(jit_uni_eltwise_bwd_t<sve>)
             CPU_INSTANCE_RV64(jit_uni_eltwise_bwd_t<v>)
             CPU_INSTANCE_RV64(jit_uni_eltwise_bwd_t<zvfh>)
+            CPU_INSTANCE_RV64(jit_uni_eltwise_bwd_t<zvfbfwma>)
             CPU_INSTANCE(ref_eltwise_bwd_t)
             nullptr,
         })},

--- a/src/cpu/rv64/jit_uni_eltwise.cpp
+++ b/src/cpu/rv64/jit_uni_eltwise.cpp
@@ -117,14 +117,20 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel_t {
                     VMA::ma);
             vle32_v(vmm_src, reg_src);
             if (!is_fwd_) vle32_v(vmm_diff_dst, reg_diff_dst);
-        } else if (dt == data_type::f16) {
+        } else if (dt == data_type::f16 || dt == data_type::bf16) {
             vsetvli(reg_vl, reg_work_amount, SEW::e16, LMUL::m1, VTA::ta,
                     VMA::ma);
             vle16_v(vmm_tmp, reg_src);
-            vfwcvt_f_f_v(vmm_src, vmm_tmp); // e16m1 -> e32m2
+            if (dt == data_type::bf16)
+                vfwcvtbf16_f_f_v(vmm_src, vmm_tmp); // Zvfbfmin: e16m1 -> e32m2
+            else
+                vfwcvt_f_f_v(vmm_src, vmm_tmp); // Zvfh: e16m1 -> e32m2
             if (!is_fwd_) {
                 vle16_v(vmm_tmp, reg_diff_dst);
-                vfwcvt_f_f_v(vmm_diff_dst, vmm_tmp);
+                if (dt == data_type::bf16)
+                    vfwcvtbf16_f_f_v(vmm_diff_dst, vmm_tmp);
+                else
+                    vfwcvt_f_f_v(vmm_diff_dst, vmm_tmp);
             }
             vsetvli(x0, reg_vl, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
         } else if (dt == data_type::s32) {
@@ -156,9 +162,12 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel_t {
         const data_type_t dt = data_type();
         if (dt == data_type::f32) {
             vse32_v(vmm_src, reg_dst);
-        } else if (dt == data_type::f16) {
+        } else if (dt == data_type::f16 || dt == data_type::bf16) {
             vsetvli(x0, reg_vl, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
-            vfncvt_f_f_w(vmm_tmp, vmm_src); // e32m2 -> e16m1
+            if (dt == data_type::bf16)
+                vfncvtbf16_f_f_w(vmm_tmp, vmm_src); // Zvfbfmin: e32m2 -> e16m1
+            else
+                vfncvt_f_f_w(vmm_tmp, vmm_src); // Zvfh: e32m2 -> e16m1
             vse16_v(vmm_tmp, reg_dst);
         } else if (dt == data_type::s32) {
             load_f32_const(freg_tmp, -2147483648.0f);
@@ -285,13 +294,14 @@ status_t jit_uni_eltwise_fwd_t<isa>::pd_t::init(const engine_t *engine) {
     const data_type_t d_type = src_md()->data_type;
 
     // Runtime ISA dispatch (this primitive is pure JIT and registered via
-    // CPU_INSTANCE_RV64). The zvfh instance owns f16; the v instance owns f32
-    // and the integer dtypes, which reuse the f32 kernel through
-    // convert-on-load / saturate-on-store.
+    // CPU_INSTANCE_RV64). The zvfh instance owns f16; the zvfbfwma instance
+    // owns bf16; the v instance owns f32 and the integer dtypes, which reuse
+    // the f32 kernel through convert-on-load / saturate-on-store.
     VDISPATCH_ELTWISE(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
     VDISPATCH_ELTWISE(is_fwd(), VERBOSE_BAD_PROPKIND);
-    VDISPATCH_ELTWISE(isa == zvfh
-                    ? d_type == data_type::f16
+    VDISPATCH_ELTWISE(isa == zvfh ? d_type == data_type::f16
+                    : isa == zvfbfwma
+                    ? d_type == data_type::bf16
                     : utils::one_of(d_type, data_type::f32, data_type::s32,
                               data_type::s8, data_type::u8),
             VERBOSE_UNSUPPORTED_DT);
@@ -378,11 +388,12 @@ status_t jit_uni_eltwise_bwd_t<isa>::pd_t::init(const engine_t *engine) {
 
     // Backward is float-only, matching x64/aarch64 (whose jit_uni_eltwise_bwd
     // JITs only floating dtypes and routes integers to ref_eltwise): zvfh owns
-    // f16, v owns f32.
+    // f16, zvfbfwma owns bf16, v owns f32.
     VDISPATCH_ELTWISE(mayiuse(isa), VERBOSE_UNSUPPORTED_ISA);
     VDISPATCH_ELTWISE(!is_fwd(), VERBOSE_BAD_PROPKIND);
-    VDISPATCH_ELTWISE(
-            isa == zvfh ? d_type == data_type::f16 : d_type == data_type::f32,
+    VDISPATCH_ELTWISE(isa == zvfh     ? d_type == data_type::f16
+                    : isa == zvfbfwma ? d_type == data_type::bf16
+                                      : d_type == data_type::f32,
             VERBOSE_UNSUPPORTED_DT);
     VDISPATCH_ELTWISE(utils::everyone_is(d_type, diff_src_md()->data_type,
                               diff_dst_md()->data_type),
@@ -465,9 +476,11 @@ status_t jit_uni_eltwise_bwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 
 template struct jit_uni_eltwise_fwd_t<v>;
 template struct jit_uni_eltwise_fwd_t<zvfh>;
+template struct jit_uni_eltwise_fwd_t<zvfbfwma>;
 
 template struct jit_uni_eltwise_bwd_t<v>;
 template struct jit_uni_eltwise_bwd_t<zvfh>;
+template struct jit_uni_eltwise_bwd_t<zvfbfwma>;
 
 } // namespace rv64
 } // namespace cpu


### PR DESCRIPTION
# Description

This PR enables the JIT eltwise path for `bf16` on RV64 by adding a third instance of `jit_uni_eltwise_{fwd,bwd}_t` keyed on the existing `zvfbfwma` ISA, alongside the already-shipped `v` (f32 / s32 / s8 / u8) and `zvfh` (f16) instances, and routing both forward and backward bf16 workloads through it on hardware that reports the Zvfbfwma extension.

This initial version provides:

1. A `bf16` forward JIT kernel that widens the input via `vfwcvtbf16_f_f_v` (Zvfbfmin), runs the existing f32 eltwise injector, and narrows the result via `vfncvtbf16_f_f_w`.
2. A `bf16` backward JIT kernel that mirrors the forward pattern on `data` and `diff_dst`; both widen via `vfwcvtbf16_f_f_v` and the result narrows back through `vfncvtbf16_f_f_w`.
3. Dispatch entries in `cpu_eltwise_list.cpp` for both forward and backward, gated on `mayiuse(zvfbfwma)`, mirroring how aarch64 routes bf16 to `jit_uni_eltwise_*` and how rv64 PReLU already routes bf16.

## Key Features

- **bf16 eltwise forward**: JIT on Zvfbfwma. Compute is always in f32, matching the injector contract.
- **bf16 eltwise backward**: JIT on Zvfbfwma. Mirrors the forward path on `data` / `diff_dst`; both widen via `vfwcvtbf16_f_f_v` and the result narrows back through `vfncvtbf16_f_f_w`.
- **Data Types**: `f32`, `f16` (Zvfh), `bf16` (Zvfbfwma), `s32`, `s8`, `u8` forward; `f32`, `f16`, `bf16` backward.
- **Memory Layouts**: dense, blocking (existing primitive contract).
- **Algorithms**: the same set the f32 eltwise injector already accepts. `eltwise_pow` and other unsupported algs still fall back to `ref_eltwise` (consistent with x64 and aarch64).

# Checklist

## General

- [x] Do all unit and benchdnn tests pass?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data?

All experiments are performed on the SG2044 (VLEN=128, RVV 1.0). Cross-compiled with GCC 14.2 (`-march=rv64gcv -O3 -Werror`). We draw comparisons among:

1. **baseline (upstream/main)**: bf16 dispatched to `ref:any` (eltwise fallback) — 14315 listed cases across the test file.
2. **this PR**: bf16 dispatched to `jit:rvv_zvfbfwma` where the injector accepts the alg — 6175 of the same 14315 listed cases; the remaining 8140 (pow + post-ops combinations) stay on `ref:any`, consistent with how x64 / aarch64 still route pow.

The benchdnn input `tests/benchdnn/inputs/eltwise/test_eltwise_bfloat16` exercises both directions (`--dir=FWD_D,BWD_D`) and a mix of algs / post-op combinations, and is the workload used for the cross-build comparison below.

### Correctness and JIT routing (full bf16 test file, `--mode=C`, 1c `taskset -c 27`)

| Build | Total cases | Ran | Pass | Fail | Skipped | `jit:rvv_zvfbfwma` | `ref:any` |
|-------|------------|-----|------|------|---------|---------------------|-----------|
| baseline (upstream/main) | 19110 | 14280 | 14280 | 0 | 4795 | 0 (0%) | 14315 (100%) |
| this PR | 19110 | 14280 | 14280 | 0 | 4795 | 6175 (43%) | 8140 (57%) |

The 4795 skipped are unsupported dtype / alg combos (identical between baseline and this PR). Both build and the 6175 JIT-routed cases (and the 8140 ref-routed cases) pass correctness on `--mode=C`. Routing was independently confirmed via `benchdnn --mode=P -v`, which prints `--impl=jit:rvv_zvfbfwma` for every fwd bf16 case and `--impl=jit:rvv_zvfbfwma --dir=BWD_D` for every bwd bf16 case — so the backward JIT kernel is in fact exercised by `--mode=C`, not silently falling through.

### Single-core (1c) `--mode=R` execute-phase timing

`--mode=R` (execution mode, no correctness / ref-compute) reports per-phase breakdown; the `execute` phase is the kernel-only time and is the cleanest A/B signal. The `total` figure is dominated by `fill` (writing reference data into the input) and `create_prim` (JIT compile), which are unrelated to kernel perf.

| Workload | Cases routed to JIT | Baseline `execute` (s) | This PR `execute` (s) | Kernel speedup |
|----------|---------------------|------------------------|------------------------|----------------|
| `test_eltwise_bfloat16`, full file, 19110 (1c `taskset -c 27`) | 6175 | 3.48 | 2.88 | **+17.2%** |
| `test_eltwise_bfloat16`, full file, 19110 (8c `taskset -c 20-28`, `OMP_NUM_THREADS=8`) | 6175 | 0.83 | 0.72 | **+13.3%** |
| Single 4096x4096 bf16 relu forward (1c) | 1 | 0.91 | 0.01 | **~91×** |

The full-file speedup measures the aggregate improvement across the 6175 JIT-routed cases, dominated by smaller shapes where the JIT paths are bandwidth-bound and the ref loops are not; the single large shape shows the kernel's compute speedup at scale, where each iteration is wide enough to amortize the bf16 widen / narrow pair.

