### PR TITLE
benchdnn: make update_ref_mem_map_from_prim() safe on call

### DIFF
--- a/tests/benchdnn/conv/conv.cpp
+++ b/tests/benchdnn/conv/conv.cpp
@@ -574,8 +574,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 break;
         }
 
-        update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
-                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res);
+        SAFE(update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
+                     cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res),
+                WARN);
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();

--- a/tests/benchdnn/deconv/deconv.cpp
+++ b/tests/benchdnn/deconv/deconv.cpp
@@ -516,8 +516,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 break;
         }
 
-        update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
-                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res);
+        SAFE(update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
+                     cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res),
+                WARN);
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();

--- a/tests/benchdnn/ip/ip.cpp
+++ b/tests/benchdnn/ip/ip.cpp
@@ -376,8 +376,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 break;
         }
 
-        update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
-                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res);
+        SAFE(update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
+                     cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res),
+                WARN);
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -966,8 +966,9 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
             } break;
         }
 
-        update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
-                cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res);
+        SAFE(update_ref_mem_map_from_prim(prim_ref, mem, ref_mem_map, exec_arg,
+                     cfg.get_swapped_dt(exec_arg2data_kind(exec_arg)), res),
+                WARN);
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();


### PR DESCRIPTION
Fixes [MFDNN-15464](https://jira.devtools.intel.com/browse/MFDNN-15464)
Gracefully finish, when it's not enough memory.