### PR TITLE
x64: conv: fix imm overflow in loop steps in jit-kernels

### DIFF
--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -1032,6 +1032,9 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                 VERBOSE_BLOCKING_FAIL, "bad argument for cpu reducer");
     }
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -1156,6 +1156,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
     jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -1785,6 +1785,9 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -1232,6 +1232,9 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             ? weights_d.extra().scale_adjust
             : 1.f;
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_PRIMITIVE_CONF_HPP
 #define CPU_X64_JIT_PRIMITIVE_CONF_HPP
 
+#include <limits>
 #include <queue>
 #include <stdint.h>
 
@@ -526,6 +527,24 @@ struct jit_1x1_conv_conf_t {
     cpu_isa_t isa;
     bool uses_permw_transposition;
 };
+
+// The 1x1 kernels advance data pointers with `add(reg64, imm)`, which encodes
+// only a 32-bit immediate, so a huge spatial silently produced a broken kernel.
+inline bool loop_steps_fit_int32(const jit_1x1_conv_conf_t &jcp) {
+    const dim_t max_imm = std::numeric_limits<int>::max();
+    // `load_loop_load_step` is multiplied by `load_loop_blk` inside generate().
+    // 6 is the maximum across all kernels that use this predicate
+    // (avx512_common / bf16 / x8s8s32x reach 6; avx2 / sse41 reach 3;
+    //  uni_x8s8s32x reaches 4).
+    const dim_t max_load_loop_blk = 6;
+    return jcp.reduce_loop_bcast_step <= max_imm
+            && jcp.reduce_loop_load_step <= max_imm
+            && jcp.bcast_loop_output_step <= max_imm
+            && jcp.bcast_loop_output_substep <= max_imm
+            && jcp.bcast_loop_bcast_step <= max_imm
+            && jcp.bcast_loop_bcast_substep <= max_imm
+            && jcp.load_loop_load_step <= max_imm / max_load_loop_blk;
+}
 
 struct jit_1x1_conv_args_t {
     const void *bcast_data = nullptr;

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -824,6 +824,9 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
     jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -943,6 +943,9 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             ? weights_d.extra().scale_adjust
             : 1.f;
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 


### PR DESCRIPTION
Fixes [MFDNN-15464](https://jira.devtools.intel.com/browse/MFDNN-15464).
It is a pre-existing issue in conv jit-kernels, causing `int`-overflow and silently creating a broken kernel, which is never used.
After widening internal datatypes to `dim_t` it starts causing SEGFAULTs on creation time. 
This fix is checking on possible overflow before kernels are created and skips the kernel creation.
