### PR TITLE
backport: x64: conv: fix imm overflow in loop steps in jit-kernels

### DIFF
--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -1031,6 +1031,9 @@ status_t jit_avx2_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
                 VERBOSE_BLOCKING_FAIL, "bad argument for cpu reducer");
     }
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -1155,6 +1155,9 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
     jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_1x1_conv_kernel.cpp
@@ -1784,6 +1784,9 @@ status_t jit_avx512_core_bf16_1x1_conv_kernel_t::init_conf(
         jcp.nthr = nstl::min(jcp.nthr, nthr);
     }
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -1287,6 +1287,9 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
             ? weights_d.extra().scale_adjust
             : 1.f;
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -17,6 +17,7 @@
 #ifndef CPU_X64_JIT_PRIMITIVE_CONF_HPP
 #define CPU_X64_JIT_PRIMITIVE_CONF_HPP
 
+#include <limits>
 #include <queue>
 #include <stdint.h>
 
@@ -528,6 +529,24 @@ struct jit_1x1_conv_conf_t {
     cpu_isa_t isa;
     bool uses_permw_transposition;
 };
+
+// The 1x1 kernels advance data pointers with `add(reg64, imm)`, which encodes
+// only a 32-bit immediate, so a huge spatial silently produced a broken kernel.
+inline bool loop_steps_fit_int32(const jit_1x1_conv_conf_t &jcp) {
+    const dim_t max_imm = std::numeric_limits<int>::max();
+    // `load_loop_load_step` is multiplied by `load_loop_blk` inside generate().
+    // 6 is the maximum across all kernels that use this predicate
+    // (avx512_common / bf16 / x8s8s32x reach 6; avx2 / sse41 reach 3;
+    //  uni_x8s8s32x reaches 4).
+    const dim_t max_load_loop_blk = 6;
+    return jcp.reduce_loop_bcast_step <= max_imm
+            && jcp.reduce_loop_load_step <= max_imm
+            && jcp.bcast_loop_output_step <= max_imm
+            && jcp.bcast_loop_output_substep <= max_imm
+            && jcp.bcast_loop_bcast_step <= max_imm
+            && jcp.bcast_loop_bcast_substep <= max_imm
+            && jcp.load_loop_load_step <= max_imm / max_load_loop_blk;
+}
 
 struct jit_1x1_conv_args_t {
     const void *bcast_data = nullptr;

--- a/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_sse41_1x1_conv_kernel_f32.cpp
@@ -823,6 +823,9 @@ status_t jit_sse41_1x1_conv_kernel_f32_t::init_conf(jit_1x1_conv_conf_t &jcp,
     jcp.nb_load = div_up(jcp.load_dim, jcp.load_block);
     jcp.nb_reduce = div_up(jcp.reduce_dim, jcp.reduce_block);
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -1002,6 +1002,9 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
             ? weights_d.extra().scale_adjust
             : 1.f;
 
+    VDISPATCH_CONV_IC(loop_steps_fit_int32(jcp), VERBOSE_BLOCKING_FAIL,
+            "loop step exceeds 32-bit immediate");
+
     return status::success;
 }
 


### PR DESCRIPTION
It's a backport of https://github.com/uxlfoundation/oneDNN/pull/5858. 