### PR TITLE
xe: ukernel: fix OpenVINO build

### DIFF
--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/fuser.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel/fuser.hpp
@@ -37,6 +37,11 @@ static constexpr const char *sigilBinary = "@_u_@";
 bool fuse(std::vector<uint8_t> &binary, const char *source, int grfBytes);
 bool hasMicrokernels(const char *source);
 
+// Transitional overload for legacy callers: skips payload validation.
+inline bool fuse(std::vector<uint8_t> &binary, const char *source) {
+    return fuse(binary, source, 0);
+}
+
 }
 GEMMSTONE_NAMESPACE_END
 

--- a/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/microkernel_selector.hpp
@@ -65,8 +65,10 @@ Package selectGEMM(const GEMMOptions &options, HostPayload host, HWInformation h
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),
                                      StrategyAdjuster strategyAdjuster = {}, SelectionObserver *observer = nullptr);
 
-/* Transitional overload for callers that do not yet pass a HostPayload. */
-GEMMSTONE_DEPRECATED("Defaults host payload base to r8, which may mismatch the host kernel and clobber the OpenCL kernel arguments. Use selectGEMM overload with HostPayload")
+/* Transitional overload for callers that do not yet pass a HostPayload.
+   Defaults the host payload base to r8, which may mismatch the host kernel and
+   clobber the OpenCL kernel arguments. Use selectGEMM with HostPayload.
+*/
 Package selectGEMM(const GEMMOptions &options, HWInformation hwInfo, SizeParams sizes,
                                      const GEMMProblem &problem,
                                      const std::vector<StrategyRequirement> &reqs = std::vector<StrategyRequirement>(),


### PR DESCRIPTION
This fixes [CVS-192933](https://jira.devtools.intel.com/browse/CVS-19293).

PR restores the old `fuse()` API and drops the deprecation warning as OpenVINO uses `/WX` (warnings are errors). Let's discuss a better approach offline with the OpenVINO team.

In the meantime, submitted a ticket for OV team: [CVS-192961](https://jira.devtools.intel.com/browse/CVS-192961).