### PR TITLE
xe: gemm: revert invalid PR 3930

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/address_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/address_setup.cxx
@@ -378,11 +378,8 @@ void Generator<hw>::setupAddr(Type T, const GRFRange &addr, const BO &ptr, const
                 auto pitch = bw * bcount * block.ebytes;
                 if (pitch < 64 || pitch & 0xF) hw_unsupported();
                 mov(1, addr[0].ud(4), pitch - 1);
-            } else {
+            } else
                 add(1, addr[0].ud(4), bld, -1);
-                if (!doBaseAdjust)
-                    max_<uint32_t>(1, addr[0].ud(4), addr[0].ud(4), addr[0].ud(2));
-	    }
 
             mov(1, addr[0].ud(7), (bw - 1) | ((bh - 1) << 8) | ((bcount - 1) << 16));
 


### PR DESCRIPTION
It looks #3930 like this was incorrectly introduced when xe3p was unembargoed.

Fixes [MFDNN-15470](https://jira.devtools.intel.com/browse/MFDNN-15470).