### PR TITLE
cpu: rv64: vectorize f16 softmax max reduction

### DIFF
--- a/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
@@ -38,6 +38,9 @@ using namespace Xbyak_riscv;
 #define F32_EXP_SUB_SUM_OFF(field) \
     static_cast<int32_t>(offsetof( \
             jit_rvv_softmax_f32_exp_sub_sum_kernel_t::call_params_t, field))
+#define F16_REDUCE_MAX_OFF(field) \
+    static_cast<int32_t>(offsetof( \
+            jit_rvv_softmax_f16_reduce_max_kernel_t::call_params_t, field))
 
 namespace {
 
@@ -65,6 +68,12 @@ template <bool store_exp>
 void dispatch_f32_exp_sub_sum(
         const jit_rvv_softmax_f32_exp_sub_sum_kernel_t::call_params_t *p) {
     static const jit_rvv_softmax_f32_exp_sub_sum_kernel_t kernel(store_exp);
+    kernel(p);
+}
+
+void dispatch_f16_reduce_max(
+        const jit_rvv_softmax_f16_reduce_max_kernel_t::call_params_t *p) {
+    static const jit_rvv_softmax_f16_reduce_max_kernel_t kernel;
     kernel(p);
 }
 
@@ -167,6 +176,108 @@ void jit_rvv_softmax_f16_exp_sub_sum(const dnnl::impl::float16_t *src,
     const jit_rvv_softmax_f16_exp_sub_sum_kernel_t::call_params_t p {
             src, tmp, len, sub, sum};
     dispatch_f16_exp_sub_sum(&p);
+}
+
+jit_rvv_softmax_f16_reduce_max_kernel_t::
+        jit_rvv_softmax_f16_reduce_max_kernel_t()
+    : jit_generator_t("jit_rvv_softmax_f16_reduce_max_kernel") {
+    create_kernel();
+}
+
+void jit_rvv_softmax_f16_reduce_max(const dnnl::impl::float16_t *src, dim_t len,
+        float *max_val, uint32_t *has_nan) {
+    const jit_rvv_softmax_f16_reduce_max_kernel_t::call_params_t p {
+            src, len, max_val, has_nan};
+    dispatch_f16_reduce_max(&p);
+}
+
+void jit_rvv_softmax_f16_reduce_max_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_len = a2;
+    const Reg reg_max_ptr = a3;
+    const Reg reg_nan_ptr = a4;
+    const Reg reg_vl = t0;
+    const Reg reg_bytes = t1;
+    const Reg reg_tmp = t2;
+    const Reg reg_has = t3;
+    const Reg reg_imm = t4;
+
+    const FReg f_seed = ft1;
+    const FReg f_max = ft2;
+
+    const VReg v_f16(4);
+    const VReg v_nan_acc(2);
+    const VReg v_x(8);
+    const VReg v_red(28);
+
+    auto load_f32_bits = [&](const FReg &freg, uint32_t bits) {
+        li(reg_imm, static_cast<int64_t>(bits));
+        fmv_w_x(freg, reg_imm);
+    };
+
+    ld(reg_src, reg_param, F16_REDUCE_MAX_OFF(src));
+    ld(reg_len, reg_param, F16_REDUCE_MAX_OFF(len));
+    ld(reg_max_ptr, reg_param, F16_REDUCE_MAX_OFF(max_val));
+    ld(reg_nan_ptr, reg_param, F16_REDUCE_MAX_OFF(has_nan));
+
+    // Seed for the max reduction: (float)numeric_limits<float16_t>::lowest()
+    // == -65504.0f == 0xC77FE000u. It only ever wins the reduction when every
+    // element is -65504, -inf or NaN, which matches the scalar `> max_val`
+    // loop seeded the same way.
+    load_f32_bits(f_seed, 0xC77FE000u);
+
+    // Clear the f16 tail lanes to +0.0 so a partial final chunk does not feed
+    // stale NaNs into the NaN-detection pass (the loop below loads with
+    // VTA::tu, i.e. tail undisturbed).
+    vsetvli(reg_vl, x0, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
+    vmv_v_i(v_f16, 0);
+    // Accumulator for the OR of all per-chunk NaN masks.
+    vmclr_m(v_nan_acc);
+
+    // Seed the vector max accumulator with float16 lowest.
+    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    vfmv_v_f(v_red, f_seed);
+
+    Label loop, finish;
+    L(loop);
+    beqz(reg_len, finish);
+
+    vsetvli(reg_vl, reg_len, SEW::e16, LMUL::m2, VTA::tu, VMA::ma);
+    vle16_v(v_f16, reg_src);
+    slli(reg_bytes, reg_vl, 1);
+    add(reg_src, reg_src, reg_bytes);
+
+    // A half is NaN iff (raw & 0x7fff) > 0x7c00, which is exactly the set of
+    // values for which x != x. Accumulate the per-chunk NaN masks.
+    vmfne_vv(v0, v_f16, v_f16);
+    vmor_mm(v_nan_acc, v_nan_acc, v0);
+
+    vfwcvt_f_f_v(v_x, v_f16);
+    vsetvli(reg_vl, reg_vl, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    // Exclude NaN lanes from the max (matches the scalar `val > max_val` test,
+    // under which a NaN never updates max_val).
+    vfmerge_vfm(v_x, v_x, f_seed);
+    vfredmax_vs(v_red, v_x, v_red);
+
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(finish);
+    vfmv_f_s(f_max, v_red);
+    fsw(f_max, reg_max_ptr, 0);
+
+    // has_nan = any set bit in the accumulated NaN mask.
+    vsetvli(reg_vl, x0, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
+    vfirst_m(reg_tmp, v_nan_acc);
+    slti(reg_has, reg_tmp, 0);
+    xori(reg_has, reg_has, 1);
+    sw(reg_has, reg_nan_ptr, 0);
+    ret();
+#else
+    ret();
+#endif
 }
 
 void jit_rvv_softmax_f16_affine_kernel_t::generate() {

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
@@ -144,6 +144,26 @@ private:
     bool store_exp_;
 };
 
+struct jit_rvv_softmax_f16_reduce_max_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const dnnl::impl::float16_t *src;
+        dim_t len;
+        float *max_val;
+        uint32_t *has_nan;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_softmax_f16_reduce_max_kernel_t)
+
+    jit_rvv_softmax_f16_reduce_max_kernel_t();
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+};
+
 void jit_rvv_softmax_f16_affine_from_f16(const dnnl::impl::float16_t *src,
         dnnl::impl::float16_t *dst, dim_t len, float sub, float mul);
 
@@ -161,6 +181,9 @@ void jit_rvv_softmax_f16_exp_sub_sum(const dnnl::impl::float16_t *src,
 
 void jit_rvv_softmax_f32_exp_sub_sum(const float *src, float *dst, dim_t len,
         float sub, float *sum, bool store_exp);
+
+void jit_rvv_softmax_f16_reduce_max(const dnnl::impl::float16_t *src, dim_t len,
+        float *max_val, uint32_t *has_nan);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/rvv_softmax.cpp
+++ b/src/cpu/rv64/rvv_softmax.cpp
@@ -133,13 +133,23 @@ void compute_softmax_f16_rvv(const dnnl::impl::float16_t *src,
         dnnl::impl::float16_t *dst, dim_t len, bool is_logsoftmax,
         bool is_softmax_inf_as_zero, float *scratchpad) {
 
-    float max_val = 0.f;
-    uint32_t has_nan = 0;
-    // Vectorized pass that replaces the former scalar loop with per-element
-    // f16->f32 widening (vfwcvt) and a vector max reduction. The seed and the
-    // NaN semantics reproduce the scalar `val > max_val` loop: a NaN never
-    // updates the max, and has_nan is set for any (raw & 0x7fff) > 0x7c00.
-    jit_rvv_softmax_f16_reduce_max(src, len, &max_val, &has_nan);
+    constexpr dim_t reduce_max_jit_min_len = 16;
+    float max_val
+            = (float)nstl::numeric_limits<dnnl::impl::float16_t>::lowest();
+    bool has_nan = false;
+    if (len >= reduce_max_jit_min_len) {
+        // The vectorized pass widens f16 to f32 and performs a vector max
+        // reduction. Its seed and NaN semantics reproduce the scalar loop.
+        uint32_t jit_has_nan = 0;
+        jit_rvv_softmax_f16_reduce_max(src, len, &max_val, &jit_has_nan);
+        has_nan = jit_has_nan;
+    } else {
+        for (dim_t i = 0; i < len; ++i) {
+            has_nan = has_nan || ((src[i].raw & 0x7fffu) > 0x7c00u);
+            const float val = (float)src[i];
+            if (val > max_val) max_val = val;
+        }
+    }
     const bool max_is_pos_inf = max_val == INFINITY;
 
     if (len == 1 && isfinite((float)src[0])) {

--- a/src/cpu/rv64/rvv_softmax.cpp
+++ b/src/cpu/rv64/rvv_softmax.cpp
@@ -133,14 +133,13 @@ void compute_softmax_f16_rvv(const dnnl::impl::float16_t *src,
         dnnl::impl::float16_t *dst, dim_t len, bool is_logsoftmax,
         bool is_softmax_inf_as_zero, float *scratchpad) {
 
-    float max_val
-            = (float)nstl::numeric_limits<dnnl::impl::float16_t>::lowest();
-    bool has_nan = false;
-    for (dim_t i = 0; i < len; ++i) {
-        has_nan = has_nan || ((src[i].raw & 0x7fffu) > 0x7c00u);
-        float val = (float)src[i];
-        if (val > max_val) max_val = val;
-    }
+    float max_val = 0.f;
+    uint32_t has_nan = 0;
+    // Vectorized pass that replaces the former scalar loop with per-element
+    // f16->f32 widening (vfwcvt) and a vector max reduction. The seed and the
+    // NaN semantics reproduce the scalar `val > max_val` loop: a NaN never
+    // updates the max, and has_nan is set for any (raw & 0x7fff) > 0x7c00.
+    jit_rvv_softmax_f16_reduce_max(src, len, &max_val, &has_nan);
     const bool max_is_pos_inf = max_val == INFINITY;
 
     if (len == 1 && isfinite((float)src[0])) {


### PR DESCRIPTION
# cpu: rv64: vectorize the f16 softmax max reduction

# Description

The RV64 f16 softmax implementation previously found the maximum value and detected NaNs with a scalar loop before entering the vectorized exponential and normalization passes. This scalar reduction becomes a visible part of the execution time, especially when the softmax axis is long.

This change replaces that loop with an RVV JIT kernel. It only affects f16 forward softmax and logsoftmax handled by `jit:rvv_zvfh`; other data types and the backward path are unchanged.

## Implementation

The new `jit_rvv_softmax_f16_reduce_max_kernel_t` processes the source in RVV chunks and:

1. Loads f16 elements with `vle16.v`.
2. Detects NaNs with an unordered self-compare and accumulates the masks.
3. Widens f16 values to f32 with `vfwcvt.f.f.v`.
4. Replaces NaN lanes with the original reduction seed, `-65504.0f`.
5. Computes the maximum with `vfredmax.vs` and reports whether any NaN was seen.

The reduction preserves the previous scalar behavior: NaNs do not update the maximum, while `has_nan` is set when any input is a NaN. The existing f16 exponential, sum, affine, and store paths are unchanged.

# Performance

## Test environment

| Item                  | Value                                    |
| --------------------- | ---------------------------------------- |
| Board                 | MUSE Pi Pro                              |
| CPU                   | SpacemiT X60, 8 cores, 1 thread per core |
| Architecture          | riscv64, RVV with Zvfh                   |
| Maximum CPU frequency | 1.6 GHz                                  |
| CPU governor          | `performance`                            |
| Memory                | 7.7 GiB                                  |
| OS/kernel             | Linux 6.6.63                             |

## Test method

The test uses the existing softmax shape batches shipped with benchdnn:

- `shapes_0d`
- `shapes_nlp`
- `shapes_large`
- `shapes_large_axis`
- `shapes_2d`
- `shapes_3d`

The matrix covers 46 existing shapes, all valid axes, softmax and logsoftmax, in-place and out-of-place execution, and the `abx` and `axb` source tag settings. The data type and direction are limited to the path changed by this patch: f16-to-f16 forward inference. This produces 992 test instances.

```sh
OMP_NUM_THREADS=8 \
OMP_PROC_BIND=close \
OMP_PLACES=cores \
LD_LIBRARY_PATH=<build>/src \
taskset -c 0-7 \
<build>/tests/benchdnn/benchdnn \
    --softmax \
    --mode=P \
    --max-ms-per-prb=300 \
    --perf-template=csv \
    --dir=FWD_D \
    --sdt=f16 \
    --ddt=f16 \
    --alg=SOFTMAX,LOGSOFTMAX \
    --inplace=true,false \
    --stag=abx,axb \
    --dtag=any \
    --axis=0,1 \
    --batch=inputs/softmax/shapes_0d \
    --batch=inputs/softmax/shapes_nlp \
    --batch=inputs/softmax/shapes_large \
    --axis=0,1,2 \
    --batch=inputs/softmax/shapes_large_axis \
    --axis=0,1,2,3 \
    --batch=inputs/softmax/shapes_2d \
    --axis=0,1,2,3,4 \
    --batch=inputs/softmax/shapes_3d
```

The baseline was run once, followed by the optimized build once. All results below use benchdnn's `avg_time` field exclusively; minimum times are not used. Speedup is defined as `baseline avg_time / optimized avg_time`. Both builds used the same CPU affinity and their own matching `libdnnl.so` through `LD_LIBRARY_PATH`.

Both builds reported 992 passed, 0 skipped, and 0 failed. Every instance selected `jit:rvv_zvfh`.

## Overall f16 forward results

| Scope      | Cases | Geometric-mean speedup | Median speedup |
| ---------- | ----: | ---------------------: | -------------: |
| All        |   992 |             **1.257x** |     **1.201x** |
| Softmax    |   496 |             **1.268x** |     **1.214x** |
| LogSoftmax |   496 |             **1.247x** |     **1.186x** |

Of the 992 instances, 737 improve by more than 2%, 63 are within +/-2%, and 192 regress by more than 2% when comparing average times.

## Results by softmax-axis length

| Axis length | Cases | Geometric-mean speedup | Median speedup | Regressions >2% |
| ----------- | ----: | ---------------------: | -------------: | --------------: |
| `<16`       |   280 |                 0.899x |         0.972x |             148 |
| `16-63`     |   248 |             **1.434x** |     **1.449x** |               5 |
| `64-255`    |   152 |             **1.583x** |     **1.559x** |               4 |
| `256-999`   |    48 |             **1.497x** |     **1.333x** |               0 |
| `>=1000`    |   264 |             **1.345x** |     **1.131x** |              35 |

The new reduction has a fixed JIT call and vector setup cost. The results show that this cost is not recovered for very short axes, especially axis length 1. The patch is consistently beneficial for the 16-999 range in this batch.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?


[optimized.csv](https://github.com/user-attachments/files/31220406/optimized.csv)

[baseline.csv](https://github.com/user-attachments/files/31220410/baseline.csv)

