### PR TITLE
oneDNN v3.12.4 patch release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 set(PROJECT_NAME "oneDNN")
 set(PROJECT_FULL_NAME "oneAPI Deep Neural Network Library (oneDNN)")
-set(PROJECT_VERSION "3.12.3")
+set(PROJECT_VERSION "3.12.4")
 
 project(${PROJECT_NAME} VERSION "${PROJECT_VERSION}" LANGUAGES C CXX)
 


### PR DESCRIPTION
This is a patch release containing the following changes to v3.12.3:
* Fixed performance regression in `f16` matmul on processors with Intel AMX (`bf16`, `u8`/`s8`) instruction set support (e9c54e5f386a4b6eb2f66b1d94aa1ef35cc2203a)
