### PR TITLE
xe: gemm: reduce compile times for kernel.db with -std=c++11

### DIFF
--- a/src/gpu/intel/gemm/jit/CMakeLists.txt
+++ b/src/gpu/intel/gemm/jit/CMakeLists.txt
@@ -92,8 +92,4 @@ if(CMAKE_COMPILER_IS_GNUCC)
     # Workaround for LTO bug in GCC 10, 11, 12 (possibly other versions)
     set_source_files_properties(generator/pieces/loop_sequencer.cpp PROPERTIES COMPILE_FLAGS -fno-lto)
     set_source_files_properties(generator/generator.cpp PROPERTIES COMPILE_FLAGS -fno-lto)
-
-
-    # Workaround for excessively long compile time in GCC 11, 12 (possibly other versions)
-    set_source_files_properties(gen_gemm_kernel_db.cpp PROPERTIES COMPILE_FLAGS -fno-var-tracking)
 endif()

--- a/src/gpu/intel/gemm/jit/include/gemmstone/kernel_catalog.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/kernel_catalog.hpp
@@ -226,24 +226,37 @@ template <std::size_t N>
 constexpr std::array<Entry, N> toArray(Entry (&&a)[N]) {
     return std::to_array(std::move(a));
 }
-#elif __cplusplus >= 201402L && __cpp_lib_integer_sequence >= 201304L
+#else
+#if __cplusplus >= 201402L && __cpp_lib_integer_sequence >= 201304L
+template <std::size_t... I> using IndexSequence = std::index_sequence<I...>;
+template <std::size_t N> using MakeIndexSequence = std::make_index_sequence<N>;
+#else
+// C++11 fallback for std::make_index_sequence
+template <std::size_t... I> struct IndexSequence {};
+template <typename S1, typename S2> struct ConcatSequence;
+template <std::size_t... I1, std::size_t... I2>
+struct ConcatSequence<IndexSequence<I1...>, IndexSequence<I2...>> {
+    using type = IndexSequence<I1..., (sizeof...(I1) + I2)...>;
+};
+template <std::size_t N> struct MakeIndexSequenceImpl {
+    using type = typename ConcatSequence<
+            typename MakeIndexSequenceImpl<N / 2>::type,
+            typename MakeIndexSequenceImpl<N - N / 2>::type>::type;
+};
+template <> struct MakeIndexSequenceImpl<0> { using type = IndexSequence<>; };
+template <> struct MakeIndexSequenceImpl<1> { using type = IndexSequence<0>; };
+template <std::size_t N>
+using MakeIndexSequence = typename MakeIndexSequenceImpl<N>::type;
+#endif
+
 template <std::size_t N, std::size_t... I>
 constexpr std::array<Entry, N>
-toArrayImpl(Entry (&&a)[N], std::index_sequence<I...>) {
-    return {{std::move(a[I])...}};
+toArrayImpl(const Entry (&a)[N], IndexSequence<I...>) {
+    return {{a[I]...}};
 }
 template <std::size_t N>
 constexpr std::array<Entry, N> toArray(Entry (&&a)[N]) {
-    return toArrayImpl(std::move(a), std::make_index_sequence<N>{});
-}
-#else
-template <std::size_t N>
-std::array<Entry, N> toArray(Entry (&&a)[N]) {
-    std::array<Entry, N> ret;
-    for(size_t i = 0; i < N; i++) {
-        ret[i] = std::move(a[i]);
-    }
-    return ret;
+    return toArrayImpl(a, MakeIndexSequence<N>{});
 }
 #endif
 


### PR DESCRIPTION
This reduces compilation time from ~2 minutes to a few seconds with gcc13. The compiler generated a very large dynamic initializer, emitting initialization per each of 1000+ of cases.

The commit converts `toArray()` to constexpr for C++11, which avoids this dynamic overhead and the need for a large dynamic initializer function.

The old workaround is dropped: 1) it wasn't applied correctly (mismatch in the file name) and 2) it addressed the same issue but only partially.