### PR TITLE
cpu: x64: remove TF32 check from AVX10_2_AMX_2 dispatching

### DIFF
--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -517,8 +517,8 @@ inline bool mayiuse(const cpu_isa_t cpu_isa, bool soft = false) {
                     && mayiuse(amx_fp16, soft));
         case avx10_2_amx_2:
             REG_AMX_ISA(return mayiuse(avx10_2, soft) && mayiuse(amx_tile, soft)
-                    && cpu().has(Cpu::tAMX_TF32) && cpu().has(Cpu::tAMX_AVX512)
-                    && cpu().has(Cpu::tAMX_MOVRS) && cpu().has(Cpu::tAMX_FP8));
+                    && cpu().has(Cpu::tAMX_AVX512) && cpu().has(Cpu::tAMX_MOVRS)
+                    && cpu().has(Cpu::tAMX_FP8));
         case avx10_2_ace:
             // ACE v1 detection:
             //   1. AVX10.2


### PR DESCRIPTION
TF32-AMX is removed from DMR, updating dispatching to don't check this ISA