### PR TITLE
xe: gemm: add auxiliary prefetch strategy parameter

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -1856,6 +1856,18 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
     allocAddrRegs(state.C_scaleAddrs, state.C_scaleLayout, state);
     allocAddrRegs(state.Ag_addrs, state.Ag_layout, state);
     allocAddrRegs(state.Bg_addrs, state.Bg_layout, state);
+    if (strategy.pfaux) {
+        if (strategy.prefetchA) {
+            allocAddrRegs(state.Ap_offsetAddrs, state.A_offsetLayout, state);
+            allocAddrRegs(state.Ap_scaleAddrs,  state.A_scaleLayout,  state);
+            allocAddrRegs(state.Agp_addrs,      state.Ag_layout,      state);
+        }
+        if (strategy.prefetchB) {
+            allocAddrRegs(state.Bp_offsetAddrs, state.B_offsetLayout, state);
+            allocAddrRegs(state.Bp_scaleAddrs,  state.B_scaleLayout,  state);
+            allocAddrRegs(state.Bgp_addrs,      state.Bg_layout,      state);
+        }
+    }
 
     // Free up some C registers temporarily for use in address calculations.
     releaseRanges(state.C_regs, state);
@@ -1965,32 +1977,50 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
         auto &A_h0o = lateOffsetA ? A_h0qLate : A_h0q;
         setupQAddr(Tao, state.A_offsetAddrs, state.A_offsetLayout, state.inputs.aoPtr,
                    i0o, A_h0o, state.inputs.ldao, state.offsetAo);
+        if (strategy.pfaux && strategy.prefetchA)
+            setupQAddr(Tao, state.Ap_offsetAddrs, state.A_offsetLayout, state.inputs.aoPtr,
+                       i0o, A_h0o, state.inputs.ldao, state.offsetAo);
     }
     if (as2D) {
         auto &i0s   = state.lateScale2DA ? i0qLate : i0q;
         auto &A_h0s = state.lateScale2DA ? A_h0qLate : A_h0q;
         setupQAddr(Ta_scale, state.A_scaleAddrs, state.A_scaleLayout, state.inputs.aScalePtr,
                    i0s, A_h0s, state.inputs.ldaScale, state.offsetAs);
+        if (strategy.pfaux && strategy.prefetchA)
+            setupQAddr(Ta_scale, state.Ap_scaleAddrs, state.A_scaleLayout, state.inputs.aScalePtr,
+                       i0s, A_h0s, state.inputs.ldaScale, state.offsetAs);
     }
     if (ag2D) {
         setupQAddr(Tag, state.Ag_addrs, state.Ag_layout, state.inputs.agPtr,
                    i0qLate, A_h0qLate, state.inputs.ldag, state.inputs.offsetAg);
+        if (strategy.pfaux && strategy.prefetchA)
+            setupQAddr(Tag, state.Agp_addrs, state.Ag_layout, state.inputs.agPtr,
+                       i0qLate, A_h0qLate, state.inputs.ldag, state.inputs.offsetAg);
     }
     if (bo2D) {
         auto &j0o   = lateOffsetB ? j0qLate   : j0q;
         auto &B_h0o = lateOffsetB ? B_h0qLate : B_h0q;
         setupQAddr(Tbo, state.B_offsetAddrs, state.B_offsetLayout, state.inputs.boPtr,
                    B_h0o, j0o, state.inputs.ldbo, state.offsetBo);
+        if (strategy.pfaux && strategy.prefetchB)
+            setupQAddr(Tbo, state.Bp_offsetAddrs, state.B_offsetLayout, state.inputs.boPtr,
+                       B_h0o, j0o, state.inputs.ldbo, state.offsetBo);
     }
     if (bs2D) {
         auto &j0s   = state.lateScale2DB ? j0qLate   : j0q;
         auto &B_h0s = state.lateScale2DB ? B_h0qLate : B_h0q;
         setupQAddr(Tb_scale, state.B_scaleAddrs, state.B_scaleLayout, state.inputs.bScalePtr,
                    B_h0s, j0s, state.inputs.ldbScale, state.offsetBs);
+        if (strategy.pfaux && strategy.prefetchB)
+            setupQAddr(Tb_scale, state.Bp_scaleAddrs, state.B_scaleLayout, state.inputs.bScalePtr,
+                       B_h0s, j0s, state.inputs.ldbScale, state.offsetBs);
     }
     if (bg2D) {
         setupQAddr(Tbg, state.Bg_addrs, state.Bg_layout, state.inputs.bgPtr,
                    B_h0qLate, j0qLate, state.inputs.ldbg, state.inputs.offsetBg);
+        if (strategy.pfaux && strategy.prefetchB)
+            setupQAddr(Tbg, state.Bgp_addrs, state.Bg_layout, state.inputs.bgPtr,
+                       B_h0qLate, j0qLate, state.inputs.ldbg, state.inputs.offsetBg);
     }
 
     if (problem.hasCMXScale()) {
@@ -2224,6 +2254,12 @@ void Generator<hw>::gemmAccumulateCTeardown(GEMMProblem &problem, GEMMStrategy &
     safeReleaseRanges(state.B_scaleAddrs, state);
     safeReleaseRanges(state.Ag_addrs, state);
     safeReleaseRanges(state.Bg_addrs, state);
+    safeReleaseRanges(state.Ap_offsetAddrs, state);
+    safeReleaseRanges(state.Bp_offsetAddrs, state);
+    safeReleaseRanges(state.Ap_scaleAddrs, state);
+    safeReleaseRanges(state.Bp_scaleAddrs, state);
+    safeReleaseRanges(state.Agp_addrs, state);
+    safeReleaseRanges(state.Bgp_addrs, state);
 
     safeReleaseRanges(state.A_regs, state);
     safeReleaseRanges(state.Ar_regs, state);

--- a/src/gpu/intel/gemm/jit/generator/pieces/k_loop.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/k_loop.cxx
@@ -367,9 +367,17 @@ void Generator<hw>::kLoop(KLoop type, const GEMMProblem &problem, GEMMStrategy &
                 | duration(aPFDuration)
                 | lookahead(strategy.prefetchA + lookaheadAGlobalLoad);
 
+    bool aQuantPFEnabled = strategy.pfaux && (ao2D || ao2DLate || as2D || as2DLate || ag2DLate);
+
     if (strategy.prefetchA && readA) {
         ls.schedule(reqPFA, [&](Iteration h) {
             gemmALoad(state.Ap_regs, state.Ap_layout, state.Ap_addrs, problem, strategy, state);
+            // Auxiliary (quantization) prefetches always immediately follow the A prefetch.
+            if (aQuantPFEnabled) {
+                if (ao2D || ao2DLate) prefetchMatrix(state.A_offsetLayout, state.Ap_offsetAddrs, strategy, state);
+                if (as2D || as2DLate) prefetchMatrix(state.A_scaleLayout,  state.Ap_scaleAddrs,  strategy, state);
+                if (ag2DLate)         prefetchMatrix(state.Ag_layout,      state.Agp_addrs,      strategy, state);
+            }
         });
     }
 
@@ -382,9 +390,17 @@ void Generator<hw>::kLoop(KLoop type, const GEMMProblem &problem, GEMMStrategy &
                 | duration(bPFDuration)
                 | lookahead(strategy.prefetchB + lookaheadBGlobalLoad);
 
+    bool bQuantPFEnabled = strategy.pfaux && (bo2D || bo2DLate || bs2D || bs2DLate || bg2DLate);
+
     if (strategy.prefetchB && readB) {
         ls.schedule(reqPFB, [&](Iteration h) {
             gemmBLoad(state.Bp_regs, state.Bp_layout, state.Bp_addrs, problem, strategy, state);
+            // Auxiliary (quantization) prefetches always immediately follow the B prefetch.
+            if (bQuantPFEnabled) {
+                if (bo2D || bo2DLate) prefetchMatrix(state.B_offsetLayout, state.Bp_offsetAddrs, strategy, state);
+                if (bs2D || bs2DLate) prefetchMatrix(state.B_scaleLayout,  state.Bp_scaleAddrs,  strategy, state);
+                if (bg2DLate)         prefetchMatrix(state.Bg_layout,      state.Bgp_addrs,      strategy, state);
+            }
         });
     }
 
@@ -709,19 +725,35 @@ void Generator<hw>::kLoop(KLoop type, const GEMMProblem &problem, GEMMStrategy &
 
     // A prefetch address increment.
     int delayAPFInc = delayABInc ? (ka_pfStride >> 1) : 0;
+    int kaPfIncQ = std::max(1, (problem.aqGroupK > 0 && ka_pfStride % problem.aqGroupK == 0)
+                                ? (ka_pfStride / problem.aqGroupK) : 1);
 
     if (strategy.prefetchA && readA) {
         ls.schedule(reqPFA.delay(delayAPFInc), [&](Iteration h) {
             gemmAIncrement(state.Ap_layout, state.Ap_addrs, kInc(h, ka_pfStride), problem, strategy, state);
+            // Auxiliary (quantization) prefetch address increments always immediately follow.
+            if (aQuantPFEnabled) {
+                if (ao2D || ao2DLate) incAddrK(state.Ap_offsetAddrs, true, kaPfIncQ, state.ldao,     state.ldaoIncrements, state.A_offsetLayout, strategy, state);
+                if (as2D || as2DLate) incAddrK(state.Ap_scaleAddrs,  true, kaPfIncQ, state.ldaScale, state.ldasIncrements, state.A_scaleLayout,  strategy, state);
+                if (ag2DLate)         incAddrK(state.Agp_addrs,      true, kaPfIncQ, state.ldag,     state.ldagIncrements, state.Ag_layout,      strategy, state);
+            }
         });
     }
 
     // B prefetch address increment.
     int delayBPFInc = delayABInc ? (kb_pfStride >> 1) : 0;
+    int kbPfIncQ = std::max(1, (problem.bqGroupK > 0 && kb_pfStride % problem.bqGroupK == 0)
+                                ? (kb_pfStride / problem.bqGroupK) : 1);
 
     if (strategy.prefetchB && readB) {
         ls.schedule(reqPFB.delay(delayBPFInc), [&](Iteration h) {
             gemmBIncrement(state.Bp_layout, state.Bp_addrs, kInc(h, kb_pfStride), problem, strategy, state);
+            // Auxiliary (quantization) prefetch address increments always immediately follow.
+            if (bQuantPFEnabled) {
+                if (bo2D || bo2DLate) incAddrK(state.Bp_offsetAddrs, false, kbPfIncQ, state.ldbo,     state.ldboIncrements, state.B_offsetLayout, strategy, state);
+                if (bs2D || bs2DLate) incAddrK(state.Bp_scaleAddrs,  false, kbPfIncQ, state.ldbScale, state.ldbsIncrements, state.B_scaleLayout,  strategy, state);
+                if (bg2DLate)         incAddrK(state.Bgp_addrs,      false, kbPfIncQ, state.ldbg,     state.ldbgIncrements, state.Bg_layout,      strategy, state);
+            }
         });
     }
 

--- a/src/gpu/intel/gemm/jit/generator/pieces/state.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/state.hpp
@@ -285,6 +285,11 @@ struct GEMMState : public CommonState {
     std::vector<ngen::GRFRange> A_offsetAddrs, B_offsetAddrs;
     std::vector<ngen::GRFRange> A_scaleAddrs, B_scaleAddrs, C_scaleAddrs;
     std::vector<ngen::GRFRange> Ag_addrs, Bg_addrs;
+    // Auxiliary (quantization) prefetch addresses -- independent copies of the above address
+    // ranges, advanced in lockstep with the A/B prefetch schedule (strategy.pfaux).
+    std::vector<ngen::GRFRange> Ap_offsetAddrs, Bp_offsetAddrs;
+    std::vector<ngen::GRFRange> Ap_scaleAddrs, Bp_scaleAddrs;
+    std::vector<ngen::GRFRange> Agp_addrs, Bgp_addrs;
     std::vector<GRFMultirange> A_regs, B_regs, C_regs;
     GRFMultirange Ar_regs, Br_regs;                         // Repacked A/B registers.
     GRFMultirange Cr_regs;                                  // C registers to be repacked.

--- a/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
@@ -424,6 +424,7 @@ void parseStrategy(const std::string &str, HW hw, const GEMMProblem &problem, GE
         {"up", [](ParserContext& ctx) { ctx.strategy.panelCheck = true; }},
         {"ek", [](ParserContext& ctx) { ctx.strategy.slmEarlyKMask = true; }},
         {"di", [](ParserContext& ctx) { ctx.strategy.delayABInc = true; }},
+        {"pfaux", [](ParserContext& ctx) { ctx.strategy.pfaux = true; }},
         {"nq", [](ParserContext& ctx) {
             auto &strategy = ctx.strategy;
             strategy.A.noExtraPad = strategy.A_prefetch.noExtraPad = true;
@@ -948,6 +949,7 @@ std::string unparseStrategy(HW hw, const GEMMProblem &problem, const GEMMStrateg
     if (strategy.cAccumulators)             s << " ac";
     if (strategy.cLoadAhead)                s << " el";
     if (strategy.delayABInc)                s << " di";
+    if (strategy.pfaux)                     s << " pfaux";
     if (strategy.loadBFirst)                s << " ba";
     if (strategy.doubleMasking)             s << " dm";
     if (strategy.kDescRem)                  s << " kd";

--- a/src/gpu/intel/gemm/jit/include/gemmstone/strategy.hpp
+++ b/src/gpu/intel/gemm/jit/include/gemmstone/strategy.hpp
@@ -232,7 +232,10 @@ struct GEMMStrategyPOD : public CommonStrategy {
     int ka_prefetch = 0, kb_prefetch = 0;        // Chunk size for prefetching A/B.
     int ka_pfStride = 0, kb_pfStride = 0;        // k stride between A/B prefetches.
     bool cooperativePF = true;                   // Enable WG-cooperative A/B prefetches.
-                                    ZPAD(H, 3)
+    bool pfaux = false;                          // Enable auxiliary (quantization scale/offset/group-sum) prefetches
+                                                  //   alongside A/B prefetches. Off by default: extra address
+                                                  //   registers may increase pressure enough to break some kernels.
+                                    ZPAD(H, 2)
     int prefetchA = 0, prefetchB = 0, prefetchC = 0;                // Prefetch distances, in units of unrollK.
     int prefetchAMasked = 0, prefetchBMasked = 0;                   // Same as above, when masking m/n.
     MatrixAddressingStrategy A_prefetch, B_prefetch, C_prefetch;    // Strategies for prefetching A/B/C.


### PR DESCRIPTION
Introduces a new kernel parameter for prefetching auxiliary tensors (currently just scales). Prefetch characteristics match the size/distance from the main tensor (A scales inherit these from the A matrix).

No kernels are added yet that make use of this parameter, but it will be useful in CRI tuning, where MX problems have less scales-based overhead than previous architectures. Previously, vector operations on scales data was the bottleneck and this was unnecessary.

This strategy will be enabled by default eventually (with `nopfaux` replacing `pfaux` as the inverse option) but I want to avoid a breaking change right now, as enabling this increases register pressure slightly, for prefetch address registers.