### PR TITLE
reduction: add fused dynamic quantization

### DIFF
--- a/doc/functional_api/primitives/reduction.md
+++ b/doc/functional_api/primitives/reduction.md
@@ -42,11 +42,52 @@ Lp-norm-power-p:
 
 where \f$eps\_op\f$ can be max and sum.
 
+### Dynamic quantization
+
+The `reduction_dynamic_quantize` algorithm performs symmetric dynamic
+quantization in one primitive dispatch. Unlike the other reduction algorithms,
+its destination has the same shape as the source (or is empty in compute-only
+mode). The reduction statistics are internal; the visible auxiliary output is
+the `f32` quantization scale. The reduction constructor's `p` and `eps`
+parameters must both be zero.
+
+The scale recipe is specified with a destination quantization attribute:
+
+```cpp
+primitive_attr attr;
+attr.set_scales(DNNL_ARG_DST, mask, groups, memory::data_type::f32,
+        false, quantization_mode::dynamic_fp);
+```
+
+The scale is returned through
+`DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST`.
+
+For each group \f$g\f$, quantization computes `scale = amax / 127`:
+
+\f[
+    scale_g = \max_{i \in g}|src_i| / 127, \qquad
+    dst_i = clamp(round(src_i / scale_g), -127, 127).
+\f]
+
+The CPU implementation supports 2D sources. `mask` and `groups` encode
+per-tensor, per-row (per-token), per-column, grouped-row, or grouped-column
+quantization. An empty destination memory descriptor selects compute-only mode,
+which writes the scale without producing a quantized tensor.
+
+For source `[M, N]`, the supported recipes are:
+- per-tensor: `mask = 0`, `groups = {}`;
+- per-row: `mask = 1 << 0`, `groups = {}`;
+- per-column: `mask = 1 << 1`, `groups = {}`;
+- grouped columns: `mask = 3`, `groups = {1, group_size_n}`;
+- grouped rows: `mask = 3`, `groups = {group_size_m, 1}`.
+
 ### Notes
 
  * The reduction primitive requires the source and destination tensors to have
    the same number of dimensions.
- * Reduction dimensions are of size 1 in a destination tensor.
+ * Reduction dimensions are of size 1 in a destination tensor, except for
+   `reduction_dynamic_quantize`, whose reduction statistics are auxiliary
+   outputs and whose quantized destination preserves the source shape.
  * The reduction primitive does not have a notion of forward or backward
    propagations.
  * For Lp-norm algorithms, the parameter \f$p\f$ must be a finite value
@@ -61,6 +102,7 @@ argument index as specified by the following table.
 |-----------------------------|---------------------------------------------------------------------------|--------------|
 | \src                        | DNNL_ARG_SRC                                                              | Input        |
 | \dst                        | DNNL_ARG_DST                                                              | Output       |
+| Dynamic scale               | DNNL_ARG_ATTR_SCALES \| DNNL_ARG_DST                                      | Output       |
 | \f$\text{binary post-op}\f$ | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_1 | Input        |
 | \                           | DNNL_ARG_ATTR_MULTIPLE_POST_OP(binary_post_op_position) \| DNNL_ARG_SRC_2 | Input        |
 | [scratchpad]                | DNNL_ARG_SCRATCHPAD                                                       | Output       |
@@ -84,11 +126,15 @@ The following attributes are supported:
 | Post-op | [Sum](@ref dnnl::post_ops::append_sum)         | Adds the operation result to the destination tensor instead of overwriting it. |                                     |
 | Post-op | [Eltwise](@ref dnnl::post_ops::append_eltwise) | Applies an @ref dnnl_api_eltwise operation to the result.                      |                                     |
 | Post-op | [Binary](@ref dnnl::post_ops::append_binary)   | Applies a @ref dnnl_api_binary operation to the result                         | General binary post-op restrictions |
+| Attribute | [Scales](@ref dnnl::primitive_attr::set_scales) | Defines dynamic quantization and returns scales | `reduction_dynamic_quantize` only |
 
 ### Data Types Support
 
 The source and destination tensors may have `f32`, `bf16`, `f16`, `s8`, or `u8` data
 types.
+
+For `reduction_dynamic_quantize`, the source may be `f32`, `bf16`, or `f16`;
+the full-mode destination is `s8`, and the dynamic scale output is `f32`.
 See @ref dev_guide_data_types page for more details.
 
 ### Data Representation
@@ -105,6 +151,17 @@ meaning associated with any of the dimensions of a tensor.
 
 2. **GPU**
    - Only tensors of 6 or fewer dimensions are supported.
+   - `reduction_dynamic_quantize` is not implemented.
+
+3. **Dynamic quantization**
+   - The portable CPU implementation supports all documented granularities and
+     compute-only mode.
+   - The optimized x64 implementation requires AVX-512 and handles dense 2D
+     per-row and grouped-column full-mode cases. Other configurations fall
+     through to the portable implementation.
+   - The optimized x64 implementation is enabled for non-MSVC GCC- and
+     Clang-compatible compiler frontends. Other compilers use the portable
+     implementation.
 
 ## Performance Tips
 

--- a/doc/functional_api/programming_model/attributes_quantization.md
+++ b/doc/functional_api/programming_model/attributes_quantization.md
@@ -101,10 +101,17 @@ following the [OCP MX Formats Specification][mx-spec], namely \f$scale_{x}\f$:
   \f$E8M0(amax(x_{quant}[:])) / E8M0(MAX\_QUANT\_DT)\f$.
 
 When using `quantization_mode::dynamic_fp`, \f$scale_{x}\f$ is computed in
-`f32` first and then converted to a scale datatype, namely \f$scale_{x}\f$:
-- has `f8_e4m3` datatype,
-- is computed for each group of size `16`,
-- is computed as \f$SCALE\_DT(amax(x_{quant}[:]) / MAX\_QUANT\_DT)\f$.
+`f32` first and then converted to the configured scale datatype. The exact
+destination datatype and supported grouping are primitive-specific:
+- NVFP4 matmul uses `f8_e4m3` scales, groups of size `16`, and
+  \f$SCALE\_DT(amax(x_{quant}[:]) / MAX\_QUANT\_DT)\f$;
+- the `reduction_dynamic_quantize` algorithm uses `f32` output scales with
+  `scale = amax / 127` and an `s8` destination. It supports per-tensor,
+  per-row, per-column, grouped-row, and grouped-column quantization. An empty
+  destination memory descriptor selects compute-only mode and returns only the
+  scales.
+
+Dynamic scales are execution outputs.
 
 ## General Numerical Behavior Notes
 

--- a/examples/primitives/cpu_reduction_dynamic_quantize.cpp
+++ b/examples/primitives/cpu_reduction_dynamic_quantize.cpp
@@ -1,0 +1,96 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+/// @example cpu_reduction_dynamic_quantize.cpp
+/// > Annotated version: @ref reduction_dynamic_quantize_example_cpp
+
+/// @page reduction_dynamic_quantize_example_cpp Reduction Dynamic Quantization
+/// This C++ API example demonstrates fused symmetric per-row dynamic
+/// quantization through the reduction primitive.
+/// @include cpu_reduction_dynamic_quantize.cpp
+
+#include <vector>
+#include <unordered_map>
+
+#include "example_utils.hpp"
+#include "oneapi/dnnl/dnnl.hpp"
+
+using namespace dnnl;
+
+void reduction_dynamic_quantize_example(engine::kind engine_kind) {
+    engine eng(engine_kind, 0);
+    stream strm(eng);
+
+    constexpr memory::dim M = 2;
+    constexpr memory::dim N = 8;
+    const memory::dims src_dims {M, N};
+    const memory::dims scale_dims {M, 1};
+
+    std::vector<float> src_data {
+            -4.f,
+            -3.f,
+            -2.f,
+            -1.f,
+            0.f,
+            1.f,
+            2.f,
+            3.f,
+            -1.f,
+            -.5f,
+            0.f,
+            .5f,
+            1.f,
+            1.5f,
+            2.f,
+            2.5f,
+    };
+    std::vector<int8_t> dst_data(M * N);
+    std::vector<float> scales(M);
+
+    const auto src_md = memory::desc(
+            src_dims, memory::data_type::f32, memory::format_tag::ab);
+    const auto dst_md = memory::desc(
+            src_dims, memory::data_type::s8, memory::format_tag::ab);
+    const auto scale_md = memory::desc(
+            scale_dims, memory::data_type::f32, memory::format_tag::ab);
+
+    auto src_mem = memory(src_md, eng);
+    auto dst_mem = memory(dst_md, eng);
+    auto scale_mem = memory(scale_md, eng);
+    write_to_dnnl_memory(src_data.data(), src_mem);
+
+    primitive_attr attr;
+    attr.set_scales(DNNL_ARG_DST, 1 << 0, {}, memory::data_type::f32, false,
+            quantization_mode::dynamic_fp);
+
+    const auto pd = reduction::primitive_desc(eng,
+            algorithm::reduction_dynamic_quantize, src_md, dst_md, 0.f, 0.f,
+            attr);
+    const auto prim = reduction(pd);
+
+    prim.execute(strm,
+            {{DNNL_ARG_SRC, src_mem}, {DNNL_ARG_DST, dst_mem},
+                    {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem}});
+    strm.wait();
+
+    read_from_dnnl_memory(dst_data.data(), dst_mem);
+    read_from_dnnl_memory(scales.data(), scale_mem);
+}
+
+int main(int argc, char **argv) {
+    return handle_example_errors(
+            reduction_dynamic_quantize_example, parse_engine_kind(argc, argv));
+}

--- a/include/oneapi/dnnl/dnnl.h
+++ b/include/oneapi/dnnl/dnnl.h
@@ -543,8 +543,9 @@ dnnl_status_t DNNL_API dnnl_primitive_attr_set_scales_v2(
 ///     NULL when @p ndims is 0.
 /// @param data_type Scaling factors data_type.
 /// @param is_on_host Indicates whether the scale is a host-side scalar.
-/// @param qmode Quantization mode, can be #dnnl_quantization_mode_static_sazp
-///     or #dnnl_quantization_mode_dynamic_mx
+/// @param qmode Quantization mode, can be #dnnl_quantization_mode_static_sazp,
+///     #dnnl_quantization_mode_dynamic_mx, or
+///     #dnnl_quantization_mode_dynamic_fp.
 /// @returns #dnnl_success on success and a status describing the error
 ///     otherwise.
 dnnl_status_t DNNL_API dnnl_primitive_attr_set_scales_v3(
@@ -3849,13 +3850,21 @@ dnnl_status_t DNNL_API dnnl_resampling_backward_primitive_desc_create(
 ///     #dnnl_reduction_max, #dnnl_reduction_min, #dnnl_reduction_sum,
 ///     #dnnl_reduction_mul, #dnnl_reduction_mean, #dnnl_reduction_norm_lp_max,
 ///     #dnnl_reduction_norm_lp_sum, #dnnl_reduction_norm_lp_power_p_max,
-///     #dnnl_reduction_norm_lp_power_p_sum.
+///     #dnnl_reduction_norm_lp_power_p_sum, or
+///     #dnnl_reduction_dynamic_quantize.
 /// @param p Algorithm specific parameter. For Lp-norm algorithms, must be a
-///     finite value >= 1.0.
-/// @param eps Algorithm specific parameter.
+///     finite value >= 1.0. Must be zero for
+///     #dnnl_reduction_dynamic_quantize.
+/// @param eps Algorithm specific parameter. Must be zero for
+///     #dnnl_reduction_dynamic_quantize.
 /// @param src_desc Source memory descriptor.
-/// @param dst_desc Destination memory descriptor.
-/// @param attr Primitive attributes (can be NULL).
+/// @param dst_desc Destination memory descriptor. For
+///     #dnnl_reduction_dynamic_quantize, the descriptor has the same dimensions
+///     as @p src_desc, or may be NULL for compute-only mode.
+/// @param attr Primitive attributes (can be NULL). For
+///     #dnnl_reduction_dynamic_quantize, dynamic `f32` destination scales are
+///     required and are execution outputs computed as `amax / 127`; the
+///     full-mode destination data type is `s8`.
 /// @returns #dnnl_success on success and a status describing the error
 ///     otherwise.
 dnnl_status_t DNNL_API dnnl_reduction_primitive_desc_create(

--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -335,7 +335,9 @@ enum class quantization_mode {
     dynamic_mx = dnnl_quantization_mode_dynamic_mx,
     /// dynamic quantization mode where quantization parameter is computed by
     /// oneDNN as \f$scale\_dt(amax(X) / max(dst\_dt))\f$ in `f32` then
-    /// converted to a scale type and written as an output.
+    /// converted to a scale type and written as an output. For
+    /// #algorithm::reduction_dynamic_quantize, the `f32` output scale is
+    /// \f$amax(X) / 127\f$ and the destination data type is `s8`.
     dynamic_fp = dnnl_quantization_mode_dynamic_fp,
 };
 
@@ -524,6 +526,9 @@ enum class algorithm {
     reduction_norm_lp_power_p_max = dnnl_reduction_norm_lp_power_p_max,
     /// Reduction using norm_lp_power_p_sum operation
     reduction_norm_lp_power_p_sum = dnnl_reduction_norm_lp_power_p_sum,
+    /// Fused symmetric dynamic quantization with an `s8` destination and
+    /// `f32` scale output.
+    reduction_dynamic_quantize = dnnl_reduction_dynamic_quantize,
     /// Softmax, numerically stable
     softmax_accurate = dnnl_softmax_accurate,
     /// LogSoftmax, numerically stable
@@ -4368,8 +4373,9 @@ struct primitive_attr : public handle<dnnl_primitive_attr_t> {
     ///     Use `1` for no sub-blocking. `{}` indicates no grouping.
     /// @param data_type Scaling factors data_type.
     /// @param is_on_host Indicates whether the scaling factor is a host-side scalar.
-    /// @param qmode Quantization mode, can be #quantization_mode::static_sazp
-    ///     or #quantization_mode::dynamic_mx
+    /// @param qmode Quantization mode, can be #quantization_mode::static_sazp,
+    ///     #quantization_mode::dynamic_mx, or
+    ///     #quantization_mode::dynamic_fp.
     void set_scales(int arg, int mask, const memory::dims &groups,
             memory::data_type data_type = memory::data_type::f32,
             bool is_on_host = false,
@@ -13969,7 +13975,8 @@ struct prelu_backward : public primitive {
 /// @addtogroup dnnl_api_cpp_reduction Reduction
 ///
 /// A primitive to compute reduction operation on data tensor
-/// using min, max, mul, sum, mean and norm_lp operations.
+/// using min, max, mul, sum, mean, norm_lp, and fused dynamic quantization
+/// operations.
 ///
 /// @sa @ref dev_guide_reduction in developer guide
 ///
@@ -13996,14 +14003,22 @@ struct reduction : public primitive {
         ///     #dnnl_reduction_mul, #dnnl_reduction_mean,
         ///     #dnnl_reduction_norm_lp_max, #dnnl_reduction_norm_lp_sum,
         ///     #dnnl_reduction_norm_lp_power_p_max,
-        ///     #dnnl_reduction_norm_lp_power_p_sum.
+        ///     #dnnl_reduction_norm_lp_power_p_sum, or
+        ///     #dnnl_reduction_dynamic_quantize.
         /// @param p algorithm specific parameter. For Lp-norm algorithms,
-        ///     must be a finite value >= 1.0.
-        /// @param eps algorithm specific parameter.
+        ///     must be a finite value >= 1.0. Must be zero for
+        ///     #dnnl_reduction_dynamic_quantize.
+        /// @param eps algorithm specific parameter. Must be zero for
+        ///     #dnnl_reduction_dynamic_quantize.
         /// @param src_desc Source memory descriptor.
-        /// @param dst_desc Destination memory descriptor.
+        /// @param dst_desc Destination memory descriptor. For
+        ///     #dnnl_reduction_dynamic_quantize, it has the same dimensions as
+        ///     @p src_desc, or is empty for compute-only mode.
         /// @param attr Primitive attributes to use. Attributes are optional
-        ///     and default to empty attributes.
+        ///     and default to empty attributes for regular reductions. For
+        ///     #dnnl_reduction_dynamic_quantize, dynamic `f32` destination
+        ///     scales are required and are outputs computed as `amax / 127`;
+        ///     the full-mode destination data type is `s8`.
         /// @param allow_empty A flag signifying whether construction is
         ///     allowed to fail without throwing an exception. In this case an
         ///     empty object will be produced. This flag is optional and

--- a/include/oneapi/dnnl/dnnl_types.h
+++ b/include/oneapi/dnnl/dnnl_types.h
@@ -2248,6 +2248,9 @@ typedef enum {
     dnnl_reduction_norm_lp_power_p_max,
     /// Reduction using lp norm without final pth-root
     dnnl_reduction_norm_lp_power_p_sum,
+    /// Fused symmetric dynamic quantization with an `s8` destination and
+    /// `f32` scale output.
+    dnnl_reduction_dynamic_quantize,
     /// Softmax
     dnnl_softmax_accurate = 0x30000,
     /// Logsoftmax
@@ -2481,7 +2484,9 @@ typedef enum {
     dnnl_quantization_mode_dynamic_mx,
     /// dynamic quantization mode where quantization parameter is computed by
     /// oneDNN as \f$scale\_dt(amax(X) / max(dst\_dt))\f$ in `f32` then
-    /// converted to a scale type and written as an output.
+    /// converted to a scale type and written as an output. For
+    /// #dnnl_reduction_dynamic_quantize, the `f32` output scale is
+    /// \f$amax(X) / 127\f$ and the destination data type is `s8`.
     dnnl_quantization_mode_dynamic_fp,
 } dnnl_quantization_mode_t;
 

--- a/src/common/c_types_map.hpp
+++ b/src/common/c_types_map.hpp
@@ -142,6 +142,7 @@ const alg_kind_t reduction_norm_lp_power_p_max
         = dnnl_reduction_norm_lp_power_p_max;
 const alg_kind_t reduction_norm_lp_power_p_sum
         = dnnl_reduction_norm_lp_power_p_sum;
+const alg_kind_t reduction_dynamic_quantize = dnnl_reduction_dynamic_quantize;
 const alg_kind_t softmax_accurate = dnnl_softmax_accurate;
 const alg_kind_t softmax_log = dnnl_softmax_log;
 // Internal only alg kinds.

--- a/src/common/dnnl_debug_autogenerated.cpp
+++ b/src/common/dnnl_debug_autogenerated.cpp
@@ -1899,6 +1899,7 @@ const char *dnnl_alg_kind2str(dnnl_alg_kind_t v) {
     if (v == dnnl_reduction_norm_lp_sum) return "reduction_norm_lp_sum";
     if (v == dnnl_reduction_norm_lp_power_p_max) return "reduction_norm_lp_power_p_max";
     if (v == dnnl_reduction_norm_lp_power_p_sum) return "reduction_norm_lp_power_p_sum";
+    if (v == dnnl_reduction_dynamic_quantize) return "reduction_dynamic_quantize";
     if (v == dnnl_softmax_accurate) return "softmax_accurate";
     if (v == dnnl_softmax_log) return "softmax_log";
     if (v == dnnl::impl::alg_kind::softmax_accurate_inf_as_zero)

--- a/src/common/primitive_attr_quant.hpp
+++ b/src/common/primitive_attr_quant.hpp
@@ -266,6 +266,8 @@ struct quant_entries_t {
         return false;
     }
 
+    const std::map<int, quant_entry_t> &get_entries() const { return entries_; }
+
     bool operator==(const quant_entries_t &rhs) const {
         return entries_ == rhs.entries_;
     }

--- a/src/common/primitive_exec_types.cpp
+++ b/src/common/primitive_exec_types.cpp
@@ -139,6 +139,14 @@ status_t cvt_primitive_args(const primitive_desc_t *pd, int nargs,
         }
     }
 
+    for (const auto &entry : pd->attr()->scales_.get_entries()) {
+        const int arg = DNNL_ARG_ATTR_SCALES | entry.first;
+        if (pd->arg_usage(arg) != primitive_desc_t::arg_usage_t::output)
+            continue;
+        VCONDCHECK(primitive, exec, check, primitive, args.count(arg) == 1,
+                invalid_arguments, "required output argument %d is missing",
+                arg);
+    }
     VCONDCHECK(primitive, exec, check, primitive,
             (n_inputs == pd->n_inputs() + extra_inputs), invalid_arguments,
             "bad number of inputs (expected %d got %d)",

--- a/src/common/reduction.cpp
+++ b/src/common/reduction.cpp
@@ -15,10 +15,14 @@
 *******************************************************************************/
 
 #include "oneapi/dnnl/dnnl.h"
+
+#include <vector>
+
 #include "opdesc.hpp"
 #include "primitive_desc_iface.hpp"
 
 #include "c_types_map.hpp"
+#include "type_helpers.hpp"
 #include "utils.hpp"
 
 using namespace dnnl::impl;
@@ -40,14 +44,66 @@ status_t reduction_desc_init(reduction_desc_t *reduction_desc,
         alg_kind_t alg_kind, const memory_desc_t *src_desc,
         const memory_desc_t *dst_desc, float p, float eps) {
 
+    const bool is_dynamic_quantize = alg_kind == reduction_dynamic_quantize;
+    const memory_desc_t zero_md = types::zero_md();
+    if (is_dynamic_quantize && dst_desc == nullptr) dst_desc = &zero_md;
+
     VCHECK_RED(!any_null(src_desc, dst_desc), VERBOSE_NULL_ARG);
     VCHECK_RED(src_desc->format_kind != format_kind::any,
             VERBOSE_UNSUPPORTED_TAG_S, "src");
-    VCHECK_RED(one_of(alg_kind, reduction_max, reduction_min, reduction_sum,
-                       reduction_mul, reduction_mean, reduction_norm_lp_max,
-                       reduction_norm_lp_sum, reduction_norm_lp_power_p_max,
-                       reduction_norm_lp_power_p_sum),
+    VCHECK_RED(
+            one_of(alg_kind, reduction_max, reduction_min, reduction_sum,
+                    reduction_mul, reduction_mean, reduction_norm_lp_max,
+                    reduction_norm_lp_sum, reduction_norm_lp_power_p_max,
+                    reduction_norm_lp_power_p_sum, reduction_dynamic_quantize),
             VERBOSE_BAD_ALGORITHM);
+
+    if (is_dynamic_quantize) {
+        using namespace data_type;
+
+        VCHECK_RED(src_desc->ndims == 2, VERBOSE_INCONSISTENT_NDIMS_WITH_VALS,
+                "src", "expected", src_desc->ndims, 2);
+        VCHECK_RED(one_of(src_desc->data_type, f32, bf16, f16),
+                VERBOSE_INVALID_DATATYPE, "src");
+        VCHECK_RED(p == 0.f, VERBOSE_BAD_PARAM, "p");
+        VCHECK_RED(eps == 0.f, VERBOSE_BAD_PARAM, "eps");
+        VCHECK_RED(src_desc->format_kind == format_kind::blocked,
+                VERBOSE_UNSUPPORTED_TAG_S, "src");
+        VCHECK_RED(
+                src_desc->extra.flags == 0, VERBOSE_UNSUPPORTED_MD_FLAG, "src");
+
+        if (!types::is_zero_md(dst_desc)) {
+            VCHECK_RED(src_desc->ndims == dst_desc->ndims,
+                    VERBOSE_INCONSISTENT_NDIMS_WITH_VALS, "src", "dst",
+                    src_desc->ndims, dst_desc->ndims);
+            VCHECK_RED(
+                    array_cmp(src_desc->dims, dst_desc->dims, src_desc->ndims),
+                    VERBOSE_INCONSISTENT_MDS, "src", "dst");
+            VCHECK_RED(
+                    dst_desc->data_type == s8, VERBOSE_INVALID_DATATYPE, "dst");
+            VCHECK_RED(one_of(dst_desc->format_kind, format_kind::blocked,
+                               format_kind::any),
+                    VERBOSE_UNSUPPORTED_TAG_S, "dst");
+            VCHECK_RED(
+                    IMPLICATION(dst_desc->format_kind == format_kind::blocked,
+                            dst_desc->extra.flags == 0),
+                    VERBOSE_UNSUPPORTED_MD_FLAG, "dst");
+        }
+
+        VCHECK_RED(!any_memory_desc_host_scalar(src_desc, dst_desc),
+                VERBOSE_UNSUPPORTED_FORMAT_KIND);
+
+        auto rd = reduction_desc_t();
+        rd.primitive_kind = primitive_kind::reduction;
+        rd.alg_kind = alg_kind;
+        rd.src_desc = *src_desc;
+        rd.dst_desc = *dst_desc;
+        rd.p = p;
+        rd.eps = eps;
+        *reduction_desc = rd;
+        return success;
+    }
+
     VCHECK_RED(IMPLICATION(one_of(alg_kind, reduction_norm_lp_max,
                                    reduction_norm_lp_sum,
                                    reduction_norm_lp_power_p_max,
@@ -105,6 +161,50 @@ status_t reduction_desc_init(reduction_desc_t *reduction_desc,
 status_t reduction_attr_check(const reduction_desc_t &desc,
         const engine_t *engine, const primitive_attr_t *attr) {
     using smask_t = primitive_attr_t::skip_mask_t;
+
+    if (desc.alg_kind == reduction_dynamic_quantize) {
+        using namespace data_type;
+
+        VCHECK_RED(attr != nullptr, VERBOSE_NULL_ARG);
+
+        const auto attr_mask
+                = smask_t::scales_data_type | smask_t::scales_groups;
+        VCHECK_RED_UNIMPL(
+                attr->has_default_values(attr_mask), VERBOSE_UNSUPPORTED_ATTR);
+        VCHECK_RED(attr->scales_.has_default_values(
+                           std::vector<int> {DNNL_ARG_DST}),
+                VERBOSE_UNSUPPORTED_ATTR);
+        const auto &scales = attr->scales_.get(DNNL_ARG_DST);
+        VCHECK_RED(!scales.has_default_values(), VERBOSE_UNSUPPORTED_ATTR);
+        VCHECK_RED(scales.is_dynamic_fp(), VERBOSE_UNSUPPORTED_ATTR);
+        VCHECK_RED(scales.get_data_type() == f32, VERBOSE_INVALID_DATATYPE,
+                "scales");
+        VCHECK_RED(!scales.is_host_scalar(), VERBOSE_UNSUPPORTED_FORMAT_KIND);
+
+        const dim_t M = desc.src_desc.dims[0];
+        const dim_t N = desc.src_desc.dims[1];
+        const int mask = scales.get_mask();
+        const bool default_groups = scales.has_default_groups();
+        const dim_t group_m = scales.get_group(0);
+        const dim_t group_n = scales.get_group(1);
+
+        const bool per_tensor = mask == 0 && default_groups;
+        const bool per_row = mask == (1 << 0) && default_groups;
+        const bool per_col = mask == (1 << 1) && default_groups;
+        const bool grouped = mask == ((1 << 0) | (1 << 1)) && !default_groups
+                && group_m > 0 && group_n > 0 && M % group_m == 0
+                && N % group_n == 0
+                && ((group_m == 1 && group_n > 1)
+                        || (group_n == 1 && group_m > 1));
+        VCHECK_RED(one_of(true, per_tensor, per_row, per_col, grouped),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+        if (!types::is_zero_md(&desc.dst_desc)) {
+            VCHECK_RED(desc.dst_desc.data_type == s8, VERBOSE_INVALID_DATATYPE,
+                    "dst");
+        }
+        return status::success;
+    }
 
     if (attr == nullptr) return status::success;
     if (attr->has_default_values()) return status::success;

--- a/src/common/reduction_pd.hpp
+++ b/src/common/reduction_pd.hpp
@@ -19,6 +19,7 @@
 
 #include "c_types_map.hpp"
 #include "primitive_desc.hpp"
+#include "type_helpers.hpp"
 #include "utils.hpp"
 
 #define VDISPATCH_REDUCTION(cond, msg, ...) \
@@ -64,10 +65,29 @@ struct reduction_pd_t : public primitive_desc_t {
         return status::success;
     }
 
+    bool is_dynamic_quantize() const {
+        return desc()->alg_kind == alg_kind::reduction_dynamic_quantize;
+    }
+
+    bool is_compute_only() const {
+        return is_dynamic_quantize() && types::is_zero_md(&dst_md_);
+    }
+
+    const memory_desc_t *scale_md() const {
+        return is_dynamic_quantize() ? &scale_md_ : &glob_zero_md;
+    }
+
     arg_usage_t arg_usage(int arg) const override {
+        if (is_dynamic_quantize()) {
+            if (arg == (DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST))
+                return arg_usage_t::output;
+        }
+
         switch (arg) {
             case DNNL_ARG_SRC: return arg_usage_t::input;
-            case DNNL_ARG_DST: return arg_usage_t::output;
+            case DNNL_ARG_DST:
+                return is_compute_only() ? arg_usage_t::unused
+                                         : arg_usage_t::output;
             default: return primitive_desc_t::arg_usage(arg);
         }
     }
@@ -77,6 +97,7 @@ struct reduction_pd_t : public primitive_desc_t {
         switch (arg) {
             case DNNL_ARG_SRC: return src_md(0);
             case DNNL_ARG_DST: return dst_md(0, user_input);
+            case DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST: return scale_md();
             default: return primitive_desc_t::arg_md(arg);
         }
     }
@@ -92,8 +113,10 @@ struct reduction_pd_t : public primitive_desc_t {
         return &glob_zero_md;
     }
 
-    int n_inputs() const override { return 1 + n_binary_po_inputs(); }
-    int n_outputs() const override { return 1; }
+    int n_inputs() const override {
+        return is_dynamic_quantize() ? 1 : 1 + n_binary_po_inputs();
+    }
+    int n_outputs() const override { return is_compute_only() ? 0 : 1; }
 
     static void memory_desc_reduce_dim(memory_desc_t &md, int dim) {
         if (md.format_kind != format_kind::blocked) return;
@@ -145,13 +168,23 @@ protected:
 
     memory_desc_t src_md_;
     memory_desc_t dst_md_;
+    memory_desc_t scale_md_;
 
     reduction_pd_t(const op_desc_t *adesc, const primitive_attr_t *attr,
             const hint_class *hint_fwd)
         : primitive_desc_t(attr, base_pkind)
         , desc_(*op_desc_t::to_desc<reduction_desc_t>(adesc))
         , src_md_(desc_.src_desc)
-        , dst_md_(desc_.dst_desc) {}
+        , dst_md_(desc_.dst_desc)
+        , scale_md_(types::zero_md()) {
+        if (is_dynamic_quantize()) {
+            auto st = this->attr()
+                              ->scales_.get(DNNL_ARG_DST)
+                              .get_md(scale_md_, src_md_);
+            assert(st == status::success);
+            UNUSED(st);
+        }
+    }
 
     status_t set_default_params() {
         if (dst_md_.format_kind != format_kind::any) return status::success;

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1389,7 +1389,10 @@ std::string init_info_reduction(const engine_t *e, const pd_t *pd) {
 
     ss << md2fmt_str("src", src_md, pd->invariant_src_user_format_kind())
        << " ";
-    ss << md2fmt_str("dst", dst_md, pd->invariant_dst_user_format_kind());
+    if (!pd->is_compute_only())
+        ss << md2fmt_str("dst", dst_md, pd->invariant_dst_user_format_kind());
+    if (pd->is_dynamic_quantize())
+        ss << " " << md2fmt_str("scale", pd->scale_md(), format_kind::undef);
 
     ss << "," << pd->attr() << ",";
     ss << "alg:" << pd->desc()->alg_kind << " p:" << pd->desc()->p

--- a/src/cpu/cpu_reduction_list.cpp
+++ b/src/cpu/cpu_reduction_list.cpp
@@ -17,9 +17,13 @@
 
 #include "cpu/cpu_engine.hpp"
 
+#include "cpu/ref_dynamic_quantize.hpp"
 #include "cpu/ref_reduction.hpp"
 
 #if DNNL_X64
+#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
+#include "cpu/x64/dynamic_quantize.hpp"
+#endif
 #include "cpu/x64/jit_uni_reduction.hpp"
 using namespace dnnl::impl::cpu::x64;
 #elif DNNL_RV64
@@ -36,6 +40,11 @@ using namespace dnnl::impl::data_type;
 
 // clang-format off
 constexpr impl_list_item_t impl_list[] = REG_REDUCTION_P({
+#if DNNL_X64 && !defined(_MSC_VER) \
+        && (defined(__GNUC__) || defined(__clang__))
+    CPU_INSTANCE_X64(dynamic_quantize_reduction_t)
+#endif
+    CPU_INSTANCE(ref_dynamic_quantize_reduction_t)
     CPU_INSTANCE_X64(jit_uni_reduction_t)
     CPU_INSTANCE_RV64(jit_uni_reduction_t)
     CPU_INSTANCE(ref_reduction_t)

--- a/src/cpu/ref_dynamic_quantize.cpp
+++ b/src/cpu/ref_dynamic_quantize.cpp
@@ -1,0 +1,158 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cmath>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+#include "common/memory_desc_wrapper.hpp"
+#include "common/nstl.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/ref_dynamic_quantize.hpp"
+#include "cpu/ref_io_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+
+namespace {
+
+constexpr float scale_eps = 1.0e-30f;
+
+float symmetric_scale(float absmax) {
+    return nstl::max(absmax / 127.0f, scale_eps);
+}
+
+void set_src_pos_from_scale_pos(
+        dims_t src_pos, const dims_t scale_pos, int ndims, dim_t m, dim_t n) {
+    for (int d = 0; d < ndims - 2; ++d)
+        src_pos[d] = scale_pos[d];
+    src_pos[ndims - 2] = m;
+    src_pos[ndims - 1] = n;
+}
+
+void get_group_bounds(const memory_desc_wrapper &src_mdw,
+        const memory_desc_wrapper &scale_mdw, const dims_t scale_pos,
+        dim_t &m_start, dim_t &m_end, dim_t &n_start, dim_t &n_end) {
+    const int ndims = src_mdw.ndims();
+    const dim_t M = src_mdw.dims()[ndims - 2];
+    const dim_t N = src_mdw.dims()[ndims - 1];
+    const dim_t sm = scale_mdw.dims()[ndims - 2];
+    const dim_t sn = scale_mdw.dims()[ndims - 1];
+    const dim_t scale_m = scale_pos[ndims - 2];
+    const dim_t scale_n = scale_pos[ndims - 1];
+
+    if (sm == 1 && sn == 1) {
+        m_start = 0;
+        m_end = M;
+        n_start = 0;
+        n_end = N;
+    } else if (sm == M && sn == 1) {
+        m_start = scale_m;
+        m_end = scale_m + 1;
+        n_start = 0;
+        n_end = N;
+    } else if (sm == 1 && sn == N) {
+        m_start = 0;
+        m_end = M;
+        n_start = scale_n;
+        n_end = scale_n + 1;
+    } else if (sn == N) {
+        const dim_t rows_per_group = M / sm;
+        m_start = scale_m * rows_per_group;
+        m_end = m_start + rows_per_group;
+        n_start = scale_n;
+        n_end = scale_n + 1;
+    } else {
+        const dim_t cols_per_group = N / sn;
+        m_start = scale_m;
+        m_end = scale_m + 1;
+        n_start = scale_n * cols_per_group;
+        n_end = n_start + cols_per_group;
+    }
+}
+
+} // namespace
+
+status_t ref_dynamic_quantize_reduction_t::execute_ref(
+        const exec_ctx_t &ctx) const {
+    auto src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+    auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+    auto scale = CTX_OUT_MEM(void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+
+    const memory_desc_wrapper src_mdw(pd()->src_md());
+    const memory_desc_wrapper dst_mdw(pd()->dst_md());
+    const memory_desc_wrapper scale_mdw(pd()->scale_md());
+
+    const int ndims = src_mdw.ndims();
+    const bool compute_only = pd()->is_compute_only();
+
+    parallel_nd(scale_mdw.nelems(), [=](dim_t scale_l_offset) {
+        dims_t scale_pos;
+        utils::l_dims_by_l_offset(
+                scale_pos, scale_l_offset, scale_mdw.dims(), ndims);
+
+        dim_t m_start, m_end, n_start, n_end;
+        get_group_bounds(
+                src_mdw, scale_mdw, scale_pos, m_start, m_end, n_start, n_end);
+
+        float absmax = 0.0f;
+
+        dims_t src_pos;
+        for (dim_t m = m_start; m < m_end; ++m) {
+            for (dim_t n = n_start; n < n_end; ++n) {
+                set_src_pos_from_scale_pos(src_pos, scale_pos, ndims, m, n);
+                const dim_t src_off = src_mdw.off_v(src_pos);
+                const float val = io::load_float_value(
+                        src_mdw.data_type(), src, src_off);
+                if (!std::isfinite(val)) continue;
+                absmax = nstl::max(absmax, nstl::abs(val));
+            }
+        }
+
+        const float scale_val = symmetric_scale(absmax);
+
+        const dim_t scale_off = scale_mdw.off_v(scale_pos);
+        io::store_float_value(
+                scale_mdw.data_type(), scale_val, scale, scale_off);
+
+        if (compute_only) return;
+
+        for (dim_t m = m_start; m < m_end; ++m) {
+            for (dim_t n = n_start; n < n_end; ++n) {
+                set_src_pos_from_scale_pos(src_pos, scale_pos, ndims, m, n);
+                const dim_t src_off = src_mdw.off_v(src_pos);
+                const dim_t dst_off = dst_mdw.off_v(src_pos);
+                const float val = io::load_float_value(
+                        src_mdw.data_type(), src, src_off);
+
+                float q = 0.0f;
+                if (std::isfinite(val)) {
+                    q = nstl::max(-127.0f,
+                            nstl::min(127.0f, nearbyintf(val / scale_val)));
+                }
+                io::store_float_value(dst_mdw.data_type(), q, dst, dst_off);
+            }
+        }
+    });
+
+    return status::success;
+}
+
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/ref_dynamic_quantize.hpp
+++ b/src/cpu/ref_dynamic_quantize.hpp
@@ -1,0 +1,68 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_REF_DYNAMIC_QUANTIZE_HPP
+#define CPU_REF_DYNAMIC_QUANTIZE_HPP
+
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/cpu_reduction_pd.hpp"
+#include "cpu/platform.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+
+struct ref_dynamic_quantize_reduction_t : public primitive_t {
+    struct pd_t : public cpu_reduction_pd_t {
+        using cpu_reduction_pd_t::cpu_reduction_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                "ref:dynamic_quantize", ref_dynamic_quantize_reduction_t);
+
+        status_t init(engine_t *engine) {
+            using namespace data_type;
+            VDISPATCH_REDUCTION(is_dynamic_quantize(), VERBOSE_BAD_ALGORITHM);
+            VDISPATCH_REDUCTION(
+                    platform::has_data_type_support(src_md()->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_REDUCTION(
+                    platform::has_data_type_support(scale_md()->data_type),
+                    VERBOSE_UNSUPPORTED_DT);
+            VDISPATCH_REDUCTION(set_default_params() == status::success,
+                    VERBOSE_UNSUPPORTED_TAG);
+
+            return status::success;
+        }
+    };
+
+    ref_dynamic_quantize_reduction_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_ref(ctx);
+    }
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t execute_ref(const exec_ctx_t &ctx) const;
+};
+
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/dynamic_quantize.cpp
+++ b/src/cpu/x64/dynamic_quantize.cpp
@@ -1,0 +1,148 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/x64/dynamic_quantize.hpp"
+#include "cpu/x64/dynamic_quantize_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+
+namespace dq = dynamic_quantize_kernels;
+
+status_t dynamic_quantize_reduction_t::pd_t::init(engine_t *engine) {
+    using namespace data_type;
+    using namespace format_tag;
+    using namespace utils;
+    VDISPATCH_REDUCTION(is_dynamic_quantize(), VERBOSE_BAD_ALGORITHM);
+
+    // The ported kernels require AVX-512 (bf16 uses an AVX-512F shim; f16 uses
+    // F16C, present on every avx512_core CPU).
+    isa_ = isa_undef;
+    if (mayiuse(avx512_core_fp16)) {
+        isa_ = avx512_core_fp16;
+    } else if (mayiuse(avx512_core_bf16)) {
+        isa_ = avx512_core_bf16;
+    } else if (mayiuse(avx512_core)) {
+        isa_ = avx512_core;
+    }
+    VDISPATCH_REDUCTION(isa_ != isa_undef, VERBOSE_UNSUPPORTED_ISA);
+
+    VDISPATCH_REDUCTION(one_of(src_md()->data_type, f32, bf16, f16),
+            VERBOSE_UNSUPPORTED_DT);
+    VDISPATCH_REDUCTION(scale_md()->data_type == f32, VERBOSE_UNSUPPORTED_DT);
+
+    // The fused kernels always write the quantized dst; compute-only mode is
+    // left to the portable reference implementation.
+    VDISPATCH_REDUCTION(
+            !is_compute_only(), VERBOSE_UNSUPPORTED_FEATURE, "compute_only");
+
+    // The kernels address memory as dense, row-major 2D matrices.
+    VDISPATCH_REDUCTION(
+            src_md()->ndims == 2, VERBOSE_BAD_NDIMS, "src", src_md()->ndims);
+
+    VDISPATCH_REDUCTION(
+            set_default_params() == status::success, VERBOSE_UNSUPPORTED_TAG);
+
+    VDISPATCH_REDUCTION(memory_desc_matches_tag(*src_md(), ab)
+                    && memory_desc_matches_tag(*dst_md(), ab)
+                    && memory_desc_matches_tag(*scale_md(), ab),
+            VERBOSE_UNSUPPORTED_TAG);
+
+    // Determine the granularity handled by the ported kernels from the scale
+    // shape. Everything else (per-tensor, per-col, per-group-row) is left to
+    // the reference implementation.
+    M_ = src_md()->dims[0];
+    N_ = src_md()->dims[1];
+    const dim_t sm_dim = scale_md()->dims[0];
+    const dim_t sn_dim = scale_md()->dims[1];
+    if (sm_dim == M_ && sn_dim == 1) {
+        gran_ = granularity_t::per_token;
+        G_ = 1;
+    } else if (sm_dim == M_ && sn_dim > 1 && N_ % sn_dim == 0) {
+        gran_ = granularity_t::per_group;
+        G_ = sn_dim;
+    } else {
+        return status::unimplemented;
+    }
+
+    return status::success;
+}
+
+status_t dynamic_quantize_reduction_t::execute(const exec_ctx_t &ctx) const {
+    using namespace data_type;
+
+    const auto *p = pd();
+    const auto sdt = p->src_md()->data_type;
+    const dim_t M = p->M_, N = p->N_, G = p->G_;
+
+    const auto *src = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+    auto *dst = CTX_OUT_MEM(int8_t *, DNNL_ARG_DST);
+    auto *scale = CTX_OUT_MEM(float *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+
+    const auto *src_u16 = static_cast<const uint16_t *>(src);
+    const auto *src_f32 = static_cast<const float *>(src);
+
+    if (p->gran_ == pd_t::granularity_t::per_token) {
+        switch (sdt) {
+            case f32:
+                dq::dynamic_per_token_quant_f32_s8_native(
+                        src_f32, dst, scale, M, N);
+                break;
+            case bf16:
+                dq::dynamic_per_token_quant_bf16_s8_native(
+                        src_u16, dst, scale, M, N);
+                break;
+            case f16:
+                dq::dynamic_per_token_quant_f16_s8_native(
+                        src_u16, dst, scale, M, N);
+                break;
+            default: return status::runtime_error;
+        }
+    } else { // per_group
+        switch (sdt) {
+            case f32:
+                dq::dynamic_per_group_quant_f32_s8_native(
+                        src_f32, dst, scale, M, N, G);
+                break;
+            case bf16:
+                dq::dynamic_per_group_quant_bf16_s8_native(
+                        src_u16, dst, scale, M, N, G);
+                break;
+            case f16:
+                dq::dynamic_per_group_quant_f16_s8_native(
+                        src_u16, dst, scale, M, N, G);
+                break;
+            default: return status::runtime_error;
+        }
+    }
+
+    return status::success;
+}
+
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))

--- a/src/cpu/x64/dynamic_quantize.hpp
+++ b/src/cpu/x64/dynamic_quantize.hpp
@@ -1,0 +1,71 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_DYNAMIC_QUANTIZE_HPP
+#define CPU_X64_DYNAMIC_QUANTIZE_HPP
+
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+
+#include "cpu/cpu_reduction_pd.hpp"
+
+#include "cpu/x64/cpu_isa_traits.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+
+// Optimized x64 implementation of reduction_dynamic_quantize. Wraps the
+// AVX-512 fused per-token and per-group INT8 kernels ported from ZenDNN.
+// Non-matching configurations (other granularities, compute-only, non-2D,
+// non-dense layouts) return unimplemented so the portable reference handles
+// them.
+struct dynamic_quantize_reduction_t : public primitive_t {
+    struct pd_t : public cpu_reduction_pd_t {
+        using cpu_reduction_pd_t::cpu_reduction_pd_t;
+
+        DECLARE_COMMON_PD_T(
+                "avx512_core:dynamic_quantize", dynamic_quantize_reduction_t);
+
+        status_t init(engine_t *engine);
+
+        // Granularity handled by the ported kernels.
+        enum class granularity_t { per_token, per_group };
+
+        granularity_t gran_ = granularity_t::per_token;
+        dim_t M_ = 0;
+        dim_t N_ = 0;
+        dim_t G_ = 1; // number of column groups for per-group mode
+        cpu_isa_t isa_ = isa_undef;
+    };
+
+    dynamic_quantize_reduction_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const {
+        return static_cast<const pd_t *>(primitive_t::pd().get());
+    }
+};
+
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/dynamic_quantize_kernels.hpp
+++ b/src/cpu/x64/dynamic_quantize_kernels.hpp
@@ -1,0 +1,52 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_DYNAMIC_QUANTIZE_KERNELS_HPP
+#define CPU_X64_DYNAMIC_QUANTIZE_KERNELS_HPP
+
+#include <cstdint>
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace dynamic_quantize_kernels {
+
+// Fused per-token (per-row) AVX-512 dynamic-quant kernels ported from ZenDNN.
+// Scale layout is [M, 1]; each row is scanned for absmax and quantized to s8.
+void dynamic_per_token_quant_bf16_s8_native(
+        const uint16_t *src, int8_t *dst, float *scales, int64_t M, int64_t N);
+void dynamic_per_token_quant_f32_s8_native(
+        const float *src, int8_t *dst, float *scales, int64_t M, int64_t N);
+void dynamic_per_token_quant_f16_s8_native(
+        const uint16_t *src, int8_t *dst, float *scales, int64_t M, int64_t N);
+// Fused per-group (per-group-col) AVX-512 dynamic-quant kernels ported from
+// ZenDNN. Scale layout is [M, G]; the K axis is split into G contiguous groups
+// of size K / G (G must divide K). Each (row, group) is scanned and quantized
+// in one pass.
+void dynamic_per_group_quant_f32_s8_native(const float *src, int8_t *dst,
+        float *scales, int64_t M, int64_t K, int64_t G);
+void dynamic_per_group_quant_bf16_s8_native(const uint16_t *src, int8_t *dst,
+        float *scales, int64_t M, int64_t K, int64_t G);
+void dynamic_per_group_quant_f16_s8_native(const uint16_t *src, int8_t *dst,
+        float *scales, int64_t M, int64_t K, int64_t G);
+} // namespace dynamic_quantize_kernels
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/dynamic_quantize_kernels_per_group.cpp
+++ b/src/cpu/x64/dynamic_quantize_kernels_per_group.cpp
@@ -1,0 +1,439 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
+
+// AVX-512 fused dynamic-quantization kernels ported from AMD ZenDNN's reorder
+// dynamic-quant path. The intrinsic kernel bodies are kept verbatim; only the
+// threading driver (oneDNN parallel_nd / parallel) and the scalar bf16/f16
+// conversion helpers are oneDNN-native.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+#include <immintrin.h>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+
+#include "cpu/x64/dynamic_quantize_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace dynamic_quantize_kernels {
+
+namespace {
+
+// Scalar bf16 -> f32: bf16 is the upper 16 bits of an IEEE-754 float32.
+static inline float dq_bf16_to_f32(uint16_t v) {
+    uint32_t u = static_cast<uint32_t>(v) << 16;
+    float f;
+    std::memcpy(&f, &u, sizeof(f));
+    return f;
+}
+
+// Scalar IEEE-754 half -> float (used only on the sub-16 element tail).
+static inline float dq_f16_to_f32(uint16_t h) {
+    const uint32_t sign = static_cast<uint32_t>(h & 0x8000u) << 16;
+    uint32_t exp = (h >> 10) & 0x1Fu;
+    uint32_t mant = h & 0x3FFu;
+    uint32_t f;
+    if (exp == 0) {
+        if (mant == 0) {
+            f = sign;
+        } else {
+            exp = 127 - 15 + 1;
+            while ((mant & 0x400u) == 0) {
+                mant <<= 1;
+                exp--;
+            }
+            mant &= 0x3FFu;
+            f = sign | (exp << 23) | (mant << 13);
+        }
+    } else if (exp == 0x1Fu) {
+        f = sign | 0x7F800000u | (mant << 13);
+    } else {
+        f = sign | ((exp - 15 + 127) << 23) | (mant << 13);
+    }
+    float out;
+    std::memcpy(&out, &f, sizeof(out));
+    return out;
+}
+
+// oneDNN-threaded replacement for ZenDNN's zendnnl_parallel_for chunked API.
+template <typename F>
+static inline void zendnnl_parallel_for(
+        int64_t begin, int64_t end, int64_t /*grain*/, const F &f) {
+    if (end <= begin) return;
+    parallel(0, [&](int ithr, int nthr) {
+        int64_t s = 0, e = 0;
+        balance211(end - begin, nthr, ithr, s, e);
+        if (s < e) f(begin + s, begin + e);
+    });
+}
+
+} // namespace
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline __m512
+finite_or_zero_pg(__m512 v) {
+    const __m512i abs_mask = _mm512_set1_epi32(0x7FFFFFFF);
+    const __m512 vinf = _mm512_set1_ps(std::numeric_limits<float>::infinity());
+    const __m512 absv = _mm512_castsi512_ps(
+            _mm512_and_si512(_mm512_castps_si512(v), abs_mask));
+    return _mm512_maskz_mov_ps(_mm512_cmp_ps_mask(absv, vinf, _CMP_LT_OQ), v);
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline __m512
+bf16x16_to_f32_pg(__m256i bf16) {
+    return _mm512_castsi512_ps(
+            _mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16), 16));
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl,f16c"))) static inline __m512
+f16x16_to_f32_pg(__m256i f16) {
+    return _mm512_cvtph_ps(f16);
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline __mmask16
+finite_mask_pg(__m512 v, __m512i abs_mask, __m512 vinf) {
+    __m512 absv = _mm512_castsi512_ps(
+            _mm512_and_si512(_mm512_castps_si512(v), abs_mask));
+    return _mm512_cmp_ps_mask(absv, vinf, _CMP_LT_OQ);
+}
+
+static inline void compute_symmetric_scale_pg(float absmax, float &scale) {
+    constexpr float scale_eps = 1.0e-30f;
+    scale = std::max(absmax / 127.0f, scale_eps);
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline void
+store_4x16_s8_pg(int8_t *dst, __m128i i0, __m128i i1, __m128i i2, __m128i i3,
+        bool cacheline_aligned) {
+    if (cacheline_aligned) {
+        __m256i lo = _mm256_set_m128i(i1, i0);
+        __m256i hi = _mm256_set_m128i(i3, i2);
+        __m512i pack = _mm512_inserti64x4(_mm512_castsi256_si512(lo), hi, 1);
+        _mm512_store_si512(reinterpret_cast<__m512i *>(dst), pack);
+    } else {
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), i0);
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst + 16), i1);
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst + 32), i2);
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst + 48), i3);
+    }
+}
+
+template <typename LoadF32>
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline float
+group_absmax(const LoadF32 &load_f32, int64_t group_size, __m512i abs_mask,
+        __m512 vinf) {
+    __m512 vam0 = _mm512_setzero_ps();
+    __m512 vam1 = _mm512_setzero_ps();
+    __m512 vam2 = _mm512_setzero_ps();
+    __m512 vam3 = _mm512_setzero_ps();
+
+    int64_t j = 0;
+    for (; j + 63 < group_size; j += 64) {
+        __m512 f0 = load_f32(j);
+        __m512 f1 = load_f32(j + 16);
+        __m512 f2 = load_f32(j + 32);
+        __m512 f3 = load_f32(j + 48);
+        __m512 a0 = _mm512_castsi512_ps(
+                _mm512_and_si512(_mm512_castps_si512(f0), abs_mask));
+        __m512 a1 = _mm512_castsi512_ps(
+                _mm512_and_si512(_mm512_castps_si512(f1), abs_mask));
+        __m512 a2 = _mm512_castsi512_ps(
+                _mm512_and_si512(_mm512_castps_si512(f2), abs_mask));
+        __m512 a3 = _mm512_castsi512_ps(
+                _mm512_and_si512(_mm512_castps_si512(f3), abs_mask));
+        vam0 = _mm512_mask_max_ps(
+                vam0, finite_mask_pg(f0, abs_mask, vinf), vam0, a0);
+        vam1 = _mm512_mask_max_ps(
+                vam1, finite_mask_pg(f1, abs_mask, vinf), vam1, a1);
+        vam2 = _mm512_mask_max_ps(
+                vam2, finite_mask_pg(f2, abs_mask, vinf), vam2, a2);
+        vam3 = _mm512_mask_max_ps(
+                vam3, finite_mask_pg(f3, abs_mask, vinf), vam3, a3);
+    }
+
+    for (; j + 15 < group_size; j += 16) {
+        __m512 f = load_f32(j);
+        __m512 af = _mm512_castsi512_ps(
+                _mm512_and_si512(_mm512_castps_si512(f), abs_mask));
+        vam0 = _mm512_mask_max_ps(
+                vam0, finite_mask_pg(f, abs_mask, vinf), vam0, af);
+    }
+
+    vam0 = _mm512_max_ps(_mm512_max_ps(vam0, vam1), _mm512_max_ps(vam2, vam3));
+    return _mm512_reduce_max_ps(vam0);
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) void
+dynamic_per_group_quant_f32_s8_native(const float *src, int8_t *dst,
+        float *scales, int64_t M, int64_t K, int64_t G) {
+    if (M <= 0 || K <= 0 || G <= 0 || (K % G) != 0) return;
+
+    const int64_t group_size = K / G;
+    const int64_t total_groups = M * G;
+    const __m512i abs_mask = _mm512_set1_epi32(0x7FFFFFFF);
+    const __m512 vinf = _mm512_set1_ps(std::numeric_limits<float>::infinity());
+
+    zendnnl_parallel_for(0, total_groups, 1,
+            [&](int64_t begin, int64_t end) __attribute__((
+                    target("avx512f,avx512bw,avx512vl"))) {
+                for (int64_t task = begin; task < end; ++task) {
+                    const int64_t m = task / G;
+                    const int64_t g = task - m * G;
+                    const int64_t offset = m * K + g * group_size;
+                    const float *grp_src = src + offset;
+                    int8_t *grp_dst = dst + offset;
+
+                    bool quantize_phase = false;
+                    auto load_f32 = ([&](int64_t j) __attribute__((
+                            target("avx512f,avx512bw,avx512vl"))) {
+                        const __m512 v = _mm512_loadu_ps(grp_src + j);
+                        return quantize_phase ? finite_or_zero_pg(v) : v;
+                    });
+
+                    float absmax = group_absmax(
+                            load_f32, group_size, abs_mask, vinf);
+                    int64_t j = group_size & ~int64_t {15};
+                    for (; j < group_size; ++j) {
+                        if (std::isfinite(grp_src[j]))
+                            absmax = std::max(absmax, std::abs(grp_src[j]));
+                    }
+
+                    float scale;
+                    compute_symmetric_scale_pg(absmax, scale);
+                    scales[task] = scale;
+
+                    quantize_phase = true;
+                    const __m512 vscale = _mm512_set1_ps(scale);
+                    const bool cl_ok
+                            = (reinterpret_cast<uintptr_t>(grp_dst) & 63) == 0;
+
+                    j = 0;
+                    for (; j + 63 < group_size; j += 64) {
+                        __m512i r0 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j), vscale));
+                        __m512i r1 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 16), vscale));
+                        __m512i r2 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 32), vscale));
+                        __m512i r3 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 48), vscale));
+                        store_4x16_s8_pg(grp_dst + j, _mm512_cvtepi32_epi8(r0),
+                                _mm512_cvtepi32_epi8(r1),
+                                _mm512_cvtepi32_epi8(r2),
+                                _mm512_cvtepi32_epi8(r3), cl_ok);
+                    }
+                    for (; j + 15 < group_size; j += 16) {
+                        __m512i r = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j), vscale));
+                        _mm_storeu_si128(
+                                reinterpret_cast<__m128i *>(grp_dst + j),
+                                _mm512_cvtepi32_epi8(r));
+                    }
+                    for (; j < group_size; ++j) {
+                        if (!std::isfinite(grp_src[j])) {
+                            grp_dst[j] = 0;
+                            continue;
+                        }
+                        int32_t q = static_cast<int32_t>(
+                                std::nearbyint(grp_src[j] / scale));
+                        grp_dst[j] = static_cast<int8_t>(q);
+                    }
+                }
+            });
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) void
+dynamic_per_group_quant_bf16_s8_native(const uint16_t *src, int8_t *dst,
+        float *scales, int64_t M, int64_t K, int64_t G) {
+    if (M <= 0 || K <= 0 || G <= 0 || (K % G) != 0) return;
+
+    const int64_t group_size = K / G;
+    const int64_t total_groups = M * G;
+    const __m512i abs_mask = _mm512_set1_epi32(0x7FFFFFFF);
+    const __m512 vinf = _mm512_set1_ps(std::numeric_limits<float>::infinity());
+
+    zendnnl_parallel_for(0, total_groups, 1,
+            [&](int64_t begin, int64_t end) __attribute__((
+                    target("avx512f,avx512bw,avx512vl"))) {
+                for (int64_t task = begin; task < end; ++task) {
+                    const int64_t m = task / G;
+                    const int64_t g = task - m * G;
+                    const int64_t offset = m * K + g * group_size;
+                    const uint16_t *grp_src = src + offset;
+                    int8_t *grp_dst = dst + offset;
+
+                    bool quantize_phase = false;
+                    auto load_f32 = ([&](int64_t j) __attribute__((
+                            target("avx512f,avx512bw,avx512vl"))) {
+                        const __m512 v = bf16x16_to_f32_pg(_mm256_loadu_si256(
+                                reinterpret_cast<const __m256i *>(
+                                        grp_src + j)));
+                        return quantize_phase ? finite_or_zero_pg(v) : v;
+                    });
+
+                    float absmax = group_absmax(
+                            load_f32, group_size, abs_mask, vinf);
+                    int64_t j = group_size & ~int64_t {15};
+                    for (; j < group_size; ++j) {
+                        float v = dq_bf16_to_f32(grp_src[j]);
+                        if (std::isfinite(v))
+                            absmax = std::max(absmax, std::abs(v));
+                    }
+
+                    float scale;
+                    compute_symmetric_scale_pg(absmax, scale);
+                    scales[task] = scale;
+
+                    quantize_phase = true;
+                    const __m512 vscale = _mm512_set1_ps(scale);
+                    const bool cl_ok
+                            = (reinterpret_cast<uintptr_t>(grp_dst) & 63) == 0;
+
+                    j = 0;
+                    for (; j + 63 < group_size; j += 64) {
+                        __m512i r0 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j), vscale));
+                        __m512i r1 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 16), vscale));
+                        __m512i r2 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 32), vscale));
+                        __m512i r3 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 48), vscale));
+                        store_4x16_s8_pg(grp_dst + j, _mm512_cvtepi32_epi8(r0),
+                                _mm512_cvtepi32_epi8(r1),
+                                _mm512_cvtepi32_epi8(r2),
+                                _mm512_cvtepi32_epi8(r3), cl_ok);
+                    }
+                    for (; j + 15 < group_size; j += 16) {
+                        __m512i r = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j), vscale));
+                        _mm_storeu_si128(
+                                reinterpret_cast<__m128i *>(grp_dst + j),
+                                _mm512_cvtepi32_epi8(r));
+                    }
+                    for (; j < group_size; ++j) {
+                        float v = dq_bf16_to_f32(grp_src[j]);
+                        if (!std::isfinite(v)) {
+                            grp_dst[j] = 0;
+                            continue;
+                        }
+                        int32_t q = static_cast<int32_t>(
+                                std::nearbyint(v / scale));
+                        grp_dst[j] = static_cast<int8_t>(q);
+                    }
+                }
+            });
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl,f16c"))) void
+dynamic_per_group_quant_f16_s8_native(const uint16_t *src, int8_t *dst,
+        float *scales, int64_t M, int64_t K, int64_t G) {
+    if (M <= 0 || K <= 0 || G <= 0 || (K % G) != 0) return;
+
+    const int64_t group_size = K / G;
+    const int64_t total_groups = M * G;
+    const __m512i abs_mask = _mm512_set1_epi32(0x7FFFFFFF);
+    const __m512 vinf = _mm512_set1_ps(std::numeric_limits<float>::infinity());
+
+    zendnnl_parallel_for(0, total_groups, 1,
+            [&](int64_t begin, int64_t end) __attribute__((
+                    target("avx512f,avx512bw,avx512vl,f16c"))) {
+                for (int64_t task = begin; task < end; ++task) {
+                    const int64_t m = task / G;
+                    const int64_t g = task - m * G;
+                    const int64_t offset = m * K + g * group_size;
+                    const uint16_t *grp_src = src + offset;
+                    int8_t *grp_dst = dst + offset;
+
+                    bool quantize_phase = false;
+                    auto load_f32 = ([&](int64_t j) __attribute__((
+                            target("avx512f,avx512bw,avx512vl,f16c"))) {
+                        const __m512 v = f16x16_to_f32_pg(_mm256_loadu_si256(
+                                reinterpret_cast<const __m256i *>(
+                                        grp_src + j)));
+                        return quantize_phase ? finite_or_zero_pg(v) : v;
+                    });
+
+                    float absmax = group_absmax(
+                            load_f32, group_size, abs_mask, vinf);
+                    int64_t j = group_size & ~int64_t {15};
+                    for (; j < group_size; ++j) {
+                        float v = dq_f16_to_f32(grp_src[j]);
+                        if (std::isfinite(v))
+                            absmax = std::max(absmax, std::abs(v));
+                    }
+
+                    float scale;
+                    compute_symmetric_scale_pg(absmax, scale);
+                    scales[task] = scale;
+
+                    quantize_phase = true;
+                    const __m512 vscale = _mm512_set1_ps(scale);
+                    const bool cl_ok
+                            = (reinterpret_cast<uintptr_t>(grp_dst) & 63) == 0;
+
+                    j = 0;
+                    for (; j + 63 < group_size; j += 64) {
+                        __m512i r0 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j), vscale));
+                        __m512i r1 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 16), vscale));
+                        __m512i r2 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 32), vscale));
+                        __m512i r3 = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j + 48), vscale));
+                        store_4x16_s8_pg(grp_dst + j, _mm512_cvtepi32_epi8(r0),
+                                _mm512_cvtepi32_epi8(r1),
+                                _mm512_cvtepi32_epi8(r2),
+                                _mm512_cvtepi32_epi8(r3), cl_ok);
+                    }
+                    for (; j + 15 < group_size; j += 16) {
+                        __m512i r = _mm512_cvtps_epi32(
+                                _mm512_div_ps(load_f32(j), vscale));
+                        _mm_storeu_si128(
+                                reinterpret_cast<__m128i *>(grp_dst + j),
+                                _mm512_cvtepi32_epi8(r));
+                    }
+                    for (; j < group_size; ++j) {
+                        float v = dq_f16_to_f32(grp_src[j]);
+                        if (!std::isfinite(v)) {
+                            grp_dst[j] = 0;
+                            continue;
+                        }
+                        int32_t q = static_cast<int32_t>(
+                                std::nearbyint(v / scale));
+                        grp_dst[j] = static_cast<int8_t>(q);
+                    }
+                }
+            });
+}
+
+} // namespace dynamic_quantize_kernels
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))

--- a/src/cpu/x64/dynamic_quantize_kernels_per_token.cpp
+++ b/src/cpu/x64/dynamic_quantize_kernels_per_token.cpp
@@ -1,0 +1,497 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#if !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))
+
+// AVX-512 fused dynamic-quantization kernels ported from AMD ZenDNN's reorder
+// dynamic-quant path. The intrinsic kernel bodies are kept verbatim; only the
+// threading driver (oneDNN parallel_nd / parallel) and the scalar bf16/f16
+// conversion helpers are oneDNN-native.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+
+#include <immintrin.h>
+
+#include "common/c_types_map.hpp"
+#include "common/dnnl_thread.hpp"
+
+#include "cpu/x64/dynamic_quantize_kernels.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace dynamic_quantize_kernels {
+
+namespace {
+
+// Scalar bf16 -> f32: bf16 is the upper 16 bits of an IEEE-754 float32.
+static inline float dq_bf16_to_f32(uint16_t v) {
+    uint32_t u = static_cast<uint32_t>(v) << 16;
+    float f;
+    std::memcpy(&f, &u, sizeof(f));
+    return f;
+}
+
+// Scalar IEEE-754 half -> float (used only on the sub-16 element tail).
+static inline float dq_f16_to_f32(uint16_t h) {
+    const uint32_t sign = static_cast<uint32_t>(h & 0x8000u) << 16;
+    uint32_t exp = (h >> 10) & 0x1Fu;
+    uint32_t mant = h & 0x3FFu;
+    uint32_t f;
+    if (exp == 0) {
+        if (mant == 0) {
+            f = sign;
+        } else {
+            exp = 127 - 15 + 1;
+            while ((mant & 0x400u) == 0) {
+                mant <<= 1;
+                exp--;
+            }
+            mant &= 0x3FFu;
+            f = sign | (exp << 23) | (mant << 13);
+        }
+    } else if (exp == 0x1Fu) {
+        f = sign | 0x7F800000u | (mant << 13);
+    } else {
+        f = sign | ((exp - 15 + 127) << 23) | (mant << 13);
+    }
+    float out;
+    std::memcpy(&out, &f, sizeof(out));
+    return out;
+}
+
+// oneDNN-threaded replacement for ZenDNN's zendnnl_parallel_for chunked API.
+template <typename F>
+static inline void zendnnl_parallel_for(
+        int64_t begin, int64_t end, int64_t /*grain*/, const F &f) {
+    if (end <= begin) return;
+    parallel(0, [&](int ithr, int nthr) {
+        int64_t s = 0, e = 0;
+        balance211(end - begin, nthr, ithr, s, e);
+        if (s < e) f(begin + s, begin + e);
+    });
+}
+
+} // namespace
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline __m512
+finite_or_zero(__m512 v) {
+    const __m512i abs_mask = _mm512_set1_epi32(0x7FFFFFFF);
+    const __m512 vinf = _mm512_set1_ps(std::numeric_limits<float>::infinity());
+    const __m512 absv = _mm512_castsi512_ps(
+            _mm512_and_si512(_mm512_castps_si512(v), abs_mask));
+    return _mm512_maskz_mov_ps(_mm512_cmp_ps_mask(absv, vinf, _CMP_LT_OQ), v);
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline __m512
+bf16x16_to_f32(__m256i bf16) {
+    return _mm512_castsi512_ps(
+            _mm512_slli_epi32(_mm512_cvtepu16_epi32(bf16), 16));
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl,f16c"))) static inline __m512
+f16x16_to_f32(__m256i f16) {
+    return _mm512_cvtph_ps(f16);
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline __m512
+load_finite_f32(const float *src) {
+    return finite_or_zero(_mm512_loadu_ps(src));
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline __mmask16
+finite_mask(__m512 v, __m512i abs_mask, __m512 vinf) {
+    __m512 absv = _mm512_castsi512_ps(
+            _mm512_and_si512(_mm512_castps_si512(v), abs_mask));
+    return _mm512_cmp_ps_mask(absv, vinf, _CMP_LT_OQ);
+}
+
+static inline void compute_symmetric_scale_from_absmax(
+        float absmax, float &scale) {
+    constexpr float scale_eps = 1.0e-30f;
+    scale = std::max(absmax / 127.0f, scale_eps);
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) static inline void
+store_4x16_s8(int8_t *dst, __m128i i0, __m128i i1, __m128i i2, __m128i i3,
+        bool cacheline_aligned) {
+    if (cacheline_aligned) {
+        __m256i lo = _mm256_set_m128i(i1, i0);
+        __m256i hi = _mm256_set_m128i(i3, i2);
+        __m512i pack = _mm512_inserti64x4(_mm512_castsi256_si512(lo), hi, 1);
+        _mm512_store_si512(reinterpret_cast<__m512i *>(dst), pack);
+    } else {
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst), i0);
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst + 16), i1);
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst + 32), i2);
+        _mm_storeu_si128(reinterpret_cast<__m128i *>(dst + 48), i3);
+    }
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) void
+dynamic_per_token_quant_bf16_s8_native(
+        const uint16_t *src, int8_t *dst, float *scales, int64_t M, int64_t N) {
+    const __m512i abs_mask = _mm512_set1_epi32(0x7FFFFFFF);
+    const __m512 vinf = _mm512_set1_ps(std::numeric_limits<float>::infinity());
+
+    auto row_loop = ([&](
+            int64_t m) __attribute__((target("avx512f,avx512bw,avx512vl"))) {
+        const uint16_t *row_src = src + m * N;
+        int8_t *row_dst = dst + m * N;
+
+        // -- Pass 1: absmax reduction -----------------------------------------
+        __m512 vam0 = _mm512_setzero_ps();
+        __m512 vam1 = _mm512_setzero_ps();
+        __m512 vam2 = _mm512_setzero_ps();
+        __m512 vam3 = _mm512_setzero_ps();
+
+        int64_t j = 0;
+        for (; j + 63 < N; j += 64) {
+            __m512 f0 = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j)));
+            __m512 f1 = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 16)));
+            __m512 f2 = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 32)));
+            __m512 f3 = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 48)));
+
+            __m512 a0 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f0), abs_mask));
+            __m512 a1 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f1), abs_mask));
+            __m512 a2 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f2), abs_mask));
+            __m512 a3 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f3), abs_mask));
+            vam0 = _mm512_mask_max_ps(
+                    vam0, finite_mask(f0, abs_mask, vinf), vam0, a0);
+            vam1 = _mm512_mask_max_ps(
+                    vam1, finite_mask(f1, abs_mask, vinf), vam1, a1);
+            vam2 = _mm512_mask_max_ps(
+                    vam2, finite_mask(f2, abs_mask, vinf), vam2, a2);
+            vam3 = _mm512_mask_max_ps(
+                    vam3, finite_mask(f3, abs_mask, vinf), vam3, a3);
+        }
+
+        for (; j + 15 < N; j += 16) {
+            __m512 f = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j)));
+            __m512 af = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f), abs_mask));
+            vam0 = _mm512_mask_max_ps(
+                    vam0, finite_mask(f, abs_mask, vinf), vam0, af);
+        }
+
+        vam0 = _mm512_max_ps(
+                _mm512_max_ps(vam0, vam1), _mm512_max_ps(vam2, vam3));
+        float absmax = _mm512_reduce_max_ps(vam0);
+
+        for (; j < N; ++j) {
+            float v = dq_bf16_to_f32(row_src[j]);
+            if (std::isfinite(v)) absmax = std::max(absmax, std::abs(v));
+        }
+
+        // -- Compute per-row scale --------------------------------------------
+        float scale;
+        compute_symmetric_scale_from_absmax(absmax, scale);
+        scales[m] = scale;
+
+        // -- Pass 2: quantize (re-load BF16 from L1, still hot from Pass 1) --
+        __m512 vscale = _mm512_set1_ps(scale);
+        bool cl_ok = (reinterpret_cast<uintptr_t>(row_dst) & 63) == 0;
+
+        j = 0;
+        for (; j + 63 < N; j += 64) {
+            __m512 f0 = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j)));
+            __m512 f1 = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 16)));
+            __m512 f2 = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 32)));
+            __m512 f3 = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 48)));
+            f0 = finite_or_zero(f0);
+            f1 = finite_or_zero(f1);
+            f2 = finite_or_zero(f2);
+            f3 = finite_or_zero(f3);
+
+            __m512i r0 = _mm512_cvtps_epi32(_mm512_div_ps(f0, vscale));
+            __m512i r1 = _mm512_cvtps_epi32(_mm512_div_ps(f1, vscale));
+            __m512i r2 = _mm512_cvtps_epi32(_mm512_div_ps(f2, vscale));
+            __m512i r3 = _mm512_cvtps_epi32(_mm512_div_ps(f3, vscale));
+
+            store_4x16_s8(row_dst + j, _mm512_cvtepi32_epi8(r0),
+                    _mm512_cvtepi32_epi8(r1), _mm512_cvtepi32_epi8(r2),
+                    _mm512_cvtepi32_epi8(r3), cl_ok);
+        }
+        for (; j + 15 < N; j += 16) {
+            __m512 f = bf16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j)));
+            f = finite_or_zero(f);
+            __m512i r = _mm512_cvtps_epi32(_mm512_div_ps(f, vscale));
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(row_dst + j),
+                    _mm512_cvtepi32_epi8(r));
+        }
+        for (; j < N; ++j) {
+            float v = dq_bf16_to_f32(row_src[j]);
+            if (!std::isfinite(v)) {
+                row_dst[j] = 0;
+                continue;
+            }
+            int32_t q = static_cast<int32_t>(std::nearbyint(v / scale));
+            row_dst[j] = static_cast<int8_t>(q);
+        }
+    });
+
+    parallel_nd(M, [&](dim_t m) { row_loop(m); });
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl"))) void
+dynamic_per_token_quant_f32_s8_native(
+        const float *src, int8_t *dst, float *scales, int64_t M, int64_t N) {
+    const __m512i abs_mask = _mm512_set1_epi32(0x7FFFFFFF);
+    const __m512 vinf = _mm512_set1_ps(std::numeric_limits<float>::infinity());
+
+    auto row_loop = ([&](
+            int64_t m) __attribute__((target("avx512f,avx512bw,avx512vl"))) {
+        const float *row_src = src + m * N;
+        int8_t *row_dst = dst + m * N;
+
+        // -- Pass 1: absmax reduction (skipping non-finite values) ---------------
+        __m512 vam0 = _mm512_setzero_ps();
+        __m512 vam1 = _mm512_setzero_ps();
+        __m512 vam2 = _mm512_setzero_ps();
+        __m512 vam3 = _mm512_setzero_ps();
+
+        int64_t j = 0;
+        for (; j + 63 < N; j += 64) {
+
+            __m512 f0 = _mm512_loadu_ps(row_src + j);
+            __m512 f1 = _mm512_loadu_ps(row_src + j + 16);
+            __m512 f2 = _mm512_loadu_ps(row_src + j + 32);
+            __m512 f3 = _mm512_loadu_ps(row_src + j + 48);
+
+            __m512 a0 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f0), abs_mask));
+            __m512 a1 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f1), abs_mask));
+            __m512 a2 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f2), abs_mask));
+            __m512 a3 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f3), abs_mask));
+            vam0 = _mm512_mask_max_ps(
+                    vam0, finite_mask(f0, abs_mask, vinf), vam0, a0);
+            vam1 = _mm512_mask_max_ps(
+                    vam1, finite_mask(f1, abs_mask, vinf), vam1, a1);
+            vam2 = _mm512_mask_max_ps(
+                    vam2, finite_mask(f2, abs_mask, vinf), vam2, a2);
+            vam3 = _mm512_mask_max_ps(
+                    vam3, finite_mask(f3, abs_mask, vinf), vam3, a3);
+        }
+
+        for (; j + 15 < N; j += 16) {
+            __m512 f = _mm512_loadu_ps(row_src + j);
+            __m512 af = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f), abs_mask));
+            vam0 = _mm512_mask_max_ps(
+                    vam0, finite_mask(f, abs_mask, vinf), vam0, af);
+        }
+
+        vam0 = _mm512_max_ps(
+                _mm512_max_ps(vam0, vam1), _mm512_max_ps(vam2, vam3));
+        float absmax = _mm512_reduce_max_ps(vam0);
+
+        for (; j < N; ++j)
+            if (std::isfinite(row_src[j]))
+                absmax = std::max(absmax, std::abs(row_src[j]));
+
+        float scale;
+        compute_symmetric_scale_from_absmax(absmax, scale);
+        scales[m] = scale;
+
+        // -- Pass 2: quantize (F32 re-read from L1, no conversion needed) -----
+        __m512 vscale = _mm512_set1_ps(scale);
+        bool cl_ok = (reinterpret_cast<uintptr_t>(row_dst) & 63) == 0;
+
+        j = 0;
+        for (; j + 63 < N; j += 64) {
+            __m512i r0 = _mm512_cvtps_epi32(
+                    _mm512_div_ps(load_finite_f32(row_src + j), vscale));
+            __m512i r1 = _mm512_cvtps_epi32(
+                    _mm512_div_ps(load_finite_f32(row_src + j + 16), vscale));
+            __m512i r2 = _mm512_cvtps_epi32(
+                    _mm512_div_ps(load_finite_f32(row_src + j + 32), vscale));
+            __m512i r3 = _mm512_cvtps_epi32(
+                    _mm512_div_ps(load_finite_f32(row_src + j + 48), vscale));
+
+            store_4x16_s8(row_dst + j, _mm512_cvtepi32_epi8(r0),
+                    _mm512_cvtepi32_epi8(r1), _mm512_cvtepi32_epi8(r2),
+                    _mm512_cvtepi32_epi8(r3), cl_ok);
+        }
+
+        for (; j + 15 < N; j += 16) {
+            __m512i r = _mm512_cvtps_epi32(
+                    _mm512_div_ps(load_finite_f32(row_src + j), vscale));
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(row_dst + j),
+                    _mm512_cvtepi32_epi8(r));
+        }
+
+        for (; j < N; ++j) {
+            if (!std::isfinite(row_src[j])) {
+                row_dst[j] = 0;
+                continue;
+            }
+            int32_t q
+                    = static_cast<int32_t>(std::nearbyint(row_src[j] / scale));
+            row_dst[j] = static_cast<int8_t>(q);
+        }
+    });
+
+    parallel_nd(M, [&](dim_t m) { row_loop(m); });
+}
+
+__attribute__((target("avx512f,avx512bw,avx512vl,f16c"))) void
+dynamic_per_token_quant_f16_s8_native(
+        const uint16_t *src, int8_t *dst, float *scales, int64_t M, int64_t N) {
+    const __m512i abs_mask = _mm512_set1_epi32(0x7FFFFFFF);
+    const __m512 vinf = _mm512_set1_ps(std::numeric_limits<float>::infinity());
+
+    auto row_loop = ([&](int64_t m) __attribute__((
+            target("avx512f,avx512bw,avx512vl,f16c"))) {
+        const uint16_t *row_src = src + m * N;
+        int8_t *row_dst = dst + m * N;
+
+        // -- Pass 1: absmax reduction -----------------------------------------
+        __m512 vam0 = _mm512_setzero_ps();
+        __m512 vam1 = _mm512_setzero_ps();
+        __m512 vam2 = _mm512_setzero_ps();
+        __m512 vam3 = _mm512_setzero_ps();
+
+        int64_t j = 0;
+        for (; j + 63 < N; j += 64) {
+            __m512 f0 = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j)));
+            __m512 f1 = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 16)));
+            __m512 f2 = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 32)));
+            __m512 f3 = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 48)));
+
+            __m512 a0 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f0), abs_mask));
+            __m512 a1 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f1), abs_mask));
+            __m512 a2 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f2), abs_mask));
+            __m512 a3 = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f3), abs_mask));
+            vam0 = _mm512_mask_max_ps(
+                    vam0, finite_mask(f0, abs_mask, vinf), vam0, a0);
+            vam1 = _mm512_mask_max_ps(
+                    vam1, finite_mask(f1, abs_mask, vinf), vam1, a1);
+            vam2 = _mm512_mask_max_ps(
+                    vam2, finite_mask(f2, abs_mask, vinf), vam2, a2);
+            vam3 = _mm512_mask_max_ps(
+                    vam3, finite_mask(f3, abs_mask, vinf), vam3, a3);
+        }
+
+        for (; j + 15 < N; j += 16) {
+            __m512 f = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j)));
+            __m512 af = _mm512_castsi512_ps(
+                    _mm512_and_si512(_mm512_castps_si512(f), abs_mask));
+            vam0 = _mm512_mask_max_ps(
+                    vam0, finite_mask(f, abs_mask, vinf), vam0, af);
+        }
+
+        vam0 = _mm512_max_ps(
+                _mm512_max_ps(vam0, vam1), _mm512_max_ps(vam2, vam3));
+        float absmax = _mm512_reduce_max_ps(vam0);
+
+        for (; j < N; ++j) {
+            float v = dq_f16_to_f32(row_src[j]);
+            if (std::isfinite(v)) absmax = std::max(absmax, std::abs(v));
+        }
+
+        // -- Compute per-row scale --------------------------------------------
+        float scale;
+        compute_symmetric_scale_from_absmax(absmax, scale);
+        scales[m] = scale;
+
+        // -- Pass 2: quantize (re-load FP16 from L1, still hot from Pass 1) --
+        __m512 vscale = _mm512_set1_ps(scale);
+        bool cl_ok = (reinterpret_cast<uintptr_t>(row_dst) & 63) == 0;
+
+        j = 0;
+        for (; j + 63 < N; j += 64) {
+            __m512 f0 = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j)));
+            __m512 f1 = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 16)));
+            __m512 f2 = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 32)));
+            __m512 f3 = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j + 48)));
+            f0 = finite_or_zero(f0);
+            f1 = finite_or_zero(f1);
+            f2 = finite_or_zero(f2);
+            f3 = finite_or_zero(f3);
+
+            __m512i r0 = _mm512_cvtps_epi32(_mm512_div_ps(f0, vscale));
+            __m512i r1 = _mm512_cvtps_epi32(_mm512_div_ps(f1, vscale));
+            __m512i r2 = _mm512_cvtps_epi32(_mm512_div_ps(f2, vscale));
+            __m512i r3 = _mm512_cvtps_epi32(_mm512_div_ps(f3, vscale));
+
+            store_4x16_s8(row_dst + j, _mm512_cvtepi32_epi8(r0),
+                    _mm512_cvtepi32_epi8(r1), _mm512_cvtepi32_epi8(r2),
+                    _mm512_cvtepi32_epi8(r3), cl_ok);
+        }
+        for (; j + 15 < N; j += 16) {
+            __m512 f = f16x16_to_f32(_mm256_loadu_si256(
+                    reinterpret_cast<const __m256i *>(row_src + j)));
+            f = finite_or_zero(f);
+            __m512i r = _mm512_cvtps_epi32(_mm512_div_ps(f, vscale));
+            _mm_storeu_si128(reinterpret_cast<__m128i *>(row_dst + j),
+                    _mm512_cvtepi32_epi8(r));
+        }
+        for (; j < N; ++j) {
+            float v = dq_f16_to_f32(row_src[j]);
+            if (!std::isfinite(v)) {
+                row_dst[j] = 0;
+                continue;
+            }
+            int32_t q = static_cast<int32_t>(std::nearbyint(v / scale));
+            row_dst[j] = static_cast<int8_t>(q);
+        }
+    });
+
+    parallel_nd(M, [&](dim_t m) { row_loop(m); });
+}
+
+} // namespace dynamic_quantize_kernels
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // !defined(_MSC_VER) && (defined(__GNUC__) || defined(__clang__))

--- a/tests/benchdnn/doc/driver_reduction.md
+++ b/tests/benchdnn/doc/driver_reduction.md
@@ -39,6 +39,7 @@ the end to specify fewer dimensions.
 ## Floating point arguments
 Some operations support `p` and `eps` arguments such as
 `norm_lp_max`, `norm_lp_sum`, `norm_lp_power_p_max`, `norm_lp_power_p_sum`.
+`dynamic_quantize` requires both values to be zero.
 
 ## Essence of Testing
 
@@ -56,6 +57,13 @@ Run a specific reduction primitive problem:
 - The reduce operation is sum.
 ``` sh
     ./benchdnn --reduction --sdt=f32 --ddt=f32 --stag=acb --alg=sum 1x2x3:1x1x3
+```
+
+Run fused symmetric per-token dynamic quantization. The `1x128` groups divide
+the two source dimensions and therefore produce one `f32` scale per row:
+``` sh
+    ./benchdnn --reduction --alg=dynamic_quantize --p=0 --sdt=f32 --ddt=s8 \
+        --attr-scales=dst:dynamic_fp:f32:1x128 8x128:8x128
 ```
 
 More examples with different driver options can be found at

--- a/tests/benchdnn/inputs/reduction/perf_reduction_dynamic_quantize
+++ b/tests/benchdnn/inputs/reduction/perf_reduction_dynamic_quantize
@@ -1,0 +1,10 @@
+# Representative LLM activation shapes for performance measurements.
+--mode=P
+--perf-template=perf,%impl%,%sdt%,%ddt%,%desc%,%0time%
+
+--reset --mode=P --alg=dynamic_quantize --p=0 --sdt=bf16 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:1x4096 1x4096:1x4096
+--reset --mode=P --alg=dynamic_quantize --p=0 --sdt=bf16 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:1x4096 8x4096:8x4096
+--reset --mode=P --alg=dynamic_quantize --p=0 --sdt=bf16 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:1x4096 32x4096:32x4096
+
+--reset --mode=P --alg=dynamic_quantize --p=0 --sdt=bf16 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:1x128 8x4096:8x4096
+--reset --mode=P --alg=dynamic_quantize --p=0 --sdt=bf16 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:1x128 32x4096:32x4096

--- a/tests/benchdnn/inputs/reduction/test_reduction_ci
+++ b/tests/benchdnn/inputs/reduction/test_reduction_ci
@@ -17,3 +17,6 @@
 
 --sdt=u8 --ddt=u8,s32,f32
 --batch=option_set_all_algs_int8_ci
+
+--reset
+--batch=test_reduction_dynamic_quantize_ci

--- a/tests/benchdnn/inputs/reduction/test_reduction_dynamic_quantize_ci
+++ b/tests/benchdnn/inputs/reduction/test_reduction_dynamic_quantize_ci
@@ -1,0 +1,10 @@
+# Fused dynamic quantization through the reduction primitive.
+# Scale tensors are outputs defined by destination quantization attributes.
+
+--reset --alg=dynamic_quantize --p=0 --sdt=f32 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:1x128 8x128:8x128
+--reset --alg=dynamic_quantize --p=0 --sdt=bf16 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:1x64 8x256:8x256
+--reset --alg=dynamic_quantize --p=0 --sdt=f16 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:1x80 5x80:5x80
+
+# Reference-only granularities: per-column and grouped rows.
+--reset --alg=dynamic_quantize --p=0 --sdt=f32 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:4x1 4x16:4x16
+--reset --alg=dynamic_quantize --p=0 --sdt=f32 --ddt=s8 --attr-scales=dst:dynamic_fp:f32:2x1 4x16:4x16

--- a/tests/benchdnn/reduction/reduction.cpp
+++ b/tests/benchdnn/reduction/reduction.cpp
@@ -231,6 +231,15 @@ void prb_t::skip_invalid(res_t *res) const {
 void setup_cmp(compare::compare_t &cmp, const base_prb_t *base_prb,
         data_kind_t kind, const args_t &ref_args) {
     const prb_t *prb = prb_t::from(base_prb);
+    if (prb->alg == alg_t::dynamic_quantize) {
+        if (kind == DST_SCALES) {
+            cmp.set_threshold(1e-5f);
+        } else {
+            cmp.set_threshold(1.f);
+        }
+        return;
+    }
+
     // accounts for inaccurate rootn/pow functions in norm algs.
     float scale = is_norm_alg(prb->alg) ? 5.0f : 1.0f;
     cmp.set_threshold(scale * epsilon_dt(prb->ddt));
@@ -244,6 +253,14 @@ void setup_cmp(compare::compare_t &cmp, const base_prb_t *base_prb,
 }
 
 std::vector<int> prb_t::supported_exec_args(bool) const {
+    if (alg == alg_t::dynamic_quantize) {
+        return {
+                DNNL_ARG_SRC,
+                DNNL_ARG_DST,
+                DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST,
+        };
+    }
+
     static const std::vector<int> exec_args = {
             DNNL_ARG_SRC,
             DNNL_ARG_DST,
@@ -369,9 +386,11 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
 
     SAFE(run_execution(prim, args, res), WARN);
 
+    std::vector<data_kind_t> kinds {DST};
+    if (prb->alg == alg_t::dynamic_quantize) { kinds.emplace_back(DST_SCALES); }
     check_correctness(
-            prb, {DST}, args, ref_args, compute_ref, setup_cmp, res, prb->dir);
-    SAFE(check_bitwise(prim, {DST}, args, prb->attr, prb->inplace, res), WARN);
+            prb, kinds, args, ref_args, compute_ref, setup_cmp, res, prb->dir);
+    SAFE(check_bitwise(prim, kinds, args, prb->attr, prb->inplace, res), WARN);
 
     return measure_perf(prb->ctx_exe, res, prim, args);
 }

--- a/tests/benchdnn/reduction/reduction.hpp
+++ b/tests/benchdnn/reduction/reduction.hpp
@@ -39,6 +39,7 @@ enum alg_t {
     norm_lp_sum,
     norm_lp_power_p_max,
     norm_lp_power_p_sum,
+    dynamic_quantize,
     reduction_min = min,
     reduction_max = max,
     reduction_mul = mul,
@@ -48,6 +49,7 @@ enum alg_t {
     reduction_norm_lp_sum = norm_lp_sum,
     reduction_norm_lp_power_p_max = norm_lp_power_p_max,
     reduction_norm_lp_power_p_sum = norm_lp_power_p_sum,
+    reduction_dynamic_quantize = dynamic_quantize,
 };
 
 alg_t str2alg(const char *str);

--- a/tests/benchdnn/reduction/reduction_aux.cpp
+++ b/tests/benchdnn/reduction/reduction_aux.cpp
@@ -40,6 +40,8 @@ alg_t str2alg(const char *str) {
     CASE(reduction_norm_lp_power_p_max);
     CASE(norm_lp_power_p_sum);
     CASE(reduction_norm_lp_power_p_sum);
+    CASE(dynamic_quantize);
+    CASE(reduction_dynamic_quantize);
 
 #undef CASE
     assert(!"unknown algorithm");
@@ -56,6 +58,7 @@ const char *alg2str(alg_t alg) {
     if (alg == norm_lp_sum) return "norm_lp_sum";
     if (alg == norm_lp_power_p_max) return "norm_lp_power_p_max";
     if (alg == norm_lp_power_p_sum) return "norm_lp_power_p_sum";
+    if (alg == dynamic_quantize) return "dynamic_quantize";
     assert(!"unknown algorithm");
     return "undef";
 }
@@ -70,6 +73,7 @@ dnnl_alg_kind_t alg2alg_kind(alg_t alg) {
     if (alg == norm_lp_sum) return dnnl_reduction_norm_lp_sum;
     if (alg == norm_lp_power_p_max) return dnnl_reduction_norm_lp_power_p_max;
     if (alg == norm_lp_power_p_sum) return dnnl_reduction_norm_lp_power_p_sum;
+    if (alg == dynamic_quantize) return dnnl_reduction_dynamic_quantize;
     assert(!"unknown algorithm");
     return dnnl_alg_kind_undef;
 }

--- a/tests/benchdnn/reduction/ref_reduction.cpp
+++ b/tests/benchdnn/reduction/ref_reduction.cpp
@@ -79,6 +79,49 @@ void compute_ref(const base_prb_t *base_prb, dir_t dir, const args_t &args,
     const dnn_mem_t &src = args.find(DNNL_ARG_SRC);
     const dnn_mem_t &dst = args.find(DNNL_ARG_DST);
 
+    if (prb->alg == alg_t::dynamic_quantize) {
+        const dnn_mem_t &scales
+                = args.find(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+        const int64_t M = src.dims()[0];
+        const int64_t N = src.dims()[1];
+        const int64_t sm = scales.dims()[0];
+        const int64_t sn = scales.dims()[1];
+        const int64_t rows_per_group = M / sm;
+        const int64_t cols_per_group = N / sn;
+        constexpr float scale_eps = 1.0e-30f;
+
+        benchdnn_parallel_nd(sm, sn, [&](int64_t gm, int64_t gn) {
+            const int64_t m_start = gm * rows_per_group;
+            const int64_t n_start = gn * cols_per_group;
+            float absmax = 0.f;
+            for (int64_t m = m_start; m < m_start + rows_per_group; ++m) {
+                for (int64_t n = n_start; n < n_start + cols_per_group; ++n) {
+                    const float value = src.get_f32_elem(m * N + n);
+                    if (!std::isfinite(value)) continue;
+                    absmax = MAX2(absmax, std::abs(value));
+                }
+            }
+
+            const float scale = MAX2(absmax / 127.f, scale_eps);
+            const int64_t scale_off = gm * sn + gn;
+            scales.set_elem(scale_off, scale);
+
+            for (int64_t m = m_start; m < m_start + rows_per_group; ++m) {
+                for (int64_t n = n_start; n < n_start + cols_per_group; ++n) {
+                    const int64_t off = m * N + n;
+                    const float value = src.get_f32_elem(off);
+                    float quantized = 0.f;
+                    if (std::isfinite(value)) {
+                        quantized = nearbyintf(value / scale);
+                        quantized = MAX2(-127.f, MIN2(127.f, quantized));
+                    }
+                    dst.set_elem(off, quantized);
+                }
+            }
+        });
+        return;
+    }
+
     float *dst_ptr = (float *)dst;
 
     const auto &ndims = prb->ndims;

--- a/tests/gtests/CMakeLists.txt
+++ b/tests/gtests/CMakeLists.txt
@@ -89,6 +89,7 @@ file(GLOB PRIM_TEST_CASES_SRC
                               test_matmul.cpp
                               test_resampling.cpp
                               test_reduction.cpp
+                              test_dynamic_quantize.cpp
                               test_softmax.cpp
                               test_concurrency.cpp
                               test_layer_normalization.cpp

--- a/tests/gtests/test_dynamic_quantize.cpp
+++ b/tests/gtests/test_dynamic_quantize.cpp
@@ -1,0 +1,381 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <vector>
+#include <unordered_map>
+
+#include "dnnl_test_common.hpp"
+#include "gtest/gtest.h"
+
+#include "oneapi/dnnl/dnnl.hpp"
+
+namespace dnnl {
+
+using tag = memory::format_tag;
+using dt = memory::data_type;
+
+struct dynamic_quantize_params_t {
+    dt src_dt;
+    memory::dims src_dims;
+    memory::dims scale_dims;
+    bool compute_only;
+};
+
+struct quant_recipe_t {
+    int mask;
+    memory::dims groups;
+};
+
+static quant_recipe_t make_recipe(
+        const memory::dims &src_dims, const memory::dims &scale_dims) {
+    const memory::dim M = src_dims[0], N = src_dims[1];
+    const memory::dim sm = scale_dims[0], sn = scale_dims[1];
+    if (sm == 1 && sn == 1) return {0, {}};
+    if (sm == M && sn == 1) return {1 << 0, {}};
+    if (sm == 1 && sn == N) return {1 << 1, {}};
+    if (sm == M && N % sn == 0) return {(1 << 0) | (1 << 1), {1, N / sn}};
+    if (sn == N && M % sm == 0) return {(1 << 0) | (1 << 1), {M / sm, 1}};
+    return {-1, {}};
+}
+
+static primitive_attr make_attr(
+        const memory::dims &src_dims, const memory::dims &scale_dims) {
+    const auto recipe = make_recipe(src_dims, scale_dims);
+    primitive_attr attr;
+    attr.set_scales(DNNL_ARG_DST, recipe.mask, recipe.groups, dt::f32, false,
+            quantization_mode::dynamic_fp);
+    return attr;
+}
+
+class dynamic_quantize_reduction_test_t
+    : public ::testing::TestWithParam<dynamic_quantize_params_t> {
+protected:
+    engine eng = get_test_engine();
+    stream strm = make_stream(eng);
+
+    static std::vector<float> to_f32(const memory &mem) {
+        const auto md = mem.get_desc();
+        const memory::dim nelems = static_cast<memory::dim>(
+                md.get_size() / memory::data_type_size(md.get_data_type()));
+
+        std::vector<float> out(nelems);
+        switch (md.get_data_type()) {
+            case dt::f32: {
+                auto mapped = map_memory<float>(mem);
+                for (memory::dim i = 0; i < nelems; ++i)
+                    out[i] = static_cast<float *>(mapped)[i];
+            } break;
+            case dt::s8: {
+                auto mapped = map_memory<int8_t>(mem);
+                for (memory::dim i = 0; i < nelems; ++i)
+                    out[i] = static_cast<float>(
+                            static_cast<int8_t *>(mapped)[i]);
+            } break;
+            default: assert(!"unexpected data type");
+        }
+        return out;
+    }
+
+    void run(const dynamic_quantize_params_t &p) {
+        SKIP_IF(get_test_engine_kind() == engine::kind::gpu,
+                "GPU engine is not supported.");
+        SKIP_IF(unsupported_data_type(p.src_dt),
+                "Engine does not support this data type.");
+
+        const memory::dim M = p.src_dims[0], N = p.src_dims[1];
+        const memory::dim sm = p.scale_dims[0], sn = p.scale_dims[1];
+
+        std::vector<float> src_ref(M * N);
+        for (memory::dim m = 0; m < M; ++m)
+            for (memory::dim n = 0; n < N; ++n)
+                src_ref[m * N + n]
+                        = 0.37f * static_cast<float>((m + 1) * (n - N / 2))
+                        - 0.11f * static_cast<float>(n);
+
+        const auto src_f32_md = memory::desc({M, N}, dt::f32, tag::ab);
+        const auto src_md = memory::desc({M, N}, p.src_dt, tag::ab);
+        auto src_f32_mem = memory(src_f32_md, eng);
+        {
+            auto mapped = map_memory<float>(src_f32_mem);
+            for (memory::dim i = 0; i < M * N; ++i)
+                static_cast<float *>(mapped)[i] = src_ref[i];
+        }
+
+        auto src_mem = memory(src_md, eng);
+        reorder(src_f32_mem, src_mem).execute(strm, src_f32_mem, src_mem);
+        auto src_back = memory(src_f32_md, eng);
+        reorder(src_mem, src_back).execute(strm, src_mem, src_back);
+        strm.wait();
+        const auto src_seen = to_f32(src_back);
+
+        const auto scale_md = memory::desc(p.scale_dims, dt::f32, tag::ab);
+        const auto dst_md = p.compute_only
+                ? memory::desc()
+                : memory::desc({M, N}, dt::s8, tag::ab);
+        const auto attr = make_attr(p.src_dims, p.scale_dims);
+
+        reduction::primitive_desc pd;
+        ASSERT_NO_THROW(pd = reduction::primitive_desc(eng,
+                                algorithm::reduction_dynamic_quantize, src_md,
+                                dst_md, 0.f, 0.f, attr));
+        ASSERT_TRUE(pd.query_md(query::exec_arg_md,
+                            DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST)
+                == scale_md);
+
+        auto scale_mem = memory(scale_md, eng);
+        memory dst_mem;
+        if (!p.compute_only) dst_mem = memory(dst_md, eng);
+
+        std::unordered_map<int, memory> args {
+                {DNNL_ARG_SRC, src_mem},
+                {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem},
+        };
+        if (!p.compute_only) args.insert({DNNL_ARG_DST, dst_mem});
+
+        reduction(pd).execute(strm, args);
+        strm.wait();
+
+        const auto scale_out = to_f32(scale_mem);
+        const auto dst_out
+                = p.compute_only ? std::vector<float>() : to_f32(dst_mem);
+
+        const memory::dim rows_per_group = M / sm;
+        const memory::dim cols_per_group = N / sn;
+        for (memory::dim gm = 0; gm < sm; ++gm) {
+            for (memory::dim gn = 0; gn < sn; ++gn) {
+                const auto m0 = gm * rows_per_group;
+                const auto m1 = m0 + rows_per_group;
+                const auto n0 = gn * cols_per_group;
+                const auto n1 = n0 + cols_per_group;
+                float absmax = 0.f;
+                for (memory::dim m = m0; m < m1; ++m) {
+                    for (memory::dim n = n0; n < n1; ++n) {
+                        const float value = src_seen[m * N + n];
+                        absmax = std::max(absmax, std::abs(value));
+                    }
+                }
+
+                constexpr float scale_eps = 1.0e-30f;
+                const float expected_scale
+                        = std::max(absmax / 127.f, scale_eps);
+                const auto scale_index = gm * sn + gn;
+                ASSERT_NEAR(scale_out[scale_index], expected_scale,
+                        1e-4f * std::max(1e-3f, expected_scale));
+
+                if (p.compute_only) continue;
+                for (memory::dim m = m0; m < m1; ++m) {
+                    for (memory::dim n = n0; n < n1; ++n) {
+                        const float value = src_seen[m * N + n];
+                        float expected = std::nearbyint(value / expected_scale);
+                        expected = std::max(-127.f, std::min(127.f, expected));
+                        ASSERT_LE(std::abs(dst_out[m * N + n] - expected), 1.f);
+                    }
+                }
+            }
+        }
+    }
+};
+
+TEST_P(dynamic_quantize_reduction_test_t, Correctness) {
+    run(GetParam());
+}
+
+INSTANTIATE_TEST_SUITE_P(Optimized, dynamic_quantize_reduction_test_t,
+        ::testing::Values(
+                dynamic_quantize_params_t {dt::f32, {8, 128}, {8, 1}, false},
+                dynamic_quantize_params_t {dt::bf16, {4, 256}, {4, 8}, false},
+                dynamic_quantize_params_t {dt::f16, {5, 80}, {5, 1}, false}));
+
+INSTANTIATE_TEST_SUITE_P(Reference, dynamic_quantize_reduction_test_t,
+        ::testing::Values(
+                dynamic_quantize_params_t {dt::f32, {4, 6}, {1, 1}, false},
+                dynamic_quantize_params_t {dt::f32, {4, 6}, {1, 6}, false},
+                dynamic_quantize_params_t {dt::f32, {4, 6}, {2, 6}, false},
+                dynamic_quantize_params_t {dt::f32, {8, 32}, {8, 1}, true}));
+
+TEST(dynamic_quantize_reduction_test_t, NonFiniteVectorLanes) {
+    const auto eng = get_test_engine();
+    SKIP_IF(get_test_engine_kind() == engine::kind::gpu,
+            "GPU engine is not supported.");
+    auto strm = make_stream(eng);
+    constexpr memory::dim M = 3;
+    constexpr memory::dim N = 35;
+    std::vector<float> src_data(M * N);
+    for (memory::dim n = 0; n < N; ++n) {
+        src_data[n] = static_cast<float>(n - 17);
+        src_data[N + n] = 5.f;
+        src_data[2 * N + n] = -5.f;
+    }
+    src_data[0] = std::numeric_limits<float>::quiet_NaN();
+    src_data[1] = std::numeric_limits<float>::infinity();
+
+    const auto src_md = memory::desc({M, N}, dt::f32, tag::ab);
+    const auto dst_md = memory::desc({M, N}, dt::s8, tag::ab);
+    const auto scale_md = memory::desc({M, 1}, dt::f32, tag::ab);
+    const auto attr = make_attr({M, N}, {M, 1});
+    auto src_mem = memory(src_md, eng, src_data.data());
+    auto dst_mem = memory(dst_md, eng);
+    auto scale_mem = memory(scale_md, eng);
+
+    const auto pd = reduction::primitive_desc(eng,
+            algorithm::reduction_dynamic_quantize, src_md, dst_md, 0.f, 0.f,
+            attr);
+    reduction(pd).execute(strm,
+            {{DNNL_ARG_SRC, src_mem}, {DNNL_ARG_DST, dst_mem},
+                    {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem}});
+    strm.wait();
+
+    auto dst = map_memory<int8_t>(dst_mem);
+    ASSERT_EQ(static_cast<int8_t *>(dst)[0], 0);
+    ASSERT_EQ(static_cast<int8_t *>(dst)[1], 0);
+    ASSERT_EQ(static_cast<int8_t *>(dst)[N], 127);
+    ASSERT_EQ(static_cast<int8_t *>(dst)[2 * N - 1], 127);
+    ASSERT_EQ(static_cast<int8_t *>(dst)[2 * N], -127);
+    ASSERT_EQ(static_cast<int8_t *>(dst)[3 * N - 1], -127);
+
+    auto scales = map_memory<float>(scale_mem);
+    ASSERT_NEAR(static_cast<float *>(scales)[0], 17.f / 127.f, 1e-6f);
+    ASSERT_NEAR(static_cast<float *>(scales)[1], 5.f / 127.f, 1e-6f);
+    ASSERT_NEAR(static_cast<float *>(scales)[2], 5.f / 127.f, 1e-6f);
+}
+
+TEST(dynamic_quantize_reduction_test_t, ConstantSameSignGroups) {
+    const auto eng = get_test_engine();
+    SKIP_IF(get_test_engine_kind() == engine::kind::gpu,
+            "GPU engine is not supported.");
+    auto strm = make_stream(eng);
+
+    constexpr memory::dim M = 1;
+    constexpr memory::dim N = 36;
+    constexpr memory::dim G = 2;
+    std::vector<float> src_data(N, 5.f);
+    std::fill(src_data.begin() + N / 2, src_data.end(), -5.f);
+
+    const auto src_md = memory::desc({M, N}, dt::f32, tag::ab);
+    const auto dst_md = memory::desc({M, N}, dt::s8, tag::ab);
+    const auto scale_md = memory::desc({M, G}, dt::f32, tag::ab);
+    const auto attr = make_attr({M, N}, {M, G});
+    const auto pd = reduction::primitive_desc(eng,
+            algorithm::reduction_dynamic_quantize, src_md, dst_md, 0.f, 0.f,
+            attr);
+
+    auto src_mem = memory(src_md, eng, src_data.data());
+    auto dst_mem = memory(dst_md, eng);
+    auto scale_mem = memory(scale_md, eng);
+    reduction(pd).execute(strm,
+            {{DNNL_ARG_SRC, src_mem}, {DNNL_ARG_DST, dst_mem},
+                    {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem}});
+    strm.wait();
+
+    auto scales = map_memory<float>(scale_mem);
+    auto dst = map_memory<int8_t>(dst_mem);
+    for (memory::dim g = 0; g < G; ++g)
+        ASSERT_NEAR(static_cast<float *>(scales)[g], 5.f / 127.f, 1e-6f);
+    for (memory::dim n = 0; n < N / 2; ++n)
+        ASSERT_EQ(static_cast<int8_t *>(dst)[n], 127);
+    for (memory::dim n = N / 2; n < N; ++n)
+        ASSERT_EQ(static_cast<int8_t *>(dst)[n], -127);
+}
+
+TEST(dynamic_quantize_reduction_test_t, ExtremeFiniteRange) {
+    const auto eng = get_test_engine();
+    SKIP_IF(get_test_engine_kind() == engine::kind::gpu,
+            "GPU engine is not supported.");
+    auto strm = make_stream(eng);
+
+    constexpr memory::dim M = 1;
+    constexpr memory::dim N = 32;
+    const float min_val = std::numeric_limits<float>::lowest();
+    const float max_val = std::numeric_limits<float>::max();
+    std::vector<float> src_data(N);
+    for (memory::dim n = 0; n < N; ++n)
+        src_data[n] = n % 2 == 0 ? min_val : max_val;
+
+    const auto src_md = memory::desc({M, N}, dt::f32, tag::ab);
+    const auto dst_md = memory::desc({M, N}, dt::s8, tag::ab);
+    const auto scale_md = memory::desc({M, 1}, dt::f32, tag::ab);
+    const auto attr = make_attr({M, N}, {M, 1});
+    const auto pd = reduction::primitive_desc(eng,
+            algorithm::reduction_dynamic_quantize, src_md, dst_md, 0.f, 0.f,
+            attr);
+
+    auto src_mem = memory(src_md, eng, src_data.data());
+    auto dst_mem = memory(dst_md, eng);
+    auto scale_mem = memory(scale_md, eng);
+    reduction(pd).execute(strm,
+            {{DNNL_ARG_SRC, src_mem}, {DNNL_ARG_DST, dst_mem},
+                    {DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, scale_mem}});
+    strm.wait();
+
+    const float expected_scale = max_val / 127.f;
+    auto scales = map_memory<float>(scale_mem);
+    auto dst = map_memory<int8_t>(dst_mem);
+    ASSERT_TRUE(std::isfinite(static_cast<float *>(scales)[0]));
+    ASSERT_FLOAT_EQ(static_cast<float *>(scales)[0], expected_scale);
+    for (memory::dim n = 0; n < N; ++n)
+        ASSERT_EQ(static_cast<int8_t *>(dst)[n], n % 2 == 0 ? -127 : 127);
+}
+
+TEST(dynamic_quantize_reduction_test_t, RequiresDynamicScaleOutput) {
+    const auto eng = get_test_engine();
+    SKIP_IF(get_test_engine_kind() == engine::kind::gpu,
+            "GPU engine is not supported.");
+    auto strm = make_stream(eng);
+
+    constexpr memory::dim M = 2;
+    constexpr memory::dim N = 16;
+    const auto src_md = memory::desc({M, N}, dt::f32, tag::ab);
+    const auto dst_md = memory::desc({M, N}, dt::s8, tag::ab);
+    const auto attr = make_attr({M, N}, {M, 1});
+    const auto pd = reduction::primitive_desc(eng,
+            algorithm::reduction_dynamic_quantize, src_md, dst_md, 0.f, 0.f,
+            attr);
+    const auto prim = reduction(pd);
+
+    auto src_mem = memory(src_md, eng);
+    auto dst_mem = memory(dst_md, eng);
+    EXPECT_ANY_THROW(prim.execute(
+            strm, {{DNNL_ARG_SRC, src_mem}, {DNNL_ARG_DST, dst_mem}}));
+}
+
+TEST(dynamic_quantize_reduction_validation_t, Errors) {
+    const auto eng = get_test_engine();
+    const auto src = memory::desc({8, 16}, dt::f32, tag::ab);
+    const auto s8_dst = memory::desc({8, 16}, dt::s8, tag::ab);
+    const auto invalid_dst = memory::desc({8, 16}, dt::u8, tag::ab);
+
+    EXPECT_ANY_THROW(reduction::primitive_desc(
+            eng, algorithm::reduction_dynamic_quantize, src, s8_dst, 0.f, 0.f));
+
+    primitive_attr static_attr;
+    static_attr.set_scales(DNNL_ARG_DST, 1 << 0, {}, dt::f32);
+    EXPECT_ANY_THROW(reduction::primitive_desc(eng,
+            algorithm::reduction_dynamic_quantize, src, s8_dst, 0.f, 0.f,
+            static_attr));
+
+    const auto dynamic_attr = make_attr({8, 16}, {8, 1});
+    EXPECT_ANY_THROW(reduction::primitive_desc(eng,
+            algorithm::reduction_dynamic_quantize, src, invalid_dst, 0.f, 0.f,
+            dynamic_attr));
+
+    EXPECT_ANY_THROW(reduction::primitive_desc(
+            eng, algorithm::reduction_sum, src, src, 0.f, 0.f));
+}
+
+} // namespace dnnl


### PR DESCRIPTION
# Description

This PR adds fused symmetric dynamic quantization as the new reduction_dynamic_quantize reduction algorithm.

The primitive computes the absolute maximum, generates an f32 scale, and optionally quantizes the source to s8 in one dispatch:

-Supports f32, bf16, and f16 sources
-Produces symmetric s8 output without zero points
-Supports per-tensor, per-row, per-column, and grouped quantization
-Supports compute-only mode for generating scales without destination data
-Returns scales through DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST
-A portable reference implementation covers all supported configurations. Optimized AVX-512 kernels handle dense 2D per-row   and grouped-column cases, with automatic fallback to the reference implementation.

The PR also adds API validation, documentation, an example, benchdnn coverage, and unit tests.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [ ] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?

### Bug fixes

- [ ] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [ ] Have you added relevant regression tests?

## [RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs) PR

- [ ] Does RFC document follow the [template](https://github.com/uxlfoundation/oneDNN/blob/rfcs/rfcs/template.md#onednn-design-document-rfc)?
- [ ] Have you added a link to the rendered document?
