### PR TITLE
cpu: rv64: synchronize binary and post-op JIT infrastructure

### DIFF
--- a/src/cpu/binary_injector_utils.cpp
+++ b/src/cpu/binary_injector_utils.cpp
@@ -31,12 +31,19 @@ std::vector<const void *> prepare_binary_args(const post_ops_t &post_ops,
     unsigned idx = first_arg_idx_offset;
     for (const auto &post_op : post_ops.entry_) {
         if (post_op.is_binary()) {
-            post_ops_binary_rhs_arg_vec.emplace_back(CTX_IN_MEM(const void *,
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1));
+            auto append_arg = [&](int arg, const memory_desc_t &md) {
+                const auto *base = static_cast<const char *>(ctx.host_ptr(arg));
+                const memory_desc_wrapper mdw(md);
+                post_ops_binary_rhs_arg_vec.emplace_back(base
+                                ? base + mdw.offset0() * mdw.data_type_size()
+                                : nullptr);
+            };
+
+            append_arg(DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1,
+                    post_op.binary.src1_desc);
             if (post_op.is_binary_with_ternary_op()) {
-                post_ops_binary_rhs_arg_vec.emplace_back(CTX_IN_MEM(
-                        const void *,
-                        DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2));
+                append_arg(DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_2,
+                        post_op.binary.src2_desc);
             }
         } else if (post_op.is_prelu()) {
             auto *arg = CTX_IN_MEM(const void *,

--- a/src/cpu/binary_injector_utils.cpp
+++ b/src/cpu/binary_injector_utils.cpp
@@ -26,17 +26,17 @@ namespace binary_injector_utils {
 std::vector<const void *> prepare_binary_args(const post_ops_t &post_ops,
         const exec_ctx_t &ctx, const unsigned first_arg_idx_offset) {
     std::vector<const void *> post_ops_binary_rhs_arg_vec;
+    if (post_ops.len() == 0) return post_ops_binary_rhs_arg_vec;
     post_ops_binary_rhs_arg_vec.reserve(post_ops.entry_.size());
 
     unsigned idx = first_arg_idx_offset;
     for (const auto &post_op : post_ops.entry_) {
         if (post_op.is_binary()) {
             auto append_arg = [&](int arg, const memory_desc_t &md) {
-                const auto *base = static_cast<const char *>(ctx.host_ptr(arg));
+                const auto *base = CTX_IN_MEM(const char *, arg);
                 const memory_desc_wrapper mdw(md);
-                post_ops_binary_rhs_arg_vec.emplace_back(base
-                                ? base + mdw.offset0() * mdw.data_type_size()
-                                : nullptr);
+                post_ops_binary_rhs_arg_vec.emplace_back(
+                        base + mdw.offset0() * mdw.data_type_size());
             };
 
             append_arg(DNNL_ARG_ATTR_MULTIPLE_POST_OP(idx) | DNNL_ARG_SRC_1,

--- a/src/cpu/binary_injector_utils.hpp
+++ b/src/cpu/binary_injector_utils.hpp
@@ -30,10 +30,11 @@ namespace impl {
 namespace cpu {
 namespace binary_injector_utils {
 /*
- * Extracts pointers to tensors passed by user as binary postops rhs (right-hand-side)
- * arguments (arg1 from binary postop) from execution context. Those pointers are placed
- * in vector in order of binary post-op appearance inside post_ops_t structure. Returned vector
- * usually is passed to kernel during execution phase in runtime params.
+ * Extracts pointers to tensors passed by user as binary postops rhs
+ * (right-hand-side) arguments from execution context and advances them to
+ * their memory descriptors' logical origins. Those pointers are placed in a
+ * vector in order of binary post-op appearance inside post_ops_t structure.
+ * The returned vector usually is passed to a kernel in runtime parameters.
  * @param first_arg_idx_offset - offset for indexation of binary postop arguments
  * (used for fusions with dw convolutions)
  */

--- a/src/cpu/rv64/injectors/injector_utils.cpp
+++ b/src/cpu/rv64/injectors/injector_utils.cpp
@@ -25,32 +25,84 @@ using namespace Xbyak_riscv;
 
 register_preserve_guard_t::register_preserve_guard_t(jit_generator_t *host,
         std::initializer_list<Reg> gpr_to_preserve,
-        std::initializer_list<FReg> freg_to_preserve)
+        std::initializer_list<VReg> vmm_to_preserve,
+        std::initializer_list<FReg> freg_to_preserve, size_t vmm_group_stride)
     : host_(host)
     , gpr_regs_(gpr_to_preserve)
+    , vmm_regs_(vmm_to_preserve)
     , freg_regs_(freg_to_preserve)
+    , vmm_group_stride_(vmm_group_stride)
     , stack_bytes_(0) {
 
     const size_t n_slots = gpr_regs_.size() + freg_regs_.size();
-    if (n_slots == 0) return;
+    if (n_slots > 0) {
+        // Keep sp 16-byte aligned per the RISC-V calling convention; each
+        // register takes one 8-byte slot.
+        stack_bytes_ = utils::rnd_up(n_slots * 8, 16);
+        host_->addi(sp, sp, -static_cast<int>(stack_bytes_));
 
-    // Keep sp 16-byte aligned per the RISC-V calling convention; each register
-    // takes one 8-byte slot.
-    stack_bytes_ = utils::rnd_up(n_slots * 8, 16);
-    host_->addi(sp, sp, -static_cast<int>(stack_bytes_));
-
-    int off = 0;
-    for (const auto &r : gpr_regs_) {
-        host_->sd(r, sp, off);
-        off += 8;
+        int off = 0;
+        for (const auto &r : gpr_regs_) {
+            host_->sd(r, sp, off);
+            off += 8;
+        }
+        for (const auto &f : freg_regs_) {
+            host_->fsd(f, sp, off);
+            off += 8;
+        }
     }
-    for (const auto &f : freg_regs_) {
-        host_->fsd(f, sp, off);
-        off += 8;
+
+    if (!vmm_regs_.empty()) {
+        // Whole-group spills with a runtime VLEN-sized frame (vs<N>r/vl<N>re8
+        // move vmm_group_stride * vlenb bytes regardless of vl); t0 is the
+        // vlenb scratch, saved and restored by the guard itself. group_stride
+        // is the spilled groups' LMUL (1/2/4); group_stride * vlenb (vlenb >= 16
+        // for VLEN >= 128) keeps sp 16-byte aligned.
+        const int lg = vmm_group_stride_ == 4 ? 2 : (int)vmm_group_stride_ - 1;
+        host_->addi(sp, sp, -16);
+        host_->sd(t0, sp, 0);
+        host_->csrr(t0, CSR::vlenb);
+        host_->slli(t0, t0, lg); // group_stride * vlenb per group
+        for (const auto &vreg : vmm_regs_) {
+            // Each entry must be a legal whole group: not v0 (the live mask
+            // register), group_stride-aligned, and fully inside the register
+            // file. JIT_ASSERT keeps the check in Release builds, failing
+            // kernel creation instead of emitting an illegal group spill.
+            JIT_ASSERT(vreg.getIdx() != 0
+                    && vreg.getIdx() % vmm_group_stride_ == 0
+                    && vreg.getIdx() + vmm_group_stride_
+                            <= (size_t)jit_isa_traits_t<v>::n_vregs);
+            host_->sub(sp, sp, t0);
+            if (vmm_group_stride_ == 1)
+                host_->vs1r_v(vreg, sp);
+            else if (vmm_group_stride_ == 2)
+                host_->vs2r_v(vreg, sp);
+            else
+                host_->vs4r_v(vreg, sp);
+        }
     }
 }
 
 register_preserve_guard_t::~register_preserve_guard_t() {
+    if (!vmm_regs_.empty()) {
+        // t0 may have been clobbered by the guarded region: recompute the
+        // group size, restore the groups in reverse, then t0 itself.
+        const int lg = vmm_group_stride_ == 4 ? 2 : (int)vmm_group_stride_ - 1;
+        host_->csrr(t0, CSR::vlenb);
+        host_->slli(t0, t0, lg);
+        for (auto it = vmm_regs_.rbegin(); it != vmm_regs_.rend(); ++it) {
+            if (vmm_group_stride_ == 1)
+                host_->vl1re8_v(*it, sp);
+            else if (vmm_group_stride_ == 2)
+                host_->vl2re8_v(*it, sp);
+            else
+                host_->vl4re8_v(*it, sp);
+            host_->add(sp, sp, t0);
+        }
+        host_->ld(t0, sp, 0);
+        host_->addi(sp, sp, 16);
+    }
+
     if (stack_bytes_ == 0) return;
 
     int off = 0;

--- a/src/cpu/rv64/injectors/injector_utils.hpp
+++ b/src/cpu/rv64/injectors/injector_utils.hpp
@@ -21,6 +21,7 @@
 #include <vector>
 #include <initializer_list>
 
+#include "common/memory_desc_wrapper.hpp"
 #include "common/utils.hpp"
 #include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/rv64/jit_generator.hpp"
@@ -48,40 +49,134 @@ namespace injector_utils {
 using vmm_index_set_t = typename std::set<size_t>;
 using vmm_index_set_iterator_t = typename std::set<size_t>::iterator;
 
-// Scope guard that preserves scalar (GPR) and floating-point (FReg) registers
-// across a region by spilling them to the stack on construction and restoring
-// them on destruction.
+// Builds the vmm-index set for a run of accumulators that occupy the half-open
+// PHYSICAL register span [start_idx, end_idx), where each accumulator is a
+// register group of group_stride vector registers (its LMUL/EMUL, one of
+// 1/2/4; consecutive accumulator bases are therefore group_stride registers
+// apart). This is the rv64-native replacement for x64's implicit stride-1
+// register numbering: unlike x64, where every vmm index is an independent
+// full-width register, an rv64 run of m>1 accumulators does NOT occupy
+// consecutive indices. A caller converting an x64 compute_vector_range(start,
+// end) must therefore state its group stride here (group_stride == 1 reproduces
+// x64's m1 behavior). The stride is mandatory precisely so that such a
+// conversion cannot compile as a silent stride-1 enumeration. Every enumerated
+// base is group-aligned when start_idx is, so the result is always a legal set
+// of RVV register-group bases. An illegal request is a host bug: JIT_ASSERT
+// keeps the checks in Release, where the throw fails kernel creation instead of
+// enumerating reserved or overlapping register indices.
 //
-// NOTE: currently unused — every rv64 injector/kernel runs with only
-// caller-saved registers and no preamble, so nothing constructs this yet. It is
-// kept as scaffolding for x64/aarch64 parity and for future injectors that may
-// need to spill; remove it if that need never materializes.
+// m8 (group_stride == 8) is intentionally rejected: the binary injector's rhs
+// helper, per-oc gather, and narrow-dtype staging are all e32/acc_lmul groups
+// (up to m4), so at m8 they plus the m8 accumulator and the v0 mask cannot fit
+// the 32-register file (m8 acc + m8 helper + m8 gather + m8 narrow + v0 > 32).
+// Compute binary post-ops at LMUL <= m4.
+template <cpu_isa_t isa>
+inline vmm_index_set_t make_vmm_group_set(
+        size_t start_idx, size_t end_idx, size_t group_stride) {
+    // JIT_ASSERT throws Xbyak_riscv::Error; make it visible to the macro here
+    // (the injector .cpp files get it from a file-scope using-directive, but
+    // this helper lives in a header ahead of any such directive).
+    using Xbyak_riscv::Error;
+    JIT_ASSERT(group_stride == 1 || group_stride == 2 || group_stride == 4);
+    JIT_ASSERT(start_idx <= end_idx && start_idx % group_stride == 0
+            && (end_idx - start_idx) % group_stride == 0);
+    JIT_ASSERT(end_idx <= (size_t)jit_isa_traits_t<isa>::n_vregs);
+    vmm_index_set_t vmm_idxs;
+    for (size_t i = start_idx; i < end_idx; i += group_stride)
+        vmm_idxs.emplace(i);
+    return vmm_idxs;
+}
+
+// Validates an already-built set of accumulator group bases (as passed to the
+// explicit set overloads): group_stride is each accumulator's register count
+// (LMUL/EMUL, 1/2/4), and every base must be group-aligned, the groups must not
+// overlap, and the top group must fit in the register file. Same
+// JIT_ASSERT/Release contract as make_vmm_group_set (an illegal host set fails
+// kernel creation instead of emitting overlapping or out-of-range registers).
+template <cpu_isa_t isa>
+inline void validate_vmm_group_set(
+        const vmm_index_set_t &bases, size_t group_stride) {
+    using Xbyak_riscv::Error;
+    JIT_ASSERT(group_stride == 1 || group_stride == 2 || group_stride == 4);
+    size_t prev_group_end = 0;
+    bool first = true;
+    for (size_t base : bases) { // std::set iterates ascending
+        JIT_ASSERT(base % group_stride == 0);
+        JIT_ASSERT(
+                base + group_stride <= (size_t)jit_isa_traits_t<isa>::n_vregs);
+        JIT_ASSERT(first || base >= prev_group_end);
+        prev_group_end = base + group_stride;
+        first = false;
+    }
+}
+
+// Mirrors x64/aarch64 injector_utils::layout_t / get_layout_type: classifies a
+// dst descriptor so the binary injector's per-channel/per-spatial address math
+// (calculate_*_{ncsp,blocked,nspc,cspn}) can pick the right stride formula.
+enum class layout_t { ncsp, c_blocked, nspc, cspn, unsupported };
+
+inline layout_t get_layout_type(const memory_desc_wrapper &dst_d) {
+    const auto strides = dst_d.blocking_desc().strides;
+    if (!dst_d.is_plain()) {
+        // x64/aarch64 classify every non-plain descriptor as c_blocked, but the
+        // channel formulas that consume this (calculate_oc_blocked and the
+        // per-lane gather) both assume the single inner block IS the channel
+        // one. A descriptor blocked on another dimension (e.g. Abcd16a, blocked
+        // on N) would silently produce a wrong channel, so report it as
+        // unsupported and let the caller decline.
+        const auto &bd = dst_d.blocking_desc();
+        return bd.inner_nblks == 1 && bd.inner_idxs[0] == 1
+                ? layout_t::c_blocked
+                : layout_t::unsupported;
+    }
+    if (strides[0] >= strides[1]
+            && IMPLICATION(dst_d.ndims() >= 3, strides[1] >= strides[2]))
+        return layout_t::ncsp;
+    if (strides[1] == 1) return layout_t::nspc;
+    if (strides[0] == 1) return layout_t::cspn;
+    return layout_t::unsupported;
+}
+
+// Scope guard that preserves scalar (GPR), vector (VReg), and floating-point
+// (FReg) registers across a region by spilling them to the stack on
+// construction and restoring them on destruction (x64's
+// register_preserve_guard_t). The binary injector constructs it around each
+// injection: preserve_gpr_helpers shields the helper GPRs and the fixed X_TMP
+// scratch the way x64 shields rax/rdx/r8/r9, and preserve_vmm_helper shields
+// the rhs dt helper vmm the way x64 pushes Vmm(vmm_hint).
 //
-// Note: vector-register preservation is intentionally not provided. RVV vector
-// length is a run-time quantity (VLEN), so a vector register cannot be spilled
-// to a compile-time-sized stack slot without first reading vlenb and growing
-// the frame dynamically. Injectors therefore take caller-provided *free* vector
-// scratch through their static_params_t instead of preserving vectors here,
-// which also avoids the v0 mask-register conflict on kernels whose accumulators
-// occupy v0 (e.g. the brgemm kernel).
+// Vector entries are spilled as whole register GROUPS of vmm_group_stride
+// registers (the injector's helper is an e32/acc_lmul group, so its LMUL is the
+// accumulator's; the VReg must be group_stride-aligned) with the vl-independent
+// whole-register moves vs<N>r.v/vl<N>re8.v (N = group_stride, one of 1/2/4).
+// The frame is sized at RUN time from csrr vlenb (group_stride * vlenb per
+// group; vlenb >= 16 for VLEN >= 128 keeps sp 16-byte aligned); t0 serves as
+// the vlenb scratch and is saved and restored by the guard itself. v0 must
+// never be passed: it is the architectural mask register and the injector's
+// compare/select paths write it by design.
 class register_preserve_guard_t {
 public:
     register_preserve_guard_t(jit_generator_t *host,
             std::initializer_list<Xbyak_riscv::Reg> gpr_to_preserve,
-            std::initializer_list<Xbyak_riscv::FReg> freg_to_preserve = {});
+            std::initializer_list<Xbyak_riscv::VReg> vmm_to_preserve = {},
+            std::initializer_list<Xbyak_riscv::FReg> freg_to_preserve = {},
+            size_t vmm_group_stride = 4);
     register_preserve_guard_t(register_preserve_guard_t &&) = default;
     register_preserve_guard_t &operator=(register_preserve_guard_t &&)
             = default;
     DNNL_DISALLOW_COPY_AND_ASSIGN(register_preserve_guard_t);
     ~register_preserve_guard_t();
 
-    // Number of stack bytes the guard currently occupies (16B-aligned).
+    // Number of compile-time stack bytes the guard occupies (16B-aligned;
+    // excludes the runtime-sized vector frame).
     size_t stack_space_occupied() const { return stack_bytes_; }
 
 private:
     jit_generator_t *host_;
     std::vector<Xbyak_riscv::Reg> gpr_regs_;
+    std::vector<Xbyak_riscv::VReg> vmm_regs_;
     std::vector<Xbyak_riscv::FReg> freg_regs_;
+    size_t vmm_group_stride_ = 4;
     size_t stack_bytes_;
 };
 

--- a/src/cpu/rv64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_binary_injector.cpp
@@ -1,4 +1,5 @@
 /*******************************************************************************
+* Copyright 2020 Intel Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +14,15 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include "common/primitive_attr.hpp"
 #include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+#include "common/verbose.hpp"
 
 #include "cpu/rv64/injectors/jit_uni_binary_injector.hpp"
 
@@ -21,354 +30,1586 @@ namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace rv64 {
+namespace binary_injector {
 
 using namespace Xbyak_riscv;
 
-namespace binary_injector {
+// Fixed scalar scratch, the aarch64 X_TMP_0..4 analogs: x64 likewise clobbers
+// fixed helper GPRs (rax/rdx/r8/r9) and shields them with the register-
+// preserve guard when the host asks for preservation. Hosts must not pick
+// these as rhs_addr_reg/rhs_helper_reg/rhs_addr_cache_reg.
+static const Reg X_TMP_0 = t4;
+static const Reg X_TMP_1 = t5;
+static const Reg X_TMP_2 = t6;
+static const Reg X_TMP_3 = a6;
+static const Reg X_TMP_4 = a7;
 
-bool is_alg_supported(alg_kind_t alg) {
-    using namespace alg_kind;
-    switch (alg) {
-        case binary_add:
-        case binary_sub:
-        case binary_mul:
-        case binary_div:
-        case binary_max:
-        case binary_min:
-        case binary_ge:
-        case binary_gt:
-        case binary_le:
-        case binary_lt:
-        case binary_eq:
-        case binary_ne: return true;
+#define VCHECK_BIN_INJ_BOOL(cond, msg) \
+    VCONDCHECK(primitive, create, check, binary_injector, cond, false, msg);
+
+// The strategy set the RVV injector realizes -- the full aarch64 set. Every
+// non-scalar/non-contiguous strategy (per_oc, per_oc_spatial, per_w,
+// per_mb_spatial, per_mb_w) is realized via the RVV per-lane gather (each lane
+// resolves its own rhs index; a VLA run spans the broadcast dim). per_mb_spatial
+// and per_mb_w are restricted to plain ncsp/nspc dst layouts (see
+// is_bcast_supported); their blocked/cspn variants are not wired. As on
+// x64/aarch64 this is the injector's ability set: each host primitive
+// advertises its own subset (the binary primitive uses the x64 set, which
+// excludes per_mb_spatial/per_mb_w).
+static bcast_set_t get_all_strategies_supported_by_injector() {
+    return bcast_set_t {broadcasting_strategy_t::scalar,
+            broadcasting_strategy_t::per_oc,
+            broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::per_mb_spatial,
+            broadcasting_strategy_t::per_mb_w, broadcasting_strategy_t::per_w,
+            broadcasting_strategy_t::no_broadcast};
+}
+
+bool is_data_supported(cpu_isa_t isa, data_type_t data_type) {
+    switch (data_type) {
+        case data_type::f32:
+        case data_type::s32:
+        case data_type::s8:
+        case data_type::u8: return true;
+        case data_type::bf16: return (isa & zvfbfwma) == zvfbfwma;
+        case data_type::f16: return (isa & zvfh) == zvfh;
         default: return false;
     }
 }
 
-} // namespace binary_injector
+bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    VCHECK_BIN_INJ_BOOL(is_data_supported(isa, src1_desc.data_type),
+            VERBOSE_ISA_DT_MISMATCH);
+
+    VCHECK_BIN_INJ_BOOL(memory_desc_wrapper(src1_desc).is_dense(true),
+            VERBOSE_NONTRIVIAL_STRIDE);
+
+    return is_bcast_supported(src1_desc, dst_d, supported_strategy_set);
+}
+
+static bool src1_desc_layout_same_as_dst_d(
+        const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d) {
+    if (dst_d.md_ == nullptr) return false;
+    const auto &lhs = src1_desc;
+    const auto &rhs = *(dst_d.md_);
+
+    using namespace dnnl::impl::utils;
+    const bool is_format_any
+            = one_of(format_kind::any, lhs.format_kind, rhs.format_kind);
+
+    return lhs.ndims == rhs.ndims
+            && (is_format_any
+                    || (lhs.format_kind == rhs.format_kind
+                            && array_cmp(lhs.format_desc.blocking.strides,
+                                    rhs.format_desc.blocking.strides,
+                                    lhs.ndims)))
+            && array_cmp(lhs.dims, rhs.dims, lhs.ndims)
+            && array_cmp(lhs.padded_dims, rhs.padded_dims, lhs.ndims)
+            && array_cmp(lhs.padded_offsets, rhs.padded_offsets, lhs.ndims)
+            && lhs.offset0 == rhs.offset0;
+}
+
+bool is_bcast_supported(const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    const auto bcast_type = get_rhs_arg_broadcasting_strategy(
+            src1_desc, dst_d, supported_strategy_set);
+
+    VCHECK_BIN_INJ_BOOL(
+            IMPLICATION(bcast_type == broadcasting_strategy_t::no_broadcast,
+                    src1_desc_layout_same_as_dst_d(src1_desc, dst_d)),
+            "src1 and dst must have the same layout if not broadcasting");
+
+    if (bcast_type == broadcasting_strategy_t::no_broadcast) return true;
+
+    VCHECK_BIN_INJ_BOOL(bcast_type != broadcasting_strategy_t::unsupported,
+            "Unsupported broadcast type");
+
+    // The per_oc/per_oc_spatial/per_w/per_mb_spatial/per_mb_w strategies read the
+    // rhs through a per-lane gather (vluxei32, e32 lane index, blocked-channel
+    // low bits via vand_vi's 5-bit immediate). Reject shapes whose flattened
+    // output position, divisor, stride, or rhs byte offset cannot be represented
+    // without wrapping.
+    if (utils::one_of(bcast_type, broadcasting_strategy_t::per_oc,
+                broadcasting_strategy_t::per_oc_spatial,
+                broadcasting_strategy_t::per_w,
+                broadcasting_strategy_t::per_mb_spatial,
+                broadcasting_strategy_t::per_mb_w)) {
+        constexpr uint64_t max_u32 = std::numeric_limits<uint32_t>::max();
+        const memory_desc_wrapper rhs_d(src1_desc);
+        const dim_t dst_nelems = dst_d.nelems(true);
+        VCHECK_BIN_INJ_BOOL(dst_nelems <= 0
+                        || static_cast<uint64_t>(dst_nelems - 1) <= max_u32,
+                "Gather index does not fit into 32 bits");
+        const dim_t rhs_nelems = rhs_d.nelems(true);
+        const size_t rhs_esz = rhs_d.data_type_size();
+        VCHECK_BIN_INJ_BOOL(rhs_nelems <= 0
+                        || static_cast<uint64_t>(rhs_nelems - 1)
+                                <= max_u32 / rhs_esz,
+                "Gather byte offset does not fit into 32 bits");
+        // per_oc/per_oc_spatial extract the blocked-channel low bits with
+        // vand_vi (5-bit immediate), so their channel inner-block must be a
+        // power of two <= 16. per_w computes the block with vdivu (any block).
+        if (utils::one_of(bcast_type, broadcasting_strategy_t::per_oc,
+                    broadcasting_strategy_t::per_oc_spatial)) {
+            const auto &bd = dst_d.blocking_desc();
+            dim_t blk = 1;
+            for (int k = 0; k < bd.inner_nblks; k++)
+                if (bd.inner_idxs[k] == 1) blk *= bd.inner_blks[k];
+            VCHECK_BIN_INJ_BOOL(blk <= 16 && (blk & (blk - 1)) == 0,
+                    "Unsupported channel inner block for gather");
+        }
+        // per_mb_spatial/per_mb_w gather the rhs by its plain logical index
+        // (rhs_idx = n*sp_size + spatial), which equals the rhs physical offset
+        // only when the rhs is plain. For a blocked/cspn dst the `any` post-op
+        // rhs is resolved to a matching non-plain layout whose physical offset
+        // differs (by the block/transpose structure) -> route those to the
+        // reference; only plain ncsp/nspc are wired.
+        if (utils::one_of(bcast_type, broadcasting_strategy_t::per_mb_spatial,
+                    broadcasting_strategy_t::per_mb_w)) {
+            const auto layout = injector_utils::get_layout_type(dst_d);
+            VCHECK_BIN_INJ_BOOL(
+                    utils::one_of(layout, injector_utils::layout_t::ncsp,
+                            injector_utils::layout_t::nspc),
+                    "per_mb_spatial/per_mb_w gather needs a plain ncsp/nspc "
+                    "dst");
+        }
+    }
+    return true;
+}
+
+bool binary_args_broadcast_supported(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+
+    return std::none_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) -> bool {
+        if (entry.is_binary()) {
+            const auto bcast_type = get_rhs_arg_broadcasting_strategy(
+                    entry.binary.src1_desc, dst_d, supported_strategy_set);
+            return bcast_type == broadcasting_strategy_t::unsupported;
+        }
+        return false;
+    });
+}
+
+bool any_binary_postop_rhs_non_scalar_broadcast(
+        const post_ops_t &post_ops, const memory_desc_wrapper &dst_d) {
+    return std::any_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) -> bool {
+        if (entry.is_like_binary()) {
+            const auto bcast_type
+                    = get_rhs_arg_broadcasting_strategy(entry.binary.src1_desc,
+                            dst_d, get_all_strategies_supported_by_injector());
+            return !utils::one_of(bcast_type, broadcasting_strategy_t::scalar,
+                    broadcasting_strategy_t::unsupported);
+        }
+        return false;
+    });
+}
+
+bool binary_args_matches_tag(format_tag_t tag, const post_ops_t &post_ops) {
+    return std::all_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) {
+        if (entry.is_binary()) {
+            const memory_desc_wrapper rhs_arg_d(entry.binary.src1_desc);
+            return rhs_arg_d.matches_tag(tag);
+        }
+        return true;
+    });
+}
+
+bool any_binary_postop_rhs_per_oc_broadcast(
+        const post_ops_t &post_ops, const memory_desc_wrapper &dst_d) {
+    return any_binary_postop_rhs_per_oc_broadcast(
+            post_ops, dst_d, get_all_strategies_supported_by_injector());
+}
+
+bool any_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    return std::any_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+            [&](const post_ops_t::entry_t &entry) -> bool {
+        if (entry.is_binary()) {
+            const auto bcast_type = get_rhs_arg_broadcasting_strategy(
+                    entry.binary.src1_desc, dst_d, supported_strategy_set);
+            return bcast_type == broadcasting_strategy_t::per_oc
+                    || bcast_type == broadcasting_strategy_t::per_oc_spatial;
+        }
+        return false;
+    });
+}
+
+static_params_t::static_params_t(const Xbyak_riscv::Reg &param1,
+        const bcast_set_t &supported_strategy_set,
+        const rhs_arg_static_params_t &rhs_arg_static_params)
+    : param1(param1)
+    , supported_strategy_set(supported_strategy_set)
+    , rhs_arg_static_params(rhs_arg_static_params) {}
+
+static_params_t::static_params_t(const Xbyak_riscv::Reg &param1,
+        const rhs_arg_static_params_t &rhs_arg_static_params)
+    : static_params_t(param1, get_all_strategies_supported_by_injector(),
+              rhs_arg_static_params) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx, const Xbyak_riscv::Reg &rhs_addr_reg,
+        const Xbyak_riscv::Reg &rhs_helper_reg,
+        const Xbyak_riscv::Reg &rhs_addr_cache_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        const memory_desc_wrapper &dst_d)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, 0, dst_d,
+              false /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx, const Xbyak_riscv::Reg &rhs_addr_reg,
+        const Xbyak_riscv::Reg &rhs_helper_reg,
+        const Xbyak_riscv::Reg &rhs_addr_cache_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d)
+    : rhs_arg_static_params_t(rhs_dt_helper_vmm_idx, rhs_addr_reg,
+              rhs_helper_reg, rhs_addr_cache_reg, preserve_gpr_helpers,
+              preserve_vmm_helper, abi_param_offset, dst_orig_offset, dst_d,
+              true /*is_dst_orig_set*/) {}
+
+rhs_arg_static_params_t::rhs_arg_static_params_t(
+        std::size_t rhs_dt_helper_vmm_idx, const Xbyak_riscv::Reg &rhs_addr_reg,
+        const Xbyak_riscv::Reg &rhs_helper_reg,
+        const Xbyak_riscv::Reg &rhs_addr_cache_reg, bool preserve_gpr_helpers,
+        bool preserve_vmm_helper, std::size_t abi_param_offset,
+        std::size_t dst_orig_offset, const memory_desc_wrapper &dst_d,
+        bool is_dst_orig_set)
+    : rhs_dt_helper_vmm_idx(rhs_dt_helper_vmm_idx)
+    , rhs_addr_reg(rhs_addr_reg)
+    , rhs_helper_reg(rhs_helper_reg)
+    , rhs_addr_cache_reg(rhs_addr_cache_reg)
+    , preserve_gpr_helpers(preserve_gpr_helpers)
+    , preserve_vmm_helper(preserve_vmm_helper)
+    , abi_param_offset(abi_param_offset)
+    , dst_orig_offset(dst_orig_offset)
+    , dst_d(dst_d)
+    , is_dst_orig_set_(is_dst_orig_set) {
+    // Only the LMUL-independent conditions can be checked here: the helper is a
+    // group of group_stride registers, but group_stride is a per-call property
+    // of compute_vector_range(), not of the static params. Hardcoding a
+    // four-register alignment here would wrongly reject a legal m1/m2 host
+    // (e.g. helper v5 at m1). Alignment, range and overlap against the
+    // processed accumulators are validated per call by validate_temp_vmm_hint()
+    // with JIT_ASSERT, so a Release build fails kernel creation rather than
+    // emitting corrupted code. v0 is excluded here because it is the
+    // architectural mask register at every LMUL.
+    assert(rhs_dt_helper_vmm_idx != 0
+            && rhs_dt_helper_vmm_idx < jit_isa_traits_t<v>::n_vregs);
+}
+
+template <cpu_isa_t isa>
+jit_uni_binary_injector_t<isa>::jit_uni_binary_injector_t(
+        jit_generator_t *host, const static_params_t &static_params)
+    : host_(host)
+    , rhs_arg_static_params_(static_params.rhs_arg_static_params)
+    , param1_(static_params.param1)
+    , supported_strategy_set_(static_params.supported_strategy_set) {}
+
+template <typename ParamsMap>
+static bool params_differ(ParamsMap &params,
+        const typename ParamsMap::key_type key1,
+        const typename ParamsMap::key_type key2) {
+    const auto &it1 = params.find(key1);
+    const auto &it2 = params.find(key2);
+    if (utils::one_of(params.end(), it1, it2)) return it1 != it2;
+    return it1->second != it2->second;
+}
+
+static bool params_differ_reg(const std::map<int, Xbyak_riscv::Reg> &params,
+        const std::map<int, Xbyak_riscv::Reg>::key_type key1,
+        const std::map<int, Xbyak_riscv::Reg>::key_type key2) {
+    const auto &it1 = params.find(key1);
+    const auto &it2 = params.find(key2);
+    if (utils::one_of(params.end(), it1, it2)) return it1 != it2;
+    return it1->second.getIdx() != it2->second.getIdx();
+}
+
+// Host-positioned mode (rv64-only; A-class): pool/gnorm/conv-epilogue compute
+// the rhs offset themselves and construct the injector without a dst descriptor
+// (memory_desc_wrapper substitutes the global zero md for a null pointer, so the
+// mode is detected via is_zero()). The strategy then reduces to scalar vs
+// no_broadcast, derived from the rhs element count; the host supplies the byte
+// offset (off_is_bytes) and optional stride (is_strided).
+static broadcasting_strategy_t get_rhs_arg_broadcasting_strategy_or_hosted(
+        const memory_desc_t &rhs_md, const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    if (dst_d.is_zero())
+        return memory_desc_wrapper(rhs_md).nelems() == 1
+                ? broadcasting_strategy_t::scalar
+                : broadcasting_strategy_t::no_broadcast;
+    return get_rhs_arg_broadcasting_strategy(
+            rhs_md, dst_d, supported_strategy_set);
+}
+
+static bool rhs_arg_params_differ(size_t vmm_idx1, size_t vmm_idx2,
+        const rhs_arg_dynamic_params_t &rhs_arg_params,
+        broadcasting_strategy_t rhs_broadcasting_strategy) {
+
+    const auto &out_addr = rhs_arg_params.vmm_idx_to_out_addr;
+    const auto &out_reg = rhs_arg_params.vmm_idx_to_out_reg;
+
+    const auto &out_elem_off_addr = rhs_arg_params.vmm_idx_to_out_elem_off_addr;
+    const auto &out_elem_off_val = rhs_arg_params.vmm_idx_to_out_elem_off_val;
+    const auto &out_off_oprnd = rhs_arg_params.vmm_idx_to_out_off_oprnd;
+    const auto &oc_off_addr = rhs_arg_params.vmm_idx_to_oc_elem_off_addr;
+    const auto &oc_off_val = rhs_arg_params.vmm_idx_to_oc_elem_off_val;
+    const auto &oc_off_oprnd = rhs_arg_params.vmm_idx_to_oc_off_oprnd;
+    const auto &sp_off_addr = rhs_arg_params.vmm_idx_to_sp_elem_off_addr;
+    const auto &sp_off_val = rhs_arg_params.vmm_idx_to_sp_elem_off_val;
+    const auto &sp_off_oprnd = rhs_arg_params.vmm_idx_to_sp_off_oprnd;
+
+    if (rhs_broadcasting_strategy == broadcasting_strategy_t::scalar) {
+        return false;
+    } else if (rhs_broadcasting_strategy
+            == broadcasting_strategy_t::no_broadcast) {
+        return params_differ(out_addr, vmm_idx1, vmm_idx2)
+                || params_differ_reg(out_reg, vmm_idx1, vmm_idx2)
+                || params_differ(out_elem_off_addr, vmm_idx1, vmm_idx2)
+                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(out_off_oprnd, vmm_idx1, vmm_idx2);
+    } else if (rhs_broadcasting_strategy == broadcasting_strategy_t::per_oc
+            || rhs_broadcasting_strategy
+                    == broadcasting_strategy_t::per_oc_spatial) {
+        return params_differ(out_addr, vmm_idx1, vmm_idx2)
+                || params_differ_reg(out_reg, vmm_idx1, vmm_idx2)
+                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(oc_off_addr, vmm_idx1, vmm_idx2)
+                || params_differ(oc_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(oc_off_oprnd, vmm_idx1, vmm_idx2);
+    } else if (rhs_broadcasting_strategy
+            == broadcasting_strategy_t::per_mb_spatial) {
+        return params_differ(out_addr, vmm_idx1, vmm_idx2)
+                || params_differ_reg(out_reg, vmm_idx1, vmm_idx2)
+                || params_differ(out_elem_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(sp_off_addr, vmm_idx1, vmm_idx2)
+                || params_differ(sp_off_val, vmm_idx1, vmm_idx2)
+                || params_differ(sp_off_oprnd, vmm_idx1, vmm_idx2);
+    }
+    return true;
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::validate_rhs_scratch(
+        const injector_utils::vmm_index_set_t &vmm_idxs, size_t group_stride,
+        const dnnl_post_ops::entry_t &post_op,
+        broadcasting_strategy_t rhs_broadcasting_strategy) const {
+    const auto &sp = rhs_arg_static_params_;
+    auto is_narrow = [](data_type_t dt) {
+        return utils::one_of(dt, data_type::s8, data_type::u8, data_type::f16,
+                data_type::bf16);
+    };
+    // narrow_stage_vmm holds a narrow-dtype vector load; the scalar (FP-reg)
+    // path bypasses it, except f16 which has no scalar path (always vector).
+    // per_oc_spatial with channel lanes also broadcasts (scalar).
+    const bool is_scalar_load
+            = rhs_broadcasting_strategy == broadcasting_strategy_t::scalar
+            || (rhs_broadcasting_strategy
+                            == broadcasting_strategy_t::per_oc_spatial
+                    && sp.per_oc_lanes_are_channels);
+    const auto src1_dt = get_src1_desc(post_op, sp.dst_d).data_type;
+    bool needs_narrow_stage = is_narrow(src1_dt)
+            && !(is_scalar_load
+                    && !utils::one_of(
+                            src1_dt, data_type::f16, data_type::bf16));
+    if (post_op.is_binary_with_ternary_op()) // src2 (no_broadcast) load
+        needs_narrow_stage
+                |= is_narrow(get_src2_desc(post_op, sp.dst_d).data_type);
+    // gather_idx_vmm holds the per-lane index of a per_oc/per_oc_spatial gather
+    // (unless the host resolves per-oc to contiguous channel lanes); per_mb_*
+    // and per_w always gather.
+    const bool needs_gather = utils::one_of(rhs_broadcasting_strategy,
+                                      broadcasting_strategy_t::per_mb_spatial,
+                                      broadcasting_strategy_t::per_mb_w,
+                                      broadcasting_strategy_t::per_w)
+            || (utils::one_of(rhs_broadcasting_strategy,
+                        broadcasting_strategy_t::per_oc,
+                        broadcasting_strategy_t::per_oc_spatial)
+                    && !sp.per_oc_lanes_are_channels);
+    // narrow_stage_vmm doubles as the gather index-build scratch (v_low for a
+    // blocked per_oc split, v_n for the per_mb/per_w flat-index math), so any
+    // gather uses it regardless of dtype -- validate it there too.
+    needs_narrow_stage |= needs_gather;
+    if (!needs_narrow_stage && !needs_gather) return;
+
+    // Each scratch is short-lived: it is consumed (staged then widened into the
+    // helper, or built then consumed by the gather) before any v0-mask write,
+    // so the v0 default is legal on its own. What must not happen is a scratch
+    // overlapping a live accumulator or the helper; and a narrow gather reads
+    // the index and writes the stage in one vluxei, so those two must be
+    // disjoint (different-EEW indexed-load overlap is illegal). Like the helper,
+    // an illegal host choice has no substitute and fails kernel creation. Every
+    // group (helper, scratch, accumulator) is e32/acc_lmul, so group_stride.
+    const int hint = sp.rhs_dt_helper_vmm_idx;
+    const int n_vregs = jit_isa_traits_t<isa>::n_vregs;
+    auto groups_overlap = [](int a, size_t sa, int b, size_t sb) {
+        return a < b + (int)sb && b < a + (int)sa;
+    };
+    // Each scratch is a full e32/acc_lmul group (group_stride registers), so it
+    // must be group-aligned and fit inside the register file. It also must not
+    // be v0: v0 is the architectural mask register -- the select condition mask
+    // lives there while a narrow/gather rhs load stages into this scratch, and
+    // the min/max/compare paths write it -- so a scratch group containing v0
+    // (base 0, which is also the unconfigured default in the static params)
+    // clobbers it. Same rigor as validate_temp_vmm_hint's helper checks: an
+    // illegal host choice has no substitute and fails kernel creation.
+    auto scratch_ok = [&](int s) {
+        if (s == 0) return false; // v0 = mask register / unconfigured default
+        if (s % (int)group_stride != 0) return false; // group-aligned
+        if (s + (int)group_stride > n_vregs) return false; // fits register file
+        if (groups_overlap(s, group_stride, hint, group_stride)) return false;
+        for (size_t base : vmm_idxs)
+            if (groups_overlap(s, group_stride, (int)base, group_stride))
+                return false;
+        return true;
+    };
+    if (needs_narrow_stage)
+        JIT_ASSERT(scratch_ok(sp.narrow_stage_vmm.getIdx()));
+    if (needs_gather) JIT_ASSERT(scratch_ok(sp.gather_idx_vmm.getIdx()));
+    if (needs_narrow_stage && needs_gather)
+        JIT_ASSERT(!groups_overlap(sp.narrow_stage_vmm.getIdx(), group_stride,
+                sp.gather_idx_vmm.getIdx(), group_stride));
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::validate_temp_vmm_hint(
+        const injector_utils::vmm_index_set_t &vmm_idxs, size_t group_stride,
+        int max_vmm_idx) const {
+    const int hint = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
+    const int stride = (int)group_stride;
+    // x64's adjust_temp_vmm_hint substitutes a free single vmm (0 or
+    // max_vmm_idx) for an invalid hint and should_preserve_vmm spills it
+    // locally around each use. Neither substitute is legal for the rv64 helper
+    // group: v0 is the live mask register (the compare/select paths write it),
+    // and the helper is an e32/acc_lmul group, so it must be group_stride-
+    // aligned and fit in the register file. The helper is host-reserved by
+    // contract, so an invalid hint is a host bug; JIT_ASSERT keeps the check in
+    // Release builds, where the throw fails kernel creation via create_kernel()
+    // instead of emitting code that corrupts the mask or an out-of-range group.
+    const bool helper_group_legal = hint != 0 && hint % stride == 0
+            && hint + stride - 1 <= max_vmm_idx;
+    // The helper occupies [hint, hint + group_stride); it must not overlap any
+    // processed accumulator's group [base, base + group_stride). Both intervals
+    // are tested directly so a legal sparse set is not rejected on its endpoints
+    // (e.g. m4 helper v8 with processed {v4, v12}: v4-v7 and v12-v15 straddle
+    // v8-v11 but never touch it).
+    bool overlaps_processed_vmms = false;
+    for (const auto idx : vmm_idxs)
+        overlaps_processed_vmms |= hint <= (int)idx + stride - 1
+                && (int)idx <= hint + stride - 1;
+    JIT_ASSERT(helper_group_legal && !overlaps_processed_vmms);
+}
 
 template <cpu_isa_t isa>
 void jit_uni_binary_injector_t<isa>::compute_vector_range(size_t start_idx,
-        size_t end_idx, const binary_injector::rhs_arg_dynamic_params_t &dyn) {
-    for (size_t i = start_idx; i < end_idx; i++)
-        compute_vector(i, dyn);
+        size_t end_idx, std::size_t rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params,
+        size_t group_stride) const {
+    // [start_idx, end_idx) is the half-open physical register span (x64
+    // semantics); group_stride is the number of registers per accumulator (its
+    // LMUL/EMUL). make_vmm_group_set steps by it, so a run of m>1 accumulators
+    // yields its true group bases rather than x64's consecutive indices.
+    compute_vector_range(injector_utils::make_vmm_group_set<isa>(
+                                 start_idx, end_idx, group_stride),
+            rhs_arg_idx, post_op, rhs_arg_params, group_stride);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_binary_injector_t<isa>::compute_vector(
-        size_t idx, const binary_injector::rhs_arg_dynamic_params_t &dyn) {
-    // scalar broadcast ignores the offset; other strategies need the per-vmm
-    // output element offset to compute the rhs address.
-    Reg out_off = x0;
-    const auto it = dyn.vmm_idx_to_out_off.find((int)idx);
-    if (it != dyn.vmm_idx_to_out_off.end())
-        out_off = it->second;
-    else
-        assert(rhs_.bcast == binary_injector::broadcast_t::scalar
-                && IMPLICATION(select_ != nullptr,
-                        select_->bcast == binary_injector::broadcast_t::scalar)
-                && "non-scalar dynamic binary rhs needs an out-offset");
-    if (alg_ == alg_kind::binary_select)
-        apply_select(Vmm(idx), out_off);
-    else {
-        const bool scalar = load_operand(out_off, rhs_);
-        apply_op(Vmm(idx), scalar);
-    }
-}
+void jit_uni_binary_injector_t<isa>::compute_vector_range(
+        const injector_utils::vmm_index_set_t &vmm_idxs,
+        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params,
+        size_t group_stride) const {
 
-// Load the rhs slice into f_rhs_ (scalar broadcast) or v_rhs_ (vector) from
-// base + strategy(out_off), converting rhs_dt_ to f32. gpr_ and off_ are address
-// scratch.
-// Returns whether the result is a broadcast scalar (true) vs a vector (false).
-//
-// Non-f32 rhs and the gather are only enabled by the binary primitive, which
-// computes at e32/m4; the s8/u8/xf16 paths briefly switch SEW (e8/m1, e16/m2 and
-// e32/m4 share VLMAX, so `vsetvli x0,x0` keeps vl) and widen v_rhs_ in place,
-// restoring e32/m4. v_idx_ holds the gather byte-index; other consumers use only
-// scalar/per_element f32, which take the no-switch paths.
-template <cpu_isa_t isa>
-bool jit_uni_binary_injector_t<isa>::load_operand(
-        const Reg &out_off, operand_t &op) {
-    using bt = binary_injector::broadcast_t;
-    // Loads the per-binary base pointer (indirect) into gpr_, or returns the
-    // direct pointer. Call after any use of gpr_ for channel math.
-    auto load_base = [&]() -> Reg {
-        if (op.indirect) {
-            h_->ld(op.gpr, op.rhs_addr, op.arg_idx * (int)sizeof(void *));
-            return op.gpr;
-        }
-        return op.rhs_addr;
-    };
-    const int esz = (int)types::data_type_size(op.rhs_dt);
-    const int sh = esz == 4 ? 2 : (esz == 2 ? 1 : 0);
+    if (vmm_idxs.empty()) return;
+    const auto start_idx = *(vmm_idxs.begin());
 
-    // Load vl elements of rhs_dt_ into v_rhs_ as f32 (e32/m4). is_gather uses the
-    // byte-index vector v_idx_ (vluxei32); else a contiguous / strided load from
-    // `base`. Narrow dtypes switch SEW (vl preserved) and widen v_rhs_ in place.
-    auto load_rhs_vec = [&](const Reg &base, bool is_gather) {
-        if (op.rhs_dt != data_type::f32 && op.rhs_dt != data_type::s32) {
-            assert(op.v_tmp != VReg(0)
-                    && "narrow binary rhs requires explicit staging scratch");
-            assert(op.v_tmp != op.v_rhs
-                    && "binary rhs staging scratch overlaps rhs result");
-            assert(IMPLICATION(is_gather, op.v_tmp != op.v_idx)
-                    && "binary rhs staging scratch overlaps gather index");
-        }
-        if (op.rhs_dt == data_type::f32 || op.rhs_dt == data_type::s32) {
-            if (is_gather)
-                h_->vluxei32_v(op.v_rhs, base, op.v_idx);
-            else if (op.strided)
-                h_->vlse32_v(op.v_rhs, base, op.rhs_stride);
-            else
-                h_->vle32_v(op.v_rhs, base);
-            if (op.rhs_dt == data_type::s32)
-                h_->vfcvt_f_x_v(op.v_rhs, op.v_rhs);
-        } else if (op.rhs_dt == data_type::s8 || op.rhs_dt == data_type::u8) {
-            // Load bytes into v_tmp_, then widen into v_rhs_ (a widening op may
-            // not overlap its source's low part, so stage in a distinct group).
-            h_->vsetvli(x0, x0, SEW::e8, LMUL::m1, VTA::ta, VMA::ma); // keep vl
-            if (is_gather)
-                h_->vluxei32_v(op.v_tmp, base, op.v_idx);
-            else if (op.strided)
-                h_->vlse8_v(op.v_tmp, base, op.rhs_stride);
-            else
-                h_->vle8_v(op.v_tmp, base);
-            h_->vsetvli(x0, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
-            if (op.rhs_dt == data_type::s8) {
-                h_->vsext_vf4(op.v_rhs, op.v_tmp);
-                h_->vfcvt_f_x_v(op.v_rhs, op.v_rhs);
-            } else {
-                h_->vzext_vf4(op.v_rhs, op.v_tmp);
-                h_->vfcvt_f_xu_v(op.v_rhs, op.v_rhs);
-            }
-        } else { // f16 / bf16
-            h_->vsetvli(
-                    x0, x0, SEW::e16, LMUL::m2, VTA::ta, VMA::ma); // keep vl
-            if (is_gather)
-                h_->vluxei32_v(op.v_tmp, base, op.v_idx);
-            else if (op.strided)
-                h_->vlse16_v(op.v_tmp, base, op.rhs_stride);
-            else
-                h_->vle16_v(op.v_tmp, base);
-            // e16m2 -> e32m4; Zvfbfmin for bf16, Zvfh for f16.
-            if (op.rhs_dt == data_type::bf16)
-                h_->vfwcvtbf16_f_f_v(op.v_rhs, op.v_tmp);
-            else
-                h_->vfwcvt_f_f_v(op.v_rhs, op.v_tmp);
-            h_->vsetvli(x0, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
-        }
-    };
+    // Phase 1 Validate the processed set and the temporary vmm user hint.
+    // group_stride is each accumulator's e32 LMUL (1/2/4): the accumulators must
+    // be group-aligned, non-overlapping, and in range, and the host-reserved
+    // helper (also an e32/acc_lmul group) must not overlap them. Unlike x64,
+    // which adjusts an invalid hint to a free single vmm, the rv64 helper has no
+    // legal substitute, so a violation fails kernel creation.
+    static constexpr int max_vmm_idx = jit_isa_traits_t<isa>::n_vregs - 1;
+    const int vmm_hint = rhs_arg_static_params_.rhs_dt_helper_vmm_idx;
+    injector_utils::validate_vmm_group_set<isa>(vmm_idxs, group_stride);
+    validate_temp_vmm_hint(vmm_idxs, group_stride, max_vmm_idx);
 
-    if (op.bcast == bt::scalar) {
-        // One rhs value broadcast to all lanes. Integer/f32 use scalar loads ->
-        // f_rhs_ (no vl change); f16/bf16 broadcast-load (stride 0) -> v_rhs_.
-        const Reg base = load_base();
-        if (op.rhs_dt == data_type::f32) {
-            h_->flw(op.f_rhs, base, 0);
-            return true;
+    const auto rhs_broadcasting_strategy
+            = get_rhs_arg_broadcasting_strategy_or_hosted(
+                    post_op.binary.src1_desc, rhs_arg_static_params_.dst_d,
+                    supported_strategy_set_);
+    const bool needs_ternary_input = post_op.is_binary_with_ternary_op();
+
+    // Writes to x0 are discarded on RV64, so a helper GPR left at its default
+    // would silently drop the address it is supposed to carry (no fault, just
+    // a wrong rhs address). rhs_addr_reg always receives the rhs base;
+    // rhs_helper_reg receives the computed offset for every non-scalar
+    // strategy. This is checked here rather than at construction because the
+    // supported-strategy set may legitimately be wider than the strategy this
+    // entry actually resolves to (gnorm advertises {scalar} only and passes x0).
+    JIT_ASSERT(rhs_arg_static_params_.rhs_addr_reg.getIdx() != x0.getIdx());
+    JIT_ASSERT(IMPLICATION(
+            rhs_broadcasting_strategy != broadcasting_strategy_t::scalar,
+            rhs_arg_static_params_.rhs_helper_reg.getIdx() != x0.getIdx()));
+
+    // Phase 2 Protect temporary registers content (x64's conditional guard
+    // ladder; the scalar per-oc path additionally clobbers the calculate_*
+    // scratch). The rhs dt helper vmm is spilled as a whole e32/acc_lmul group
+    // (group_stride registers) when the host asks for it and this entry stages
+    // through it (x64's preserve_vmm_helper && dt_helper_vmm_needed).
+    const auto rhs_arg_data_type
+            = get_src1_desc(post_op, rhs_arg_static_params_.dst_d).data_type;
+    // The helper vmm is written unless the scalar strategy keeps the value in
+    // the FP helper (.vf forms); f16 and the ternary condition always stage
+    // through it, and so do min/max and the compare algs, whose ordered
+    // compare-and-merge sequences materialize the scalar into a vector
+    // operand (mirrors inject_binary/execute_binary's vrhs()).
+    const bool alg_stages_through_helper_vmm = utils::one_of(post_op.binary.alg,
+            alg_kind::binary_max, alg_kind::binary_min, alg_kind::binary_ge,
+            alg_kind::binary_gt, alg_kind::binary_le, alg_kind::binary_lt,
+            alg_kind::binary_eq, alg_kind::binary_ne);
+    // The min/max/compare/select paths write the mask register v0 (vmflt/vmfeq
+    // into VReg(0)) and then merge into dst; an accumulator group based at v0
+    // (start_idx == 0, the only base whose group contains register 0) would
+    // alias that mask. Non-mask algs (add/mul/sub/div) never touch v0, so v0 is
+    // a legal accumulator for them. As with the helper hint, an illegal host
+    // choice fails kernel creation rather than emitting mask-corrupting code.
+    JIT_ASSERT(!((needs_ternary_input || alg_stages_through_helper_vmm)
+            && start_idx == 0));
+    // Phase 1b Validate the rv64-only rhs scratch groups this entry will use
+    // (x64 has no analog -- its helper adjustment covers all temporaries).
+    validate_rhs_scratch(
+            vmm_idxs, group_stride, post_op, rhs_broadcasting_strategy);
+    const bool dt_helper_vmm_needed = needs_ternary_input
+            || alg_stages_through_helper_vmm
+            || !(rhs_broadcasting_strategy == broadcasting_strategy_t::scalar
+                    && !utils::one_of(rhs_arg_data_type, data_type::f16,
+                            data_type::bf16));
+    const bool use_oc_conversion_regs
+            = utils::one_of(rhs_broadcasting_strategy,
+                      broadcasting_strategy_t::per_oc,
+                      broadcasting_strategy_t::per_oc_spatial)
+            && rhs_arg_static_params_.per_oc_lanes_are_channels;
+    const injector_utils::register_preserve_guard_t register_guard {host_,
+            rhs_arg_static_params_.preserve_gpr_helpers
+                    ? (use_oc_conversion_regs
+                                      ? std::initializer_list<Xbyak_riscv::Reg>(
+                                                {rhs_arg_static_params_
+                                                                .rhs_addr_reg,
+                                                        rhs_arg_static_params_
+                                                                .rhs_helper_reg,
+                                                        rhs_arg_static_params_
+                                                                .rhs_addr_cache_reg,
+                                                        X_TMP_0, X_TMP_1,
+                                                        X_TMP_2, X_TMP_3,
+                                                        X_TMP_4})
+                                      : std::initializer_list<Xbyak_riscv::Reg>(
+                                                {rhs_arg_static_params_
+                                                                .rhs_addr_reg,
+                                                        rhs_arg_static_params_
+                                                                .rhs_helper_reg,
+                                                        rhs_arg_static_params_
+                                                                .rhs_addr_cache_reg,
+                                                        X_TMP_0}))
+                    : std::initializer_list<Xbyak_riscv::Reg>(),
+            rhs_arg_static_params_.preserve_vmm_helper && dt_helper_vmm_needed
+                    ? std::initializer_list<Xbyak_riscv::VReg>(
+                              {Xbyak_riscv::VReg(vmm_hint)})
+                    : std::initializer_list<Xbyak_riscv::VReg>(),
+            {} /*freg*/, group_stride};
+
+    rhs_address_t rhs_arg_addr(Xbyak_riscv::Reg(0));
+
+    // Phase 3 Apply binary post-op over all vmms. rhs_arg_params_differ compares
+    // this accumulator's params against the previously processed one to decide
+    // whether the rhs address must be rebuilt. Unlike x64 -- where accumulators
+    // are consecutive vmm indices, so vmm_idx - 1 is the previous one -- an rv64
+    // run of m>1 accumulators steps its group bases by group_stride, so the
+    // previous base is not vmm_idx - 1; track it explicitly (the ordered set
+    // iterates ascending).
+    size_t prev_vmm_idx = start_idx;
+    for (const auto vmm_idx : vmm_idxs) {
+        // For binary ops with ternary inputs the select condition src2 is
+        // loaded first and immediately consumed into the v0 mask: rv64 cannot
+        // stack-spill a vector like x64's push_vmm, so the mask register is
+        // the only carrier that survives the src1 load reusing the same
+        // helper vmm. The condition supports no broadcast (x64 contract), so
+        // its address follows the no_broadcast offset path.
+        if (needs_ternary_input) {
+            const auto rhs2_arg_data_type
+                    = get_src2_desc(post_op, rhs_arg_static_params_.dst_d)
+                              .data_type;
+            const auto rhs2_arg_addr = prepare_rhs_arg_addr(vmm_idx,
+                    rhs_arg_idx + 1, post_op, rhs_arg_params,
+                    broadcasting_strategy_t::no_broadcast, true);
+
+            const Vmm tern_tmp_vmm
+                    = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+            load_rhs(rhs2_arg_data_type, tern_tmp_vmm, rhs2_arg_addr,
+                    group_stride);
+            if (rhs2_arg_data_type != data_type::f32
+                    && !utils::one_of(rhs2_arg_data_type, data_type::f16,
+                            data_type::bf16))
+                cvt_to_f32(tern_tmp_vmm);
+            // v0 = (cond == 0): the lanes where the select picks src1. NaN
+            // compares unequal to 0, so a NaN condition keeps the
+            // accumulator, matching bool(NaN) == true in the reference.
+            const auto &tmp_freg = rhs_arg_static_params_.rhs_dt_helper_freg;
+            host_->fmv_w_x(tmp_freg, x0);
+            host_->vmfeq_vf(VReg(0), tern_tmp_vmm, tmp_freg);
         }
-        if (op.rhs_dt == data_type::s32) {
-            h_->lw(op.gpr, base, 0);
-            h_->fcvt_s_w(op.f_rhs, op.gpr);
-            return true;
+
+        // The src1 address must also be rebuilt whenever the ternary
+        // condition was prepared: both operands share rhs_addr_reg (x64
+        // reloads only under the scalar strategy because its other
+        // strategies keep cached addresses).
+        if (vmm_idx == start_idx || needs_ternary_input
+                || rhs_arg_params_differ(vmm_idx, prev_vmm_idx, rhs_arg_params,
+                        rhs_broadcasting_strategy)) {
+            rhs_arg_addr = prepare_rhs_arg_addr(vmm_idx, rhs_arg_idx, post_op,
+                    rhs_arg_params, rhs_broadcasting_strategy, false);
         }
-        if (op.rhs_dt == data_type::s8) {
-            h_->lb(op.gpr, base, 0);
-            h_->fcvt_s_w(op.f_rhs, op.gpr);
-            return true;
-        }
-        if (op.rhs_dt == data_type::u8) {
-            h_->lbu(op.gpr, base, 0);
-            h_->fcvt_s_wu(op.f_rhs, op.gpr);
-            return true;
-        }
-        // f16/bf16: broadcast one value to every lane (stride 0) into v_tmp_,
-        // then widen into v_rhs_ (staged, a widen cannot overlap its source).
-        assert(op.v_tmp != VReg(0)
-                && "xf16 binary rhs requires explicit staging scratch");
-        assert(op.v_tmp != op.v_rhs
-                && "binary rhs staging scratch overlaps rhs result");
-        h_->vsetvli(x0, x0, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
-        h_->vlse16_v(op.v_tmp, base, x0);
-        if (op.rhs_dt == data_type::bf16)
-            h_->vfwcvtbf16_f_f_v(op.v_rhs, op.v_tmp);
+
+        if (needs_ternary_input)
+            inject_binary_with_ternary_op(
+                    post_op, Vmm(vmm_idx), rhs_arg_addr, group_stride);
         else
-            h_->vfwcvt_f_f_v(op.v_rhs, op.v_tmp);
-        h_->vsetvli(x0, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
-        return false;
+            inject_binary(post_op, Vmm(vmm_idx), rhs_arg_addr, group_stride);
+
+        prev_vmm_idx = vmm_idx;
     }
-    if (op.bcast == bt::per_oc) {
-        assert(op.v_idx != VReg(0)
-                && "per-oc binary rhs requires explicit index scratch");
-        assert(op.v_idx != op.v_rhs
-                && "binary rhs gather index overlaps rhs result");
-        // Per-lane gather index (element): a vl-run may span dim boundaries, so
-        // each lane resolves its own broadcast-dim index.
-        //   idx = ((o / oc_stride) % C) * blk + (o % blk), o = out_off + lane
-        // Covers per_oc / per_w (blk=1) and blocked per_oc (blk = inner block).
-        h_->vid_v(op.v_idx);
-        h_->vadd_vx(op.v_idx, op.v_idx, out_off); // o
-        if (op.blk > 1)
-            h_->vand_vi(op.v_rhs, op.v_idx, (int)(op.blk - 1)); // low=o%blk
-        if (op.oc_stride != 1) {
-            h_->li(op.gpr, op.oc_stride);
-            h_->vdivu_vx(op.v_idx, op.v_idx, op.gpr);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::compute_vector(size_t idx,
+        std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params,
+        size_t group_stride) const {
+    compute_vector_range(
+            {idx}, rhs_arg_idx, post_op, rhs_arg_params, group_stride);
+}
+
+template <cpu_isa_t isa>
+rhs_address_t jit_uni_binary_injector_t<isa>::prepare_rhs_arg_addr(
+        std::size_t vmm_idx, std::size_t rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params,
+        const broadcasting_strategy_t rhs_broadcasting_strategy,
+        bool is_ternary_input) const {
+
+    static constexpr auto rhs_arg_ptr_size = sizeof(const void *);
+    const auto &rhs_addr_reg = rhs_arg_static_params_.rhs_addr_reg;
+    const auto &rhs_helper_reg = rhs_arg_static_params_.rhs_helper_reg;
+    const auto &rhs_md = is_ternary_input
+            ? get_src2_desc(post_op, rhs_arg_static_params_.dst_d)
+            : get_src1_desc(post_op, rhs_arg_static_params_.dst_d);
+    const auto rhs_arg_elem_size = types::data_type_size(rhs_md.data_type);
+
+    // x64: param1 is the kernel abi param (the args struct), abi_param_offset
+    // the rhs pointer-array field, dereferenced twice. x64 gates the reload on
+    // is_first (its addresses are cached); rv64 caches no addresses and
+    // reloads on every call.
+    host_->ld(rhs_addr_reg, param1_,
+            (int)rhs_arg_static_params_.abi_param_offset);
+    host_->ld(
+            rhs_addr_reg, rhs_addr_reg, (int)(rhs_arg_idx * rhs_arg_ptr_size));
+
+    switch (rhs_broadcasting_strategy) {
+        case broadcasting_strategy_t::scalar:
+            return rhs_address_t(rhs_addr_reg, 0, true);
+        case broadcasting_strategy_t::no_broadcast: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_out_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_out_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_out_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_no_broadcast_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            if (rhs_arg_static_params_.is_strided)
+                return rhs_address_t(rhs_addr_reg, 0, false, false,
+                        true /*isStrided*/, rhs_arg_static_params_.rhs_stride);
+            return rhs_address_t(rhs_addr_reg);
         }
-        h_->li(op.gpr, op.C);
-        h_->vremu_vx(op.v_idx, op.v_idx, op.gpr); // outer index
-        if (op.blk > 1) {
-            int lg = 0;
-            for (dim_t b = op.blk; b > 1; b >>= 1)
-                lg++;
-            h_->vsll_vi(op.v_idx, op.v_idx, lg); // outer * blk
-            h_->vadd_vv(op.v_idx, op.v_idx, op.v_rhs); // + low
+        case broadcasting_strategy_t::per_oc:
+        case broadcasting_strategy_t::per_oc_spatial: {
+            const bool is_per_oc_spatial = rhs_broadcasting_strategy
+                    == broadcasting_strategy_t::per_oc_spatial;
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_oc_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_oc_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_oc_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_oc_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size,
+                    is_per_oc_spatial);
+
+            // Channel-aligned host: aarch64's per-call addressing (broadcast
+            // for per_oc_spatial, contiguous otherwise); else both are
+            // realized by the per-lane gather (see append_oc_offset).
+            if (rhs_arg_static_params_.per_oc_lanes_are_channels)
+                return rhs_address_t(rhs_addr_reg, 0, is_per_oc_spatial);
+            return rhs_address_t(rhs_addr_reg, 0, false, true /*isGather*/);
         }
-        if (sh) h_->vsll_vi(op.v_idx, op.v_idx, sh); // * esz -> byte offset
-        load_rhs_vec(load_base(), /*is_gather=*/true);
-        return false;
+        case broadcasting_strategy_t::per_mb_spatial: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_sp_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_sp_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_sp_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_mb_sp_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            return rhs_address_t(rhs_addr_reg, 0, false, true /*isGather*/);
+        }
+        case broadcasting_strategy_t::per_mb_w: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_mb_w_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_mb_w_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_mb_w_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_mb_w_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            return rhs_address_t(rhs_addr_reg, 0, false, true /*isGather*/);
+        }
+        case broadcasting_strategy_t::per_w: {
+            append_offset_from_operand(rhs_arg_params.vmm_idx_to_w_off_oprnd,
+                    vmm_idx, rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_offset_under_mem_addr(
+                    rhs_arg_params.vmm_idx_to_w_elem_off_addr, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+            append_value_offset(rhs_arg_params.vmm_idx_to_w_elem_off_val,
+                    vmm_idx, rhs_addr_reg, rhs_arg_elem_size);
+            append_w_offset(rhs_arg_params.vmm_idx_to_out_addr,
+                    rhs_arg_params.vmm_idx_to_out_reg,
+                    rhs_arg_params.vmm_idx_to_out_elem_off_val, vmm_idx,
+                    rhs_addr_reg, rhs_helper_reg, rhs_arg_elem_size);
+
+            return rhs_address_t(rhs_addr_reg, 0, false, true /*isGather*/);
+        }
+        default: assert(false && "Broadcasting type not supported");
     }
-    // per_element: address of the first active lane. Byte-offset consumers
-    // (indirect, f32) add the offset in place; element-offset consumers scale by
-    // sizeof(rhs_dt_) into off_.
-    Reg addr;
-    if (op.off_is_bytes) {
-        h_->ld(op.gpr, op.rhs_addr, op.arg_idx * (int)sizeof(void *));
-        h_->add(op.gpr, op.gpr, out_off);
-        addr = op.gpr;
+
+    return rhs_address_t(rhs_addr_reg, 0, true);
+}
+
+// --- offset helpers (mirror aarch64 append_offset_from_operand /
+// append_offset_under_mem_addr / append_value_offset). rv64 consumers use the
+// out_reg + out_elem_off_val path, so these three are structural parity and
+// no-ops in the current consumers (is_dst_orig_set gates them out, matching
+// aarch64). ---
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_offset_from_operand(
+        const std::map<int, rhs_operand_t> &vmm_idx_to_elem_operand_off,
+        int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+        const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes) const {
+    const auto it_operand_off = vmm_idx_to_elem_operand_off.find(vmm_idx);
+    if (it_operand_off != vmm_idx_to_elem_operand_off.end()
+            && !rhs_arg_static_params_.is_dst_orig_set()) {
+        const auto &op = it_operand_off->second;
+        if (op.isAddress_)
+            host_->ld(tmp_reg, op.address_.base_, (int)op.address_.offt_);
+        else
+            host_->mv(tmp_reg, Xbyak_riscv::Reg(op.idx_));
+        if (elem_size_bytes > 1)
+            host_->slli(tmp_reg, tmp_reg, (int)std::log2(elem_size_bytes));
+        host_->add(addr_reg, addr_reg, tmp_reg);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_offset_under_mem_addr(
+        const std::map<int, rhs_address_t> &vmm_idx_to_elem_addr_off,
+        int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+        const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes) const {
+    const auto it_off_addr = vmm_idx_to_elem_addr_off.find(vmm_idx);
+    if (it_off_addr != vmm_idx_to_elem_addr_off.end()
+            && !rhs_arg_static_params_.is_dst_orig_set()) {
+        host_->ld(tmp_reg, it_off_addr->second.base_,
+                (int)it_off_addr->second.offt_);
+        if (elem_size_bytes > 1)
+            host_->slli(tmp_reg, tmp_reg, (int)std::log2(elem_size_bytes));
+        host_->add(addr_reg, addr_reg, tmp_reg);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_value_offset(
+        const std::map<int, size_t> &vmm_idx_to_elem_val_off, int vmm_idx,
+        const Xbyak_riscv::Reg &addr_reg, std::size_t elem_size_bytes) const {
+    const auto it_off_val = vmm_idx_to_elem_val_off.find(vmm_idx);
+    if (it_off_val != vmm_idx_to_elem_val_off.end()
+            && !rhs_arg_static_params_.is_dst_orig_set()) {
+        const auto &t = X_TMP_0;
+        host_->load_imm64(t, (int64_t)(it_off_val->second * elem_size_bytes));
+        host_->add(addr_reg, addr_reg, t);
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_no_broadcast_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_riscv::Reg &addr_reg, const Xbyak_riscv::Reg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+
+    if (is_out_addr || is_out_reg) {
+        rhs_address_t out_addr = is_out_addr
+                ? it_out_addr->second
+                : rhs_address_t(it_out_reg->second);
+        const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+        calculate_no_broadcast(out_addr,
+                it_off_val != vmm_idx_to_out_elem_off_val.end()
+                        ? it_off_val->second
+                        : 0,
+                tmp_reg);
+
+        // byte-offset host (pooling): the byte offset is added straight to the
+        // rhs base (elements already scaled by the caller).
+        if (rhs_arg_static_params_.off_is_bytes) {
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        } else {
+            if (elem_size_bytes > 1)
+                host_->slli(tmp_reg, tmp_reg, (int)std::log2(elem_size_bytes));
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        }
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_no_broadcast(rhs_address_t addr,
+        std::size_t offset, const Xbyak_riscv::Reg &out_reg) const {
+    const auto &t0 = X_TMP_0;
+    if (!rhs_arg_static_params_.is_dst_orig_set()) {
+        // Host-positioned mode (rv64-only, null dst_d): addr.getBase()
+        // already holds the running element offset the VLA host maintains (a
+        // byte offset under off_is_bytes); no address recovery is needed.
+        if (offset > 0) {
+            host_->load_imm64(t0, (int64_t)offset);
+            host_->add(out_reg, addr.getBase(), t0);
+        } else
+            host_->mv(out_reg, addr.getBase());
+        return;
+    }
+    // aarch64: recover the dst element offset from the dst address,
+    // (addr + offt + offset - dst_orig) >> log2(dst data type size), with
+    // dst_orig loaded from param1 + dst_orig_offset.
+    if (addr.offt_ != 0) {
+        host_->load_imm64(t0, addr.offt_);
+        host_->add(out_reg, addr.getBase(), t0);
+    } else
+        host_->mv(out_reg, addr.getBase());
+    if (offset > 0) {
+        host_->load_imm64(t0, (int64_t)offset);
+        host_->add(out_reg, out_reg, t0);
+    }
+    host_->ld(t0, param1_, (int)rhs_arg_static_params_.dst_orig_offset);
+    host_->sub(out_reg, out_reg, t0);
+    host_->srli(out_reg, out_reg,
+            (uint32_t)std::log2(types::data_type_size(
+                    rhs_arg_static_params_.dst_d.data_type())));
+}
+
+// Build the per-lane byte-index gather vector (gather_idx_vmm) that realizes a
+// per-channel rhs load under VLA: a vl-run may span the channel dimension, so
+// each lane resolves its own index. The compute vtype (e32/m4) must be active.
+// `flat_off_reg` (tmp_reg) holds the run's first-lane element offset.
+//   idx_bytes[lane] = (((o+lane) / oc_stride) % oc_count) * blk + ((o+lane) % blk)
+//                     scaled by elem_size.
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_oc_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_riscv::Reg &addr_reg, const Xbyak_riscv::Reg &tmp_reg,
+        std::size_t elem_size_bytes, bool is_per_oc_spatial) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+    if (!(is_out_addr || is_out_reg)) return;
+
+    rhs_address_t out_addr = is_out_addr ? it_out_addr->second
+                                         : rhs_address_t(it_out_reg->second);
+    const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+    calculate_no_broadcast(out_addr,
+            it_off_val != vmm_idx_to_out_elem_off_val.end() ? it_off_val->second
+                                                            : 0,
+            tmp_reg); // tmp_reg = flat element offset o
+
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+
+    if (rhs_arg_static_params_.per_oc_lanes_are_channels) {
+        // aarch64's scalar path: derive the channel (block) offset from the
+        // recovered element offset and add it to the rhs base. The host
+        // guarantees every vector's lanes stay within the addressed channel
+        // row/block (see static params), so the rhs is then a contiguous
+        // slice (per_oc) or a single value (per_oc_spatial).
+        MAYBE_UNUSED(is_per_oc_spatial);
+        const auto strides = dst_d.blocking_desc().strides;
+        const auto layout = injector_utils::get_layout_type(dst_d);
+        // get_layout_type() classifies a blocked dst as c_blocked only when the
+        // single inner block is the channel one; anything else (e.g. Abcd16a,
+        // blocked on N) is `unsupported` and has no valid channel formula here.
+        // The host's post_ops_ok must have rejected it -- fail kernel creation
+        // rather than emit garbage addresses in a Release build.
+        JIT_ASSERT(layout != injector_utils::layout_t::unsupported);
+        switch (layout) {
+            case injector_utils::layout_t::ncsp:
+                calculate_oc_ncsp(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::c_blocked:
+                calculate_oc_blocked(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::nspc:
+                calculate_oc_nspc(strides, tmp_reg);
+                break;
+            case injector_utils::layout_t::cspn:
+                calculate_oc_cspn(strides, tmp_reg);
+                break;
+            default: assert(!"Unknown layout");
+        }
+
+        if (elem_size_bytes == 1) {
+            host_->add(addr_reg, addr_reg, X_TMP_0);
+        } else {
+            const int shift_val = std::log2(elem_size_bytes);
+            host_->mv(tmp_reg, X_TMP_0);
+            host_->slli(tmp_reg, tmp_reg, shift_val);
+            host_->add(addr_reg, addr_reg, tmp_reg);
+        }
+        return;
+    }
+
+    // Otherwise both per_oc and per_oc_spatial are realized by the per-lane
+    // gather: under RVV VLA an unrouted run spans channel boundaries even for
+    // per_oc_spatial layouts, so each lane resolves its own channel.
+    MAYBE_UNUSED(is_per_oc_spatial);
+
+    // per_oc gather. Derive (oc_count, oc_stride, blk) for the channel dim.
+    const auto &bd = dst_d.blocking_desc();
+    dim_t blk = 1;
+    for (int k = 0; k < bd.inner_nblks; k++)
+        if (bd.inner_idxs[k] == 1) blk *= bd.inner_blks[k];
+    const dim_t oc_count = (dst_d.dims()[1] + blk - 1) / blk;
+    const dim_t oc_stride = bd.strides[1];
+
+    const auto &v_idx = rhs_arg_static_params_.gather_idx_vmm;
+    const auto &v_low = rhs_arg_static_params_.narrow_stage_vmm;
+    const auto &t = X_TMP_0;
+    host_->vid_v(v_idx);
+    host_->vadd_vx(v_idx, v_idx, tmp_reg); // o + lane
+    if (blk > 1) host_->vand_vi(v_low, v_idx, (int)(blk - 1)); // low = o % blk
+    if (oc_stride != 1) {
+        host_->load_imm64(t, oc_stride);
+        host_->vdivu_vx(v_idx, v_idx, t);
+    }
+    host_->load_imm64(t, oc_count);
+    host_->vremu_vx(v_idx, v_idx, t); // outer index
+    if (blk > 1) {
+        int lg = 0;
+        for (dim_t b = blk; b > 1; b >>= 1)
+            lg++;
+        host_->vsll_vi(v_idx, v_idx, lg); // outer * blk
+        host_->vadd_vv(v_idx, v_idx, v_low); // + low
+        // A padded channel tail makes the reconstructed index run up to
+        // padded_C - 1 while the per_oc rhs only holds the logical C elements,
+        // so clamp before scaling to bytes. This bounds the gather; the lanes
+        // that get clamped are padding, and the HOST still owns making their
+        // result harmless (mask them off, or zero the padded dst tail as the
+        // binary tail kernel does).
+        host_->load_imm64(t, dst_d.dims()[1] - 1);
+        host_->vminu_vx(v_idx, v_idx, t);
+    }
+    if (elem_size_bytes > 1)
+        host_->vsll_vi(v_idx, v_idx, (int)std::log2(elem_size_bytes));
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_oc_ncsp(const dim_t *strides,
+        const Xbyak_riscv::Reg &tmp_reg, const bool residue) const {
+    // c = (offset % strides[0]) / strides[1]; output = x_tmp0
+    const auto &x0t = X_TMP_0;
+    const auto &x1t = X_TMP_1;
+    const auto &x2t = X_TMP_2;
+    const auto &x3t = X_TMP_3;
+    const auto &x4t = X_TMP_4;
+
+    host_->load_imm64(x3t, strides[0]);
+    host_->load_imm64(x4t, strides[1]);
+    host_->remu(x2t, tmp_reg, x3t);
+    if (residue) {
+        host_->divu(x0t, x2t, x4t);
+        host_->remu(x1t, x2t, x4t);
+    } else
+        host_->divu(x0t, x2t, x4t);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_oc_blocked(
+        const dim_t *strides, const Xbyak_riscv::Reg &tmp_reg) const {
+    // c = ((offset % strides[0]) / strides[1]) * blk + offset % blk_size
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    // Unlike the gather path -- which folds every channel-dim inner block
+    // (`for k: if inner_idxs[k] == 1 blk *= inner_blks[k]`) -- this formula
+    // assumes a single channel block. Keep the two in agreement by requiring
+    // that shape here; the hosts' post_ops_ok already gate it (see x64's
+    // identical blocked-format check), and a violation would silently compute a
+    // wrong channel rather than fault.
+    JIT_ASSERT(dst_d.blocking_desc().inner_nblks == 1
+            && dst_d.blocking_desc().inner_idxs[0] == 1);
+    const int blk_size = dst_d.blocking_desc().inner_blks[0];
+    const auto &x0t = X_TMP_0;
+    const auto &x1t = X_TMP_1;
+    const auto &x2t = X_TMP_2;
+    const auto &x3t = X_TMP_3;
+
+    calculate_oc_ncsp(strides, tmp_reg, /*residue=*/true);
+    // extract c % blk_size
+    host_->load_imm64(x3t, blk_size);
+    host_->remu(x2t, x1t, x3t);
+
+    host_->load_imm64(tmp_reg, blk_size);
+    host_->mul(x0t, x0t, tmp_reg);
+    host_->add(x0t, x0t, x2t);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_oc_nspc(
+        const dim_t *strides, const Xbyak_riscv::Reg &tmp_reg) const {
+    // c = offset % C; output = x_tmp0
+    const auto &x0t = X_TMP_0;
+    const auto &x1t = X_TMP_1;
+    const auto C = rhs_arg_static_params_.dst_d.dims()[1];
+    host_->load_imm64(x1t, C);
+    host_->remu(x0t, tmp_reg, x1t);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::calculate_oc_cspn(
+        const dim_t *strides, const Xbyak_riscv::Reg &tmp_reg) const {
+    // c = offset / strides[1]; output = x_tmp0
+    const auto &x0t = X_TMP_0;
+    const auto &x1t = X_TMP_1;
+    host_->load_imm64(x1t, strides[1]);
+    host_->divu(x0t, tmp_reg, x1t);
+}
+
+// --- per_mb_spatial / per_mb_w: rhs broadcasts the channel (rhs [N,1,D,H,W] or
+// [N,1,1,1,W], dense/plain). Under VLA a run spans the broadcast dim, so both
+// are realized by the per-lane gather: each lane's plain rhs element index is
+// computed from its flat dst offset with vector div/mod. This is the same index
+// the scalar calculate_mb_* methods compute per vmm, generalized to per-lane
+// and to all four dst layouts. per_mb_spatial: rhs_idx = n*sp_size + spatial
+// (sp_size = product of spatial dims); per_mb_w: rhs_idx = n*W + w. Uses
+// gather_idx_vmm + narrow_stage_vmm as the two vector temporaries (the
+// narrow-load staging is temporally free during index build) and x_tmp0 as the
+// scalar constant register. ---
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_mb_sp_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_riscv::Reg &addr_reg, const Xbyak_riscv::Reg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+    if (!(is_out_addr || is_out_reg)) return;
+
+    rhs_address_t out_addr = is_out_addr ? it_out_addr->second
+                                         : rhs_address_t(it_out_reg->second);
+    const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+    calculate_no_broadcast(out_addr,
+            it_off_val != vmm_idx_to_out_elem_off_val.end() ? it_off_val->second
+                                                            : 0,
+            tmp_reg); // tmp_reg = flat element offset o
+
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto strides = dst_d.blocking_desc().strides;
+    const auto layout = injector_utils::get_layout_type(dst_d);
+
+    const auto &v_idx = rhs_arg_static_params_.gather_idx_vmm;
+    const auto &v_n = rhs_arg_static_params_.narrow_stage_vmm;
+    const auto &t = X_TMP_0;
+    host_->vid_v(v_idx);
+    host_->vadd_vx(v_idx, v_idx, tmp_reg); // o + lane
+    // Gated to plain ncsp/nspc by is_bcast_supported (a blocked/cspn dst
+    // resolves the `any` rhs to a matching non-plain layout the plain index
+    // below does not model).
+    if (layout == injector_utils::layout_t::ncsp) {
+        // rhs_idx = n*sp_size + spatial, sp_size == strides[1] (channel stride).
+        host_->load_imm64(t, strides[0]);
+        host_->vdivu_vx(v_n, v_idx, t); // n
+        host_->vremu_vx(v_idx, v_idx, t); // within = o % strides[0]
+        host_->load_imm64(t, strides[1]);
+        host_->vremu_vx(v_idx, v_idx, t); // spatial = within % strides[1]
+        host_->vmul_vx(v_n, v_n, t); // n * sp_size
+        host_->vadd_vv(v_idx, v_idx, v_n);
+    } else { // nspc: channel innermost -> rhs_idx = o / C_padded
+        host_->load_imm64(t, dst_d.padded_dims()[1]);
+        host_->vdivu_vx(v_idx, v_idx, t);
+    }
+    if (elem_size_bytes > 1)
+        host_->vsll_vi(v_idx, v_idx, (int)std::log2(elem_size_bytes));
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_mb_w_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_riscv::Reg &addr_reg, const Xbyak_riscv::Reg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+    if (!(is_out_addr || is_out_reg)) return;
+
+    rhs_address_t out_addr = is_out_addr ? it_out_addr->second
+                                         : rhs_address_t(it_out_reg->second);
+    const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+    calculate_no_broadcast(out_addr,
+            it_off_val != vmm_idx_to_out_elem_off_val.end() ? it_off_val->second
+                                                            : 0,
+            tmp_reg); // tmp_reg = flat element offset o
+
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto strides = dst_d.blocking_desc().strides;
+    const auto ndims = dst_d.ndims();
+    const dim_t W = dst_d.dims()[ndims - 1];
+    const auto layout = injector_utils::get_layout_type(dst_d);
+
+    const auto &v_idx = rhs_arg_static_params_.gather_idx_vmm;
+    const auto &v_n = rhs_arg_static_params_.narrow_stage_vmm;
+    const auto &t = X_TMP_0;
+    host_->vid_v(v_idx);
+    host_->vadd_vx(v_idx, v_idx, tmp_reg); // o + lane
+    // rhs [N,1,1,1,W]: rhs_idx = n * W + w. Gated to plain ncsp/nspc.
+    host_->load_imm64(t, strides[0]);
+    host_->vdivu_vx(v_n, v_idx, t); // n = o / strides[0]
+    if (layout == injector_utils::layout_t::ncsp) {
+        // w = o % strides[ndims-2] (the last dim's parent stride == W; the
+        // innermost dim has stride 1).
+        host_->load_imm64(t, strides[ndims - 2]);
+        host_->vremu_vx(v_idx, v_idx, t); // w
+    } else { // nspc: channel innermost -> w = (o / C_padded) % W
+        host_->load_imm64(t, dst_d.padded_dims()[1]);
+        host_->vdivu_vx(v_idx, v_idx, t); // spatial-flat
+        host_->load_imm64(t, W);
+        host_->vremu_vx(v_idx, v_idx, t); // w
+    }
+    host_->load_imm64(t, W);
+    host_->vmul_vx(v_n, v_n, t); // n * W
+    host_->vadd_vv(v_idx, v_idx, v_n);
+    if (elem_size_bytes > 1)
+        host_->vsll_vi(v_idx, v_idx, (int)std::log2(elem_size_bytes));
+}
+
+// --- per_w (advertised; realized via the RVV gather) ---
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::append_w_offset(
+        const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+        const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+        const std::map<int, size_t> &vmm_idx_to_out_elem_off_val, int vmm_idx,
+        const Xbyak_riscv::Reg &addr_reg, const Xbyak_riscv::Reg &tmp_reg,
+        std::size_t elem_size_bytes) const {
+
+    const auto it_out_addr = vmm_idx_to_out_addr.find(vmm_idx);
+    const auto it_out_reg = vmm_idx_to_out_reg.find(vmm_idx);
+    const bool is_out_addr = it_out_addr != vmm_idx_to_out_addr.end();
+    const bool is_out_reg = it_out_reg != vmm_idx_to_out_reg.end();
+    if (!(is_out_addr || is_out_reg)) return;
+
+    rhs_address_t out_addr = is_out_addr ? it_out_addr->second
+                                         : rhs_address_t(it_out_reg->second);
+    const auto it_off_val = vmm_idx_to_out_elem_off_val.find(vmm_idx);
+    calculate_no_broadcast(out_addr,
+            it_off_val != vmm_idx_to_out_elem_off_val.end() ? it_off_val->second
+                                                            : 0,
+            tmp_reg); // tmp_reg = flat element offset o
+
+    // Per-lane gather over the W dim: idx[lane] = ((o + lane) / w_stride) % W.
+    const auto dst_d = rhs_arg_static_params_.dst_d;
+    const auto strides = dst_d.blocking_desc().strides;
+    const int wd = dst_d.ndims() - 1;
+    const dim_t W = dst_d.dims()[wd];
+    const dim_t w_stride = strides[wd];
+
+    const auto &v_idx = rhs_arg_static_params_.gather_idx_vmm;
+    const auto &t = X_TMP_0;
+    host_->vid_v(v_idx);
+    host_->vadd_vx(v_idx, v_idx, tmp_reg); // o + lane
+    if (w_stride != 1) {
+        host_->load_imm64(t, w_stride);
+        host_->vdivu_vx(v_idx, v_idx, t);
+    }
+    host_->load_imm64(t, W);
+    host_->vremu_vx(v_idx, v_idx, t);
+    if (elem_size_bytes > 1)
+        host_->vsll_vi(v_idx, v_idx, (int)std::log2(elem_size_bytes));
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::inject_binary(
+        const dnnl_post_ops::entry_t &post_op, Vmm dst,
+        const rhs_address_t &rhs_addr, size_t group_stride) const {
+
+    const auto &alg = post_op.binary.alg;
+    const auto &rhs_arg_data_type = post_op.binary.src1_desc.data_type;
+
+    // The rv64 counterpart of x64's process_rhs_arg_using_tmp_vmm decision: a
+    // broadcast scalar stays in the FP helper and the .vf instruction forms
+    // consume it directly (f16 excepted -- its conversion needs the vector
+    // unit); everything else (per_element/gather) loads into the vmm helper.
+    if (rhs_addr.isBroadcast()
+            && !utils::one_of(
+                    rhs_arg_data_type, data_type::f16, data_type::bf16)) {
+        const auto &tmp_freg = rhs_arg_static_params_.rhs_dt_helper_freg;
+        execute_broadcast(rhs_arg_data_type, tmp_freg, rhs_addr);
+        execute_binary(alg, dst, dst, tmp_freg);
     } else {
-        h_->slli(op.off, out_off, sh);
-        h_->add(op.off, load_base(), op.off);
-        addr = op.off;
+        const Vmm tmp_vmm = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+        load_rhs(rhs_arg_data_type, tmp_vmm, rhs_addr, group_stride);
+        if (rhs_arg_data_type != data_type::f32
+                && !utils::one_of(
+                        rhs_arg_data_type, data_type::f16, data_type::bf16))
+            cvt_to_f32(tmp_vmm);
+        execute_binary(alg, dst, dst, tmp_vmm);
     }
-    load_rhs_vec(addr, /*is_gather=*/false);
-    return false;
 }
 
 template <cpu_isa_t isa>
-void jit_uni_binary_injector_t<isa>::materialize_cmp(const Vmm &dst) {
-    // v0 contains the comparison result. Materialize the public binary
-    // contract (0.0f/1.0f), reusing the injector's scalar/GPR scratch only
-    // after the rhs comparison has consumed them.
-    h_->fmv_w_x(rhs_.f_rhs, x0);
-    h_->vfmv_v_f(dst, rhs_.f_rhs);
-    h_->li(rhs_.gpr, 0x3f800000);
-    h_->fmv_w_x(rhs_.f_rhs, rhs_.gpr);
-    h_->vfmerge_vfm(dst, dst, rhs_.f_rhs);
+void jit_uni_binary_injector_t<isa>::inject_binary_with_ternary_op(
+        const dnnl_post_ops::entry_t &post_op, Vmm dst,
+        const rhs_address_t &rhs_addr, size_t group_stride) const {
+    const auto alg = post_op.binary.alg;
+    const auto rhs_arg_data_type
+            = get_src1_desc(post_op, rhs_arg_static_params_.dst_d).data_type;
+
+    if (alg == alg_kind::binary_select) {
+        // dst = cond ? dst : src1 with v0 = (cond == 0) prepared by the
+        // caller. RVV selects with a single mask merge, so unlike x64's
+        // AND/blend spill sequence no extra register state is needed: a
+        // scalar src1 merges via vfmerge.vfm straight from the FP helper, a
+        // vector src1 via vmerge.vvm from the loaded helper vmm.
+        if (rhs_addr.isBroadcast()
+                && !utils::one_of(
+                        rhs_arg_data_type, data_type::f16, data_type::bf16)) {
+            const auto &tmp_freg = rhs_arg_static_params_.rhs_dt_helper_freg;
+            execute_broadcast(rhs_arg_data_type, tmp_freg, rhs_addr);
+            host_->vfmerge_vfm(dst, dst, tmp_freg);
+        } else {
+            const Vmm tmp_vmm
+                    = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+            load_rhs(rhs_arg_data_type, tmp_vmm, rhs_addr, group_stride);
+            if (rhs_arg_data_type != data_type::f32
+                    && !utils::one_of(
+                            rhs_arg_data_type, data_type::f16, data_type::bf16))
+                cvt_to_f32(tmp_vmm);
+            host_->vmerge_vvm(dst, dst, tmp_vmm);
+        }
+    } else {
+        assert(!"unsupported algorithm");
+    }
 }
 
 template <cpu_isa_t isa>
-void jit_uni_binary_injector_t<isa>::apply_select(
-        const Vmm &dst, const Reg &out_off) {
-    assert(select_ != nullptr);
-
-    // Preserve src1 in its vector scratch while loading the independent select
-    // condition. The two operands may use different dtypes and broadcasts.
-    const bool rhs_scalar = load_operand(out_off, rhs_);
-    if (rhs_scalar) h_->vfmv_v_f(rhs_.v_rhs, rhs_.f_rhs);
-
-    operand_t &cond = *select_;
-    const bool cond_scalar = load_operand(out_off, cond);
-    if (cond_scalar) h_->vfmv_v_f(cond.v_rhs, cond.f_rhs);
-
-    // oneDNN select is condition ? accumulator : src1. Numeric zero (including
-    // -0) is false; every nonzero value, including NaN, is true.
-    h_->fmv_w_x(cond.f_rhs, x0);
-    h_->vmfne_vf(VReg(0), cond.v_rhs, cond.f_rhs);
-    h_->vmerge_vvm(dst, rhs_.v_rhs, dst);
-}
-
-template <cpu_isa_t isa>
-void jit_uni_binary_injector_t<isa>::apply_op(const Vmm &dst, bool scalar) {
+void jit_uni_binary_injector_t<isa>::compute_cmp_mask(
+        const Vmm &lhs, const Vmm &rhs, const alg_kind_t cmp_alg) const {
     using namespace alg_kind;
-    // dst = dst OP rhs (src0 is the accumulator, src1 the rhs).
-    switch (alg_) {
-        case binary_add:
-            if (scalar)
-                h_->vfadd_vf(dst, dst, rhs_.f_rhs);
-            else
-                h_->vfadd_vv(dst, dst, rhs_.v_rhs);
-            break;
-        case binary_sub:
-            if (scalar)
-                h_->vfsub_vf(dst, dst, rhs_.f_rhs);
-            else
-                h_->vfsub_vv(dst, dst, rhs_.v_rhs);
-            break;
-        case binary_mul:
-            if (scalar)
-                h_->vfmul_vf(dst, dst, rhs_.f_rhs);
-            else
-                h_->vfmul_vv(dst, dst, rhs_.v_rhs);
-            break;
-        case binary_div:
-            if (scalar)
-                h_->vfdiv_vf(dst, dst, rhs_.f_rhs);
-            else
-                h_->vfdiv_vv(dst, dst, rhs_.v_rhs);
-            break;
-        case binary_max:
-            // nstl::max(dst,rhs) = (rhs < dst) ? dst : rhs (picks rhs on
-            // ties/unordered, matching the reference and x86 vmaxps).
-            if (scalar) h_->vfmv_v_f(rhs_.v_rhs, rhs_.f_rhs);
-            h_->vmflt_vv(VReg(0), rhs_.v_rhs, dst);
-            h_->vmerge_vvm(dst, rhs_.v_rhs, dst);
-            break;
-        case binary_min:
-            // nstl::min(dst,rhs) = (dst < rhs) ? dst : rhs.
-            if (scalar) h_->vfmv_v_f(rhs_.v_rhs, rhs_.f_rhs);
-            h_->vmflt_vv(VReg(0), dst, rhs_.v_rhs);
-            h_->vmerge_vvm(dst, rhs_.v_rhs, dst);
-            break;
-        case binary_ge:
-            if (scalar)
-                h_->vmfge_vf(VReg(0), dst, rhs_.f_rhs);
-            else
-                h_->vmfge_vv(VReg(0), dst, rhs_.v_rhs);
-            materialize_cmp(dst);
-            break;
-        case binary_gt:
-            if (scalar)
-                h_->vmfgt_vf(VReg(0), dst, rhs_.f_rhs);
-            else
-                h_->vmfgt_vv(VReg(0), dst, rhs_.v_rhs);
-            materialize_cmp(dst);
-            break;
-        case binary_le:
-            if (scalar)
-                h_->vmfle_vf(VReg(0), dst, rhs_.f_rhs);
-            else
-                h_->vmfle_vv(VReg(0), dst, rhs_.v_rhs);
-            materialize_cmp(dst);
-            break;
-        case binary_lt:
-            if (scalar)
-                h_->vmflt_vf(VReg(0), dst, rhs_.f_rhs);
-            else
-                h_->vmflt_vv(VReg(0), dst, rhs_.v_rhs);
-            materialize_cmp(dst);
-            break;
-        case binary_eq:
-            if (scalar)
-                h_->vmfeq_vf(VReg(0), dst, rhs_.f_rhs);
-            else
-                h_->vmfeq_vv(VReg(0), dst, rhs_.v_rhs);
-            materialize_cmp(dst);
-            break;
-        case binary_ne:
-            if (scalar)
-                h_->vmfne_vf(VReg(0), dst, rhs_.f_rhs);
-            else
-                h_->vmfne_vv(VReg(0), dst, rhs_.v_rhs);
-            materialize_cmp(dst);
-            break;
-        default: assert(!"unsupported binary alg"); break;
+    switch (cmp_alg) {
+        case binary_ge: host_->vmfge_vv(VReg(0), lhs, rhs); break;
+        case binary_gt: host_->vmfgt_vv(VReg(0), lhs, rhs); break;
+        case binary_le: host_->vmfle_vv(VReg(0), lhs, rhs); break;
+        case binary_lt: host_->vmflt_vv(VReg(0), lhs, rhs); break;
+        case binary_eq: host_->vmfeq_vv(VReg(0), lhs, rhs); break;
+        case binary_ne: host_->vmfne_vv(VReg(0), lhs, rhs); break;
+        default: assert(!"unsupported comparison algorithm");
     }
 }
 
-template struct jit_uni_binary_injector_t<v>;
-template struct jit_uni_binary_injector_t<zvfh>;
-template struct jit_uni_binary_injector_t<zvfbfwma>;
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::execute_cmp_binary(const Vmm &dst,
+        const Vmm &lhs, const Vmm &rhs, const alg_kind_t cmp_alg) const {
+    compute_cmp_mask(lhs, rhs, cmp_alg);
+    // Materialize the oneDNN-required f32 0/1 result under the v0 mask (x64
+    // blends 1.0f from a preloaded register instead). The 1.0f constant goes
+    // through the x_tmp0 scratch: rhs_addr_reg must stay intact so a shared
+    // rhs address remains valid across the vmm loop.
+    const auto &tmp_freg = rhs_arg_static_params_.rhs_dt_helper_freg;
+    const auto &tmp_reg = X_TMP_0;
+    host_->fmv_w_x(tmp_freg, x0);
+    host_->vfmv_v_f(dst, tmp_freg);
+    host_->li(tmp_reg, 0x3f800000);
+    host_->fmv_w_x(tmp_freg, tmp_reg);
+    host_->vfmerge_vfm(dst, dst, tmp_freg);
+}
 
+// .vf (scalar FP rhs) / .vv (vector rhs) dispatch. x64 funnels both through one
+// `uni_v*ps(dst, lhs, rhs)` because every x86 instruction takes a unified
+// Operand; on rv64 the two forms are distinct mnemonics and FReg/VReg share no
+// base class, so overload resolution does the dispatch. (The project builds as
+// C++11, so `if constexpr` is not available and a reinterpret_cast between the
+// two register types would be a strict-aliasing violation.)
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::emit_arith(alg_kind_t alg, const Vmm &dst,
+        const Vmm &lhs, const Xbyak_riscv::FReg &rhs) const {
+    switch (alg) {
+        case alg_kind::binary_add: host_->vfadd_vf(dst, lhs, rhs); break;
+        case alg_kind::binary_sub: host_->vfsub_vf(dst, lhs, rhs); break;
+        case alg_kind::binary_mul: host_->vfmul_vf(dst, lhs, rhs); break;
+        case alg_kind::binary_div: host_->vfdiv_vf(dst, lhs, rhs); break;
+        default: assert(!"unsupported algorithm");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::emit_arith(
+        alg_kind_t alg, const Vmm &dst, const Vmm &lhs, const Vmm &rhs) const {
+    switch (alg) {
+        case alg_kind::binary_add: host_->vfadd_vv(dst, lhs, rhs); break;
+        case alg_kind::binary_sub: host_->vfsub_vv(dst, lhs, rhs); break;
+        case alg_kind::binary_mul: host_->vfmul_vv(dst, lhs, rhs); break;
+        case alg_kind::binary_div: host_->vfdiv_vv(dst, lhs, rhs); break;
+        default: assert(!"unsupported algorithm");
+    }
+}
+
+template <cpu_isa_t isa>
+typename jit_uni_binary_injector_t<isa>::Vmm
+jit_uni_binary_injector_t<isa>::materialize_rhs(
+        const Xbyak_riscv::FReg &rhs) const {
+    const Vmm helper_vmm = Vmm(rhs_arg_static_params_.rhs_dt_helper_vmm_idx);
+    host_->vfmv_v_f(helper_vmm, rhs);
+    return helper_vmm;
+}
+
+template <cpu_isa_t isa>
+typename jit_uni_binary_injector_t<isa>::Vmm
+jit_uni_binary_injector_t<isa>::materialize_rhs(const Vmm &rhs) const {
+    return rhs;
+}
+
+template <cpu_isa_t isa>
+template <typename T>
+void jit_uni_binary_injector_t<isa>::execute_binary(alg_kind_t binary_alg,
+        const Vmm &dst, const Vmm &lhs, const T &rhs) const {
+    switch (binary_alg) {
+        case alg_kind::binary_add:
+        case alg_kind::binary_sub:
+        case alg_kind::binary_mul:
+        case alg_kind::binary_div:
+            // The plain arithmetic ops keep the .vf form for a scalar rhs.
+            emit_arith(binary_alg, dst, lhs, rhs);
+            break;
+        case alg_kind::binary_max: {
+            // nstl::max(lhs,rhs) = (rhs < lhs) ? lhs : rhs (picks rhs on
+            // ties/unordered, matching the reference and x86 vmaxps).
+            const Vmm r = materialize_rhs(rhs);
+            host_->vmflt_vv(VReg(0), r, lhs);
+            host_->vmerge_vvm(dst, r, lhs);
+            break;
+        }
+        case alg_kind::binary_min: {
+            // nstl::min(lhs,rhs) = (lhs < rhs) ? lhs : rhs.
+            const Vmm r = materialize_rhs(rhs);
+            host_->vmflt_vv(VReg(0), lhs, r);
+            host_->vmerge_vvm(dst, r, lhs);
+            break;
+        }
+        // The compare sequences need a vector operand as well.
+        case alg_kind::binary_ge:
+        case alg_kind::binary_gt:
+        case alg_kind::binary_le:
+        case alg_kind::binary_lt:
+        case alg_kind::binary_eq:
+        case alg_kind::binary_ne:
+            execute_cmp_binary(dst, lhs, materialize_rhs(rhs), binary_alg);
+            break;
+        default: assert(!"unsupported algorithm");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::execute_broadcast(
+        const data_type_t &data_type, const Xbyak_riscv::FReg &tmp_freg,
+        const rhs_address_t &rhs_addr) const {
+    assert(is_data_supported(isa, data_type) && "unsupported data type");
+    const auto &base = rhs_addr.getBase();
+    const int offt = (int)rhs_addr.offt_;
+    // The integer value stages through x_tmp0 (aarch64 uses its reserved
+    // W_TMP_0): the base register must stay intact so a shared scalar address
+    // remains valid across the vmm loop (the scalar strategy never recomputes
+    // it).
+    const auto &tmp_reg = X_TMP_0;
+    switch (data_type) {
+        case data_type::f32: host_->flw(tmp_freg, base, offt); break;
+        case data_type::s32:
+            host_->lw(tmp_reg, base, offt);
+            host_->fcvt_s_w(tmp_freg, tmp_reg);
+            break;
+        case data_type::s8:
+            host_->lb(tmp_reg, base, offt);
+            host_->fcvt_s_w(tmp_freg, tmp_reg);
+            break;
+        case data_type::u8:
+            host_->lbu(tmp_reg, base, offt);
+            host_->fcvt_s_wu(tmp_freg, tmp_reg);
+            break;
+        default: assert(!"unsupported data type");
+    }
+}
+
+// The accumulator computes at e32/acc_lmul, where acc_lmul is encoded by
+// group_stride (the accumulator's register count: 1->m1, 2->m2, 4->m4). A
+// narrower rhs must be loaded at the LMUL that shares the accumulator's VLMAX so
+// that `vsetvli x0,x0` preserves vl and the widen lands in e32/acc_lmul: e16
+// (f16) at acc_lmul/2 and e8 (s8/u8) at acc_lmul/4, taking a fractional LMUL
+// when the accumulator is below m4. m8 is unsupported (see make_vmm_group_set).
+static Xbyak_riscv::LMUL acc_e32_lmul(size_t group_stride) {
+    switch (group_stride) {
+        case 1: return Xbyak_riscv::LMUL::m1;
+        case 2: return Xbyak_riscv::LMUL::m2;
+        default: return Xbyak_riscv::LMUL::m4;
+    }
+}
+static Xbyak_riscv::LMUL rhs_e16_lmul(size_t group_stride) {
+    switch (group_stride) {
+        case 1: return Xbyak_riscv::LMUL::mf2;
+        case 2: return Xbyak_riscv::LMUL::m1;
+        default: return Xbyak_riscv::LMUL::m2;
+    }
+}
+static Xbyak_riscv::LMUL rhs_e8_lmul(size_t group_stride) {
+    switch (group_stride) {
+        case 1: return Xbyak_riscv::LMUL::mf4;
+        case 2: return Xbyak_riscv::LMUL::mf2;
+        default: return Xbyak_riscv::LMUL::m1;
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::load_rhs(const data_type_t &data_type,
+        const Vmm &tmp_vmm, const rhs_address_t &rhs_addr,
+        size_t group_stride) const {
+    assert(is_data_supported(isa, data_type) && "unsupported data type");
+    const auto &base = rhs_addr.getBase();
+    const auto &v_idx = rhs_arg_static_params_.gather_idx_vmm;
+    const auto &v_stage = rhs_arg_static_params_.narrow_stage_vmm;
+
+    // The accumulator computes at e32/acc_lmul. Narrow dtypes briefly switch SEW
+    // to the LMUL that shares that VLMAX (see the helpers above), so `vsetvli
+    // x0,x0` keeps vl; they load into the staging group and widen into tmp_vmm
+    // at e32/acc_lmul. f32/s32 load at the accumulator's active e32/acc_lmul.
+    switch (data_type) {
+        case data_type::f32:
+        case data_type::s32:
+            if (rhs_addr.isGather())
+                host_->vluxei32_v(tmp_vmm, base, v_idx);
+            else if (rhs_addr.isStrided())
+                host_->vlse32_v(tmp_vmm, base, rhs_addr.getStride());
+            else
+                host_->vle32_v(tmp_vmm, base);
+            break;
+        case data_type::s8:
+        case data_type::u8:
+            host_->vsetvli(x0, x0, SEW::e8, rhs_e8_lmul(group_stride), VTA::ta,
+                    VMA::ma);
+            if (rhs_addr.isGather())
+                host_->vluxei32_v(v_stage, base, v_idx);
+            else if (rhs_addr.isStrided())
+                host_->vlse8_v(v_stage, base, rhs_addr.getStride());
+            else
+                host_->vle8_v(v_stage, base);
+            host_->vsetvli(x0, x0, SEW::e32, acc_e32_lmul(group_stride),
+                    VTA::ta, VMA::ma);
+            if (data_type == data_type::s8)
+                host_->vsext_vf4(tmp_vmm, v_stage);
+            else
+                host_->vzext_vf4(tmp_vmm, v_stage);
+            break;
+        case data_type::f16:
+        case data_type::bf16:
+            host_->vsetvli(x0, x0, SEW::e16, rhs_e16_lmul(group_stride),
+                    VTA::ta, VMA::ma);
+            if (rhs_addr.isBroadcast())
+                host_->vlse16_v(v_stage, base, x0); // stride-0 broadcast
+            else if (rhs_addr.isGather())
+                host_->vluxei32_v(v_stage, base, v_idx);
+            else if (rhs_addr.isStrided())
+                host_->vlse16_v(v_stage, base, rhs_addr.getStride());
+            else
+                host_->vle16_v(v_stage, base);
+            if (data_type == data_type::bf16)
+                host_->vfwcvtbf16_f_f_v(tmp_vmm, v_stage);
+            else
+                host_->vfwcvt_f_f_v(
+                        tmp_vmm, v_stage); // e16/(acc_lmul/2) -> e32/acc
+            host_->vsetvli(x0, x0, SEW::e32, acc_e32_lmul(group_stride),
+                    VTA::ta, VMA::ma);
+            break;
+        default: assert(!"unsupported data type");
+    }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_binary_injector_t<isa>::cvt_to_f32(const Vmm &tmp_vmm) const {
+    // Signed convert is exact for u8 too (vzext leaves 0..255, below 2^31; the
+    // same reasoning as x64's shared uni_vcvtdq2ps).
+    host_->vfcvt_f_x_v(tmp_vmm, tmp_vmm);
+}
+
+template class jit_uni_binary_injector_t<v>;
+template class jit_uni_binary_injector_t<zvfh>;
+template class jit_uni_binary_injector_t<zvfbfwma>;
+
+#undef VCHECK_BIN_INJ_BOOL
+
+} // namespace binary_injector
 } // namespace rv64
 } // namespace cpu
 } // namespace impl

--- a/src/cpu/rv64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/rv64/injectors/jit_uni_binary_injector.hpp
@@ -1,4 +1,5 @@
 /*******************************************************************************
+* Copyright 2020 Intel Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,214 +14,569 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
+
 #ifndef CPU_RV64_INJECTORS_JIT_UNI_BINARY_INJECTOR_HPP
 #define CPU_RV64_INJECTORS_JIT_UNI_BINARY_INJECTOR_HPP
 
+#include <functional>
 #include <map>
-#include <memory>
+#include <utility>
 
+#include "common/broadcast_strategy.hpp"
 #include "common/c_types_map.hpp"
 #include "common/primitive_attr.hpp"
-
+#include "cpu/binary_injector_utils.hpp"
+#include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/rv64/injectors/injector_utils.hpp"
 #include "cpu/rv64/jit_generator.hpp"
+
+// This injector is a faithful port of the x64/aarch64 binary post-op injector
+// (aarch64 is the primary reference: it ports x64 to a scalable-vector ISA, as
+// SVE and RVV are both VLA). The file mirrors aarch64's structure
+// function-by-function, variable-by-variable, and in declaration order. The
+// intentional (A-class) differences from aarch64/x64 are: RV64 register
+// conventions, RVV instruction selection, no bf16, the <v>/<zvfh> ISA template
+// selecting only a registration slot, and no tail machinery (a single VLA
+// vsetvli loop subsumes the tail, so the with_tail / tail-opmask / tail-load
+// family is dropped). The addressing math (calculate_*_{ncsp,blocked,nspc,cspn})
+// is arch-neutral scalar div/mod and is ported verbatim; the loads/compute and
+// the per_oc VLA gather are the RVV-native realizations.
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace rv64 {
-
 namespace binary_injector {
+using dnnl::impl::cpu::binary_injector_utils::get_src1_desc;
+using dnnl::impl::cpu::binary_injector_utils::get_src2_desc;
+using dnnl::impl::cpu::binary_injector_utils::prepare_binary_args;
 
-// How the right-hand-side (src1) operand is laid out relative to the
-// accumulator lanes the host is currently holding.
-//   scalar      - one value broadcast to every lane (per_tensor src1)
-//   per_element - a contiguous run of values matching the active lanes (a plain
-//                 dst-shaped src1).
-//   per_oc      - one value per output channel [1, C, 1, ...]. The dynamic path
-//                 maps the output element offset to a channel index using C and
-//                 oc_stride: channels-last/blocked (oc_stride==1) loads a channel
-//                 vector; channels-first (oc_stride>1) broadcasts one channel
-//                 value across the run.
-enum class broadcast_t { scalar, per_element, per_oc };
+bool binary_args_matches_tag(format_tag_t tag, const post_ops_t &post_ops);
 
-// Caller-provided scratch + config. The rhs is addressed through an indirect
-// per-binary pointer array (post_ops_binary_rhs_arg_vec): each binary injector
-// loads its own base from rhs_ptrs[arg_idx], then the dynamic-params path
-// computes the lane address from the per-register output offset (the caller
-// hands it in at call time). `off` and `gpr` are address scratch the injector
-// clobbers per binary; `strided`/`rhs_stride` request a vlse load for
-// channels-strided (ncsp) rhs.
-struct static_params_t {
-    // Contiguous rhs: per-element vle / scalar flw.
-    static_params_t(const Xbyak_riscv::VReg &v_rhs,
-            const Xbyak_riscv::FReg &f_rhs, const Xbyak_riscv::Reg &rhs_ptrs,
-            const Xbyak_riscv::Reg &off, const Xbyak_riscv::Reg &gpr)
-        : v_rhs(v_rhs)
-        , f_rhs(f_rhs)
-        , rhs_addr(rhs_ptrs)
-        , rhs_stride(rhs_ptrs) // unused when indirect (contiguous vle)
-        , strided(false)
-        , off(off)
-        , gpr(gpr)
-        , indirect(true) {}
-    // Indirect + strided: like the indirect ctor but per-element lanes are
-    // rhs_stride bytes apart (vlse from base + off). Used when the rhs lanes are
-    // not contiguous in memory (e.g. a full-dst binary over a channels-strided
-    // ncsp destination) while still carrying any number of binaries via the
-    // per-binary pointer array.
-    static_params_t(const Xbyak_riscv::VReg &v_rhs,
-            const Xbyak_riscv::FReg &f_rhs, const Xbyak_riscv::Reg &rhs_ptrs,
-            const Xbyak_riscv::Reg &off, const Xbyak_riscv::Reg &gpr,
-            const Xbyak_riscv::Reg &rhs_stride)
-        : v_rhs(v_rhs)
-        , f_rhs(f_rhs)
-        , rhs_addr(rhs_ptrs)
-        , rhs_stride(rhs_stride)
-        , strided(true)
-        , off(off)
-        , gpr(gpr)
-        , indirect(true) {}
+bool binary_args_broadcast_supported(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+bool any_binary_postop_rhs_non_scalar_broadcast(
+        const post_ops_t &post_ops, const memory_desc_wrapper &dst_d);
 
-    Xbyak_riscv::VReg v_rhs; // scratch to load a per-element rhs vector
-    // Second vector scratch for the per_oc gather (per-lane channel index).
-    // Only read on the dynamic per_oc path; consumers that enable per_oc must
-    // set it to a group distinct from v_rhs and the live accumulator/aux.
-    // v0 is the reserved mask register and serves as an unset sentinel here.
-    Xbyak_riscv::VReg v_idx = Xbyak_riscv::VReg(0);
-    // Staging group for a narrow rhs (the narrow load lands here and is
-    // widened into v_rhs; a widening op cannot overlap its source's low part, so
-    // this must be distinct from v_rhs, v_idx and the live accumulator/aux).
-    // Only read for f16/s8/u8; f32/s32 consumers may leave it default.
-    // v0 is the reserved mask register and serves as an unset sentinel here.
-    Xbyak_riscv::VReg v_tmp = Xbyak_riscv::VReg(0);
-    Xbyak_riscv::FReg f_rhs; // scratch to load a scalar rhs value
-    Xbyak_riscv::Reg rhs_addr; // direct: rhs ptr; indirect: ptr-array base
-    Xbyak_riscv::Reg rhs_stride; // byte stride for the strided (vlse) load
-    bool strided; // false: contiguous vle; true: vlse with rhs_stride
-    // Address scratch for the dynamic output offset. off_is_bytes selects
-    // whether that offset is already in bytes or must be scaled by rhs_dt.
-    Xbyak_riscv::Reg off;
-    Xbyak_riscv::Reg gpr; // indirect: scratch clobbered per binary
-    bool indirect; // false: rhs_addr is the data ptr; true: ptr-array base
-    // rhs data type; the rhs is loaded and converted from this dtype to f32.
-    data_type_t rhs_dt = data_type::f32;
-    // If true, the dynamic out-offset is already a byte offset (added straight to
-    // the base) rather than an element offset the injector scales by the dtype
-    // size. Indirect consumers that maintain a byte offset (pooling) set this to
-    // avoid needing a second address-scratch register. Incompatible with per_oc.
+bool any_binary_postop_rhs_per_oc_broadcast(
+        const post_ops_t &post_ops, const memory_desc_wrapper &dst_d);
+bool any_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+
+/*
+ * Represents params related to all binary post-ops right-hand side arguments
+ * (arg1) that don't change during jit_uni_binary_injector_t object lifetime
+ * and between compute_vector_range calls.
+ *
+ * @param rhs_dt_helper_vmm_idx - index of vmm helper used when loading data for
+ * calculations. Names a host-reserved e32/acc_lmul group (same LMUL as the
+ * processed accumulators): group_stride-aligned, not v0 (the live mask
+ * register), whole group inside the register file, and disjoint from the
+ * processed vmms. Unlike x64, an invalid hint is not adjusted but rejected at
+ * injection time (JIT_ASSERT; in Release the throw fails kernel creation).
+ * @param rhs_addr_reg - gpr register, used as the currently processed address of
+ * rhs tensor slice. Data of rhs(arg1) for the binary operation is loaded from address
+ * stored inside rhs_addr_reg.
+ * @param rhs_helper_reg - gpr register used as helper for calculations during data
+ * loading phase.
+ * @param rhs_addr_cache_reg - gpr register used for caching part of calculated
+ * offset, this register is always preserved.
+ * @param preserve_gpr_helpers - determines whether gpr registers specified above
+ * should be preserved (pushed to stack and poped back afterwords) between
+ * compute_vector_range calls.
+ * @param preserve_vmm_helper - determines whether vmm helper register specified
+ * above should be preserved between compute_vector_range calls.
+ * @param abi_param_offset - offset to rhs tensor from first binary post-op operation
+ * specified by user from runtime structure passed to kernel as abi param 1.
+ * @param dst_orig_offset - offset 0 to destination tensor
+ * @param dst_d - descriptor of destination tensor (result after applying all post-ops
+ * operations).
+ *
+ * Scalar scratch: like x64 (which clobbers rax/rdx/r8/r9 and shields them
+ * with the register-preserve guard when preserve_gpr_helpers is set), the
+ * injector clobbers the fixed GPRs t4/t5/t6/a6/a7 (the aarch64 X_TMP_0..4
+ * analogs; see the cpp). Hosts either keep them dead across the injection or
+ * pass preserve_gpr_helpers = true; they must not be chosen as
+ * rhs_addr_reg/rhs_helper_reg/rhs_addr_cache_reg.
+ *
+ * Note on x64 parity here: x64 also preserves rax/rdx even when
+ * preserve_gpr_helpers is false, because x86 `div`/`mul` clobber them
+ * implicitly and are never declared to the host. On rv64 the clobber set is
+ * declared (the X_TMP_* above) and `divu`/`remu` take explicit operands, so
+ * preserve_gpr_helpers == false genuinely means "the host guarantees these are
+ * dead" and nothing is spilled. Do not add unconditional preservation: it would
+ * contradict the flag and cost a stack frame per injection.
+ *
+ * rhs_addr_reg must never be x0: the injector unconditionally loads the rhs
+ * base into it. rhs_helper_reg must not be x0 for any non-scalar strategy (it
+ * receives the computed offset). rhs_addr_cache_reg is never written by the
+ * rv64 injector at all (it only appears in the preserve list), so x0 is
+ * harmless there. Both requirements are checked in compute_vector_range() once
+ * the actual broadcasting strategy is known -- not at construction, where the
+ * supported-strategy set may legitimately be wider than what is used.
+ *
+ * rv64-only members (A-class; no aarch64 analog):
+ * @param rhs_dt_helper_freg - FP scalar register that receives a scalar
+ * (broadcast) rhs value; RVV .vf instruction forms consume it directly, so a
+ * full-vector broadcast into rhs_dt_helper_vmm is unnecessary.
+ * @param gather_idx_vmm - vector group receiving the per-lane byte index for the
+ * per_oc VLA gather (vluxei32). A VLA run may span channel boundaries, so per_oc
+ * cannot be a contiguous load as on aarch64; each lane resolves its own channel.
+ * @param narrow_stage_vmm - staging group for a narrow (s8/u8/f16) rhs load,
+ * widened into rhs_dt_helper_vmm (a widening op may not overlap its source low
+ * part).
+ *
+ * The select (ternary) post-op needs no dedicated condition scratch: the
+ * condition is loaded through the shared rhs helper and immediately consumed
+ * into the v0 mask (rv64 cannot stack-spill a vector like x64's push_vmm, and
+ * the mask register is the only state that survives the src1 load reusing the
+ * same helper).
+ *
+ * aarch64 members with no rv64 analog (VLA / no stack frame): the tail machinery
+ * (tail_size, tail_opmask, reg_tail_size, use_exact_tail_scalar_bcast) is
+ * subsumed by vsetvli's runtime vl. preserve_gpr_helpers works as on x64 (the
+ * guard spills the helper GPRs and the fixed scratch around the injection).
+ * preserve_vmm_helper spills the rhs dt helper as a whole e32/acc_lmul group
+ * with a runtime vlenb-sized frame (x64 pushes Vmm(vmm_hint) the same way); the
+ * rv64-only gather_idx/narrow_stage scratch stays host-reserved, and x64's
+ * hint-conflict fallback of borrowing Vmm(0) is unsound here (v0 is the
+ * architectural mask the compare/select paths write), so hosts must supply
+ * non-conflicting hints (validated at injection time; an invalid hint fails
+ * kernel creation). rhs_addr_cache_reg caches no addresses on rv64 -- every
+ * call rebuilds the address from param1 -- so it is carried only to be spilled
+ * by the preserve guard.
+ */
+struct rhs_arg_static_params_t {
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_riscv::Reg &rhs_addr_reg,
+            const Xbyak_riscv::Reg &rhs_helper_reg,
+            const Xbyak_riscv::Reg &rhs_addr_cache_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, const memory_desc_wrapper &dst_d);
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_riscv::Reg &rhs_addr_reg,
+            const Xbyak_riscv::Reg &rhs_helper_reg,
+            const Xbyak_riscv::Reg &rhs_addr_cache_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, std::size_t dst_orig_offset,
+            const memory_desc_wrapper &dst_d);
+
+    bool is_dst_orig_set() const noexcept { return is_dst_orig_set_; }
+
+    std::size_t rhs_dt_helper_vmm_idx;
+    Xbyak_riscv::Reg rhs_addr_reg;
+    Xbyak_riscv::Reg rhs_helper_reg;
+    Xbyak_riscv::Reg rhs_addr_cache_reg;
+    bool preserve_gpr_helpers;
+    bool preserve_vmm_helper;
+    std::size_t abi_param_offset;
+    std::size_t dst_orig_offset;
+    memory_desc_wrapper dst_d;
+
+    // rv64-only scratch (see the struct comment).
+    Xbyak_riscv::FReg rhs_dt_helper_freg = Xbyak_riscv::FReg(0);
+    Xbyak_riscv::VReg gather_idx_vmm = Xbyak_riscv::VReg(0);
+    Xbyak_riscv::VReg narrow_stage_vmm = Xbyak_riscv::VReg(0);
+    // rv64-only: the host maintains a byte offset (pooling) instead of a dst
+    // address; the injector then adds it straight to the rhs base.
     bool off_is_bytes = false;
-    // broadcast strategy for the rhs (mirrors the `broadcast_t bcast` ctor arg).
-    // per_oc covers the per-lane gather strategies (per_oc / per_oc_spatial /
-    // per_w): the gathered index is ((out_off / oc_stride) % C) * blk +
-    // (out_off % blk).
-    //   per_oc/per_w plain: blk=1, C=dim size, oc_stride=that dim's stride.
-    //   per_oc blocked (nChw8c): blk=block, C=C/block, oc_stride=outer stride.
-    broadcast_t bcast = broadcast_t::per_element;
-    dim_t C = 0; // outer count of the broadcast dim (per_oc: C/blk; per_w: W)
-    dim_t oc_stride = 0; // outer stride of the broadcast dim
-    dim_t blk = 1; // inner block of the broadcast dim (1 = non-blocked / per_w)
+    // rv64-only: a no_broadcast rhs whose lanes are rhs_stride bytes apart (a
+    // VLA host may vectorize across a non-innermost dst dim, e.g. pooling ncsp
+    // full-dst); the rhs is then loaded with vlse.
+    Xbyak_riscv::Reg rhs_stride = Xbyak_riscv::Reg(0);
+    bool is_strided = false;
+    // rv64-only: the host guarantees channel-aligned vectors for a per_oc/
+    // per_oc_spatial rhs -- every vector's lanes lie within one channel
+    // row/block (contiguous channels; a single channel for per_oc_spatial).
+    // The injector then recovers the channel offset with the x64/aarch64
+    // scalar calculate_oc_* math (from the dst address and dst_orig) and
+    // loads the rhs contiguously (per_oc) or broadcasts one value
+    // (per_oc_spatial) instead of the per-lane gather.
+    bool per_oc_lanes_are_channels = false;
+
+private:
+    rhs_arg_static_params_t(std::size_t rhs_dt_helper_vmm_idx,
+            const Xbyak_riscv::Reg &rhs_addr_reg,
+            const Xbyak_riscv::Reg &rhs_helper_reg,
+            const Xbyak_riscv::Reg &rhs_addr_cache_reg,
+            bool preserve_gpr_helpers, bool preserve_vmm_helper,
+            std::size_t abi_param_offset, std::size_t dst_orig_offset,
+            const memory_desc_wrapper &dst_d, bool is_dst_orig_set);
+
+    bool is_dst_orig_set_;
 };
 
-// Call-time parameters, mirroring x64/aarch64 rhs_arg_dynamic_params_t: each
-// accumulator vmm is mapped to a register holding that register's output
-// ELEMENT offset (index of its first active lane into the dst logical tensor).
-// The injector maps that offset to the rhs slice address per broadcast strategy
-// (no_broadcast/per_element, per_oc, scalar), so the address is computed inside
-// the injector at call time rather than pre-positioned by the caller.
+/*
+ * Represents params required by jit_uni_binary_injector_t that don't change
+ * during it's entire lifetime.
+ *
+ * @param param1 - register storing abi param1. At the moment of calling
+ * compute_vector_range method can be different than the default one defined
+ * inside jit_generator.
+ * @param bcast_set_t supported_strategy_set - set allowing disabling particular
+ * bcast strategies
+ * @param rhs_arg_static_params - params related to all binary post-ops right-hand side
+ * arguments that don't change during entire lifetime of jit_uni_binary_injector_t
+ * object.
+ */
+struct static_params_t {
+    static_params_t(const Xbyak_riscv::Reg &param1,
+            const bcast_set_t &supported_strategy_set,
+            const rhs_arg_static_params_t &rhs_arg_static_params);
+    static_params_t(const Xbyak_riscv::Reg &param1,
+            const rhs_arg_static_params_t &rhs_arg_static_params);
+
+    Xbyak_riscv::Reg param1;
+    const bcast_set_t supported_strategy_set;
+    rhs_arg_static_params_t rhs_arg_static_params;
+};
+
+/*
+ * Represents the address of the rhs tensor slice (the rv64 analog of x64's
+ * Xbyak::Address / aarch64's rhs_address_t). RVV has no memory operands, so the
+ * "address" is a base gpr plus an immediate offset plus the load mode the
+ * strategy selected:
+ *   isBroadcast_ - one element at base_+offt_ broadcast over all lanes;
+ *   isGather_    - per-lane byte-index gather (vluxei32) via gather_idx_vmm
+ *                  (rv64-only: the per_oc VLA realization);
+ *   otherwise    - contiguous unit-stride load (vle).
+ * aarch64's `bits_` (operand width) has no rv64 analog: the width comes from
+ * the active vtype, so it is not carried here.
+ */
+struct rhs_address_t {
+    Xbyak_riscv::Reg base_;
+    int64_t offt_ = 0;
+    bool isBroadcast_ = false;
+    bool isGather_ = false;
+    bool isStrided_ = false;
+    Xbyak_riscv::Reg stride_ = Xbyak_riscv::Reg(0);
+
+    rhs_address_t(const Xbyak_riscv::Reg &base, const int64_t offt = 0,
+            bool isBroadcast = false, bool isGather = false,
+            bool isStrided = false,
+            const Xbyak_riscv::Reg &stride = Xbyak_riscv::Reg(0))
+        : base_(base)
+        , offt_(offt)
+        , isBroadcast_(isBroadcast)
+        , isGather_(isGather)
+        , isStrided_(isStrided)
+        , stride_(stride) {}
+
+    bool operator==(const rhs_address_t &rhs) const {
+        return base_.getIdx() == rhs.base_.getIdx() && offt_ == rhs.offt_
+                && isBroadcast_ == rhs.isBroadcast_
+                && isGather_ == rhs.isGather_ && isStrided_ == rhs.isStrided_;
+    }
+    bool operator!=(const rhs_address_t &rhs) const { return !operator==(rhs); }
+
+    Xbyak_riscv::Reg getBase() const { return base_; }
+    Xbyak_riscv::Reg getStride() const { return stride_; }
+    bool isBroadcast() const { return isBroadcast_; }
+    bool isGather() const { return isGather_; }
+    bool isStrided() const { return isStrided_; }
+};
+
+/*
+ * An offset operand: either a register index or an address (base+offt). Mirrors
+ * aarch64's rhs_operand_t; used by the no_broadcast/oc/sp/w offset-from-operand
+ * dynamic-params path.
+ */
+struct rhs_operand_t {
+    bool isAddress_ = false;
+    uint32_t idx_ = 0;
+    rhs_address_t address_ {Xbyak_riscv::Reg(0)};
+
+    bool operator==(const rhs_operand_t &rhs) const {
+        if (isAddress_ != rhs.isAddress_) return false;
+        return isAddress_ ? address_ == rhs.address_ : idx_ == rhs.idx_;
+    }
+    bool operator!=(const rhs_operand_t &rhs) const { return !operator==(rhs); }
+
+    bool isBroadcast() const { return isAddress_ && address_.isBroadcast(); }
+};
+
+/*
+ * Represents params passed to compute_vector_range method of
+ * jit_uni_binary_injector_t that can be different for each call. Contains
+ * configurable std::maps where key is vmm index and value is the destination
+ * tensor slice location (address / register / element offset). This is utilized
+ * by the broadcasting mechanism. Mirrors aarch64's rhs_arg_dynamic_params_t.
+ */
 struct rhs_arg_dynamic_params_t {
-    std::map<int, Xbyak_riscv::Reg> vmm_idx_to_out_off;
+    std::map<int, rhs_address_t> vmm_idx_to_out_addr;
+    std::map<int, Xbyak_riscv::Reg> vmm_idx_to_out_reg;
+
+    std::map<int, rhs_address_t> vmm_idx_to_out_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_out_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_out_off_oprnd;
+
+    std::map<int, rhs_address_t> vmm_idx_to_oc_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_oc_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_oc_off_oprnd;
+
+    std::map<int, rhs_address_t> vmm_idx_to_sp_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_sp_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_sp_off_oprnd;
+
+    std::map<int, rhs_address_t> vmm_idx_to_mb_w_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_mb_w_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_mb_w_off_oprnd;
+
+    std::map<int, rhs_address_t> vmm_idx_to_w_elem_off_addr;
+    std::map<int, size_t> vmm_idx_to_w_elem_off_val;
+    std::map<int, rhs_operand_t> vmm_idx_to_w_off_oprnd;
 };
 
-// Which binary algorithms the in-kernel injector can emit. Comparisons produce
-// the oneDNN-required f32 0/1 result and use v0 as their temporary mask.
-bool is_alg_supported(alg_kind_t alg);
+/*
+ * Checks if src1 data type is supported by binary injector.
+ */
+bool is_data_supported(cpu_isa_t isa, data_type_t data_type);
 
-} // namespace binary_injector
+/*
+ * Checks if broadcast of src1 is supported by binary injector.
+ */
+bool is_bcast_supported(const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
 
-// In-kernel binary post-op injector for RVV: applies `dst = dst OP rhs` to an
-// accumulator register group in place, loading the rhs base from the pointer
-// array and deriving its address from the configured broadcast strategy.
+/*
+ * Checks if binary injection for given args is supported.
+ */
+bool is_supported(cpu_isa_t isa, const dnnl::impl::memory_desc_t &src1_desc,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+
+/*
+ * Main mechanism responsible for injecting binary postops supporting isa: rvv
+ * (v, zvfh -- the template parameter selects the registration slot only; RVV
+ * code is vector-length-agnostic) as well as data types: f32, s32, u8, s8, f16.
+ */
 template <cpu_isa_t isa>
-struct jit_uni_binary_injector_t {
+class jit_uni_binary_injector_t {
     using Vmm = typename jit_isa_traits_t<isa>::Vmm;
 
-private:
-    struct operand_t {
-        operand_t(binary_injector::broadcast_t bcast,
-                const binary_injector::static_params_t &sp, int arg_idx)
-            : bcast(bcast)
-            , v_rhs(sp.v_rhs)
-            , v_idx(sp.v_idx)
-            , v_tmp(sp.v_tmp)
-            , f_rhs(sp.f_rhs)
-            , rhs_addr(sp.rhs_addr)
-            , rhs_stride(sp.rhs_stride)
-            , strided(sp.strided)
-            , off(sp.off)
-            , gpr(sp.gpr)
-            , indirect(sp.indirect)
-            , arg_idx(arg_idx)
-            , rhs_dt(sp.rhs_dt)
-            , C(sp.C)
-            , oc_stride(sp.oc_stride)
-            , blk(sp.blk)
-            , off_is_bytes(sp.off_is_bytes) {}
-
-        binary_injector::broadcast_t bcast;
-        Xbyak_riscv::VReg v_rhs, v_idx, v_tmp;
-        Xbyak_riscv::FReg f_rhs;
-        Xbyak_riscv::Reg rhs_addr, rhs_stride;
-        bool strided;
-        Xbyak_riscv::Reg off, gpr;
-        bool indirect;
-        int arg_idx;
-        data_type_t rhs_dt;
-        dim_t C, oc_stride, blk;
-        bool off_is_bytes;
-    };
-
 public:
-    // arg_idx selects this operand's base from the rhs pointer array. Ordinary
-    // binary entries consume one slot; select consumes adjacent src1/src2 slots.
-    jit_uni_binary_injector_t(jit_generator_t *host, alg_kind_t alg,
-            binary_injector::broadcast_t bcast,
-            const binary_injector::static_params_t &sp, int arg_idx = 0,
-            binary_injector::broadcast_t select_bcast
-            = binary_injector::broadcast_t::scalar,
-            const binary_injector::static_params_t *select_sp = nullptr)
-        : alg_(alg), h_(host), rhs_(bcast, sp, arg_idx) {
-        if (select_sp)
-            select_.reset(new operand_t(select_bcast, *select_sp, arg_idx + 1));
-        assert(alg_ == alg_kind::binary_select
-                        ? select_ != nullptr
-                        : binary_injector::is_alg_supported(alg_));
-    }
+    jit_uni_binary_injector_t(
+            jit_generator_t *host, const static_params_t &static_params);
 
-    // The caller passes the output element (or byte) offset per register; the
-    // injector computes the rhs address from it and the broadcast strategy /
-    // rhs dtype held in static_params (x64/aarch64 dynamic-params parity).
-    void compute_vector(
-            size_t idx, const binary_injector::rhs_arg_dynamic_params_t &dyn);
+    /*
+     * Generates code of binary post_op injected to host primitive. Applied to
+     * ordered set of vector registers' indexes. group_stride is each
+     * accumulator's e32 LMUL (registers per accumulator, one of 1/2/4); it
+     * drives the SEW/LMUL of the narrow-dtype rhs load so the widen lands in
+     * e32/LMUL (see load_rhs) and validates the set geometry. Function loads the
+     * appropriate rhs slice per the internally determined broadcast strategy and
+     * rhs_arg_params.
+     */
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
+            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params,
+            size_t group_stride) const;
+
+    /*
+     * Generates code of binary post_op injected to host primitive. Applied to
+     * the accumulators occupying the half-open physical register span
+     * <start_idx, end_idx). group_stride is the number of vector registers per
+     * accumulator (its LMUL/EMUL, one of 1/2/4; m8 is unsupported -- the helper
+     * scratch is m4, see make_vmm_group_set); the run's group bases are
+     * enumerated by stepping it, so unlike x64 an m>1 run maps to its true
+     * bases, not consecutive indices. It is mandatory: an x64
+     * compute_vector_range(start, end) must be converted deliberately, never
+     * copied as a silent stride-1 enumeration (see make_vmm_group_set). Loads
+     * the appropriate rhs slice per the internally determined broadcast
+     * strategy and rhs_arg_params.
+     */
     void compute_vector_range(size_t start_idx, size_t end_idx,
-            const binary_injector::rhs_arg_dynamic_params_t &dyn);
+            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params,
+            size_t group_stride) const;
+
+    /*
+     * Generates code of binary post_op injected to host primitive. Applied to
+     * a single vector register index. Function loads appropriate slice of rhs tensor
+     * for computations based on internally determined broadcast strategy and information
+     * about stored data in particular vmm described inside rhs_arg_params.
+     */
+    void compute_vector(size_t idx, std::size_t rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params,
+            size_t group_stride) const;
 
 private:
-    void apply_op(const Vmm &dst, bool scalar); // the op switch
-    void apply_select(const Vmm &dst, const Xbyak_riscv::Reg &out_off);
-    void materialize_cmp(const Vmm &dst); // v0 mask -> f32 0/1 in dst
-    // Dynamic operand load into v_rhs/f_rhs (f32) from base + strategy(out_off);
-    // returns whether the rhs is a broadcast scalar (f_rhs_) vs a vector (v_rhs_).
-    bool load_operand(const Xbyak_riscv::Reg &out_off, operand_t &op);
-    const alg_kind_t alg_;
-    jit_generator_t *const h_;
-    operand_t rhs_;
-    std::unique_ptr<operand_t> select_;
+    /*
+     * Validates the host-supplied temporary vmm hint against the processed
+     * set. x64 adjusts an invalid hint to a free single vmm (0 or
+     * max_vmm_idx); the rv64 helper is a host-reserved e32/acc_lmul group
+     * (group_stride) with no legal substitute, so an invalid hint fails kernel
+     * creation instead (JIT_ASSERT). The whole set is tested (not just its
+     * endpoints) so a legal sparse set is not rejected.
+     */
+    void validate_temp_vmm_hint(const injector_utils::vmm_index_set_t &vmm_idxs,
+            size_t group_stride, int max_vmm_idx) const;
+    /*
+     * Validates the rv64-only rhs scratch groups (narrow_stage_vmm for a
+     * narrow-dtype vector load, gather_idx_vmm for a per-oc/spatial/w gather)
+     * this entry will use: each must not overlap a live accumulator or the m4
+     * helper, and a narrow gather's index and stage must be mutually disjoint.
+     * x64 has no analog (its helper adjustment resolves all temporaries).
+     */
+    void validate_rhs_scratch(const injector_utils::vmm_index_set_t &vmm_idxs,
+            size_t group_stride, const dnnl_post_ops::entry_t &post_op,
+            broadcasting_strategy_t rhs_broadcasting_strategy) const;
+    /*
+     * Taking into account rhs_broadcasting_strategy and information from user
+     * about tensor slice (rhs_arg_params) stored in Vmm(vmm_idx) calculates
+     * address of rhs tensor slice needed for binary operation and returns it.
+     * is_ternary_input selects the select (ternary) condition src2 instead of
+     * src1 (x64 additionally passes is_first for its address cache; rv64
+     * reloads the base on every call, so only the operand selector remains).
+     */
+    rhs_address_t prepare_rhs_arg_addr(std::size_t vmm_idx,
+            std::size_t rhs_arg_idx, const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params,
+            const broadcasting_strategy_t rhs_broadcasting_strategy,
+            bool is_ternary_input) const;
+    /*
+     * Loads data and applies particular binary operation.
+     */
+    void inject_binary(const dnnl_post_ops::entry_t &post_op, Vmm dst,
+            const rhs_address_t &rhs_addr, size_t group_stride) const;
+
+    /*
+     * Loads data and applies binary operation that require ternary inputs.
+     * The caller has already consumed the condition operand into the v0 mask
+     * (v0 = (cond == 0)); x64 instead carries the condition in a spilled
+     * temporary vmm.
+     */
+    void inject_binary_with_ternary_op(const dnnl_post_ops::entry_t &post_op,
+            Vmm dst, const rhs_address_t &rhs_addr, size_t group_stride) const;
+
+    /*
+     * Helper functions responsible for preparing rhs tensor slice address.
+     */
+    void append_offset_from_operand(
+            const std::map<int, rhs_operand_t> &vmm_idx_to_elem_operand_off,
+            int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+            const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes) const;
+    void append_offset_under_mem_addr(
+            const std::map<int, rhs_address_t> &vmm_idx_to_elem_addr_off,
+            int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+            const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes) const;
+    void append_value_offset(
+            const std::map<int, size_t> &vmm_idx_to_elem_val_off, int vmm_idx,
+            const Xbyak_riscv::Reg &addr_reg,
+            std::size_t elem_size_bytes) const;
+
+    void append_no_broadcast_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+            const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes) const;
+    void calculate_no_broadcast(rhs_address_t addr, std::size_t offset,
+            const Xbyak_riscv::Reg &out_reg) const;
+
+    void append_oc_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+            const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes,
+            bool is_per_oc_spatial) const;
+    void calculate_oc_ncsp(const dim_t *strides,
+            const Xbyak_riscv::Reg &tmp_reg, const bool residue = false) const;
+    void calculate_oc_blocked(
+            const dim_t *strides, const Xbyak_riscv::Reg &tmp_reg) const;
+    void calculate_oc_nspc(
+            const dim_t *strides, const Xbyak_riscv::Reg &tmp_reg) const;
+    void calculate_oc_cspn(
+            const dim_t *strides, const Xbyak_riscv::Reg &tmp_reg) const;
+
+    // per_mb_spatial / per_mb_w / per_w are realized entirely by the per-lane
+    // gather built inside these append_* helpers, so unlike x64/aarch64 there
+    // are no calculate_mb_sp_* / calculate_mb_w_* / calculate_w_* scalar
+    // variants here. Do not reintroduce them without also extending the
+    // register-preserve guard in compute_vector_range(): the scalar offset math
+    // clobbers X_TMP_1..4, which the guard currently only saves on the
+    // per_oc-with-channel-lanes path (that is the sole live X_TMP_1..4 user).
+    void append_mb_sp_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+            const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes) const;
+
+    void append_mb_w_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+            const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes) const;
+
+    void append_w_offset(
+            const std::map<int, rhs_address_t> &vmm_idx_to_out_addr,
+            const std::map<int, Xbyak_riscv::Reg> &vmm_idx_to_out_reg,
+            const std::map<int, size_t> &vmm_idx_to_out_elem_off_val,
+            int vmm_idx, const Xbyak_riscv::Reg &addr_reg,
+            const Xbyak_riscv::Reg &tmp_reg, std::size_t elem_size_bytes) const;
+
+    // The comparison predicate is the alg itself: RVV encodes it in the
+    // instruction mnemonic (vmfge/vmfgt/vmfle/vmflt/vmfeq/vmfne), so there is
+    // no x86 _cmp_* immediate to forward.
+    void compute_cmp_mask(
+            const Vmm &lhs, const Vmm &rhs, const alg_kind_t cmp_alg) const;
+    void execute_cmp_binary(const Vmm &dst, const Vmm &lhs, const Vmm &rhs,
+            const alg_kind_t cmp_alg) const;
+    // T is Vmm (.vv forms) or Xbyak_riscv::FReg (.vf forms) -- the rv64
+    // counterpart of x64's register-vs-memory-operand rhs duality. x64 can pass
+    // both through one `uni_v*ps(dst, lhs, rhs)` because every x86 instruction
+    // takes a unified Operand; on rv64 the two forms are different mnemonics
+    // and FReg/VReg share no base class, so the dispatch is done with these
+    // overload pairs (the project builds as C++11 -- no `if constexpr`).
+    void emit_arith(alg_kind_t alg, const Vmm &dst, const Vmm &lhs,
+            const Xbyak_riscv::FReg &rhs) const;
+    void emit_arith(alg_kind_t alg, const Vmm &dst, const Vmm &lhs,
+            const Vmm &rhs) const;
+    // Materialize a scalar rhs into the helper group; a vector rhs is returned
+    // as is. Used by the min/max/compare sequences, which need a vector operand.
+    Vmm materialize_rhs(const Xbyak_riscv::FReg &rhs) const;
+    Vmm materialize_rhs(const Vmm &rhs) const;
+    template <typename T>
+    void execute_binary(alg_kind_t binary_alg, const Vmm &dst, const Vmm &lhs,
+            const T &rhs) const;
+
+    /*
+     * Used in scalar broadcast strategy, loading a single value of the given
+     * data type into the scalar helper FP register (RVV .vf forms broadcast it
+     * implicitly; f16 has no scalar path and is loaded as a stride-0 vector
+     * through load_rhs instead).
+     */
+    void execute_broadcast(const data_type_t &data_type,
+            const Xbyak_riscv::FReg &tmp_freg,
+            const rhs_address_t &rhs_addr) const;
+    /*
+     * Loads vl elements of the rhs slice into tmp_vmm as f32. VLA folds x64's
+     * tail/no_tail split; narrow dtypes (s8/u8/f16) load into narrow_stage_vmm
+     * and widen into tmp_vmm. group_stride is the accumulator's e32 LMUL: the
+     * narrow load uses the SEW/LMUL that shares its VLMAX (e16 at LMUL/2, e8 at
+     * LMUL/4) so the widen preserves vl.
+     */
+    void load_rhs(const data_type_t &data_type, const Vmm &tmp_vmm,
+            const rhs_address_t &rhs_addr, size_t group_stride) const;
+    void cvt_to_f32(const Vmm &tmp_vmm) const;
+
+    jit_generator_t *host_;
+    const rhs_arg_static_params_t rhs_arg_static_params_;
+    const Xbyak_riscv::Reg param1_;
+    const bcast_set_t supported_strategy_set_;
 };
 
+} // namespace binary_injector
 } // namespace rv64
 } // namespace cpu
 } // namespace impl
 } // namespace dnnl
 
-#endif // CPU_RV64_INJECTORS_JIT_UNI_BINARY_INJECTOR_HPP
+#endif

--- a/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_eltwise_injector.cpp
@@ -945,6 +945,12 @@ template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &vmm_src) {
     using namespace alg_kind;
 
+    // v0 (vmm_mask_) is this injector's reserved mask scratch: nearly every alg
+    // computes a compare mask into it and then merges into vmm_src, so a vmm_src
+    // of v0 would alias the mask and corrupt the result. An illegal host choice
+    // fails kernel creation rather than emitting corrupt code.
+    JIT_ASSERT(vmm_src.getIdx() != vmm_mask_.getIdx());
+
     if (is_fwd_) {
         // The *_use_dst_for_bwd variants share the forward math of their base
         // algorithm (the forward companion of a use-dst backward training
@@ -1043,14 +1049,24 @@ void jit_uni_eltwise_injector_t<isa>::compute_body(const Vmm &vmm_src) {
 
 template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_t<isa>::compute_vector_range(
-        size_t start_idx, size_t end_idx) {
-    for (size_t i = start_idx; i < end_idx; i++)
-        compute_body(Vmm(i));
+        size_t start_idx, size_t end_idx, size_t group_stride) {
+    // [start_idx, end_idx) is the half-open physical register span;
+    // group_stride is the registers per accumulator (LMUL/EMUL), stepped so an
+    // m>1 run maps to its true group bases rather than x64's consecutive
+    // indices (see make_vmm_group_set).
+    for (size_t idx : injector_utils::make_vmm_group_set<isa>(
+                 start_idx, end_idx, group_stride))
+        compute_body(Vmm(idx));
 }
 
 template <cpu_isa_t isa>
 void jit_uni_eltwise_injector_t<isa>::compute_vector_range(
-        const injector_utils::vmm_index_set_t &vmm_idxs) {
+        const injector_utils::vmm_index_set_t &vmm_idxs, size_t group_stride) {
+    // Reject an illegal set (m8 / misaligned / overlapping / out-of-range) at
+    // the interface even though the injector itself is LMUL-agnostic, so a
+    // future non-m1/m2/m4 consumer fails kernel creation rather than silently
+    // relying on the host vtype.
+    injector_utils::validate_vmm_group_set<isa>(vmm_idxs, group_stride);
     for (size_t idx : vmm_idxs)
         compute_body(Vmm(idx));
 }

--- a/src/cpu/rv64/injectors/jit_uni_eltwise_injector.hpp
+++ b/src/cpu/rv64/injectors/jit_uni_eltwise_injector.hpp
@@ -163,9 +163,24 @@ struct jit_uni_eltwise_injector_t {
         : jit_uni_eltwise_injector_t(
                   host, e.alg, e.alpha, e.beta, e.scale, sp) {}
 
-    void compute_vector_range(size_t start_idx, size_t end_idx);
-    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs);
-    void compute_vector(size_t idx) { compute_vector_range(idx, idx + 1); }
+    // [start_idx, end_idx) is the half-open physical register span (x64
+    // semantics); group_stride is the registers per accumulator (LMUL/EMUL,
+    // one of 1/2/4), stepped to enumerate the run's true group bases (see
+    // make_vmm_group_set). Mandatory so an x64 compute_vector_range(start, end)
+    // is not copied as a silent stride-1 enumeration.
+    void compute_vector_range(
+            size_t start_idx, size_t end_idx, size_t group_stride);
+    // group_stride is each accumulator's e32 LMUL (1/2/4). The eltwise injector
+    // issues no vsetvli (it computes at the host vtype and is LMUL-agnostic), so
+    // it is used only to validate the set geometry and reject an illegal (e.g.
+    // m8) request at the interface -- symmetric with the binary injector.
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
+            size_t group_stride);
+    void compute_vector(size_t idx, size_t group_stride) {
+        // A single accumulator spans group_stride registers ([idx, idx+stride)),
+        // not one, so the half-open range is a whole group at this LMUL.
+        compute_vector_range(idx, idx + group_stride, group_stride);
+    }
 
     // This call is `static` and `public` so a host can size its
     // static_params_t before constructing the injector. Unlike x64 (which

--- a/src/cpu/rv64/injectors/jit_uni_postops_injector.cpp
+++ b/src/cpu/rv64/injectors/jit_uni_postops_injector.cpp
@@ -1,4 +1,5 @@
 /*******************************************************************************
+* Copyright 2020 Intel Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,9 +14,8 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#include "common/broadcast_strategy.hpp"
-#include "common/memory_desc_wrapper.hpp"
-
+#include <cassert>
+#include "common/verbose.hpp"
 #include "cpu/rv64/injectors/jit_uni_postops_injector.hpp"
 
 namespace dnnl {
@@ -24,168 +24,260 @@ namespace cpu {
 namespace rv64 {
 namespace injector {
 
-namespace {
-struct bcast_info_t {
-    binary_injector::broadcast_t bcast;
-    dim_t C, oc_stride, blk;
-};
-
-// Classify the binary rhs vs dst using the shared strategy classifier (x64
-// parity), restricted to the strategies the RVV injector implements. per_oc /
-// per_oc_spatial / per_w all map to the injector's per-lane gather with
-// (C = outer count, oc_stride = outer stride, blk = inner block); scalar and
-// no_broadcast map to scalar / per_element.
-bcast_info_t classify_binary(
-        const memory_desc_t &rhs_md, const memory_desc_t *dst_md) {
-    using bt = binary_injector::broadcast_t;
-    const memory_desc_wrapper src1_d(rhs_md);
-    if (!dst_md)
-        return {src1_d.nelems() == 1 ? bt::scalar : bt::per_element, 0, 0, 1};
-
-    const memory_desc_wrapper d(dst_md);
-    static const bcast_set_t supported {broadcasting_strategy_t::scalar,
-            broadcasting_strategy_t::per_oc,
-            broadcasting_strategy_t::per_oc_spatial,
-            broadcasting_strategy_t::per_w,
-            broadcasting_strategy_t::no_broadcast};
-    const auto strat = get_rhs_arg_broadcasting_strategy(rhs_md, d, supported);
-    const auto &bd = d.blocking_desc();
-    switch (strat) {
-        case broadcasting_strategy_t::scalar: return {bt::scalar, 0, 0, 1};
-        case broadcasting_strategy_t::per_oc:
-        case broadcasting_strategy_t::per_oc_spatial: {
-            // channel = ((o / stride) % (C/blk)) * blk + (o % blk); for a
-            // channel-blocked dst (nChw8c) blk is the inner block on dim 1.
-            dim_t blk = 1;
-            for (int k = 0; k < bd.inner_nblks; k++)
-                if (bd.inner_idxs[k] == 1) blk *= bd.inner_blks[k];
-            return {bt::per_oc, (d.dims()[1] + blk - 1) / blk, bd.strides[1],
-                    blk};
-        }
-        case broadcasting_strategy_t::per_w: {
-            const int wd = d.ndims() - 1;
-            return {bt::per_oc, d.dims()[wd], bd.strides[wd], 1};
-        }
-        default: // no_broadcast (unsupported is gated out by the consumer pd)
-            return {bt::per_element, 0, 0, 1};
-    }
-}
-} // namespace
+#define VCHECK_PO_INJ_BOOL(cond, msg) \
+    VCONDCHECK(primitive, create, check, postops_injector, cond, false, msg);
 
 template <cpu_isa_t isa>
 jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
         jit_generator_t *host, const post_ops_t &post_ops,
+        const binary_injector::static_params_t &binary_static_params,
         const eltwise_injector::static_params_t &eltwise_static_params,
-        const binary_injector::static_params_t *binary_static_params,
-        const memory_desc_t *dst_md,
-        const binary_injector::static_params_t *select_static_params)
-    : host_(host), post_ops_(post_ops) {
-    eltwise_injectors_.reserve(post_ops.len());
-    binary_injectors_.reserve(post_ops.len());
-    int arg_idx = 0; // this binary's slot in the rhs pointer array
+        const lambda_jit_injectors_t &lambda_jit_injectors)
+    : post_ops_(post_ops)
+    , host_(host)
+    , binary_injector_(nullptr)
+    , lambda_jit_injectors_(lambda_jit_injectors) {
+
+    const auto &esp = eltwise_static_params;
+    bool is_like_binary = false;
+
     for (int i = 0; i < post_ops.len(); i++) {
-        const auto &e = post_ops.entry_[i];
-        if (e.is_eltwise()) {
-            eltwise_injectors_.emplace_back(
-                    host_, e.eltwise, eltwise_static_params);
-        } else if (e.is_binary()) {
-            assert(binary_static_params != nullptr
-                    && "binary post-op requires binary scratch");
-            const bcast_info_t info
-                    = classify_binary(e.binary.src1_desc, dst_md);
-            // per-binary static params: strategy + channel map + rhs dtype.
-            binary_injector::static_params_t bsp = *binary_static_params;
-            bsp.bcast = info.bcast;
-            bsp.C = info.C;
-            bsp.oc_stride = info.oc_stride;
-            bsp.blk = info.blk;
-            bsp.rhs_dt = e.binary.src1_desc.data_type;
-            if (e.is_binary_with_ternary_op()) {
-                assert(select_static_params != nullptr
-                        && "binary select requires condition scratch");
-                const bcast_info_t select_info
-                        = classify_binary(e.binary.src2_desc, dst_md);
-                binary_injector::static_params_t ssp = *select_static_params;
-                ssp.bcast = select_info.bcast;
-                ssp.C = select_info.C;
-                ssp.oc_stride = select_info.oc_stride;
-                ssp.blk = select_info.blk;
-                ssp.rhs_dt = e.binary.src2_desc.data_type;
-                binary_injectors_.emplace_back(host_, e.binary.alg, info.bcast,
-                        bsp, arg_idx, select_info.bcast, &ssp);
-                arg_idx += 2;
-            } else {
-                binary_injectors_.emplace_back(
-                        host_, e.binary.alg, info.bcast, bsp, arg_idx++);
-            }
+        const auto &post_op = post_ops.entry_[i];
+        if (post_op.is_eltwise()) {
+            alg_to_eltwise_injector_.emplace(i,
+                    jit_uni_eltwise_injector_t<isa>(
+                            host_, post_op.eltwise, esp));
+        } else if (post_op.is_like_binary()) {
+            is_like_binary = true;
         }
     }
+
+    if (is_like_binary)
+        binary_injector_ = utils::make_unique<
+                binary_injector::jit_uni_binary_injector_t<isa>>(
+                host, binary_static_params);
 }
 
 template <cpu_isa_t isa>
-void jit_uni_postops_injector_t<isa>::compute_body(const Vmm &v,
-        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params,
-        int entry_begin, int entry_end) {
-    // Apply entries [entry_begin, entry_end) in attribute order: eltwise and
-    // binary injectors are consumed in creation order (binaries index the rhs
-    // array by the arg_idx baked in at construction). Non-eltwise/non-binary
-    // entries (sum) are skipped — the host applies sum at its position. Advance
-    // the injector counters over the skipped prefix so the sub-range picks the
-    // right injectors.
-    size_t e_idx = 0, b_idx = 0;
-    for (int i = 0; i < entry_begin; i++) {
-        if (post_ops_.entry_[i].is_eltwise())
-            e_idx++;
-        else if (post_ops_.entry_[i].is_binary())
-            b_idx++;
-    }
-    for (int i = entry_begin; i < entry_end; i++) {
-        const auto &e = post_ops_.entry_[i];
-        if (e.is_eltwise())
-            eltwise_injectors_[e_idx++].compute_vector(v.getIdx());
-        else if (e.is_binary())
-            binary_injectors_[b_idx++].compute_vector(
-                    v.getIdx(), rhs_arg_params);
-    }
-}
+jit_uni_postops_injector_t<isa>::jit_uni_postops_injector_t(
+        jit_generator_t *host, const post_ops_t &post_ops,
+        const binary_injector::static_params_t &binary_static_params,
+        const eltwise_injector::static_params_t &eltwise_static_params)
+    : jit_uni_postops_injector_t(host, post_ops, binary_static_params,
+              eltwise_static_params, lambda_jit_injectors_t()) {}
 
 template <cpu_isa_t isa>
 void jit_uni_postops_injector_t<isa>::compute_vector_range(size_t start_idx,
         size_t end_idx,
-        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params) {
-    // NB: a per-element/per_oc binary post-op reads a per-register rhs slice, so
-    // a multi-register range is only correct when every register's offset is in
-    // rhs_arg_params; all current consumers pass exactly one register (an
-    // eltwise-only chain is safe for any range).
-    for (size_t i = start_idx; i < end_idx; i++)
-        compute_body(Vmm(i), rhs_arg_params, 0, (int)post_ops_.len());
+        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params,
+        size_t group_stride) {
+
+    // [start_idx, end_idx) is the half-open physical register span (x64
+    // semantics); group_stride is the registers-per-accumulator (LMUL/EMUL).
+    // make_vmm_group_set steps by it so an m>1 run maps to its true group
+    // bases; both sub-injectors then consume the explicit set.
+    compute_vector_range(injector_utils::make_vmm_group_set<isa>(
+                                 start_idx, end_idx, group_stride),
+            rhs_arg_params, group_stride);
 }
 
 template <cpu_isa_t isa>
-bool jit_uni_postops_injector_t<isa>::post_ops_ok(
-        const post_ops_t &post_ops, int n_vaux, bool allow_binary_select) {
-    for (int i = 0; i < post_ops.len(); i++) {
-        const auto &e = post_ops.entry_[i];
-        if (e.is_eltwise()) {
-            const auto alg = e.eltwise.alg;
-            const bool ok = eltwise_injector::is_alg_supported(alg)
-                    || (n_vaux >= 4 && eltwise_injector::needs_extra_aux(alg));
-            if (!ok) return false;
-        } else if (e.is_binary()) {
-            if (e.binary.alg == alg_kind::binary_select) {
-                if (!allow_binary_select) return false;
-            } else if (!binary_injector::is_alg_supported(e.binary.alg))
-                return false;
+void jit_uni_postops_injector_t<isa>::compute_vector_range(
+        size_t start_idx, size_t end_idx, size_t group_stride) {
+    compute_vector_range(start_idx, end_idx,
+            binary_injector::rhs_arg_dynamic_params_t(), group_stride);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector_range(
+        const injector_utils::vmm_index_set_t &vmm_idxs,
+        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params,
+        size_t group_stride) {
+
+    // group_stride is each accumulator's e32 LMUL (1/2/4); the binary injector
+    // needs it to pick the narrow-dtype rhs load LMUL. The eltwise injector
+    // computes at the host vtype (it issues no vsetvli) and so is LMUL-agnostic.
+    std::size_t rhs_arg_idx = 0;
+    for (int i = 0; i < post_ops_.len(); i++) {
+        const auto &post_op = post_ops_.entry_[i];
+        if (post_op.is_eltwise()) {
+            alg_to_eltwise_injector_.at(i).compute_vector_range(
+                    vmm_idxs, group_stride);
+        } else if (post_op.is_like_binary()) {
+            binary_injector_->compute_vector_range(vmm_idxs, rhs_arg_idx,
+                    post_op, rhs_arg_params, group_stride);
+            ++rhs_arg_idx;
+            // Ternary op handles two arguments at the same time, thus,
+            // skipping one more.
+            if (post_op.is_binary_with_ternary_op()) ++rhs_arg_idx;
         } else {
-            return false; // sum/prelu/... -> consumer falls back to a ref impl
+            const auto lam = lambda_jit_injectors_.find(post_op.kind);
+            if (lam != lambda_jit_injectors_.end()) lam->second();
         }
     }
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector_range(
+        const injector_utils::vmm_index_set_t &vmm_idxs, size_t group_stride) {
+    compute_vector_range(vmm_idxs, binary_injector::rhs_arg_dynamic_params_t(),
+            group_stride);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector(size_t idx,
+        const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params,
+        size_t group_stride) {
+    compute_vector_range({idx}, rhs_arg_params, group_stride);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::compute_vector(
+        size_t idx, size_t group_stride) {
+    compute_vector_range({idx}, group_stride);
+}
+
+template <cpu_isa_t isa>
+void jit_uni_postops_injector_t<isa>::set_lambda_injector(
+        dnnl_primitive_kind_t kind, const std::function<void()> &jit_injector) {
+    lambda_jit_injectors_[kind] = jit_injector;
+}
+
+post_ops_ok_args_t::post_ops_ok_args_t(const cpu_isa_t isa,
+        const std::vector<post_op_type> &accepted_post_op_types,
+        const post_ops_t &post_ops, const memory_desc_wrapper *dst_d,
+        const bool sum_at_pos_0_only, const bool sum_requires_scale_one,
+        const bool sum_requires_zp_zero, const bool sum_requires_same_params,
+        const bcast_set_t &enabled_bcast_strategy, const int n_vaux,
+        const bool allow_binary_select)
+    : isa(isa)
+    , accepted_post_op_types(accepted_post_op_types)
+    , post_ops(post_ops)
+    , dst_d(dst_d)
+    , sum_at_pos_0_only(sum_at_pos_0_only)
+    , sum_requires_scale_one(sum_requires_scale_one)
+    , sum_requires_zp_zero(sum_requires_zp_zero)
+    , sum_requires_same_params(sum_requires_same_params)
+    , enabled_bcast_strategy(enabled_bcast_strategy)
+    , n_vaux(n_vaux)
+    , allow_binary_select(allow_binary_select) {};
+
+bool post_ops_ok(const post_ops_ok_args_t &post_ops_ok_args) {
+    const cpu_isa_t isa = post_ops_ok_args.isa;
+    const std::vector<post_op_type> &accepted_post_op_types
+            = post_ops_ok_args.accepted_post_op_types;
+    const post_ops_t &post_ops = post_ops_ok_args.post_ops;
+    const memory_desc_wrapper *dst_d = post_ops_ok_args.dst_d;
+    const bool sum_at_pos_0_only = post_ops_ok_args.sum_at_pos_0_only;
+    const bool sum_requires_scale_one = post_ops_ok_args.sum_requires_scale_one;
+    const bool sum_requires_zp_zero = post_ops_ok_args.sum_requires_zp_zero;
+    const bool sum_requires_same_params
+            = post_ops_ok_args.sum_requires_same_params;
+    const auto &enabled_bcast_strategy
+            = post_ops_ok_args.enabled_bcast_strategy;
+
+    VCHECK_PO_INJ_BOOL(dst_d && dst_d->md_->format_kind != dnnl_format_kind_any,
+            VERBOSE_UNSUPPORTED_FORMAT_KIND);
+
+    // Save scale and zero point of first sum postop in order to check that any
+    // subsequent sum postops have the same values. This check is necessary
+    // because there is only one lambda injector.
+    const auto sum_idx = post_ops.find(primitive_kind::sum);
+    const bool with_sum = sum_idx != -1;
+    const auto &entry
+            = with_sum ? post_ops.entry_[sum_idx] : dnnl_post_ops::entry_t();
+    const auto sum_scale = with_sum ? entry.sum.scale : 0;
+    const auto sum_zero_point = with_sum ? entry.sum.zero_point : 0;
+
+    const auto is_accepted_postop = [&](const int idx) {
+        for (const auto &post_op : accepted_post_op_types) {
+            const auto &entry = post_ops.entry_[idx];
+            // Note: check for post-op kinds is needed as `post_op` value
+            // represents all supported but not only passed kinds.
+            switch (post_op) {
+                case sum:
+                    if (!entry.is_sum(false, false)) continue;
+                    if (sum_requires_same_params) {
+                        VCHECK_PO_INJ_BOOL(entry.sum.scale == sum_scale,
+                                "Unsupported sum scale value");
+                        VCHECK_PO_INJ_BOOL(
+                                entry.sum.zero_point == sum_zero_point,
+                                "Unsupported sum zero-point value");
+                    }
+                    if (sum_requires_scale_one) {
+                        VCHECK_PO_INJ_BOOL(entry.sum.scale == 1.f,
+                                "Unsupported sum scale value");
+                    }
+                    if (sum_requires_zp_zero) {
+                        VCHECK_PO_INJ_BOOL(entry.sum.zero_point == 0,
+                                "Unsupported sum zero-point value");
+                    }
+                    VCHECK_PO_INJ_BOOL(IMPLICATION(sum_at_pos_0_only, idx == 0),
+                            "Unsupported sum position in post-ops");
+                    return true;
+                case eltwise: {
+                    if (!entry.is_eltwise()) continue;
+                    // The heavy algs (log/soft_relu/gelu_erf) need a fourth
+                    // aux group from the host; x64 instead checks
+                    // eltwise_injector::is_supported(isa, alg, f32) -- the
+                    // aux budget is an rv64 host contract (no stack spill).
+                    const auto alg = entry.eltwise.alg;
+                    return post_ops_ok_args.n_vaux >= 4
+                            ? eltwise_injector::is_supported(alg)
+                            : eltwise_injector::is_alg_supported(alg);
+                }
+                case binary:
+                    if (entry.is_binary()) {
+                        assert(dst_d != nullptr && "dst_d is null");
+                        bool ok = binary_injector::is_supported(isa,
+                                binary_injector::get_src1_desc(entry, *dst_d),
+                                *dst_d, enabled_bcast_strategy);
+                        if (entry.is_binary_with_ternary_op()) {
+                            // rv64: the select condition goes through the
+                            // same load machinery as src1, so it gets the
+                            // full is_supported check (x64 checks only the
+                            // src2 data type).
+                            VCHECK_PO_INJ_BOOL(
+                                    post_ops_ok_args.allow_binary_select,
+                                    "Unsupported binary select post-op");
+                            const auto src2_d = binary_injector::get_src2_desc(
+                                    entry, *dst_d);
+                            ok = ok
+                                    && binary_injector::is_supported(isa,
+                                            src2_d, *dst_d,
+                                            enabled_bcast_strategy);
+                            // The injector addresses the condition through
+                            // the no_broadcast path only (x64 likewise
+                            // supports no src2 broadcasting).
+                            VCHECK_PO_INJ_BOOL(
+                                    get_rhs_arg_broadcasting_strategy(src2_d,
+                                            *dst_d, enabled_bcast_strategy)
+                                            == broadcasting_strategy_t::
+                                                    no_broadcast,
+                                    "Unsupported broadcast for binary select "
+                                    "condition");
+                        }
+                        return ok;
+                    }
+                    break;
+                default: assert(!"Unhandled post_op type");
+            }
+        }
+        return false;
+    };
+
+    for (int i = 0; i < post_ops.len(); i++) {
+        if (!is_accepted_postop(i)) return false;
+    }
+
     return true;
 }
 
-template struct jit_uni_postops_injector_t<v>;
-template struct jit_uni_postops_injector_t<zvfh>;
-template struct jit_uni_postops_injector_t<zvfbfwma>;
+template class jit_uni_postops_injector_t<v>;
+template class jit_uni_postops_injector_t<zvfh>;
+template class jit_uni_postops_injector_t<zvfbfwma>;
+
+#undef VCHECK_PO_INJ_BOOL
 
 } // namespace injector
 } // namespace rv64

--- a/src/cpu/rv64/injectors/jit_uni_postops_injector.hpp
+++ b/src/cpu/rv64/injectors/jit_uni_postops_injector.hpp
@@ -1,4 +1,5 @@
 /*******************************************************************************
+* Copyright 2020 Intel Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +17,12 @@
 #ifndef CPU_RV64_INJECTORS_JIT_UNI_POSTOPS_INJECTOR_HPP
 #define CPU_RV64_INJECTORS_JIT_UNI_POSTOPS_INJECTOR_HPP
 
+#include <functional>
+#include <map>
 #include <memory>
-#include <vector>
 
 #include "common/c_types_map.hpp"
 #include "common/primitive_attr.hpp"
-
 #include "cpu/rv64/injectors/injector_utils.hpp"
 #include "cpu/rv64/injectors/jit_uni_binary_injector.hpp"
 #include "cpu/rv64/injectors/jit_uni_eltwise_injector.hpp"
@@ -33,68 +34,152 @@ namespace cpu {
 namespace rv64 {
 namespace injector {
 
-// In-kernel post-op chain injector for RVV, mirroring the x64/aarch64
-// jit_uni_postops_injector_t role: the host kernel computes its accumulator
-// tile into vector registers, then hands those register groups to
-// compute_vector(_range) to apply the full post-op chain in place, in attribute
-// order.
-//
-// Coverage (gated by post_ops_ok): a chain of injector-supported forward
-// eltwise ops plus any number of injector-supported binary ops. Each binary
-// reads its rhs from the pointer array carried in the (indirect) binary scratch,
-// indexed by its position among the chain's binaries — the x64/aarch64 scheme.
-// Exotic broadcasts, sum and prelu are not covered — the consumer pd rejects
-// them so the framework selects a reference impl. Binary select additionally
-// needs an independent condition scratch configuration and is enabled only by
-// the standalone binary host. The binary scratch is optional: pass nullptr when
-// the chain has no binary entry.
-template <cpu_isa_t isa>
-struct jit_uni_postops_injector_t {
-    using Vmm = typename jit_isa_traits_t<isa>::Vmm;
+/*
+ * Allows specifying custom injector function for given post-op type - one
+ * function per primitive. There are post-ops type (example: sum) that don't
+ * have specialized injector. They heavily rely on kernel specific intrnals,
+ * which makes the generalization unreasonable. As so user can prepare internal
+ * kernel lambda and pass it explicitly to injector.
+ */
+using lambda_jit_injectors_t
+        = std::map<dnnl_primitive_kind_t, std::function<void()>>;
 
-    // dst_md (optional): when provided, per-channel binary post-op rhs
-    // ([1, C, 1, ...]) is classified as per_oc and the injector computes the
-    // channel offset from the output offset at call time. Without it, binaries
-    // are scalar / per_element only.
+struct post_ops_ok_args_t;
+/*
+ * Checks if postops injection for given args is supported.
+ */
+bool post_ops_ok(const post_ops_ok_args_t &args);
+
+/*
+ * Main mechanism of handling various post-ops types. It utilizes internally
+ * specialized injectors to generate post-ops code to host primitive. Random
+ * order of post-ops is supported.
+ */
+template <cpu_isa_t isa>
+class jit_uni_postops_injector_t {
+public:
+    /*
+     * @param host <required> - user primitive where post-ops generated code is
+     * injected
+     * @param post_ops <required> - struct representing requested post-ops chain
+     * @binary_static_params <reguired> - static params needed for binary_injector.
+     * see: jit_uni_binary_injector.hpp for more info.
+     * @param eltwise_static_params <required> - static params needed for
+     * eltwise_injector. Unlike x64 (where a default-constructed value exists)
+     * the rv64 eltwise params carry the host-reserved aux register groups and
+     * are therefore mandatory.
+     * @param lambda_jit_injectors <optional> - allows user specify custom injector
+     * function for given post-op type
+     */
     jit_uni_postops_injector_t(jit_generator_t *host,
             const post_ops_t &post_ops,
+            const binary_injector::static_params_t &binary_static_params,
+            const eltwise_injector::static_params_t &eltwise_static_params);
+    jit_uni_postops_injector_t(jit_generator_t *host,
+            const post_ops_t &post_ops,
+            const binary_injector::static_params_t &binary_static_params,
             const eltwise_injector::static_params_t &eltwise_static_params,
-            const binary_injector::static_params_t *binary_static_params
-            = nullptr,
-            const memory_desc_t *dst_md = nullptr,
-            const binary_injector::static_params_t *select_static_params
-            = nullptr);
+            const lambda_jit_injectors_t &lambda_jit_injectors);
 
-    // Apply the chain to the accumulator register group, identified by index
-    // (x64/aarch64 parity). Binary entries compute their rhs address from the
-    // per-register output offset in rhs_arg_params. entry_begin/entry_end select
-    // an entry sub-range so a host can apply the chain in pieces (e.g. around an
-    // in-kernel sum, which the injector skips); default is the whole chain.
+    /*
+     * Generates code of post_ops chain injected to host primitive. Applied to
+     * ordered set of vector registers' indexes. group_stride is each
+     * accumulator's e32 LMUL (registers per accumulator, one of 1/2/4); the
+     * binary sub-injector uses it to pick the narrow-dtype rhs load LMUL, the
+     * eltwise sub-injector is LMUL-agnostic (it issues no vsetvli).
+     *
+     * @rhs_arg_params: see jit_uni_binary_injector description
+     */
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params,
+            size_t group_stride);
+
+    void compute_vector_range(const injector_utils::vmm_index_set_t &vmm_idxs,
+            size_t group_stride);
+
+    /*
+     * Generates code of post_ops chain injected to host primitive. Applied to
+     * the accumulators occupying the half-open physical register span
+     * <start_idx, end_idx). group_stride is the vector registers per
+     * accumulator (LMUL/EMUL, one of 1/2/4; m8 is unsupported -- the helper
+     * scratch is m4); the run's group bases are enumerated by stepping it (see
+     * make_vmm_group_set), so unlike x64 an m>1 run maps to its true bases. It
+     * is mandatory so an x64 compute_vector_range(start, end) cannot be copied
+     * as a silent stride-1 enumeration.
+     *
+     * @rhs_arg_params: see jit_uni_binary_injector description
+     */
+    void compute_vector_range(size_t start_idx, size_t end_idx,
+            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params,
+            size_t group_stride);
+
+    void compute_vector_range(
+            size_t start_idx, size_t end_idx, size_t group_stride);
+
+    /*
+     * Generates code of post_ops chain injected to host primitive. Applied to
+     * a single vector register index. group_stride is the accumulator's e32
+     * LMUL (1/2/4); see the set overload.
+     *
+     * @rhs_arg_params: see jit_uni_binary_injector description
+     */
     void compute_vector(size_t idx,
             const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params,
-            int entry_begin = 0, int entry_end = -1) {
-        compute_body(Vmm(idx), rhs_arg_params, entry_begin,
-                entry_end < 0 ? (int)post_ops_.len() : entry_end);
-    }
-    void compute_vector_range(size_t start_idx, size_t end_idx,
-            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params);
+            size_t group_stride);
+    void compute_vector(size_t idx, size_t group_stride);
 
-    // True when every entry of `post_ops` can be injected in-kernel by this
-    // injector: any number of supported forward eltwise ops, plus any number of
-    // supported binary ops. n_vaux is how many vector aux groups the host
-    // supplies to the eltwise static_params; the heavy eltwise algs (log/
-    // soft_relu/gelu_erf) require n_vaux >= 4.
-    static bool post_ops_ok(const post_ops_t &post_ops, int n_vaux = 3,
-            bool allow_binary_select = false);
+    // x64's prepare_table thin wrapper has no rv64 analog: the rv64 eltwise
+    // injector materializes constants inline (li + fmv.w.x) instead of a
+    // rodata table.
+    void set_lambda_injector(lambda_jit_injectors_t::key_type,
+            const lambda_jit_injectors_t::mapped_type &jit_injector);
 
 private:
-    void compute_body(const Vmm &v,
-            const binary_injector::rhs_arg_dynamic_params_t &rhs_arg_params,
-            int entry_begin, int entry_end);
-    jit_generator_t *const host_;
     post_ops_t post_ops_;
-    std::vector<jit_uni_eltwise_injector_t<isa>> eltwise_injectors_;
-    std::vector<jit_uni_binary_injector_t<isa>> binary_injectors_;
+    jit_generator_t *host_;
+    // Key is a numerical order of a post-op in attributes.
+    std::map<int, jit_uni_eltwise_injector_t<isa>> alg_to_eltwise_injector_;
+    std::unique_ptr<binary_injector::jit_uni_binary_injector_t<isa>>
+            binary_injector_;
+    lambda_jit_injectors_t lambda_jit_injectors_;
+};
+
+// prelu is not supported by the rv64 binary injector (an intentional gap next
+// to bf16), so unlike x64 it is not an accepted post-op type.
+enum post_op_type { sum = 0, eltwise, binary };
+
+struct post_ops_ok_args_t {
+    // The two trailing arguments are rv64-only:
+    // @param n_vaux - how many vector aux groups the host supplies to the
+    // eltwise injector static params; the heavy eltwise algs (log/soft_relu/
+    // gelu_erf) require n_vaux >= 4 (x64 spills to stack and has no such
+    // budget).
+    // @param allow_binary_select - opts a host into the select (ternary)
+    // post-op. The injected select consumes the v0 mask and reuses the shared
+    // rhs helper for the condition load (rv64 cannot stack-spill a vector
+    // like x64's push_vmm), so only a host that keeps v0 dead across the
+    // inject point and audits the extra rhs pointer-array slot enables it
+    // (x64 has no such gate).
+    post_ops_ok_args_t(const cpu_isa_t isa,
+            const std::vector<post_op_type> &accepted_post_op_types,
+            const post_ops_t &post_ops, const memory_desc_wrapper *dst_d,
+            const bool sum_at_pos_0_only, const bool sum_requires_scale_one,
+            const bool sum_requires_zp_zero = true,
+            const bool sum_requires_same_params = true,
+            const bcast_set_t &enabled_bcast_strategy = default_strategies(),
+            const int n_vaux = 3, const bool allow_binary_select = false);
+
+    const cpu_isa_t isa;
+    const std::vector<post_op_type> &accepted_post_op_types;
+    const post_ops_t &post_ops;
+    const memory_desc_wrapper *dst_d;
+    const bool sum_at_pos_0_only;
+    const bool sum_requires_scale_one;
+    const bool sum_requires_zp_zero;
+    const bool sum_requires_same_params;
+    const bcast_set_t enabled_bcast_strategy;
+    const int n_vaux;
+    const bool allow_binary_select;
 };
 
 } // namespace injector
@@ -103,4 +188,4 @@ private:
 } // namespace impl
 } // namespace dnnl
 
-#endif // CPU_RV64_INJECTORS_JIT_UNI_POSTOPS_INJECTOR_HPP
+#endif

--- a/src/cpu/rv64/jit_generator.hpp
+++ b/src/cpu/rv64/jit_generator.hpp
@@ -106,6 +106,27 @@ public:
         return status::runtime_error;
     }
 
+    // x64's `mov(Reg64, imm64)` analog: materialize an arbitrary 64-bit
+    // immediate without a scratch register (Xbyak_riscv's li covers
+    // sign-extended 32-bit immediates only). Standard lui/addi + slli/addi
+    // recursion, at most ~8 instructions; values in the signed 32-bit range
+    // emit exactly what li would.
+    void load_imm64(const Xbyak_riscv::Reg &rd, int64_t imm) {
+        if (imm >= INT32_MIN && imm <= INT32_MAX) {
+            li(rd, (uint32_t)(int32_t)imm);
+            return;
+        }
+        // Sign-extend the low 12 bits (well-defined, no signed-shift UB) and
+        // recurse on the remaining upper part. The subtraction is done in
+        // 128-bit arithmetic: for imm near INT64_MAX with a negative lo12,
+        // imm - lo12 exceeds int64_t (the result still fits -- it is at most
+        // a 53-bit quantity after the >> 12).
+        const int64_t lo12 = ((imm & 0xfff) ^ 0x800) - 0x800;
+        load_imm64(rd, (int64_t)(((__int128)imm - lo12) >> 12));
+        slli(rd, rd, 12);
+        if (lo12 != 0) addi(rd, rd, (int32_t)lo12);
+    }
+
     inline cpu_isa_t max_cpu_isa() const noexcept { return max_cpu_isa_; }
 
     // Helper to check that a requested ISA is both within the per‑kernel limit

--- a/src/cpu/rv64/jit_primitive_conf.hpp
+++ b/src/cpu/rv64/jit_primitive_conf.hpp
@@ -289,6 +289,84 @@ struct jit_resampling_args_t {
     dim_t post_op_off0 = 0;
 };
 
+enum class binary_op_t : unsigned { none, c_blocked, n_spatial_c, n_c_spatial };
+
+enum class binary_bcast_t : unsigned {
+    none, // tensor operation
+    scalar,
+    per_batch,
+    per_c,
+    per_w
+};
+
+// Binary configuration, mirroring the x64/aarch64 jit_binary_conf_t. Fields that
+// only make sense for x86 (i8/bf16/f16 selection, per_w scratchpad expansion,
+// isa/ternary-vmm budgeting) are dropped; RVV keeps a single f32 compute domain
+// and lets the driver's strategies compute all offsets from the mds at run time
+// (like x64), so no rv64-specific run-decomposition plan is stored here.
+struct jit_binary_conf_t {
+    binary_op_t op_type = binary_op_t::none;
+    binary_bcast_t bcast_type = binary_bcast_t::none;
+    bool do_scale_src0 = false;
+    bool do_scale_src1 = false;
+    bool do_sum = false;
+    bool with_eltwise = false;
+    bool with_binary = false;
+    bool with_postops = false;
+    float sum_scale = 0.f;
+    // src1 is a single value broadcast over the whole run: the kernel keeps it
+    // in a scalar FP register and uses the .vf instruction forms (x64 broadcasts
+    // it into a full vector register instead).
+    bool broadcast_src1_value = false;
+    // src1 advances 1:1 with the run (contiguous vle, or strided vlse when the
+    // src0/src1 plain layouts differ). When neither this nor broadcast is set,
+    // the driver slices the call so a fixed src1 vector maps to each run.
+    bool use_stride_src1 = false;
+    // x64 parity: a per_oc/per_oc_spatial post-op rhs exists. The dispatch
+    // then routes to the channel-aligned per_c/per_w strategies and the
+    // kernel addresses the rhs with a per-call channel offset (x64's model)
+    // instead of the general per-lane gather; an op_t::none src0 cannot be
+    // routed and keeps the gather-addressed flat path. x64's
+    // use_stride_rhs_postops is not needed: the dst_l_off the kernel already
+    // maintains advances with the run.
+    bool postops_per_oc_broadcast_exists = false;
+    bool is_ternary_op = false; // select: dst = src2 ? src0 : src1 (src2 is s8)
+    bool is_i8 = false; // dst is s8/u8 (x64-parity gating; kernel saturates)
+    bool is_src_different_layouts = false;
+    dim_t outer_dims = 1;
+    // src1 element stride along the run when layouts differ: 1 = contiguous
+    // (vle), >1 = strided (vlse; e.g. nchw:nhwc — x64 gathers with an indices
+    // vector instead). dim_t rather than x64's int: the byte stride is
+    // materialized in a 64-bit GPR, no narrowing needed.
+    dim_t src1_stride = 1;
+    int not_bcasted_sp_dims = 0;
+
+    data_type_t src0_type = data_type::undef;
+    data_type_t src1_type = data_type::undef;
+    data_type_t dst_type = data_type::undef;
+};
+
+// Per-call arguments. Pointer/size fields mirror x64/aarch64
+// jit_uni_binary_args_t names; divergences (element-count work_amount, scale
+// values instead of pointers) are noted in place.
+struct jit_uni_binary_args_t {
+    const void *src0;
+    const void *src1;
+    const void *src2; // ternary select condition (s8), else null
+    const void *dst;
+    // Per-binary post-op rhs base array, or null.
+    const void *post_ops_binary_rhs_arg_vec;
+    // Elements to process in this call. The VLA loop consumes elements via
+    // vsetvli, unlike x64's byte-based spat_offt_count.
+    dim_t work_amount;
+    // Per-tensor scale and sum values, resolved by the driver (x64 passes
+    // scale pointers and broadcasts in-kernel; sum_scale is baked into code).
+    float scales_src0, scales_src1, sum_scale;
+    // x64: the dst tensor origin; the binary post-op injector recovers each
+    // chunk's element offset as (dst address - dst_orig) >> log2(dt size).
+    const void *dst_orig;
+};
+
 struct jit_1x1_conv_conf_t {
     prop_kind_t prop_kind;
     int mb;

--- a/src/cpu/rv64/jit_primitive_conf.hpp
+++ b/src/cpu/rv64/jit_primitive_conf.hpp
@@ -302,8 +302,9 @@ enum class binary_bcast_t : unsigned {
 // Binary configuration, mirroring the x64/aarch64 jit_binary_conf_t. Fields that
 // only make sense for x86 (i8/bf16/f16 selection, per_w scratchpad expansion,
 // isa/ternary-vmm budgeting) are dropped; RVV keeps a single f32 compute domain
-// and lets the driver's strategies compute all offsets from the mds at run time
-// (like x64), so no rv64-specific run-decomposition plan is stored here.
+// and lets the driver's strategies compute offsets from the mds at run time.
+// A compact RV64 physical run plan is retained for dense combinations outside
+// the synchronized x64 strategy matrix.
 struct jit_binary_conf_t {
     binary_op_t op_type = binary_op_t::none;
     binary_bcast_t bcast_type = binary_bcast_t::none;
@@ -340,6 +341,24 @@ struct jit_binary_conf_t {
     // materialized in a 64-bit GPR, no narrowing needed.
     dim_t src1_stride = 1;
     int not_bcasted_sp_dims = 0;
+
+    // RV64's VLA kernel can also execute dense broadcast/layout combinations
+    // outside the x64 strategy matrix. The PD coalesces the physical dst
+    // dimensions into contiguous inner runs and records the src1 stride for
+    // each outer dimension. This retains the pre-synchronization JIT coverage
+    // while keeping the x64-style driver paths as the primary implementation.
+    bool use_generic_strategy = false;
+    bool generic_whole = false;
+    bool generic_scalar_inner = false;
+    bool generic_src1_same_layout = false;
+    int generic_ndims = 0;
+    dim_t generic_inner = 0;
+    dim_t generic_n_outer = 0;
+    dim_t generic_total = 0;
+    dim_t generic_tail = 0;
+    int generic_tail_axis = -1;
+    dims_t generic_outer_dims = {};
+    dims_t generic_src1_strides = {};
 
     data_type_t src0_type = data_type::undef;
     data_type_t src1_type = data_type::undef;

--- a/src/cpu/rv64/jit_uni_binary.cpp
+++ b/src/cpu/rv64/jit_uni_binary.cpp
@@ -157,8 +157,7 @@ status_t jit_uni_binary_t::pd_t::init(const engine_t *engine) {
     // dtype). i8 (quantized) dst may differ from src0 (e.g. f32 src0 -> s8 dst).
     VDISPATCH_BINARY(IMPLICATION(!conf_.is_i8, src0_md_ == dst_md_),
             VERBOSE_INCONSISTENT_MDS, "src", "dst");
-    VDISPATCH_BINARY(
-            is_applicable(), "not applicable for current implementation");
+    bool use_standard_strategy = is_applicable();
     VDISPATCH_BINARY(attr()->has_default_values(sm::post_ops | sm::scales),
             VERBOSE_UNSUPPORTED_ATTR);
     // Resolve formats before classifying the post-op chain: the post-op
@@ -170,15 +169,36 @@ status_t jit_uni_binary_t::pd_t::init(const engine_t *engine) {
 
     // All operations over blocking descriptors should have md initialized.
     conf_.is_src_different_layouts = !compare_layouts(src0_md_, src1_md_);
-    const cpu_isa_t postops_isa = mayiuse(zvfbfwma)
-            ? zvfbfwma
-            : (mayiuse(zvfh) ? zvfh : v);
+    const bool postops_per_oc_broadcast_exists
+            = binary_injector::any_binary_postop_rhs_per_oc_broadcast(
+                    po, src0_md_, get_supported_postops_bcast_strategies());
+    const auto &src0_blocking = src0_md_.blocking_desc();
+    // The synchronized driver is efficient for flat tensor/scalar work, but
+    // slices a plain broadcast into short x64-shaped calls. RVV can retain a
+    // longer VLA run by coalescing the physical dimensions instead.
+    const bool generic_plain_bcast_strategy = src0_md_.is_plain()
+            && src1_md_.is_plain() && !is_tensor_op()
+            && src1_md_.nelems(false) != 1;
+    const bool generic_postops_strategy
+            = (elt_idx != -1 && !dst_md_.is_dense()
+                      && !cpu_eltwise_fwd_pd_t::eltwise_preserves_zero(
+                              po.entry_[elt_idx].eltwise))
+            || (postops_per_oc_broadcast_exists
+                    && (conf_.is_src_different_layouts
+                            || (!src0_md_.is_plain()
+                                    && src0_blocking.inner_nblks != 1)));
+    if (generic_plain_bcast_strategy || generic_postops_strategy)
+        use_standard_strategy = false;
+    const cpu_isa_t postops_isa
+            = mayiuse(zvfbfwma) ? zvfbfwma : (mayiuse(zvfh) ? zvfh : v);
     VDISPATCH_BINARY(
             post_ops_ok(attr(), src_md(0), dst_md(),
-                    conf_.is_src_different_layouts, postops_isa),
+                    use_standard_strategy ? conf_.is_src_different_layouts
+                                          : false,
+                    postops_isa, !use_standard_strategy),
             VERBOSE_UNSUPPORTED_POSTOP);
     VDISPATCH_BINARY(
-            (conf_.is_i8 || elt_idx == -1
+            (conf_.is_i8 || elt_idx == -1 || !use_standard_strategy
                     || IMPLICATION(!dst_md_.is_dense(),
                             cpu_eltwise_fwd_pd_t::eltwise_preserves_zero(
                                     po.entry_[elt_idx].eltwise))),
@@ -187,10 +207,6 @@ status_t jit_uni_binary_t::pd_t::init(const engine_t *engine) {
                              check_scales_mask()),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-    conf_.postops_per_oc_broadcast_exists
-            = binary_injector::any_binary_postop_rhs_per_oc_broadcast(
-                    po, src0_md_, get_supported_postops_bcast_strategies());
-    conf_.op_type = get_op_type(src0_md_);
     conf_.do_scale_src0 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
     conf_.do_scale_src1 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_1);
     const auto sum_idx = po.find(primitive_kind::sum);
@@ -200,41 +216,64 @@ status_t jit_uni_binary_t::pd_t::init(const engine_t *engine) {
     conf_.with_postops
             = conf_.with_binary || conf_.with_eltwise || conf_.do_sum;
     conf_.sum_scale = conf_.do_sum ? po.entry_[sum_idx].sum.scale : 0.f;
-    const auto &bcast_dims = broadcast_dims();
-    conf_.bcast_type = is_tensor_op() ? bcast_t::none
-                                      : get_bcast_type(src1_md_, bcast_dims);
-    // op_type only matters for broadcasted operation
-    VDISPATCH_BINARY(IMPLICATION(conf_.bcast_type != bcast_t::none,
-                             conf_.op_type != op_t::none),
-            "unsupported src0 layout for broadcast operation");
-    // src1 addressing mode (x64 parity): a single value broadcast across the
-    // run, or advancing 1:1 with it (else a fixed src1 vector maps to each run,
-    // which the driver slices for).
-    conf_.broadcast_src1_value = (conf_.op_type == op_t::n_c_spatial
-                                         && conf_.bcast_type == bcast_t::per_c)
-            || (utils::one_of(conf_.op_type, op_t::n_spatial_c, op_t::c_blocked)
-                    && conf_.bcast_type == bcast_t::per_w)
-            || conf_.bcast_type == bcast_t::scalar;
-    conf_.use_stride_src1 = !conf_.broadcast_src1_value
-            && (utils::one_of(
-                        conf_.bcast_type, bcast_t::none, bcast_t::per_batch)
-                    || (conf_.op_type == op_t::n_spatial_c
-                            && conf_.bcast_type == bcast_t::per_c)
-                    || (conf_.op_type == op_t::n_c_spatial
-                            && conf_.bcast_type == bcast_t::per_w));
 
-    const auto ndims = src0_md_.ndims();
-    if (conf_.is_src_different_layouts) {
-        const auto &strides0 = src0_md_.blocking_desc().strides;
-        const auto &strides1 = src1_md_.blocking_desc().strides;
-        conf_.src1_stride
-                = get_different_layout_stride(strides0, strides1, ndims);
-        conf_.outer_dims
-                = get_outer_dims_product(strides0, src0_md_.dims(), ndims);
-    }
-    if (conf_.bcast_type == bcast_t::per_w) {
-        for (int d = 2; d < ndims; ++d)
-            conf_.not_bcasted_sp_dims += !bcast_dims[d];
+    if (!use_standard_strategy) {
+        conf_.use_generic_strategy = true;
+        VDISPATCH_BINARY(init_generic_conf(),
+                "not applicable for current implementation");
+        // Generic calls are already sliced at a physical run boundary. Keep
+        // post-op RHS addressing in the general gather mode instead of routing
+        // it through a channel-aligned x64 strategy.
+        conf_.op_type = op_t::none;
+        conf_.bcast_type
+                = conf_.generic_scalar_inner ? bcast_t::scalar : bcast_t::none;
+        conf_.broadcast_src1_value = conf_.generic_scalar_inner;
+        conf_.use_stride_src1 = !conf_.generic_scalar_inner;
+        conf_.is_src_different_layouts = conf_.src1_stride > 1;
+        conf_.outer_dims = conf_.generic_inner;
+    } else {
+        conf_.postops_per_oc_broadcast_exists = postops_per_oc_broadcast_exists;
+        conf_.op_type = get_op_type(src0_md_);
+
+        const auto &bcast_dims = broadcast_dims();
+        conf_.bcast_type = is_tensor_op()
+                ? bcast_t::none
+                : get_bcast_type(src1_md_, bcast_dims);
+        // op_type only matters for broadcasted operation
+        VDISPATCH_BINARY(IMPLICATION(conf_.bcast_type != bcast_t::none,
+                                 conf_.op_type != op_t::none),
+                "unsupported src0 layout for broadcast operation");
+        // src1 addressing mode (x64 parity): a single value broadcast across the
+        // run, or advancing 1:1 with it (else a fixed src1 vector maps to each run,
+        // which the driver slices for).
+        conf_.broadcast_src1_value
+                = (conf_.op_type == op_t::n_c_spatial
+                          && conf_.bcast_type == bcast_t::per_c)
+                || (utils::one_of(
+                            conf_.op_type, op_t::n_spatial_c, op_t::c_blocked)
+                        && conf_.bcast_type == bcast_t::per_w)
+                || conf_.bcast_type == bcast_t::scalar;
+        conf_.use_stride_src1 = !conf_.broadcast_src1_value
+                && (utils::one_of(
+                            conf_.bcast_type, bcast_t::none, bcast_t::per_batch)
+                        || (conf_.op_type == op_t::n_spatial_c
+                                && conf_.bcast_type == bcast_t::per_c)
+                        || (conf_.op_type == op_t::n_c_spatial
+                                && conf_.bcast_type == bcast_t::per_w));
+
+        const auto ndims = src0_md_.ndims();
+        if (conf_.is_src_different_layouts) {
+            const auto &strides0 = src0_md_.blocking_desc().strides;
+            const auto &strides1 = src1_md_.blocking_desc().strides;
+            conf_.src1_stride
+                    = get_different_layout_stride(strides0, strides1, ndims);
+            conf_.outer_dims
+                    = get_outer_dims_product(strides0, src0_md_.dims(), ndims);
+        }
+        if (conf_.bcast_type == bcast_t::per_w) {
+            for (int d = 2; d < ndims; ++d)
+                conf_.not_bcasted_sp_dims += !bcast_dims[d];
+        }
     }
 
     if (is_ternary_op()) {
@@ -497,9 +536,153 @@ bool jit_uni_binary_t::pd_t::is_applicable() {
     }
 }
 
+bool jit_uni_binary_t::pd_t::init_generic_conf() {
+    const memory_desc_wrapper src0_d(src_md(0));
+    const memory_desc_wrapper src1_d(src_md(1));
+    const memory_desc_wrapper dst_d(dst_md());
+    if (!dst_d.is_dense(true) || !src0_d.is_dense(true)
+            || !src1_d.is_dense(true))
+        return false;
+    if (!src0_d.similar_to(dst_d, true, false)) return false;
+    if (is_ternary_op()) {
+        const memory_desc_wrapper src2_d(src_md(2));
+        if (!src2_d.is_dense(true)
+                || !src2_d.similar_to(src0_d, true, false, 0))
+            return false;
+    }
+
+    conf_.generic_ndims = dst_d.ndims();
+    conf_.generic_total = dst_d.nelems(false);
+    const bool has_padding = dst_d.nelems(true) != dst_d.nelems(false);
+
+    // Flat tensor and scalar cases keep one long VLA pass per thread.
+    if (!has_padding && src1_d.nelems(false) == 1) {
+        conf_.generic_whole = true;
+        conf_.generic_scalar_inner = true;
+        conf_.generic_inner = conf_.generic_total;
+        return true;
+    }
+    if (!has_padding && src1_d.similar_to(dst_d, true, false)) {
+        conf_.generic_whole = true;
+        conf_.generic_inner = conf_.generic_total;
+        return true;
+    }
+
+    // Build a physical-dimension iteration plan. dst is walked in contiguous
+    // order; each src1 dimension either broadcasts (stride 0) or follows its
+    // memory descriptor. A single channel inner block is represented as an
+    // extra unit-stride physical dimension.
+    const auto &dst_bd = dst_d.blocking_desc();
+    const auto &src1_bd = src1_d.blocking_desc();
+    const bool src1_scalar = src1_d.nelems(false) == 1;
+    if (dst_bd.inner_nblks > 1) return false;
+
+    const int blocked_dim = dst_bd.inner_nblks == 1 ? dst_bd.inner_idxs[0] : -1;
+    const dim_t block = dst_bd.inner_nblks == 1 ? dst_bd.inner_blks[0] : 1;
+    const bool src1_blocked = src1_bd.inner_nblks == 1 && blocked_dim >= 0
+            && src1_bd.inner_idxs[0] == blocked_dim
+            && src1_bd.inner_blks[0] == block;
+    if (src1_bd.inner_nblks != 0 && !src1_blocked && !src1_scalar) return false;
+
+    const dim_t *dst_dims = dst_d.dims();
+    const dim_t *src1_dims = src1_d.dims();
+    const auto &dst_strides = dst_bd.strides;
+    const auto &src1_strides = src1_bd.strides;
+    for (int d = 0; d < conf_.generic_ndims; ++d)
+        if (src1_dims[d] != 1 && src1_dims[d] != dst_dims[d]) return false;
+
+    if (has_padding) {
+        if (blocked_dim != 1 || block > 16 || (block & (block - 1)) != 0)
+            return false;
+        for (int d = 0; d < conf_.generic_ndims; ++d)
+            if (d != blocked_dim && dst_d.padded_dims()[d] != dst_dims[d])
+                return false;
+        if (dst_d.padded_dims()[blocked_dim]
+                != utils::rnd_up(dst_dims[blocked_dim], block))
+            return false;
+        conf_.generic_tail = dst_dims[blocked_dim] % block;
+    }
+
+    struct physical_dim_t {
+        dim_t size;
+        dim_t src1_stride;
+        dim_t dst_stride;
+        int logical_dim;
+    } physical_dims[DNNL_MAX_NDIMS + 1];
+    int nphysical = 0;
+    for (int d = 0; d < conf_.generic_ndims; ++d) {
+        const dim_t outer_size = d == blocked_dim
+                ? utils::div_up(dst_dims[d], block)
+                : dst_dims[d];
+        if (outer_size < 1) return false;
+        const dim_t src1_stride = src1_dims[d] == 1
+                ? 0
+                : (d == blocked_dim && !src1_blocked ? src1_strides[d] * block
+                                                     : src1_strides[d]);
+        physical_dims[nphysical++]
+                = {outer_size, src1_stride, dst_strides[d], d};
+    }
+    for (int a = 0; a < nphysical; ++a)
+        for (int b = a + 1; b < nphysical; ++b)
+            if (physical_dims[b].dst_stride > physical_dims[a].dst_stride) {
+                const auto tmp = physical_dims[a];
+                physical_dims[a] = physical_dims[b];
+                physical_dims[b] = tmp;
+            }
+    if (blocked_dim >= 0) {
+        const dim_t src1_inner_stride = src1_dims[blocked_dim] == 1
+                ? 0
+                : (src1_blocked ? 1 : src1_strides[blocked_dim]);
+        physical_dims[nphysical++] = {block, src1_inner_stride, 1, blocked_dim};
+    }
+
+    // Coalesce adjacent physical dimensions while both dst and src1 remain
+    // uniform. Preserve enough outer runs to expose all available threads and
+    // keep padded channel blocks separate for explicit tail zeroing.
+    const dim_t min_outer = dnnl_get_max_threads();
+    while (conf_.generic_tail == 0 && nphysical >= 2) {
+        const auto inner = physical_dims[nphysical - 1];
+        const auto outer = physical_dims[nphysical - 2];
+        if (outer.dst_stride != inner.dst_stride * inner.size) break;
+        const bool both_broadcast
+                = outer.src1_stride == 0 && inner.src1_stride == 0;
+        const bool uniform = inner.src1_stride != 0
+                && outer.src1_stride == inner.src1_stride * inner.size;
+        if (!both_broadcast && !uniform) break;
+        dim_t outer_runs = 1;
+        for (int d = 0; d + 2 < nphysical; ++d)
+            outer_runs *= physical_dims[d].size;
+        if (outer_runs < min_outer) break;
+        physical_dims[nphysical - 2].size = outer.size * inner.size;
+        physical_dims[nphysical - 2].src1_stride = inner.src1_stride;
+        physical_dims[nphysical - 2].dst_stride = inner.dst_stride;
+        --nphysical;
+    }
+
+    const auto &inner = physical_dims[nphysical - 1];
+    if (inner.dst_stride != 1) return false;
+    conf_.generic_inner = inner.size;
+    conf_.generic_scalar_inner = inner.src1_stride == 0;
+    conf_.src1_stride = nstl::max((dim_t)1, inner.src1_stride);
+    conf_.generic_n_outer = 1;
+    conf_.generic_ndims = nphysical;
+    for (int d = 0; d < nphysical - 1; ++d) {
+        conf_.generic_outer_dims[d] = physical_dims[d].size;
+        conf_.generic_src1_strides[d] = physical_dims[d].src1_stride;
+        conf_.generic_n_outer *= physical_dims[d].size;
+        if (conf_.generic_tail != 0
+                && physical_dims[d].logical_dim == blocked_dim)
+            conf_.generic_tail_axis = d;
+    }
+    if (conf_.generic_tail != 0 && conf_.generic_tail_axis < 0) return false;
+    conf_.generic_src1_same_layout = src1_d.similar_to(dst_d, true, false);
+    return true;
+}
+
 bool jit_uni_binary_t::post_ops_ok(const primitive_attr_t *attr,
         const memory_desc_wrapper &src0_d, const memory_desc_wrapper &dst_d,
-        const bool is_src_different_layouts, const cpu_isa_t isa) {
+        const bool is_src_different_layouts, const cpu_isa_t isa,
+        const bool use_generic_strategy) {
     using namespace injector;
     using namespace primitive_kind;
 
@@ -537,8 +720,8 @@ bool jit_uni_binary_t::post_ops_ok(const primitive_attr_t *attr,
     for (int i = 0; i < p.len(); i++) {
         if (is_binary(i)) {
             const auto &post_ops_mem = p.entry_[i].binary.src1_desc;
-            const bool is_src1_xf16 = utils::one_of(post_ops_mem.data_type,
-                    data_type::f16, data_type::bf16);
+            const bool is_src1_xf16 = utils::one_of(
+                    post_ops_mem.data_type, data_type::f16, data_type::bf16);
             // x64 parity: an i8 dst rejects an xf16 binary post-op rhs.
             if (is_i8 && is_src1_xf16) return false;
             // TODO: eliminate in favor of check in injectors::post_ops_ok
@@ -555,12 +738,14 @@ bool jit_uni_binary_t::post_ops_ok(const primitive_attr_t *attr,
     const bool postops_per_oc_broadcast_exists
             = binary_injector::any_binary_postop_rhs_per_oc_broadcast(
                     p, src0_d, supported_strategies);
-    if (postops_per_oc_broadcast_exists && is_src_different_layouts)
+    if (!use_generic_strategy && postops_per_oc_broadcast_exists
+            && is_src_different_layouts)
         return false;
 
     const bool blocked_format = !src0_d.is_plain() && src0_d.is_blocking_desc();
 
-    if (postops_per_oc_broadcast_exists && blocked_format) {
+    if (!use_generic_strategy && postops_per_oc_broadcast_exists
+            && blocked_format) {
         /*
          * check blocking_desc consistency: with a per_oc rhs the per-C driver
          * slicing and the injector's channel recovery assume the only inner
@@ -949,6 +1134,73 @@ void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
     }
 }
 
+void jit_uni_binary_t::execute_generic_strategy(const data_t *src0,
+        const data_t *src1, const data_t *src2, data_t *dst, float scale0,
+        float scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec) const {
+    const auto conf = pd()->get_conf();
+    const size_t es0 = types::data_type_size(conf.src0_type);
+    const size_t es1 = types::data_type_size(conf.src1_type);
+    const size_t esd = types::data_type_size(conf.dst_type);
+    const size_t es2 = conf.is_ternary_op
+            ? types::data_type_size(pd()->src_md(2)->data_type)
+            : 0;
+    const void *const *rhs_ptrs = post_ops_binary_rhs_arg_vec.empty()
+            ? nullptr
+            : post_ops_binary_rhs_arg_vec.data();
+
+    auto call = [&](dim_t off0, dim_t off1, dim_t offd, dim_t work) {
+        jit_uni_binary_args_t p = {};
+        p.src0 = src0 + off0 * es0;
+        p.src1 = src1 + off1 * es1;
+        if (conf.is_ternary_op) p.src2 = src2 + offd * es2;
+        p.dst = dst + offd * esd;
+        p.post_ops_binary_rhs_arg_vec = rhs_ptrs;
+        p.work_amount = work;
+        p.scales_src0 = scale0;
+        p.scales_src1 = scale1;
+        p.sum_scale = conf.sum_scale;
+        p.dst_orig = dst;
+        (*kernel_)(&p);
+    };
+
+    if (conf.generic_whole) {
+        parallel(0, [&](int ithr, int nthr) {
+            dim_t start = 0, end = 0;
+            balance211(conf.generic_total, nthr, ithr, start, end);
+            if (start >= end) return;
+            call(start, conf.generic_scalar_inner ? 0 : start, start,
+                    end - start);
+        });
+        return;
+    }
+
+    parallel(0, [&](int ithr, int nthr) {
+        dim_t begin = 0, end = 0;
+        balance211(conf.generic_n_outer, nthr, ithr, begin, end);
+        for (dim_t outer = begin; outer < end; ++outer) {
+            dim_t src1_off = 0;
+            dim_t rem = outer;
+            bool tail_run = false;
+            for (int d = conf.generic_ndims - 2; d >= 0; --d) {
+                const dim_t dim = conf.generic_outer_dims[d];
+                const dim_t index = rem % dim;
+                rem /= dim;
+                src1_off += index * conf.generic_src1_strides[d];
+                if (d == conf.generic_tail_axis) tail_run = index == dim - 1;
+            }
+            if (conf.generic_src1_same_layout)
+                src1_off = outer * conf.generic_inner;
+            const dim_t run = tail_run ? conf.generic_tail : conf.generic_inner;
+            const dim_t dst_off = outer * conf.generic_inner;
+            call(dst_off, src1_off, dst_off, run);
+            if (run < conf.generic_inner)
+                std::memset(dst + (dst_off + run) * esd, 0,
+                        (conf.generic_inner - run) * esd);
+        }
+    });
+}
+
 status_t jit_uni_binary_t::execute(const exec_ctx_t &ctx) const {
     auto src0 = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC_0);
     auto src1 = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC_1);
@@ -1021,7 +1273,10 @@ status_t jit_uni_binary_t::execute(const exec_ctx_t &ctx) const {
     const bool route_postops_per_oc
             = conf.postops_per_oc_broadcast_exists && op_type != op_t::none;
 
-    if ((bcast_type == bcast_t::none || point_broadcast_no_oc_tail)
+    if (conf.use_generic_strategy)
+        execute_generic_strategy(src0, src1, src2, dst, scale0, scale1,
+                post_ops_binary_rhs_arg_vec);
+    else if ((bcast_type == bcast_t::none || point_broadcast_no_oc_tail)
             && !route_postops_per_oc && !blocked_oc_tail)
         execute_no_bcast_strategy(src0, src1, src2, dst, scale0, scale1,
                 post_ops_binary_rhs_arg_vec, bcast_type);

--- a/src/cpu/rv64/jit_uni_binary.cpp
+++ b/src/cpu/rv64/jit_uni_binary.cpp
@@ -1,4 +1,5 @@
 /*******************************************************************************
+* Copyright 2019 Intel Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,18 +14,21 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 *******************************************************************************/
-#include <algorithm>
-#include <cstddef>
+
+#include <cassert>
 #include <cstring>
+#include <limits>
 #include <vector>
 
+#include "common/broadcast_strategy.hpp"
 #include "common/c_types_map.hpp"
 #include "common/dnnl_thread.hpp"
 #include "common/memory_desc_wrapper.hpp"
+#include "common/nstl.hpp"
 #include "common/type_helpers.hpp"
 
+#include "cpu/binary_injector_utils.hpp"
 #include "cpu/rv64/injectors/jit_uni_postops_injector.hpp"
-#include "cpu/rv64/jit_generator.hpp"
 #include "cpu/rv64/jit_uni_binary.hpp"
 
 namespace dnnl {
@@ -32,753 +36,1007 @@ namespace impl {
 namespace cpu {
 namespace rv64 {
 
-using namespace Xbyak_riscv;
+// The x64 binary primitive's set. The rv64 injector itself realizes the wider
+// aarch64 set (get_all_strategies_supported_by_injector adds per_mb_spatial/
+// per_mb_w via the per-lane gather), but as on x64 the binary primitive does
+// not advertise those: such a post-op rhs classifies as unsupported here and
+// the primitive defers to ref.
+static bcast_set_t get_supported_postops_bcast_strategies() {
+    return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
+            broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::per_w,
+            broadcasting_strategy_t::no_broadcast};
+}
 
-// Config baked into the kernel (broadcast/dtype/attr shape is compile-time; the
-// scale/sum values and pointers arrive at run time via call_params_t).
-struct binary_kernel_conf_t {
-    alg_kind_t alg;
-    bool scalar_src1; // src1 broadcasts the vectorized (inner) dim
-    data_type_t dt_s0, dt_s1, dt_dst;
-    bool do_scale0, do_scale1, do_sum;
-    bool has_binary_po; // chain contains a binary post-op (advance rhs off)
-    // src1 inner-dim element stride: 1 = contiguous (vle); >1 = strided (vlse,
-    // src0/src1 different layouts, e.g. nchw:nhwc); ignored when scalar_src1.
-    dim_t s1_inner_stride;
-    bool is_select; // ternary select: dst = src2 ? src0 : src1 (src2 is s8)
-    post_ops_t post_ops; // full post-op chain (sums applied in attribute order)
-    const memory_desc_t *dst_md = nullptr; // for per_oc binary post-op rhs
-    // Emit the unrolled (three src0/src1 pairs per step) f32 main loop; the
-    // host enables it only for the streaming f32 case it applies to.
-    bool unrolled = false;
-    // Emit the narrow (single m1-vector, strictly interleaved) f32 main loop
-    // instead — same streaming gate, selected per call at low thread counts.
-    bool narrow = false;
-};
+static bool compare_layouts(const memory_desc_wrapper &src0_md,
+        const memory_desc_wrapper &src1_md) {
+    const strides_t &strides0 = src0_md.blocking_desc().strides;
+    const strides_t &strides1 = src1_md.blocking_desc().strides;
+    const dims_t &dims0 = src0_md.dims();
+    const dims_t &dims1 = src1_md.dims();
+    const int ndims = src0_md.ndims();
 
-struct jit_uni_binary_kernel_t : public jit_generator_t {
-    struct call_params_t {
-        const void *src0;
-        const void *src1;
-        const void *src2; // ternary select condition (s8), else null
-        const void *dst;
-        const void *const *rhs_ptrs; // binary post-op rhs base array, or null
-        dim_t len;
-        size_t rhs_off; // element offset of the first lane for binary post-op rhs
-        float scale0, scale1, sum_scale;
-    };
-    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_binary_kernel_t)
+    bool is_bcast = false;
+    for (int d = 1; d < ndims; d++)
+        is_bcast = is_bcast || dims0[d] != dims1[d];
+    if (is_bcast) return true;
 
-    jit_uni_binary_kernel_t(const binary_kernel_conf_t &c)
-        : jit_generator_t("jit_uni_binary"), c_(c) {}
-    void operator()(const call_params_t *p) const {
-        jit_generator_t::operator()(p);
+    bool same_layouts = true;
+    // For batch size == 1, the first dimension is ignored for stride checks,
+    // as non-contiguous strides in this dimension do not affect correctness.
+    int start_dim = (dims0[0] == 1 && dims1[0] == 1) ? 1 : 0;
+    for (int d = start_dim; d < ndims; ++d)
+        same_layouts = same_layouts && strides0[d] == strides1[d];
+    return same_layouts;
+}
+
+static dim_t get_different_layout_stride(
+        const strides_t &strides0, const strides_t &strides1, const int ndims) {
+    for (int d = 0; d < ndims; d++)
+        if (strides0[d] == 1) return strides1[d];
+    return strides1[ndims - 1];
+}
+
+static dim_t get_outer_dims_product(
+        const strides_t &strides0, const dims_t &dims, const int ndims) {
+    // nchw:nhwc->nchw
+    if (strides0[1] == 1) return dims[1];
+    // nhwc:nchw->nhwc
+    else if (strides0[ndims - 1] == 1)
+        return utils::array_product(dims + 2, ndims - 2);
+    else
+        return dims[ndims - 1];
+}
+
+// Runtime-dispatch analog of x64's data_type_supported(dtype, isa): this
+// primitive is pure JIT registered via CPU_INSTANCE_RV64, so the dtype gate
+// carries the mayiuse checks for the f16 (zvfh) and bf16 (zvfbfwma) paths.
+// f32/s32/s8/u8 are always supported (as on x64).
+static bool data_type_supported(const data_type_t dtype) {
+    switch (dtype) {
+        case data_type::f16: return mayiuse(zvfh);
+        case data_type::bf16: return mayiuse(zvfbfwma);
+        case data_type::f32:
+        case data_type::s32:
+        case data_type::s8:
+        case data_type::u8: return true;
+        default: return false;
+    }
+}
+
+static bool data_format_supported(const memory_desc_wrapper &mdw) {
+    if (mdw.is_plain()) return true;
+    // The {16, 8, 4} channel-block family x64 supports on its widest isa;
+    // RVV's VLA code has no per-isa block split.
+    const auto blk_size = mdw.blocking_desc().inner_blks[0];
+    return utils::one_of(blk_size, 16, 8, 4);
+}
+
+status_t jit_uni_binary_t::pd_t::init(const engine_t *engine) {
+    UNUSED(engine);
+    using sm = primitive_attr_t::skip_mask_t;
+
+    conf_.dst_type = dst_md()->data_type;
+    conf_.src0_type = src_md(0)->data_type;
+    conf_.src1_type = src_md(1)->data_type;
+
+    memory_desc_wrapper dst_md_(dst_md());
+    memory_desc_wrapper src0_md_(src_md(0));
+    memory_desc_wrapper src1_md_(src_md(1));
+
+    const auto &po = attr()->post_ops_;
+    const int elt_idx = po.find(primitive_kind::eltwise);
+    conf_.is_i8 = utils::one_of(conf_.dst_type, data_type::s8, data_type::u8);
+
+    // RVV is not part of the rv64gc baseline: gate the whole primitive on the
+    // V extension at runtime.
+    VDISPATCH_BINARY(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
+
+    // The supported algorithms are checked explicitly (instead of accepting
+    // whatever the common layer validated) to avoid silently taking on new,
+    // unsupported algorithms in the future; the set matches x64 (aarch64
+    // additionally excludes binary_select).
+    const bool alg_ok = utils::one_of(desc()->alg_kind, alg_kind::binary_add,
+            alg_kind::binary_sub, alg_kind::binary_mul, alg_kind::binary_div,
+            alg_kind::binary_ge, alg_kind::binary_gt, alg_kind::binary_le,
+            alg_kind::binary_lt, alg_kind::binary_eq, alg_kind::binary_ne,
+            alg_kind::binary_max, alg_kind::binary_min,
+            alg_kind::binary_select);
+    VDISPATCH_BINARY(alg_ok, VERBOSE_BAD_ALGORITHM);
+
+    VDISPATCH_BINARY(
+            data_type_supported(conf_.dst_type), VERBOSE_UNSUPPORTED_DT);
+    VDISPATCH_BINARY(
+            data_type_supported(conf_.src0_type), VERBOSE_UNSUPPORTED_DT);
+    VDISPATCH_BINARY(
+            data_type_supported(conf_.src1_type), VERBOSE_UNSUPPORTED_DT);
+    VDISPATCH_BINARY(data_format_supported(src0_md_), VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_BINARY_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_BINARY(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "src0");
+    // x64's non-int8 rule: src0 and dst share one memory desc (layout and
+    // dtype). i8 (quantized) dst may differ from src0 (e.g. f32 src0 -> s8 dst).
+    VDISPATCH_BINARY(IMPLICATION(!conf_.is_i8, src0_md_ == dst_md_),
+            VERBOSE_INCONSISTENT_MDS, "src", "dst");
+    VDISPATCH_BINARY(
+            is_applicable(), "not applicable for current implementation");
+    VDISPATCH_BINARY(attr()->has_default_values(sm::post_ops | sm::scales),
+            VERBOSE_UNSUPPORTED_ATTR);
+    // Resolve formats before classifying the post-op chain: the post-op
+    // binary rhs may arrive as `any`, and post_ops_ok() compares the rhs
+    // layout to dst -- x64's ordering, so a dst-shaped (per_element) rhs is
+    // not spuriously rejected.
+    VDISPATCH_BINARY_SC(
+            attr_.set_default_formats(dst_md(0)), VERBOSE_UNSUPPORTED_POSTOP);
+
+    // All operations over blocking descriptors should have md initialized.
+    conf_.is_src_different_layouts = !compare_layouts(src0_md_, src1_md_);
+    const cpu_isa_t postops_isa = mayiuse(zvfbfwma)
+            ? zvfbfwma
+            : (mayiuse(zvfh) ? zvfh : v);
+    VDISPATCH_BINARY(
+            post_ops_ok(attr(), src_md(0), dst_md(),
+                    conf_.is_src_different_layouts, postops_isa),
+            VERBOSE_UNSUPPORTED_POSTOP);
+    VDISPATCH_BINARY(
+            (conf_.is_i8 || elt_idx == -1
+                    || IMPLICATION(!dst_md_.is_dense(),
+                            cpu_eltwise_fwd_pd_t::eltwise_preserves_zero(
+                                    po.entry_[elt_idx].eltwise))),
+            "unsupported datatype or sparse configuration");
+    VDISPATCH_BINARY(IMPLICATION((!attr()->scales_.has_default_values()),
+                             check_scales_mask()),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+    conf_.postops_per_oc_broadcast_exists
+            = binary_injector::any_binary_postop_rhs_per_oc_broadcast(
+                    po, src0_md_, get_supported_postops_bcast_strategies());
+    conf_.op_type = get_op_type(src0_md_);
+    conf_.do_scale_src0 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
+    conf_.do_scale_src1 = !attr()->scales_.has_default_values(DNNL_ARG_SRC_1);
+    const auto sum_idx = po.find(primitive_kind::sum);
+    conf_.do_sum = sum_idx != -1 && po.entry_[sum_idx].sum.scale != 0.f;
+    conf_.with_eltwise = po.find(primitive_kind::eltwise) != -1;
+    conf_.with_binary = po.find(primitive_kind::binary) != -1;
+    conf_.with_postops
+            = conf_.with_binary || conf_.with_eltwise || conf_.do_sum;
+    conf_.sum_scale = conf_.do_sum ? po.entry_[sum_idx].sum.scale : 0.f;
+    const auto &bcast_dims = broadcast_dims();
+    conf_.bcast_type = is_tensor_op() ? bcast_t::none
+                                      : get_bcast_type(src1_md_, bcast_dims);
+    // op_type only matters for broadcasted operation
+    VDISPATCH_BINARY(IMPLICATION(conf_.bcast_type != bcast_t::none,
+                             conf_.op_type != op_t::none),
+            "unsupported src0 layout for broadcast operation");
+    // src1 addressing mode (x64 parity): a single value broadcast across the
+    // run, or advancing 1:1 with it (else a fixed src1 vector maps to each run,
+    // which the driver slices for).
+    conf_.broadcast_src1_value = (conf_.op_type == op_t::n_c_spatial
+                                         && conf_.bcast_type == bcast_t::per_c)
+            || (utils::one_of(conf_.op_type, op_t::n_spatial_c, op_t::c_blocked)
+                    && conf_.bcast_type == bcast_t::per_w)
+            || conf_.bcast_type == bcast_t::scalar;
+    conf_.use_stride_src1 = !conf_.broadcast_src1_value
+            && (utils::one_of(
+                        conf_.bcast_type, bcast_t::none, bcast_t::per_batch)
+                    || (conf_.op_type == op_t::n_spatial_c
+                            && conf_.bcast_type == bcast_t::per_c)
+                    || (conf_.op_type == op_t::n_c_spatial
+                            && conf_.bcast_type == bcast_t::per_w));
+
+    const auto ndims = src0_md_.ndims();
+    if (conf_.is_src_different_layouts) {
+        const auto &strides0 = src0_md_.blocking_desc().strides;
+        const auto &strides1 = src1_md_.blocking_desc().strides;
+        conf_.src1_stride
+                = get_different_layout_stride(strides0, strides1, ndims);
+        conf_.outer_dims
+                = get_outer_dims_product(strides0, src0_md_.dims(), ndims);
+    }
+    if (conf_.bcast_type == bcast_t::per_w) {
+        for (int d = 2; d < ndims; ++d)
+            conf_.not_bcasted_sp_dims += !bcast_dims[d];
     }
 
-#define GET_OFF(f) (int)offsetof(call_params_t, f)
-    void generate() override {
-        ld(a1, a0, GET_OFF(src0));
-        ld(a2, a0, GET_OFF(src1));
-        ld(a5, a0, GET_OFF(src2));
-        ld(a3, a0, GET_OFF(dst));
-        ld(a6, a0, GET_OFF(rhs_ptrs));
-        ld(a4, a0, GET_OFF(len));
-        ld(a7, a0, GET_OFF(rhs_off));
-        flw(fa4, a0, GET_OFF(scale0));
-        flw(fa5, a0, GET_OFF(scale1));
-        flw(fa6, a0, GET_OFF(sum_scale));
-        emit_binary(); // handles the ordinary ops and ternary select
-        ret();
-    }
-#undef GET_OFF
-
-private:
-    const binary_kernel_conf_t c_;
-
-    // Registers (e32/m4 compute): a1=src0 a2=src1 a3=dst a4=len a5=src2
-    // a6=rhs_ptrs a7=rhs_off(elems); t0=vl t1=bytes t2/t3=scratch; t4/t5/t6
-    // hold the unrolled-loop strides (f32 bytes / step elements / stream
-    // step); v0=mask
-    // v4=acc v8=src1f32 v12/v16=narrow staging v20=binary-rhs; fa2=const
-    // fa3=scalar-src1 fa4/fa5=scales fa6=sum fa7=binary-rhs-scalar
-    // fa0/fa1=eltwise injector scratch; ft0/ft1=compare-result constants.
-    const Reg p0 = a1, p1 = a2, pd = a3, len = a4, p2 = a5, rhs_ptrs = a6,
-              off = a7, vl = t0, bytes = t1, gpr = t2;
-    const VReg vd {4}, vs1 {8}, st0 {12}, st1 {16}, vrhs {20};
-    const FReg f_s1 = fa3, f_sc0 = fa4, f_sc1 = fa5, f_sum = fa6, fc = fa2,
-               f_zero = ft0, f_one = ft1;
-
-    void setf(const FReg &f, float val) {
-        uint32_t b;
-        std::memcpy(&b, &val, sizeof(b));
-        li(gpr, b);
-        fmv_w_x(f, gpr);
+    if (is_ternary_op()) {
+        conf_.is_ternary_op = true;
+        // The common binary descriptor forces the condition src2 to s8; keep
+        // the check explicit (x64 validates the src2 dtype the same way).
+        VDISPATCH_BINARY(
+                src_md(2)->data_type == data_type::s8, VERBOSE_UNSUPPORTED_DT);
     }
 
-    // Set vl for `len` elements at the e32/m4 compute vtype.
-    void set_compute_vl() {
-        vsetvli(vl, len, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
-    }
-    void to_compute_vtype() {
-        vsetvli(x0, vl, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    return status::success;
+}
+
+op_t jit_uni_binary_t::pd_t::get_op_type(const memory_desc_wrapper &src0_d) {
+    const auto &strides = src0_d.blocking_desc().strides;
+    const auto ndims = src0_d.ndims();
+
+    if (!src0_d.is_plain() && src0_d.blocking_desc().inner_idxs[0] == 1)
+        return op_t::c_blocked;
+    else if (strides[1] == 1)
+        return op_t::n_spatial_c;
+    else if (strides[0] >= strides[1]
+            && IMPLICATION(ndims >= 3, strides[1] >= strides[2]))
+        return op_t::n_c_spatial;
+    return op_t::none;
+}
+
+bool jit_uni_binary_t::pd_t::is_only_dim0_bcasted(
+        const dims_t &bcast_dims, const int ndims) {
+    bool only_dim0_bcasted = true;
+    for (int d = 1; d < ndims; d++)
+        only_dim0_bcasted = only_dim0_bcasted && bcast_dims[d] == 0;
+    return only_dim0_bcasted;
+}
+
+// non-blocked: nxc || ncx
+bool jit_uni_binary_t::pd_t::is_format_non_blocked(
+        const memory_desc_wrapper &mdw) const {
+    const auto &dims = mdw.dims();
+    const auto &strides = mdw.blocking_desc().strides;
+    const auto &ndims = mdw.ndims();
+
+    const bool is_ncx
+            = IMPLICATION(strides[0] != 0,
+                      strides[0] >= utils::array_product(dims + 1, ndims - 1))
+            && IMPLICATION(ndims >= 3 && strides[1] != 0,
+                    strides[1] >= utils::array_product(dims + 2, ndims - 2))
+            && IMPLICATION(ndims >= 4 && strides[2] != 0,
+                    strides[2] >= utils::array_product(dims + 3, ndims - 3))
+            && IMPLICATION(ndims >= 5 && strides[3] != 0,
+                    strides[3] >= utils::array_product(dims + 4, ndims - 4))
+            && IMPLICATION(strides[ndims - 1] != 0, strides[ndims - 1] == 1);
+    const bool is_nxc
+            = IMPLICATION(strides[0] != 0,
+                      strides[0] >= utils::array_product(dims + 1, ndims - 1))
+            && IMPLICATION(ndims >= 3 && strides[2] != 0,
+                    strides[2] >= dims[1]
+                                    * utils::array_product(dims + 3, ndims - 3))
+            && IMPLICATION(ndims >= 4 && strides[3] != 0,
+                    strides[3] >= dims[1]
+                                    * utils::array_product(dims + 4, ndims - 4))
+            && IMPLICATION(ndims >= 5 && strides[4] != 0,
+                    strides[4] >= dims[1]
+                                    * utils::array_product(dims + 5, ndims - 5))
+            && IMPLICATION(strides[1] != 0, strides[1] == 1);
+    return is_nxc || is_ncx;
+}
+
+bcast_t jit_uni_binary_t::pd_t::get_bcast_type(
+        const memory_desc_wrapper &src1_d, const dims_t &bcast_dims) {
+    if (src1_d.nelems() == 1)
+        return bcast_t::scalar;
+    else if (bcast_dims[1] == 1)
+        return bcast_t::per_w;
+    else if (is_only_dim0_bcasted(bcast_dims, src1_d.ndims()))
+        return bcast_t::per_batch;
+    else
+        return bcast_t::per_c;
+}
+
+bool jit_uni_binary_t::pd_t::alg_preserves_zero() const {
+    using namespace utils;
+    using namespace alg_kind;
+    return utils::one_of(desc()->alg_kind, binary_add, binary_max, binary_min,
+            binary_mul, binary_sub, binary_ge, binary_gt, binary_le, binary_lt,
+            binary_eq, binary_ne, binary_select);
+}
+
+bool jit_uni_binary_t::pd_t::check_scales_mask() const {
+    const std::vector<int> supported_args = {DNNL_ARG_SRC_0, DNNL_ARG_SRC_1};
+    return attr_scales_ok(supported_args);
+}
+
+bool jit_uni_binary_t::pd_t::is_bcast_pattern(const dims_t &bcast_dims,
+        const dim_t ndims, const dim_t N_bcast, const dim_t C_bcast,
+        const dim_t W_bcast) const {
+    return bcast_dims[0] == N_bcast && bcast_dims[1] == C_bcast
+            && bcast_dims[ndims - 1] == W_bcast;
+}
+
+bool jit_uni_binary_t::pd_t::is_bcast_allowed(const int ndims) const {
+    // supported cases: NxCxDxHxW:{NxCx1x1x1,1xCx1x1x1,Nx1xDxHxW,Nx1x1xHxW,
+    //                            Nx1x1x1xW,1xCxDxHxW,1x1xDxHxW,1x1x1xHxW,
+    //                            1x1x1x1xW,1x1x1x1x1}
+    const auto &bcast_dims = broadcast_dims();
+    // check if there is continuous broadcast between non-broadcast dims
+    // if next_bcast_expected == 1, not broadcast dim not met
+    int next_bcast_expected = 1;
+    bool sp_not_bcasted = true;
+    bool ok = true;
+    for (int d = 2; d < ndims; ++d) {
+        if (bcast_dims[d] == 0)
+            next_bcast_expected = 0;
+        else
+            sp_not_bcasted = false;
+        ok = ok && bcast_dims[d] == next_bcast_expected;
     }
 
-    // Load `vl` elements of dtype dt from `ptr` into f32 group vf (e32/m4),
-    // using `stage` for narrow staging. Ends at the e32/m4 vtype. stride_elems>1
-    // reads with an element stride (vlse) — src0/src1 different plain layouts.
-    void load_vec(data_type_t dt, const VReg &vf, const VReg &stage,
-            const Reg &ptr, dim_t stride_elems = 1) {
-        using namespace data_type;
-        const bool strided = stride_elems > 1;
-        if (strided) li(t3, stride_elems * (int)types::data_type_size(dt));
-        auto ld = [&](int w, const VReg &v) {
-            if (w == 32)
-                strided ? vlse32_v(v, ptr, t3) : vle32_v(v, ptr);
-            else if (w == 16)
-                strided ? vlse16_v(v, ptr, t3) : vle16_v(v, ptr);
-            else
-                strided ? vlse8_v(v, ptr, t3) : vle8_v(v, ptr);
+#define BCAST_PATTERN(N, C, W, condition) \
+    (is_bcast_pattern(bcast_dims, ndims, N, C, W) && (condition))
+    if (ndims > 2)
+        ok = ok
+                && (BCAST_PATTERN(0, 1, 0, true) || BCAST_PATTERN(1, 1, 0, true)
+                        || BCAST_PATTERN(1, 0, 0, sp_not_bcasted)
+                        || BCAST_PATTERN(0, 0, 1, !!next_bcast_expected)
+                        || BCAST_PATTERN(1, 0, 1, !!next_bcast_expected)
+                        || BCAST_PATTERN(1, 1, 1, !!next_bcast_expected));
+#undef BCAST_PATTERN
+    return ok;
+}
+
+// check for different src formats with same dims
+// broadcast can be accepted if src_dim == src1_dims (1 == 1)
+bool jit_uni_binary_t::pd_t::is_different_layouts_allowed(
+        const memory_desc_wrapper &src0_d,
+        const memory_desc_wrapper &src1_d) const {
+    const dims_t &src0_dims = src0_d.dims();
+    const dims_t &src1_dims = src1_d.dims();
+    const int ndims = src0_d.ndims();
+
+    bool without_bcast = true;
+    for (int d = 0; d < ndims; d++)
+        without_bcast = without_bcast && src0_dims[d] == src1_dims[d];
+    if (!without_bcast) return false;
+
+    // allow nchw:nhwc and nhwc:nchw and disable for blocked layouts
+    return src0_d.is_plain() && src1_d.is_plain()
+            && is_format_non_blocked(src0_d) && is_format_non_blocked(src1_d);
+}
+
+bool jit_uni_binary_t::pd_t::is_applicable() {
+    const memory_desc_wrapper src0_d(src_md(0));
+    const memory_desc_wrapper src1_d(src_md(1));
+    const memory_desc_wrapper src2_d(src_md(2));
+    const memory_desc_wrapper dst_d(dst_md());
+    const auto ndims = src0_d.ndims();
+
+    // check density first to avoid same non-dense src0 and src1 to pass
+    // the next check
+    bool ok = src0_d.is_dense(true) && src1_d.is_dense(true)
+            && dst_d.is_dense(true);
+    ok = ok
+            && IMPLICATION(
+                    is_ternary_op(), src2_d.similar_to(src0_d, true, false, 0));
+    if (!ok) return false;
+
+    // Keep x64's padded-tensor family: a single blocking with block size <= 16.
+    const auto &blk_d = dst_d.blocking_desc();
+    if (!dst_d.is_dense()
+            && (blk_d.inner_nblks > 1 || blk_d.inner_blks[0] > 16))
+        return false;
+
+    const bool is_src_different_layouts = !compare_layouts(src0_d, src1_d);
+    const bool different_layouts_allowed
+            = is_different_layouts_allowed(src0_d, src1_d);
+    if (!conf_.is_i8) {
+        // Non-i8: padded tensors require a zero-preserving algorithm. (x64
+        // computes the padded lanes and relies on 0 OP 0 == 0; the rv64 driver
+        // explicitly zeroes the padded tail, but mirrors the accept surface.)
+        const bool has_padding = utils::one_of(true,
+                src0_d.nelems(true) != src0_d.nelems(false),
+                src1_d.nelems(true) != src1_d.nelems(false),
+                dst_d.nelems(true) != dst_d.nelems(false));
+        ok = IMPLICATION(has_padding, alg_preserves_zero());
+        if (!ok) return false;
+
+        // full tensor operation
+        bool same_dims = true;
+        const auto &src0_dims = src0_d.dims();
+        const auto &src1_dims = src1_d.dims();
+        for (int d = 0; d < ndims; d++)
+            same_dims = same_dims && src0_dims[d] == src1_dims[d];
+        if (same_dims
+                && IMPLICATION(
+                        is_src_different_layouts, different_layouts_allowed))
+            return true;
+    } else {
+        const dim_t C = ndims >= 2 ? src0_d.dims()[1] : 1;
+        const bool has_oc_tail = C != src0_d.padded_dims()[1];
+        const bool has_outer_dims_tail = is_src_different_layouts
+                && get_outer_dims_product(src0_d.blocking_desc().strides,
+                        src0_d.dims(), src0_d.ndims());
+
+        // Disable compare operations when blocked tag with tail. Tail
+        // processing is not supported and the comparison overwrites the output.
+        if (utils::one_of(desc()->alg_kind, alg_kind::binary_ge,
+                    alg_kind::binary_gt, alg_kind::binary_le,
+                    alg_kind::binary_lt, alg_kind::binary_eq,
+                    alg_kind::binary_ne)
+                && (has_oc_tail || has_outer_dims_tail))
+            return false;
+
+        // The kernel walks src0/src1/dst in flat physical lockstep, so an i8
+        // dst -- whose md is allowed to differ from src0's (f32 src0 -> s8 dst)
+        // -- must still share src0's physical layout; only the dtype may
+        // differ. This has to precede the full-tensor early return below:
+        // otherwise a same-shaped src1 lets a differently-laid-out dst through
+        // and the three walks desynchronize. It also keeps the original
+        // meaning for the broadcast path (source0 broadcast not supported).
+        if (!src0_d.similar_to(dst_d, true, false, 0)) return false;
+
+        // full tensor operation
+        if (src0_d.similar_to(src1_d, true, false, 0)
+                || different_layouts_allowed)
+            return true;
+    }
+
+    // broadcast or different layouts operation
+    if (!(is_bcast_allowed(ndims)
+                && IMPLICATION(
+                        is_src_different_layouts, different_layouts_allowed)))
+        return false;
+
+    // only nspc and ncsp formats are supported for bcast
+    if (src0_d.is_plain() && src1_d.is_plain())
+        return is_format_non_blocked(src0_d) && is_format_non_blocked(src1_d)
+                && get_op_type(src0_d) != op_t::none;
+
+    // blocked formats
+    if (!conf_.is_i8) {
+        // x64 additionally requires the channel block to equal the machine simd
+        // width; the VLA analog keeps the {16, 8, 4} single-C-block family (the
+        // driver handles the exact src1/dst block compatibility incl. a scalar
+        // src1).
+        const auto valid_bd = [&](const memory_desc_wrapper &mdw) {
+            const auto &bd = mdw.blocking_desc();
+            return bd.inner_nblks == 1
+                    && utils::one_of(bd.inner_blks[0], 16, 8, 4)
+                    && bd.inner_idxs[0] == 1;
         };
-        if (dt == f32) {
-            to_compute_vtype();
-            ld(32, vf);
-        } else if (dt == s32) {
-            to_compute_vtype();
-            ld(32, vf);
-            vfcvt_f_x_v(vf, vf);
-        } else if (dt == f16 || dt == bf16) {
-            vsetvli(x0, vl, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
-            ld(16, stage);
-            // e16m2 -> e32m4; Zvfbfmin for bf16, Zvfh for f16.
-            if (dt == bf16)
-                vfwcvtbf16_f_f_v(vf, stage);
-            else
-                vfwcvt_f_f_v(vf, stage);
-            to_compute_vtype();
-        } else { // s8 / u8
-            vsetvli(x0, vl, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
-            ld(8, stage);
-            to_compute_vtype();
-            if (dt == s8) {
-                vsext_vf4(vf, stage);
-                vfcvt_f_x_v(vf, vf);
-            } else {
-                vzext_vf4(vf, stage);
-                vfcvt_f_xu_v(vf, vf);
+        return valid_bd(src0_d) && valid_bd(src1_d);
+    } else {
+        const auto &bd0 = src0_d.blocking_desc();
+        const auto &bd1 = src1_d.blocking_desc();
+        const auto &bcast_dims = broadcast_dims();
+        // disable blocked tag for source1 when W is not broadcast
+        return bd0.strides[1] == 1 && bd0.inner_nblks == 0
+                && IMPLICATION(
+                        bcast_dims[ndims - 1] == 0, bd1.inner_nblks == 0);
+    }
+}
+
+bool jit_uni_binary_t::post_ops_ok(const primitive_attr_t *attr,
+        const memory_desc_wrapper &src0_d, const memory_desc_wrapper &dst_d,
+        const bool is_src_different_layouts, const cpu_isa_t isa) {
+    using namespace injector;
+    using namespace primitive_kind;
+
+    const auto &p = attr->post_ops_;
+    const auto supported_strategies = get_supported_postops_bcast_strategies();
+    // The kernel supplies 4 eltwise aux groups (heavy algs available) and
+    // keeps v0 dead across the inject point, so the select (ternary) post-op
+    // is enabled (x64 accepts it unconditionally).
+    if (!injector::post_ops_ok(post_ops_ok_args_t(isa, {binary, eltwise, sum},
+                p, &dst_d, false /*sum_at_pos_0_only*/,
+                false /*sum_requires_scale_one*/, true /*sum_requires_zp_zero*/,
+                true /*sum_requires_same_params*/, supported_strategies,
+                4 /*n_vaux*/, true /*allow_binary_select*/)))
+        return false;
+
+    // data type of int8 dst is allowed to differ from src0 unless there is a sum postop
+    if (p.find(primitive_kind::sum) != -1) {
+        if (src0_d.data_type() != dst_d.data_type()) return false;
+        // the in-kernel sum reads the old dst back at the dst dtype
+        for (int i = 0; i < p.len(); i++) {
+            if (!p.entry_[i].is_sum(false, false)) continue;
+            const auto &s = p.entry_[i].sum;
+            if (s.dt != data_type::undef && s.dt != dst_d.data_type())
+                return false;
+        }
+    }
+
+    // no prelu support
+    if (p.find(primitive_kind::prelu) != -1) return false;
+
+    const auto is_binary = [&](int idx) { return p.entry_[idx].is_binary(); };
+    const bool is_i8
+            = utils::one_of(dst_d.data_type(), data_type::s8, data_type::u8);
+
+    for (int i = 0; i < p.len(); i++) {
+        if (is_binary(i)) {
+            const auto &post_ops_mem = p.entry_[i].binary.src1_desc;
+            const bool is_src1_xf16 = utils::one_of(post_ops_mem.data_type,
+                    data_type::f16, data_type::bf16);
+            // x64 parity: an i8 dst rejects an xf16 binary post-op rhs.
+            if (is_i8 && is_src1_xf16) return false;
+            // TODO: eliminate in favor of check in injectors::post_ops_ok
+            // (conditions are slightly different, need to check corner cases)
+            if (get_rhs_arg_broadcasting_strategy(
+                        post_ops_mem, dst_d, supported_strategies)
+                    == broadcasting_strategy_t::no_broadcast) {
+                const memory_desc_wrapper post_op_mem_d(post_ops_mem);
+                if (!post_op_mem_d.similar_to(dst_d, true, false)) return false;
             }
         }
     }
 
-    // Load one scalar of dtype dt from ptr as f32 into FReg f.
-    void load_scalar(data_type_t dt, const FReg &f, const Reg &ptr) {
-        using namespace data_type;
-        if (dt == f32)
-            flw(f, ptr, 0);
-        else if (dt == s32) {
-            lw(gpr, ptr, 0);
-            fcvt_s_w(f, gpr);
-        } else if (dt == s8) {
-            lb(gpr, ptr, 0);
-            fcvt_s_w(f, gpr);
-        } else if (dt == u8) {
-            lbu(gpr, ptr, 0);
-            fcvt_s_wu(f, gpr);
-        } else { // f16 / bf16: widen via the vector unit, extract lane 0
-            li(gpr, 1);
-            vsetvli(x0, gpr, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
-            vle16_v(vrhs, ptr);
-            if (dt == bf16)
-                vfwcvtbf16_f_f_v(vs1, vrhs); // e16m1 -> e32m2
-            else
-                vfwcvt_f_f_v(vs1, vrhs); // e16m1 -> e32m2
-            vsetvli(x0, gpr, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
-            vfmv_f_s(f, vs1);
-        }
+    const bool postops_per_oc_broadcast_exists
+            = binary_injector::any_binary_postop_rhs_per_oc_broadcast(
+                    p, src0_d, supported_strategies);
+    if (postops_per_oc_broadcast_exists && is_src_different_layouts)
+        return false;
+
+    const bool blocked_format = !src0_d.is_plain() && src0_d.is_blocking_desc();
+
+    if (postops_per_oc_broadcast_exists && blocked_format) {
+        /*
+         * check blocking_desc consistency: with a per_oc rhs the per-C driver
+         * slicing and the injector's channel recovery assume the only inner
+         * block is C (x64 additionally pins it to the machine simd width; the
+         * VLA analog keeps the {16, 8, 4} family, as in is_applicable()).
+         */
+        const auto &blocking_desc = src0_d.blocking_desc();
+        if (blocking_desc.inner_nblks != 1
+                || !utils::one_of(blocking_desc.inner_blks[0], 16, 8, 4)
+                || blocking_desc.inner_idxs[0] != 1)
+            return false;
     }
 
-    // Convert f32 result group vd (e32/m4) to dt and store `vl` elements to ptr.
-    void store_vec(
-            data_type_t dt, const VReg &v, const VReg &stage, const Reg &ptr) {
-        using namespace data_type;
-        if (dt == f32) {
-            to_compute_vtype();
-            vse32_v(v, ptr);
-        } else if (dt == s32) {
-            setf(fc, -2147483648.0f);
-            vfmax_vf(v, v, fc);
-            // RISC-V vfcvt.x.f saturates; max f32 below 2^31 is 2147483520.
-            setf(fc, 2147483520.0f);
-            vfmin_vf(v, v, fc);
-            vfcvt_x_f_v(v, v);
-            vse32_v(v, ptr);
-        } else if (dt == f16 || dt == bf16) {
-            vsetvli(x0, vl, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
-            // e32m4 -> e16m2; Zvfbfmin for bf16 (RNE), Zvfh for f16.
-            if (dt == bf16)
-                vfncvtbf16_f_f_w(stage, v);
-            else
-                vfncvt_f_f_w(stage, v);
-            vse16_v(stage, ptr);
-        } else { // s8 / u8
-            const bool is_s8 = dt == s8;
-            setf(fc, is_s8 ? -128.0f : 0.0f);
-            vfmax_vf(v, v, fc);
-            setf(fc, is_s8 ? 127.0f : 255.0f);
-            vfmin_vf(v, v, fc);
-            if (is_s8)
-                vfcvt_x_f_v(v, v);
-            else
-                vfcvt_xu_f_v(v, v);
-            vsetvli(x0, vl, SEW::e16, LMUL::m2, VTA::ta, VMA::ma);
-            vnsrl_wi(stage, v, 0); // e32m4 -> e16m2
-            vsetvli(x0, vl, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
-            vnsrl_wi(st0, stage, 0); // e16m2 -> e8m1 (st0 as byte temp)
-            vse8_v(st0, ptr);
-        }
-    }
+    const dim_t n_dims = src0_d.ndims();
+    const dim_t &oc = n_dims >= 2 ? src0_d.dims()[1] : 1;
 
-    // v(acc) = v OP src1, comparisons yield 0.0/1.0. vtype is e32/m4.
-    // f_zero/f_one are prepared once per kernel (see emit_binary).
-    void cmp_to_01(const VReg &v) {
-        vfmv_v_f(v, f_zero);
-        vfmerge_vfm(v, v, f_one); // v[i] = v0[i] ? 1.0 : 0.0
-    }
-    // scratch takes the scalar-broadcast src1 of the max/min algorithms; it is
-    // a dead vector group of the caller (vs1 in the generic loop).
-    void binop_vf(const VReg &v, const FReg &f, const VReg &scratch) {
-        using namespace alg_kind;
-        switch (c_.alg) {
-            case binary_add: vfadd_vf(v, v, f); break;
-            case binary_sub: vfsub_vf(v, v, f); break;
-            case binary_mul: vfmul_vf(v, v, f); break;
-            case binary_div: vfdiv_vf(v, v, f); break;
-            case binary_max:
-                // nstl::max(src0,src1) = (src1 < src0) ? src0 : src1 (picks src1
-                // on ties/unordered, matching the reference and x86 vmaxps).
-                vfmv_v_f(scratch, f);
-                vmflt_vv(VReg(0), scratch, v);
-                vmerge_vvm(v, scratch, v);
-                break;
-            case binary_min:
-                // nstl::min(src0,src1) = (src0 < src1) ? src0 : src1.
-                vfmv_v_f(scratch, f);
-                vmflt_vv(VReg(0), v, scratch);
-                vmerge_vvm(v, scratch, v);
-                break;
-            case binary_ge:
-                vmfge_vf(VReg(0), v, f);
-                cmp_to_01(v);
-                break;
-            case binary_gt:
-                vmfgt_vf(VReg(0), v, f);
-                cmp_to_01(v);
-                break;
-            case binary_le:
-                vmfle_vf(VReg(0), v, f);
-                cmp_to_01(v);
-                break;
-            case binary_lt:
-                vmflt_vf(VReg(0), v, f);
-                cmp_to_01(v);
-                break;
-            case binary_eq:
-                vmfeq_vf(VReg(0), v, f);
-                cmp_to_01(v);
-                break;
-            case binary_ne:
-                vmfne_vf(VReg(0), v, f);
-                cmp_to_01(v);
-                break;
-            default: break;
-        }
-    }
-    void binop_vv(const VReg &v, const VReg &v1) {
-        using namespace alg_kind;
-        switch (c_.alg) {
-            case binary_add: vfadd_vv(v, v, v1); break;
-            case binary_sub: vfsub_vv(v, v, v1); break;
-            case binary_mul: vfmul_vv(v, v, v1); break;
-            case binary_div: vfdiv_vv(v, v, v1); break;
-            case binary_max:
-                // nstl::max(src0,src1) = (src1 < src0) ? src0 : src1 (picks src1
-                // on ties/unordered, matching the reference and x86 vmaxps).
-                vmflt_vv(VReg(0), v1, v);
-                vmerge_vvm(v, v1, v);
-                break;
-            case binary_min:
-                // nstl::min(src0,src1) = (src0 < src1) ? src0 : src1.
-                vmflt_vv(VReg(0), v, v1);
-                vmerge_vvm(v, v1, v);
-                break;
-            // vmfgt/vmfge have no vv form: swap operands.
-            case binary_ge:
-                vmfle_vv(VReg(0), v1, v);
-                cmp_to_01(v);
-                break;
-            case binary_gt:
-                vmflt_vv(VReg(0), v1, v);
-                cmp_to_01(v);
-                break;
-            case binary_le:
-                vmfle_vv(VReg(0), v, v1);
-                cmp_to_01(v);
-                break;
-            case binary_lt:
-                vmflt_vv(VReg(0), v, v1);
-                cmp_to_01(v);
-                break;
-            case binary_eq:
-                vmfeq_vv(VReg(0), v, v1);
-                cmp_to_01(v);
-                break;
-            case binary_ne:
-                vmfne_vv(VReg(0), v, v1);
-                cmp_to_01(v);
-                break;
-            default: break;
-        }
-    }
+    /*
+     * TODO: Remove limitation supporting tail with blocked format for i8i8
+     */
+    const dim_t blksize
+            = blocked_format ? src0_d.blocking_desc().inner_blks[0] : 1;
+    const bool blocked_tail = p.len() && blocked_format && oc % blksize;
 
-    // Ternary select condition: set v0 = (src2 == 0), reading vl elements into
-    // `stage`. src2 is s8 (forced by the common binary descriptor). Ends at the
-    // e32/m4 compute vtype (the mask is valid across the SEW switch: same vl).
-    void select_mask(const VReg &stage) {
-        vsetvli(x0, vl, SEW::e8, LMUL::m1, VTA::ta, VMA::ma);
-        vle8_v(stage, p2);
-        vmseq_vx(VReg(0), stage, x0); // v0 = (src2 == 0)
-        to_compute_vtype();
-    }
-
-    void emit_binary() {
-        using namespace data_type;
-        // Post-op injectors (eltwise + binary chain) have five aux groups
-        // (v8/v12/v16 + v24/v28); v24/v28 are free at m4 (vd=v4,
-        // vs1=v8, staging v12/v16, binary rhs v20), so log/soft_relu/gelu_erf
-        // eltwise post-ops fit here too.
-        eltwise_injector::static_params_t esp(VReg(8), VReg(12), VReg(16),
-                VReg(24), VReg(28), fa0, fa1, gpr, /*is_fwd=*/true);
-        // Dynamic rhs addressing: the injector computes the rhs address from the
-        // per-register output element offset (kept in `off`=a7 below) + the rhs
-        // dtype/strategy in static params. `bytes` and t3 are address scratch.
-        binary_injector::static_params_t bsp(vrhs, fa7, rhs_ptrs, bytes, t3);
-        // default rhs dtype; the postops injector overrides it per binary from
-        // src1_desc. Every rhs dtype is converted to f32 at load: scalar via
-        // scalar loads (f16 via a stride-0 broadcast load), per_element and
-        // per_oc/per_w gather via a narrow load + in-place widen.
-        bsp.rhs_dt = f32;
-        // per_oc gather index scratch (v24; the eltwise aux3 shares it but runs
-        // in a different post-op entry, so there is no temporal overlap).
-        bsp.v_idx = VReg(24);
-        // narrow-rhs staging (v12 = st0, dead during post-ops; distinct from
-        // v_rhs=v20 and v_idx=v24 so the widen into v_rhs is a legal overlap).
-        bsp.v_tmp = VReg(12);
-        // A select post-op loads its independent condition into v8. It reuses
-        // the gather/narrow/address scratch after src1 has been materialized in
-        // v20; all are dead from the main binary operation at this point.
-        binary_injector::static_params_t select_bsp(
-                VReg(8), fa0, rhs_ptrs, bytes, t3);
-        select_bsp.v_idx = VReg(24);
-        select_bsp.v_tmp = VReg(12);
-        injector::jit_uni_postops_injector_t<v> po_inj(this, c_.post_ops, esp,
-                c_.has_binary_po ? &bsp : nullptr, c_.dst_md, &select_bsp);
-        binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
-        if (c_.has_binary_po) rhs_dyn.vmm_idx_to_out_off[vd.getIdx()] = off;
-
-        // Preload the broadcast scalar src1 into f_s1 (f32), scaled once.
-        if (c_.scalar_src1) {
-            load_scalar(c_.dt_s1, f_s1, p1);
-            if (c_.do_scale1) fmul_s(f_s1, f_s1, f_sc1);
-        }
-
-        // Comparison results are 0.0/1.0: the constants live in f_zero/f_one,
-        // which no injector touches, so they are set once here instead of per
-        // vector (see cmp_to_01).
-        using namespace alg_kind;
-        if (utils::one_of(c_.alg, binary_ge, binary_gt, binary_le, binary_lt,
-                    binary_eq, binary_ne)) {
-            fmv_w_x(f_zero, x0);
-            setf(f_one, 1.0f);
-        }
-
-        Label loop, done;
-
-        // Tuned f32 main loops (second kernels; the driver picks per call by
-        // the thread count). Both cover only chains whose post-ops need no
-        // injector aux (none, or only zero-alpha relu) and a contiguous f32
-        // src1, so a zero-aux chain never reads the aux slots and they may
-        // all alias the one group the loops leave unused.
-        if (c_.unrolled || c_.narrow) {
-            // All five eltwise aux vector groups are aliased to VReg(28):
-            // the init-time gate below restricts the chain to empty or
-            // zero-alpha relu, neither of which reads any aux vector group,
-            // so a single group can be shared. Any future relaxation of
-            // that gate must break this aliasing before forward-aux
-            // algorithms become visible here.
-            eltwise_injector::static_params_t esp_u(VReg(28), VReg(28),
-                    VReg(28), VReg(28), VReg(28), fa0, fa1, gpr,
-                    /*is_fwd=*/true);
-            injector::jit_uni_postops_injector_t<v> po_u(
-                    this, c_.post_ops, esp_u);
-            binary_injector::rhs_arg_dynamic_params_t no_rhs;
-
-            if (c_.unrolled) {
-                // Three independent src0/src1 pairs keep six full-width loads
-                // in flight. The loop needs the six m4 data groups. Fastest
-                // when enough threads share the memory system.
-                const VReg vdu[3] = {VReg(4), VReg(12), VReg(20)};
-                const VReg vsu[3] = {VReg(8), VReg(16), VReg(24)};
-                const Reg b = t4; // vl * 4 bytes (f32 element stride)
-                const Reg n3 = t5; // 3 * vl elements per step
-                const Reg b3 = t6; // 3 * vl * 4 bytes (stream step)
-                const Reg a1r = t1, a2r = t2; // step-1/step-2 addresses
-                vsetvli(vl, x0, SEW::e32, LMUL::m4, VTA::ta,
-                        VMA::ma); // vl = VLMAX
-                slli(b, vl, 2);
-                slli(n3, vl, 1);
-                add(n3, n3, vl);
-                slli(b3, b, 1);
-                add(b3, b3, b);
-                Label main_loop, tail;
-                L(main_loop);
-                bltu(len, n3, tail);
-                add(a1r, p0, b);
-                add(a2r, a1r, b);
-                vle32_v(vdu[0], p0);
-                vle32_v(vdu[1], a1r);
-                vle32_v(vdu[2], a2r);
-                add(p0, p0, b3);
-                if (!c_.scalar_src1) {
-                    add(a1r, p1, b);
-                    add(a2r, a1r, b);
-                    vle32_v(vsu[0], p1);
-                    vle32_v(vsu[1], a1r);
-                    vle32_v(vsu[2], a2r);
-                    add(p1, p1, b3);
-                }
-                for (int i = 0; i < 3; i++) {
-                    if (c_.do_scale0) vfmul_vf(vdu[i], vdu[i], f_sc0);
-                    if (!c_.scalar_src1 && c_.do_scale1)
-                        vfmul_vf(vsu[i], vsu[i], f_sc1);
-                    if (c_.scalar_src1)
-                        binop_vf(vdu[i], f_s1, vsu[0]);
-                    else
-                        binop_vv(vdu[i], vsu[i]);
-                    po_u.compute_vector(vdu[i].getIdx(), no_rhs);
-                }
-                add(a1r, pd, b);
-                add(a2r, a1r, b);
-                vse32_v(vdu[0], pd);
-                vse32_v(vdu[1], a1r);
-                vse32_v(vdu[2], a2r);
-                add(pd, pd, b3);
-                sub(len, len, n3);
-                j_(main_loop);
-                L(tail);
-            } else {
-                // Strictly interleaved single m1-vector loop with a hoisted
-                // vsetvli: on an in-order core the vector queue drains in
-                // order, so per-access width — not the number of groups —
-                // sets the DRAM-visible request pattern, and the narrow
-                // pattern extracts the most memory throughput when few
-                // threads drive the memory system.
-                const Reg b = t4; // vl * 4 bytes (f32 element stride)
-                vsetvli(vl, x0, SEW::e32, LMUL::m1, VTA::ta,
-                        VMA::ma); // vl = VLMAX
-                slli(b, vl, 2);
-                Label narrow_loop;
-                L(narrow_loop);
-                bltu(len, vl, loop);
-                vle32_v(vd, p0);
-                if (!c_.scalar_src1) vle32_v(vs1, p1);
-                if (c_.do_scale0) vfmul_vf(vd, vd, f_sc0);
-                if (!c_.scalar_src1 && c_.do_scale1) vfmul_vf(vs1, vs1, f_sc1);
-                if (c_.scalar_src1)
-                    binop_vf(vd, f_s1, vs1);
-                else
-                    binop_vv(vd, vs1);
-                po_u.compute_vector(vd.getIdx(), no_rhs);
-                vse32_v(vd, pd);
-                add(p0, p0, b);
-                if (!c_.scalar_src1) add(p1, p1, b);
-                add(pd, pd, b);
-                sub(len, len, vl);
-                j_(narrow_loop);
-            }
-        }
-
-        L(loop);
-        beqz(len, done);
-
-        set_compute_vl();
-        load_vec(c_.dt_s0, vd, st0, p0); // src0 -> vd (f32)
-        if (c_.do_scale0) vfmul_vf(vd, vd, f_sc0);
-        if (!c_.scalar_src1) {
-            // src1 -> vs1 (f32); strided for different plain layouts.
-            load_vec(c_.dt_s1, vs1, st1, p1, c_.s1_inner_stride);
-            if (c_.do_scale1) vfmul_vf(vs1, vs1, f_sc1);
-        }
-
-        if (c_.is_select) {
-            // dst = src2 ? src0 : src1. Materialize a scalar-broadcast src1, then
-            // v0 = (src2 == 0) and merge (v0 ? src1 : src0).
-            if (c_.scalar_src1) vfmv_v_f(vs1, f_s1);
-            select_mask(st1); // sets v0 = (src2 == 0), ends at e32/m4
-            vmerge_vvm(vd, vd, vs1);
-        } else if (c_.scalar_src1) {
-            binop_vf(vd, f_s1, vs1);
-        } else {
-            binop_vv(vd, vs1);
-        }
-
-        // Apply the post-op chain in attribute order. Every sum entry invokes
-        // the same old-dst lambda (the PD requires identical sum parameters),
-        // matching the x64/AArch64 post-op injector contract.
-        const int n_po = c_.post_ops.len();
-        if (c_.do_sum) {
-            int begin = 0;
-            for (int i = 0; i < n_po; i++) {
-                if (!c_.post_ops.entry_[i].is_sum(false, false)) continue;
-                po_inj.compute_vector(vd.getIdx(), rhs_dyn, begin, i);
-                load_vec(c_.dt_dst, st1, st0, pd); // old dst -> st1 (f32)
-                vfmacc_vf(vd, f_sum, st1);
-                begin = i + 1;
-            }
-            po_inj.compute_vector(vd.getIdx(), rhs_dyn, begin, n_po);
-        } else {
-            po_inj.compute_vector(vd.getIdx(), rhs_dyn, 0, n_po);
-        }
-
-        store_vec(c_.dt_dst, vd, st1, pd);
-
-        // advance pointers by vl elements
-        auto adv = [&](const Reg &p, data_type_t dt) {
-            const int es = (int)types::data_type_size(dt);
-            const int sh = es == 4 ? 2 : (es == 2 ? 1 : 0);
-            if (sh)
-                slli(bytes, vl, sh);
-            else
-                mv(bytes, vl);
-            add(p, p, bytes);
-        };
-        // strided src1: advance by vl * stride * sizeof(dt).
-        auto adv_strided = [&](const Reg &p, data_type_t dt, dim_t stride) {
-            li(t3, stride * (int)types::data_type_size(dt));
-            mul(bytes, vl, t3);
-            add(p, p, bytes);
-        };
-        adv(p0, c_.dt_s0);
-        adv(pd, c_.dt_dst);
-        if (!c_.scalar_src1) {
-            if (c_.s1_inner_stride > 1)
-                adv_strided(p1, c_.dt_s1, c_.s1_inner_stride);
-            else
-                adv(p1, c_.dt_s1);
-        }
-        if (c_.is_select) adv(p2, data_type::s8); // src2 full, s8 (1 B/elem)
-        // advance the rhs output ELEMENT offset by vl (the injector scales by
-        // the rhs dtype size).
-        if (c_.has_binary_po) add(off, off, vl);
-        sub(len, len, vl);
-        j_(loop);
-        L(done);
-    }
-};
+    return binary_injector::binary_args_broadcast_supported(
+                   p, src0_d, get_supported_postops_bcast_strategies())
+            && IMPLICATION(utils::one_of(src0_d.data_type(), data_type::s8,
+                                   data_type::u8),
+                    !blocked_tail);
+}
 
 jit_uni_binary_t::jit_uni_binary_t(const pd_t *apd) : primitive_t(apd) {}
-jit_uni_binary_t::~jit_uni_binary_t() = default;
 
 status_t jit_uni_binary_t::init(engine_t *engine) {
     UNUSED(engine);
-    const auto *p = pd();
-    binary_kernel_conf_t c;
-    c.alg = p->desc()->alg_kind;
-    c.scalar_src1 = p->scalar_whole_ || p->scalar_inner_;
-    c.dt_s0 = p->src_md(0)->data_type;
-    c.dt_s1 = p->src_md(1)->data_type;
-    c.dt_dst = p->dst_md()->data_type;
-    c.do_scale0 = p->do_scale0_;
-    c.do_scale1 = p->do_scale1_;
-    c.do_sum = p->do_sum_;
-    c.s1_inner_stride = p->s1_inner_stride_;
-    c.is_select = p->desc()->alg_kind == alg_kind::binary_select;
-    c.post_ops = p->po_;
-    c.has_binary_po = c.post_ops.find(primitive_kind::binary) != -1;
-    c.dst_md = p->dst_md(); // per_oc binary post-op rhs classification
-    kernel_.reset(new jit_uni_binary_kernel_t(c));
-    status_t status = kernel_->create_kernel();
-    if (status != status::success) return status;
+    CHECK(safe_ptr_assign(kernel_,
+            new jit_uni_binary_kernel_t(
+                    pd(), pd()->get_conf(), false /*tail_kernel*/)));
 
-    // The tuned f32 streaming kernels (unrolled + narrow): the unrolled loop
-    // needs the six m4 data groups, so they cover only chains whose post-ops
-    // use no injector aux (none, or just zero-alpha relu) and a contiguous
-    // f32 src1.
-    const bool unrolled_ok = !c.is_select && !c.do_sum && !c.has_binary_po
-            && c.s1_inner_stride == 1 && c.dt_s0 == data_type::f32
-            && c.dt_s1 == data_type::f32 && c.dt_dst == data_type::f32
-            && std::all_of(c.post_ops.entry_.begin(), c.post_ops.entry_.end(),
-                    [](const post_ops_t::entry_t &e) {
-        return e.is_eltwise() && e.eltwise.alg == alg_kind::eltwise_relu
-                && e.eltwise.alpha == 0.f;
-    });
-    if (unrolled_ok) {
-        // Both tuned kernels alias all five eltwise aux slots to VReg(28):
-        // their post-op chain is empty or only zero-alpha relu, which never
-        // reads the aux vector groups (relu_zero_ns uses only f_aux0 + vmask).
-        // The 6 m4 data groups used by the unrolled loop likewise do not
-        // collide with this aliasing.
-        c.unrolled = true;
-        kernel_unrolled_.reset(new jit_uni_binary_kernel_t(c));
-        status = kernel_unrolled_->create_kernel();
-        if (status != status::success) return status;
-        c.unrolled = false;
-        c.narrow = true;
-        kernel_narrow_.reset(new jit_uni_binary_kernel_t(c));
-        status = kernel_narrow_->create_kernel();
+    // The tail kernel stores the valid lanes of each channel block and zeroes
+    // the padded tail in-kernel. x64 builds it only for a non-i8 dst, yet its
+    // execute() selects the tail kernel without looking at the dst dtype, so an
+    // i8 dst with a blocked oc tail dereferences a null kernel there. The rv64
+    // tail kernel is dtype-generic (store_vector covers s8/u8, zero_pad_tail
+    // writes zero BYTES), so build it whenever the dispatch can ask for it --
+    // the creation predicate must equal the execute-side one.
+    const memory_desc_wrapper src0_d(pd_->src_md(0));
+    const auto oc = src0_d.ndims() >= 2 ? src0_d.dims()[1] : 1;
+
+    if (op_t::c_blocked == pd()->get_conf().op_type
+            && oc % src0_d.blocking_desc().inner_blks[0]) {
+        CHECK(safe_ptr_assign(kernel_tail_,
+                new jit_uni_binary_kernel_t(
+                        pd(), pd()->get_conf(), true /*tail_kernel*/)));
+        CHECK(kernel_tail_->create_kernel());
     }
-    return status;
+
+    return kernel_->create_kernel();
 }
 
-// Collect the per-binary rhs base pointers (post-op src1), advanced by their own
-// logical origin, matching the x64/aarch64 post_ops_binary_rhs_arg_vec scheme.
-static std::vector<const void *> collect_binary_rhs(
-        const post_ops_t &po, const exec_ctx_t &ctx) {
-    std::vector<const void *> rhs;
-    for (int i = 0; i < po.len(); i++)
-        if (po.entry_[i].is_binary()) {
-            const memory_desc_wrapper s1_d(po.entry_[i].binary.src1_desc);
-            const auto *base = static_cast<const char *>(ctx.host_ptr(
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-            rhs.push_back(base + s1_d.off_l(0) * s1_d.data_type_size());
-            if (po.entry_[i].is_binary_with_ternary_op()) {
-                const memory_desc_wrapper s2_d(po.entry_[i].binary.src2_desc);
-                const auto *base2 = static_cast<const char *>(ctx.host_ptr(
-                        DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_2));
-                rhs.push_back(base2 + s2_d.off_l(0) * s2_d.data_type_size());
+void jit_uni_binary_t::execute_no_bcast_strategy(const data_t *src0,
+        const data_t *src1, const data_t *src2, data_t *dst, float scale0,
+        float scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        const bcast_t bcast_type) const {
+    const auto conf = pd()->get_conf();
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper src1_d(pd()->src_md(1));
+
+    const size_t es0 = types::data_type_size(conf.src0_type);
+    const size_t es1 = types::data_type_size(conf.src1_type);
+    const size_t esd = types::data_type_size(conf.dst_type);
+    const size_t es2 = conf.is_ternary_op
+            ? types::data_type_size(pd()->src_md(2)->data_type)
+            : 0;
+    const void *const *rhs_ptrs = post_ops_binary_rhs_arg_vec.empty()
+            ? nullptr
+            : post_ops_binary_rhs_arg_vec.data();
+
+    auto call = [&](dim_t off0, dim_t off1, dim_t offd, dim_t work) {
+        jit_uni_binary_args_t p = {};
+        p.src0 = src0 + off0 * es0;
+        p.src1 = src1 + off1 * es1;
+        if (conf.is_ternary_op) p.src2 = src2 + offd * es2;
+        p.dst = dst + offd * esd;
+        p.post_ops_binary_rhs_arg_vec = rhs_ptrs;
+        p.work_amount = work;
+        p.dst_orig = dst;
+        p.scales_src0 = scale0;
+        p.scales_src1 = scale1;
+        p.sum_scale = conf.sum_scale;
+        (*kernel_)(&p);
+    };
+
+    if (conf.is_src_different_layouts) {
+        // Different plain layouts (nchw:nhwc): src0/dst are contiguous, src1
+        // is read with the element stride conf.src1_stride (vlse). x64
+        // batches whole-run chunks per thread and lets the kernel iterate the
+        // runs, resetting src1 to the next contiguous element after each
+        // stride range; the rv64 kernel does the same with outer_dims and
+        // src1_stride baked as codegen constants (instead of x64's indices
+        // vector + runtime stride-range register). Consecutive runs start at
+        // consecutive src1 elements within a batch, so a chunk's src1 base is
+        // batch base + first run index.
+        const dim_t batch = src0_d.dims()[0];
+        const dim_t run_len = conf.outer_dims;
+        const dim_t batch_stride = src1_d.blocking_desc().strides[0];
+        const dim_t nelems_per_batch = src0_d.nelems(true) / batch;
+        const dim_t runs_per_batch = nelems_per_batch / run_len;
+
+        const int nthr = dnnl_get_current_num_threads();
+        const dim_t thr_per_run_group = nstl::min(
+                nstl::max((dim_t)nthr / batch, (dim_t)1), runs_per_batch);
+
+        // Compute strategy:
+        // Iterate over batch and over runs. Divide number of threads by batch
+        // size and limit it by the number of runs to parallelize over them
+        // when needed (x64's thr_per_nelems_group).
+        parallel_nd(batch, thr_per_run_group, [&](dim_t b, dim_t run_group) {
+            dim_t start = 0, end = 0;
+            balance211(
+                    runs_per_batch, thr_per_run_group, run_group, start, end);
+            if (start >= end) return;
+
+            const dim_t off = b * nelems_per_batch + start * run_len;
+            call(off, b * batch_stride + start, off, (end - start) * run_len);
+        });
+        return;
+    }
+
+    // Plain no-broadcast (or point broadcast): one flat pass, split by threads.
+    const dim_t nelems = src0_d.nelems(true);
+    const bool point_broadcast = bcast_type == bcast_t::scalar;
+    parallel(0, [&](const int ithr, const int nthr) {
+        dim_t start = 0, end = 0;
+        balance211(nelems, nthr, ithr, start, end);
+        if (start >= end) return;
+        call(start, point_broadcast ? 0 : start, start, end - start);
+    });
+}
+
+void jit_uni_binary_t::execute_bcast_per_batch_strategy(const data_t *src0,
+        const data_t *src1, const data_t *src2, data_t *dst, float scale0,
+        float scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec) const {
+    const auto conf = pd()->get_conf();
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+
+    const size_t es0 = types::data_type_size(conf.src0_type);
+    const size_t es1 = types::data_type_size(conf.src1_type);
+    const size_t esd = types::data_type_size(conf.dst_type);
+    const size_t es2 = conf.is_ternary_op
+            ? types::data_type_size(pd()->src_md(2)->data_type)
+            : 0;
+    const void *const *rhs_ptrs = post_ops_binary_rhs_arg_vec.empty()
+            ? nullptr
+            : post_ops_binary_rhs_arg_vec.data();
+
+    const dim_t MB = src0_d.dims()[0];
+    const dim_t nelems_per_b = src0_d.nelems(true) / MB;
+
+    // Compute strategy: src1 is one per-batch block reused for every batch;
+    // parallelize over MB and chunks of the per-batch elements (src1 advances
+    // 1:1 within a chunk, resetting per batch).
+    const dim_t nthr
+            = nstl::min(nelems_per_b, (dim_t)dnnl_get_current_num_threads());
+    parallel_nd(MB, nthr, [&](dim_t b, dim_t ithr) {
+        dim_t start = 0, end = 0;
+        balance211(nelems_per_b, nthr, ithr, start, end);
+        if (start >= end) return;
+        const dim_t off = b * nelems_per_b + start;
+        jit_uni_binary_args_t p = {};
+        p.src0 = src0 + off * es0;
+        p.src1 = src1 + start * es1;
+        if (conf.is_ternary_op) p.src2 = src2 + off * es2;
+        p.dst = dst + off * esd;
+        p.post_ops_binary_rhs_arg_vec = rhs_ptrs;
+        p.work_amount = end - start;
+        p.dst_orig = dst;
+        p.scales_src0 = scale0;
+        p.scales_src1 = scale1;
+        p.sum_scale = conf.sum_scale;
+        (*kernel_)(&p);
+    });
+}
+
+void jit_uni_binary_t::execute_bcast_per_c_strategy(const data_t *src0,
+        const data_t *src1, const data_t *src2, data_t *dst, float scale0,
+        float scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        const op_t op_type, const bcast_t bcast_type,
+        const bool blocked_oc_tail) const {
+    const auto conf = pd()->get_conf();
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper src1_d(pd()->src_md(1));
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+
+    const size_t es0 = types::data_type_size(conf.src0_type);
+    const size_t es1 = types::data_type_size(conf.src1_type);
+    const size_t esd = types::data_type_size(conf.dst_type);
+    const size_t es2 = conf.is_ternary_op
+            ? types::data_type_size(pd()->src_md(2)->data_type)
+            : 0;
+    const void *const *rhs_ptrs = post_ops_binary_rhs_arg_vec.empty()
+            ? nullptr
+            : post_ops_binary_rhs_arg_vec.data();
+
+    const auto ndims = src0_d.ndims();
+    const auto &dims = src0_d.dims();
+    const dim_t MB = dims[0];
+    const dim_t C = ndims >= 2 ? dims[1] : 1;
+    const dim_t SP = ndims >= 3 ? utils::array_product(dims + 2, ndims - 2) : 1;
+    const auto &bcast_dims = pd()->broadcast_dims();
+
+    const dim_t nelems_slice_src0
+            = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
+    const dim_t nelems_slice_src1 = bcast_type == bcast_t::none
+            ? nelems_slice_src0
+            : ((bcast_dims[0] == 0)
+                              ? utils::array_product(
+                                        src1_d.padded_dims() + 1, ndims - 1)
+                              : 0);
+
+    auto call = [&](binary_kernel_t *kernel, dim_t off0, dim_t off1, dim_t offd,
+                        dim_t work) {
+        jit_uni_binary_args_t p = {};
+        p.src0 = src0 + off0 * es0;
+        p.src1 = src1 + off1 * es1;
+        if (conf.is_ternary_op) p.src2 = src2 + offd * es2;
+        p.dst = dst + offd * esd;
+        p.post_ops_binary_rhs_arg_vec = rhs_ptrs;
+        p.work_amount = work;
+        p.dst_orig = dst;
+        p.scales_src0 = scale0;
+        p.scales_src1 = scale1;
+        p.sum_scale = conf.sum_scale;
+        (*kernel)(&p);
+    };
+
+    if (op_type == op_t::c_blocked) {
+        const dim_t c_block = dst_d.blocking_desc().inner_blks[0];
+        const dim_t C_blocks = utils::div_up(dst_d.padded_dims()[1], c_block);
+        // Compute strategy:
+        // Each block is individual - parallel over MB and C_blocks safely.
+        // One kernel call covers the whole SP run (x64 granularity); the
+        // kernel steps one channel block per iteration, re-reading the fixed
+        // per_c src1 vector each block (x64's offt_src1_ == 0). The last
+        // block goes to kernel_tail_, which stores the valid lanes and zeroes
+        // the padded tail in-kernel.
+        const auto src1_off = [&](dim_t mb, dim_t C_blk, dim_t off) -> dim_t {
+            switch (bcast_type) {
+                case bcast_t::scalar: return mb * nelems_slice_src1;
+                case bcast_t::per_batch: return C_blk * SP * c_block;
+                case bcast_t::none: return off;
+                default: return mb * nelems_slice_src1 + C_blk * c_block;
             }
-        }
-    return rhs;
+        };
+        parallel_nd(MB, C_blocks, [&](dim_t mb, dim_t C_blk) {
+            const dim_t off = mb * nelems_slice_src0 + C_blk * SP * c_block;
+            auto *kernel = blocked_oc_tail && C_blk == (C_blocks - 1)
+                    ? kernel_tail_.get()
+                    : kernel_.get();
+            call(kernel, off, src1_off(mb, C_blk, off), off, SP * c_block);
+        });
+    } else if (op_type == op_t::n_spatial_c) {
+        // Each line of channels is individual, parallel over MB and spatial.
+        // src1 (per_c) is the C-vector reused per spatial position, advancing
+        // 1:1 with the run (use_stride_src1).
+        const auto src1_off = [&](dim_t mb, dim_t off) -> dim_t {
+            switch (bcast_type) {
+                case bcast_t::per_batch: return off - mb * nelems_slice_src0;
+                case bcast_t::none: return off;
+                default: return mb * nelems_slice_src1;
+            }
+        };
+        parallel_nd(MB, SP, [&](dim_t mb, dim_t sp) {
+            const dim_t off = mb * nelems_slice_src0 + sp * C;
+            call(kernel_.get(), off, src1_off(mb, off), off, C);
+        });
+    } else if (op_type == op_t::n_c_spatial) {
+        // Each line of spatial is individual, parallel over MB and C. src1
+        // (per_c) is one value per channel broadcast over the SP run
+        // (broadcast_src1_value).
+        const auto src1_off = [&](dim_t mb, dim_t c, dim_t off) -> dim_t {
+            switch (bcast_type) {
+                case bcast_t::scalar: return mb * nelems_slice_src1;
+                case bcast_t::per_batch: return c * SP;
+                case bcast_t::none: return off;
+                default: return mb * nelems_slice_src1 + c;
+            }
+        };
+        parallel_nd(MB, C, [&](dim_t mb, dim_t c) {
+            const dim_t off = mb * nelems_slice_src0 + c * SP;
+            call(kernel_.get(), off, src1_off(mb, c, off), off, SP);
+        });
+    }
+}
+
+void jit_uni_binary_t::execute_bcast_per_w_strategy(const data_t *src0,
+        const data_t *src1, const data_t *src2, data_t *dst, float scale0,
+        float scale1,
+        const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        const op_t op_type, const bool blocked_oc_tail) const {
+    const auto conf = pd()->get_conf();
+    const memory_desc_wrapper src0_d(pd()->src_md(0));
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+
+    const size_t es0 = types::data_type_size(conf.src0_type);
+    const size_t es1 = types::data_type_size(conf.src1_type);
+    const size_t esd = types::data_type_size(conf.dst_type);
+    const size_t es2 = conf.is_ternary_op
+            ? types::data_type_size(pd()->src_md(2)->data_type)
+            : 0;
+    const void *const *rhs_ptrs = post_ops_binary_rhs_arg_vec.empty()
+            ? nullptr
+            : post_ops_binary_rhs_arg_vec.data();
+
+    const auto ndims = src0_d.ndims();
+    const auto &dims = src0_d.dims();
+    const auto &bcast_dims = pd()->broadcast_dims();
+    const int not_bcasted_sp_dims = conf.not_bcasted_sp_dims;
+    const dim_t MB = dims[0];
+    const dim_t SP_no_bcast = ndims >= 3
+            ? utils::array_product(
+                      dims + (ndims - not_bcasted_sp_dims), not_bcasted_sp_dims)
+            : 1;
+    const dim_t C = ndims >= 2 ? dims[1] : 1;
+    const dim_t SP = ndims >= 3 ? utils::array_product(dims + 2, ndims - 2) : 1;
+    const dim_t N = SP / SP_no_bcast; // broadcasted spatial dims
+    const dim_t nelems_slice_src0
+            = utils::array_product(src0_d.padded_dims() + 1, ndims - 1);
+
+    auto call = [&](binary_kernel_t *kernel, dim_t off0, dim_t off1, dim_t offd,
+                        dim_t work) {
+        jit_uni_binary_args_t p = {};
+        p.src0 = src0 + off0 * es0;
+        p.src1 = src1 + off1 * es1;
+        if (conf.is_ternary_op) p.src2 = src2 + offd * es2;
+        p.dst = dst + offd * esd;
+        p.post_ops_binary_rhs_arg_vec = rhs_ptrs;
+        p.work_amount = work;
+        p.dst_orig = dst;
+        p.scales_src0 = scale0;
+        p.scales_src1 = scale1;
+        p.sum_scale = conf.sum_scale;
+        (*kernel)(&p);
+    };
+
+    if (op_type == op_t::c_blocked) {
+        const dim_t c_block = dst_d.blocking_desc().inner_blks[0];
+        const dim_t C_blocks = utils::div_up(dst_d.padded_dims()[1], c_block);
+        // Each (mb, C_blk, n, sp) block: one src1 value (per_w, broadcast over
+        // C) broadcast across the c_block channels (broadcast_src1_value).
+        // The per_w src1 value is real data, so the last block's padded lanes
+        // must not compute 0 OP src1: they go to kernel_tail_, which stores
+        // the valid lanes and zeroes the padded tail in-kernel (x64 shape).
+        parallel_nd(MB, C_blocks, N, SP_no_bcast,
+                [&](dim_t mb, dim_t C_blk, dim_t n, dim_t sp) {
+            const dim_t off = mb * nelems_slice_src0
+                    + c_block * (C_blk * SP + n * SP_no_bcast + sp);
+            const dim_t s1 = bcast_dims[0] == 1
+                    ? sp * c_block
+                    : (mb * SP_no_bcast + sp) * c_block;
+            auto *kernel = blocked_oc_tail && C_blk == (C_blocks - 1)
+                    ? kernel_tail_.get()
+                    : kernel_.get();
+            call(kernel, off, s1, off, c_block);
+        });
+    } else if (op_type == op_t::n_spatial_c) {
+        // Each line of channels: one src1 value (per_w) broadcast over C
+        // (broadcast_src1_value).
+        parallel_nd(MB, N, SP_no_bcast, [&](dim_t mb, dim_t n, dim_t sp) {
+            const dim_t off
+                    = mb * nelems_slice_src0 + n * SP_no_bcast * C + sp * C;
+            const dim_t s1 = bcast_dims[0] == 1 ? sp : mb * SP_no_bcast + sp;
+            call(kernel_.get(), off, s1, off, C);
+        });
+    } else if (op_type == op_t::n_c_spatial) {
+        // Each line of width: the src1 W-vector advances 1:1 over SP_no_bcast
+        // (use_stride_src1), reused across C and the broadcasted spatial dims.
+        parallel_nd(MB, C, N, [&](dim_t mb, dim_t c, dim_t n) {
+            const dim_t off = mb * nelems_slice_src0 + c * N * SP_no_bcast
+                    + n * SP_no_bcast;
+            const dim_t s1 = bcast_dims[0] == 1 ? 0 : mb * SP_no_bcast;
+            call(kernel_.get(), off, s1, off, SP_no_bcast);
+        });
+    }
 }
 
 status_t jit_uni_binary_t::execute(const exec_ctx_t &ctx) const {
-    const auto *pp = pd();
-    const auto *s0 = CTX_IN_MEM(const char *, DNNL_ARG_SRC_0);
-    const auto *s1 = CTX_IN_MEM(const char *, DNNL_ARG_SRC_1);
-    auto *d = CTX_OUT_MEM(char *, DNNL_ARG_DST);
+    auto src0 = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC_0);
+    auto src1 = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC_1);
+    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
 
-    const data_type_t dt_dst = pp->dst_md()->data_type;
-    const data_type_t dt_s0 = pp->src_md(0)->data_type;
-    const data_type_t dt_s1 = pp->src_md(1)->data_type;
-    const size_t es0 = types::data_type_size(dt_s0);
-    const size_t es1 = types::data_type_size(dt_s1);
-    const size_t esd = types::data_type_size(dt_dst);
+    const auto &post_ops = pd()->attr()->post_ops_;
+    const auto &post_ops_binary_rhs_arg_vec
+            = binary_injector::prepare_binary_args(post_ops, ctx);
 
-    // scale values (per-tensor, mask 0)
+    const auto conf = pd()->get_conf();
+
+    // Per-tensor scale values are resolved once here and passed by value (x64
+    // forwards the scale pointers to the kernel instead).
     float scale0 = 1.f, scale1 = 1.f;
-    if (pp->do_scale0_)
+    if (conf.do_scale_src0)
         scale0 = *CTX_IN_MEM(
                 const float *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_0);
-    if (pp->do_scale1_)
+    if (conf.do_scale_src1)
         scale1 = *CTX_IN_MEM(
                 const float *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC_1);
-    const float sum_scale = pp->sum_scale_;
-
-    std::vector<const void *> po_rhs = collect_binary_rhs(pp->po_, ctx);
-    const void *const *rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
     // Honor md offsets (dense submemory views).
-    s0 += (size_t)pp->src_md(0)->offset0 * es0;
-    s1 += (size_t)pp->src_md(1)->offset0 * es1;
-    d += (size_t)pp->dst_md()->offset0 * esd;
+    src0 += (size_t)pd()->src_md(0)->offset0
+            * types::data_type_size(conf.src0_type);
+    src1 += (size_t)pd()->src_md(1)->offset0
+            * types::data_type_size(conf.src1_type);
+    dst += (size_t)pd()->dst_md()->offset0
+            * types::data_type_size(conf.dst_type);
 
-    // Ternary select reads a full (dst-shaped) src2 condition, advancing with
-    // the run like src0/dst (the kernel folds select into the general path). s2
-    // is null for non-select.
-    const bool is_select = pp->desc()->alg_kind == alg_kind::binary_select;
-    const char *s2 = nullptr;
-    size_t es2 = 0;
-    if (is_select) {
-        s2 = CTX_IN_MEM(const char *, DNNL_ARG_SRC_2);
-        es2 = types::data_type_size(pp->src_md(2)->data_type);
-        s2 += (size_t)pp->src_md(2)->offset0 * es2;
+    const data_t *src2 = nullptr;
+    if (conf.is_ternary_op) {
+        src2 = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC_2);
+        src2 += (size_t)pd()->src_md(2)->offset0
+                * types::data_type_size(pd()->src_md(2)->data_type);
     }
 
-    auto fill = [&](jit_uni_binary_kernel_t::call_params_t &cp) {
-        cp.scale0 = scale0;
-        cp.scale1 = scale1;
-        cp.sum_scale = sum_scale;
-        cp.rhs_ptrs = rhs_arr;
-        cp.src2 = nullptr;
-    };
-    // The tuned kernels cover the streaming f32 case. The unrolled kernel
-    // issues per-stream bursts of loads/stores, which extracts more memory
-    // throughput once enough threads share the memory system; below that the
-    // narrow single-vector interleave is fastest, so pick per call by the
-    // thread count.
-    auto pick_kernel = [&](int nthr) -> const jit_uni_binary_kernel_t & {
-        if (nthr >= unrolled_kernel_min_nthrs && kernel_unrolled_)
-            return *kernel_unrolled_;
-        if (kernel_narrow_) return *kernel_narrow_;
-        return *kernel_;
-    };
+    const auto op_type = conf.op_type;
+    const auto bcast_type = conf.bcast_type;
+    const bool point_broadcast = bcast_type == bcast_t::scalar;
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const dim_t C = dst_d.ndims() >= 2 ? dst_d.dims()[1] : 1;
+    const bool with_postops = !post_ops.entry_.empty();
+    const bool has_oc_tail = op_type == op_t::c_blocked
+            && (C % dst_d.blocking_desc().inner_blks[0]);
+    const bool point_broadcast_no_oc_tail = point_broadcast && !has_oc_tail;
+    const auto alg = pd()->desc()->alg_kind;
 
-    if (pp->whole_) {
-        // one flat pass; parallelize the range. src1 is scalar or matches dst.
-        const dim_t total = pp->total_;
-        const bool scalar = pp->scalar_whole_;
-        parallel(0, [&](int ithr, int nthr) {
-            dim_t start = 0, end = 0;
-            balance211(total, nthr, ithr, start, end);
-            if (start >= end) return;
-            jit_uni_binary_kernel_t::call_params_t cp = {};
-            fill(cp);
-            cp.src0 = s0 + start * es0;
-            cp.src1 = scalar ? s1 : s1 + start * es1;
-            if (is_select) cp.src2 = s2 + start * es2;
-            cp.dst = d + start * esd;
-            cp.len = end - start;
-            cp.rhs_off = (size_t)start; // element offset (injector scales)
-            pick_kernel(nthr)(&cp);
-        });
-        return status::success;
-    }
+    // Use the tail-handling per_c/per_w strategies for compare ops with
+    // oc_tail and blocked format due to overwriting the padded lanes, and
+    // whenever post-ops could write them (x64 routes the same cases to its
+    // kernel_tail_; the rv64 driver computes the valid lanes and zeroes the
+    // padded tail itself).
+    const bool vector_overwrite = utils::one_of(alg, alg_kind::binary_ge,
+            alg_kind::binary_gt, alg_kind::binary_le, alg_kind::binary_lt,
+            alg_kind::binary_eq, alg_kind::binary_ne);
+    const bool blocked_oc_tail = op_type == op_t::c_blocked && has_oc_tail
+            && (with_postops || point_broadcast || bcast_type == bcast_t::per_w
+                    || vector_overwrite);
+    // init()'s creation predicate must cover every case this dispatch routes to
+    // kernel_tail_ (it is strictly weaker: c_blocked && oc % blk).
+    assert(IMPLICATION(blocked_oc_tail, kernel_tail_ != nullptr));
 
-    // General broadcast: iterate runs of `inner` elements; offset src1 by the
-    // per-dim broadcast strides. The inner dim is either contiguous in src1
-    // (vector) or broadcast (scalar), captured by pp->scalar_inner_.
-    const dim_t inner = pp->inner_;
-    const dim_t n_outer = pp->n_outer_;
-    const int nd = pp->nd_;
-    parallel(0, [&](int ithr, int nthr) {
-        dim_t bstart = 0, bend = 0;
-        balance211(n_outer, nthr, ithr, bstart, bend);
-        for (dim_t b = bstart; b < bend; b++) {
-            // decompose the run index b over dst dims [0..nd-2] to compute the
-            // src1 element offset via broadcast strides.
-            dim_t s1_off = 0, rem = b;
-            bool tail_run = false;
-            for (int i = nd - 2; i >= 0; i--) {
-                const dim_t dim = pp->out_dims_[i];
-                const dim_t idx = rem % dim;
-                rem /= dim;
-                s1_off += idx * pp->s1_str_[i];
-                if (i == pp->tail_axis_) tail_run = idx == dim - 1;
-            }
-            if (pp->s1_same_layout_) s1_off = b * inner;
-            const dim_t run = tail_run ? pp->tail_ : inner;
-            jit_uni_binary_kernel_t::call_params_t cp = {};
-            fill(cp);
-            cp.src0 = s0 + b * inner * es0;
-            cp.src1 = s1 + s1_off * es1;
-            if (is_select) cp.src2 = s2 + b * inner * es2;
-            cp.dst = d + b * inner * esd;
-            cp.len = run;
-            cp.rhs_off = (size_t)b * inner; // element offset (injector scales)
-            pick_kernel(nthr)(&cp);
-            if (run < inner)
-                std::memset(
-                        d + (b * inner + run) * esd, 0, (inner - run) * esd);
-        }
-    });
+    // x64 also forces the per_c/per_w strategies whenever a per_oc post-op
+    // rhs exists so its per-call channel addressing stays valid; the rv64
+    // kernel uses the same channel-aligned addressing under the identical
+    // routing (see conf). An op_t::none src0 cannot be routed (no per_c
+    // strategy branch would run) and keeps the gather-addressed flat path;
+    // x64's per_w-rhs condition is not needed (the per-lane gather stays in
+    // bounds without the expanded scratchpad copy).
+    const bool route_postops_per_oc
+            = conf.postops_per_oc_broadcast_exists && op_type != op_t::none;
+
+    if ((bcast_type == bcast_t::none || point_broadcast_no_oc_tail)
+            && !route_postops_per_oc && !blocked_oc_tail)
+        execute_no_bcast_strategy(src0, src1, src2, dst, scale0, scale1,
+                post_ops_binary_rhs_arg_vec, bcast_type);
+    else if (bcast_type == bcast_t::per_batch && !route_postops_per_oc
+            && !blocked_oc_tail)
+        execute_bcast_per_batch_strategy(src0, src1, src2, dst, scale0, scale1,
+                post_ops_binary_rhs_arg_vec);
+    else if (bcast_type == bcast_t::per_w)
+        execute_bcast_per_w_strategy(src0, src1, src2, dst, scale0, scale1,
+                post_ops_binary_rhs_arg_vec, op_type, blocked_oc_tail);
+    else
+        execute_bcast_per_c_strategy(src0, src1, src2, dst, scale0, scale1,
+                post_ops_binary_rhs_arg_vec, op_type, bcast_type,
+                blocked_oc_tail);
+
     return status::success;
 }
 

--- a/src/cpu/rv64/jit_uni_binary.hpp
+++ b/src/cpu/rv64/jit_uni_binary.hpp
@@ -1,4 +1,5 @@
 /*******************************************************************************
+* Copyright 2019 Intel Corporation
 * Copyright 2025 ZTE Corporation
 * Copyright 2026 Institute of Software, Chinese Academy of Sciences
 * Copyright 2026 Intel Corporation
@@ -19,454 +20,120 @@
 #ifndef CPU_RV64_JIT_UNI_BINARY_HPP
 #define CPU_RV64_JIT_UNI_BINARY_HPP
 
-#include <cstdint>
-#include <limits>
-#include <memory>
-
-#include "common/broadcast_strategy.hpp"
-#include "common/c_types_map.hpp"
-#include "common/dnnl_thread.hpp"
-#include "common/memory_desc_wrapper.hpp"
 #include "common/primitive.hpp"
-#include "common/type_helpers.hpp"
-#include "common/utils.hpp"
 
-#include "cpu/cpu_binary_pd.hpp"
-#include "cpu/platform.hpp"
-#include "cpu/rv64/cpu_isa_traits.hpp"
-#include "cpu/rv64/injectors/jit_uni_binary_injector.hpp"
-#include "cpu/rv64/injectors/jit_uni_eltwise_injector.hpp"
+#include "cpu/cpu_eltwise_pd.hpp"
+
+#include "cpu/rv64/jit_uni_binary_kernel.hpp"
 
 namespace dnnl {
 namespace impl {
 namespace cpu {
 namespace rv64 {
 
-struct jit_uni_binary_kernel_t;
+struct binary_kernel_t;
+
+using op_t = binary_op_t;
+using bcast_t = binary_bcast_t;
 
 // Standalone binary primitive: a VLA JIT wrapper that computes
 // (scale0*src0) OP (scale1*src1) in f32, applies the sum + eltwise + binary
-// post-op chain, and stores to dst (converted/saturated at the boundary),
-// mirroring x64/aarch64 jit_uni_binary_t. Supports:
-//   - dtypes f32/f16/bf16/s32/s8/u8, freely mixed across src0/src1/dst (f16
-//     needs zvfh, bf16 needs zvfbfwma)
-//   - arbitrary src1 broadcast over plain (nchw/nhwc/...) and single-inner-block
-//     (nChw4c/8c/16c, including a padded channel tail) dst, plus src0/src1
-//     different plain layouts (nchw:nhwc, read via a strided src1 load)
+// post-op chain, and stores to dst (converted at the boundary), mirroring the
+// x64/aarch64 jit_uni_binary_t contract. Supports:
+//   - f32/f16/bf16/s32/s8/u8 tensors (f16 needs zvfh, bf16 needs
+//     zvfbfwma); src0 and dst share one memory desc unless dst is int8,
+//     and src1's dtype may differ
+//   - the x64 broadcast surface: full-tensor, scalar, per-batch/per-C/per-W
+//     pattern families over plain (ncx/nxc) and single-inner-block
+//     (nChw4c/8c/16c, incl. a padded channel tail with a zero-preserving alg)
+//     dst, plus src0/src1 different plain layouts (nchw:nhwc, strided load)
 //   - per-tensor src0/src1 scales
-//   - a post-op chain: same-parameter sums at any positions (applied in-kernel)
-//     plus any number of eltwise ops (incl. log/soft_relu/gelu_erf, which fit the
-//     available aux budget) and binary ops (any supported rhs dtype; scalar /
-//     per_element / per_oc / per_oc_spatial / per_w broadcast)
-//   - ternary select (dst = src2 ? src0 : src1) folded into the same f32 path,
-//     so it also supports broadcast, scales, and post-ops; src2 is s8
-// A single instance handles every case internally (RVV has one vector isa).
+//   - a post-op chain: same-parameter sums at any positions (applied
+//     in-kernel) plus any number of eltwise ops (incl. log/soft_relu/gelu_erf,
+//     which fit the available aux budget) and binary ops
+//     (f32/f16/bf16/s32/s8/u8 rhs; scalar / per_element / per_oc /
+//     per_oc_spatial / per_w broadcast),
+//     including the select (ternary) binary post-op with a dst-shaped
+//     condition
+//   - ternary select (dst = src2 ? src0 : src1) folded into the same f32
+//     path, so it also supports broadcast, scales, and post-ops; src2 is s8
+// A single class handles every case internally (RVV has one vector isa); like
+// x64 a second tail-kernel instance covers the blocked channel tail.
 struct jit_uni_binary_t : public primitive_t {
     struct pd_t : public cpu_binary_pd_t {
         using cpu_binary_pd_t::cpu_binary_pd_t;
+
         DECLARE_COMMON_PD_T("jit:uni", jit_uni_binary_t);
 
-        status_t init(const engine_t *engine) {
-            UNUSED(engine);
-            using namespace data_type;
-            using sm = primitive_attr_t::skip_mask_t;
-            const data_type_t dd = dst_md()->data_type;
-            const data_type_t d0 = src_md(0)->data_type;
-            const data_type_t d1 = src_md(1)->data_type;
+        status_t init(const engine_t *engine);
 
-            // Pure JIT, registered via CPU_INSTANCE_RV64 (runtime dispatch):
-            // gate on the V extension, on zvfh if any f16 operand is present,
-            // and on zvfbfwma (which implies the Zvfbfmin conversions the bf16
-            // path emits) if any bf16 operand is present.
-            VDISPATCH_BINARY(mayiuse(v), VERBOSE_UNSUPPORTED_ISA);
-            auto dt_ok = [](data_type_t dt) {
-                return utils::one_of(dt, f32, f16, bf16, s32, s8, u8);
-            };
-            VDISPATCH_BINARY(dt_ok(dd) && dt_ok(d0) && dt_ok(d1),
-                    VERBOSE_UNSUPPORTED_DT);
-            const bool any_f16 = utils::one_of(f16, dd, d0, d1);
-            VDISPATCH_BINARY(IMPLICATION(any_f16, mayiuse(zvfh)),
-                    VERBOSE_UNSUPPORTED_ISA);
-            const bool any_bf16 = utils::one_of(bf16, dd, d0, d1);
-            VDISPATCH_BINARY(IMPLICATION(any_bf16, mayiuse(zvfbfwma)),
-                    VERBOSE_UNSUPPORTED_ISA);
-            VDISPATCH_BINARY(platform::has_data_type_support(dd)
-                            && platform::has_data_type_support(d0)
-                            && platform::has_data_type_support(d1),
-                    VERBOSE_UNSUPPORTED_DT);
-            VDISPATCH_BINARY(check_alg(), VERBOSE_BAD_ALGORITHM);
-
-            // Attributes: per-tensor src0/src1 scales + a post-op chain.
-            VDISPATCH_BINARY(
-                    attr()->has_default_values(sm::post_ops | sm::scales),
-                    VERBOSE_UNSUPPORTED_ATTR);
-            const bool scales_ok
-                    = attr_scales_ok({DNNL_ARG_SRC_0, DNNL_ARG_SRC_1});
-            VDISPATCH_BINARY(scales_ok, VERBOSE_UNSUPPORTED_SCALES_CFG);
-            // Resolve formats before classifying the post-op chain: the post-op
-            // binary rhs (and dst) may arrive as `any`, and post_ops_supported()
-            // compares the rhs layout to dst — mirror x64's ordering so a
-            // dst-shaped (per_element) rhs is not spuriously rejected.
-            VDISPATCH_BINARY_SC(set_default_params(), VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_BINARY_SC(attr_.set_default_formats(dst_md()),
-                    VERBOSE_UNSUPPORTED_TAG);
-            VDISPATCH_BINARY(post_ops_supported(), VERBOSE_UNSUPPORTED_POSTOP);
-            VDISPATCH_BINARY(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
-
-            const bool is_select = desc()->alg_kind == alg_kind::binary_select;
-            if (is_select) {
-                // Ternary select is folded into the general f32 path (broadcast,
-                // scales, sum + post-ops, mixed src0/src1/dst dtypes). The common
-                // binary descriptor forces the condition src2 to s8; it must be
-                // full (dst-shaped, no broadcast — read contiguously per run).
-                VDISPATCH_BINARY(
-                        src_md(2)->data_type == s8, VERBOSE_UNSUPPORTED_DT);
-                const memory_desc_wrapper s2_d(src_md(2));
-                VDISPATCH_BINARY(s2_d.similar_to(memory_desc_wrapper(dst_md()),
-                                         true, false),
-                        VERBOSE_UNSUPPORTED_TAG);
-            }
-
-            VDISPATCH_BINARY(init_conf(), VERBOSE_UNSUPPORTED_TAG);
-            return status::success;
-        }
-
-        // --- broadcast / iteration plan (filled by init_conf) ---
-        // whole_: one flat pass over the tensor (scalar or no-broadcast). Else
-        // the driver iterates n_outer_ runs of inner_ elements, offsetting src1
-        // by the per-dim broadcast strides s1_str_.
-        bool whole_ = false;
-        bool scalar_whole_ = false; // whole_ && src1 is a single scalar
-        bool scalar_inner_ = false; // per-run: src1 broadcasts the inner dim
-        // src1 inner-dim element stride: 1 = contiguous, >1 = strided (src0/src1
-        // different plain layouts, e.g. nchw:nhwc); 0/unused when scalar_inner_.
-        dim_t s1_inner_stride_ = 1;
-        int nd_ = 0;
-        dim_t inner_ = 0; // elements per run (dst last dim)
-        dim_t n_outer_ = 0; // number of runs
-        dim_t total_ = 0; // dst element count
-        // A padded single channel block is processed as one run per physical
-        // block. The last C block uses tail_ active lanes and its remaining dst
-        // padding is explicitly zeroed by the driver.
-        dim_t tail_ = 0;
-        int tail_axis_ = -1; // physical outer axis containing the C-block index
-        bool s1_same_layout_
-                = false; // src1 offset follows the physical dst run
-        dims_t out_dims_ = {}; // dst dims [0..nd-2] (run-major decomposition)
-        dims_t s1_str_ = {}; // src1 element stride per dst dim (0 == broadcast)
-
-        // --- attribute plan ---
-        bool do_scale0_ = false, do_scale1_ = false;
-        bool do_sum_ = false;
-        float sum_scale_ = 0.f;
-        post_ops_t po_; // full post-op chain (kernel applies each sum in place)
-
-        bool check_alg() const {
-            using namespace alg_kind;
-            return utils::one_of(desc()->alg_kind, binary_add, binary_sub,
-                    binary_mul, binary_div, binary_max, binary_min,
-                    binary_select, binary_ge, binary_gt, binary_le, binary_lt,
-                    binary_eq, binary_ne);
-        }
-
-        // Post-ops: sums applied by the kernel at their chain positions (x64/
-        // AArch64 parity: multiple sums are allowed when scale/zero-point match),
-        // plus a chain of eltwise / binary ops the injector can emit.
-        bool post_ops_supported() const {
-            const auto &po = attr()->post_ops_;
-            const int sum_idx = po.find(primitive_kind::sum);
-            if (sum_idx != -1) {
-                const auto &first = po.entry_[sum_idx].sum;
-                for (int i = sum_idx; i < po.len(); i++) {
-                    if (!po.entry_[i].is_sum(false, false)) continue;
-                    const auto &s = po.entry_[i].sum;
-                    if (s.dt != data_type::undef && s.dt != dst_md()->data_type)
-                        return false;
-                    if (s.zero_point != 0 || s.scale != first.scale
-                            || s.zero_point != first.zero_point)
-                        return false;
-                }
-            }
-            for (int i = 0; i < po.len(); i++) {
-                const auto &e = po.entry_[i];
-                if (e.is_sum(false, false)) continue; // handled in-kernel
-                if (e.is_eltwise()) {
-                    // the kernel supplies 4 aux, so the heavy eltwise algs
-                    // (log/soft_relu/gelu_erf) are available here too.
-                    const auto a = e.eltwise.alg;
-                    if (!eltwise_injector::is_alg_supported(a)
-                            && !eltwise_injector::needs_extra_aux(a))
-                        return false;
-                } else if (e.is_binary()) {
-                    if (e.binary.alg != alg_kind::binary_select
-                            && !binary_injector::is_alg_supported(e.binary.alg))
-                        return false;
-                    static const bcast_set_t sb {
-                            broadcasting_strategy_t::scalar,
-                            broadcasting_strategy_t::per_oc,
-                            broadcasting_strategy_t::per_oc_spatial,
-                            broadcasting_strategy_t::per_w,
-                            broadcasting_strategy_t::no_broadcast};
-                    const memory_desc_wrapper dw(dst_md());
-                    // Each operand is converted to f32 at load. Select validates
-                    // its independent condition descriptor with the same current
-                    // dtype/broadcast/layout contract as src1.
-                    const auto rhs_ok = [&](const memory_desc_t &md) {
-                        const memory_desc_wrapper rhs_d(md);
-                        const data_type_t rdt = md.data_type;
-                        if (!utils::one_of(rdt, data_type::f32, data_type::f16,
-                                    data_type::bf16, data_type::s32,
-                                    data_type::s8, data_type::u8))
-                            return false;
-                        if (rdt == data_type::f16 && !mayiuse(zvfh))
-                            return false;
-                        if (rdt == data_type::bf16 && !mayiuse(zvfbfwma))
-                            return false;
-                        // The RVV address paths consume a packed logical rhs.
-                        // Explicit descriptors with holes must fall through,
-                        // matching the x64/AArch64 injector applicability gate.
-                        if (!rhs_d.is_dense(true)) return false;
-                        const auto strat
-                                = get_rhs_arg_broadcasting_strategy(md, dw, sb);
-                        if (strat == broadcasting_strategy_t::unsupported)
-                            return false;
-                        if (strat == broadcasting_strategy_t::no_broadcast
-                                && !memory_desc_wrapper(md).similar_to(
-                                        dw, true, false))
-                            return false;
-                        const bool indexed = utils::one_of(strat,
-                                broadcasting_strategy_t::per_oc,
-                                broadcasting_strategy_t::per_oc_spatial,
-                                broadcasting_strategy_t::per_w);
-                        if (indexed) {
-                            // per_oc/per_w uses an e32 lane index and vluxei32
-                            // byte offsets. Reject shapes whose flattened output
-                            // position, divisor, stride, or rhs byte offset cannot
-                            // be represented without wrapping.
-                            constexpr uint64_t max_u32
-                                    = std::numeric_limits<uint32_t>::max();
-                            const auto last_index_fits = [&](dim_t nelems) {
-                                return nelems <= 0
-                                        || static_cast<uint64_t>(nelems - 1)
-                                        <= max_u32;
-                            };
-                            if (!last_index_fits(dw.nelems(true))) return false;
-                            const dim_t rhs_nelems = rhs_d.nelems(true);
-                            const size_t rhs_esz = rhs_d.data_type_size();
-                            if (rhs_nelems > 0
-                                    && static_cast<uint64_t>(rhs_nelems - 1)
-                                            > max_u32 / rhs_esz)
-                                return false;
-
-                            const auto &bd = dw.blocking_desc();
-                            dim_t count = 0;
-                            dim_t stride = 0;
-                            dim_t blk = 1;
-                            if (strat == broadcasting_strategy_t::per_w) {
-                                const int wd = dw.ndims() - 1;
-                                count = dw.dims()[wd];
-                                stride = bd.strides[wd];
-                            } else {
-                                for (int k = 0; k < bd.inner_nblks; k++)
-                                    if (bd.inner_idxs[k] == 1)
-                                        blk *= bd.inner_blks[k];
-                                if (blk > 16 || (blk & (blk - 1)) != 0)
-                                    return false;
-                                count = (dw.dims()[1] + blk - 1) / blk;
-                                stride = bd.strides[1];
-                            }
-                            if (count <= 0 || stride <= 0
-                                    || static_cast<uint64_t>(count) > max_u32
-                                    || static_cast<uint64_t>(stride) > max_u32)
-                                return false;
-                        }
-                        return true;
-                    };
-                    if (!rhs_ok(e.binary.src1_desc)) return false;
-                    if (e.is_binary_with_ternary_op()
-                            && !rhs_ok(e.binary.src2_desc))
-                        return false;
-                } else
-                    return false; // prelu / etc -> ref
-            }
-            return true;
-        }
+        jit_binary_conf_t get_conf() const { return conf_; }
 
     private:
-        // Layout equality ignoring data type (dims + strides + blocking).
-        static bool layout_eq(
-                const memory_desc_wrapper &a, const memory_desc_wrapper &b) {
-            return a.similar_to(b, true, false);
-        }
+        op_t get_op_type(const memory_desc_wrapper &src0_d);
+        bool is_only_dim0_bcasted(const dims_t &bcast_dims, const int ndims);
+        bcast_t get_bcast_type(
+                const memory_desc_wrapper &src1_d, const dims_t &bcast_dims);
 
-        bool init_conf() {
-            const memory_desc_wrapper s0(src_md(0));
-            const memory_desc_wrapper s1(src_md(1));
-            const memory_desc_wrapper d(dst_md());
-            if (!d.is_dense(true) || !s0.is_dense(true) || !s1.is_dense(true))
-                return false;
-            // src0 must match dst layout exactly (no src0 broadcast).
-            if (!layout_eq(s0, d)) return false;
+        // alg_preserves_zero returns true if operation preserves zero in case
+        // of both inputs contain zero.
+        bool alg_preserves_zero() const;
+        bool check_scales_mask() const;
+        bool is_bcast_pattern(const dims_t &bcast_dims, const dim_t ndims,
+                const dim_t N_bcast, const dim_t C_bcast,
+                const dim_t W_bcast) const;
+        bool is_bcast_allowed(const int ndims) const;
+        bool is_format_non_blocked(const memory_desc_wrapper &mdw) const;
+        bool is_different_layouts_allowed(const memory_desc_wrapper &src0_d,
+                const memory_desc_wrapper &src1_d) const;
+        bool is_applicable();
 
-            nd_ = d.ndims();
-            total_ = d.nelems(false);
-            const bool has_padding = d.nelems(true) != d.nelems(false);
-
-            // scales
-            do_scale0_ = !attr()->scales_.has_default_values(DNNL_ARG_SRC_0);
-            do_scale1_ = !attr()->scales_.has_default_values(DNNL_ARG_SRC_1);
-
-            // Full post-op chain; the kernel applies every sum at its position
-            // and the injector skips those entries.
-            const auto &po = attr()->post_ops_;
-            const int sum_pos = po.find(primitive_kind::sum);
-            do_sum_ = sum_pos != -1;
-            sum_scale_ = do_sum_ ? po.entry_[sum_pos].sum.scale : 0.f;
-            po_ = po;
-
-            // src1 whole-tensor cases
-            if (!has_padding && s1.nelems(false) == 1) {
-                whole_ = true;
-                scalar_whole_ = true;
-                return true;
-            }
-            if (!has_padding && layout_eq(s1, d)) {
-                whole_ = true;
-                scalar_whole_ = false;
-                return true;
-            }
-
-            // General broadcast over a plain OR single-inner-block dst (nchw,
-            // nhwc, nChw8c/16c, ...). src1 may be plain or use the same inner
-            // block as dst; dst may carry at most one inner block.
-            const auto &dbd = d.blocking_desc();
-            const auto &s1bd = s1.blocking_desc();
-            s1_same_layout_ = layout_eq(s1, d);
-            const bool scalar_s1 = s1.nelems(false) == 1;
-            if (dbd.inner_nblks > 1) return false; // at most one inner block
-
-            const int bdim = dbd.inner_nblks == 1 ? dbd.inner_idxs[0] : -1;
-            const dim_t blk = dbd.inner_nblks == 1 ? dbd.inner_blks[0] : 1;
-            const bool s1_blocked = s1bd.inner_nblks == 1 && bdim >= 0
-                    && s1bd.inner_idxs[0] == bdim && s1bd.inner_blks[0] == blk;
-            if (s1bd.inner_nblks != 0 && !s1_blocked && !scalar_s1)
-                return false;
-
-            const dim_t *dd = d.dims();
-            const dim_t *d1 = s1.dims();
-            const auto &dstr = dbd.strides;
-            const auto &s1str = s1bd.strides;
-            for (int i = 0; i < nd_; i++)
-                if (d1[i] != 1 && d1[i] != dd[i]) return false;
-
-            // Build the physical dims outer->inner: each logical dim's outer
-            // part (sorted by dst stride, memory order), then the inner block
-            // (if any) as the unit-stride innermost. For the blocked dim, the
-            // outer part advances src1 by blk channels per step. The run index
-            // then maps to contiguous dst blocks and the correct src1 offset.
-            if (has_padding) {
-                // Match the x64/AArch64 supported tail family: one power-of-two
-                // channel block no wider than 16, with padding only on C.
-                if (bdim != 1 || blk > 16 || (blk & (blk - 1)) != 0)
-                    return false;
-                for (int i = 0; i < nd_; i++)
-                    if (i != bdim && d.padded_dims()[i] != dd[i]) return false;
-                if (d.padded_dims()[bdim] != ((dd[bdim] + blk - 1) / blk) * blk)
-                    return false;
-                tail_ = dd[bdim] % blk;
-            }
-            struct phys_t {
-                dim_t size, s1s, sort;
-                int logical_dim;
-            } ph[DNNL_MAX_NDIMS + 1];
-            int np = 0;
-            for (int i = 0; i < nd_; i++) {
-                const dim_t osz = (i == bdim) ? (dd[i] + blk - 1) / blk : dd[i];
-                if (osz < 1) return false;
-                const dim_t s1s = d1[i] == 1
-                        ? 0
-                        : (i == bdim && !s1_blocked ? s1str[i] * blk
-                                                    : s1str[i]);
-                ph[np++] = {osz, s1s, dstr[i], i};
-            }
-            for (int a = 0; a < np; a++)
-                for (int b = a + 1; b < np; b++)
-                    if (ph[b].sort > ph[a].sort) {
-                        const phys_t t = ph[a];
-                        ph[a] = ph[b];
-                        ph[b] = t;
-                    }
-            if (bdim >= 0) {
-                const dim_t s1s_in
-                        = d1[bdim] == 1 ? 0 : (s1_blocked ? 1 : s1str[bdim]);
-                ph[np++] = {blk, s1s_in, 1, bdim};
-            }
-
-            // Coalesce trailing physical dims into one longer run while the
-            // dst stays contiguous across the boundary and src1 advances
-            // uniformly (both dims broadcast, or the outer stride continues
-            // the inner element pattern). Short innermost runs otherwise
-            // dominate with per-call overhead: channels-first per-C measured
-            // ~2x slower with W-sized runs than with plane-sized runs. Padded
-            // tensors keep per-block runs (the zeroed tail must stay a run
-            // suffix); keep at least nthr runs so the driver can parallelize.
-            const dim_t min_outer = dnnl_get_max_threads();
-            while (tail_ == 0 && np >= 2) {
-                const phys_t in = ph[np - 1];
-                const phys_t out = ph[np - 2];
-                if (out.sort != in.sort * in.size) break;
-                const bool both_bcast = out.s1s == 0 && in.s1s == 0;
-                const bool uniform = in.s1s != 0 && out.s1s == in.s1s * in.size;
-                if (!both_bcast && !uniform) break;
-                dim_t outer = 1;
-                for (int k = 0; k + 2 < np; k++)
-                    outer *= ph[k].size;
-                if (outer < min_outer) break;
-                ph[np - 2].size = out.size * in.size;
-                ph[np - 2].s1s = in.s1s;
-                ph[np - 2].sort = in.sort;
-                np--;
-            }
-
-            const phys_t &in = ph[np - 1];
-            if (in.sort != 1) return false; // innermost must be dst-unit-stride
-            inner_ = in.size;
-            scalar_inner_ = in.s1s == 0;
-            // src1 inner stride: 0 = broadcast (scalar), 1 = contiguous (vle),
-            // >1 = strided (vlse) — src0/src1 different plain layouts, e.g.
-            // nchw:nhwc, mirroring x64's is_different_layouts_allowed.
-            s1_inner_stride_ = in.s1s;
-            n_outer_ = 1;
-            nd_ = np; // physical dim count drives the execute decomposition
-            for (int k = 0; k < np - 1; k++) {
-                out_dims_[k] = ph[k].size;
-                s1_str_[k] = ph[k].s1s;
-                n_outer_ *= ph[k].size;
-                if (tail_ != 0 && ph[k].logical_dim == bdim) tail_axis_ = k;
-            }
-            if (tail_ != 0 && tail_axis_ < 0) return false;
-            whole_ = false;
-            return true;
-        }
+        jit_binary_conf_t conf_;
     };
 
     jit_uni_binary_t(const pd_t *apd);
-    ~jit_uni_binary_t() override;
+
+    ~jit_uni_binary_t() override = default;
 
     status_t init(engine_t *engine) override;
-    status_t execute(const exec_ctx_t &ctx) const override;
 
-    // Threads at or above this count switch to the unrolled (per-stream-burst)
-    // f32 main loop; below, the narrow (m1-interleaved) loop is faster.
-    static constexpr int unrolled_kernel_min_nthrs = 4;
+    using data_t = int8_t;
+
+    // Same driver-strategy split as x64/aarch64, chosen by op_type x bcast_type.
+    // The scale pointers x64 forwards to the kernel are dereferenced up front on
+    // rv64 and passed by value. Under blocked_oc_tail the last channel block is
+    // dispatched to kernel_tail_ (x64 shape), which stores the valid lanes of
+    // each block and zeroes the padded tail in-kernel.
+    void execute_no_bcast_strategy(const data_t *src0, const data_t *src1,
+            const data_t *src2, data_t *dst, float scale0, float scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+            const bcast_t bcast_type) const;
+    void execute_bcast_per_batch_strategy(const data_t *src0,
+            const data_t *src1, const data_t *src2, data_t *dst, float scale0,
+            float scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec) const;
+    void execute_bcast_per_c_strategy(const data_t *src0, const data_t *src1,
+            const data_t *src2, data_t *dst, float scale0, float scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+            const op_t op_type, const bcast_t bcast_type,
+            const bool blocked_oc_tail) const;
+    void execute_bcast_per_w_strategy(const data_t *src0, const data_t *src1,
+            const data_t *src2, data_t *dst, float scale0, float scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+            const op_t op_type, const bool blocked_oc_tail) const;
+
+    status_t execute(const exec_ctx_t &ctx) const override;
 
 private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
-    std::unique_ptr<jit_uni_binary_kernel_t> kernel_;
-    // Unrolled / narrow f32 streaming variants; null when the shape/attr
-    // does not fit them. The driver selects one by the call's thread count.
-    std::unique_ptr<jit_uni_binary_kernel_t> kernel_unrolled_;
-    std::unique_ptr<jit_uni_binary_kernel_t> kernel_narrow_;
+    static bool post_ops_ok(const primitive_attr_t *attr,
+            const memory_desc_wrapper &src0_d, const memory_desc_wrapper &dst_d,
+            const bool is_src_different_layouts, const cpu_isa_t isa);
+
+    std::unique_ptr<binary_kernel_t> kernel_;
+    // used only in bcast_c_blocked strategy if tail exists (the plain-shape
+    // element tail needs no second kernel: vsetvli subsumes it)
+    std::unique_ptr<binary_kernel_t> kernel_tail_;
 };
 
 } // namespace rv64
@@ -474,4 +141,4 @@ private:
 } // namespace impl
 } // namespace dnnl
 
-#endif // CPU_RV64_JIT_UNI_BINARY_HPP
+#endif

--- a/src/cpu/rv64/jit_uni_binary.hpp
+++ b/src/cpu/rv64/jit_uni_binary.hpp
@@ -87,6 +87,7 @@ struct jit_uni_binary_t : public primitive_t {
         bool is_different_layouts_allowed(const memory_desc_wrapper &src0_d,
                 const memory_desc_wrapper &src1_d) const;
         bool is_applicable();
+        bool init_generic_conf();
 
         jit_binary_conf_t conf_;
     };
@@ -121,6 +122,9 @@ struct jit_uni_binary_t : public primitive_t {
             const data_t *src2, data_t *dst, float scale0, float scale1,
             const std::vector<const void *> &post_ops_binary_rhs_arg_vec,
             const op_t op_type, const bool blocked_oc_tail) const;
+    void execute_generic_strategy(const data_t *src0, const data_t *src1,
+            const data_t *src2, data_t *dst, float scale0, float scale1,
+            const std::vector<const void *> &post_ops_binary_rhs_arg_vec) const;
 
     status_t execute(const exec_ctx_t &ctx) const override;
 
@@ -128,7 +132,8 @@ private:
     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
     static bool post_ops_ok(const primitive_attr_t *attr,
             const memory_desc_wrapper &src0_d, const memory_desc_wrapper &dst_d,
-            const bool is_src_different_layouts, const cpu_isa_t isa);
+            const bool is_src_different_layouts, const cpu_isa_t isa,
+            const bool use_generic_strategy);
 
     std::unique_ptr<binary_kernel_t> kernel_;
     // used only in bcast_c_blocked strategy if tail exists (the plain-shape

--- a/src/cpu/rv64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_binary_kernel.cpp
@@ -1,0 +1,598 @@
+/*******************************************************************************
+* Copyright 2022 Intel Corporation
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include <cstring>
+
+#include "cpu/rv64/jit_uni_binary_kernel.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+#define PARAM_OFF(x) offsetof(jit_uni_binary_args_t, x)
+
+// Keep in sync with the pd's set in jit_uni_binary.cpp (x64 duplicates the
+// file-local function the same way): the codegen-time classification must
+// match the pd's, and both stay the x64 subset of the injector's abilities.
+static bcast_set_t get_supported_postops_bcast_strategies() {
+    return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
+            broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::per_w,
+            broadcasting_strategy_t::no_broadcast};
+}
+
+jit_uni_binary_kernel_t::jit_uni_binary_kernel_t(
+        const binary_pd_t *pd, const jit_binary_conf_t &conf, bool tail_kernel)
+    // rv64's DECLARE_CPU_JIT_AUX_FUNCTIONS has no static jit_name(); keep the
+    // stable generated-code name registered with jit_utils.
+    : binary_kernel_t(pd, conf, "jit_uni_binary", tail_kernel) {
+    init();
+}
+
+void jit_uni_binary_kernel_t::init() {
+    if (conf_.with_postops) init_post_ops_injector();
+}
+
+void jit_uni_binary_kernel_t::init_post_ops_injector() {
+    const auto &po = pd_->attr()->post_ops_;
+    const memory_desc_wrapper dst_d(pd_->dst_md(0));
+
+    // The eltwise post-op injector gets five aux groups (v8/v12/v16 +
+    // v24/v28); v24/v28 are free at m4 (accumulator v4, src1 v8, staging
+    // v12/v16, binary rhs v20), so the heavy eltwise algs (log/soft_relu/
+    // gelu_erf) fit here too.
+    eltwise_injector::static_params_t esp(vreg_src1_, vreg_tmp0_, vreg_tmp1_,
+            VReg(24), VReg(28), fa0, fa1, reg_tmp_, /*is_fwd=*/true);
+    // Binary rhs addressing: the injector derives each entry's broadcast
+    // strategy and rhs dtype from post_op + dst_d at call time and recovers
+    // the output element offset from the dst chunk address and dst_orig (x64
+    // model). reg_tmp1_/reg_bytes_ are its address scratch, v24 the per-oc
+    // gather index (the eltwise aux3 shares it but runs in a different
+    // post-op entry, so there is no temporal overlap), and v12 the narrow-rhs
+    // staging (distinct from v20/v24 so the widen is a legal overlap). A
+    // select post-op consumes the v0 mask plus the shared v20/v12 helpers; v0
+    // is dead here between injector calls (the main op's mask is consumed
+    // before post-ops run).
+    // x64-style rhs_arg_static_params_t: helper vmm index, rhs addr/helper/
+    // cache GPRs, preserve flags (GPR preservation shields the injector's
+    // fixed X_TMP scratch, which doubles as this kernel's t4/t5 loop state;
+    // vmm helpers are host-reserved statically -> false), the args-struct
+    // offsets of the rhs pointer array and dst_orig, dst_d.
+    binary_injector::rhs_arg_static_params_t rhs_arg_bsp(vreg_rhs_.getIdx(),
+            reg_tmp1_, reg_bytes_, reg_tmp_, true /*preserve gpr*/,
+            false /*preserve vmm*/, PARAM_OFF(post_ops_binary_rhs_arg_vec),
+            PARAM_OFF(dst_orig), dst_d);
+    rhs_arg_bsp.rhs_dt_helper_freg = fa7;
+    rhs_arg_bsp.gather_idx_vmm = VReg(24);
+    rhs_arg_bsp.narrow_stage_vmm = vreg_tmp0_;
+    // Channel-aligned per-oc rhs (x64's per-call scalar addressing): the
+    // dispatch routes per-oc post-op cases to the per_c/per_w strategies, so
+    // the injector recovers the channel offset from the dst address and loads
+    // the rhs contiguously (or broadcasts one value) instead of the per-lane
+    // gather. op_t::none cannot be routed and keeps the gather (the dispatch
+    // predicate must equal this creation predicate).
+    rhs_arg_bsp.per_oc_lanes_are_channels
+            = conf_.postops_per_oc_broadcast_exists
+            && conf_.op_type != op_t::none;
+    const binary_injector::static_params_t bsp(
+            reg_param_, get_supported_postops_bcast_strategies(), rhs_arg_bsp);
+
+    // The in-kernel sum is a host lambda (the x64/aarch64 lambda-injector
+    // scheme): the postops injector invokes it at the sum's exact chain
+    // position, so sums land anywhere in the chain. Following x64's do_sum
+    // definition, a zero sum scale drops the old-dst read (no lambda).
+    injector::lambda_jit_injectors_t lambda_jit_injectors;
+    if (conf_.do_sum)
+        lambda_jit_injectors.emplace(primitive_kind::sum, [this]() {
+            // old dst -> vreg_tmp1_ (f32)
+            load_vector(conf_.dst_type, vreg_tmp1_, vreg_tmp0_, reg_dst_);
+            vfmacc_vf(vreg_src0_, freg_sum_scale_, vreg_tmp1_);
+        });
+
+    // Instantiate the injector at the isa the pd validated the post-op chain
+    // with so its is_data_supported contract admits exactly the rhs dtypes the
+    // pd accepted. RVV codegen is otherwise identical for each instantiation.
+    if (mayiuse(zvfbfwma))
+        postops_injector_zvfbfwma_.reset(
+                new injector::jit_uni_postops_injector_t<zvfbfwma>(
+                        this, po, bsp, esp, lambda_jit_injectors));
+    else if (mayiuse(zvfh))
+        postops_injector_zvfh_.reset(
+                new injector::jit_uni_postops_injector_t<zvfh>(
+                        this, po, bsp, esp, lambda_jit_injectors));
+    else
+        postops_injector_v_.reset(new injector::jit_uni_postops_injector_t<v>(
+                this, po, bsp, esp, lambda_jit_injectors));
+}
+
+void jit_uni_binary_kernel_t::apply_postops() {
+    // The per-register rhs addressing (x64's rhs_arg_params analog): map the
+    // accumulator to the register holding its dst chunk address; the injector
+    // recovers the element offset via dst_orig.
+    binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
+    if (conf_.with_binary)
+        rhs_arg_params.vmm_idx_to_out_reg.emplace(
+                vreg_src0_.getIdx(), reg_dst_);
+
+    // The kernel computes at e32/m4 (group_stride 4); the injector uses it to
+    // load a narrow rhs at the matching LMUL.
+    if (postops_injector_zvfbfwma_)
+        postops_injector_zvfbfwma_->compute_vector(
+                vreg_src0_.getIdx(), rhs_arg_params, compute_group_stride_);
+    else if (postops_injector_zvfh_)
+        postops_injector_zvfh_->compute_vector(
+                vreg_src0_.getIdx(), rhs_arg_params, compute_group_stride_);
+    else
+        postops_injector_v_->compute_vector(
+                vreg_src0_.getIdx(), rhs_arg_params, compute_group_stride_);
+}
+
+void jit_uni_binary_kernel_t::load_kernel_params() {
+    ld(reg_src0_, reg_param_, PARAM_OFF(src0));
+    ld(reg_src1_, reg_param_, PARAM_OFF(src1));
+    if (conf_.is_ternary_op) ld(reg_src2_, reg_param_, PARAM_OFF(src2));
+    ld(reg_dst_, reg_param_, PARAM_OFF(dst));
+    ld(reg_work_amount_, reg_param_, PARAM_OFF(work_amount));
+    if (conf_.do_scale_src0)
+        flw(freg_scales_src0_, reg_param_, PARAM_OFF(scales_src0));
+    if (conf_.do_scale_src1)
+        flw(freg_scales_src1_, reg_param_, PARAM_OFF(scales_src1));
+    if (conf_.do_sum) flw(freg_sum_scale_, reg_param_, PARAM_OFF(sum_scale));
+}
+
+void jit_uni_binary_kernel_t::materialize_cmp() {
+    // Comparisons yield the oneDNN-required f32 0.0/1.0 (x64 blends from a
+    // preloaded ones register under the compare mask instead).
+    const FReg freg_zero = fa0, freg_one = fa1;
+    fmv_w_x(freg_zero, x0);
+    li(reg_tmp_, 0x3f800000);
+    fmv_w_x(freg_one, reg_tmp_);
+    vfmv_v_f(vreg_src0_, freg_zero);
+    // vreg_src0_[i] = v0[i] ? 1.0 : 0.0
+    vfmerge_vfm(vreg_src0_, vreg_src0_, freg_one);
+}
+
+void jit_uni_binary_kernel_t::perform_op(const VReg &v0, const VReg &v1) {
+    using namespace alg_kind;
+    switch (pd_->desc()->alg_kind) {
+        case binary_add: vfadd_vv(v0, v0, v1); break;
+        case binary_sub: vfsub_vv(v0, v0, v1); break;
+        case binary_mul: vfmul_vv(v0, v0, v1); break;
+        case binary_div: vfdiv_vv(v0, v0, v1); break;
+        case binary_max:
+            // nstl::max(src0,src1) = (src1 < src0) ? src0 : src1 (picks src1
+            // on ties/unordered, matching the reference and x86 vmaxps).
+            vmflt_vv(vreg_mask_, v1, v0);
+            vmerge_vvm(v0, v1, v0);
+            break;
+        case binary_min:
+            // nstl::min(src0,src1) = (src0 < src1) ? src0 : src1.
+            vmflt_vv(vreg_mask_, v0, v1);
+            vmerge_vvm(v0, v1, v0);
+            break;
+        // vmfgt/vmfge have no vv form: swap operands.
+        case binary_ge:
+            vmfle_vv(vreg_mask_, v1, v0);
+            materialize_cmp();
+            break;
+        case binary_gt:
+            vmflt_vv(vreg_mask_, v1, v0);
+            materialize_cmp();
+            break;
+        case binary_le:
+            vmfle_vv(vreg_mask_, v0, v1);
+            materialize_cmp();
+            break;
+        case binary_lt:
+            vmflt_vv(vreg_mask_, v0, v1);
+            materialize_cmp();
+            break;
+        case binary_eq:
+            vmfeq_vv(vreg_mask_, v0, v1);
+            materialize_cmp();
+            break;
+        case binary_ne:
+            vmfne_vv(vreg_mask_, v0, v1);
+            materialize_cmp();
+            break;
+        default: assert(!"unsupported operation!"); break;
+    }
+}
+
+void jit_uni_binary_kernel_t::perform_op(const VReg &v0, const FReg &s1) {
+    using namespace alg_kind;
+    switch (pd_->desc()->alg_kind) {
+        case binary_add: vfadd_vf(v0, v0, s1); break;
+        case binary_sub: vfsub_vf(v0, v0, s1); break;
+        case binary_mul: vfmul_vf(v0, v0, s1); break;
+        case binary_div: vfdiv_vf(v0, v0, s1); break;
+        case binary_max:
+            // nstl::max(src0,src1) = (src1 < src0) ? src0 : src1 (picks src1
+            // on ties/unordered, matching the reference and x86 vmaxps).
+            vfmv_v_f(vreg_src1_, s1);
+            vmflt_vv(vreg_mask_, vreg_src1_, v0);
+            vmerge_vvm(v0, vreg_src1_, v0);
+            break;
+        case binary_min:
+            // nstl::min(src0,src1) = (src0 < src1) ? src0 : src1.
+            vfmv_v_f(vreg_src1_, s1);
+            vmflt_vv(vreg_mask_, v0, vreg_src1_);
+            vmerge_vvm(v0, vreg_src1_, v0);
+            break;
+        case binary_ge:
+            vmfge_vf(vreg_mask_, v0, s1);
+            materialize_cmp();
+            break;
+        case binary_gt:
+            vmfgt_vf(vreg_mask_, v0, s1);
+            materialize_cmp();
+            break;
+        case binary_le:
+            vmfle_vf(vreg_mask_, v0, s1);
+            materialize_cmp();
+            break;
+        case binary_lt:
+            vmflt_vf(vreg_mask_, v0, s1);
+            materialize_cmp();
+            break;
+        case binary_eq:
+            vmfeq_vf(vreg_mask_, v0, s1);
+            materialize_cmp();
+            break;
+        case binary_ne:
+            vmfne_vf(vreg_mask_, v0, s1);
+            materialize_cmp();
+            break;
+        default: assert(!"unsupported operation!"); break;
+    }
+}
+
+void jit_uni_binary_kernel_t::perform_ternary_op(
+        const VReg &v0, const VReg &v1, const VReg &vreg_stage) {
+    // dst = src2 ? src0 : src1. Materialize a scalar-broadcast src1, then set
+    // v0 = (src2 == 0) and merge (v0 ? src1 : src0). The s8 condition is
+    // forced by the common binary descriptor; the mask stays valid across the
+    // SEW switch back to the compute vtype (same vl).
+    if (conf_.broadcast_src1_value) vfmv_v_f(v1, freg_bcast_src1_);
+    vsetvli(x0, reg_vl_, SEW::e8, stage_e8_lmul_, VTA::ta, VMA::ma);
+    vle8_v(vreg_stage, reg_src2_);
+    vmseq_vx(vreg_mask_, vreg_stage, x0); // v0 = (src2 == 0)
+    to_compute_vtype();
+    vmerge_vvm(v0, v0, v1);
+}
+
+void jit_uni_binary_kernel_t::compute_bcast() {
+    // Preload the broadcast scalar src1 (f32) once per kernel call, scaled
+    // once (x64 compute_bcast broadcasts into a vector register; RVV keeps a
+    // scalar FP register and uses the .vf instruction forms).
+    if (conf_.broadcast_src1_value) {
+        load_scalar(conf_.src1_type, freg_bcast_src1_, reg_src1_);
+        if (conf_.do_scale_src1)
+            fmul_s(freg_bcast_src1_, freg_bcast_src1_, freg_scales_src1_);
+    }
+}
+
+void jit_uni_binary_kernel_t::load_vector(data_type_t dt, const VReg &vreg,
+        const VReg &vreg_stage, const Reg &reg_ptr, dim_t stride_elems) {
+    using namespace data_type;
+    // The src1 byte stride is hoisted into reg_src1_stride_ by
+    // forward_over_outer_dims (the only strided consumer).
+    const bool strided = stride_elems > 1;
+    if (dt == f32) {
+        to_compute_vtype();
+        strided ? vlse32_v(vreg, reg_ptr, reg_src1_stride_)
+                : vle32_v(vreg, reg_ptr);
+    } else if (dt == s32) {
+        to_compute_vtype();
+        strided ? vlse32_v(vreg, reg_ptr, reg_src1_stride_)
+                : vle32_v(vreg, reg_ptr);
+        vfcvt_f_x_v(vreg, vreg);
+    } else if (dt == f16 || dt == bf16) {
+        vsetvli(x0, reg_vl_, SEW::e16, stage_e16_lmul_, VTA::ta, VMA::ma);
+        strided ? vlse16_v(vreg_stage, reg_ptr, reg_src1_stride_)
+                : vle16_v(vreg_stage, reg_ptr);
+        if (dt == bf16)
+            vfwcvtbf16_f_f_v(vreg, vreg_stage);
+        else
+            vfwcvt_f_f_v(vreg, vreg_stage); // e16m2 -> e32m4
+        to_compute_vtype();
+    } else { // s8 / u8
+        // vsext/vzext.vf4 read the source group as 8-bit at the e32/m4 dest
+        // vtype, so load at e8/m1 then switch vtype before extending.
+        vsetvli(x0, reg_vl_, SEW::e8, stage_e8_lmul_, VTA::ta, VMA::ma);
+        strided ? vlse8_v(vreg_stage, reg_ptr, reg_src1_stride_)
+                : vle8_v(vreg_stage, reg_ptr);
+        to_compute_vtype();
+        if (dt == s8) {
+            vsext_vf4(vreg, vreg_stage);
+            vfcvt_f_x_v(vreg, vreg);
+        } else {
+            vzext_vf4(vreg, vreg_stage);
+            vfcvt_f_xu_v(vreg, vreg);
+        }
+    }
+}
+
+void jit_uni_binary_kernel_t::load_scalar(
+        data_type_t dt, const FReg &freg, const Reg &reg_ptr) {
+    using namespace data_type;
+    if (dt == f32) {
+        flw(freg, reg_ptr, 0);
+    } else if (dt == s32) {
+        lw(reg_tmp_, reg_ptr, 0);
+        fcvt_s_w(freg, reg_tmp_);
+    } else if (dt == s8) {
+        lb(reg_tmp_, reg_ptr, 0);
+        fcvt_s_w(freg, reg_tmp_);
+    } else if (dt == u8) {
+        lbu(reg_tmp_, reg_ptr, 0);
+        fcvt_s_wu(freg, reg_tmp_);
+    } else { // f16/bf16: widen via the vector unit, extract lane 0
+        // Single-lane extraction (AVL = 1), so these LMULs are unrelated to the
+        // compute vtype and stay literal: any e16/e32 pair works at vl = 1.
+        li(reg_tmp_, 1);
+        vsetvli(x0, reg_tmp_, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+        vle16_v(vreg_rhs_, reg_ptr);
+        if (dt == bf16)
+            vfwcvtbf16_f_f_v(vreg_src1_, vreg_rhs_);
+        else
+            vfwcvt_f_f_v(vreg_src1_, vreg_rhs_); // e16m1 -> e32m2
+        vsetvli(x0, reg_tmp_, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+        vfmv_f_s(freg, vreg_src1_);
+    }
+}
+
+void jit_uni_binary_kernel_t::store_vector(data_type_t dt, const VReg &vreg,
+        const VReg &vreg_stage, const Reg &reg_ptr) {
+    using namespace data_type;
+    if (dt == f32) {
+        to_compute_vtype();
+        vse32_v(vreg, reg_ptr);
+    } else if (dt == s32) {
+        to_compute_vtype();
+        load_f32_const(freg_tmp_, -2147483648.0f);
+        vfmax_vf(vreg, vreg, freg_tmp_);
+        // RISC-V vfcvt.x.f saturates; max f32 below 2^31 is 2147483520.
+        load_f32_const(freg_tmp_, 2147483520.0f);
+        vfmin_vf(vreg, vreg, freg_tmp_);
+        vfcvt_x_f_v(vreg, vreg);
+        vse32_v(vreg, reg_ptr);
+    } else if (dt == f16 || dt == bf16) {
+        vsetvli(x0, reg_vl_, SEW::e16, stage_e16_lmul_, VTA::ta, VMA::ma);
+        if (dt == bf16)
+            vfncvtbf16_f_f_w(vreg_stage, vreg);
+        else
+            vfncvt_f_f_w(vreg_stage, vreg); // e32m4 -> e16m2
+        vse16_v(vreg_stage, reg_ptr);
+    } else { // s8 / u8
+        const bool is_s8 = dt == s8;
+        to_compute_vtype();
+        load_f32_const(freg_tmp_, is_s8 ? -128.0f : 0.0f);
+        vfmax_vf(vreg, vreg, freg_tmp_);
+        load_f32_const(freg_tmp_, is_s8 ? 127.0f : 255.0f);
+        vfmin_vf(vreg, vreg, freg_tmp_);
+        if (is_s8)
+            vfcvt_x_f_v(vreg, vreg);
+        else
+            vfcvt_xu_f_v(vreg, vreg);
+        // Narrow i32(m4) -> i16(m2) -> i8(m1) through the staging group; values
+        // are pre-clamped so the vnsrl-by-0 truncation is exact.
+        vsetvli(x0, reg_vl_, SEW::e16, stage_e16_lmul_, VTA::ta, VMA::ma);
+        vnsrl_wi(vreg_stage, vreg, 0);
+        vsetvli(x0, reg_vl_, SEW::e8, stage_e8_lmul_, VTA::ta, VMA::ma);
+        vnsrl_wi(vreg_stage, vreg_stage, 0);
+        vse8_v(vreg_stage, reg_ptr);
+    }
+}
+
+void jit_uni_binary_kernel_t::compute_dst_body() {
+    // src0 -> vreg_src0_ (f32)
+    load_vector(conf_.src0_type, vreg_src0_, vreg_tmp0_, reg_src0_);
+    if (conf_.do_scale_src0)
+        vfmul_vf(vreg_src0_, vreg_src0_, freg_scales_src0_);
+    if (!conf_.broadcast_src1_value) {
+        // src1 -> vreg_src1_ (f32); strided for different plain layouts.
+        load_vector(conf_.src1_type, vreg_src1_, vreg_tmp1_, reg_src1_,
+                conf_.src1_stride);
+        if (conf_.do_scale_src1)
+            vfmul_vf(vreg_src1_, vreg_src1_, freg_scales_src1_);
+    }
+
+    if (conf_.is_ternary_op)
+        perform_ternary_op(vreg_src0_, vreg_src1_, vreg_tmp1_);
+    else if (conf_.broadcast_src1_value)
+        perform_op(vreg_src0_, freg_bcast_src1_);
+    else
+        perform_op(vreg_src0_, vreg_src1_);
+}
+
+void jit_uni_binary_kernel_t::compute_dst() {
+    compute_dst_body();
+    if (has_postops_injector()) apply_postops();
+    store_vector(conf_.dst_type, vreg_src0_, vreg_tmp1_, reg_dst_);
+}
+
+void jit_uni_binary_kernel_t::forward() {
+    compute_bcast(); // bcast scalar loaded just one time per a kernel call
+
+    // Channel-aligned per-oc post-op rhs addressing (see conf /
+    // init_post_ops_injector).
+    const bool per_oc_rhs = conf_.postops_per_oc_broadcast_exists
+            && conf_.op_type != op_t::none;
+
+    if (conf_.is_src_different_layouts) {
+        forward_over_outer_dims();
+        return;
+    }
+
+    const bool is_blk = conf_.op_type == op_t::c_blocked;
+    const memory_desc_wrapper dst_d(pd_->dst_md(0));
+    const int c_blk = is_blk ? (int)dst_d.blocking_desc().inner_blks[0] : 0;
+    // per_c x c_blocked: src1 is neither broadcast nor advancing -- the same
+    // c_block vector is re-read every block (x64's offt_src1_ == 0).
+    const bool src1_block_reuse
+            = is_blk && !conf_.broadcast_src1_value && !conf_.use_stride_src1;
+    // Step one channel block per iteration (AVL = a constant the vsetvli
+    // always grants in full, VLMAX(e32, m4) >= 16 >= c_block): the tail
+    // kernel must stop at the valid lanes, src1 reuse must not cross a block,
+    // and the per-oc rhs slice must stay within one block. The driver only
+    // ever sends multiples of c_block. The plain-shape/no-constraint cases
+    // keep the full-VLMAX VLA loop.
+    const bool block_stepped
+            = is_tail_kernel_ || src1_block_reuse || (is_blk && per_oc_rhs);
+    if (block_stepped)
+        li(reg_blk_avl_, is_tail_kernel_ ? (uint32_t)tail_size_ : c_blk);
+
+    Label loop, end;
+    L(loop);
+    beqz(reg_work_amount_, end);
+
+    if (block_stepped)
+        vsetvli(reg_vl_, reg_blk_avl_, SEW::e32, compute_lmul_, VTA::ta,
+                VMA::ma);
+    else
+        set_compute_vl();
+    compute_dst();
+    if (is_tail_kernel_) zero_pad_tail(c_blk);
+
+    // Advance pointers by vl elements using the vl granted by vsetvli, not
+    // the requested work amount.
+    auto advance = [&](const Reg &reg_ptr, data_type_t dt) {
+        const int dt_size = (int)types::data_type_size(dt);
+        const int shift = dt_size == 4 ? 2 : (dt_size == 2 ? 1 : 0);
+        if (shift)
+            slli(reg_bytes_, reg_vl_, shift);
+        else
+            mv(reg_bytes_, reg_vl_);
+        add(reg_ptr, reg_ptr, reg_bytes_);
+    };
+    // Block-stepped: advance by the constant c_block regardless of vl (the
+    // tail kernel computes only the valid lanes but still steps whole
+    // blocks).
+    auto advance_const = [&](const Reg &reg_ptr, int nelems, data_type_t dt) {
+        addi(reg_ptr, reg_ptr, nelems * (int)types::data_type_size(dt));
+    };
+    if (block_stepped) {
+        advance_const(reg_src0_, c_blk, conf_.src0_type);
+        advance_const(reg_dst_, c_blk, conf_.dst_type);
+        if (!conf_.broadcast_src1_value && !src1_block_reuse)
+            advance_const(reg_src1_, c_blk, conf_.src1_type);
+        if (conf_.is_ternary_op) advance_const(reg_src2_, c_blk, data_type::s8);
+        addi(reg_work_amount_, reg_work_amount_, -c_blk);
+    } else {
+        advance(reg_src0_, conf_.src0_type);
+        advance(reg_dst_, conf_.dst_type);
+        if (!conf_.broadcast_src1_value) advance(reg_src1_, conf_.src1_type);
+        // select condition: full (dst-shaped), s8 (1 B/elem)
+        if (conf_.is_ternary_op) advance(reg_src2_, data_type::s8);
+        sub(reg_work_amount_, reg_work_amount_, reg_vl_);
+    }
+    j_(loop);
+    L(end);
+}
+
+void jit_uni_binary_kernel_t::forward_over_outer_dims() {
+    // x64 iterates the gathered src1 through reg_src1_stride_range_ and, when
+    // a run of outer_dims elements completes, rebases src1 to the next
+    // contiguous element; outer_dims and src1_stride are codegen constants
+    // here, so the stride and the per-run rebase are baked instead of the
+    // runtime indices vector + stride-range register.
+    const int es1 = (int)types::data_type_size(conf_.src1_type);
+    load_imm64(reg_src1_stride_, (conf_.src1_stride * es1));
+
+    Label run_loop, inner_loop, end;
+    L(run_loop);
+    beqz(reg_work_amount_, end);
+    load_imm64(reg_blk_avl_, conf_.outer_dims); // remaining in this run
+    L(inner_loop);
+    vsetvli(reg_vl_, reg_blk_avl_, SEW::e32, compute_lmul_, VTA::ta, VMA::ma);
+    compute_dst();
+
+    auto advance = [&](const Reg &reg_ptr, data_type_t dt) {
+        const int dt_size = (int)types::data_type_size(dt);
+        const int shift = dt_size == 4 ? 2 : (dt_size == 2 ? 1 : 0);
+        if (shift)
+            slli(reg_bytes_, reg_vl_, shift);
+        else
+            mv(reg_bytes_, reg_vl_);
+        add(reg_ptr, reg_ptr, reg_bytes_);
+    };
+    advance(reg_src0_, conf_.src0_type);
+    advance(reg_dst_, conf_.dst_type);
+    // strided src1: advance by vl * stride * sizeof(dt).
+    mul(reg_bytes_, reg_vl_, reg_src1_stride_);
+    add(reg_src1_, reg_src1_, reg_bytes_);
+    if (conf_.is_ternary_op) advance(reg_src2_, data_type::s8);
+    sub(reg_blk_avl_, reg_blk_avl_, reg_vl_);
+    sub(reg_work_amount_, reg_work_amount_, reg_vl_);
+    bnez(reg_blk_avl_, inner_loop);
+    // Run done: rebase src1 to the next contiguous element,
+    // -(outer_dims * stride - 1) * es1 (x64 pops the saved base + 1 elem).
+    load_imm64(reg_bytes_, (conf_.outer_dims * conf_.src1_stride - 1) * es1);
+    sub(reg_src1_, reg_src1_, reg_bytes_);
+    j_(run_loop);
+    L(end);
+}
+
+void jit_uni_binary_kernel_t::generate() {
+    // rv64 jit_generator_t has no preamble()/postamble(): the kernel is a
+    // leaf function touching only caller-saved registers (x64 additionally
+    // emits the eltwise constant table here; RVV loads constants inline).
+    load_kernel_params();
+    forward();
+    ret();
+}
+
+// --- rv64-specific low-level helpers (no x64 method analog; cf. aarch64,
+// which defines its arch-specific helpers after generate()) ---
+
+void jit_uni_binary_kernel_t::set_compute_vl() {
+    vsetvli(reg_vl_, reg_work_amount_, SEW::e32, compute_lmul_, VTA::ta,
+            VMA::ma);
+}
+
+void jit_uni_binary_kernel_t::to_compute_vtype() {
+    vsetvli(x0, reg_vl_, SEW::e32, compute_lmul_, VTA::ta, VMA::ma);
+}
+
+void jit_uni_binary_kernel_t::load_f32_const(const FReg &freg, float val) {
+    uint32_t bits;
+    std::memcpy(&bits, &val, sizeof(bits));
+    li(reg_tmp_, bits);
+    fmv_w_x(freg, reg_tmp_);
+}
+
+void jit_uni_binary_kernel_t::zero_pad_tail(int c_blk) {
+    // Zero the padded lanes [tail, c_block) of the current block (x64's
+    // tail-kernel zero-padding store); zero BYTES at e8 cover any dst dtype.
+    const int dsz = (int)types::data_type_size(conf_.dst_type);
+    const int pad_bytes = (c_blk - (int)tail_size_) * dsz;
+    load_imm64(reg_tmp_, pad_bytes);
+    // pad_bytes <= 15 * 4 = 60 <= VLMAX(e8, m4) = VLEN / 2 for VLEN >= 128.
+    vsetvli(x0, reg_tmp_, SEW::e8, compute_lmul_, VTA::ta, VMA::ma);
+    vmv_v_x(vreg_tmp1_, x0);
+    addi(reg_bytes_, reg_dst_, (int)tail_size_ * dsz);
+    vse8_v(vreg_tmp1_, reg_bytes_);
+}
+
+#undef PARAM_OFF
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/rv64/jit_uni_binary_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_binary_kernel.cpp
@@ -515,10 +515,13 @@ void jit_uni_binary_kernel_t::forward_over_outer_dims() {
     const int es1 = (int)types::data_type_size(conf_.src1_type);
     load_imm64(reg_src1_stride_, (conf_.src1_stride * es1));
 
-    Label run_loop, inner_loop, end;
+    Label run_loop, inner_loop, run_avl_ready, end;
     L(run_loop);
     beqz(reg_work_amount_, end);
     load_imm64(reg_blk_avl_, conf_.outer_dims); // remaining in this run
+    bge(reg_work_amount_, reg_blk_avl_, run_avl_ready);
+    mv(reg_blk_avl_, reg_work_amount_);
+    L(run_avl_ready);
     L(inner_loop);
     vsetvli(reg_vl_, reg_blk_avl_, SEW::e32, compute_lmul_, VTA::ta, VMA::ma);
     compute_dst();

--- a/src/cpu/rv64/jit_uni_binary_kernel.hpp
+++ b/src/cpu/rv64/jit_uni_binary_kernel.hpp
@@ -1,0 +1,234 @@
+/*******************************************************************************
+* Copyright 2021 Intel Corporation
+* Copyright 2026 Institute of Software, Chinese Academy of Sciences
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_RV64_JIT_UNI_BINARY_KERNEL_HPP
+#define CPU_RV64_JIT_UNI_BINARY_KERNEL_HPP
+
+#include <cassert>
+#include <memory>
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/rv64/cpu_isa_traits.hpp"
+#include "cpu/rv64/injectors/jit_uni_postops_injector.hpp"
+#include "cpu/rv64/jit_generator.hpp"
+#include "cpu/rv64/jit_primitive_conf.hpp"
+
+#include "cpu/cpu_binary_pd.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace rv64 {
+
+using namespace Xbyak_riscv;
+
+struct binary_kernel_t : public jit_generator_t {
+    using op_t = binary_op_t;
+    using bcast_t = binary_bcast_t;
+
+    binary_kernel_t(const binary_pd_t *pd, const jit_binary_conf_t &conf,
+            const char *name, bool tail_kernel = false)
+        : jit_generator_t(name)
+        , pd_(pd)
+        , conf_(conf)
+        , is_tail_kernel_(tail_kernel)
+        , tail_size_(get_tail_size()) {}
+    ~binary_kernel_t() override = default;
+
+    void operator()(const jit_uni_binary_args_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    // The c_blocked channel tail (x64's get_tail_size specialized to the
+    // driver contract: the tail kernel exists for c_blocked oc tails only).
+    dim_t get_tail_size() const {
+        const memory_desc_wrapper src0_d(pd_->src_md(0));
+        return conf_.op_type == op_t::c_blocked && !src0_d.is_plain()
+                ? src0_d.dims()[1] % src0_d.blocking_desc().inner_blks[0]
+                : 0;
+    }
+
+    // Unlike x64/aarch64 there is no vlen_/simd_w_/tail-mask machinery: the
+    // generated code is vector-length-agnostic and a single vsetvli loop
+    // covers the plain-shape element tail. The tail KERNEL (x64 shape) exists
+    // only for the blocked channel tail: it stores the valid lanes of each
+    // channel block and zeroes the padded tail.
+    const binary_pd_t *pd_;
+    const jit_binary_conf_t conf_;
+    const bool is_tail_kernel_;
+    const dim_t tail_size_;
+};
+
+// Vector-length-agnostic binary kernel. A single class rather than the
+// x64/aarch64 <isa> template family: RVV has one scalable vector ISA and the
+// generated code adapts to the hardware VLEN at run time.
+//
+// All arithmetic runs in the f32 e32/m4 compute domain; f16/bf16 operands are
+// widened/narrowed at the load/store edge (LMUL pair e16/m2).
+// The dtype conversions x64 delegates to io_multi_dt_helper_t are emitted
+// directly by load_vector/store_vector/load_scalar. A broadcast (scalar) src1
+// stays in a scalar FP register and feeds the .vf instruction forms instead of
+// being broadcast into a vector register as on x64; a strided src1 (different
+// plain src0/src1 layouts, e.g. nchw:nhwc) is read with vlse instead of x64's
+// index-vector gather. Ternary select folds into the same path via the v0 mask.
+struct jit_uni_binary_kernel_t : public binary_kernel_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_uni_binary_kernel_t)
+
+    // --- compute vtype ---
+    // The f32 compute domain is e32 at compute_lmul_. m4 is NOT a taste
+    // choice, it is load-bearing on the two paths below; changing it requires
+    // re-deriving both invariants.
+    //   1. The c_blocked block-stepped loop uses a constant AVL of c_blk and
+    //      advances the pointers by that same constant, so the vsetvli must
+    //      grant it in full: VLMAX(e32, compute_lmul_) >= c_blk (<= 16).
+    //   2. zero_pad_tail() writes the padded lanes of one block in a single
+    //      store: VLMAX(e8, compute_lmul_) >= (16 - 1) * sizeof(f32).
+    // Both hold at the smallest legal vector length, and the V extension
+    // implies Zvl128b, so VLEN >= min_vlen_ is architecturally guaranteed.
+    static constexpr int min_vlen_ = 128;
+    static constexpr size_t compute_group_stride_ = 4; // registers per acc
+    static constexpr LMUL compute_lmul_ = LMUL::m4;
+    // Narrow staging LMULs, chosen to share the compute VLMAX so that
+    // `vsetvli x0, x0` preserves vl across the widen/narrow (see load_vector).
+    static constexpr LMUL stage_e16_lmul_ = LMUL::m2;
+    static constexpr LMUL stage_e8_lmul_ = LMUL::m1;
+    static_assert(compute_group_stride_ * (min_vlen_ / 32) >= 16,
+            "VLMAX(e32, compute_lmul_) must cover a full 16-channel block");
+    static_assert(
+            compute_group_stride_ * (min_vlen_ / 8) >= 15 * (int)sizeof(float),
+            "VLMAX(e8, compute_lmul_) must cover one block's zero padding");
+
+    // Register map (e32/m4 compute): a1..a5 hold the unpacked call arguments
+    // (a0 stays live as the args pointer -- the binary post-op injector reads
+    // the rhs pointer array and dst_orig through it, as x64 reads through
+    // abi_param1), t0 = vl granted by vsetvli, t1/t2/t3 = byte-stride/address
+    // scratch (t1/t3 double as the binary post-op injector's address scratch;
+    // t4/t5/t6/a6/a7 are the injector's fixed X_TMP scratch, preserved around
+    // each injection via preserve_gpr_helpers as on x64).
+    // v4 = src0/accumulator, v8 = src1, v12/v16 = xf16 staging (also the sum
+    // old-dst and select condition staging), v20 = binary post-op rhs;
+    // v8/v12/v16 + v24/v28 are the five eltwise-injector aux groups (all dead
+    // around the injector call), v0 is the mask register.
+    const Reg reg_param_ = a0; // no abi_param aliases on rv64
+    const Reg reg_src0_ = a1;
+    const Reg reg_src1_ = a2;
+    const Reg reg_dst_ = a3;
+    const Reg reg_work_amount_ = a4;
+    const Reg reg_src2_ = a5;
+    const Reg reg_vl_ = t0;
+    const Reg reg_bytes_ = t1;
+    const Reg reg_tmp_ = t2;
+    const Reg reg_tmp1_ = t3;
+    // Block-stepped AVL constant (c_block, or the valid tail lanes in the
+    // tail kernel), and the per-run remaining count in the different-layouts
+    // loop -- the two modes never coexist. Doubles as injector scratch, kept
+    // alive across injections by the preserve guard.
+    const Reg reg_blk_avl_ = t4;
+    // Hoisted src1 byte stride for the different-layouts vlse (x64 keeps it
+    // in the indices vector instead); guarded like reg_blk_avl_.
+    const Reg reg_src1_stride_ = t5;
+    // v0 is the architecturally fixed mask register (vmerge/vfmerge only read
+    // v0.t), unlike x64's assignable k-masks.
+    const VReg vreg_mask_ = VReg(0);
+    const VReg vreg_src0_ = VReg(4);
+    const VReg vreg_src1_ = VReg(8);
+    const VReg vreg_tmp0_ = VReg(12);
+    const VReg vreg_tmp1_ = VReg(16);
+    const VReg vreg_rhs_ = VReg(20);
+    const FReg freg_tmp_ = fa2; // integer saturation bounds (dead post-inject)
+    const FReg freg_bcast_src1_ = fa3;
+    const FReg freg_scales_src0_ = fa4;
+    const FReg freg_scales_src1_ = fa5;
+    const FReg freg_sum_scale_ = fa6;
+
+    // The postops injector's isa selects its is_data_supported contract -- in
+    // particular whether an xf16 binary rhs is a legal post-op operand.
+    // It must therefore match the isa the pd validated the chain with
+    // (post_ops_ok(mayiuse(zvfh) ? zvfh : v)); otherwise a zvfh machine accepts
+    // an f16 rhs that the <v> injector then rejects (an is_data_supported assert
+    // fires at codegen time). RVV codegen is vector-length-agnostic and
+    // identical across v/zvfh, so the single non-templated kernel just holds
+    // whichever instantiation matches the runtime isa (x64 templates the whole
+    // kernel on isa instead). Exactly one is set; see init_post_ops_injector.
+    std::unique_ptr<injector::jit_uni_postops_injector_t<v>>
+            postops_injector_v_;
+    std::unique_ptr<injector::jit_uni_postops_injector_t<zvfh>>
+            postops_injector_zvfh_;
+    std::unique_ptr<injector::jit_uni_postops_injector_t<zvfbfwma>>
+            postops_injector_zvfbfwma_;
+    bool has_postops_injector() const {
+        return postops_injector_v_ || postops_injector_zvfh_
+                || postops_injector_zvfbfwma_;
+    }
+
+    void init();
+    void init_post_ops_injector();
+    void apply_postops();
+    void load_kernel_params();
+    // v0 mask -> f32 0.0/1.0 in the accumulator (comparison result contract).
+    void materialize_cmp();
+    void perform_op(const VReg &v0, const VReg &v1);
+    void perform_op(const VReg &v0, const FReg &s1);
+    void perform_ternary_op(
+            const VReg &v0, const VReg &v1, const VReg &vreg_stage);
+    void compute_bcast();
+    // Load vl elements of dtype dt from reg_ptr into the f32 group vreg
+    // (e32/m4), staging narrow dtypes in vreg_stage. Ends at the compute
+    // vtype. stride_elems > 1 reads with an element stride (vlse).
+    void load_vector(data_type_t dt, const VReg &vreg, const VReg &vreg_stage,
+            const Reg &reg_ptr, dim_t stride_elems = 1);
+    // Load one scalar of dtype dt from reg_ptr as f32 into freg.
+    void load_scalar(data_type_t dt, const FReg &freg, const Reg &reg_ptr);
+    // Convert the f32 result group (e32/m4) to dt and store vl elements.
+    void store_vector(data_type_t dt, const VReg &vreg, const VReg &vreg_stage,
+            const Reg &reg_ptr);
+    void compute_dst_body();
+    void compute_dst();
+    void forward();
+    // The different-layouts loop: runs of outer_dims strided-src1 elements
+    // with a per-run src1 rebase (x64's stride-range reset, with outer_dims/
+    // src1_stride baked as codegen constants).
+    void forward_over_outer_dims();
+    void generate() override;
+    // --- rv64-specific low-level helpers (no x64 method analog; cf. aarch64,
+    // which declares its arch-specific helpers after generate()) ---
+    // Set vl for the remaining work at the e32/m4 compute vtype.
+    void set_compute_vl();
+    // Reissue the e32/m4 compute vtype for the current vl.
+    void to_compute_vtype();
+    // Materialize an f32 constant into freg via a GPR (RVV .vf/.vx ops take a
+    // scalar register directly, so no rodata table -- x64 loads from p_table).
+    void load_f32_const(const FReg &freg, float val);
+    // Tail kernel: zero the padded lanes [tail, c_block) of the current block
+    // (x64's tail-kernel zero-padding store).
+    void zero_pad_tail(int c_blk);
+
+    jit_uni_binary_kernel_t(const binary_pd_t *pd,
+            const jit_binary_conf_t &conf, bool tail_kernel = false);
+    ~jit_uni_binary_kernel_t() override = default;
+};
+
+} // namespace rv64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/rv64/jit_uni_eltwise.cpp
+++ b/src/cpu/rv64/jit_uni_eltwise.cpp
@@ -203,7 +203,14 @@ struct jit_uni_kernel_t : public jit_uni_eltwise_kernel_t {
     // subsumes the tail case).
     void compute_dst() {
         load_vector();
-        eltwise_injector_->compute_vector(vmm_src.getIdx());
+        // load_vector() leaves the vtype at e32 / the dtype's compute LMUL:
+        // f32 -> m1, f16 -> m2 (widened), s32/s8/u8 -> m4. The eltwise injector
+        // is LMUL-agnostic, but pass the matching stride so its interface can
+        // validate the accumulator group.
+        const data_type_t dt = data_type();
+        const size_t group_stride
+                = dt == data_type::f32 ? 1 : (dt == data_type::f16 ? 2 : 4);
+        eltwise_injector_->compute_vector(vmm_src.getIdx(), group_stride);
         if (!is_fwd_) vfmul_vv(vmm_src, vmm_src, vmm_diff_dst);
         store_vector();
     }

--- a/src/cpu/rv64/jit_uni_group_normalization.cpp
+++ b/src/cpu/rv64/jit_uni_group_normalization.cpp
@@ -634,8 +634,8 @@ status_t jit_uni_group_normalization_fwd_t::execute_forward(
     const dim_t src_off0 = src_d.off_l(0);
     const dim_t dst_off0 = dst_d.off_l(0);
 
-    // Binary post-op src1 bases (scalar broadcast), one per binary in attr
-    // order -- the raw handles from the common helper (x64 model).
+    // Binary post-op src1 logical origins (scalar broadcast), one per binary
+    // in attribute order.
     const auto &po = pd()->attr()->post_ops_;
     const std::vector<const void *> po_rhs
             = binary_injector::prepare_binary_args(po, ctx);

--- a/src/cpu/rv64/jit_uni_group_normalization.cpp
+++ b/src/cpu/rv64/jit_uni_group_normalization.cpp
@@ -342,9 +342,6 @@ void norm_kernel_t<isa, d_type>::generate() {
     flw(ft1, reg_param, (int)offsetof(norm_call_params_t, inv_std));
     if (use_scale_) ld(s2, reg_param, (int)offsetof(norm_call_params_t, scale));
     if (use_shift_) ld(s3, reg_param, (int)offsetof(norm_call_params_t, shift));
-    if (with_binary_)
-        ld(s4, reg_param,
-                (int)offsetof(norm_call_params_t, post_ops_binary_rhs));
     ld(s5, reg_param, (int)offsetof(norm_call_params_t, c_per_g));
     ld(s6, reg_param, (int)offsetof(norm_call_params_t, sp));
 
@@ -352,9 +349,18 @@ void norm_kernel_t<isa, d_type>::generate() {
     // binary uses indirect (rhs pointer array) scalar broadcast (off unused).
     eltwise_injector::static_params_t esp(VReg(16), VReg(20), VReg(24),
             VReg(12), VReg(12), fa4, fa5, t3, /*is_fwd=*/true);
-    binary_injector::static_params_t bsp(VReg(28), fa6, s4, x0, t4);
-    injector::jit_uni_postops_injector_t<isa> po_inj(
-            this, post_ops_, esp, with_binary_ ? &bsp : nullptr);
+    // Host-positioned injector mode (null dst_d): the binary rhs is scalar
+    // (per_tensor) only, so no offset machinery is needed (the helper reg is
+    // the never-written x0), and the rhs pointer array is read through the
+    // args pointer (x64 model). The hosted scalar path clobbers only the
+    // injector's t4 scratch, which is free here -> no GPR preservation.
+    binary_injector::rhs_arg_static_params_t rhs_arg_bsp(28, t3, x0, x0,
+            false /*preserve gpr*/, false /*preserve vmm*/,
+            (int)offsetof(norm_call_params_t, post_ops_binary_rhs),
+            memory_desc_wrapper(nullptr));
+    rhs_arg_bsp.rhs_dt_helper_freg = fa6;
+    const binary_injector::static_params_t bsp(reg_param, rhs_arg_bsp);
+    injector::jit_uni_postops_injector_t<isa> po_inj(this, post_ops_, bsp, esp);
     // gnorm binary post-ops are scalar (per_tensor) broadcast, so the dynamic
     // rhs params carry no offset (the scalar path ignores it).
     binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
@@ -392,7 +398,11 @@ void norm_kernel_t<isa, d_type>::generate() {
             } else
                 vfadd_vf(v_dst, v_dst, ft3);
         }
-        if (with_postops_) po_inj.compute_vector(v_dst.getIdx(), rhs_dyn);
+        // Normalization computes at e32/m1 (f32) or e32/m2 (f16 widened); the
+        // injector uses the matching group_stride for a narrow rhs load.
+        if (with_postops_)
+            po_inj.compute_vector(
+                    v_dst.getIdx(), rhs_dyn, is_f16 ? 2 : 1 /*group_stride*/);
         if (!is_f16) {
             vse32_v(v_dst, reg_rdst);
         } else {
@@ -552,8 +562,14 @@ status_t jit_uni_group_normalization_fwd_t::pd_t::init(const engine_t *engine) {
     VDISPATCH_GNORM(attr_.set_default_formats(dst_md(0)) == status::success,
             VERBOSE_UNSUPPORTED_POSTOP);
     const auto &po = attr()->post_ops_;
-    VDISPATCH_GNORM(injector::jit_uni_postops_injector_t<v>::post_ops_ok(
-                            po, /*n_vaux=*/4),
+    const memory_desc_wrapper dst_d(dst_md(0));
+    VDISPATCH_GNORM(injector::post_ops_ok(injector::post_ops_ok_args_t(v,
+                            {injector::eltwise, injector::binary}, po, &dst_d,
+                            false /*sum_at_pos_0_only*/,
+                            false /*sum_requires_scale_one*/,
+                            true /*sum_requires_zp_zero*/,
+                            true /*sum_requires_same_params*/,
+                            {broadcasting_strategy_t::scalar}, /*n_vaux=*/4)),
             VERBOSE_UNSUPPORTED_POSTOP);
     for (int i = 0; i < po.len(); i++) {
         if (!po.entry_[i].is_binary()) continue;
@@ -618,16 +634,11 @@ status_t jit_uni_group_normalization_fwd_t::execute_forward(
     const dim_t src_off0 = src_d.off_l(0);
     const dim_t dst_off0 = dst_d.off_l(0);
 
-    // Binary post-op src1 bases (scalar broadcast), one per binary in attr order.
+    // Binary post-op src1 bases (scalar broadcast), one per binary in attr
+    // order -- the raw handles from the common helper (x64 model).
     const auto &po = pd()->attr()->post_ops_;
-    std::vector<const void *> po_rhs;
-    for (int i = 0; i < po.len(); i++)
-        if (po.entry_[i].is_binary()) {
-            const memory_desc_wrapper s1_d(po.entry_[i].binary.src1_desc);
-            const auto *base = static_cast<const char *>(ctx.host_ptr(
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-            po_rhs.push_back(base + s1_d.off_l(0) * sizeof(float));
-        }
+    const std::vector<const void *> po_rhs
+            = binary_injector::prepare_binary_args(po, ctx);
     const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
     parallel_nd(N, G, [&](dim_t n, dim_t g) {

--- a/src/cpu/rv64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_pool_kernel.cpp
@@ -80,6 +80,14 @@ static Xbyak_riscv::LMUL pool_lmul_to_enum(int lmul) {
     }
 }
 
+// The strategies the pool kernels can position themselves (the injector runs
+// in host-positioned byte-offset mode): scalar / per-oc(-spatial) / full-dst.
+static bcast_set_t get_supported_postops_bcast_strategies() {
+    return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
+            broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::no_broadcast};
+}
+
 // Fill the shape/stride/kernel/padding fields shared verbatim by all three
 // init_conf paths (baked, native forward, native backward). Channel bookkeeping
 // (c / c_block / c_without_padding) differs per path and stays with the caller.
@@ -186,22 +194,28 @@ bool jit_uni_pool_kernel_t<isa>::post_ops_ok(jit_pool_conf_t &jpp,
 
     if (jpp.is_backward) return post_ops.len() == 0;
 
-    // Accept an injector-supported chain: any number of forward eltwise ops plus
-    // any number of binaries. Binaries fuse at f32 (for f16 the accumulator is
-    // already widened to f32 at the inject point, and the rhs is loaded as f32).
-    // The rv64 injector positions every binary in a chain at ONE shared byte
-    // offset, so all binaries must share the same broadcast category (scalar /
-    // per-oc / full-dst); a mixed chain would need per-entry offsets and is left
-    // to the reference. src1 must be f32.
+    // Injector-level acceptance (x64 pattern): any number of forward eltwise
+    // ops plus any number of binaries, no sum; the kernels supply 4 eltwise
+    // aux groups.
+    if (!injector::post_ops_ok(injector::post_ops_ok_args_t(isa,
+                {injector::eltwise, injector::binary}, post_ops, &dst_d,
+                false /*sum_at_pos_0_only*/, false /*sum_requires_scale_one*/,
+                true /*sum_requires_zp_zero*/,
+                true /*sum_requires_same_params*/,
+                get_supported_postops_bcast_strategies(), /*n_vaux=*/4)))
+        return false;
+
+    // Pool-specific residue. Binaries fuse at f32 (for f16 the accumulator is
+    // already widened to f32 at the inject point, and the rhs is loaded as
+    // f32 -- no narrow staging group is reserved). The kernels position every
+    // binary in a chain at ONE shared byte offset, so all binaries must share
+    // the same broadcast category (scalar / per-oc / full-dst); a mixed chain
+    // would need per-entry offsets and is left to the reference.
     pool_binary_bcast_t bcast = pool_binary_bcast_t::none;
     for (const auto &e : post_ops.entry_) {
         if (e.is_eltwise()) {
-            if (!eltwise_injector::is_alg_supported(e.eltwise.alg)
-                    && !eltwise_injector::needs_extra_aux(e.eltwise.alg))
-                return false;
             jpp.with_eltwise = true;
         } else if (e.is_binary()) {
-            if (!binary_injector::is_alg_supported(e.binary.alg)) return false;
             if (e.binary.src1_desc.data_type != data_type::f32) return false;
             const memory_desc_wrapper s1(e.binary.src1_desc);
             const pool_binary_bcast_t k = classify_binary_src1(s1, dst_d);
@@ -826,11 +840,11 @@ void jit_uni_pool_kernel_t<isa>::apply_postops(int ur_w, int c_off) {
             addr_off(t2, t5, jj * c_off); // element index of output column jj
             slli(t2, t2, 2); // * sizeof(f32)
         }
-        // dynamic-params: t2 is the (byte) rhs offset for this column, exactly
-        // what the legacy static path read from bsp.off.
+        // dynamic-params: t2 is the (byte) rhs offset for this column. The
+        // baked kernel computes at e32/m1 (group_stride 1).
         binary_injector::rhs_arg_dynamic_params_t rd;
-        rd.vmm_idx_to_out_off[acc] = t2;
-        postops_injector_->compute_vector(acc, rd);
+        rd.vmm_idx_to_out_reg.emplace(acc, t2);
+        postops_injector_->compute_vector(acc, rd, 1 /*group_stride*/);
     }
 }
 
@@ -861,8 +875,6 @@ void jit_uni_pool_kernel_t<isa>::generate() {
     ld(reg_k_shift, reg_param, GET_OFF(kh_padding_shift));
     flw(f_area, reg_param, GET_OFF(ker_area_h));
     ld(reg_bc, reg_param, GET_OFF(b_c));
-    if (jpp.with_binary)
-        ld(reg_rhs, reg_param, GET_OFF(post_ops_binary_rhs_arg_vec));
 
     // Channel AVL for this block: c_block, or c_tail for the nspc last block.
     li(reg_vl, jpp.c_block);
@@ -885,12 +897,22 @@ void jit_uni_pool_kernel_t<isa>::generate() {
         // eltwise aux at the post-op inject point.
         eltwise_injector::static_params_t esp(v_eltw0, v_eltw1, v_eltw2, v_tmp,
                 v_tmp, f_eltw0, f_eltw1, t4, /*is_fwd=*/true);
-        binary_injector::static_params_t bsp(v_bin_rhs, f_bin, reg_rhs, t2, t3);
-        bsp.off_is_bytes = true; // t2 is the per-column byte offset
+        // Host-positioned injector mode (null dst_d): the kernel computes the
+        // per-column byte offset itself, so the rhs classifies as scalar /
+        // no_broadcast from the rhs element count. rhs is f32 (no gather/narrow).
+        // The rhs pointer array is read through the args pointer (x64 model);
+        // preserve_gpr shields the injector's fixed X_TMP scratch (t4 is this
+        // kernel's aux_ih and t5 the bcast==3 base).
+        binary_injector::rhs_arg_static_params_t rhs_arg_bsp(v_bin_rhs.getIdx(),
+                t3, t2, t2, true /*preserve gpr*/, false /*preserve vmm*/,
+                GET_OFF(post_ops_binary_rhs_arg_vec),
+                memory_desc_wrapper(nullptr));
+        rhs_arg_bsp.rhs_dt_helper_freg = f_bin;
+        rhs_arg_bsp.off_is_bytes = true; // t2 is the per-column byte offset
+        const binary_injector::static_params_t bsp(reg_param, rhs_arg_bsp);
         postops_injector_
                 = utils::make_unique<injector::jit_uni_postops_injector_t<isa>>(
-                        this, jpp.post_ops, esp,
-                        jpp.with_binary ? &bsp : nullptr);
+                        this, jpp.post_ops, bsp, esp);
     }
 
     prev_kw = 0;
@@ -1081,8 +1103,11 @@ status_t jit_uni_pool_ncsp_kernel_t<isa, d_type>::init_conf(
     // contains the binary is routed by the driver through the channel-vectorized
     // single-position path so the rhs broadcast is uniform; the injector loads
     // the rhs (f32) per channel chunk. post_ops_ok already gated the chain.
-    const bool inj_ok = injector::jit_uni_postops_injector_t<isa>::post_ops_ok(
-            po, /*n_vaux=*/4);
+    const bool inj_ok = injector::post_ops_ok(injector::post_ops_ok_args_t(isa,
+            {injector::eltwise, injector::binary}, po, &dst_d,
+            false /*sum_at_pos_0_only*/, false /*sum_requires_scale_one*/,
+            true /*sum_requires_zp_zero*/, true /*sum_requires_same_params*/,
+            get_supported_postops_bcast_strategies(), /*n_vaux=*/4));
     bool po_has_binary = false;
     for (int i = 0; i < po.len(); i++)
         if (po.entry_[i].is_binary()) po_has_binary = true;
@@ -1195,9 +1220,8 @@ void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate_f32() {
     ld(s8, reg_param, GET_OFF_P(src_vec_byte_stride));
     ld(s9, reg_param, GET_OFF_P(dst_vec_byte_stride));
     if (jpp_.fuse_binary && !max_train) {
-        // s10 = rhs origin pointer array; s11 = shared byte offset (advanced per
-        // channel chunk). The injector runs in indirect mode.
-        ld(s10, reg_param, GET_OFF_P(post_op_rhs));
+        // s11 = shared byte offset (advanced per channel chunk); the injector
+        // reads the rhs pointer array through the args pointer (x64 model).
         ld(s11, reg_param, GET_OFF_P(post_op_off0));
     }
     if (max_train) {
@@ -1323,27 +1347,34 @@ void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate_f32() {
         // so it is free as the fourth eltwise aux during an eltwise entry.
         eltwise_injector::static_params_t esp(VReg(12), VReg(16), VReg(20),
                 VReg(24), VReg(24), fa3, fa4, t2, /*is_fwd=*/true);
-        // Indirect injector mode (any number of binaries): rhs origin array in
-        // s10 (or a4 when max-training, since s10 is then the ws pointer), s11 =
-        // shared byte offset, a3 = per-binary scratch. Binary rhs scratch v24/fa5
-        // (clear of v_ind = v28). full-dst uses a strided (vlse) load keyed on the
-        // dst channel stride (s9 == the f32 rhs channel stride); per-oc/scalar the
-        // contiguous form.
-        const Reg reg_rhs = mt_bin ? a4 : s10;
-        if (mt_bin) ld(a4, reg_param, GET_OFF_P(post_op_rhs));
-        binary_injector::static_params_t bsp_contig(
-                VReg(24), fa5, reg_rhs, s11, a3);
-        binary_injector::static_params_t bsp_strided(
-                VReg(24), fa5, reg_rhs, s11, a3, s9);
-        bsp_contig.off_is_bytes = bsp_strided.off_is_bytes = true;
-        injector::jit_uni_postops_injector_t<isa> po_inj(this, jpp_.post_ops,
-                esp,
-                jpp_.fuse_binary ? (bin_strided ? &bsp_strided : &bsp_contig)
-                                 : nullptr);
+        // Indirect injector mode (any number of binaries): the rhs pointer
+        // array is read through the args pointer (x64 model; max-training
+        // needs no dedicated array-base register anymore), s11 = shared byte
+        // offset, a3 = per-binary scratch. Binary rhs scratch v24/fa5 (clear
+        // of v_ind = v28). full-dst uses a strided (vlse) load keyed on the
+        // dst channel stride (s9 == the f32 rhs channel stride);
+        // per-oc/scalar the contiguous form.
+        // Host-positioned injector mode (null dst_d): the kernel maintains
+        // the shared byte offset itself; preserve_gpr shields the injector's
+        // fixed X_TMP scratch (t4 holds the live unit-stride comparison
+        // constant here).
+        binary_injector::rhs_arg_static_params_t rhs_arg_bsp(24, a3, s11, s11,
+                true /*preserve gpr*/, false /*preserve vmm*/,
+                GET_OFF_P(post_op_rhs), memory_desc_wrapper(nullptr));
+        rhs_arg_bsp.rhs_dt_helper_freg = fa5;
+        rhs_arg_bsp.off_is_bytes = true;
+        if (bin_strided) {
+            rhs_arg_bsp.is_strided = true;
+            rhs_arg_bsp.rhs_stride = s9;
+        }
+        const binary_injector::static_params_t bsp(reg_param, rhs_arg_bsp);
+        injector::jit_uni_postops_injector_t<isa> po_inj(
+                this, jpp_.post_ops, bsp, esp);
         // dynamic-params: s11 is the per-chunk byte offset (off_is_bytes).
         binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
-        rhs_dyn.vmm_idx_to_out_off[v_acc.getIdx()] = s11;
-        po_inj.compute_vector(v_acc.getIdx(), rhs_dyn);
+        rhs_dyn.vmm_idx_to_out_reg.emplace(v_acc.getIdx(), s11);
+        // ncsp channel-vec computes at e32/m1 (group_stride 1).
+        po_inj.compute_vector(v_acc.getIdx(), rhs_dyn, 1 /*group_stride*/);
     }
     // Store result — use vse32_v for unit stride
     {
@@ -1525,11 +1556,11 @@ void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate_xf16() {
     } else if (jpp_.fuse_binary) {
         // fuse_binary => the driver routes each output column through the
         // single-position path (n_pos == 1), so no position loop is needed.
-        // Indirect injector mode: s10 = rhs origin array, s11 = shared byte
-        // offset, t3 = f32 rhs channel stride for full-dst (= 2 * the f16 dst
-        // channel stride s9; the rhs is f32 while the dst is f16). t3 held
-        // inD_stride only until s5 was derived above, so it is free here.
-        ld(s10, reg_param, GET_OFF_P(post_op_rhs));
+        // Indirect injector mode: the rhs pointer array is read through the
+        // args pointer (x64 model), s11 = shared byte offset, t3 = f32 rhs
+        // channel stride for full-dst (= 2 * the f16 dst channel stride s9;
+        // the rhs is f32 while the dst is f16). t3 held inD_stride only until
+        // s5 was derived above, so it is free here.
         ld(s11, reg_param, GET_OFF_P(post_op_off0));
         slli(t3, s9, 1);
     } else {
@@ -1546,27 +1577,33 @@ void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate_xf16() {
     // v28 is the binary rhs scratch and is temporally free for eltwise entries.
     eltwise_injector::static_params_t esp(VReg(12), VReg(16), VReg(20),
             VReg(28), VReg(28), fa3, fa4, t1, /*is_fwd=*/true);
-    // Indirect mode (any number of binaries): rhs origin array in s10 (or a4 when
-    // max-training, since s10 is then the ws pointer), s11 = shared byte offset,
-    // a3 = per-binary scratch. full-dst uses a strided (vlse) f32 load keyed on
-    // the f32 rhs channel stride (t3, or a6 when max-training); per-oc/scalar vle.
-    const Reg reg_rhs = mt_bin ? a4 : s10;
+    // Indirect mode (any number of binaries): the rhs pointer array is read
+    // through the args pointer (x64 model; max-training needs no dedicated
+    // array-base register anymore), s11 = shared byte offset, a3 = per-binary
+    // scratch. full-dst uses a strided (vlse) f32 load keyed on the f32 rhs
+    // channel stride (t3, or a6 when max-training); per-oc/scalar vle.
     const Reg reg_stride = mt_bin ? a6 : t3;
-    binary_injector::static_params_t bsp_contig(
-            VReg(28), fa5, reg_rhs, s11, a3);
-    binary_injector::static_params_t bsp_strided(
-            VReg(28), fa5, reg_rhs, s11, a3, reg_stride);
-    bsp_contig.off_is_bytes = bsp_strided.off_is_bytes = true;
+    // Host-positioned injector mode (null dst_d): the kernel maintains the
+    // shared byte offset itself; preserve_gpr shields the injector's fixed
+    // X_TMP scratch (t4 holds the live unit-stride comparison constant here).
+    binary_injector::rhs_arg_static_params_t rhs_arg_bsp(28, a3, s11, s11,
+            true /*preserve gpr*/, false /*preserve vmm*/,
+            GET_OFF_P(post_op_rhs), memory_desc_wrapper(nullptr));
+    rhs_arg_bsp.rhs_dt_helper_freg = fa5;
+    rhs_arg_bsp.off_is_bytes = true;
+    if (bin_strided) {
+        rhs_arg_bsp.is_strided = true;
+        rhs_arg_bsp.rhs_stride = reg_stride;
+    }
+    const binary_injector::static_params_t bsp(reg_param, rhs_arg_bsp);
     injector::jit_uni_postops_injector_t<isa> po_inj(this,
             (jpp_.fuse_eltwise || jpp_.fuse_binary) ? jpp_.post_ops : no_po,
-            esp,
-            jpp_.fuse_binary ? (bin_strided ? &bsp_strided : &bsp_contig)
-                             : nullptr);
+            bsp, esp);
     // dynamic-params: s11 is the per-chunk byte offset (off_is_bytes). Both the
     // avg (v_acc) and max (v24) post-op registers use the same offset.
     binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
-    rhs_dyn.vmm_idx_to_out_off[v_acc.getIdx()] = s11;
-    rhs_dyn.vmm_idx_to_out_off[24] = s11;
+    rhs_dyn.vmm_idx_to_out_reg.emplace(v_acc.getIdx(), s11);
+    rhs_dyn.vmm_idx_to_out_reg.emplace(24, s11);
 
     Label pos_loop, pos_done;
     if (!jpp_.fuse_binary && !max_train) {
@@ -1716,7 +1753,7 @@ void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate_xf16() {
                 ld(a4, reg_param, GET_OFF_P(post_op_rhs));
                 slli(a6, s9, 1);
             }
-            po_inj.compute_vector(v_acc.getIdx(), rhs_dyn);
+            po_inj.compute_vector(v_acc.getIdx(), rhs_dyn, 2 /*group_stride*/);
         }
         vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         if (is_bf16)
@@ -1726,17 +1763,17 @@ void jit_uni_pool_ncsp_kernel_t<isa, d_type>::generate_xf16() {
     } else if (jpp_.fuse_eltwise || jpp_.fuse_binary) {
         // max: the accumulator is f16; widen to f32 (v24/m2), apply the post-op
         // chain (eltwise and/or binary, rhs in v28), then narrow back in place
-        // so the store path is unchanged. For max-training the rhs origin array
-        // (a4) and f32 rhs stride (a6) are positioned here (s10/t3 hold the ws
-        // pointer / argmax scratch), free after the window sweep.
+        // so the store path is unchanged. For max-training the f32 rhs stride
+        // (a6) is positioned here (t3 holds the argmax scratch), free after
+        // the window sweep.
         if (mt_bin) {
-            ld(a4, reg_param, GET_OFF_P(post_op_rhs));
             slli(a6, s9, 1); // f32 rhs channel stride (= 2 * f16 dst stride)
         }
         vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vfwcvt_f_f_v(VReg(24), v_acc);
         vsetvli(t0, s2, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
-        po_inj.compute_vector(24, rhs_dyn);
+        // f16 max widened to f32 at e32/m2 (group_stride 2).
+        po_inj.compute_vector(24, rhs_dyn, 2 /*group_stride*/);
         vsetvli(t0, s2, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
         vfncvt_f_f_w(v_acc, VReg(24));
     }
@@ -1933,8 +1970,15 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
     post_ops_t no_po;
     eltwise_injector::static_params_t esp(VReg(12), VReg(16), VReg(20),
             VReg(24), VReg(24), fa4, fa5, t6, /*is_fwd=*/true);
+    // The chain here is eltwise-only, so the (mandatory) binary static params
+    // are never consumed; pass placeholder scratch.
+    binary_injector::rhs_arg_static_params_t rhs_arg_bsp(24, x0, x0, x0,
+            false /*preserve gpr*/, false /*preserve vmm*/,
+            0 /*abi_param_offset*/, memory_desc_wrapper(nullptr));
+    rhs_arg_bsp.rhs_dt_helper_freg = fa5;
+    const binary_injector::static_params_t bsp(x0, rhs_arg_bsp);
     injector::jit_uni_postops_injector_t<isa> po_inj(
-            this, jpp_.fuse_eltwise ? jpp_.post_ops : no_po, esp);
+            this, jpp_.fuse_eltwise ? jpp_.post_ops : no_po, bsp, esp);
     binary_injector::rhs_arg_dynamic_params_t rhs_dyn; // eltwise-only here
 
     Label block_loop, block_done;
@@ -1999,7 +2043,9 @@ void jit_uni_pool_interior_kernel_t<isa, d_type>::generate_nspc() {
     mv(a1, a5); // dst_ptr
     for (int j = 0; j < ur_w; j++) {
         if (!is_max) vfmul_vf(acc(j), acc(j), fa1);
-        if (jpp_.fuse_eltwise) po_inj.compute_vector(acc(j).getIdx(), rhs_dyn);
+        // nspc interior computes at e32/m1 (group_stride 1); eltwise-only here.
+        if (jpp_.fuse_eltwise)
+            po_inj.compute_vector(acc(j).getIdx(), rhs_dyn, 1 /*group_stride*/);
         vse32_v(acc(j), a1);
         if (j + 1 < ur_w) add(a1, a1, s5); // dst column stride == w_stride
     }

--- a/src/cpu/rv64/jit_uni_pooling.cpp
+++ b/src/cpu/rv64/jit_uni_pooling.cpp
@@ -141,24 +141,6 @@ dim_t binary_off0(
     return elem_off * (dim_t)sizeof(float);
 }
 
-// Per-binary src1 origin pointer array (in attribute order) for the indirect
-// injector mode: each entry is the binary's src1 base advanced to its logical
-// origin (off_l(0)), in f32 units since src1 is always f32. Shared by the baked
-// blocked/nspc drivers and the native forward path.
-static std::vector<const void *> collect_binary_rhs(
-        const jit_pool_conf_t &jpp, const exec_ctx_t &ctx) {
-    std::vector<const void *> rhs;
-    for (int i = 0; i < jpp.post_ops.len(); i++)
-        if (jpp.post_ops.entry_[i].is_binary()) {
-            const memory_desc_wrapper s1_d(
-                    jpp.post_ops.entry_[i].binary.src1_desc);
-            const auto *base = static_cast<const char *>(ctx.host_ptr(
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-            rhs.push_back(base + s1_d.off_l(0) * sizeof(float));
-        }
-    return rhs;
-}
-
 // Vectorize along C (strided) for a single ncsp output column.
 template <cpu_isa_t isa, data_type_t d_type>
 void pool_column_vec_c(const ncsp_kernel_t<isa, d_type> &kernel,
@@ -832,7 +814,8 @@ void jit_uni_pooling_fwd_t<isa>::execute_forward_blk(const data_t *src,
             = indices ? (int)types::data_type_size(indices_d.data_type()) : 0;
     const auto &jpp = pd()->jpp_;
 
-    std::vector<const void *> po_rhs = collect_binary_rhs(jpp, ctx);
+    std::vector<const void *> po_rhs
+            = binary_injector::prepare_binary_args(jpp.post_ops, ctx);
     const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
     const int c_mult
@@ -850,9 +833,9 @@ void jit_uni_pooling_fwd_t<isa>::execute_forward_blk(const data_t *src,
         arg.dst = &dst[dst_d.blk_off(n, c_off, oh)];
         // full-dst binary offset = (arg.dst - dst_orig); dst_orig must be the
         // dst LOGICAL origin (raw base + off_l(0)) so the offset excludes the
-        // md's offset0. blk_off() already includes offset0, and the rhs base is
-        // advanced by its own off_l(0) in collect_binary_rhs(); a raw-base
-        // dst_orig would double-count offset0 for a non-zero-offset submemory.
+        // md's offset0 (blk_off() already includes it). The rhs bases are the
+        // raw handles from the common prepare_binary_args -- like x64, a
+        // nonzero rhs offset0 is not folded in.
         arg.dst_orig = dst + dst_d.off_l(0);
         if (indices)
             arg.indices
@@ -890,7 +873,8 @@ void jit_uni_pooling_fwd_t<isa>::execute_forward_blk_3d(const data_t *src,
             = indices ? (int)types::data_type_size(indices_d.data_type()) : 0;
     const auto &jpp = pd()->jpp_;
 
-    std::vector<const void *> po_rhs = collect_binary_rhs(jpp, ctx);
+    std::vector<const void *> po_rhs
+            = binary_injector::prepare_binary_args(jpp.post_ops, ctx);
     const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
     const int c_mult
@@ -958,7 +942,9 @@ status_t jit_uni_pooling_fwd_t<isa>::execute_forward(
         // mode (one f32 pointer per binary, in attribute order). The kernel adds
         // the shared per-call offset (post_op_off0 + channel offset).
         std::vector<const void *> po_rhs_vec;
-        if (jpp.fuse_binary) po_rhs_vec = collect_binary_rhs(jpp, ctx);
+        if (jpp.fuse_binary)
+            po_rhs_vec
+                    = binary_injector::prepare_binary_args(jpp.post_ops, ctx);
         const void *po_rhs = po_rhs_vec.empty()
                 ? nullptr
                 : (const void *)po_rhs_vec.data();

--- a/src/cpu/rv64/jit_uni_pooling.cpp
+++ b/src/cpu/rv64/jit_uni_pooling.cpp
@@ -833,9 +833,8 @@ void jit_uni_pooling_fwd_t<isa>::execute_forward_blk(const data_t *src,
         arg.dst = &dst[dst_d.blk_off(n, c_off, oh)];
         // full-dst binary offset = (arg.dst - dst_orig); dst_orig must be the
         // dst LOGICAL origin (raw base + off_l(0)) so the offset excludes the
-        // md's offset0 (blk_off() already includes it). The rhs bases are the
-        // raw handles from the common prepare_binary_args -- like x64, a
-        // nonzero rhs offset0 is not folded in.
+        // md's offset0 (blk_off() already includes it). RHS pointers are at
+        // their own logical origins, so the offset applies to both tensors.
         arg.dst_orig = dst + dst_d.off_l(0);
         if (indices)
             arg.indices

--- a/src/cpu/rv64/jit_uni_postops_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_postops_kernel.cpp
@@ -54,16 +54,14 @@ struct jit_uni_postops_kernel_t::impl_t : public jit_generator_t {
         const Reg reg_param = a0;
         const Reg reg_dst = a1;
         const Reg reg_bias = a2;
-        const Reg reg_rhs = a3; // base of the per-binary rhs pointer array
         const Reg reg_len = a4;
         const Reg reg_vl = t0;
         const Reg reg_bytes = t1;
         const Reg reg_off = t3; // element offset of the chunk within the unit
-        const Reg reg_gpr = t4; // binary injector scratch
+        const Reg reg_gpr = a5; // binary injector address scratch
 
         ld(reg_dst, reg_param, GET_OFF(dst));
         ld(reg_bias, reg_param, GET_OFF(bias));
-        ld(reg_rhs, reg_param, GET_OFF(rhs));
         ld(reg_len, reg_param, GET_OFF(len));
 
         // Accumulator group v24 (m4). The injectors may use v0 as a mask
@@ -79,15 +77,25 @@ struct jit_uni_postops_kernel_t::impl_t : public jit_generator_t {
         // per-binary pointer array; the injector computes each rhs address from
         // the per-chunk output element offset (reg_off) it is handed at call
         // time. reg_bytes is the injector's address scratch.
-        binary_injector::static_params_t bsp(
-                VReg(16), fa2, reg_rhs, reg_bytes, reg_gpr);
-        injector::jit_uni_postops_injector_t<v> inj(this, po_, esp, &bsp);
+        // Host-positioned injector mode (null dst_d): the epilogue works on
+        // flat units, so the rhs classifies as scalar / no_broadcast from its
+        // element count and the unit offset is handed in at call time.
+        // The rhs pointer array is read through the args pointer (x64 model).
+        // The hosted scalar/no_broadcast paths clobber only the injector's t4
+        // scratch, which is free here -> no GPR preservation.
+        binary_injector::rhs_arg_static_params_t rhs_arg_bsp(16, reg_gpr,
+                reg_bytes, reg_bytes, false /*preserve gpr*/,
+                false /*preserve vmm*/, GET_OFF(rhs),
+                memory_desc_wrapper(nullptr));
+        rhs_arg_bsp.rhs_dt_helper_freg = fa2;
+        const binary_injector::static_params_t bsp(reg_param, rhs_arg_bsp);
+        injector::jit_uni_postops_injector_t<v> inj(this, po_, bsp, esp);
         binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
 
         if (has_per_elem_binary_) {
             ld(reg_off, reg_param, GET_OFF(off0)); // byte offset
             srli(reg_off, reg_off, 2); // -> element offset (rhs is f32)
-            rhs_dyn.vmm_idx_to_out_off[v_data.getIdx()] = reg_off;
+            rhs_dyn.vmm_idx_to_out_reg.emplace(v_data.getIdx(), reg_off);
         }
 
         Label loop, done;
@@ -108,7 +116,8 @@ struct jit_uni_postops_kernel_t::impl_t : public jit_generator_t {
             }
         }
 
-        inj.compute_vector(v_data.getIdx(), rhs_dyn);
+        // Epilogue computes at e32/m4 (group_stride 4).
+        inj.compute_vector(v_data.getIdx(), rhs_dyn, 4 /*group_stride*/);
         vse32_v(v_data, reg_dst);
 
         slli(reg_bytes, reg_vl, 2);
@@ -177,19 +186,36 @@ bool jit_uni_postops_kernel_t::binary_per_last_dim_ok(
     return true;
 }
 
+// Chain-level injector acceptance. The epilogue works on flat units without a
+// dst descriptor, so it cannot use injector::post_ops_ok (which classifies the
+// binary rhs against dst); the chain entry kinds are checked directly: eltwise
+// with a 4-aux budget (heavy algs included), any non-ternary binary alg
+// (select needs a condition scratch group this host does not reserve), no
+// other kinds.
+static bool injector_chain_ok(const post_ops_t &po) {
+    for (int i = 0; i < po.len(); i++) {
+        const auto &e = po.entry_[i];
+        if (e.is_eltwise()) {
+            if (!eltwise_injector::is_supported(e.eltwise.alg)) return false;
+        } else if (e.is_binary()) {
+            if (e.is_binary_with_ternary_op()) return false;
+        } else
+            return false;
+    }
+    return true;
+}
+
 bool jit_uni_postops_kernel_t::post_ops_supported(
         const post_ops_t &po, dim_t unit_nelems) {
-    return injector::jit_uni_postops_injector_t<v>::post_ops_ok(
-                   po, /*n_vaux=*/4)
-            && binary_broadcast_ok(po, unit_nelems) && binary_rhs_dt_ok(po);
+    return injector_chain_ok(po) && binary_broadcast_ok(po, unit_nelems)
+            && binary_rhs_dt_ok(po);
 }
 
 status_t jit_uni_postops_kernel_t::create(
         std::shared_ptr<jit_uni_postops_kernel_t> &kernel, const post_ops_t &po,
         const conf_t &conf) {
     if (conf.dst_dt != data_type::f32) return status::unimplemented;
-    if (!injector::jit_uni_postops_injector_t<v>::post_ops_ok(po, /*n_vaux=*/4))
-        return status::unimplemented;
+    if (!injector_chain_ok(po)) return status::unimplemented;
     // The injector loads the binary rhs as f32 only (flw/vle32/vlse32).
     if (!binary_rhs_dt_ok(po)) return status::unimplemented;
 

--- a/src/cpu/rv64/jit_uni_resampling.hpp
+++ b/src/cpu/rv64/jit_uni_resampling.hpp
@@ -115,10 +115,22 @@ struct jit_uni_resampling_fwd_t : public primitive_t {
                 if (!utils::one_of(e.sum.dt, data_type::undef, d_type))
                     return false;
             }
-            if (!injector::jit_uni_postops_injector_t<isa>::post_ops_ok(
-                        po_no_sum))
-                return false;
             const memory_desc_wrapper dst_d(dst_md());
+            // The kernel positions every rhs host-side, so it advertises only
+            // the broadcasts it can place. n_vaux = 3: v_aux3/v_aux4 alias the
+            // binary rhs scratch, so the heavy eltwise algs stay out.
+            if (!injector::post_ops_ok(injector::post_ops_ok_args_t(isa,
+                        {injector::eltwise, injector::binary}, po_no_sum,
+                        &dst_d, false /*sum_at_pos_0_only*/,
+                        false /*sum_requires_scale_one*/,
+                        true /*sum_requires_zp_zero*/,
+                        true /*sum_requires_same_params*/,
+                        bcast_set_t {broadcasting_strategy_t::scalar,
+                                broadcasting_strategy_t::per_oc,
+                                broadcasting_strategy_t::per_oc_spatial,
+                                broadcasting_strategy_t::no_broadcast},
+                        /*n_vaux=*/3)))
+                return false;
             int n_binary = 0;
             for (int i = 0; i < po.len(); i++) {
                 if (!po.entry_[i].is_binary()) continue;

--- a/src/cpu/rv64/jit_uni_resampling_kernel.cpp
+++ b/src/cpu/rv64/jit_uni_resampling_kernel.cpp
@@ -31,6 +31,15 @@ namespace rv64 {
 
 using namespace Xbyak_riscv;
 
+// The broadcasts the resampling kernel can position itself (the injector runs
+// in host-positioned byte-offset mode). Keep in sync with the pd's set in
+// jit_uni_resampling.hpp.
+static bcast_set_t get_supported_postops_bcast_strategies() {
+    return {broadcasting_strategy_t::scalar, broadcasting_strategy_t::per_oc,
+            broadcasting_strategy_t::per_oc_spatial,
+            broadcasting_strategy_t::no_broadcast};
+}
+
 template <cpu_isa_t isa, data_type_t d_type>
 jit_uni_resampling_kernel_t<isa, d_type>::jit_uni_resampling_kernel_t(
         const jit_resampling_conf_t &conf)
@@ -127,9 +136,12 @@ status_t jit_uni_resampling_kernel_t<isa, d_type>::init_conf(
             } else
                 po_no_sum.entry_.push_back(e);
         }
-        const bool inj_ok
-                = injector::jit_uni_postops_injector_t<isa>::post_ops_ok(
-                        po_no_sum);
+        const bool inj_ok = injector::post_ops_ok(injector::post_ops_ok_args_t(
+                isa, {injector::eltwise, injector::binary}, po_no_sum, &dst_d,
+                false /*sum_at_pos_0_only*/, false /*sum_requires_scale_one*/,
+                true /*sum_requires_zp_zero*/,
+                true /*sum_requires_same_params*/,
+                get_supported_postops_bcast_strategies(), /*n_vaux=*/3));
         bool has_binary = false, has_eltwise = false;
         for (int i = 0; i < po_no_sum.len(); i++) {
             if (po_no_sum.entry_[i].is_binary()) has_binary = true;
@@ -206,29 +218,65 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f32() {
     ld(s11, reg_param, static_cast<int>(offsetof(p_t, src_vec_byte_stride)));
     ld(a1, reg_param, static_cast<int>(offsetof(p_t, dst_vec_byte_stride)));
     if (conf_.fuse_binary) {
-        // a4 = rhs ORIGIN pointer array; a5 = shared byte offset (advanced per
-        // channel chunk). The injector runs in indirect mode.
-        ld(a4, reg_param, static_cast<int>(offsetof(p_t, post_op_rhs)));
+        // a5 = shared byte offset (advanced per channel chunk); the injector
+        // reads the rhs pointer array through the args pointer (x64 model).
         ld(a5, reg_param, static_cast<int>(offsetof(p_t, post_op_off0)));
     }
 
     addi(t2, x0, 4); // element size, for the unit-stride fast path
 
     // Post-op injector (built once; the binary rhs base is read from the
-    // pointer array in a4 at the offset in a5, advanced per chunk).
+    // pointer array through the args pointer, at the offset in a5, advanced
+    // per chunk).
     injector::jit_uni_postops_injector_t<isa> *po_inj = nullptr;
     // v24 doubles as the binary rhs scratch; entries execute serially, and
     // post_ops_ok(n_vaux = 3) rejects the algs that would read v_aux3/v_aux4.
     eltwise_injector::static_params_t esp(VReg(12), VReg(16), VReg(20),
             VReg(24), VReg(24), ft0, ft1, t3, /*is_fwd=*/true);
-    binary_injector::static_params_t bsp_contig(VReg(24), ft2, a4, a5, a3);
-    binary_injector::static_params_t bsp_strided(VReg(24), ft2, a4, a5, a3, a1);
-    bsp_contig.off_is_bytes = bsp_strided.off_is_bytes = true;
-    injector::jit_uni_postops_injector_t<isa> po_inj_obj(this, conf_.post_ops,
-            esp,
-            conf_.fuse_binary ? (bin_strided ? &bsp_strided : &bsp_contig)
-                              : nullptr);
-    if (po) po_inj = &po_inj_obj;
+    // Host-positioned injector mode (null dst_d): the kernel maintains the
+    // shared byte offset in a5 itself, so the rhs classifies as scalar /
+    // no_broadcast from its element count. The rhs pointer array is read
+    // through the args pointer (x64 model), so a4 is now only the injector's
+    // address scratch. The rhs is f32 (pd-gated), so neither the narrow-dtype
+    // staging group nor the gather index group is needed. preserve_gpr shields
+    // a5 -- the live per-chunk offset -- and the injector's fixed X_TMP
+    // scratch (t4, which this kernel uses for the sum scale).
+    binary_injector::rhs_arg_static_params_t rhs_arg_bsp(VReg(24).getIdx(), a4,
+            a5, a3, true /*preserve gpr*/, false /*preserve vmm*/,
+            static_cast<std::size_t>(offsetof(p_t, post_op_rhs)),
+            memory_desc_wrapper(nullptr));
+    rhs_arg_bsp.rhs_dt_helper_freg = ft2;
+    rhs_arg_bsp.off_is_bytes = true;
+    if (bin_strided) {
+        rhs_arg_bsp.is_strided = true;
+        rhs_arg_bsp.rhs_stride = a1;
+    }
+    const binary_injector::static_params_t bsp(reg_param, rhs_arg_bsp);
+    // The in-kernel sum runs as a host lambda at its exact chain position (the
+    // x64/aarch64 scheme), so a single compute_vector covers the whole chain --
+    // replacing the old split into two entry sub-ranges around the sum.
+    injector::lambda_jit_injectors_t lambda_jit_injectors;
+    if (conf_.fuse_sum)
+        lambda_jit_injectors.emplace(primitive_kind::sum, [&]() {
+            // dst is read back with the same access form as the store.
+            Label sum_strided, sum_done;
+            bne(a1, t2, sum_strided);
+            vle32_v(v_tmp, s9);
+            j_(sum_done);
+            L(sum_strided);
+            vlse32_v(v_tmp, s9, a1);
+            L(sum_done);
+            if (conf_.sum_scale == 1.f)
+                vfadd_vv(v_acc, v_acc, v_tmp);
+            else {
+                li(t4, (int32_t)utils::bit_cast<uint32_t>(conf_.sum_scale));
+                fmv_w_x(ft3, t4);
+                vfmacc_vf(v_acc, ft3, v_tmp);
+            }
+        });
+    injector::jit_uni_postops_injector_t<isa> po_inj_obj(
+            this, conf_.post_ops, bsp, esp, lambda_jit_injectors);
+    if (po || conf_.fuse_sum) po_inj = &po_inj_obj;
 
     auto load_vec = [&](const VReg &vd, const Reg &ptr) {
         Label strided, done;
@@ -258,34 +306,12 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f32() {
 
     if (po || conf_.fuse_sum) {
         // a5 is the per-chunk byte offset of the first active lane
-        // (off_is_bytes); the injector derives each rhs address from it.
+        // (off_is_bytes); the injector derives each rhs address from it. The
+        // sum lands in attribute order via its lambda injector.
         binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
-        rhs_dyn.vmm_idx_to_out_off[v_acc.getIdx()] = a5;
-        const int n_po = conf_.post_ops.len();
-        const int s_idx = conf_.fuse_sum ? conf_.sum_idx : -1;
-        // The injector skips sum, so apply the chain around it in two ranges.
-        if (po)
-            po_inj->compute_vector(
-                    v_acc.getIdx(), rhs_dyn, 0, s_idx < 0 ? n_po : s_idx);
-        if (conf_.fuse_sum) {
-            // dst is read back with the same access form as the store.
-            Label sum_strided, sum_done;
-            bne(a1, t2, sum_strided);
-            vle32_v(v_tmp, s9);
-            j_(sum_done);
-            L(sum_strided);
-            vlse32_v(v_tmp, s9, a1);
-            L(sum_done);
-            if (conf_.sum_scale == 1.f)
-                vfadd_vv(v_acc, v_acc, v_tmp);
-            else {
-                li(t4, (int32_t)utils::bit_cast<uint32_t>(conf_.sum_scale));
-                fmv_w_x(ft3, t4);
-                vfmacc_vf(v_acc, ft3, v_tmp);
-            }
-        }
-        if (po && s_idx >= 0)
-            po_inj->compute_vector(v_acc.getIdx(), rhs_dyn, s_idx + 1, n_po);
+        rhs_dyn.vmm_idx_to_out_reg.emplace(v_acc.getIdx(), a5);
+        // The f32 path computes at e32/m1 (group_stride 1).
+        po_inj->compute_vector(v_acc.getIdx(), rhs_dyn, 1 /*group_stride*/);
     }
 
     {
@@ -404,9 +430,40 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f16() {
     injector::jit_uni_postops_injector_t<isa> *po_inj = nullptr;
     eltwise_injector::static_params_t esp(VReg(12), VReg(16), VReg(20),
             VReg(24), VReg(24), ft0, ft1, t3, /*is_fwd=*/true);
+    // The pd rejects a binary for f16, so the (mandatory) binary static params
+    // are never consumed; pass placeholder scratch.
+    binary_injector::rhs_arg_static_params_t rhs_arg_bsp(VReg(24).getIdx(), x0,
+            x0, x0, false /*preserve gpr*/, false /*preserve vmm*/,
+            0 /*abi_param_offset*/, memory_desc_wrapper(nullptr));
+    rhs_arg_bsp.rhs_dt_helper_freg = ft2;
+    const binary_injector::static_params_t bsp(x0, rhs_arg_bsp);
+    // The in-kernel sum runs as a host lambda at its exact chain position, so a
+    // single compute_vector covers the whole chain. It is entered and left at
+    // e32/m2; dst is read back with the same access form as the store.
+    injector::lambda_jit_injectors_t lambda_jit_injectors;
+    if (conf_.fuse_sum)
+        lambda_jit_injectors.emplace(primitive_kind::sum, [&]() {
+            vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
+            Label sum_strided, sum_done;
+            bne(a1, t2, sum_strided);
+            vle16_v(v_f16, s9);
+            j_(sum_done);
+            L(sum_strided);
+            vlse16_v(v_f16, s9, a1);
+            L(sum_done);
+            vfwcvt_f_f_v(v_wide, v_f16); // f16 m1 -> f32 m2
+            vsetvli(t0, s10, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
+            if (conf_.sum_scale == 1.f)
+                vfadd_vv(v_acc, v_acc, v_wide);
+            else {
+                li(t4, (int32_t)utils::bit_cast<uint32_t>(conf_.sum_scale));
+                fmv_w_x(ft3, t4);
+                vfmacc_vf(v_acc, ft3, v_wide);
+            }
+        });
     injector::jit_uni_postops_injector_t<isa> po_inj_obj(
-            this, conf_.post_ops, esp);
-    if (po) po_inj = &po_inj_obj;
+            this, conf_.post_ops, bsp, esp, lambda_jit_injectors);
+    if (po || conf_.fuse_sum) po_inj = &po_inj_obj;
     // Eltwise-only here: no binary rhs to address.
     binary_injector::rhs_arg_dynamic_params_t rhs_dyn;
 
@@ -426,32 +483,9 @@ void jit_uni_resampling_kernel_t<isa, d_type>::generate_f16() {
     // sum reads dst back as f16 and widens it (same access form as the store).
     const bool need_f32 = po || conf_.fuse_sum;
     auto apply_chain = [&]() {
-        const int n_po = conf_.post_ops.len();
-        const int s_idx = conf_.fuse_sum ? conf_.sum_idx : -1;
-        if (po)
-            po_inj->compute_vector(
-                    v_acc.getIdx(), rhs_dyn, 0, s_idx < 0 ? n_po : s_idx);
-        if (conf_.fuse_sum) {
-            vsetvli(t0, s10, SEW::e16, LMUL::m1, VTA::ta, VMA::ma);
-            Label sum_strided, sum_done;
-            bne(a1, t2, sum_strided);
-            vle16_v(v_f16, s9);
-            j_(sum_done);
-            L(sum_strided);
-            vlse16_v(v_f16, s9, a1);
-            L(sum_done);
-            vfwcvt_f_f_v(v_wide, v_f16); // f16 m1 -> f32 m2
-            vsetvli(t0, s10, SEW::e32, LMUL::m2, VTA::ta, VMA::ma);
-            if (conf_.sum_scale == 1.f)
-                vfadd_vv(v_acc, v_acc, v_wide);
-            else {
-                li(t4, (int32_t)utils::bit_cast<uint32_t>(conf_.sum_scale));
-                fmv_w_x(ft3, t4);
-                vfmacc_vf(v_acc, ft3, v_wide);
-            }
-        }
-        if (po && s_idx >= 0)
-            po_inj->compute_vector(v_acc.getIdx(), rhs_dyn, s_idx + 1, n_po);
+        // The f16 path computes at e32/m2 (group_stride 2); the sum lands in
+        // attribute order via its lambda injector.
+        po_inj->compute_vector(v_acc.getIdx(), rhs_dyn, 2 /*group_stride*/);
     };
 
     Label ch_loop, ch_done;

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -26,6 +26,7 @@
 #include "common/utils.hpp"
 #include "common/verbose.hpp"
 
+#include "cpu/binary_injector_utils.hpp"
 #include "cpu/platform.hpp"
 #include "cpu/rv64/jit_generator.hpp"
 #include "cpu/rv64/rvv_brgemm_matmul.hpp"
@@ -496,17 +497,10 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
 
     // Binary post-op src1 bases, one per binary in chain order (scalar or per-N;
     // each broadcasts over M/batch so the same array serves every row). Empty
-    // when the chain has no binary entry. Shift each base by src1's own offset0
-    // (off_l(0)) so a submemory rhs is read from its logical origin, not the
-    // buffer base — the kernel only adds the in-row column offset on top.
-    std::vector<const void *> po_rhs;
-    for (int i = 0; i < post_ops.len(); i++)
-        if (post_ops.entry_[i].is_binary()) {
-            const memory_desc_wrapper s1_d(post_ops.entry_[i].binary.src1_desc);
-            const auto *base = static_cast<const char *>(ctx.host_ptr(
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-            po_rhs.push_back(base + s1_d.off_l(0) * sizeof(float));
-        }
+    // when the chain has no binary entry. The raw handles from the common
+    // helper (x64 model) -- the kernel only adds the in-row column offset.
+    const std::vector<const void *> po_rhs
+            = binary_injector_utils::prepare_binary_args(post_ops, ctx);
     const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
     parallel_nd(batch, [&](dim_t b) {

--- a/src/cpu/rv64/rvv_brgemm_matmul.cpp
+++ b/src/cpu/rv64/rvv_brgemm_matmul.cpp
@@ -497,8 +497,8 @@ status_t rvv_brgemm_matmul_t::execute(const exec_ctx_t &ctx) const {
 
     // Binary post-op src1 bases, one per binary in chain order (scalar or per-N;
     // each broadcasts over M/batch so the same array serves every row). Empty
-    // when the chain has no binary entry. The raw handles from the common
-    // helper (x64 model) -- the kernel only adds the in-row column offset.
+    // when the chain has no binary entry. Each pointer starts at its memory
+    // descriptor's logical origin; the kernel adds the in-row column offset.
     const std::vector<const void *> po_rhs
             = binary_injector_utils::prepare_binary_args(post_ops, ctx);
     const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();

--- a/src/cpu/rv64/rvv_gemm_convolution.cpp
+++ b/src/cpu/rv64/rvv_gemm_convolution.cpp
@@ -73,22 +73,14 @@ status_t riscv_gemm_convolution_fwd_t::execute_forward_thr_nspc(
     const conv_gemm_conf_t &jcp = pd()->jcp_;
 
     // Binary post-op src1 bases (scalar or per-oc), one per binary in chain
-    // order. The contiguous oc-slice reads each at base + channel-base off0, so
-    // the same array serves every slice. Each base is shifted by src1's own
-    // offset0 (off_l(0)) so a submemory rhs reads from its logical origin (the
-    // per-slice channel-base off0 is added by the kernel on top). Empty unless
-    // the in-kernel post-op path is active and the chain has a binary entry.
+    // order -- the raw handles from the common helper (x64 model); the
+    // per-slice channel-base offset is added by the kernel on top. Empty
+    // unless the in-kernel post-op path is active and the chain has a binary
+    // entry.
     std::vector<const void *> po_rhs;
-    if (jit_postops_kernel_ && jcp.with_binary) {
-        const auto &po = pd()->attr()->post_ops_;
-        for (int i = 0; i < po.len(); i++)
-            if (po.entry_[i].is_binary()) {
-                const memory_desc_wrapper s1_d(po.entry_[i].binary.src1_desc);
-                const auto *base = static_cast<const char *>(ctx.host_ptr(
-                        DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-                po_rhs.push_back(base + s1_d.off_l(0) * sizeof(float));
-            }
-    }
+    if (jit_postops_kernel_ && jcp.with_binary)
+        po_rhs = binary_injector_utils::prepare_binary_args(
+                pd()->attr()->post_ops_, ctx);
     const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
     // Src Format: mb-spatial-groups-input_channels

--- a/src/cpu/rv64/rvv_gemm_convolution.cpp
+++ b/src/cpu/rv64/rvv_gemm_convolution.cpp
@@ -72,11 +72,10 @@ status_t riscv_gemm_convolution_fwd_t::execute_forward_thr_nspc(
         data_t *dst_base, const memory_tracking::grantor_t &scratchpad) const {
     const conv_gemm_conf_t &jcp = pd()->jcp_;
 
-    // Binary post-op src1 bases (scalar or per-oc), one per binary in chain
-    // order -- the raw handles from the common helper (x64 model); the
-    // per-slice channel-base offset is added by the kernel on top. Empty
-    // unless the in-kernel post-op path is active and the chain has a binary
-    // entry.
+    // Binary post-op src1 logical origins (scalar or per-oc), one per binary
+    // in chain order; the per-slice channel-base offset is added by the kernel
+    // on top. Empty unless the in-kernel post-op path is active and the chain
+    // has a binary entry.
     std::vector<const void *> po_rhs;
     if (jit_postops_kernel_ && jcp.with_binary)
         po_rhs = binary_injector_utils::prepare_binary_args(

--- a/src/cpu/rv64/rvv_matmul.cpp
+++ b/src/cpu/rv64/rvv_matmul.cpp
@@ -406,8 +406,8 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
 
     // Binary post-op src1 bases, one per binary in chain order (per-N or scalar;
     // each broadcasts over M/batch so the same array serves every row). Empty
-    // when the chain has no binary entry. The raw handles from the common
-    // helper (x64 model) -- the kernel only adds the in-row column offset.
+    // when the chain has no binary entry. Each pointer starts at its memory
+    // descriptor's logical origin; the kernel adds the in-row column offset.
     const std::vector<const void *> po_rhs
             = binary_injector_utils::prepare_binary_args(post_ops, ctx);
     const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();

--- a/src/cpu/rv64/rvv_matmul.cpp
+++ b/src/cpu/rv64/rvv_matmul.cpp
@@ -20,6 +20,7 @@
 #include "common/memory_desc_wrapper.hpp"
 #include "common/nstl.hpp"
 #include "common/utils.hpp"
+#include "cpu/binary_injector_utils.hpp"
 #include "cpu/platform.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_f16.hpp"
 #include "cpu/rv64/gemm/rvv_gemm_f32.hpp"
@@ -405,17 +406,10 @@ status_t rvv_matmul_t::execute(const exec_ctx_t &ctx) const {
 
     // Binary post-op src1 bases, one per binary in chain order (per-N or scalar;
     // each broadcasts over M/batch so the same array serves every row). Empty
-    // when the chain has no binary entry. Shift each base by src1's own offset0
-    // (off_l(0)) so a submemory rhs is read from its logical origin, not the
-    // buffer base — the kernel only adds the in-row column offset on top.
-    std::vector<const void *> po_rhs;
-    for (int i = 0; i < post_ops.len(); i++)
-        if (post_ops.entry_[i].is_binary()) {
-            const memory_desc_wrapper s1_d(post_ops.entry_[i].binary.src1_desc);
-            const auto *base = static_cast<const char *>(ctx.host_ptr(
-                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(i) | DNNL_ARG_SRC_1));
-            po_rhs.push_back(base + s1_d.off_l(0) * sizeof(float));
-        }
+    // when the chain has no binary entry. The raw handles from the common
+    // helper (x64 model) -- the kernel only adds the in-row column offset.
+    const std::vector<const void *> po_rhs
+            = binary_injector_utils::prepare_binary_args(post_ops, ctx);
     const void *const *po_rhs_arr = po_rhs.empty() ? nullptr : po_rhs.data();
 
     parallel_nd(batch, [&](dim_t b) {

--- a/tests/gtests/test_binary.cpp
+++ b/tests/gtests/test_binary.cpp
@@ -340,9 +340,6 @@ TEST(binary_attr_test, BinaryPostOpHonorsRhsOffset0) {
 
     const binary::primitive_desc pd(
             eng, algorithm::binary_add, data_md, data_md, data_md, attr);
-#if DNNL_X64 || DNNL_AARCH64 || DNNL_RV64
-    ASSERT_NE(std::string(pd.impl_info_str()).find("jit"), std::string::npos);
-#endif
 
     std::vector<float> src0(16, 0.f);
     std::vector<float> src1(16, 0.f);

--- a/tests/gtests/test_binary.cpp
+++ b/tests/gtests/test_binary.cpp
@@ -321,6 +321,49 @@ INSTANTIATE_TEST_SUITE_P(BinaryTensorDims, binary_attr_test_t,
                         memory::dims {1, 1024, 1, 1},
                         memory::format_tag::abcd)));
 
+TEST(binary_attr_test, BinaryPostOpHonorsRhsOffset0) {
+    SKIP_IF(get_test_engine_kind() != engine::kind::cpu,
+            "The test requires host-accessible memory.");
+
+    auto eng = get_test_engine();
+    auto strm = make_stream(eng);
+
+    const memory::desc data_md({1, 16}, data_type::f32, memory::format_tag::ab);
+    const memory::desc rhs_parent_md(
+            {1, 4}, data_type::f32, memory::format_tag::ab);
+    const memory::desc rhs_md = rhs_parent_md.submemory_desc({1, 1}, {0, 2});
+
+    post_ops ops;
+    ops.append_binary(algorithm::binary_add, rhs_md);
+    primitive_attr attr;
+    attr.set_post_ops(ops);
+
+    const binary::primitive_desc pd(
+            eng, algorithm::binary_add, data_md, data_md, data_md, attr);
+#if DNNL_X64 || DNNL_AARCH64 || DNNL_RV64
+    ASSERT_NE(std::string(pd.impl_info_str()).find("jit"), std::string::npos);
+#endif
+
+    std::vector<float> src0(16, 0.f);
+    std::vector<float> src1(16, 0.f);
+    std::vector<float> dst(16, -1.f);
+    std::vector<float> rhs_parent {100.f, 101.f, 12.f, 103.f};
+    memory src0_mem(data_md, eng, src0.data());
+    memory src1_mem(data_md, eng, src1.data());
+    memory dst_mem(data_md, eng, dst.data());
+    memory rhs_mem(rhs_md, eng, rhs_parent.data());
+
+    binary(pd).execute(strm,
+            {{DNNL_ARG_SRC_0, src0_mem}, {DNNL_ARG_SRC_1, src1_mem},
+                    {DNNL_ARG_DST, dst_mem},
+                    {DNNL_ARG_ATTR_MULTIPLE_POST_OP(0) | DNNL_ARG_SRC_1,
+                            rhs_mem}});
+    strm.wait();
+
+    for (const float value : dst)
+        EXPECT_FLOAT_EQ(value, rhs_parent[2]);
+}
+
 static auto expected_failures = []() {
     return ::testing::Values(
             // test tag::any support

--- a/tests/gtests/test_binary.cpp
+++ b/tests/gtests/test_binary.cpp
@@ -328,10 +328,10 @@ TEST(binary_attr_test, BinaryPostOpHonorsRhsOffset0) {
     auto eng = get_test_engine();
     auto strm = make_stream(eng);
 
-    const memory::desc data_md({1, 16}, data_type::f32, memory::format_tag::ab);
+    const memory::desc data_md({1, 2}, data_type::f32, memory::format_tag::ab);
     const memory::desc rhs_parent_md(
             {1, 4}, data_type::f32, memory::format_tag::ab);
-    const memory::desc rhs_md = rhs_parent_md.submemory_desc({1, 1}, {0, 2});
+    const memory::desc rhs_md = rhs_parent_md.submemory_desc({1, 2}, {0, 2});
 
     post_ops ops;
     ops.append_binary(algorithm::binary_add, rhs_md);
@@ -341,13 +341,13 @@ TEST(binary_attr_test, BinaryPostOpHonorsRhsOffset0) {
     const binary::primitive_desc pd(
             eng, algorithm::binary_add, data_md, data_md, data_md, attr);
 
-    std::vector<float> src0(16, 0.f);
-    std::vector<float> src1(16, 0.f);
-    std::vector<float> dst(16, -1.f);
-    std::vector<float> rhs_parent {100.f, 101.f, 12.f, 103.f};
+    std::vector<float> src0(2, 0.f);
+    std::vector<float> src1(2, 0.f);
+    std::vector<float> dst(4, 0.f);
+    std::vector<float> rhs_parent {100.f, 101.f, 12.f, 13.f};
     memory src0_mem(data_md, eng, src0.data());
     memory src1_mem(data_md, eng, src1.data());
-    memory dst_mem(data_md, eng, dst.data());
+    memory dst_mem(data_md, eng, dst.data() + 2);
     memory rhs_mem(rhs_md, eng, rhs_parent.data());
 
     binary(pd).execute(strm,
@@ -357,8 +357,10 @@ TEST(binary_attr_test, BinaryPostOpHonorsRhsOffset0) {
                             rhs_mem}});
     strm.wait();
 
-    for (const float value : dst)
-        EXPECT_FLOAT_EQ(value, rhs_parent[2]);
+    EXPECT_FLOAT_EQ(dst[0], 0.f);
+    EXPECT_FLOAT_EQ(dst[1], 0.f);
+    EXPECT_FLOAT_EQ(dst[2], rhs_parent[2]);
+    EXPECT_FLOAT_EQ(dst[3], rhs_parent[3]);
 }
 
 static auto expected_failures = []() {


### PR DESCRIPTION
## Summary

The RV64 binary synchronization adopts the x64/Arm driver and post-op injector contracts, but its fixed strategy matrix dropped dense layout and broadcast combinations previously handled by the RVV JIT. It also split plain broadcasts into short kernel calls, which is a poor fit for a variable-length vector kernel.

This update retains the synchronized kernel and driver paths while adding a bounded RV64 physical-run plan for dense combinations outside that matrix. The plan coalesces adjacent physical dimensions when dst is contiguous and src1 is either uniformly strided or broadcast. Plain non-scalar broadcasts use this path to keep longer VLA runs. Padded channel tails remain separate runs and are explicitly zeroed. Generic `binary_select` execution additionally requires src2 to be dense and layout-compatible with src0/dst.

## Builds

| Build | Commit | Compiler/configuration |
|---|---|---|
| Upstream baseline | `a541457b7e` | GCC 13.3.0, `RelWithAssert`, OpenMP, `-march=rv64gc` |
| Optimized | `a18cb0d9e4` | GCC 13.3.0, `RelWithAssert`, OpenMP, `-march=rv64gc` |

Both builds were cross-compiled on the same host. RVV and Zvfh instructions are emitted at run time by the RV64 JIT and gated by oneDNN ISA detection.

## Test environment

| Item | Value |
|---|---|
| Board | MUSE Pi Pro |
| CPU | SpacemiT X60, 8 cores |
| Memory | 7.7 GiB |
| OS/kernel | Linux 6.6.63, riscv64 |
| CPU frequency governor | `performance` (`cpufreq-dt`) |
| Threads/affinity | 8, cores 0-7, close binding |

## Performance method

The existing `test_binary_float16` and `harness_binary_f32` batches were used. Each expands to 5000 instances spanning 13 algorithms, in-place and out-of-place execution, broadcasts, layout combinations, post-ops, and scales. The baseline ran first and the optimized build second.

```sh
OMP_NUM_THREADS=8 OMP_PROC_BIND=close OMP_PLACES=cores \
LD_LIBRARY_PATH=<build>/src taskset -c 0-7 \
<build>/tests/benchdnn/benchdnn \
    --binary --mode=P --max-ms-per-prb=300 \
    --perf-template=csv \
    --batch=tests/benchdnn/inputs/binary/test_binary_float16
```

The f32 run used the same command with `harness_binary_f32` as the batch file.

## Performance results

All statistics below use benchdnn's `avg_time`. Per-case speedup is baseline `avg_time` divided by optimized `avg_time`.

Both f16 and f32 runs completed 4450 cases, skipped the same 550 invalid cases, and reported zero failures. Their implementation transitions were also identical: 3588 `jit:uni -> jit:uni`, 46 `ref:any -> jit:uni`, 816 `ref:any -> ref:any`, and zero `jit:uni -> ref:any`.

| Data type | Scope | Cases | Geometric mean | Median | Regressions >2% | Improvements >2% |
|---|---|---:|---:|---:|---:|---:|
| f16 | All executed cases | 4450 | **1.092x** | **1.045x** | 580 | 3062 |
| f16 | `jit:uni` in both builds | 3588 | **1.079x** | **1.051x** | 493 | 2559 |
| f16 | `ref:any` to `jit:uni` | 46 | **7.828x** | **7.331x** | 0 | 46 |
| f16 | `ref:any` in both builds | 816 | **1.030x** | **1.025x** | 87 | 457 |
| f32 | All executed cases | 4450 | **1.087x** | **1.045x** | 557 | 3051 |
| f32 | `jit:uni` in both builds | 3588 | **1.074x** | **1.051x** | 513 | 2537 |
| f32 | `ref:any` to `jit:uni` | 46 | **7.537x** | **7.021x** | 0 | 46 |
| f32 | `ref:any` in both builds | 816 | **1.031x** | **1.024x** | 44 | 468 |

Representative f16 layout groups:

| Source tags | Cases | Geometric mean |
|---|---:|---:|
| `aBcd8b:aBcd16b` | 159 | **1.877x** |
| `aBcd8b:any` | 368 | **1.249x** |
| `aBcd16b:any` | 414 | **1.150x** |
| `abcdef:any` | 46 | **1.090x** |
| `ab:any` | 184 | **1.053x** |
| `abcd:any` | 414 | **1.045x** |
| `abcd:acdb` | 230 | 0.970x |

The `abcd:acdb` group is the main remaining regression. Routing all such cases back to the synchronized fixed driver was not adopted: the earlier candidate showed that driver's short-call behavior was materially worse for common plain broadcast families, while the final policy is layout-agnostic and improves the full common-JIT population by 7.9%. The f32 results independently confirm that the broader execution coverage does not come at the cost of JIT fallback.
