### PR TITLE
cpu: aarch64: enable KAI for deconvolution

### DIFF
--- a/src/cpu/aarch64/kai_deconvolution.cpp
+++ b/src/cpu/aarch64/kai_deconvolution.cpp
@@ -1,0 +1,284 @@
+/*******************************************************************************
+* Copyright 2018, 2022 Intel Corporation
+* Copyright 2025-2026 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/aarch64/kai_deconvolution.hpp"
+
+#include "common/dnnl_thread.hpp"
+#include "common/memory.hpp"
+#include "common/memory_desc_wrapper.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive_desc_iterator.hpp"
+#include "common/type_helpers.hpp"
+#include "common/utils.hpp"
+
+#include "cpu/aarch64/kai_direct_1x1_convolution.hpp"
+#include "cpu/aarch64/kai_indirect_convolution.hpp"
+#include "cpu/ref_io_helper.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+namespace {
+
+// Express a unit-stride deconvolution as an inverted forward convolution.
+status_t create_fwd_conv_desc(const deconvolution_desc_t *deconv_d,
+        convolution_desc_t *conv_d, const memory_desc_t *bias_md,
+        data_type_t dst_dt) {
+    constexpr int spatial_ndims = 2;
+    // Padding used by the nested forward convolution for height and width.
+    dims_t padding_l {};
+    dims_t padding_r {};
+    // Product of the spatial kernel sizes, used to identify non-1x1 cases.
+    dim_t kernel_size = 1;
+
+    for (int d = 0; d < spatial_ndims; ++d) {
+        if (deconv_d->strides[d] != 1) return status::unimplemented;
+
+        // weights_d is the height or width axis in the weights descriptor.
+        const int weights_d = deconv_d->weights_desc.ndims - spatial_ndims + d;
+        const dim_t kernel = deconv_d->weights_desc.dims[weights_d];
+        // oneDNN stores dilation as the number of skipped points.
+        const dim_t dilation = deconv_d->dilates[d] + 1;
+        // Distance from the first kernel point to the last one.
+        const dim_t effective_kernel = (kernel - 1) * dilation;
+        padding_l[d] = effective_kernel - deconv_d->padding[0][d];
+        padding_r[d] = effective_kernel - deconv_d->padding[1][d];
+        if (padding_l[d] < 0 || padding_r[d] < 0) return status::unimplemented;
+        kernel_size *= kernel;
+    }
+
+    // Copy the public destination layout with the datatype needed by KAI.
+    memory_desc_t dst_md;
+    CHECK(memory_desc_init_by_md_and_dt(dst_md, deconv_d->dst_desc, dst_dt));
+    CHECK(conv_desc_init(conv_d, prop_kind::forward_training,
+            alg_kind::convolution_direct, &deconv_d->src_desc,
+            &deconv_d->weights_desc, bias_md, &dst_md, deconv_d->strides,
+            deconv_d->dilates, padding_l, padding_r));
+
+    // Distinguish the converted descriptor in the primitive cache.
+    if (kernel_size > 1) {
+        conv_d->diff_src_desc = conv_d->src_desc;
+        conv_d->diff_dst_desc = conv_d->dst_desc;
+    }
+    conv_d->use_inversion = true;
+    return status::success;
+}
+
+bool is_kai_convolution(const primitive_desc_t *pd) {
+    return dynamic_cast<const kai_direct_1x1_convolution_fwd_t::pd_t *>(pd)
+            != nullptr
+            || dynamic_cast<const kai_indirect_convolution_fwd_t::pd_t *>(pd)
+            != nullptr;
+}
+
+} // namespace
+
+status_t kai_deconvolution_fwd_t::pd_t::try_kai_convolution(
+        const engine_t *engine, const primitive_attr_t &conv_attr,
+        const memory_desc_t *bias_md, data_type_t dst_dt) {
+    // conv_d is the equivalent forward-convolution descriptor searched below.
+    convolution_desc_t conv_d {};
+    const status_t desc_status
+            = create_fwd_conv_desc(desc(), &conv_d, bias_md, dst_dt);
+    if (desc_status != status::success) return desc_status;
+
+    primitive_desc_iterator_t it(engine,
+            reinterpret_cast<const op_desc_t *>(&conv_d), &conv_attr, nullptr);
+    if (!it.is_initialized()) return status::out_of_memory;
+
+    while (++it != it.end()) {
+        if (!is_kai_convolution((*it).get())) continue;
+        conv_pd_ = *it;
+        return status::success;
+    }
+    return status::unimplemented;
+}
+
+status_t kai_deconvolution_fwd_t::pd_t::init(const engine_t *engine) {
+    using mask_t = primitive_attr_t::skip_mask_t;
+    // Keep the public destination type even if the nested fallback uses f32.
+    const data_type_t dst_dt = dst_md()->data_type;
+    // These attributes are handled by KAI or by this wrapper's epilogue.
+    const auto attr_mask = mask_t::fpmath_mode | mask_t::accumulation_mode
+            | mask_t::post_ops;
+
+    VDISPATCH_DECONVOLUTION(is_fwd(), VERBOSE_BAD_PROPKIND);
+    VDISPATCH_DECONVOLUTION(desc()->alg_kind == alg_kind::deconvolution_direct,
+            VERBOSE_BAD_ALGORITHM);
+    VDISPATCH_DECONVOLUTION(ndims() == 4, VERBOSE_BAD_NDIMS, "src", ndims());
+    VDISPATCH_DECONVOLUTION(
+            !with_groups(), VERBOSE_UNSUPPORTED_FEATURE, "groups");
+    VDISPATCH_DECONVOLUTION(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+    VDISPATCH_DECONVOLUTION(
+            !has_runtime_dims_or_strides(), VERBOSE_RUNTIMEDIM_UNSUPPORTED);
+    VDISPATCH_DECONVOLUTION(attr()->has_default_values(attr_mask, dst_dt),
+            VERBOSE_UNSUPPORTED_ATTR);
+    VDISPATCH_DECONVOLUTION(
+            attr()->post_ops_.check_sum_consistency(dst_dt, false),
+            VERBOSE_UNSUPPORTED_POSTOP);
+    VDISPATCH_DECONVOLUTION(impl::is_dense_format_kind({src_md(0),
+                                    weights_md(0), weights_md(1), dst_md(0)}),
+            VERBOSE_UNSUPPORTED_SPARSE_CFG);
+
+    // A null descriptor tells the nested convolution that there is no bias.
+    const memory_desc_t *bias_md = with_bias() ? weights_md(1) : nullptr;
+    // First try to let KAI own the complete bias and post-op operation.
+    status_t status = try_kai_convolution(engine, *attr(), bias_md, dst_dt);
+    if (status == status::out_of_memory) return status;
+
+    if (status != status::success) {
+        VDISPATCH_DECONVOLUTION(with_bias() || attr()->post_ops_.len() > 0,
+                "KAI convolution implementation not found");
+        VDISPATCH_DECONVOLUTION(ref_post_ops_t::post_ops_ok(attr()->post_ops_),
+                VERBOSE_UNSUPPORTED_POSTOP);
+
+        // Retry KAI without bias/post-ops and finish them from an f32 result.
+        primitive_attr_t conv_attr(*attr());
+        if (!conv_attr.is_initialized()) return status::out_of_memory;
+        CHECK(conv_attr.set_post_ops(post_ops_t {}));
+        CHECK(try_kai_convolution(engine, conv_attr, nullptr, data_type::f32));
+        use_outer_epilogue_ = true;
+    }
+
+    if (weights_md_.format_kind == format_kind::any)
+        weights_md_ = *conv_pd_->weights_md();
+    if (src_md_.format_kind == format_kind::any) src_md_ = *conv_pd_->src_md();
+    if (dst_md_.format_kind == format_kind::any) {
+        CHECK(memory_desc_init_by_md_and_dt(
+                dst_md_, *conv_pd_->dst_md(), dst_dt));
+    }
+    if (bias_md_.format_kind == format_kind::any)
+        CHECK(memory_desc_init_by_tag(bias_md_, format_tag::x));
+    CHECK(attr_.set_default_formats(dst_md(0)));
+
+    init_name();
+
+    using namespace memory_tracking::names;
+    auto scratchpad = scratchpad_registry().registrar();
+    // key_nested owns any temporary storage requested by the selected KAI PD.
+    scratchpad.book(key_nested, conv_pd_->scratchpad_registry());
+    if (use_outer_epilogue_) {
+        const memory_desc_wrapper conv_dst_d(conv_pd_->dst_md());
+        assert(conv_dst_d.data_type() == data_type::f32);
+        // Keep KAI output separate so sum can read the original destination.
+        scratchpad.book(
+                key_deconv_bias, conv_dst_d.nelems(true), sizeof(float));
+    }
+
+    return status::success;
+}
+
+void kai_deconvolution_fwd_t::pd_t::init_name() {
+    name_ = "kai_deconv+";
+    name_.append(conv_pd_->name());
+    if (use_outer_epilogue_) name_.append("+outer_post_ops");
+}
+
+status_t kai_deconvolution_fwd_t::init(engine_t *engine) {
+    CHECK(pd()->conv_pd_->create_primitive(conv_p_, engine));
+    if (pd()->use_outer_epilogue_) {
+        ref_post_ops_
+                = utils::make_unique<ref_post_ops_t>(pd()->attr()->post_ops_);
+        if (!ref_post_ops_) return status::out_of_memory;
+        CHECK(ref_post_ops_->init(pd()->dst_md()));
+    }
+    return status::success;
+}
+
+status_t kai_deconvolution_fwd_t::execute(const exec_ctx_t &ctx) const {
+    using namespace memory_tracking::names;
+    const auto &args = ctx.args();
+    // Arguments passed to KAI; the fallback starts with source and weights.
+    exec_args_t conv_args;
+    conv_args[DNNL_ARG_SRC] = args.at(DNNL_ARG_SRC);
+    conv_args[DNNL_ARG_WEIGHTS] = args.at(DNNL_ARG_WEIGHTS);
+
+    // View of the f32 output scratchpad; it does not own the storage.
+    std::unique_ptr<memory_t, memory_deleter_t> tmp_dst;
+    if (pd()->use_outer_epilogue_) {
+        const auto &dst = args.at(DNNL_ARG_DST);
+        CHECK(safe_ptr_assign(tmp_dst,
+                new memory_t(dst.mem()->engine(), pd()->conv_pd_->dst_md(),
+                        ctx.get_scratchpad_grantor().get_memory_storage(
+                                key_deconv_bias))));
+        conv_args[DNNL_ARG_DST] = {tmp_dst.get(), false};
+    } else {
+        conv_args = args;
+    }
+
+    exec_ctx_t conv_ctx(ctx, std::move(conv_args));
+    auto *nested_grantor = create_nested_grantor(ctx.get_scratchpad_grantor(),
+            key_nested, conv_p_->pd()->scratchpad_registry());
+    conv_ctx.set_scratchpad_grantor(nested_grantor);
+    CHECK(conv_p_->execute(conv_ctx));
+
+    if (!pd()->use_outer_epilogue_) return status::success;
+
+    const auto &scratchpad = ctx.get_scratchpad_grantor();
+    // conv_output is the f32 result that still needs public bias and post-ops.
+    const auto *conv_output = scratchpad.get<const float>(key_deconv_bias);
+    auto *dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+    const auto *bias = pd()->with_bias()
+            ? CTX_IN_MEM(const void *, DNNL_ARG_BIAS)
+            : nullptr;
+    // The nested and public destinations can have different datatypes/layouts.
+    const memory_desc_wrapper conv_dst_d(pd()->conv_pd_->dst_md());
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const memory_desc_wrapper bias_d(pd()->weights_md(1));
+    // Sum needs the original public destination value and its declared type.
+    const bool has_sum
+            = pd()->attr()->post_ops_.find(primitive_kind::sum) != -1;
+    const auto sum_dt = pd()->attr()->post_ops_.get_sum_dt(dst_d.data_type());
+    const auto *post_ops = ref_post_ops_.get();
+    // Logical output sizes: minibatch, channels, height, and width.
+    const auto MB = pd()->MB();
+    const auto OC = pd()->OC();
+    const auto OH = pd()->OH();
+    const auto OW = pd()->OW();
+
+    parallel_nd(
+            MB, OC, OH, OW, [=, &ctx](dim_t mb, dim_t oc, dim_t oh, dim_t ow) {
+        // Nested scratch and public output may use different physical offsets.
+        const dim_t conv_off = conv_dst_d.off(mb, oc, oh, ow);
+        const dim_t dst_off = dst_d.off(mb, oc, oh, ow);
+        msan_unpoison((void *)&conv_output[conv_off], sizeof(float));
+        float value = conv_output[conv_off];
+        if (bias) {
+            value += io::load_float_value(bias_d.data_type(), bias, oc);
+        }
+
+        ref_post_ops_t::args_t post_ops_args;
+        if (has_sum) {
+            post_ops_args.dst_val = io::load_float_value(sum_dt, dst, dst_off);
+        }
+        post_ops_args.ctx = &ctx;
+        // Logical NCHW offset used to broadcast binary and PReLU arguments.
+        post_ops_args.l_offset = ((mb * OC + oc) * OH + oh) * OW + ow;
+        post_ops_args.dst_md = pd()->dst_md();
+        post_ops->execute(value, post_ops_args);
+        io::store_float_value(dst_d.data_type(), value, dst, dst_off);
+    });
+
+    return status::success;
+}
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/aarch64/kai_deconvolution.hpp
+++ b/src/cpu/aarch64/kai_deconvolution.hpp
@@ -1,0 +1,86 @@
+/*******************************************************************************
+* Copyright 2022 Intel Corporation
+* Copyright 2025-2026 Arm Ltd. and affiliates
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_AARCH64_KAI_DECONVOLUTION_HPP
+#define CPU_AARCH64_KAI_DECONVOLUTION_HPP
+
+#include <memory>
+#include <string>
+
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+
+#include "cpu/cpu_deconvolution_pd.hpp"
+#include "cpu/primitive_attr_postops.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace aarch64 {
+
+struct kai_deconvolution_fwd_t : public primitive_t {
+    struct pd_t : public cpu_deconvolution_fwd_pd_t {
+        using cpu_deconvolution_fwd_pd_t::cpu_deconvolution_fwd_pd_t;
+
+        pd_t(const pd_t &other)
+            : cpu_deconvolution_fwd_pd_t(other)
+            , conv_pd_(other.conv_pd_->clone())
+            , use_outer_epilogue_(other.use_outer_epilogue_)
+            , name_(other.name_) {}
+
+        DECLARE_COMMON_PD_T(name_.c_str(), kai_deconvolution_fwd_t);
+
+        status_t init(const engine_t *engine);
+
+        // Descriptor of the direct 1x1 or indirect KAI convolution we reuse.
+        std::shared_ptr<primitive_desc_t> conv_pd_;
+        // True when this wrapper applies bias and post-ops after KAI finishes.
+        bool use_outer_epilogue_ = false;
+
+    private:
+        // Finds an exact KAI convolution for the converted descriptor.
+        status_t try_kai_convolution(const engine_t *engine,
+                const primitive_attr_t &conv_attr, const memory_desc_t *bias_md,
+                data_type_t dst_dt);
+        void init_name();
+
+        // Composite name shown by oneDNN verbose output.
+        std::string name_;
+    };
+
+    kai_deconvolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
+
+    status_t init(engine_t *engine) override;
+    status_t execute(const exec_ctx_t &ctx) const override;
+
+private:
+    const pd_t *pd() const {
+        return static_cast<const pd_t *>(primitive_t::pd().get());
+    }
+
+    // Executable nested KAI convolution created from conv_pd_.
+    std::shared_ptr<primitive_t> conv_p_;
+    // Applies the public post-ops only on the outer-epilogue route.
+    std::unique_ptr<ref_post_ops_t> ref_post_ops_;
+};
+
+} // namespace aarch64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/aarch64/kai_indirect_convolution.cpp
+++ b/src/cpu/aarch64/kai_indirect_convolution.cpp
@@ -69,10 +69,23 @@ status_t kai_indirect_convolution_fwd_t::setup_kernel_arrays(
     const auto &pd = static_cast<const kai_indirect_convolution_fwd_t::pd_t &>(
             args.pd);
 
-    args.kernel.set_convolution_parameters(
-            kai::ops::ConvolutionParameters {pd.IW(), pd.IH(), pd.IC(), pd.KW(),
-                    pd.KH(), pd.OW(), pd.OH(), pd.KSW(), pd.KSH(), pd.KDW() + 1,
-                    pd.KDH() + 1, pd.padT(), pd.padL(), 0.f});
+    const bool invert = pd.desc()->use_inversion;
+    const dim_t dilation_w = pd.KDW() + 1;
+    const dim_t dilation_h = pd.KDH() + 1;
+
+    // Negative dilation reverses the spatial offsets. Shift the origin so the
+    // first kernel point remains aligned with deconvolution padding.
+    const dim_t kai_dilation_w = invert ? -dilation_w : dilation_w;
+    const dim_t kai_dilation_h = invert ? -dilation_h : dilation_h;
+    const dim_t kai_padding_l
+            = invert ? pd.padL() - (pd.KW() - 1) * dilation_w : pd.padL();
+    const dim_t kai_padding_t
+            = invert ? pd.padT() - (pd.KH() - 1) * dilation_h : pd.padT();
+
+    args.kernel.set_convolution_parameters(kai::ops::ConvolutionParameters {
+            pd.IW(), pd.IH(), pd.IC(), pd.KW(), pd.KH(), pd.OW(), pd.OH(),
+            pd.KSW(), pd.KSH(), kai_dilation_w, kai_dilation_h, kai_padding_t,
+            kai_padding_l, 0.f});
     args.kernel.set_arrays_generic(args.src_base, args.ld_src,
             args.src_batch_stride, 0, args.wei_base, args.ld_wei, 0,
             args.kernel_dst_base, args.ld_dst, args.dst_batch_stride, 0,

--- a/src/cpu/cpu_deconvolution_list.cpp
+++ b/src/cpu/cpu_deconvolution_list.cpp
@@ -30,6 +30,9 @@ using namespace dnnl::impl::cpu::x64;
 #elif DNNL_AARCH64
 #include "cpu/aarch64/jit_brgemm_deconv.hpp"
 #include "cpu/aarch64/jit_sve_512_core_x8s8s32x_deconvolution.hpp"
+#if !DNNL_AARCH64_DISABLE_KAI
+#include "cpu/aarch64/kai_deconvolution.hpp"
+#endif
 using namespace dnnl::impl::cpu::aarch64;
 #endif
 
@@ -66,6 +69,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
             CPU_INSTANCE_AARCH64(brgemm_deconvolution_fwd_t<sve_256>)
             CPU_INSTANCE_AARCH64(brgemm_deconvolution_fwd_t<sve_128>)
             CPU_INSTANCE_AARCH64(jit_sve_512_core_x8s8s32x_deconvolution_fwd_t)
+            CPU_INSTANCE_AARCH64_KAI(kai_deconvolution_fwd_t)
             CPU_INSTANCE(ref_deconvolution_fwd_t)
             nullptr,
         }},


### PR DESCRIPTION
# Description

This change allows eligible forward deconvolutions to use the AArch64 KAI
forward-convolution kernels.

oneDNN normally implements forward deconvolution internally using convolution
backward-data. That cannot select forward-only implementations such as KAI.
For a direct, unit-stride deconvolution, the same calculation can instead use a
forward convolution if its padding is adjusted and source indexing
is reversed.

The conversion is owned by a dedicated AArch64 `kai_deconvolution_fwd_t`, 
similar to the existing `jit_brgemm_deconv`
BRGEMM deconvolution wrapper. It does not change `ref_deconvolution`.

This patch:

- converts the deconvolution padding into a forward-convolution descriptor and
  accepts only KAI direct 1x1 or KAI indirect convolution;
- tells KAI indirect convolution to reverse its spatial offsets for that
  descriptor. Direct 1x1 needs no kernel change because reversing a 1x1 kernel
  is the identity; and
- first gives bias and post-ops to the nested KAI convolution, then uses an f32
  result and a wrapper epilogue only when that implementation cannot accept
  them.

The wrapper declines backward operations, groups, non-unit strides,
1D/3D shapes, unsupported data types, unsupported converted padding,
and non-KAI nested implementations.

## Coverage Tests

### ACL

```text
============================================================
= Implementation statistics (--summary=no-impl to disable) =
============================================================
|                        acl : 235 (51%)                   |
|          conv:any+gemm:acl : 190 (42%)                   |
| conv:any+indirect_gemm:acl : 20 (4%)                     |
|  conv:any+gemm_s8u8s32:ref : 9 (2%)                      |
|           conv:any+ref:any : 1 (0%)                      |
|          conv:any+gemm:ref : 1 (0%)                      |
|  conv:any+gemm_s8s8s32:ref : 1 (0%)                      |
============================================================
tests:5766 passed:457 skipped:5309 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 4.57s; create_pd: 0.62s (14%); create_prim: 0.05s (1%); fill: 0.85s (19%); execute: 0.36s (8%); compute_ref: 0.88s (19%); compare: 0.58s (13%);
```

### KAI

```text
===============================================================
= Implementation statistics (--summary=no-impl to disable)    =
===============================================================
|    kai_deconv+indirect_gemm:kai+outer_post_ops : 648 (30%)  |
|                   kai_deconv+indirect_gemm:kai : 360 (17%)  |
|       kai_deconv+direct_1x1:kai+outer_post_ops : 297 (14%)  |
|                     conv:any+indirect_gemm:kai : 288 (13%)  |
|                      kai_deconv+direct_1x1:kai : 229 (11%)  |
| kai_deconv+indirect_gemm:kai+post_ops_fallback : 144 (7%)   |
|                        conv:any+direct_1x1:kai : 132 (6%)   |
|    kai_deconv+direct_1x1:kai+post_ops_fallback : 66 (3%)    |
|                      conv:any+gemm_s8u8s32:ref : 9 (0%)     |
|                               conv:any+ref:any : 1 (0%)     |
|                              conv:any+gemm:ref : 1 (0%)     |
|                      conv:any+gemm_s8s8s32:ref : 1 (0%)     |
===============================================================
tests:5766 passed:2176 skipped:3590 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0 listed:0
total: 21.37s; create_pd: 0.57s (3%); create_prim: 0.23s (1%); fill: 5.89s (28%); execute: 2.73s (13%); compute_ref: 5.95s (28%); compare: 3.70s (17%);
```

## Performance context

The local KAI package was compared with current upstream oneDNN `main` built
with ACL. This table uses the 234 joint forward cases and excludes 210
unaffected `BWD_D` cases. `KAI / ACL` is the ratio of summed average latency;
values above one favor ACL.

| Forward joint population | Cases | 16 threads | 32 threads |
| --- | ---: | ---: | ---: |
| All | 234 | 0.906x | 0.880x |
| No post-ops | 166 | 0.912x | 0.868x |
| With post-ops | 68 | 0.895x | 0.907x |

KAI is faster in aggregate for every population at both thread counts. The
post-op population also favors KAI in this current-main ACL comparison; unlike
the earlier #5881 table, no large post-op gap appears in this joint population.

The earlier #5881 measurements in the previous commit showed a large post-op regression because the
deconvolution wrapper applied post-ops through the scalar `ref_post_ops`
epilogue. The current wrapper first passes the attributes to KAI, so all 68 f32
post-op cases above use KAI's existing `+post_ops_fallback` path and that
regression is no longer present. The improvement is not kernel fusion; KAI runs oneDNN post-op primitives.

# Checklist

## General

- Do all unit and benchdnn tests (`make test` and
  `make test_benchdnn_*`) pass locally for each commit? Yes, with known exceptions: 

  - `test_iface_wino_convolution`: stale AArch64 f16 Winograd capability
    expectation; fix proposed in [#5905](https://github.com/uxlfoundation/oneDNN/pull/5905);
  - `test_benchdnn_modeC_graph_ci_cpu`: six known MHA/dropout reference
    failures; and
  - `test_benchdnn_modeC_matmul_ci_cpu`: known KAI kernel-reselection and
    workspace failure; fix proposed in [#5904](https://github.com/uxlfoundation/oneDNN/pull/5904).

- Have you formatted the code using clang-format? Yes

## Performance improvements

- Have you submitted performance data that demonstrates performance
  improvements? Yes
