### PR TITLE
Fix unused template warnings

### DIFF
--- a/src/common/utils.hpp
+++ b/src/common/utils.hpp
@@ -822,7 +822,7 @@ public:
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
 template <typename T>
-static size_t hash_combine(size_t seed, const T &v) {
+inline size_t hash_combine(size_t seed, const T &v) {
     return seed ^= std::hash<T> {}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 

--- a/tests/benchdnn/utils/parser.hpp
+++ b/tests/benchdnn/utils/parser.hpp
@@ -95,7 +95,7 @@ execution_mode_t str2execution_mode(const std::string &s);
 // treated as vector object. `process_func` should return an object of type `U`
 // in this notation.
 template <typename T, typename F>
-static bool parse_vector_str(T &vec, const T &def, F process_func,
+bool parse_vector_str(T &vec, const T &def, F process_func,
         const std::string &str, char delimiter = ',', bool allow_empty = true) {
     if (str.empty()) return vec = def, true;
 
@@ -126,10 +126,9 @@ static bool parse_vector_str(T &vec, const T &def, F process_func,
 }
 
 template <typename T, typename F>
-static bool parse_multivector_str(std::vector<T> &vec,
-        const std::vector<T> &def, F process_func, const std::string &str,
-        char vector_delim = ',', char element_delim = ':',
-        bool allow_empty = true) {
+bool parse_multivector_str(std::vector<T> &vec, const std::vector<T> &def,
+        F process_func, const std::string &str, char vector_delim = ',',
+        char element_delim = ':', bool allow_empty = true) {
     auto process_subword = [&](const char *word) {
         T v, empty_def_v; // defualt value is not expected to be set here
         // parse vector elements separated by @p element_delim
@@ -143,9 +142,8 @@ static bool parse_multivector_str(std::vector<T> &vec,
 }
 
 template <typename T, typename F>
-static bool parse_vector_option(T &vec, const T &def, F process_func,
-        const char *str, const std::string &option_name,
-        const std::string &help_message = "") {
+bool parse_vector_option(T &vec, const T &def, F process_func, const char *str,
+        const std::string &option_name, const std::string &help_message = "") {
     utils::add_option_to_help(option_name, help_message);
     const std::string pattern = utils::get_pattern(option_name);
     if (!utils::option_matched(pattern, str)) return false;
@@ -153,10 +151,10 @@ static bool parse_vector_option(T &vec, const T &def, F process_func,
 }
 
 template <typename T, typename F>
-static bool parse_multivector_option(std::vector<T> &vec,
-        const std::vector<T> &def, F process_func, const char *str,
-        const std::string &option_name, const std::string &help_message = "",
-        char vector_delim = ',', char element_delim = ':') {
+bool parse_multivector_option(std::vector<T> &vec, const std::vector<T> &def,
+        F process_func, const char *str, const std::string &option_name,
+        const std::string &help_message = "", char vector_delim = ',',
+        char element_delim = ':') {
     utils::add_option_to_help(option_name, help_message);
     const std::string pattern = utils::get_pattern(option_name);
     if (!utils::option_matched(pattern, str)) return false;
@@ -165,7 +163,7 @@ static bool parse_multivector_option(std::vector<T> &vec,
 }
 
 template <typename T, typename F>
-static bool parse_single_value_option(T &val, const T &def_val, F process_func,
+bool parse_single_value_option(T &val, const T &def_val, F process_func,
         const char *str, const std::string &option_name,
         const std::string &help_message = "") {
     utils::add_option_to_help(option_name, help_message);
@@ -177,7 +175,7 @@ static bool parse_single_value_option(T &val, const T &def_val, F process_func,
 }
 
 template <typename T, typename F>
-static bool parse_cfg(T &vec, const T &def, F process_func, const char *str,
+bool parse_cfg(T &vec, const T &def, F process_func, const char *str,
         const std::string &option_name = "cfg") {
     static const std::string help
             = "CFG    (Default: `f32`)\n    Specifies data types `CFG` for "
@@ -187,7 +185,7 @@ static bool parse_cfg(T &vec, const T &def, F process_func, const char *str,
 }
 
 template <typename T, typename F>
-static bool parse_alg(T &vec, const T &def, F process_func, const char *str,
+bool parse_alg(T &vec, const T &def, F process_func, const char *str,
         const std::string &option_name = "alg") {
     static const std::string help
             = "ALG    (Default: depends on driver)\n    Specifies operation "

--- a/tests/gtests/dnnl_test_common.hpp
+++ b/tests/gtests/dnnl_test_common.hpp
@@ -452,7 +452,7 @@ static inline data_t set_value(
 }
 
 template <typename data_t>
-static void fill_data(const memory::dim nelems, data_t *data, data_t mean,
+void fill_data(const memory::dim nelems, data_t *data, data_t mean,
         data_t deviation, double sparsity = 1.) {
     dnnl::impl::parallel_nd(nelems, [=](memory::dim n) {
         data[n] = set_value<data_t>(n, mean, deviation, sparsity);
@@ -460,7 +460,7 @@ static void fill_data(const memory::dim nelems, data_t *data, data_t mean,
 }
 
 template <typename data_t>
-static void fill_data(const memory::dim nelems, const memory &mem, data_t mean,
+void fill_data(const memory::dim nelems, const memory &mem, data_t mean,
         data_t deviation, double sparsity = 1.) {
     auto data_ptr = map_memory<data_t>(mem);
     fill_data<data_t>(nelems, data_ptr, mean, deviation, sparsity);
@@ -502,8 +502,8 @@ inline void fill_data(memory::data_type dt, const memory &mem, float mean,
 }
 
 template <typename data_t>
-static void fill_data(const memory::dim nelems, data_t *data,
-        double sparsity = 1., bool init_negs = false) {
+void fill_data(const memory::dim nelems, data_t *data, double sparsity = 1.,
+        bool init_negs = false) {
     dnnl::impl::parallel_nd(nelems, [=](memory::dim n) {
         data[n] = set_value<data_t>(n, data_t(1), data_t(0.2f), sparsity);
 
@@ -514,7 +514,7 @@ static void fill_data(const memory::dim nelems, data_t *data,
 }
 
 template <typename data_t>
-static void fill_data(const memory::dim nelems, const memory &mem,
+void fill_data(const memory::dim nelems, const memory &mem,
         double sparsity = 1., bool init_negs = false) {
     auto data_ptr = map_memory<data_t>(mem);
 #if !defined(TEST_DNNL_DPCPP_BUFFER)
@@ -540,7 +540,7 @@ static void fill_data(const memory::dim nelems, const memory &mem,
 }
 
 template <typename data_t>
-static void remove_zeroes(const memory &mem) {
+void remove_zeroes(const memory &mem) {
     size_t nelems = mem.get_desc().get_size() / sizeof(data_t);
     auto mem_data = map_memory<data_t>(mem);
     data_t *data_ptr = mem_data;
@@ -550,7 +550,7 @@ static void remove_zeroes(const memory &mem) {
 }
 
 template <typename data_t>
-static void compare_data(
+void compare_data(
         const memory &ref, const memory &dst, data_t threshold = (data_t)1e-4) {
     using data_type = memory::data_type;
 


### PR DESCRIPTION
ICX 2026.2 gets upset when static template functions defined in a header are unused:
```
/sources/src/common/utils.hpp:825:15: error: unused function template 'hash_combine' [-Werror,-Wunused-template]
  825 | static size_t hash_combine(size_t seed, const T &v) {
      |               ^~~~~~~~~~~~
1 error generated.
```

`-Wunused-template` was enabled in `-Wall` in Clang/LLVM: https://github.com/llvm/llvm-project/issues/202945

Fixes [MFDNN-15484](https://jira.devtools.intel.com/browse/MFDNN-15484)

[Orphan CI](https://intel-ci.intel.com/f19da6b5-d25b-f1fe-9f11-d4f5ef20c6a0)
