### PR TITLE
cpu: x64: zen64: add lowp matmul for int8 static quant and WOQ

### DIFF
--- a/src/cpu/matmul/cpu_matmul_list.cpp
+++ b/src/cpu/matmul/cpu_matmul_list.cpp
@@ -33,6 +33,7 @@
 #include "cpu/x64/matmul/brgemm_matmul.hpp"
 #include "cpu/x64/matmul/jit_uni_sparse_matmul.hpp"
 #if DNNL_X64_USE_ZEN
+#include "cpu/x64/zen64/matmul/zen_lowp_matmul.hpp"
 #include "cpu/x64/zen64/matmul/zen_matmul.hpp"
 #if DNNL_EXPERIMENTAL_GROUPED_MEMORY
 #include "cpu/x64/zen64/matmul/zen_grouped_matmul.hpp"
@@ -80,6 +81,7 @@ constexpr impl_list_item_t impl_list[] = REG_MATMUL_P({
         CPU_INSTANCE_AARCH64(jit_int8_matmul_t<sve>)
         CPU_INSTANCE_AARCH64(brgemm_matmul_t<sve_256>)
         CPU_INSTANCE_AARCH64(brgemm_matmul_t<sve_128>)
+        CPU_INSTANCE_X64_ZEN(zen_lowp_matmul_t)
         CPU_INSTANCE_X64_ZEN(zen_matmul_t)
         CPU_INSTANCE_AMX(brgemm_matmul_t<avx10_2_amx_2>)
         CPU_INSTANCE_AMX(brgemm_matmul_t<avx512_core_amx_fp16>)

--- a/src/cpu/reorder/cpu_reorder_regular_f32_s8.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f32_s8.cpp
@@ -30,6 +30,7 @@ const impl_list_map_t &regular_f32_s8_impl_list_map() {
             CPU_REORDER_INSTANCE(rnn_data_reorder_t<f32, s8>)
             CPU_REORDER_INSTANCE(rnn_weights_reorder_s8_t<f32>)
             CPU_REORDER_INSTANCE(rnn_brgemm_weights_reorder_s8_t<f32, s8>)
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
 
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_blk_reorder_t))

--- a/src/cpu/reorder/cpu_reorder_regular_s4.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_s4.cpp
@@ -25,10 +25,12 @@ namespace cpu {
 const impl_list_map_t &regular_s4_impl_list_map() {
     static const impl_list_map_t the_map = REG_REORDER_P({
         {{f32, s4, 0}, {
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
             REG_SR(f32, any, s4, any, fmt_order::any, spec::reference)
             nullptr,
         }},
         {{s4, data_type::undef, 0}, {
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_copy_reorder_t))
             REG_SR(s4, any, f32, any, fmt_order::any, spec::reference)
             REG_SR(s4, any, bf16, any, fmt_order::any, spec::reference)

--- a/src/cpu/reorder/cpu_reorder_regular_s8.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_s8.cpp
@@ -30,6 +30,7 @@ const impl_list_map_t &regular_s8_impl_list_map() {
         {{s8, data_type::undef, 0}, {
             CPU_REORDER_INSTANCE(rnn_weights_reorder_s8_t<s8>)
             CPU_REORDER_INSTANCE(rnn_brgemm_weights_reorder_s8_t<s8, s8>)
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_copy_reorder_t))
 
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))

--- a/src/cpu/reorder/cpu_reorder_regular_u4.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_u4.cpp
@@ -25,10 +25,12 @@ namespace cpu {
 const impl_list_map_t &regular_u4_impl_list_map() {
     static const impl_list_map_t the_map = REG_REORDER_P({
         {{f32, u4, 0}, {
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
             REG_SR(f32, any, u4, any, fmt_order::any, spec::reference)
             nullptr,
         }},
         {{u4, data_type::undef, 0}, {
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_copy_reorder_t))
             REG_SR(u4, any, f32, any, fmt_order::any, spec::reference)
             REG_SR(u4, any, bf16, any, fmt_order::any, spec::reference)

--- a/src/cpu/x64/zen64/common/zen_format_tag.hpp
+++ b/src/cpu/x64/zen64/common/zen_format_tag.hpp
@@ -76,6 +76,7 @@ inline zendnnl::common::data_type_t to_zen_dt(data_type_t dt) {
         case data_type::s8: return zd::s8;
         case data_type::s32: return zd::s32;
         case data_type::s4: return zd::s4;
+        case data_type::u4: return zd::u4;
         default: return zd::none;
     }
 }
@@ -107,21 +108,6 @@ inline dim_t zen_prepack_size(
 }
 #endif
 
-// Zen packer required buffer size (bytes) for weights of type `dt`, with the
-// matmul source data type equal to the weight type (the f32/bf16 Zen matmul
-// configs). The exact size is obtained from the backend's weight_prepack_size()
-// API; returns 0 for unsupported types or when Zen is disabled.
-inline dim_t zen_packed_bytes(dim_t K, dim_t N, data_type_t dt) {
-#if DNNL_X64_USE_ZEN
-    return zen_prepack_size(dt, dt, K, N);
-#else
-    MAYBE_UNUSED(K);
-    MAYBE_UNUSED(N);
-    MAYBE_UNUSED(dt);
-    return 0;
-#endif
-}
-
 // True when the weights memory descriptor uses the dedicated Zen packed
 // opaque format. Execute uses mem_format_b='r', transB='N', ldb=N for such
 // weights.
@@ -134,10 +120,13 @@ inline bool is_zen_packed(const memory_desc_t &md) {
 // (they must already be set, e.g. by set_default_formats()); only
 // `format_kind` and `format_desc` are overwritten.
 //
-// gemm_src_dt is the matmul source/compute data type. For the supported Zen
+// gemm_src_dt is the matmul source/compute data type. For the f32/bf16 Zen
 // configs (uniform f32, uniform bf16, bf16 src/wei -> f32 dst) it equals the
-// weights compute type; it is recorded so packed descriptors for different
-// GEMM source types stay distinct in the primitive cache.
+// weights compute type; for the int8 static-quant configs it may differ from
+// the weights type (e.g. u8 src with s8 weights). It is used to size the
+// packed buffer (the AOCL-DLP blocked layout can depend on the source dtype)
+// and recorded so packed descriptors for different GEMM source types stay
+// distinct in the primitive cache.
 // K and N are the GEMM dimensions (contraction, output). weights_transposed
 // tells how the md's dims map to them: false => [K, N] (matmul); true =>
 // [N, K] = [OC, IC] (inner product). It only affects how zen_reorder reads the
@@ -145,7 +134,15 @@ inline bool is_zen_packed(const memory_desc_t &md) {
 inline status_t init_zen_packed_md(memory_desc_t &weights_md,
         data_type_t gemm_src_dt, dim_t K, dim_t N, dim_t batch = 1,
         bool weights_transposed = false) {
-    const dim_t per_slice = zen_packed_bytes(K, N, weights_md.data_type);
+#if DNNL_X64_USE_ZEN
+    const dim_t per_slice
+            = zen_prepack_size(weights_md.data_type, gemm_src_dt, K, N);
+#else
+    MAYBE_UNUSED(gemm_src_dt);
+    MAYBE_UNUSED(K);
+    MAYBE_UNUSED(N);
+    const dim_t per_slice = 0;
+#endif
     if (per_slice <= 0) return status::unimplemented;
 
     // Guard the total-size multiplication: a non-positive batch or a

--- a/src/cpu/x64/zen64/matmul/zen_lowp_matmul.cpp
+++ b/src/cpu/x64/zen64/matmul/zen_lowp_matmul.cpp
@@ -1,0 +1,915 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/x64/zen64/matmul/zen_lowp_matmul.hpp"
+
+#include <assert.h>
+#include <limits>
+
+#include "common/memory_desc_wrapper.hpp"
+#include "common/memory_tracking.hpp"
+#include "common/primitive_attr.hpp"
+#include "common/primitive_exec_types.hpp"
+#include "common/utils.hpp"
+#include "common/verbose.hpp"
+
+#include "cpu/ref_io_helper.hpp"
+
+#include "cpu/matmul/gemm_based_common.hpp"
+#include "cpu/matmul/matmul_utils.hpp"
+#include "cpu/x64/cpu_isa_traits.hpp"
+#include "cpu/x64/injectors/jit_uni_binary_injector.hpp"
+#include "cpu/x64/zen64/common/zen_format_tag.hpp"
+
+#if DNNL_X64_USE_ZEN
+#include "lowoha_operators/matmul/lowoha_matmul.hpp"
+#include "zendnnl.hpp"
+#endif
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace zen {
+namespace matmul {
+
+using namespace data_type;
+using namespace dnnl::impl::cpu::matmul;
+
+#if DNNL_X64_USE_ZEN
+using namespace zen_lowp;
+
+namespace {
+
+struct zen_lowp_bmm_params_t {
+    int batch_a = 1;
+    int batch_b = 1;
+    size_t stride_src = static_cast<size_t>(-1);
+    size_t stride_wei = static_cast<size_t>(-1);
+    size_t stride_dst = static_cast<size_t>(-1);
+};
+
+inline zen_lowp_bmm_params_t compute_zen_lowp_bmm_params(
+        const memory_desc_wrapper &src_d, const memory_desc_wrapper &weights_d,
+        const matmul_helper_t &helper, bool wei_is_zen_packed) {
+    zen_lowp_bmm_params_t p;
+    if (src_d.ndims() != 3) return p;
+
+    p.batch_a = static_cast<int>(src_d.dims()[0]);
+    p.batch_b = static_cast<int>(weights_d.dims()[0]);
+    p.stride_src = static_cast<size_t>(helper.get_a_stride(0));
+    p.stride_dst = static_cast<size_t>(helper.get_c_stride(0));
+    if (wei_is_zen_packed) {
+        const size_t wei_storage_size = weights_d.data_type_size();
+        assert(wei_storage_size > 0
+                && weights_d.zen_packed_desc().per_slice_size % wei_storage_size
+                        == 0);
+        // ZenDNN multiplies this stride by size_of(weight dtype). Its s4/u4
+        // size is one byte (the packed storage unit), so this also advances
+        // correctly between packed 4-bit slices.
+        p.stride_wei
+                = weights_d.zen_packed_desc().per_slice_size / wei_storage_size;
+    } else {
+        p.stride_wei = static_cast<size_t>(helper.get_b_stride(0));
+    }
+    return p;
+}
+
+} // namespace
+#endif
+
+status_t zen_lowp_matmul_t::pd_t::init(const engine_t *engine) {
+    using smask_t = primitive_attr_t::skip_mask_t;
+
+#if !DNNL_X64_USE_ZEN
+    return status::unimplemented;
+#else
+    // CPU engine only.
+    VDISPATCH_MATMUL(
+            engine->kind() == engine_kind::cpu, VERBOSE_BAD_ENGINE_KIND);
+
+    // Dense format only (no sparse).
+    VDISPATCH_MATMUL(is_dense_format_kind(), VERBOSE_UNSUPPORTED_SPARSE_CFG);
+
+    // AMD-only vendor gate via xbyak (portable across GCC/Clang/MSVC).
+    VDISPATCH_MATMUL(::dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAMD),
+            "This implementation only supports AMD CPUs");
+
+    // Base ISA gate: AVX-512 core (bf16 is a superset on AMD Zen4+).
+    VDISPATCH_MATMUL(mayiuse(avx512_core), VERBOSE_UNSUPPORTED_ISA);
+
+    // ---- Memory descriptor data types ----
+    const auto src_dt = src_md(0)->data_type;
+    const auto wei_dt = weights_md(0)->data_type;
+    const auto dst_dt = dst_md(0)->data_type;
+
+    // Support a single leading batch dimension. Higher-rank batching cannot be
+    // represented by ZenDNN's single Batch_A/Batch_B stride pair.
+    VDISPATCH_MATMUL(
+            utils::one_of(ndims(), 2, 3), VERBOSE_BAD_NDIMS, "dst", ndims());
+    const bool is_batched = ndims() == 3;
+
+    // No zero-dim tensors.
+    VDISPATCH_MATMUL(!has_zero_dim_memory(), VERBOSE_EMPTY_TENSOR, "");
+
+    dim_t src_batch = 1, wei_batch = 1;
+    if (is_batched) {
+        src_batch = src_md(0)->dims[0];
+        wei_batch = weights_md(0)->dims[0];
+        VDISPATCH_MATMUL(
+                src_batch == wei_batch || src_batch == 1 || wei_batch == 1,
+                VERBOSE_INCONSISTENT_DIM, "src", 0, "weights", 0);
+    }
+
+    // ---- Datatype validation ----
+    // Two low-precision configurations are handled by this impl:
+    //  1. int8 static quant: u8/s8 src, s8 wei, u8/s8/s32/f32/bf16 dst; s32
+    //     accum.
+    //  2. WOQ (weight decompression): bf16 src, s4/u4 wei, bf16/f32 dst; f32
+    //     accum; weights dequantized via weight scales (+ a u4 weight zp,
+    //     which is required for u4 and rejected for s4).
+    const bool is_int8 = utils::one_of(src_dt, u8, s8) && wei_dt == s8
+            && utils::one_of(dst_dt, u8, s8, s32, f32, bf16);
+    const bool is_woq = src_dt == bf16 && utils::one_of(wei_dt, s4, u4)
+            && utils::one_of(dst_dt, bf16, f32);
+    VDISPATCH_MATMUL(
+            utils::one_of(true, is_int8, is_woq), VERBOSE_UNSUPPORTED_DT_CFG);
+    VDISPATCH_MATMUL(desc()->accum_data_type == (is_woq ? f32 : s32),
+            VERBOSE_UNSUPPORTED_DT_CFG);
+
+    // int8 dot-product needs AVX-512 VNNI (vpdpbusd); WOQ decompresses weights
+    // to bf16 and only needs avx512_core.
+    VDISPATCH_MATMUL(IMPLICATION(is_int8, mayiuse(avx512_core_vnni)),
+            VERBOSE_UNSUPPORTED_ISA);
+
+    // WOQ is opt-in via fpmath_mode with apply_to_int (weight decompression).
+    // Weights are decompressed to bf16, so the mode must permit bf16 math.
+    const bool woq_fpmath_ok = attr()->fpmath_.apply_to_int_
+            && utils::one_of(
+                    attr()->fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any);
+    VDISPATCH_MATMUL(
+            IMPLICATION(is_woq, woq_fpmath_ok), VERBOSE_UNSUPPORTED_ATTR);
+
+    // ---- Bias validation ----
+    // Bias, when present, must be f32 or bf16 and follow the 1xN broadcast.
+    if (with_bias()) {
+        const auto bia_dt = weights_md(1)->data_type;
+        VDISPATCH_MATMUL(utils::one_of(bia_dt, f32, bf16) && is_bias_1xN(),
+                VERBOSE_UNSUPPORTED_BIAS_CFG);
+    }
+
+    // ---- Attribute validation ----
+    // Allow post-ops, sum dtype, scales (including a non-default scale data
+    // type), and zero-points. For WOQ also allow grouped scales/zero-points and
+    // a non-default fpmath mode. For the int8 path scales_groups /
+    // zero_points_groups stay out of the mask, so any grouped scale/zp is
+    // rejected. Path-specific scale/zp constraints are enforced below.
+    auto attr_mask = smask_t::post_ops | smask_t::sum_dt | smask_t::scales
+            | smask_t::scales_data_type | smask_t::zero_points;
+    if (is_woq)
+        attr_mask = attr_mask | smask_t::scales_groups
+                | smask_t::zero_points_groups | smask_t::zero_points_data_type
+                | smask_t::fpmath_mode;
+    VDISPATCH_MATMUL(attr()->has_default_values(attr_mask, dst_dt),
+            VERBOSE_UNSUPPORTED_ATTR);
+
+    // ZenDNN consumes all quantization buffers as precomputed inputs. In
+    // particular, it does not compute dynamic destination scales, which oneDNN
+    // exposes as an output argument. Keep this implementation restricted to
+    // static scales; path-specific masks, groups, and data types are checked
+    // below.
+    CHECK(attr_scales_ok(engine));
+
+    // ZenDNN reuses one quantization buffer for every BMM slice. Reject any
+    // scale or zero-point whose mask varies along the leading batch dimension,
+    // even if a future path-specific mask check becomes more permissive.
+    if (is_batched) {
+        constexpr int batch_mask = 1 << 0;
+        const auto has_batch_quant = [&](const auto &q) {
+            for (int arg : {DNNL_ARG_SRC, DNNL_ARG_WEIGHTS, DNNL_ARG_DST}) {
+                if (!q.has_default_values(arg)
+                        && (q.get_mask(arg) & batch_mask) != 0)
+                    return true;
+            }
+            return false;
+        };
+        VDISPATCH_MATMUL(!has_batch_quant(attr()->scales_),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
+        VDISPATCH_MATMUL(!has_batch_quant(attr()->zero_points_),
+                VERBOSE_UNSUPPORTED_ZP_CFG);
+    }
+
+    // Sum-consistency check (catches sum.dt != dst_dt precision bugs).
+    VDISPATCH_MATMUL(attr()->post_ops_.check_sum_consistency(dst_dt, is_int8),
+            VERBOSE_UNSUPPORTED_POSTOP);
+
+    // ---- Post-ops validation ----
+    // Zen supports: sum, eltwise (relu, gelu_tanh, gelu_erf, tanh,
+    // sigmoid/logistic, swish), binary (add, mul).
+    auto check_postops = [&]() -> bool {
+        const auto &po = attr()->post_ops_;
+        for (int i = 0; i < po.len(); i++) {
+            const auto &entry = po.entry_[i];
+            if (entry.is_sum(/*require_scale_one=*/true,
+                        /*require_zp_zero=*/true)) {
+                // Sum maps to Zen beta = 1 (plain accumulate); a non-unit sum
+                // scale is not detected as sum here and is rejected below as an
+                // unsupported post-op.
+                if (i != 0) return false;
+                if (!utils::one_of(entry.sum.dt, data_type::undef, dst_dt))
+                    return false;
+                continue;
+            } else if (entry.is_eltwise()) {
+                if (entry.eltwise.scale != 1.f) return false;
+                using namespace alg_kind;
+                if (!utils::one_of(entry.eltwise.alg, eltwise_relu,
+                            eltwise_gelu_tanh, eltwise_gelu_erf, eltwise_tanh,
+                            eltwise_logistic, eltwise_swish))
+                    return false;
+                if (entry.eltwise.alg == eltwise_relu
+                        && entry.eltwise.alpha != 0.f)
+                    return false;
+            } else if (entry.is_binary()) {
+                using namespace alg_kind;
+                if (!utils::one_of(entry.binary.alg, binary_add, binary_mul))
+                    return false;
+                const auto src1_dt = entry.binary.src1_desc.data_type;
+                if (!utils::one_of(src1_dt, f32, bf16)) return false;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    };
+    VDISPATCH_MATMUL(check_postops(), VERBOSE_UNSUPPORTED_POSTOP);
+
+    // ---- Scale / zero-point validation (path-specific) ----
+    if (is_woq) {
+        // WOQ weight-scale / weight-zero-point validation lives in init_woq().
+        CHECK(init_woq(engine));
+    } else {
+        // int8 static quant.
+        // Scales: f32/bf16 dtype; no groups; masks limited to
+        //   src : per-tensor only (mask 0)
+        //   wei : per-tensor (0) or per-channel along N/OC (wei_qmask_N())
+        //   dst : per-tensor only (mask 0)
+        // ZenDNN's AOCL-DLP int8 path supports a per-channel weights scale but
+        // only a per-tensor dst scale, so per-channel dst scales are rejected.
+        const auto &scales = attr()->scales_;
+        auto scale_arg_ok
+                = [&](int arg, std::initializer_list<int> allowed_masks) {
+            if (scales.has_default_values(arg)) return true;
+            if (!utils::one_of(scales.get_data_type(arg), f32, bf16))
+                return false;
+            if (!scales.get(arg).has_default_groups()) return false;
+            const int mask = scales.get_mask(arg);
+            for (int m : allowed_masks)
+                if (mask == m) return true;
+            return false;
+        };
+        const bool scales_ok = scale_arg_ok(DNNL_ARG_SRC, {0})
+                && scale_arg_ok(DNNL_ARG_WEIGHTS, {0, wei_qmask_N()})
+                && scale_arg_ok(DNNL_ARG_DST, {0});
+        VDISPATCH_MATMUL(scales_ok, VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+        // ZenDNN applies source/weight scales to beta*C as well as A*B, while
+        // oneDNN sum semantics apply those scales only to A*B before adding C.
+        // A destination scale is safe because oneDNN applies it after sum too.
+        const bool with_sum = attr()->post_ops_.find(primitive_kind::sum) != -1;
+        VDISPATCH_MATMUL(
+                IMPLICATION(with_sum,
+                        scales.has_default_values(DNNL_ARG_SRC)
+                                && scales.has_default_values(DNNL_ARG_WEIGHTS)),
+                VERBOSE_UNSUPPORTED_POSTOP);
+
+        // Zero-points: a per-tensor source zero-point with a u8 source, and a
+        // per-tensor destination zero-point with a u8 destination (ZenDNN's
+        // AOCL-DLP static-quant zero-point compensation is u8-only). Weight
+        // zero-points, s8 src/dst zero-points, and any non-per-tensor / grouped
+        // zero-point are rejected.
+        const auto &zero_points = attr()->zero_points_;
+        VDISPATCH_MATMUL(zero_points.has_default_values(DNNL_ARG_WEIGHTS),
+                VERBOSE_UNSUPPORTED_ZP_CFG);
+        if (!zero_points.has_default_values(DNNL_ARG_SRC)) {
+            VDISPATCH_MATMUL(src_dt == u8
+                            && zero_points.get_mask(DNNL_ARG_SRC) == 0
+                            && zero_points.get(DNNL_ARG_SRC)
+                                       .has_default_groups(),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+        }
+        if (!zero_points.has_default_values(DNNL_ARG_DST)) {
+            VDISPATCH_MATMUL(dst_dt == u8
+                            && zero_points.get_mask(DNNL_ARG_DST) == 0
+                            && zero_points.get(DNNL_ARG_DST)
+                                       .has_default_groups(),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+        }
+    }
+
+    // oneDNN applies the dst scale as a division after bias/post-ops, whereas
+    // ZenDNN's AOCL-DLP applies it as a multiply SCALE post-op. We therefore
+    // pass ZenDNN the reciprocal of the dst scale, computed at execute() into
+    // this scratchpad (per-tensor: 1 element). The reciprocal is always stored
+    // as f32 -- computing 1/scale in f32 avoids the extra rounding error a
+    // bf16 reciprocal buffer would introduce versus oneDNN's f32 division.
+    // (WOQ has no dst scale, so this books nothing for that path.)
+    if (!attr()->scales_.has_default_values(DNNL_ARG_DST)) {
+        auto scratchpad = scratchpad_registry().registrar();
+        scratchpad.book(memory_tracking::names::key_matmul_dst_scales,
+                /*nelems=*/1, types::data_type_size(f32),
+                /*alignment=*/64);
+    }
+
+    // Zen matmul_direct uses int for M/N/K; reject runtime dims/strides
+    // before set_default_formats() to avoid undefined behavior.
+    VDISPATCH_MATMUL(
+            !has_runtime_dims_or_strides(), VERBOSE_RUNTIMEDIM_UNSUPPORTED);
+
+    // Prepack path: when the framework leaves the weights layout open
+    // (format_any) we advertise the dedicated opaque `format_kind::zen_packed`
+    // weights format, produced by zen_reorder_t and consumed with
+    // mem_format_b='r'. The int8 path also supports plain weights; WOQ requires
+    // the prepacked (zen_packed) layout (see the reject below).
+    const bool wei_format_any = memory_desc_wrapper(weights_md(0)).format_any();
+    const bool wei_already_packed = zen::is_zen_packed(*weights_md(0));
+    VDISPATCH_MATMUL(!wei_already_packed
+                    || memory_desc_wrapper(weights_md(0))
+                                    .zen_packed_desc()
+                                    .gemm_src_dt
+                            == src_dt,
+            VERBOSE_INCONSISTENT_MDS, "weights", "packed-gemm-src-dtype");
+
+    VDISPATCH_MATMUL(set_default_formats(), VERBOSE_UNSUPPORTED_TAG);
+
+    bool wei_zen_packed = wei_already_packed;
+    if (wei_format_any && (wei_dt == s8 || is_woq)) {
+        // gemm_src_dt = src_dt records the matmul source dtype (u8/s8 for int8,
+        // bf16 for WOQ) so the packed buffer is sized/keyed correctly.
+        VDISPATCH_MATMUL_SC(zen::init_zen_packed_md(weights_md_, src_dt, K(),
+                                    N(), is_batched ? wei_batch : 1),
+                VERBOSE_UNSUPPORTED_TAG);
+        wei_zen_packed = true;
+    }
+
+    // WOQ consumes only the opaque zen_packed weights (s4/u4 must be
+    // prepacked by zen_reorder_t); reject plain WOQ weights so they fall
+    // through to the next impl.
+    VDISPATCH_MATMUL(
+            IMPLICATION(is_woq, wei_zen_packed), VERBOSE_UNSUPPORTED_TAG);
+
+    VDISPATCH_MATMUL(
+            wei_zen_packed || gemm_based::check_gemm_compatible_formats(*this),
+            VERBOSE_INCOMPATIBLE_GEMM_FMT);
+
+    // Source and destination may have padded inner leading dimensions, but
+    // must expose layouts representable by the Zen GEMM/BMM API.
+    const memory_desc_wrapper dst_d(dst_md(0));
+    VDISPATCH_MATMUL(gemm_based::check_gemm_output_format(*dst_md(0)),
+            VERBOSE_UNSUPPORTED_TAG);
+    VDISPATCH_MATMUL(gemm_based::check_gemm_input_format(*src_md(0)),
+            VERBOSE_UNSUPPORTED_TAG);
+
+    const auto &dst_strides = dst_d.blocking_desc().strides;
+    bool dst_no_zero_stride = true;
+    for (int i = 0; i < dst_d.ndims(); i++)
+        dst_no_zero_stride = dst_no_zero_stride && dst_strides[i] != 0;
+    VDISPATCH_MATMUL(dst_no_zero_stride, VERBOSE_UNSUPPORTED_TAG);
+
+    if (is_batched) {
+        auto batch_is_outermost = [](const memory_desc_t *md) {
+            const memory_desc_wrapper mdw(md);
+            const auto &s = mdw.blocking_desc().strides;
+            return s[0] >= s[1] && s[0] >= s[2];
+        };
+        VDISPATCH_MATMUL(
+                batch_is_outermost(src_md(0)), VERBOSE_UNSUPPORTED_TAG);
+        VDISPATCH_MATMUL(
+                batch_is_outermost(dst_md(0)), VERBOSE_UNSUPPORTED_TAG);
+        if (!wei_zen_packed)
+            VDISPATCH_MATMUL(
+                    batch_is_outermost(weights_md(0)), VERBOSE_UNSUPPORTED_TAG);
+    }
+
+    VDISPATCH_MATMUL(!::dnnl::impl::cpu::x64::binary_injector::
+                             any_binary_postop_rhs_with_ternary_scalar_bcast(
+                                     attr()->post_ops_, dst_d),
+            VERBOSE_UNSUPPORTED_POSTOP);
+
+    // Resolve format_tag::any on binary post-op src1 memory descriptors.
+    VDISPATCH_MATMUL(attr_.set_default_formats(dst_md(0)) == status::success,
+            VERBOSE_UNSUPPORTED_POSTOP);
+
+    // ---- Binary post-op shape/format validation ----
+    auto check_binary_postop_formats = [&]() -> bool {
+        const auto &po = attr()->post_ops_;
+        for (int i = 0; i < po.len(); i++) {
+            const auto &entry = po.entry_[i];
+            if (!entry.is_binary()) continue;
+
+            const auto &src1_desc = entry.binary.src1_desc;
+            const auto *dst = dst_md(0);
+
+            if (src1_desc.ndims != dst->ndims) return false;
+            const int nd = src1_desc.ndims;
+            const int channel_dim = nd - 1;
+            for (int d = 0; d < nd; d++) {
+                const bool full = src1_desc.dims[d] == dst->dims[d];
+                const bool bcast = src1_desc.dims[d] == 1;
+                if (!(full || bcast)) return false;
+                if (d == channel_dim && !full) return false;
+            }
+            // ZenDNN's BMM post-op offset advances by m_start*N, so an
+            // M-broadcast binary operand cannot be represented.
+            if (nd == 3 && src1_desc.dims[nd - 2] != dst->dims[nd - 2])
+                return false;
+
+            const memory_desc_wrapper src1_mdw(src1_desc);
+            if (!src1_mdw.is_plain()) return false;
+            const auto &strides = src1_mdw.blocking_desc().strides;
+            if (strides[nd - 1] != 1
+                    || strides[nd - 2] != src1_desc.dims[nd - 1])
+                return false;
+            if (nd == 3 && src1_desc.dims[0] != 1) {
+                const size_t m = static_cast<size_t>(src1_desc.dims[1]);
+                const size_t n = static_cast<size_t>(src1_desc.dims[2]);
+                if (n != 0 && m > std::numeric_limits<size_t>::max() / n)
+                    return false;
+                if (static_cast<size_t>(strides[0]) != m * n) return false;
+            }
+        }
+        return true;
+    };
+    VDISPATCH_MATMUL(check_binary_postop_formats(), VERBOSE_UNSUPPORTED_POSTOP);
+
+    // Zen matmul_direct uses int for M/N/K and leading dimensions.
+    const matmul_helper_t helper(memory_desc_wrapper(src_md(0)),
+            memory_desc_wrapper(weights_md(0)), memory_desc_wrapper(dst_md(0)));
+    const dim_t int_max = std::numeric_limits<int>::max();
+    const dim_t wei_ldb = wei_zen_packed ? N() : helper.ldb();
+    const dim_t batch_count = src_batch > wei_batch ? src_batch : wei_batch;
+    bool fits_zen_int_api = helper.M() <= int_max && helper.N() <= int_max
+            && helper.K() <= int_max && helper.lda() <= int_max
+            && wei_ldb <= int_max && helper.ldc() <= int_max
+            && src_batch <= int_max && wei_batch <= int_max
+            && batch_count <= int_max;
+
+    if (is_batched && wei_zen_packed) {
+        const memory_desc_wrapper wei_d(weights_md(0));
+        const size_t wei_storage_size = wei_d.data_type_size();
+        const size_t per_slice = wei_d.zen_packed_desc().per_slice_size;
+        VDISPATCH_MATMUL(
+                wei_storage_size > 0 && per_slice % wei_storage_size == 0,
+                VERBOSE_INCONSISTENT_MDS, "weights", "packed-slice-size");
+    }
+
+    if (is_batched && fits_zen_int_api) {
+        const auto bmm = compute_zen_lowp_bmm_params(
+                memory_desc_wrapper(src_md(0)),
+                memory_desc_wrapper(weights_md(0)), helper, wei_zen_packed);
+        const size_t int_max_sz = static_cast<size_t>(int_max);
+        fits_zen_int_api = bmm.stride_src <= int_max_sz
+                && bmm.stride_wei <= int_max_sz && bmm.stride_dst <= int_max_sz;
+    }
+    VDISPATCH_MATMUL(fits_zen_int_api, VERBOSE_UNSUPPORTED_FEATURE,
+            "dimension/stride > INT_MAX is not supported");
+
+    return status::success;
+#endif // DNNL_X64_USE_ZEN
+}
+
+status_t zen_lowp_matmul_t::pd_t::init_woq(const engine_t *engine) {
+    // Weight-only quantization: bf16 src, s4/u4 wei dequantized via a weight
+    // scale (per-channel along N, or per-group along K), with a u4 weight
+    // zero-point matching the scale granularity -- required for u4 and
+    // rejected for s4. No src/dst scales or src/dst zero-points.
+    const auto wei_dt = weights_md(0)->data_type;
+    const auto &scales = attr()->scales_;
+    const auto &zero_points = attr()->zero_points_;
+
+    // No source / destination scales in WOQ; a weight scale is required.
+    VDISPATCH_MATMUL(scales.has_default_values(DNNL_ARG_SRC)
+                    && scales.has_default_values(DNNL_ARG_DST),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VDISPATCH_MATMUL(!scales.has_default_values(DNNL_ARG_WEIGHTS),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+    // Weight scale: f32/bf16 dtype; granularity is per-channel (mask N, no
+    // groups) or per-group along K (mask K+N, group {G,1}, K % G == 0, and
+    // G % 16 == 0 when 1 < G < K to satisfy the hardware group alignment).
+    VDISPATCH_MATMUL(
+            utils::one_of(scales.get_data_type(DNNL_ARG_WEIGHTS), f32, bf16),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+    const int wei_scale_mask = scales.get_mask(DNNL_ARG_WEIGHTS);
+    const bool wei_scale_grouped
+            = !scales.get(DNNL_ARG_WEIGHTS).has_default_groups();
+    bool wei_scale_ok = false;
+    if (!wei_scale_grouped) {
+        wei_scale_ok = wei_scale_mask == wei_qmask_N();
+    } else {
+        const dim_t gK = scales.get_group(DNNL_ARG_WEIGHTS, 0);
+        const dim_t gN = scales.get_group(DNNL_ARG_WEIGHTS, 1);
+        wei_scale_ok = wei_scale_mask == (wei_qmask_K() | wei_qmask_N())
+                && gN == 1 && gK > 1 && (K() % gK == 0)
+                && IMPLICATION(gK < K(), gK % 16 == 0);
+    }
+    VDISPATCH_MATMUL(wei_scale_ok, VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+    // Zero-points: none on src/dst. A weight zero-point is supported only for
+    // u4 weights, with s8 dtype, and must match the weight-scale granularity
+    // (same mask and, if grouped, the same K group size). ZenDNN mandates a
+    // weight zero-point for u4 weights and forbids one for (symmetric) s4.
+    VDISPATCH_MATMUL(zero_points.has_default_values(DNNL_ARG_SRC)
+                    && zero_points.has_default_values(DNNL_ARG_DST),
+            VERBOSE_UNSUPPORTED_ZP_CFG);
+    const bool has_wei_zp = !zero_points.has_default_values(DNNL_ARG_WEIGHTS);
+    VDISPATCH_MATMUL(
+            IMPLICATION(wei_dt == u4, has_wei_zp), VERBOSE_UNSUPPORTED_ZP_CFG);
+    VDISPATCH_MATMUL(
+            IMPLICATION(wei_dt == s4, !has_wei_zp), VERBOSE_UNSUPPORTED_ZP_CFG);
+    if (has_wei_zp) {
+        VDISPATCH_MATMUL(wei_dt == u4, VERBOSE_UNSUPPORTED_ZP_CFG);
+        VDISPATCH_MATMUL(zero_points.get_data_type(DNNL_ARG_WEIGHTS) == s8,
+                VERBOSE_UNSUPPORTED_ZP_CFG);
+        const bool wei_zp_grouped
+                = !zero_points.get(DNNL_ARG_WEIGHTS).has_default_groups();
+        VDISPATCH_MATMUL(
+                zero_points.get_mask(DNNL_ARG_WEIGHTS) == wei_scale_mask
+                        && wei_zp_grouped == wei_scale_grouped,
+                VERBOSE_UNSUPPORTED_ZP_CFG);
+        if (wei_zp_grouped) {
+            VDISPATCH_MATMUL(zero_points.get_group(DNNL_ARG_WEIGHTS, 0)
+                                    == scales.get_group(DNNL_ARG_WEIGHTS, 0)
+                            && zero_points.get_group(DNNL_ARG_WEIGHTS, 1)
+                                    == scales.get_group(DNNL_ARG_WEIGHTS, 1),
+                    VERBOSE_UNSUPPORTED_ZP_CFG);
+        }
+    }
+
+    return status::success;
+}
+
+status_t zen_lowp_matmul_t::init(engine_t *engine) {
+    MAYBE_UNUSED(engine);
+#if DNNL_X64_USE_ZEN
+    // Build Zen matmul_post_op chain directly from oneDNN attributes.
+    const auto &po = pd()->attr()->post_ops_;
+    zen_postop_.clear();
+    zen_postop_.reserve(po.len());
+    postop_indices_.clear();
+    postop_indices_.reserve(po.len());
+    beta_ = 0.f;
+
+    using pot = zendnnl::ops::post_op_type_t;
+    using zd = zendnnl::common::data_type_t;
+
+    for (int i = 0; i < po.len(); i++) {
+        const auto &entry = po.entry_[i];
+        if (entry.is_sum(/*require_scale_one=*/true,
+                    /*require_zp_zero=*/true)) {
+            // Sum maps to Zen beta = 1 (C = alpha*A*B + C). pd_t::init() only
+            // accepts a unit-scale sum, so beta is always 1 here.
+            beta_ = 1.f;
+            continue; // not a Zen post-op entry
+        }
+        matmul_post_op lpo {};
+        if (entry.is_eltwise()) {
+            switch (entry.eltwise.alg) {
+                case alg_kind::eltwise_relu: lpo.po_type = pot::relu; break;
+                case alg_kind::eltwise_gelu_tanh:
+                    lpo.po_type = pot::gelu_tanh;
+                    break;
+                case alg_kind::eltwise_gelu_erf:
+                    lpo.po_type = pot::gelu_erf;
+                    break;
+                case alg_kind::eltwise_tanh: lpo.po_type = pot::tanh; break;
+                case alg_kind::eltwise_logistic:
+                    lpo.po_type = pot::sigmoid;
+                    break;
+                case alg_kind::eltwise_swish: lpo.po_type = pot::swish; break;
+                default: return status::runtime_error;
+            }
+            lpo.alpha = entry.eltwise.alpha;
+            lpo.beta = entry.eltwise.beta;
+        } else if (entry.is_binary()) {
+            lpo.po_type = (entry.binary.alg == alg_kind::binary_add)
+                    ? pot::binary_add
+                    : pot::binary_mul;
+            switch (entry.binary.src1_desc.data_type) {
+                case f32: lpo.dtype = zd::f32; break;
+                case bf16: lpo.dtype = zd::bf16; break;
+                default: return status::runtime_error;
+            }
+            const auto &src1_desc = entry.binary.src1_desc;
+            lpo.dims.assign(src1_desc.dims, src1_desc.dims + src1_desc.ndims);
+        }
+        zen_postop_.push_back(lpo);
+        postop_indices_.push_back(i);
+    }
+
+    // ---- Quantization metadata (scales + zero-points) ----
+    // Resolve per-argument dtype and granularity dims once here; the buffer
+    // pointers are patched from the exec context at execute().
+    const auto &scales = pd()->attr()->scales_;
+    const auto &zero_points = pd()->attr()->zero_points_;
+    const dim_t N = pd()->N();
+    const dim_t K = pd()->K();
+
+    // Weight granularity dims for ZenDNN quant_params:
+    //   per-tensor (mask 0)          -> {1}
+    //   per-channel along N          -> {1, N}
+    //   per-group along K (WOQ)      -> {K / gK, N}  (gK = group size along K)
+    // (ZenDNN treats empty dims as 0 elements, so per-tensor uses {1}.)
+    auto wei_quant_dims = [&](const auto &q, int arg) -> std::vector<int64_t> {
+        const int mask = q.get_mask(arg);
+        if (mask == 0) return {1};
+        if (!q.get(arg).has_default_groups()) {
+            const dim_t gK = q.get_group(arg, 0);
+            return {static_cast<int64_t>(K / gK), static_cast<int64_t>(N)};
+        }
+        return {1, static_cast<int64_t>(N)};
+    };
+
+    // Per-tensor src/dst scales (int8 path only).
+    auto setup_scalar = [&](int arg, zen_lowp_scale_info_t &s) {
+        if (scales.has_default_values(arg)) return;
+        s.present = true;
+        s.dt = to_zen_dt(scales.get_data_type(arg));
+        s.dims = {1};
+    };
+    setup_scalar(DNNL_ARG_SRC, src_scale_);
+    setup_scalar(DNNL_ARG_DST, dst_scale_);
+    // The dst scale is passed to ZenDNN as an f32 reciprocal (computed at
+    // execute), so advertise f32 regardless of the incoming scale dtype.
+    if (dst_scale_.present) dst_scale_.dt = zd::f32;
+
+    // Weight scale: per-tensor/per-channel (int8) or per-channel/per-group
+    // along K (WOQ).
+    if (!scales.has_default_values(DNNL_ARG_WEIGHTS)) {
+        wei_scale_.present = true;
+        wei_scale_.dt = to_zen_dt(scales.get_data_type(DNNL_ARG_WEIGHTS));
+        wei_scale_.dims = wei_quant_dims(scales, DNNL_ARG_WEIGHTS);
+    }
+
+    // Per-tensor src/dst zero-points (int8 path, s32).
+    if (!zero_points.has_default_values(DNNL_ARG_SRC)) {
+        src_zp_.present = true;
+        src_zp_.dt = zd::s32;
+        src_zp_.dims = {1};
+    }
+    if (!zero_points.has_default_values(DNNL_ARG_DST)) {
+        dst_zp_.present = true;
+        dst_zp_.dt = zd::s32;
+        dst_zp_.dims = {1};
+    }
+    // Weight zero-point (WOQ: u4 weights, s8 dtype, matching the weight-scale
+    // granularity).
+    if (!zero_points.has_default_values(DNNL_ARG_WEIGHTS)) {
+        wei_zp_.present = true;
+        wei_zp_.dt = to_zen_dt(zero_points.get_data_type(DNNL_ARG_WEIGHTS));
+        wei_zp_.dims = wei_quant_dims(zero_points, DNNL_ARG_WEIGHTS);
+    }
+#endif // DNNL_X64_USE_ZEN
+    return status::success;
+}
+
+// ================================================================
+// Zen helpers and wrapper (translation-unit local).
+// ================================================================
+#if DNNL_X64_USE_ZEN
+namespace {
+
+status_t zen_lowp_matmul_direct(data_type_t src_dt, data_type_t wei_dt,
+        data_type_t dst_dt, data_type_t bia_dt, const void *A, const void *B,
+        void *C, const void *bias, dim_t M, dim_t N, dim_t K, dim_t lda,
+        dim_t ldb, dim_t ldc, char transA, char transB, char mem_format_b,
+        int Batch_A, int Batch_B, size_t batch_stride_src,
+        size_t batch_stride_wei, size_t batch_stride_dst,
+        const std::vector<matmul_post_op> &cached_postops,
+        const std::vector<int> &cached_postop_po_indices, float cached_beta,
+        const zen_lowp_scale_info_t &src_scale,
+        const zen_lowp_scale_info_t &wei_scale,
+        const zen_lowp_scale_info_t &dst_scale, const void *dst_scale_recip,
+        const zen_lowp_scale_info_t &src_zp,
+        const zen_lowp_scale_info_t &dst_zp,
+        const zen_lowp_scale_info_t &wei_zp, const exec_ctx_t &ctx) {
+    using zd = zendnnl::common::data_type_t;
+
+    matmul_batch_params_t batch {};
+    batch.Batch_A = Batch_A;
+    batch.Batch_B = Batch_B;
+    batch.batch_stride_src = batch_stride_src;
+    batch.batch_stride_wei = batch_stride_wei;
+    batch.batch_stride_dst = batch_stride_dst;
+
+    matmul_params params {};
+    params.dtypes.src = to_zen_dt(src_dt);
+    params.dtypes.wei = to_zen_dt(wei_dt);
+    params.dtypes.dst = to_zen_dt(dst_dt);
+    params.dtypes.bias = (bias ? to_zen_dt(bia_dt) : zd::none);
+    // Static int8: leave compute unset (none) so ZenDNN infers s32 accumulation
+    // for the AOCL-DLP int8 path (a non-none value selects dynamic-quant).
+    params.dtypes.compute = zd::none;
+
+    // 'r' = pre-packed, 'n' = plain weights.
+    params.mem_format_b = mem_format_b;
+
+    const char layout = 'r'; // row-major
+    const bool trans_a = (transA != 'N');
+    const bool trans_b = (transB != 'N');
+    const float alpha = 1.f;
+    // Prepacked weights are constant. WOQ (s4/u4) always arrives prepacked
+    // (the pd rejects non-zen_packed WOQ weights), so mem_format_b=='r' already
+    // covers it; ZenDNN's WOQ path relies on is_weights_const to cache the
+    // dequantized/reordered weights.
+    const bool is_weights_const = (mem_format_b == 'r');
+
+    // Copy pre-built post-ops and patch binary buffer pointers.
+    params.postop_ = cached_postops;
+    for (size_t j = 0; j < params.postop_.size(); j++) {
+        auto &lpo = params.postop_[j];
+        if (lpo.po_type == zendnnl::ops::post_op_type_t::binary_add
+                || lpo.po_type == zendnnl::ops::post_op_type_t::binary_mul) {
+            lpo.buff = const_cast<void *>(CTX_IN_MEM(const void *,
+                    DNNL_ARG_ATTR_MULTIPLE_POST_OP(cached_postop_po_indices[j])
+                            | DNNL_ARG_SRC_1));
+        }
+    }
+
+    // Static-quantization scales and (u8) source/destination zero-points.
+    // Metadata (dtype, granularity dims) is resolved at primitive init(); only
+    // the buffer pointers come from the execution context.
+    // Weight zero-points: rejected for int8 static quant; populated for WOQ u4
+    // (validated in pd_t::init_woq()).
+    auto set_quant = [&](matmul_quantization_params_t::matmul_quant_t &q,
+                             const zen_lowp_scale_info_t &s, const void *buff) {
+        if (!s.present) return;
+        q.buff = buff;
+        q.dt = s.dt;
+        q.dims = s.dims;
+    };
+    // src/wei scales pass through directly (ZenDNN multiplies, matching oneDNN);
+    // dst scale uses the precomputed reciprocal buffer.
+    set_quant(params.quant_params.src_scale, src_scale,
+            CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC));
+    set_quant(params.quant_params.wei_scale, wei_scale,
+            CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS));
+    if (dst_zp.present && !dst_scale.present) {
+        // LOWOHA wires dst_zp through its destination SCALE post-op.
+        static constexpr float unit_dst_scale = 1.f;
+        params.quant_params.dst_scale.buff = &unit_dst_scale;
+        params.quant_params.dst_scale.dt = zd::f32;
+        params.quant_params.dst_scale.dims = {1};
+    } else {
+        set_quant(params.quant_params.dst_scale, dst_scale, dst_scale_recip);
+    }
+    set_quant(params.quant_params.src_zp, src_zp,
+            CTX_IN_MEM(const void *, DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC));
+    set_quant(params.quant_params.dst_zp, dst_zp,
+            CTX_IN_MEM(const void *, DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST));
+    // WOQ weight zero-point (u4 weights).
+    set_quant(params.quant_params.wei_zp, wei_zp,
+            CTX_IN_MEM(const void *,
+                    DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS));
+
+    const auto st = matmul_direct(layout, trans_a, trans_b, (int)M, (int)N,
+            (int)K, alpha, A, (int)lda, B, (int)ldb, bias, cached_beta, C,
+            (int)ldc, is_weights_const, batch, params);
+
+    // Defensive: scrub buffer pointers (owned by the exec_ctx) before the
+    // local params destructs.
+    for (auto &lpo : params.postop_)
+        lpo.buff = nullptr;
+    params.quant_params.src_scale.buff = nullptr;
+    params.quant_params.wei_scale.buff = nullptr;
+    params.quant_params.dst_scale.buff = nullptr;
+    params.quant_params.src_zp.buff = nullptr;
+    params.quant_params.dst_zp.buff = nullptr;
+    params.quant_params.wei_zp.buff = nullptr;
+
+    return to_dnnl_status(st);
+}
+
+} // anonymous namespace
+#endif // DNNL_X64_USE_ZEN
+
+status_t zen_lowp_matmul_t::execute_body(const exec_ctx_t &ctx) const {
+#if !DNNL_X64_USE_ZEN
+    return status::unimplemented;
+#else
+    const auto src_d = ctx.memory_mdw(DNNL_ARG_SRC, pd()->src_md());
+    const auto weights_d = ctx.memory_mdw(DNNL_ARG_WEIGHTS, pd()->weights_md());
+    const auto dst_d = ctx.memory_mdw(DNNL_ARG_DST, pd()->dst_md());
+
+    if (src_d.has_zero_dim() || weights_d.has_zero_dim()
+            || dst_d.has_zero_dim())
+        return status::success;
+
+    matmul_helper_t helper(src_d, weights_d, dst_d);
+
+    const dim_t M = helper.M();
+    const dim_t N = helper.N();
+    const dim_t K = helper.K();
+    const char transA = helper.transA();
+    const dim_t lda = helper.lda();
+    // ZenDNN uses row-major dst, so ldc must be at least N.
+    const dim_t ldc = nstl::max(N, helper.ldc());
+
+    const bool wei_is_zen_packed = is_zen_packed(*pd()->weights_md(0));
+    assert(!wei_is_zen_packed
+            || weights_d.zen_packed_desc().gemm_src_dt == src_d.data_type());
+    char mem_format_b = 'n';
+    char transB;
+    dim_t ldb;
+    if (wei_is_zen_packed) {
+        mem_format_b = 'r';
+        transB = 'N';
+        ldb = N;
+    } else {
+        transB = helper.transB();
+        ldb = helper.ldb();
+    }
+
+    const auto bmm = compute_zen_lowp_bmm_params(
+            src_d, weights_d, helper, wei_is_zen_packed);
+    const int Batch_A = bmm.batch_a;
+    const int Batch_B = bmm.batch_b;
+    const size_t batch_stride_src = bmm.stride_src;
+    const size_t batch_stride_wei = bmm.stride_wei;
+    const size_t batch_stride_dst = bmm.stride_dst;
+
+    assert(M <= std::numeric_limits<int>::max()
+            && N <= std::numeric_limits<int>::max()
+            && K <= std::numeric_limits<int>::max()
+            && lda <= std::numeric_limits<int>::max()
+            && ldb <= std::numeric_limits<int>::max()
+            && ldc <= std::numeric_limits<int>::max());
+    const size_t int_max_sz
+            = static_cast<size_t>(std::numeric_limits<int>::max());
+    assert(IMPLICATION(pd()->ndims() == 3,
+            batch_stride_src <= int_max_sz && batch_stride_wei <= int_max_sz
+                    && batch_stride_dst <= int_max_sz));
+    MAYBE_UNUSED(int_max_sz);
+
+    const auto src_dt = src_d.data_type();
+    const auto wei_dt = weights_d.data_type();
+    const auto dst_dt = dst_d.data_type();
+    const auto bia_dt = pd()->with_bias() ? pd()->weights_md(1)->data_type
+                                          : data_type::undef;
+
+    VDEBUGINFO(2, primitive, matmul,
+            "zen lowp matmul: M=%ld N=%ld K=%ld transA=%c transB=%c lda=%ld "
+            "ldb=%ld ldc=%ld src_dt=%d wei_dt=%d dst_dt=%d Batch_A=%d "
+            "Batch_B=%d",
+            (long)M, (long)N, (long)K, transA, transB, (long)lda, (long)ldb,
+            (long)ldc, (int)src_dt, (int)wei_dt, (int)dst_dt, Batch_A, Batch_B);
+
+    const void *A = CTX_IN_MEM(const void *, DNNL_ARG_SRC);
+    const void *B = CTX_IN_MEM(const void *, DNNL_ARG_WEIGHTS);
+    void *C = CTX_OUT_MEM(void *, DNNL_ARG_DST);
+    const void *bias = pd()->with_bias()
+            ? CTX_IN_MEM(const void *, DNNL_ARG_BIAS)
+            : nullptr;
+
+    // Precompute the reciprocal of the dst scale (oneDNN divides by the dst
+    // scale; ZenDNN multiplies), storing it in the scratchpad booked in init().
+    const void *dst_scale_recip = nullptr;
+    if (dst_scale_.present) {
+        const auto dsc_dt = pd()->attr()->scales_.get_data_type(DNNL_ARG_DST);
+        const void *dsc
+                = CTX_IN_MEM(const void *, DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST);
+        void *recip = ctx.get_scratchpad_grantor().get<void>(
+                memory_tracking::names::key_matmul_dst_scales);
+        if (recip == nullptr) return status::out_of_memory;
+        const float v = io::load_float_value(dsc_dt, dsc, 0);
+        io::store_float_value(
+                data_type::f32, v != 0.f ? 1.f / v : 0.f, recip, 0);
+        dst_scale_recip = recip;
+    }
+
+    return zen_lowp_matmul_direct(src_dt, wei_dt, dst_dt, bia_dt, A, B, C, bias,
+            M, N, K, lda, ldb, ldc, transA, transB, mem_format_b, Batch_A,
+            Batch_B, batch_stride_src, batch_stride_wei, batch_stride_dst,
+            zen_postop_, postop_indices_, beta_, src_scale_, wei_scale_,
+            dst_scale_, dst_scale_recip, src_zp_, dst_zp_, wei_zp_, ctx);
+#endif // DNNL_X64_USE_ZEN
+}
+
+} // namespace matmul
+} // namespace zen
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl

--- a/src/cpu/x64/zen64/matmul/zen_lowp_matmul.hpp
+++ b/src/cpu/x64/zen64/matmul/zen_lowp_matmul.hpp
@@ -1,0 +1,124 @@
+/*******************************************************************************
+* Copyright 2026 Advanced Micro Devices, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_ZEN64_MATMUL_ZEN_LOWP_MATMUL_HPP
+#define CPU_X64_ZEN64_MATMUL_ZEN_LOWP_MATMUL_HPP
+
+#include <vector>
+
+#include "common/c_types_map.hpp"
+#include "common/primitive.hpp"
+#include "common/type_helpers.hpp"
+
+#include "cpu/matmul/cpu_matmul_pd.hpp"
+
+#if DNNL_X64_USE_ZEN
+#include "lowoha_operators/matmul/lowoha_common.hpp"
+#endif
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace zen {
+namespace matmul {
+
+#if DNNL_X64_USE_ZEN
+namespace zen_lowp = zendnnl::lowoha::matmul;
+
+// Per-argument (src/wei/dst) static-quantization scale metadata resolved at
+// primitive init() and consumed at execute() (the scale buffer pointers live
+// in the execution context and are patched in there). dims follow the ZenDNN
+// convention: {1} for per-tensor, {1, N} for per-channel along N.
+struct zen_lowp_scale_info_t {
+    bool present = false;
+    zendnnl::common::data_type_t dt = zendnnl::common::data_type_t::none;
+    std::vector<int64_t> dims;
+};
+#endif
+
+// Low-precision Zen matmul, separate from the f32/bf16 zen_matmul_t so the
+// floating-point path is unaffected. Supports 2D matmul and 3D BMM with one
+// leading batch dimension, including src/weights batch broadcasting. All
+// quantization scales and zero-points are shared across batches.
+// Two configurations:
+//   int8 static quant: u8/s8 src, s8 wei, u8/s8/s32/f32/bf16 dst; ungrouped
+//     f32/bf16 scales (wei also per-channel-N); per-tensor u8 src/dst zp only.
+//   WOQ: bf16 src, s4/u4 wei, bf16/f32 dst; needs fpmath_mode bf16|any with
+//     apply_to_int and prepacked weights; wei scale per-channel-N or grouped
+//     along K; s8 wei zp required for u4, rejected for s4.
+//   bias (both): f32/bf16, 1xN.
+struct zen_lowp_matmul_t : public primitive_t {
+    struct pd_t : public ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
+        using ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t::cpu_matmul_pd_t;
+
+        DECLARE_COMMON_PD_T("zen:matmul:lowp:amd", zen_lowp_matmul_t);
+
+        status_t init(const engine_t *engine);
+
+    private:
+        // Weight-only-quantization (WOQ / weight decompression) validation:
+        // bf16 source with s4/u4 weights dequantized via weight scales
+        // (per-channel or per-group along K) and a u4 weight zero-point,
+        // which is required for u4 and rejected for s4. Called from init()
+        // on the WOQ branch.
+        status_t init_woq(const engine_t *engine);
+    };
+
+    zen_lowp_matmul_t(const pd_t *apd) : primitive_t(apd) {}
+
+    // Build Zen post-op chain + scale metadata once per primitive (mirrors
+    // brgemm_matmul_t convention; keeps pd_t cheaply-copyable for the cache).
+    status_t init(engine_t *engine) override;
+
+    status_t execute(const exec_ctx_t &ctx) const override {
+        return execute_body(ctx);
+    }
+
+private:
+    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+    status_t execute_body(const exec_ctx_t &ctx) const;
+
+#if DNNL_X64_USE_ZEN
+    // Pre-built Zen post-op chain. Owned by the primitive (never copied by the
+    // framework). Binary buffer pointers are patched at execute time.
+    std::vector<zen_lowp::matmul_post_op> zen_postop_;
+    std::vector<int> postop_indices_;
+    float beta_ = 0.f;
+
+    // Static-quantization scale metadata (dtype + granularity dims); buffers
+    // are patched from the execution context at execute().
+    zen_lowp_scale_info_t src_scale_;
+    zen_lowp_scale_info_t wei_scale_;
+    zen_lowp_scale_info_t dst_scale_;
+    // Zero-point metadata: source (u8 source only) and destination (u8
+    // destination only) for int8 static quant, both per-tensor; weight
+    // zero-point (u4 weights only) for WOQ, matching the weight-scale
+    // granularity.
+    zen_lowp_scale_info_t src_zp_;
+    zen_lowp_scale_info_t dst_zp_;
+    zen_lowp_scale_info_t wei_zp_;
+#endif
+};
+
+} // namespace matmul
+} // namespace zen
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/zen64/matmul/zen_matmul.cpp
+++ b/src/cpu/x64/zen64/matmul/zen_matmul.cpp
@@ -163,6 +163,7 @@ status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
     //  2. Uniform bf16: bf16 src, bf16 wei, bf16 dst
     //  3. bf16 mixed:   bf16 src, bf16 wei, f32 dst
     // Explicitly unsupported: f32 src with bf16 dst.
+    // int8 static quant is handled by the dedicated zen_lowp_matmul_t impl.
     const bool all_f32 = utils::everyone_is(f32, src_dt, wei_dt, dst_dt);
     const bool all_bf16 = utils::everyone_is(bf16, src_dt, wei_dt, dst_dt);
     const bool bf16_mixed
@@ -253,6 +254,7 @@ status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
     VDISPATCH_MATMUL(check_postops(), VERBOSE_UNSUPPORTED_POSTOP);
 
     // ---- Scales / zero-points validation ----
+    // f32/bf16 path does not support scales or zero-points.
     VDISPATCH_MATMUL(attr()->scales_.has_default_values(),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
     VDISPATCH_MATMUL(attr()->zero_points_.has_default_values(),
@@ -651,7 +653,8 @@ status_t zen_matmul_t::execute_body(const exec_ctx_t &ctx) const {
     const dim_t K = helper.K();
     const char transA = helper.transA();
     const dim_t lda = helper.lda();
-    const dim_t ldc = helper.ldc();
+    // ZenDNN uses row-major dst, so ldc must be at least N.
+    const dim_t ldc = nstl::max(N, helper.ldc());
 
     // If weights are Zen pre-packed (opaque format_kind::zen_packed,
     // produced by zen_reorder_t), the backend expects:

--- a/src/cpu/x64/zen64/reorder/zen_reorder.cpp
+++ b/src/cpu/x64/zen64/reorder/zen_reorder.cpp
@@ -17,9 +17,11 @@
 #include "cpu/x64/zen64/reorder/zen_reorder.hpp"
 
 #include "common/c_types_map.hpp"
+#include "common/int4.hpp"
 #include "common/memory_desc.hpp"
 #include "common/memory_desc_wrapper.hpp"
 #include "common/memory_tracking.hpp"
+#include "common/nibble.hpp"
 #include "common/primitive_desc.hpp"
 #include "common/primitive_exec_types.hpp"
 #include "common/type_helpers.hpp"
@@ -28,6 +30,7 @@
 #include <cstdint>
 #include <limits>
 
+#include "cpu/ref_io_helper.hpp"
 #include "cpu/x64/cpu_isa_traits.hpp" // cpu().has(tAMD)
 #include "cpu/x64/zen64/common/zen_format_tag.hpp" // is_zen_packed
 
@@ -56,13 +59,16 @@ using zendnnl::ops::matmul_algo_t;
 
 // Zen weight prepack via reorder_direct (is_prepack=true); see
 // ZenDNN/zendnnl/src/lowoha_operators/reorder/lowoha_reorder.hpp.
-status_t zen_weight_prepack(const void *src, void *dst, zd wei_dt, int64_t K,
-        int64_t N, int64_t ldb, bool transposed) {
+// src_dt is the matmul source dtype: for f32/bf16 it equals wei_dt, but for
+// int8 configs it may differ (e.g. u8 source with s8 weights), and the AOCL-DLP
+// blocked layout can depend on it, so it is passed explicitly.
+status_t zen_weight_prepack(const void *src, void *dst, zd wei_dt, zd src_dt,
+        int64_t K, int64_t N, int64_t ldb, bool transposed) {
     zendnnl::lowoha::reorder::reorder_params_t rp;
     rp.is_prepack = true;
     rp.prepack.algo = matmul_algo_t::aocl_dlp_blocked;
     rp.prepack.wei_dtype = wei_dt;
-    rp.prepack.src_dtype = wei_dt;
+    rp.prepack.src_dtype = src_dt;
     rp.prepack.K = K;
     rp.prepack.N = N;
     rp.prepack.ldb = ldb;
@@ -95,6 +101,67 @@ status_t f32_to_bf16_plain(const void *src, void *dst, int64_t K, int64_t N,
 
     return to_dnnl_status(
             zendnnl::lowoha::reorder::reorder_direct(src, dst, rp));
+}
+
+// Plain f32 -> s8 element conversion (saturating round-to-nearest). Writes K
+// rows of N elements contiguously into `dst` (row-major `ab`). `ldb` is the
+// source leading dim (in elements), read from the actual src strides so a
+// padded leading dim is honored:
+//   * ab (row-major): src_strides = {ldb, 1}  -> element (k,n) at k*ldb + n
+//   * ba (col-major): src_strides = {1, ldb}  -> element (k,n) at k + n*ldb
+// Used by the int8 prepack path when the caller supplies an f32 weight
+// reference (e.g. benchdnn keeps integer-valued weights in f32); the values
+// are exact int8s so the cast is lossless. No quantization scale is applied
+// here -- the matmul applies the weight scale.
+status_t f32_to_s8_plain(const void *src, void *dst, int64_t K, int64_t N,
+        int64_t ldb, bool src_is_ab) {
+    const float *s = static_cast<const float *>(src);
+    int8_t *d = static_cast<int8_t *>(dst);
+    for (int64_t k = 0; k < K; k++) {
+        for (int64_t n = 0; n < N; n++) {
+            const int64_t soff = src_is_ab ? (k * ldb + n) : (k + n * ldb);
+            const float v = io::load_float_value(
+                    data_type::f32, s, static_cast<dim_t>(soff));
+            io::store_float_value(
+                    data_type::s8, v, d, static_cast<dim_t>(k * N + n));
+        }
+    }
+    return status::success;
+}
+
+// Plain f32 -> packed s4/u4 element conversion (saturating round-to-nearest),
+// writing a contiguous row-major (`ab`) K*N nibble stream (2 values per byte,
+// low nibble = even element index -- oneDNN's nibble packing). Used by the WOQ
+// prepack path when the caller supplies an f32 weight reference (e.g. benchdnn
+// keeps the integer-valued 4-bit codes in f32). No scale is applied -- the
+// matmul applies the weight scale. `out_dt` is s4 or u4.
+status_t f32_to_int4_plain(const void *src, void *dst, int64_t K, int64_t N,
+        int64_t ldb, bool src_is_ab, data_type_t out_dt) {
+    // NOTE: io::store_float_value() has no s4/u4 case (it hits default:
+    // assert(!"bad data_type") in debug builds), so convert with the
+    // reference reorder's saturate-and-round semantics, then pack the
+    // resulting 4-bit value directly via nibble2_t.
+    const float *s = static_cast<const float *>(src);
+    auto *d = reinterpret_cast<nibble2_t *>(dst);
+    for (int64_t k = 0; k < K; k++) {
+        for (int64_t n = 0; n < N; n++) {
+            const int64_t soff = src_is_ab ? (k * ldb + n) : (k + n * ldb);
+            const float v = io::load_float_value(
+                    data_type::f32, s, static_cast<dim_t>(soff));
+            const uint8_t raw = out_dt == data_type::u4
+                    ? q10n::saturate_and_round<uint4_t>(v).raw_bits_
+                    : q10n::saturate_and_round<int4_t>(v).raw_bits_;
+            const int64_t oidx = k * N + n;
+            const int nibble = static_cast<int>(oidx % 2);
+            nibble2_t pair(0);
+            // An even element starts a new byte. Preserve the existing low
+            // nibble only when writing the following odd element.
+            if (nibble != 0) pair = d[oidx / 2];
+            pair.set(raw, nibble);
+            d[oidx / 2] = pair;
+        }
+    }
+    return status::success;
 }
 
 } // namespace
@@ -135,9 +202,23 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
     //   f32  -> f32   : reorder_direct prepack (Zen blocked algo)
     //   f32  -> bf16  : f32->bf16 plain reorder_direct, then bf16 prepack
     //                   (avoids the backend f32->bf16 fringe-N bug; see execute)
+    //   s8   -> s8    : int8 static-quant weight prepack (Zen blocked algo)
+    //   f32  -> s8    : f32->s8 plain cast, then s8 prepack (for callers that
+    //                   keep integer-valued weights in f32, e.g. benchdnn)
+    //   s4   -> s4    : WOQ 4-bit weight prepack (bf16 gemm source)
+    //   u4   -> u4    : WOQ 4-bit weight prepack (bf16 gemm source)
+    //   f32  -> s4/u4 : f32->4-bit plain cast, then WOQ prepack (for callers
+    //                   that keep integer-valued 4-bit codes in f32, e.g.
+    //                   benchdnn)
     const bool dt_ok = (type_i == data_type::bf16 && type_o == data_type::bf16)
             || (type_i == data_type::f32 && type_o == data_type::f32)
-            || (type_i == data_type::f32 && type_o == data_type::bf16);
+            || (type_i == data_type::f32 && type_o == data_type::bf16)
+            || (type_i == data_type::s8 && type_o == data_type::s8)
+            || (type_i == data_type::f32 && type_o == data_type::s8)
+            || (type_i == data_type::s4 && type_o == data_type::s4)
+            || (type_i == data_type::u4 && type_o == data_type::u4)
+            || (type_i == data_type::f32
+                    && utils::one_of(type_o, data_type::s4, data_type::u4));
     VDISPATCH_REORDER_IC(dt_ok, VERBOSE_UNSUPPORTED_DT);
 
     // Dispatch trigger: only fire when the dst uses the dedicated opaque
@@ -185,6 +266,16 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
                     || (src_strides[0] >= src_strides[1]
                             && src_strides[0] >= src_strides[2]),
             VERBOSE_UNSUPPORTED_TAG_S, "src");
+    // A batched sub-byte source can be advanced with a raw byte pointer only
+    // when every slice starts on a byte boundary. An odd logical-element batch
+    // stride starts the next slice in the high nibble, which this direct
+    // prepack interface cannot represent.
+    const size_t src_sub_byte_multiplier = id.sub_byte_data_type_multiplier();
+    VDISPATCH_REORDER_IC(!batched || src_sub_byte_multiplier == 1
+                    || static_cast<size_t>(src_strides[0])
+                                    % src_sub_byte_multiplier
+                            == 0,
+            VERBOSE_UNSUPPORTED_TAG_S, "src");
 
     // src and dst logical dims must agree (oneDNN reorder API contract).
     for (int i = 0; i < ndims; i++)
@@ -219,7 +310,11 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
     // per-slice size to turn a silent overrun into a clean dispatch failure.
     // The opaque dst carries per_slice_size and size == per_slice_size * batch.
     const auto &zpd = od.zen_packed_desc();
-    const dim_t expected_per_slice = zen_packed_bytes(K, N, type_o);
+    // The per-slice packed size can depend on the matmul source dtype (recorded
+    // in the packed descriptor as gemm_src_dt), so query with
+    // (wei=type_o, src=gemm_src_dt) -- for f32/bf16 gemm_src_dt == type_o.
+    const dim_t expected_per_slice
+            = zen_prepack_size(type_o, zpd.gemm_src_dt, K, N);
     VDISPATCH_REORDER_IC(expected_per_slice > 0
                     && zpd.per_slice_size
                             == static_cast<size_t>(expected_per_slice),
@@ -236,13 +331,22 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
             zpd.size == zpd.per_slice_size * batch_sz && od.size() == zpd.size,
             VERBOSE_INCONSISTENT_MDS, "dst", "packed-size");
 
-    // The f32 -> bf16 prepack path needs a K*N bf16 conversion buffer. Book it
-    // on the primitive scratchpad (declared here, consumed in execute() via the
-    // grantor) so execution stays allocation-free.
-    if (type_i == data_type::f32 && type_o == data_type::bf16) {
-        // One (K, N) bf16 slice; reused across batches in execute().
-        const size_t conv_bytes = static_cast<size_t>(K)
-                * static_cast<size_t>(N) * sizeof(int16_t);
+    // The f32 -> {bf16, s8, s4, u4} prepack paths need a per-slice K*N
+    // conversion buffer (bf16 = 2 bytes/elem, s8 = 1 byte/elem, s4/u4 =
+    // 2 elems/byte). Book it on the primitive scratchpad (declared here,
+    // consumed in execute() via the grantor), reused across batches so
+    // execution stays allocation-free.
+    if (type_i == data_type::f32
+            && utils::one_of(type_o, data_type::bf16, data_type::s8,
+                    data_type::s4, data_type::u4)) {
+        const size_t nelems = static_cast<size_t>(K) * static_cast<size_t>(N);
+        size_t conv_bytes;
+        if (type_o == data_type::bf16)
+            conv_bytes = nelems * sizeof(int16_t);
+        else if (type_o == data_type::s8)
+            conv_bytes = nelems * sizeof(int8_t);
+        else // s4 / u4: two 4-bit values per byte
+            conv_bytes = (nelems + 1) / 2;
         auto scratchpad = scratchpad_registry().registrar();
         scratchpad.book(memory_tracking::names::key_reorder_space, conv_bytes,
                 /*data_size=*/1, /*alignment=*/64);
@@ -317,33 +421,58 @@ status_t zen_reorder_t::execute(const exec_ctx_t &ctx) const {
     const auto src_dt = src_d.data_type();
     const auto dst_dt = dst_d.data_type();
 
-    // Per-batch advance: src by its leading-dim stride (elements), dst by one
-    // fixed-size packed slot (per_slice_size bytes).
+    // Per-batch advance: source strides are expressed in logical elements.
+    // Convert to bytes explicitly because s4/u4 store two elements per byte.
+    // pd_t::init() rejects a sub-byte stride that starts on a high nibble.
     const size_t src_elem = src_d.data_type_size();
-    const size_t src_slice_bytes
-            = batched ? static_cast<size_t>(src_strides[0]) * src_elem : 0;
+    const size_t src_sub_byte_multiplier
+            = src_d.sub_byte_data_type_multiplier();
+    const size_t src_slice_bytes = batched ? static_cast<size_t>(src_strides[0])
+                    * src_elem / src_sub_byte_multiplier
+                                           : 0;
     const size_t dst_slice_bytes = dst_d.zen_packed_desc().per_slice_size;
 
     const auto *src_base = CTX_IN_MEM(const uint8_t *, DNNL_ARG_FROM);
     auto *dst_base = CTX_OUT_MEM(uint8_t *, DNNL_ARG_TO);
 
-    // f32 -> bf16 prepack needs a per-slice bf16 conversion buffer (booked in
-    // pd_t::init), reused across batches so execute() stays allocation-free.
+    // f32 -> {bf16, s8, s4, u4} prepack needs a per-slice conversion buffer
+    // (booked in pd_t::init), reused across batches so execute() stays
+    // allocation-free.
     void *conv = nullptr;
-    if (src_dt == data_type::f32 && dst_dt == data_type::bf16) {
-        conv = ctx.get_scratchpad_grantor().get<int16_t>(
+    if (src_dt == data_type::f32
+            && utils::one_of(dst_dt, data_type::bf16, data_type::s8,
+                    data_type::s4, data_type::u4)) {
+        conv = ctx.get_scratchpad_grantor().get<void>(
                 memory_tracking::names::key_reorder_space);
         if (conv == nullptr) return status::out_of_memory;
     }
+
+    // The matmul source dtype (u8/s8 for int8; f32/bf16 otherwise) is recorded
+    // in the packed descriptor; the AOCL-DLP blocked layout can depend on it,
+    // so forward it explicitly to the packer.
+    const zd gemm_src = to_zen_dt(dst_d.zen_packed_desc().gemm_src_dt);
 
     // Pack one (K, N) slice from `src` into `dst`.
     auto prepack_slice = [&](const void *src, void *dst) -> status_t {
         if (src_dt == data_type::bf16 && dst_dt == data_type::bf16)
             return zen_weight_prepack(
-                    src, dst, zd::bf16, K, N, ldb, transposed);
+                    src, dst, zd::bf16, zd::bf16, K, N, ldb, transposed);
 
         if (src_dt == data_type::f32 && dst_dt == data_type::f32)
-            return zen_weight_prepack(src, dst, zd::f32, K, N, ldb, transposed);
+            return zen_weight_prepack(
+                    src, dst, zd::f32, zd::f32, K, N, ldb, transposed);
+
+        if (src_dt == data_type::s8 && dst_dt == data_type::s8)
+            // int8 static-quant weight prepack.
+            return zen_weight_prepack(
+                    src, dst, zd::s8, gemm_src, K, N, ldb, transposed);
+
+        if ((src_dt == data_type::s4 && dst_dt == data_type::s4)
+                || (src_dt == data_type::u4 && dst_dt == data_type::u4))
+            // WOQ 4-bit weight prepack; the gemm source (bf16) is recorded in
+            // the packed descriptor and forwarded to the packer.
+            return zen_weight_prepack(src, dst, to_zen_dt(src_dt), gemm_src, K,
+                    N, ldb, transposed);
 
         if (src_dt == data_type::f32 && dst_dt == data_type::bf16) {
             // Convert f32 -> plain bf16 (contiguous `ab`), then prepack that
@@ -351,8 +480,31 @@ status_t zen_reorder_t::execute(const exec_ctx_t &ctx) const {
             // backend's f32->bf16 fringe-N bug (see header note).
             status_t st = f32_to_bf16_plain(src, conv, K, N, ldb, src_is_ab);
             if (st == success)
-                st = zen_weight_prepack(conv, dst, zd::bf16, K, N,
+                st = zen_weight_prepack(conv, dst, zd::bf16, zd::bf16, K, N,
                         /*ldb=*/N, /*transposed=*/false);
+            return st;
+        }
+
+        if (src_dt == data_type::f32 && dst_dt == data_type::s8) {
+            // int8 prepack from an f32 weight reference: cast f32 -> plain s8
+            // (contiguous `ab`), then prepack that s8 slice into the Zen
+            // blocked layout.
+            status_t st = f32_to_s8_plain(src, conv, K, N, ldb, src_is_ab);
+            if (st == success)
+                st = zen_weight_prepack(conv, dst, zd::s8, gemm_src, K, N,
+                        /*ldb=*/N, /*transposed=*/false);
+            return st;
+        }
+
+        if (src_dt == data_type::f32
+                && utils::one_of(dst_dt, data_type::s4, data_type::u4)) {
+            // WOQ prepack from an f32 weight reference: cast f32 -> packed
+            // 4-bit (contiguous `ab`), then prepack that 4-bit slice.
+            status_t st = f32_to_int4_plain(
+                    src, conv, K, N, ldb, src_is_ab, dst_dt);
+            if (st == success)
+                st = zen_weight_prepack(conv, dst, to_zen_dt(dst_dt), gemm_src,
+                        K, N, /*ldb=*/N, /*transposed=*/false);
             return st;
         }
 


### PR DESCRIPTION
# Description

Add zen_lowp_matmul for u8/s8 x s8 static quantization and bf16 x s4/u4 WOQ via zen_packed weights. Extend zen_reorder for 4-bit prepack and register the impl in matmul/reorder dispatch.

Fixes # (github issue)

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [ ] Have you added relevant tests?
