### PR TITLE
x64: eliminate C4267 warning 

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -349,7 +349,7 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
     brg->dt_bias = dt_bias;
     brg->typesize_bias = (dt_bias == data_type::undef)
             ? 0
-            : types::data_type_size(brg->dt_bias);
+            : static_cast<int>(types::data_type_size(brg->dt_bias));
 
     brg->LDD = LDD;
     brg->is_runtime_ldd = is_runtime_value(LDD);
@@ -428,7 +428,7 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
         return status::unimplemented;
 
     brg->dt_d = dt_d;
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    brg->typesize_D = static_cast<int>(types::data_type_size(brg->dt_d));
 
     if (!IMPLICATION(brg->is_int8 && brg->dt_d == bf16,
                 is_superset(brg->isa_impl, avx512_core)

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -1176,10 +1176,10 @@ status_t init_brgemm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->dt_d = brg->dt_c;
     brg->dt_bias = brg->dt_c;
 
-    brg->typesize_A = types::data_type_size(brg->dt_a);
-    brg->typesize_B = types::data_type_size(brg->dt_b);
-    brg->typesize_C = types::data_type_size(brg->dt_c);
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    brg->typesize_A = static_cast<int>(types::data_type_size(brg->dt_a));
+    brg->typesize_B = static_cast<int>(types::data_type_size(brg->dt_b));
+    brg->typesize_C = static_cast<int>(types::data_type_size(brg->dt_c));
+    brg->typesize_D = static_cast<int>(types::data_type_size(brg->dt_d));
 
     brg->isa_user = isa;
 
@@ -1250,10 +1250,10 @@ status_t init_brdgmm_conf(brgemm_desc_t *brg, cpu_isa_t isa,
     brg->dt_d = brg->dt_c;
     brg->dt_bias = brg->dt_c;
 
-    brg->typesize_A = types::data_type_size(brg->dt_a);
-    brg->typesize_B = types::data_type_size(brg->dt_b);
-    brg->typesize_C = types::data_type_size(brg->dt_c);
-    brg->typesize_D = types::data_type_size(brg->dt_d);
+    brg->typesize_A = static_cast<int>(types::data_type_size(brg->dt_a));
+    brg->typesize_B = static_cast<int>(types::data_type_size(brg->dt_b));
+    brg->typesize_C = static_cast<int>(types::data_type_size(brg->dt_c));
+    brg->typesize_D = static_cast<int>(types::data_type_size(brg->dt_d));
 
     brg->isa_user = isa;
     auto is_isa_ok = [&](cpu_isa_t isa) {

--- a/src/cpu/x64/cpu_isa_traits.hpp
+++ b/src/cpu/x64/cpu_isa_traits.hpp
@@ -55,13 +55,6 @@
 #define XBYAK_STRICT_CHECK_MEM_REG_SIZE 0
 #endif
 
-#if defined(_MSC_VER) && !defined(__INTEL_COMPILER)
-/* turn off `size_t to other-type implicit casting` warning
- * currently we have a lot of jit-generated instructions that
- * take uint32_t, but we pass size_t (e.g. due to using sizeof).
- * FIXME: replace size_t parameters with the appropriate ones */
-#pragma warning(disable : 4267)
-#endif
 #include "common/compiler_workarounds.hpp"
 #include "xbyak/xbyak.h"
 #include "xbyak/xbyak_util.h"

--- a/src/cpu/x64/cpu_reducer.cpp
+++ b/src/cpu/x64/cpu_reducer.cpp
@@ -101,8 +101,8 @@ template <impl::data_type_t data_type>
 struct reducer_2d_driver_t : public jit_generator_t {
     using data_t = typename prec_traits_t<data_type>::type;
 
-    reducer_2d_driver_t(int n_src, size_t src_ld, size_t src_step,
-            size_t dst_step, bool nullify_dst, const char *name)
+    reducer_2d_driver_t(int n_src, dim_t src_ld, dim_t src_step, dim_t dst_step,
+            bool nullify_dst, const char *name)
         : jit_generator_t(name)
         , n_src_(n_src)
         , src_ld_(src_ld)
@@ -115,7 +115,7 @@ struct reducer_2d_driver_t : public jit_generator_t {
 
 protected:
     int n_src_;
-    size_t src_ld_, src_step_, dst_step_;
+    dim_t src_ld_, src_step_, dst_step_;
     bool nullify_dst_;
 };
 
@@ -158,8 +158,8 @@ struct reducer_2d_driver_f_s_32_t : public reducer_2d_driver_t<data_type> {
     Xbyak::Reg64 reg_src_id = this->r10;
     Xbyak::Reg64 reg_long_offt = this->r11;
 
-    reducer_2d_driver_f_s_32_t(int n_src, size_t src_ld, size_t src_step,
-            size_t dst_step, bool nullify_dst)
+    reducer_2d_driver_f_s_32_t(int n_src, dim_t src_ld, dim_t src_step,
+            dim_t dst_step, bool nullify_dst)
         : reducer_2d_driver_t<data_type>(
                   n_src, src_ld, src_step, dst_step, nullify_dst, jit_name()) {}
 
@@ -330,8 +330,8 @@ struct reducer_2d_driver_xf16_t : public reducer_2d_driver_t<data_type> {
 
     Xbyak::Opmask k_tail_mask = Xbyak::Opmask(1);
 
-    reducer_2d_driver_xf16_t(int n_src, size_t src_ld, size_t src_step,
-            size_t dst_step, bool nullify_dst)
+    reducer_2d_driver_xf16_t(int n_src, dim_t src_ld, dim_t src_step,
+            dim_t dst_step, bool nullify_dst)
         : reducer_2d_driver_t<data_type>(
                   n_src, src_ld, src_step, dst_step, nullify_dst, jit_name()) {}
 
@@ -441,8 +441,8 @@ struct reducer_2d_driver_xf16_t : public reducer_2d_driver_t<data_type> {
 
         loop_x();
 
-        this->add(reg_dst, this->dst_step_ * (size_t)typesize);
-        this->add(reg_src, this->src_step_ * (size_t)typesize);
+        this->add(reg_dst, this->dst_step_ * typesize);
+        this->add(reg_src, this->src_step_ * typesize);
 
         this->dec(reg_ny);
         this->jnz(ny_loop, this->T_NEAR);
@@ -453,7 +453,7 @@ struct reducer_2d_driver_xf16_t : public reducer_2d_driver_t<data_type> {
 
 template <impl::data_type_t data_type>
 inline reducer_2d_driver_t<data_type> *create_reduce_2d_drv(int n_src,
-        size_t src_ld, size_t src_step, size_t dst_step, bool nullify_dst) {
+        dim_t src_ld, dim_t src_step, dim_t dst_step, bool nullify_dst) {
     if (utils::one_of(data_type, data_type::bf16, data_type::f16)) {
         // bf16 downconvert needs AVX512_BF16 (vcvtneps2bf16). f16 needs
         // F16C/AVX512F. Caller is expected to only request these types

--- a/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
+++ b/src/cpu/x64/gemm/f32/jit_avx_gemm_f32.cpp
@@ -2024,7 +2024,8 @@ private:
     const Address ARG_A = ptr[rsp + OFFSET_SHADOWSPACE + STACKSIZE];
     const Address ARG_LDA
             = qword[rsp + OFFSET_SHADOWSPACE + sizeof(float *) + STACKSIZE];
-    const int stackOffset = OFFSET_SHADOWSPACE + sizeof(float *) + STACKSIZE;
+    const int stackOffset = static_cast<int>(
+            OFFSET_SHADOWSPACE + sizeof(float *) + STACKSIZE);
     const Reg64 A = rsi;
     const Reg64 LDA = rdi;
 #else

--- a/src/cpu/x64/injectors/jit_uni_sum_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_sum_injector.cpp
@@ -63,9 +63,9 @@ void jit_uni_sum_injector_t<Vmm>::compute_vector_range(
     int tmp_idx = scratch;
     bool scratch_changed = false;
 
-    if (vmm_idxs.find((size_t)scratch) != vmm_idxs.end()) {
+    if (vmm_idxs.find(scratch) != vmm_idxs.end()) {
         for (int idx = max_idx; idx >= 0; idx--) {
-            if (vmm_idxs.find((size_t)idx) == vmm_idxs.end()) {
+            if (vmm_idxs.find(idx) == vmm_idxs.end()) {
                 // Found a free register.
                 tmp_idx = idx;
                 scratch_changed = true;
@@ -74,7 +74,7 @@ void jit_uni_sum_injector_t<Vmm>::compute_vector_range(
         }
     }
 
-    assert(vmm_idxs.find((size_t)tmp_idx) == vmm_idxs.end()
+    assert(vmm_idxs.find(tmp_idx) == vmm_idxs.end()
             && "native sum could not find a free scratch vector register");
 
     // Preserve when the caller asked to or whenever we picked a new scratch.

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -96,7 +96,7 @@ void postops_injector_t::apply(const std::vector<int> &acc_phys, int base_phys,
         const std::vector<dim_t> &out_byte_off, int mask_phys, int elems) {
     injector_utils::vmm_index_set_t vmm_idxs;
     for (int idx : acc_phys)
-        vmm_idxs.insert((size_t)idx);
+        vmm_idxs.insert(idx);
 
     if (!needs_rhs_args_) {
         // Chains without a binary, prelu or sum post-op have nothing to address

--- a/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_avx2_1x1_conv_kernel_f32.cpp
@@ -606,9 +606,9 @@ void jit_avx2_1x1_conv_kernel_f32_t::generate() {
         generate_bcast_loop(load_loop_blk);
         add(reg_load_data,
                 static_cast<uint32_t>(load_loop_blk * jcp.load_loop_load_step));
-        const size_t offst_with_dw_conv
+        const dim_t offst_with_dw_conv
                 = get_load_loop_output_fwd_offset(jcp, load_loop_blk);
-        const size_t offst_wo_dw_conv
+        const dim_t offst_wo_dw_conv
                 = get_load_loop_output_fwd_offset(jcp, load_loop_blk, true);
         switch (jcp.prop_kind) {
             case forward_training:

--- a/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_1x1_conv_kernel.cpp
@@ -730,9 +730,10 @@ status_t jit_avx512_common_1x1_conv_kernel_t::init_conf(
 
     jcp.load_grp_count = 1;
 
-    const int L1_capacity
-            = platform::get_per_core_cache_size(1) / sizeof(float);
-    const int L2_size = platform::get_per_core_cache_size(2) / sizeof(float);
+    const int L1_capacity = static_cast<int>(
+            platform::get_per_core_cache_size(1) / sizeof(float));
+    const int L2_size = static_cast<int>(
+            platform::get_per_core_cache_size(2) / sizeof(float));
     const int L2_capacity = (L2_size * 3) / 4;
 
     if (one_of(jcp.prop_kind, forward_training, forward_inference,

--- a/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_common_conv_kernel.cpp
@@ -3081,8 +3081,8 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
     Zmm zero = Zmm(0);
     vpxord(zero, zero, zero);
     const bool generate_icb_loop = jcp.nb_ic_blocking_max > 1;
-    const size_t kernel_block_bytes = (size_t)jcp.ic_block * jcp.oc_block
-            * jcp.kw * jcp.kh * jcp.kd * jcp.typesize_out;
+    const dim_t kernel_block_bytes = static_cast<dim_t>(jcp.ic_block)
+            * jcp.oc_block * jcp.kw * jcp.kh * jcp.kd * jcp.typesize_out;
     Label icb_block_label, icb_block_label_cb;
     if (generate_icb_loop) {
         push(reg_kernel);
@@ -3172,7 +3172,7 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::bias_kernel_3d() {
     cmp(reg_oi, 0);
     jle(skip_bias, T_NEAR); // no iterations along depth dimension
 
-    const size_t oc_mult
+    const dim_t oc_mult
             = is_ddst_layout_nxc() ? jcp.ngroups * jcp.oc : jcp.oc_block;
     mov(reg_tmp, oc_mult * jcp.ow * jcp.oh * jcp.typesize_out);
     imul(reg_oi, reg_tmp);
@@ -3400,9 +3400,9 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     const dim_t bottom_pad_input_correction
             = jcp.ih + jcp.t_pad - input_bottom_padding_overlap * jcp.stride_h;
 
-    const size_t filter_shift = jcp.typesize_out * jcp.kw * ic_block * oc_block;
-    const size_t input_shift = jcp.typesize_in * jcp.iw * inp_mult;
-    const size_t output_shift = jcp.typesize_out * jcp.ow * out_mult;
+    const dim_t filter_shift = jcp.typesize_out * jcp.kw * ic_block * oc_block;
+    const dim_t input_shift = jcp.typesize_in * jcp.iw * inp_mult;
+    const dim_t output_shift = jcp.typesize_out * jcp.ow * out_mult;
 
     Label loop_begin_label, loop_end_label, common_block_label,
             top_padding_end_label, bottom_padding_end_label,
@@ -3533,10 +3533,10 @@ void jit_avx512_common_conv_bwd_weights_kernel_f32_t::
     const dim_t back_pad_input_correction
             = jcp.id + jcp.f_pad - input_backpad_overlap * jcp.stride_d;
 
-    const size_t filter_shift
+    const dim_t filter_shift
             = jcp.typesize_out * jcp.kh * jcp.kw * ic_block * oc_block;
-    const size_t input_shift = jcp.typesize_in * jcp.ih * iw * inp_mult;
-    const size_t output_shift = jcp.typesize_in * jcp.oh * ow * out_mult;
+    const dim_t input_shift = jcp.typesize_in * jcp.ih * iw * inp_mult;
+    const dim_t output_shift = jcp.typesize_in * jcp.oh * ow * out_mult;
 
     Label d_loop_label, loop_end_label, common_block_label, fpad_end_label,
             backpad_end_label, backpad_label;

--- a/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_conv_kernel.cpp
@@ -271,7 +271,7 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
         dim_t ur_w, dim_t pad_l, dim_t pad_r, bool handle_h_pad) {
 
     Label icb_label;
-    const size_t nb_ic = jcp.nb_ic_int;
+    const dim_t nb_ic = jcp.nb_ic_int;
     const bool do_icb_loop = nb_ic > 1;
 
     /* Initialize zmm_one for weight accumulation */
@@ -308,13 +308,14 @@ void jit_avx512_core_amx_compute_zp_pbuff_t::icb_loop(
     if (do_icb_loop) {
         const dim_t shift_wei_icb_step
                 = jcp.kd * jcp.kh * jcp.kw * jcp.oc_block * jcp.ic_block_int_np;
-        add(reg_filt, sizeof(char) * shift_wei_icb_step);
+        add(reg_filt, static_cast<dim_t>(sizeof(char)) * shift_wei_icb_step);
 
         dec(reg_icb);
         cmp(reg_icb, 0);
         jg(icb_label, T_NEAR);
 
-        sub(reg_filt, sizeof(char) * shift_wei_icb_step * nb_ic);
+        sub(reg_filt,
+                static_cast<dim_t>(sizeof(char)) * shift_wei_icb_step * nb_ic);
     }
 
     if (jcp.oc_without_padding != jcp.oc) {

--- a/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_amx_convolution.cpp
@@ -2179,7 +2179,7 @@ void jit_avx512_core_amx_convolution_bwd_weights_t::prepare_scratchpad_data(
     // race condition due to buffer overflows from memory optimization where
     // buffers sharing padding
 
-    for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
+    for (dim_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
         src_data_t *ts
                 = &tr_src[ithr * jcp.tr_src_buf_size * jcp.nb_ic_blocking];
         for (dim_t i = 0; i < jcp.tr_src_num_guard_elems; ++i)

--- a/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_conv_kernel.cpp
@@ -3350,7 +3350,7 @@ void jit_avx512_core_bf16_conv_bwd_weights_kernel_f32_t::maybe_zero_kernel() {
             jmp(skip_zeroing, T_NEAR);
     }
 
-    const size_t kernel_block_bytes = get_kernel_offset(
+    const dim_t kernel_block_bytes = get_kernel_offset(
             0, static_cast<dim_t>(jcp.kw) * jcp.kh * jcp.kd);
     Label icb_block_label, icb_block_label_cb;
 

--- a/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_convolution.cpp
@@ -1949,7 +1949,7 @@ void jit_avx512_core_bf16_convolution_bwd_weights_t::prepare_scratchpad_data(
         // Zero out guard elements that cross a buffer boundary to prevent a
         // race condition due to buffer overflows from memory optimization where
         // buffers sharing padding
-        for (size_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
+        for (dim_t ithr = 1; ithr <= jcp.tr_src_buf_count; ++ithr) {
             src_data_t *ts = &tr_src[ithr * jcp.tr_src_buf_size];
             for (dim_t i = 0; i < jcp.tr_src_num_guard_elems; ++i)
                 ts[i] = 0;

--- a/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_bf16_dw_conv_kernel.cpp
@@ -379,14 +379,14 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::compute_loop(
 
     // ch_loop currently happen only when data layout is nxc. The strides are
     // calculated for this layout only.
-    const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kh * jcp.kw
-            * jcp.ch_block * jcp.typesize_in;
-    const size_t inp_ch_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_in;
-    const size_t out_ch_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_out;
-    const size_t bias_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+    const dim_t nb_ch_blocking = jcp.nb_ch_blocking;
+    const dim_t wei_ch_stride
+            = nb_ch_blocking * jcp.kh * jcp.kw * jcp.ch_block * jcp.typesize_in;
+    const dim_t inp_ch_stride = nb_ch_blocking * jcp.ch_block * jcp.typesize_in;
+    const dim_t out_ch_stride
+            = nb_ch_blocking * jcp.ch_block * jcp.typesize_out;
+    const dim_t bias_stride
+            = nb_ch_blocking * jcp.ch_block * static_cast<dim_t>(sizeof(float));
 
     auto compute = [&](int ur_ch_blocks, bool last_ch_block_flag = false) {
         if (jcp.is_fused_conv) {
@@ -470,8 +470,8 @@ void jit_avx512_dw_conv_fwd_kernel_bf16_t::loop_ow(int ur_ch_blocks) {
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
-    size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
-    size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
+    dim_t inp_shift = jcp.typesize_in * ur_w * stride_w * dat_c_stride;
+    dim_t out_shift = jcp.typesize_out * ur_w * dat_c_stride;
 
     const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
@@ -644,8 +644,8 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
     const dim_t stride_w = jcp.stride_w;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
-    const size_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
-    const size_t sp_step = ddst_layout_nxc ? jcp.ngroups : ch_blk;
+    const dim_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
+    const dim_t sp_step = ddst_layout_nxc ? jcp.ngroups : ch_blk;
 
     Label iter_exit_label;
 
@@ -677,9 +677,9 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::apply_filter(
                         ptr[aux1_reg_kernel + ker_off * jcp.typesize_in]);
 
                 for (int w = 0; w < ur_str_w; w++) {
-                    size_t sp_offset = w * sp_step;
-                    size_t ch_offset = ch * ch_block_step;
-                    size_t ddst_off = sp_offset + ch_offset;
+                    dim_t sp_offset = w * sp_step;
+                    dim_t ch_offset = ch * ch_block_step;
+                    dim_t ddst_off = sp_offset + ch_offset;
                     Zmm zmm_acc = get_acc_reg(ch * ur_str_w + w);
                     Zmm mm_zmm_dst // mm: maybe masked
                             = mask_flag ? zmm_dst_reg | k_ch_tail_mask | T_z
@@ -783,9 +783,10 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::ch_loop_body(
                 jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking)));
         const int ch_step = static_cast<int>(jcp.nb_ch_blocking * jcp.ch_block);
 
-        const size_t wei_ch_stride
-                = (size_t)jcp.nb_ch_blocking * jcp.kh * jcp.kw * jcp.ch_block;
-        const size_t data_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.ch_block;
+        const dim_t wei_ch_stride = static_cast<dim_t>(jcp.nb_ch_blocking)
+                * jcp.kh * jcp.kw * jcp.ch_block;
+        const dim_t data_ch_stride
+                = static_cast<dim_t>(jcp.nb_ch_blocking) * jcp.ch_block;
 
         mov(aux_reg_ch_blocks, reg_ch_blocks);
         push(reg_dsrc);
@@ -841,7 +842,7 @@ inline void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::unroll_width_body(
         Label unroll_w_label, skip_compute_label;
         L(unroll_w_label);
         {
-            const size_t ch_step = unroll_w
+            const dim_t ch_step = unroll_w
                     * (is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block);
             cmp(reg_ur_str_w, unroll_w);
             jl(skip_compute_label, T_NEAR);
@@ -879,7 +880,7 @@ void jit_avx512_dw_conv_bwd_data_kernel_bf16_t::generate() {
     if (is_dsrc_layout_nxc()) {
         if (jcp.ch_tail) {
             Label masking_done;
-            const size_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
+            const dim_t channel_step = jcp.nb_ch_blocking * jcp.ch_block;
             kxnorw(k_ch_tail_mask, k_ch_tail_mask,
                     k_ch_tail_mask); // dummy mask all 1's
             cmp(reg_ch_blocks, channel_step);
@@ -1065,8 +1066,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_spatial_loop_bias(
     const int unroll_w_trips = static_cast<int>(jcp.ow / unroll_w);
     const int tail_w = jcp.ow > max_unroll_w_ ? jcp.ow % max_unroll_w_ : 0;
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const size_t ch_offset = ch_step * jcp.typesize_in;
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t ch_offset = ch_step * jcp.typesize_in;
 
     mov(reg_oh, ptr[this->param1 + GET_OFF(oh_index)]);
     mov(reg_oh_worksize, ptr[this->param1 + GET_OFF(oh_count)]);
@@ -1209,8 +1210,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_bias() {
 
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::zero_filter_kh_loop() {
 
-    const size_t filter_offset_kw = jcp.kw * jcp.ch_block * jcp.typesize_out;
-    const size_t filter_offset_kh = jcp.kh * filter_offset_kw;
+    const dim_t filter_offset_kw = jcp.kw * jcp.ch_block * jcp.typesize_out;
+    const dim_t filter_offset_kh = jcp.kh * filter_offset_kw;
 
     Label kh_loop_label;
 
@@ -1249,9 +1250,9 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::deploy_zero_filter() {
 void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_kh_step(int unroll_w,
         int l_pad, int pad_offset, int ow_block, bool is_last_ch) {
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const size_t input_offset = jcp.iw * ch_step * jcp.typesize_in;
-    const size_t filter_offset = jcp.kw * jcp.ch_block * jcp.typesize_out;
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t input_offset = jcp.iw * ch_step * jcp.typesize_in;
+    const dim_t filter_offset = jcp.kw * jcp.ch_block * jcp.typesize_out;
 
     Label kh_loop_label, skip_loop_label;
 
@@ -1326,10 +1327,10 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_h_loop(
     const dim_t input_bottom_padding_overlap
             = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const size_t input_shift = jcp.typesize_in * jcp.iw * ch_step;
-    const size_t output_shift = jcp.typesize_in * jcp.ow * ch_step;
-    const size_t filter_shift = jcp.typesize_out * jcp.kw * jcp.ch_block;
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t input_shift = jcp.typesize_in * jcp.iw * ch_step;
+    const dim_t output_shift = jcp.typesize_in * jcp.ow * ch_step;
+    const dim_t filter_shift = jcp.typesize_out * jcp.kw * jcp.ch_block;
 
     Label loop_begin_label, loop_end_label, common_block_label,
             top_padding_end_label, bottom_padding_end_label,
@@ -1460,9 +1461,8 @@ void jit_avx512_dw_conv_bwd_weights_kernel_bf16_t::compute_ow_block_unroll() {
     int unroll_trips = 0;
     calculate_w_unrolling(unroll_trips, unroll_w, unroll_w_tail);
 
-    const size_t ch_offset = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const size_t data_offset
-            = static_cast<size_t>(unroll_w * ch_offset * jcp.typesize_in);
+    const dim_t ch_offset = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t data_offset = unroll_w * ch_offset * jcp.typesize_in;
 
     if (jcp.with_bias) compute_bias();
 

--- a/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
+++ b/src/cpu/x64/jit_avx512_core_bf16cvt.hpp
@@ -229,9 +229,15 @@ struct jit_avx512_core_add_cvt_ps_to_bf16_t : public jit_generator_t {
                 for (int j = 0; j < simd_w_ * unroll; j += simd_w_) {
                     add_cvt(j, ktail_mask);
                 }
-                add(reg_inp, simd_w_ * unroll * sizeof(float));
-                add(reg_add, simd_w_ * unroll * sizeof(float));
-                add(reg_out, simd_w_ * unroll * sizeof(bfloat16_t));
+                add(reg_inp,
+                        static_cast<uint32_t>(
+                                simd_w_ * unroll * sizeof(float)));
+                add(reg_add,
+                        static_cast<uint32_t>(
+                                simd_w_ * unroll * sizeof(float)));
+                add(reg_out,
+                        static_cast<uint32_t>(
+                                simd_w_ * unroll * sizeof(bfloat16_t)));
 
                 sub(reg_nelems, simd_w_ * unroll);
                 jmp(l_simd_loop[i + 1], T_NEAR);

--- a/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_f16_dw_conv_kernel.cpp
@@ -341,14 +341,14 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::compute_loop(
     const bool ch_loop = ur_ch_blocks > jcp.nb_ch_blocking;
     // ch_loop currently happen only when data layout is nxc. The strides are
     // calculated for this layout only.
-    const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kh * jcp.kw
-            * jcp.ch_block * jcp.typesize_in;
-    const size_t inp_ch_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_in;
-    const size_t out_ch_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_out;
-    const size_t bias_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+    const dim_t nb_ch_blocking = jcp.nb_ch_blocking;
+    const dim_t wei_ch_stride
+            = nb_ch_blocking * jcp.kh * jcp.kw * jcp.ch_block * jcp.typesize_in;
+    const dim_t inp_ch_stride = nb_ch_blocking * jcp.ch_block * jcp.typesize_in;
+    const dim_t out_ch_stride
+            = nb_ch_blocking * jcp.ch_block * jcp.typesize_out;
+    const dim_t bias_stride
+            = nb_ch_blocking * jcp.ch_block * static_cast<dim_t>(sizeof(float));
 
     auto compute = [&](int ur_ch_blocks, bool is_ch_tail) {
         if (jcp.is_fused_conv) {
@@ -426,8 +426,8 @@ void jit_avx512_dw_conv_fwd_kernel_f16_t::ow_loop(int ur_ch_blocks) {
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
-    size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
-    size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
+    dim_t inp_shift = jcp.typesize_in * ur_w * stride_w * dat_c_stride;
+    dim_t out_shift = jcp.typesize_out * ur_w * dat_c_stride;
 
     const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;

--- a/src/cpu/x64/jit_avx512_core_fp16cvt.cpp
+++ b/src/cpu/x64/jit_avx512_core_fp16cvt.cpp
@@ -65,9 +65,13 @@ void jit_avx512_core_fp16_add_cvt_ps_to_f16_t::generate() {
             for (int j = 0; j < simd_w_ * unroll; j += simd_w_) {
                 add_cvt(j, ktail_mask);
             }
-            add(reg_inp, simd_w_ * unroll * sizeof(float));
-            add(reg_add, simd_w_ * unroll * sizeof(float));
-            add(reg_out, simd_w_ * unroll * sizeof(float16_t));
+            add(reg_inp,
+                    static_cast<uint32_t>(simd_w_ * unroll * sizeof(float)));
+            add(reg_add,
+                    static_cast<uint32_t>(simd_w_ * unroll * sizeof(float)));
+            add(reg_out,
+                    static_cast<uint32_t>(
+                            simd_w_ * unroll * sizeof(float16_t)));
 
             sub(reg_nelems, simd_w_ * unroll);
             jmp(l_simd_loop[i + 1], T_NEAR);

--- a/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_avx512_core_x8s8s32x_1x1_conv_kernel.cpp
@@ -728,14 +728,16 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         if (jcp.signed_input) {
             mov(reg_comp_data, EVEX_compress_addr(rsp, reg_comp_data_off));
             add(reg_comp_data,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(EVEX_compress_addr(rsp, reg_comp_data_off), reg_comp_data);
         }
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation,
                     EVEX_compress_addr(rsp, reg_zp_compensation_off));
             add(reg_zp_compensation,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(EVEX_compress_addr(rsp, reg_zp_compensation_off),
                     reg_zp_compensation);
         }
@@ -743,8 +745,8 @@ void jit_avx512_core_x8s8s32x_1x1_conv_kernel_vmm_t<Vmm>::generate() {
         if (jcp.with_wei_scales) {
             mov(reg_wei_scales, EVEX_compress_addr(rsp, reg_wei_scales_off));
             add(reg_wei_scales,
-                    jcp.is_oc_scale * load_loop_blk * jcp.load_block
-                            * sizeof(float));
+                    static_cast<uint32_t>(jcp.is_oc_scale * load_loop_blk
+                            * jcp.load_block * sizeof(float)));
             mov(EVEX_compress_addr(rsp, reg_wei_scales_off), reg_wei_scales);
         }
         mov(reg_bcast_data, EVEX_compress_addr(rsp, reg_bcast_data_off));
@@ -1032,8 +1034,8 @@ status_t jit_avx512_core_x8s8s32x_1x1_conv_kernel_t::init_conf(
     jcp.load_grp_count = 1;
     jcp.use_vmovntps = false;
 
-    const int L2_size
-            = platform::get_per_core_cache_size(2) / sizeof(jcp.typesize_in);
+    const int L2_size = static_cast<int>(
+            platform::get_per_core_cache_size(2) / sizeof(jcp.typesize_in));
     const int L2_capacity = (L2_size * 3) / 4;
 
     const bool req_extra_bf16_regs

--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -2055,7 +2055,7 @@ void brgemm_convolution_fwd_t<isa>::maybe_conv_inp(brgemm_thread_ctx_t &btc,
                         size_to_sero = jcp.vnni_block;
                     if (_pd->rd > jcp.simd_w && _pd->rd % jcp.simd_w != 0)
                         size_to_sero = jcp.simd_w;
-                    size_to_sero *= jcp.src_dsz;
+                    size_to_sero *= static_cast<int>(jcp.src_dsz);
                     void *const __restrict p_zeroing = (char *)cp.dst
                             + src_dsz * cp.h_count * _pd->pbuf_w_sz;
                     if (size_to_sero > 0 && btc.inp_buffer_zero != p_zeroing) {

--- a/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_bwd_utils.cpp
@@ -1556,8 +1556,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.acc_dsz = types::data_type_size(jcp.acc_dt);
     jcp.bia_dsz = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
 
-    jcp.simd_w = isa_max_vlen(isa) / jcp.src_dsz;
-    jcp.acc_simd_w = isa_max_vlen(isa) / jcp.acc_dsz;
+    jcp.simd_w = static_cast<int>(isa_max_vlen(isa) / jcp.src_dsz);
+    jcp.acc_simd_w = static_cast<int>(isa_max_vlen(isa) / jcp.acc_dsz);
     jcp.is_bf32 = everyone_is(f32, jcp.src_dt, jcp.wei_dt)
             && one_of(attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any)
             && isa == avx512_core_amx;
@@ -1693,7 +1693,7 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             VERBOSE_ISA_DT_MISMATCH);
 
     jcp.amx_h = 16;
-    jcp.amx_w = 64 / jcp.src_dsz;
+    jcp.amx_w = static_cast<int>(64 / jcp.src_dsz);
 
     if (jcp.with_bias) {
         if (bias_d.format_kind() == format_kind::any)

--- a/src/cpu/x64/jit_brgemm_conv_utils.cpp
+++ b/src/cpu/x64/jit_brgemm_conv_utils.cpp
@@ -1817,8 +1817,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
     jcp.acc_dsz = types::data_type_size(jcp.acc_dt);
     jcp.bia_dsz = jcp.with_bias ? types::data_type_size(jcp.bia_dt) : 0;
 
-    jcp.simd_w = isa_max_vlen(isa) / jcp.src_dsz;
-    jcp.acc_simd_w = isa_max_vlen(isa) / jcp.acc_dsz;
+    jcp.simd_w = static_cast<int>(isa_max_vlen(isa) / jcp.src_dsz);
+    jcp.acc_simd_w = static_cast<int>(isa_max_vlen(isa) / jcp.acc_dsz);
     jcp.is_bf32 = everyone_is(f32, jcp.src_dt, jcp.wei_dt)
             && one_of(attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any)
             && isa == avx512_core_amx;
@@ -1960,7 +1960,8 @@ status_t init_jcp(jit_brgemm_conv_conf_t &jcp, cpu_isa_t isa,
             VERBOSE_ISA_DT_MISMATCH);
 
     jcp.amx_h = 16;
-    jcp.amx_w = 64 / (jcp.is_bf32 ? types::data_type_size(bf16) : jcp.src_dsz);
+    jcp.amx_w = static_cast<int>(
+            64 / (jcp.is_bf32 ? types::data_type_size(bf16) : jcp.src_dsz));
 
     const auto &p = attr.post_ops_;
     jcp.with_sum = p.find(primitive_kind::sum) != -1;

--- a/src/cpu/x64/jit_gemm_inner_product_utils.cpp
+++ b/src/cpu/x64/jit_gemm_inner_product_utils.cpp
@@ -384,7 +384,7 @@ void jit_pp_kernel_t<isa>::advance_binary_postops_per_oc_off(const T &offset) {
 
     if (this->ndims_ == 2) {
         Xbyak::Label end;
-        cmp(binary_post_op_oc_off_reg, this->OC_);
+        cmp(binary_post_op_oc_off_reg, static_cast<uint32_t>(this->OC_));
         jl(end, T_NEAR);
         xor_(binary_post_op_oc_off_reg, binary_post_op_oc_off_reg);
         L(end);
@@ -427,12 +427,13 @@ void jit_pp_kernel_t<isa>::advance_binary_postops_channel_bcast_off(
 template <cpu_isa_t isa>
 void jit_pp_kernel_t<isa>::advance_binary_postops_off(const size_t offset) {
     if (offset) {
+        const auto imm_offset = static_cast<uint32_t>(offset);
         if (any_binary_postop_is_per_oc_bcast_type_)
-            advance_binary_postops_per_oc_off(offset);
+            advance_binary_postops_per_oc_off(imm_offset);
         if (any_binary_postop_is_no_bcast_type_)
             update_binary_postops_per_tensor_off();
         if (any_binary_postop_is_oc_bcast_type_)
-            advance_binary_postops_channel_bcast_off(offset);
+            advance_binary_postops_channel_bcast_off(imm_offset);
     }
 }
 
@@ -797,11 +798,13 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
     // Advance all pointers by an immediate
     auto advance_ptrs_imm = [&](size_t offset) {
-        add(reg_dst, offset * this->dst_data_type_size_);
-        add(reg_acc, offset * this->acc_data_type_size_);
+        add(reg_dst, static_cast<uint32_t>(offset * this->dst_data_type_size_));
+        add(reg_acc, static_cast<uint32_t>(offset * this->acc_data_type_size_));
         if (this->do_scale_ && this->scale_idx_mult_ == 1)
-            add(reg_scales, offset * sizeof(float));
-        if (this->do_bias()) add(reg_bias, offset * this->bias_data_type_size_);
+            add(reg_scales, static_cast<uint32_t>(offset * sizeof(float)));
+        if (this->do_bias())
+            add(reg_bias,
+                    static_cast<uint32_t>(offset * this->bias_data_type_size_));
         if (this->do_binary_ || this->do_prelu_) {
             advance_binary_postops_off(offset);
         }
@@ -849,7 +852,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
     // Process one row of reg_tmp elements
     auto process_runtime_oc = [&]() {
         Label l_loop, l_loop_tail, l_loop_end;
-        cmp(reg_tmp, vlen);
+        cmp(reg_tmp, static_cast<uint32_t>(vlen));
         jl(l_loop_tail, T_NEAR);
 
         L(l_loop);
@@ -857,8 +860,8 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
             compute(0, 0, true);
             advance_ptrs_imm(vlen);
 
-            sub(reg_tmp, vlen);
-            cmp(reg_tmp, vlen);
+            sub(reg_tmp, static_cast<uint32_t>(vlen));
+            cmp(reg_tmp, static_cast<uint32_t>(vlen));
             jge(l_loop, T_NEAR);
         }
 
@@ -955,7 +958,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
                     for (size_t offset = 0; offset < OC_loop; offset += vlen)
                         compute(offset, static_cast<int>(offset / vlen), false);
                     advance_ptrs_imm(OC_loop);
-                    sub(reg_tmp, OC_loop);
+                    sub(reg_tmp, static_cast<uint32_t>(OC_loop));
                     jnz(l_oc_loop);
                 }
             }
@@ -971,7 +974,7 @@ void jit_pp_kernel_t<isa>::compute_oc_channel_blk() {
 
             if (any_binary_postop_is_per_oc_sp_bcast_type_
                     && this->ndims_ <= 3) {
-                static constexpr size_t offset_oc_spatial = 1;
+                static constexpr uint32_t offset_oc_spatial = 1;
                 advance_binary_postops_per_oc_off(offset_oc_spatial);
             }
 
@@ -1035,7 +1038,7 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         load_and_cvt(vmm_bias, arg_t::bias, 0, oc, false);
 
         // write repeated MB*OC entries into stack
-        sub(rsp, mb_oc_blk * sizeof(uint32_t));
+        sub(rsp, static_cast<uint32_t>(mb_oc_blk * sizeof(uint32_t)));
         for (size_t i = 0; i < mb_step; ++i)
             cvt_and_store(vmm_bias, arg_t::stack,
                     i * this->OC_ * sizeof(uint32_t), oc);
@@ -1048,13 +1051,15 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         uni_vcvtdq2ps(vmm_bias, vmm_bias);
     L(mb_main_loop);
     {
-        cmp(reg_len, mb_oc_blk);
+        cmp(reg_len, static_cast<uint32_t>(mb_oc_blk));
         jl(end_main_loop, T_NEAR);
 
         compute(!expl_broadcast ? tail_size : 0);
-        add(reg_dst, mb_oc_blk * this->dst_data_type_size_);
-        add(reg_acc, mb_oc_blk * this->acc_data_type_size_);
-        sub(reg_len, mb_oc_blk);
+        add(reg_dst,
+                static_cast<uint32_t>(mb_oc_blk * this->dst_data_type_size_));
+        add(reg_acc,
+                static_cast<uint32_t>(mb_oc_blk * this->acc_data_type_size_));
+        sub(reg_len, static_cast<uint32_t>(mb_oc_blk));
         jmp(mb_main_loop, T_NEAR);
     }
     L(end_main_loop);
@@ -1090,7 +1095,8 @@ void jit_pp_kernel_t<isa>::compute_mb_blk() {
         L(end_runtime_tail);
     }
 
-    if (!expl_broadcast) add(rsp, mb_oc_blk * sizeof(uint32_t));
+    if (!expl_broadcast)
+        add(rsp, static_cast<uint32_t>(mb_oc_blk * sizeof(uint32_t)));
 }
 
 template <cpu_isa_t isa>

--- a/src/cpu/x64/jit_generator.cpp
+++ b/src/cpu/x64/jit_generator.cpp
@@ -36,8 +36,8 @@ void jit_generator_t::transpose(const Xbyak::Reg64 &reg_src,
     // Only avx2 version is supported for now. TODO: support other cases.
     // The transpose size is always calculated for f32 because bf16 is
     // is supported via upconversion.
-    const int transpose_size = vreg_traits_t<Xbyak::Ymm>::vlen
-            / types::data_type_size(data_type::f32);
+    const int transpose_size = static_cast<int>(vreg_traits_t<Xbyak::Ymm>::vlen
+            / types::data_type_size(data_type::f32));
     assert(is_valid_isa(avx2));
     assert(nrows <= transpose_size && ncolumns <= transpose_size);
 

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -413,7 +413,7 @@ public:
             mov(reg_offt, raw_offt);
             add(base, reg_offt);
         } else {
-            add(base, raw_offt);
+            add(base, static_cast<uint32_t>(raw_offt));
         }
     }
 
@@ -423,7 +423,7 @@ public:
             mov(reg_offt, raw_offt);
             sub(base, reg_offt);
         } else {
-            sub(base, raw_offt);
+            sub(base, static_cast<uint32_t>(raw_offt));
         }
     }
 
@@ -2755,8 +2755,8 @@ public:
             const Xbyak::Reg64 &reg_tmp,
             const std::function<void(int)> &tail_process,
             const data_type_t data_type = data_type::f32) {
-        const auto simd_w
-                = vreg_traits_t<Vmm>::vlen / types::data_type_size(data_type);
+        const int simd_w = vreg_traits_t<Vmm>::vlen
+                / static_cast<int>(types::data_type_size(data_type));
 
         Xbyak::Label label_tbl, label_tbl_end;
         std::vector<Xbyak::Label> l_case(simd_w);
@@ -2768,13 +2768,13 @@ public:
 
         // create jump table
         L(label_tbl);
-        for (size_t i = 0; i < simd_w; i++)
+        for (int i = 0; i < simd_w; i++)
             putL(l_case[i]);
 
         // cases for each tail size - from 0 to 3/7
         L(l_case[0]);
         jmp(label_tbl_end, T_NEAR);
-        for (size_t i = 1; i < simd_w; i++) {
+        for (int i = 1; i < simd_w; i++) {
             L(l_case[i]);
             tail_process(i);
             jmp(label_tbl_end, T_NEAR);

--- a/src/cpu/x64/jit_primitive_conf.hpp
+++ b/src/cpu/x64/jit_primitive_conf.hpp
@@ -146,8 +146,8 @@ struct jit_conv_conf_t {
     dim_t tr_src_num_guard_elems;
 
     // Transpose buffer management
-    size_t tr_src_buf_size, tr_src_buf_count;
-    size_t tr_diff_dst_buf_size, tr_diff_dst_buf_count;
+    dim_t tr_src_buf_size, tr_src_buf_count;
+    dim_t tr_diff_dst_buf_size, tr_diff_dst_buf_count;
     dim_t nthr_mb_work;
 
     int typesize_in;

--- a/src/cpu/x64/jit_uni_convert_xf16.cpp
+++ b/src/cpu/x64/jit_uni_convert_xf16.cpp
@@ -54,8 +54,12 @@ void jit_uni_cvt_ps_to_xf16_t<isa>::generate() {
                 for (int j = 0; j < simd_w_ * unroll; j += simd_w_) {
                     cvt_ps_to_xf16(j, false);
                 }
-                add(reg_input, simd_w_ * unroll * sizeof(float));
-                add(reg_output, simd_w_ * unroll * sizeof(float16_t));
+                add(reg_input,
+                        static_cast<uint32_t>(
+                                simd_w_ * unroll * sizeof(float)));
+                add(reg_output,
+                        static_cast<uint32_t>(
+                                simd_w_ * unroll * sizeof(float16_t)));
                 sub(reg_nelems, simd_w_ * unroll);
                 jmp(l_simd_loop[i + 1], T_NEAR);
             }
@@ -276,8 +280,11 @@ void jit_uni_cvt_xf16_to_ps_t<isa>::generate() {
             jl(l_simd_loop[i], T_NEAR);
             for (int j = 0; j < utils::div_up(unroll, elem_granularity); ++j)
                 convert_xf16(j, unroll > 1);
-            add(reg_input, simd_w_ * unroll * sizeof(float16_t));
-            add(reg_output, simd_w_ * unroll * sizeof(float));
+            add(reg_input,
+                    static_cast<uint32_t>(
+                            simd_w_ * unroll * sizeof(float16_t)));
+            add(reg_output,
+                    static_cast<uint32_t>(simd_w_ * unroll * sizeof(float)));
             sub(reg_nelems, simd_w_ * unroll);
             if (i == n_unroll && n_unroll != 0) jmp(l_simd_loop[i + 1], T_NEAR);
         }

--- a/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
+++ b/src/cpu/x64/jit_uni_dw_conv_kernel_f32.cpp
@@ -244,12 +244,14 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::apply_filter_unrolled(
             }
         }
 
-        add(aux_reg_kernel, jcp.kw * ch_blk * sizeof(float));
+        add(aux_reg_kernel,
+                jcp.kw * ch_blk * static_cast<dim_t>(sizeof(float)));
         if (jcp.is_fused_conv) {
             // Move to next row pointer in the buffer
             add(aux_reg_input_buffer_ptr, sizeof(void *));
         } else {
-            add(aux_reg_input, ih_stride * dilate_h * sizeof(float));
+            add(aux_reg_input,
+                    ih_stride * dilate_h * static_cast<dim_t>(sizeof(float)));
         }
 
         dec(iter_kh);
@@ -429,14 +431,14 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::compute_loop(
     const bool ch_loop = ur_ch_blocks > jcp.nb_ch_blocking;
     // ch_loop currently happen only when data layout is nxc. The strides are
     // calculated for this layout only.
-    const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kh * jcp.kw
-            * jcp.ch_block * jcp.typesize_in;
-    const size_t inp_ch_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_in;
-    const size_t out_ch_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * jcp.typesize_out;
-    const size_t bias_stride
-            = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+    const dim_t nb_ch_blocking = jcp.nb_ch_blocking;
+    const dim_t wei_ch_stride
+            = nb_ch_blocking * jcp.kh * jcp.kw * jcp.ch_block * jcp.typesize_in;
+    const dim_t inp_ch_stride = nb_ch_blocking * jcp.ch_block * jcp.typesize_in;
+    const dim_t out_ch_stride
+            = nb_ch_blocking * jcp.ch_block * jcp.typesize_out;
+    const dim_t bias_stride
+            = nb_ch_blocking * jcp.ch_block * static_cast<dim_t>(sizeof(float));
 
     auto compute = [&](int ur_ch_blocks, bool is_ch_tail) {
         if (jcp.is_fused_conv) {
@@ -515,8 +517,8 @@ void jit_uni_dw_conv_fwd_kernel_f32_t<isa>::ow_loop(int ur_ch_blocks) {
 
     const auto src_layout_nxc = is_src_layout_nxc();
     const auto dat_c_stride = src_layout_nxc ? jcp.ngroups : jcp.ch_block;
-    size_t inp_shift = (size_t)jcp.typesize_in * ur_w * stride_w * dat_c_stride;
-    size_t out_shift = (size_t)jcp.typesize_out * ur_w * dat_c_stride;
+    dim_t inp_shift = jcp.typesize_in * ur_w * stride_w * dat_c_stride;
+    dim_t out_shift = jcp.typesize_out * ur_w * dat_c_stride;
 
     const dim_t inp_shift_pad
             = jcp.typesize_in * (ur_w * stride_w - l_pad) * dat_c_stride;
@@ -714,8 +716,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
     const dim_t stride_w = jcp.stride_w;
 
     const bool ddst_layout_nxc = is_ddst_layout_nxc();
-    const size_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
-    const size_t sp_step = ddst_layout_nxc ? jcp.ngroups : ch_blk;
+    const dim_t ch_block_step = ch_blk * (ddst_layout_nxc ? 1 : oh * ow);
+    const dim_t sp_step = ddst_layout_nxc ? jcp.ngroups : ch_blk;
 
     Label iter_exit_label;
 
@@ -748,11 +750,10 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
                             masked_load);
 
                     for (int w = 0; w < ur_str_w; w++) {
-                        size_t sp_offset = w * sp_step;
-                        size_t ch_offset = ch * ch_block_step;
-                        size_t ddst_off = static_cast<size_t>(
-                                (sp_offset + ch_offset + r * simd_w_)
-                                * sizeof(float));
+                        dim_t sp_offset = w * sp_step;
+                        dim_t ch_offset = ch * ch_block_step;
+                        dim_t ddst_off = (sp_offset + ch_offset + r * simd_w_)
+                                * static_cast<dim_t>(sizeof(float));
 
                         Vmm vmm_ddst = get_ddst_reg(0);
                         load_vmm(vmm_ddst, ptr[aux1_reg_ddst + ddst_off],
@@ -765,16 +766,18 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::apply_filter(
                 }
             }
 
-            add(aux1_reg_kernel, ch_blk * stride_w * sizeof(float));
-            sub(aux1_reg_ddst, sp_step * sizeof(float));
+            add(aux1_reg_kernel,
+                    ch_blk * stride_w * static_cast<dim_t>(sizeof(float)));
+            sub(aux1_reg_ddst, sp_step * static_cast<dim_t>(sizeof(float)));
 
             sub(iter_kw, stride_w);
             cmp(iter_kw, 0);
             jg(kw_label, T_NEAR);
         }
 
-        add(aux_reg_kernel, kw * ch_blk * stride_h * sizeof(float));
-        sub(aux_reg_ddst, ow * sp_step * sizeof(float));
+        add(aux_reg_kernel,
+                kw * ch_blk * stride_h * static_cast<dim_t>(sizeof(float)));
+        sub(aux_reg_ddst, ow * sp_step * static_cast<dim_t>(sizeof(float)));
 
         sub(iter_kh, stride_h);
         cmp(iter_kh, 0);
@@ -793,8 +796,8 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_dsrc(
     const dim_t stride_w = jcp.stride_w;
 
     const auto dsrc_layout_nxc = is_dsrc_layout_nxc();
-    const size_t ch_block_step = ch_block * (dsrc_layout_nxc ? 1 : ih * iw);
-    const size_t sp_step
+    const dim_t ch_block_step = ch_block * (dsrc_layout_nxc ? 1 : ih * iw);
+    const dim_t sp_step
             = dsrc_layout_nxc ? jcp.ngroups : ch_block; // spatial step
 
     for (int r = 0; r < reg_repeats_; r++) {
@@ -806,10 +809,10 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::store_dsrc(
             if (last_block && tail_simd_overlap(r)) break;
 
             for (int w = 0; w < ur_str_w; w++) {
-                size_t sp_offset = w * stride_w * sp_step;
-                size_t ch_offset = ch * ch_block_step + r * simd_w_;
-                size_t dsrc_off = static_cast<size_t>(
-                        (sp_offset + ch_offset) * sizeof(float));
+                dim_t sp_offset = w * stride_w * sp_step;
+                dim_t ch_offset = ch * ch_block_step + r * simd_w_;
+                dim_t dsrc_off = (sp_offset + ch_offset)
+                        * static_cast<dim_t>(sizeof(float));
 
                 Vmm vmm_acc
                         = get_acc_reg((r * ur_ch_blocks + ch) * ur_str_w + w);
@@ -843,10 +846,10 @@ inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::ch_loop_body(
                 jcp.nb_ch - (utils::rnd_dn(nb_oc, jcp.nb_ch_blocking)));
         const int ch_step = jcp.nb_ch_blocking * jcp.ch_block;
 
-        const size_t wei_ch_stride = (size_t)jcp.nb_ch_blocking * jcp.kh
-                * jcp.kw * jcp.ch_block * sizeof(float);
-        const size_t data_ch_stride
-                = (size_t)jcp.nb_ch_blocking * jcp.ch_block * sizeof(float);
+        const dim_t wei_ch_stride = static_cast<dim_t>(jcp.nb_ch_blocking)
+                * jcp.kh * jcp.kw * jcp.ch_block * sizeof(float);
+        const dim_t data_ch_stride = static_cast<dim_t>(jcp.nb_ch_blocking)
+                * jcp.ch_block * sizeof(float);
 
         mov(aux_reg_ch_blocks, reg_ch_blocks);
         push(reg_dsrc);
@@ -895,7 +898,7 @@ template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_data_kernel_f32_t<isa>::unroll_width_body(
         int ur_ch_blocks) {
     assert(is_dsrc_layout_nxc() == is_ddst_layout_nxc());
-    const size_t ch_step = sizeof(float)
+    const dim_t ch_step = static_cast<dim_t>(sizeof(float))
             * (is_ddst_layout_nxc() ? jcp.ngroups : jcp.ch_block);
 
     auto unroll_width_loop = [&](int unroll_w) {
@@ -1362,8 +1365,8 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_spatial_loop_bias(
     const int unroll_w_trips = static_cast<int>(jcp.ow / unroll_w);
     const int tail_w = jcp.ow > max_unroll_w_ ? jcp.ow % max_unroll_w_ : 0;
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const size_t ch_offset = ch_step * sizeof(float);
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t ch_offset = ch_step * static_cast<dim_t>(sizeof(float));
 
     mov(reg_oh, ptr[this->param1 + GET_OFF(oh_index)]);
     mov(reg_oh_worksize, ptr[this->param1 + GET_OFF(oh_count)]);
@@ -1525,8 +1528,9 @@ template <cpu_isa_t isa>
 inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::zero_filter_kh_loop(
         int nb_ch_blocking) {
 
-    const size_t filter_offset_kw = jcp.kw * jcp.ch_block * sizeof(float);
-    const size_t filter_offset_kh = jcp.kh * filter_offset_kw;
+    const dim_t filter_offset_kw
+            = jcp.kw * jcp.ch_block * static_cast<dim_t>(sizeof(float));
+    const dim_t filter_offset_kh = jcp.kh * filter_offset_kw;
 
     Label kh_loop_label;
 
@@ -1601,9 +1605,11 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_kh_step(
         int unroll_w, int l_pad, int pad_offset, int ow_block,
         int nb_ch_blocking, bool is_last_ch) {
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const size_t input_offset = jcp.iw * ch_step * sizeof(float);
-    const size_t filter_offset = jcp.kw * jcp.ch_block * sizeof(float);
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t input_offset
+            = jcp.iw * ch_step * static_cast<dim_t>(sizeof(float));
+    const dim_t filter_offset
+            = jcp.kw * jcp.ch_block * static_cast<dim_t>(sizeof(float));
 
     Label kh_loop_label, skip_loop_label;
 
@@ -1692,11 +1698,11 @@ inline void jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_h_loop(
     const dim_t input_bottom_padding_overlap
             = div_up(jcp.ih + jcp.t_pad - (jcp.kh - 1), jcp.stride_h);
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const size_t typesize = sizeof(float);
-    const size_t input_shift = typesize * jcp.iw * ch_step;
-    const size_t output_shift = typesize * jcp.ow * ch_step;
-    const size_t filter_shift = typesize * jcp.kw * jcp.ch_block;
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t typesize = sizeof(float);
+    const dim_t input_shift = typesize * jcp.iw * ch_step;
+    const dim_t output_shift = typesize * jcp.ow * ch_step;
+    const dim_t filter_shift = typesize * jcp.kw * jcp.ch_block;
 
     Label loop_begin_label, loop_end_label, common_block_label,
             top_padding_end_label, bottom_padding_end_label,
@@ -1830,8 +1836,9 @@ jit_uni_dw_conv_bwd_weights_kernel_f32_t<isa>::compute_ow_block_unroll() {
     int unroll_trips = 0;
     calculate_w_unrolling(unroll_trips, unroll_w, unroll_w_tail);
 
-    const size_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
-    const size_t data_offset = unroll_w * ch_step * sizeof(float);
+    const dim_t ch_step = is_layout_nxc() ? jcp.ngroups : jcp.ch_block;
+    const dim_t data_offset
+            = unroll_w * ch_step * static_cast<dim_t>(sizeof(float));
 
     if (jcp.with_bias) compute_bias();
 

--- a/src/cpu/x64/jit_uni_eltwise.cpp
+++ b/src/cpu/x64/jit_uni_eltwise.cpp
@@ -339,7 +339,7 @@ status_t jit_uni_eltwise_fwd_t<isa>::execute(const exec_ctx_t &ctx) const {
 
     const memory_desc_wrapper data_d(pd()->src_md());
     const auto nelems = data_d.nelems(true);
-    const int simd_w = 64 / data_d.data_type_size();
+    const int simd_w = static_cast<int>(64 / data_d.data_type_size());
 
     src += data_d.data_type_size() * data_d.offset0();
     dst += data_d.data_type_size() * data_d.offset0();
@@ -435,7 +435,7 @@ status_t jit_uni_eltwise_bwd_t<isa>::execute(const exec_ctx_t &ctx) const {
     const memory_desc_wrapper data_d(pd()->data_md());
     const memory_desc_wrapper diff_data_d(pd()->diff_src_md());
     const auto nelems = data_d.nelems(true);
-    const int simd_w = 64 / data_d.data_type_size();
+    const int simd_w = static_cast<int>(64 / data_d.data_type_size());
 
     src += data_d.data_type_size() * data_d.offset0();
     diff_dst += diff_data_d.data_type_size() * diff_data_d.offset0();

--- a/src/cpu/x64/jit_uni_i8i8_pooling.cpp
+++ b/src/cpu/x64/jit_uni_i8i8_pooling.cpp
@@ -381,8 +381,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::load_src_avg_op(
             //    vreg_src = [x,x,x,x,.....,x,-,-,-,-,-] ; x => byte data
             //    shift to transform vreg_src = [-,-,-,-,-,x,..,x,x,x,x,]
             // Re-purposing vreg_zeros here. Set it back to zero immmediately.
-            const int msk_gran = cpu_isa_traits_t<avx2>::vlen
-                    / data_type_size(avg_proc_dt);
+            const int msk_gran = static_cast<int>(
+                    cpu_isa_traits_t<avx2>::vlen / data_type_size(avg_proc_dt));
 
             const uint8_t shift
                     = static_cast<uint8_t>(cpu_isa_traits_t<avx2>::vlen
@@ -639,8 +639,8 @@ void jit_uni_i8i8_pooling_fwd_ker_t<avx2>::store_dst_avg_op(
         // mmx_full_msk - mask for all 8 bytes in zero-tail case
         // mmx_mask(ll) - ll-th mask of tail in non-zero-tail case
 
-        const int msk_gran
-                = cpu_isa_traits_t<avx2>::vlen / data_type_size(avg_proc_dt);
+        const int msk_gran = static_cast<int>(
+                cpu_isa_traits_t<avx2>::vlen / data_type_size(avg_proc_dt));
 
         const int ll_end = (ll + 1) * msk_gran; // ((ll + 1) * 8)
 
@@ -1215,7 +1215,8 @@ status_t jit_uni_i8i8_pooling_fwd_ker_t<isa>::init_conf(
     // data_type items per one vreg on the <isa>
     //     isa == avx2    : 32 bytes -> 32 for s8/u8, 8 for s32
     //     isa == avx512* : 64 bytes -> 64 for s8/u8, 16 for s32
-    int simd_w = cpu_isa_traits_t<isa>::vlen / data_type_size(jpp.src_dt);
+    int simd_w = static_cast<int>(
+            cpu_isa_traits_t<isa>::vlen / data_type_size(jpp.src_dt));
 
     /* Verify that vlen-sized memory access happens within the tensor's
      * size, otherwise load/store will always spill outside the memory

--- a/src/cpu/x64/jit_uni_pool_kernel.cpp
+++ b/src/cpu/x64/jit_uni_pool_kernel.cpp
@@ -1212,12 +1212,13 @@ void jit_uni_pool_kernel_t<isa>::zero_diff_src(
         mov(aux_reg_zero_ih, reg_zero_ih);
         L(l_ih_loop);
         {
-            const int step = c_off * dt_size;
+            const int step = static_cast<int>(c_off * dt_size);
 
             // TODO: maybe a big code generated here
             for_(dim_t i = 0; i < width_size; i += step)
             for (int bci = 0; bci < ur_bc; bci++) {
-                const int offs = i + bci * jpp.c_block * dt_size;
+                const int offs
+                        = static_cast<int>(i + bci * jpp.c_block * dt_size);
                 store(src_dt, vzero.getIdx(), reg_zero_ptr, offs,
                         is_tail_processing(bci));
             }

--- a/src/cpu/x64/jit_uni_pooling.cpp
+++ b/src/cpu/x64/jit_uni_pooling.cpp
@@ -744,8 +744,8 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward(
                 const memory_desc_wrapper tmp_d
                         = memory_desc_wrapper(jpp.tmp_md);
                 // offset needs to be f32
-                const int dt_scale
-                        = sizeof(float) / types::data_type_size(d_type);
+                const int dt_scale = static_cast<int>(
+                        sizeof(float) / types::data_type_size(d_type));
                 const auto blk_off = tmp_d.blk_off(n, c_off, oh) * dt_scale;
                 args.dst_po_helper = static_cast<const void *>(&dst[blk_off]);
             }
@@ -875,8 +875,8 @@ void jit_uni_pooling_fwd_t<isa, d_type>::execute_forward_3d(
                 const memory_desc_wrapper tmp_d
                         = memory_desc_wrapper(jpp.tmp_md);
                 // offset needs to be f32
-                const int dt_scale
-                        = sizeof(float) / types::data_type_size(d_type);
+                const int dt_scale = static_cast<int>(
+                        sizeof(float) / types::data_type_size(d_type));
                 const auto blk_off = tmp_d.blk_off(n, c_off, od, oh) * dt_scale;
                 args.dst_po_helper = static_cast<const void *>(&dst[blk_off]);
             }

--- a/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_1x1_conv_kernel.cpp
@@ -573,21 +573,23 @@ void jit_uni_x8s8s32x_1x1_conv_kernel_vmm_t<isa, Vmm>::generate() {
         if (jcp.signed_input) {
             mov(reg_comp_data, ptr[rsp + reg_comp_data_off]);
             add(reg_comp_data,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(ptr[rsp + reg_comp_data_off], reg_comp_data);
         }
         if (jcp.src_zero_point) {
             mov(reg_zp_compensation, ptr[rsp + reg_zp_compensation_off]);
             add(reg_zp_compensation,
-                    load_loop_blk * jcp.load_block * sizeof(int32_t));
+                    static_cast<uint32_t>(
+                            load_loop_blk * jcp.load_block * sizeof(int32_t)));
             mov(ptr[rsp + reg_zp_compensation_off], reg_zp_compensation);
         }
         mov(ptr[rsp + reg_bcast_data_off], reg_bcast_data);
         if (jcp.with_wei_scales) {
             mov(reg_wei_scales, ptr[rsp + reg_wei_scales_off]);
             add(reg_wei_scales,
-                    jcp.is_oc_scale * load_loop_blk * jcp.load_block
-                            * sizeof(float));
+                    static_cast<uint32_t>(jcp.is_oc_scale * load_loop_blk
+                            * jcp.load_block * sizeof(float)));
             mov(ptr[rsp + reg_wei_scales_off], reg_wei_scales);
         }
         mov(reg_bcast_data, ptr[rsp + reg_bcast_data_off]);
@@ -781,8 +783,8 @@ status_t jit_uni_x8s8s32x_1x1_conv_kernel_t<isa>::init_conf(
     int reduce_blocking_max = 0;
     jcp.load_grp_count = 1;
 
-    const int L2_size
-            = platform::get_per_core_cache_size(2) / sizeof(jcp.typesize_in);
+    const int L2_size = static_cast<int>(
+            platform::get_per_core_cache_size(2) / sizeof(jcp.typesize_in));
     const int L2_capacity = (L2_size * 3) / 4;
 
     int size_threshold = 28;

--- a/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
+++ b/src/cpu/x64/jit_uni_x8s8s32x_deconvolution.cpp
@@ -652,8 +652,8 @@ void jit_uni_x8s8s32x_deconv_fwd_kernel_vmm_t<isa,
     if (jcp_.ndims > 3) {
         if (!base_comp_addr_loaded) load_base_zp_src_pad_comp_addr();
 
-        const auto kh_offset = jcp_.kw * jcp_.oc_without_padding * jcp_.ngroups
-                * sizeof(int32_t);
+        const dim_t kh_offset = jcp_.kw * jcp_.oc_without_padding * jcp_.ngroups
+                * static_cast<dim_t>(sizeof(int32_t));
 
         add(reg_zp_src_pad_comp, kh_offset);
         mov(zp_src_pad_comp_addr_, reg_zp_src_pad_comp);

--- a/src/cpu/x64/jit_uni_xf16_sum.cpp
+++ b/src/cpu/x64/jit_uni_xf16_sum.cpp
@@ -165,7 +165,9 @@ void jit_avx512_core_bf16_sum_kernel_t::tail_iteration() {
 
     for (int s = 0; s < jsp.num_srcs; s++)
         add(reg_src[s], bf16_half_reg * jsp.typesize_in);
-    add(reg_dst, (vreg_traits_t<Zmm>::vlen / 4) * jsp.typesize_out);
+    add(reg_dst,
+            static_cast<uint32_t>(
+                    (vreg_traits_t<Zmm>::vlen / 4) * jsp.typesize_out));
 
     jmp(tail_label, T_NEAR);
 }

--- a/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.cpp
+++ b/src/cpu/x64/lrn/jit_avx512_common_lrn_fwd_base.cpp
@@ -74,7 +74,7 @@ void jit_avx512_common_lrn_kernel_fwd_t<d_type>::load_tail(int tail_value,
 
     // TODO: Investigate if this method can be simplified by using mask or
     // jit_generator_t load utilities.
-    static constexpr auto src_size = sizeof(data_t);
+    static constexpr int src_size = static_cast<int>(sizeof(data_t));
     auto tmp_xreg = this->xreg(0, tmp_load_to_stack_idx_tail);
 
     const auto load_tail_simd = [&](Xmm tmp_reg, int vlen) {

--- a/src/cpu/x64/platform.cpp
+++ b/src/cpu/x64/platform.cpp
@@ -117,7 +117,7 @@ uint32_t calculate_per_core_cache(size_t cpu_index, int level) {
     // Physical cores sharing this cache (mirrors legacy smt_width division).
     size_t sharing_cores = std::max(sharing_logical / smt_width, size_t(1));
 
-    return cache.size / sharing_cores;
+    return static_cast<uint32_t>(cache.size / sharing_cores);
 }
 
 struct cache_level_info_t {

--- a/src/cpu/x64/prelu/jit_prelu_utils.cpp
+++ b/src/cpu/x64/prelu/jit_prelu_utils.cpp
@@ -212,7 +212,9 @@ void apply_zero_padding(jit_generator_t *host, const size_t tail_size,
     if (reg_offset == nullptr)
         host->lea(reg_ptr, ptr[reg_dst + off_start]);
     else
-        host->lea(reg_ptr, ptr[reg_dst + (*reg_offset * dt_size) + off_start]);
+        host->lea(reg_ptr,
+                ptr[reg_dst + (*reg_offset * static_cast<int>(dt_size))
+                        + off_start]);
     host->mov(reg_counter, off_end - off_start);
     host->rep();
     host->stosb();

--- a/src/cpu/x64/rnn/jit_brgemm_transpose_src.cpp
+++ b/src/cpu/x64/rnn/jit_brgemm_transpose_src.cpp
@@ -245,7 +245,7 @@ void jit_brgemm_trans_m_k_f32_t::transpose_16x16_avx2(int nrows, int ncolumns) {
     // mask stores.
     assert(conf_->os_block % transpose_size == 0);
     auto load_src = [&](Xmm vmm, int r, int c) {
-        const int simd_w = vmm.getBit() / (sizeof(float) * 8);
+        const int simd_w = static_cast<int>(vmm.getBit() / (sizeof(float) * 8));
         const auto addr = ptr[reg_src + r * src_stride + c * sizeof(float)];
         if (r >= nrows) {
             uni_vxorps(vmm, vmm, vmm);

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_bwd.hpp
@@ -45,9 +45,8 @@ protected:
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
     const int vlen_scratch = vlen
-            / (sizeof(float)
-                    / static_cast<dim_t>(
-                            types::data_type_size(scratch_data_t)));
+            / static_cast<int>(
+                    sizeof(float) / types::data_type_size(scratch_data_t));
     static constexpr int hstate_dt_size = sizeof(float);
     const int gate_dt_size
             = static_cast<int>(types::data_type_size(scratch_data_t));

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_1_fwd.hpp
@@ -57,9 +57,11 @@ protected:
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
     static constexpr int qscale_dt_size = sizeof(float);
-    const int vlen_dst
-            = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const int vlen_bias_ = vlen / (sizeof(float) / bias_dt_size_);
+    const int vlen_dst = vlen
+            / static_cast<int>(
+                    sizeof(float) / types::data_type_size(src_data_t));
+    const int vlen_bias_
+            = vlen / static_cast<int>(sizeof(float) / bias_dt_size_);
     const int hstate_dt_size
             = static_cast<int>(types::data_type_size(src_data_t));
     const int gate_dt_size

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_bwd.hpp
@@ -46,9 +46,8 @@ protected:
     static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
     static constexpr int hstate_dt_size = sizeof(float);
     const int vlen_scratch = vlen
-            / (sizeof(float)
-                    / static_cast<dim_t>(
-                            types::data_type_size(scratch_data_t)));
+            / static_cast<int>(
+                    sizeof(float) / types::data_type_size(scratch_data_t));
     const int gate_dt_size
             = static_cast<int>(types::data_type_size(scratch_data_t));
     const int scratch_dt_size

--- a/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_gru_cell_postgemm_2_fwd.hpp
@@ -56,9 +56,11 @@ protected:
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
     static constexpr int qscale_dt_size = sizeof(float);
-    const int vlen_dst
-            = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const int vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
+    const int vlen_dst = vlen
+            / static_cast<int>(
+                    sizeof(float) / types::data_type_size(src_data_t));
+    const int vlen_bias
+            = vlen / static_cast<int>(sizeof(float) / bias_dt_size_);
     const int hstate_dt_size
             = static_cast<int>(types::data_type_size(src_data_t));
     const int gate_dt_size

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_bwd.hpp
@@ -65,14 +65,16 @@ protected:
 
     // register size in bytes
     static constexpr int vlen_ = cpu_isa_traits_t<isa>::vlen;
-    const int vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
+    const int vlen_c_states_
+            = vlen_ / static_cast<int>(sizeof(float) / cstate_dt_size_);
 
     static constexpr int diff_cstate_dt_size_ = sizeof(float);
     static constexpr int hstate_dt_size_ = sizeof(float);
     static constexpr int weights_peephole_dt_size_ = sizeof(float);
 
-    const int vlen_scratch_
-            = vlen_ / (sizeof(float) / types::data_type_size(scratch_data_t));
+    const int vlen_scratch_ = vlen_
+            / static_cast<int>(
+                    sizeof(float) / types::data_type_size(scratch_data_t));
     const int gate_dt_size_
             = static_cast<int>(types::data_type_size(scratch_data_t));
     const int scratch_dt_size_

--- a/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_lstm_cell_postgemm_fwd.hpp
@@ -72,10 +72,13 @@ protected:
     static constexpr int vlen_ = cpu_isa_traits_t<isa>::vlen;
     static constexpr int qscale_dt_size = sizeof(float);
     static constexpr int weights_peephole_dt_size_ = sizeof(float);
-    const int vlen_dst_
-            = vlen_ / (sizeof(float) / types::data_type_size(src_data_t));
-    const int vlen_bias_ = vlen_ / (sizeof(float) / bias_dt_size_);
-    const int vlen_c_states_ = vlen_ / (sizeof(float) / cstate_dt_size_);
+    const int vlen_dst_ = vlen_
+            / static_cast<int>(
+                    sizeof(float) / types::data_type_size(src_data_t));
+    const int vlen_bias_
+            = vlen_ / static_cast<int>(sizeof(float) / bias_dt_size_);
+    const int vlen_c_states_
+            = vlen_ / static_cast<int>(sizeof(float) / cstate_dt_size_);
     const int hstate_dt_size_
             = static_cast<int>(types::data_type_size(src_data_t));
     const int gate_dt_size_

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_bwd.hpp
@@ -45,8 +45,9 @@ protected:
     using Vmm = typename cpu_isa_traits_t<isa>::Vmm;
     static constexpr int vlen = cpu_isa_traits_t<isa>::vlen;
     static constexpr int hstate_dt_size = sizeof(float);
-    const int vlen_scratch
-            = vlen / (sizeof(float) / types::data_type_size(scratch_data_t));
+    const int vlen_scratch = vlen
+            / static_cast<int>(
+                    sizeof(float) / types::data_type_size(scratch_data_t));
     const int gate_dt_size
             = static_cast<int>(types::data_type_size(scratch_data_t));
     const int scratch_dt_size

--- a/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
+++ b/src/cpu/x64/rnn/jit_uni_rnn_cell_postgemm_fwd.hpp
@@ -55,9 +55,11 @@ protected:
     static constexpr int cstate_dt_size = sizeof(float);
     static constexpr int qscale_dt_size = sizeof(float);
 
-    const int vlen_dst
-            = vlen / (sizeof(float) / types::data_type_size(src_data_t));
-    const int vlen_bias = vlen / (sizeof(float) / bias_dt_size_);
+    const int vlen_dst = vlen
+            / static_cast<int>(
+                    sizeof(float) / types::data_type_size(src_data_t));
+    const int vlen_bias
+            = vlen / static_cast<int>(sizeof(float) / bias_dt_size_);
     const int hstate_dt_size
             = static_cast<int>(types::data_type_size(src_data_t));
     const int gate_dt_size

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -270,8 +270,8 @@ protected:
         if (postops_cfg_.post_ops) {
             injector.reset(new postops_injector_t(*this, avx2,
                     *postops_cfg_.post_ops, *postops_cfg_.dst_md, abi_param1,
-                    postops_cfg_.rhs_arg_offset, postops_cfg_.dst_orig_offset,
-                    postops_cfg_.tail_elems));
+                    static_cast<int>(postops_cfg_.rhs_arg_offset),
+                    postops_cfg_.dst_orig_offset, postops_cfg_.tail_elems));
             emit_injector = [&](const std::vector<int> &acc_phys, int base_phys,
                                     const std::vector<dim_t> &out_byte_off,
                                     int mask_phys, int elems) {


### PR DESCRIPTION
This PR eliminates C4267 warning (unsigned implicit down-conversion) as complementary fix to [MFDNN-14954](https://jira.devtools.intel.com/browse/MFDNN-14954).
Fixed via changing local variables and casting. 