### PR TITLE
[CPU] Asynchronous verbose mode for async threadpool 

### DIFF
--- a/include/oneapi/dnnl/dnnl_threadpool_iface.hpp
+++ b/include/oneapi/dnnl/dnnl_threadpool_iface.hpp
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <memory>
 
 namespace dnnl {
 
@@ -36,6 +37,23 @@ namespace dnnl {
 /// @{
 
 namespace threadpool_interop {
+
+/// Completion event interface for async threadpool work. oneDNN's verbose
+/// profiler polls these to determine when deferred execution has finished
+/// and to extract timing information.
+struct threadpool_event_iface_t {
+    virtual ~threadpool_event_iface_t() = default;
+    /// Returns true if the associated work has completed.
+    virtual bool is_complete() const = 0;
+    /// Blocks until completion.
+    virtual void wait() const = 0;
+    /// Measured execution time in milliseconds. Valid only after completion.
+    /// Should reflect wall-clock duration from when the first worker begins
+    /// to when the last worker finishes. Use a CAS to stamp the start time
+    /// so only the first worker records it, and record the end time in the
+    /// async completion callback once all workers have resolved.
+    virtual double exec_time_ms() const = 0;
+};
 
 /// Abstract threadpool interface. The users are expected to subclass this
 /// interface and pass an object to the library during CPU stream creation or
@@ -59,6 +77,19 @@ struct threadpool_iface {
 
     // Does nothing if SYNCHRONOUS, waits for all jobs for ASYNCHRONOUS
     virtual void wait() = 0;
+
+    /// Returns a single completion event for the most recently submitted
+    /// primitive dispatch, or nullptr if profiling is disabled or
+    /// unsupported. oneDNN calls this once per primitive immediately after
+    /// enqueue_primitive() returns.
+    ///
+    /// Implementations should lazily create the event in parallel_for() and
+    /// move it out here, registering an async completion callback (e.g.
+    /// AndThen) that calls mark_complete() once all workers have finished.
+    /// This ensures exec_time_ms() is valid when is_complete() returns true.
+    virtual std::shared_ptr<threadpool_event_iface_t> get_event() {
+        return nullptr;
+    }
 
     /// If set, parallel_for() returns immediately and oneDNN needs implement
     /// waiting for the submitted closures to finish execution on its own.

--- a/src/common/primitive_iface.cpp
+++ b/src/common/primitive_iface.cpp
@@ -163,32 +163,23 @@ status_t primitive_execute(
             pd_info = pd->info();
         }
 
-        if (!stream->is_verbose_profiler_enabled()) {
-            bool block_on_wait = true;
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
-            dnnl::threadpool_interop::threadpool_iface *tp;
-            auto st = stream->get_threadpool(&tp);
-            const bool is_async_cpu = st == status::success && tp
-                    && (tp->get_flags()
-                            & dnnl::threadpool_interop::threadpool_iface::
-                                    ASYNCHRONOUS)
-                    && stream->engine()->kind() == engine_kind::cpu;
-            block_on_wait = !is_async_cpu;
-#endif
+        // Block around execution to measure host-side timing, unless the runtime
+        // supports non-blocking device-measured profiling (GPU runtimes and
+        // async threadpool CPU).
+        const bool block_on_wait = !stream->is_verbose_profiler_enabled()
+                && !stream->impl()->is_async_threadpool();
 
-            if (block_on_wait) stream->wait();
-            double start_ms = get_msec();
-            status = stream->enqueue_primitive(primitive_iface, ctx);
-            if (block_on_wait) stream->wait();
+        if (block_on_wait) stream->wait();
+        double start_ms = get_msec();
+        status = stream->enqueue_primitive(primitive_iface, ctx);
+        if (block_on_wait) stream->wait();
+
+        if (stream->is_verbose_profiler_enabled()) {
+            CHECK(stream->run_verbose_profiler(pd_info, start_ms, 0));
+        } else {
             double duration_ms = get_msec() - start_ms;
             VPROF(start_ms, primitive, exec, VERBOSE_profile, pd_info.c_str(),
                     duration_ms);
-        } else {
-            // For OpenCL/SYCL GPU streams, the verbose logs print device-
-            // measured execution times in a non-blocking manner.
-            double start_ms = get_msec();
-            status = stream->enqueue_primitive(primitive_iface, ctx);
-            CHECK(stream->run_verbose_profiler(pd_info, start_ms, 0));
         }
     } else {
         status = stream->enqueue_primitive(primitive_iface, ctx);

--- a/src/common/stream_impl.hpp
+++ b/src/common/stream_impl.hpp
@@ -21,10 +21,13 @@
 
 #include "common/c_types_map.hpp"
 #include "common/utils.hpp"
+#include "common/verbose.hpp"
 
 namespace dnnl {
 namespace impl {
 
+// TODO: introduce a stream_impl_t subclass for CPU streams to separate general
+// and CPU-specific attributes.
 class stream_impl_t {
 public:
     stream_impl_t() = delete;
@@ -47,16 +50,41 @@ public:
 
     bool is_verbose_profiler_enabled() const { return use_verbose_profiler_; }
 
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+    bool is_async_threadpool() const {
+        if (!threadpool_) return false;
+        return threadpool_->get_flags()
+                & threadpool_interop::threadpool_iface::ASYNCHRONOUS;
+    }
+
     // Checks and initializes profiler for supported runtime configs
-    virtual status_t init_verbose_profiler(engine_kind_t) {
+    virtual status_t init_verbose_profiler(engine_kind_t engine_kind) {
         use_verbose_profiler_ = false;
+
+        // The checks are only relevant for a CPU engine
+        if (engine_kind != engine_kind::cpu) return status::success;
+
+        if (!dnnl::impl::get_verbose(dnnl::impl::verbose_t::exec_profile))
+            return status::success;
+
+        // CPU stream must be backed by an async threadpool to support
+        // profiling
+        if (!is_async_threadpool()) return status::success;
+
+        use_verbose_profiler_ = true;
         return status::success;
     }
 
-#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     status_t get_threadpool(
             threadpool_interop::threadpool_iface **threadpool) const {
         *threadpool = threadpool_;
+        return status::success;
+    }
+#else
+    bool is_async_threadpool() const { return false; }
+
+    virtual status_t init_verbose_profiler(engine_kind_t) {
+        use_verbose_profiler_ = false;
         return status::success;
     }
 #endif

--- a/src/common/verbose_profiler.hpp
+++ b/src/common/verbose_profiler.hpp
@@ -1,0 +1,101 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef COMMON_VERBOSE_PROFILER_HPP
+#define COMMON_VERBOSE_PROFILER_HPP
+
+#include <string>
+#include "c_types_map.hpp"
+
+namespace dnnl {
+namespace impl {
+
+// The verbose profiler logs primitive profiling information using device-
+// measured execution times without host-to-device synchronization overhead or
+// blocking stream.wait() calls. It operates asynchronously by polling device
+// events to track primitive completion status.
+// During primitive execution, the profiler groups and registers kernel events
+// for each primitive with the associated profiling metadata. During each
+// primitive post-exec hook, it polls previously registered events to identify
+// completed primitives and logs their timing info. Pending primitives remain
+// in the profiling data containers (different for different runtimes) list
+// until detected as complete in subsequent polling cycles.
+// During profiler destruction, any remaining primitives are checked and
+// waited for to ensure no executions are left unlogged.
+// This profiler is intended to be thread-local via thread_local_storage_t,
+// ensuring thread-safety for multi-threaded execution environments. Each
+// thread maintains its own profiler instance and event tracking state,
+// operating independently from other stream profilers during primitive
+// execution.
+struct verbose_profiler_t {
+    verbose_profiler_t(const stream_t *stream)
+        : stream_(stream), active_(true) {}
+
+    virtual ~verbose_profiler_t() = default;
+
+    // Pausing capabilities are added to allow skipping event profiling
+    // queries when they are temporarily unavailable.
+    // These methods check and update profiler status where such force-pausing
+    // is required. Pausing action is localized to each thread for multi-
+    // threaded execution
+    bool is_active() const { return active_; }
+    void start_profiling() { active_ = true; }
+    void pause_profiling() { active_ = false; }
+
+    // The profiler operates through a multi-step event tracking workflow:
+    // 1. stream->before_exec_hook() calls update_event_list()
+    //    to add a new entry for the current primitive. Since there can be
+    //    multiple event registration calls, this spot is a guaranteed single
+    //    call for the coming primitive.
+    // 2. During primitive execution, register_event() (defined in subclasses)
+    //    adds device events to the latest primitive entry corresponding to the
+    //    number of invoked kernels.
+    // 3. add_to_pending_primitive_list() stores profiling metadata
+    //    for the registered primitive
+    // 4. stream->after_exec_hook() calls check_for_completed_primitives()
+    //    to poll events and log completed primitives
+    // 5. Incomplete primitives are not removed until detected as
+    //    complete in future polling cycles
+    // This asynchronous workflow allows tracking multiple concurrent
+    // primitives without blocking execution.
+    virtual void update_event_list() = 0;
+
+    // populates profiling metadata for the last primitive entry
+    virtual void add_to_pending_primitive_list(
+            double start_ms, const std::string &pd_info, uint64_t component)
+            = 0;
+
+    // Completed primitive executions are periodically checked and logged
+    // during after_exec_hook() calls and during stream destruction.
+    // The profiler does not wait for pending events to complete
+    // and instead prints them at the next concurrent after_exec_hook()
+    // call.
+    virtual void check_for_completed_primitives() = 0;
+
+protected:
+    const stream_t *stream_;
+    bool active_;
+
+private:
+    // This is invoked during profiler destruction to account for any
+    // pending primitives that have not yet been logged.
+    virtual void wait_for_pending_primitives() = 0;
+};
+
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/cpu_stream.hpp
+++ b/src/cpu/cpu_stream.hpp
@@ -20,6 +20,8 @@
 #include "oneapi/dnnl/dnnl_config.h"
 
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "common/thread_local_storage.hpp"
+#include "cpu/verbose_profiler.hpp"
 #include "oneapi/dnnl/dnnl_threadpool_iface.hpp"
 #endif
 
@@ -33,7 +35,17 @@ namespace cpu {
 
 struct cpu_stream_t : public stream_t {
     cpu_stream_t(engine_t *engine, impl::stream_impl_t *stream_impl)
-        : stream_t(engine, stream_impl) {}
+        : stream_t(engine, stream_impl) {
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+        // Initialize the verbose profiler based on threadpool capabilities.
+        // init_verbose_profiler() enables verbose profiling on the
+        // stream_impl_t if all required conditions are met.
+        // (Streams created via dnnl_threadpool_interop_stream_create() take
+        // this path rather than the dedicated threadpool constructor, so
+        // init_verbose_profiler() must be called here too.)
+        impl()->init_verbose_profiler(engine->kind());
+#endif
+    }
     ~cpu_stream_t() override = default;
 
     dnnl::impl::status_t wait() override {
@@ -53,17 +65,83 @@ struct cpu_stream_t : public stream_t {
 #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
     cpu_stream_t(engine_t *engine,
             dnnl::threadpool_interop::threadpool_iface *threadpool)
-        : stream_t(engine, new impl::stream_impl_t(threadpool)) {}
+        : stream_t(engine, new impl::stream_impl_t(threadpool)) {
+        // Initialize the verbose profiler based on threadpool capabilities.
+        // init_verbose_profiler() enables verbose profiling on the
+        // stream_impl_t if all required conditions are met.
+        impl()->init_verbose_profiler(engine->kind());
+    }
+
+    // Returns a pointer to the active per-thread verbose profiler,
+    // or nullptr if the profiler has not been initialized for this thread.
+    cpu::verbose_profiler_t *verbose_profiler() const {
+        return (is_verbose_profiler_enabled() && verbose_profiler_.is_set())
+                ? verbose_profiler_.get().get()
+                : nullptr;
+    }
 
     void before_exec_hook() override {
         dnnl::threadpool_interop::threadpool_iface *tp;
         auto rc = this->get_threadpool(&tp);
         if (rc == status::success) threadpool_utils::activate_threadpool(tp);
+
+        // Instantiate the per-thread verbose profiler on first use and
+        // add a new entry for the incoming primitive.
+        if (is_verbose_profiler_enabled()) {
+            auto &verbose_profiler = verbose_profiler_.get_or_set(
+                    utils::make_unique<cpu::verbose_profiler_t>(this));
+            verbose_profiler->update_event_list();
+        }
     }
 
     void after_exec_hook() override {
+        if (auto *vp = verbose_profiler()) {
+            vp->check_for_completed_primitives();
+        }
         threadpool_utils::deactivate_threadpool();
     }
+
+    status_t run_verbose_profiler(
+            const std::string &pd_info, double start_ms, uint64_t component) {
+        if (!is_verbose_profiler_enabled()) {
+            VERROR(primitive, exec,
+                    "running verbose profiler while it is not enabled");
+            return status::success;
+        }
+
+        auto *vp = verbose_profiler();
+        if (!vp) return status::success;
+
+        // Retrieve the completion event for the most recently dispatched
+        // parallel_for() from the threadpool. This must be called after
+        // enqueue_primitive() returns to ensure the event corresponds to
+        // the correct dispatch.
+        dnnl::threadpool_interop::threadpool_iface *tp;
+        CHECK(get_threadpool(&tp));
+        if (!tp) {
+            VERROR(primitive, exec,
+                    "unable to fetch threadpool for verbose profiling");
+            return status::success;
+        }
+
+        // register_event() is a no-op if event is null, which is the
+        // fallback path for threadpools that do not support profiling
+        const auto event = tp->get_event();
+        vp->register_event(event);
+        vp->add_to_pending_primitive_list(start_ms, pd_info, component);
+
+        return status::success;
+    }
+
+private:
+    // Per-thread verbose profiler instance.
+    // Thread-local storage ensures each submission thread maintains its
+    // own independent profiling_data_ list and event tracking state.
+    // Worker threads interact only with threadpool_event_iface_t directly via
+    // the completion mechanism and never access the profiler state.
+    utils::thread_local_storage_t<std::unique_ptr<cpu::verbose_profiler_t>>
+            verbose_profiler_;
+
 #endif
 };
 

--- a/src/cpu/verbose_profiler.cpp
+++ b/src/cpu/verbose_profiler.cpp
@@ -1,0 +1,206 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "cpu/verbose_profiler.hpp"
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#include "common/verbose.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+
+void verbose_profiler_t::add_to_pending_primitive_list(
+        double start_ms, const std::string &pd_info, uint64_t component) {
+    assert(!profiling_data_.empty());
+
+    auto &last_entry = profiling_data_.back();
+    last_entry.start_ms_ = start_ms;
+    last_entry.pd_info_ = pd_info;
+    last_entry.component_kind_ = component;
+}
+
+void verbose_profiler_t::check_for_completed_primitives() {
+    if (!active_) return;
+
+    // Polling stops at the first pending primitive to ensure primitives
+    // are logged in the same order they were enqueued. Pending primitives
+    // remain in profiling_data_ until the next polling cycle.
+    size_t first_pending = profiling_data_.size();
+
+    auto log_profile
+            = [](const prim_profile_data_t &prof_data, double duration_ms) {
+        // allows execution time-tracking for different component kinds
+        switch (static_cast<component_t::flag_kind>(
+                prof_data.component_kind_)) {
+            case component_t::graph:
+                VPROF(prof_data.start_ms_, graph, exec, VERBOSE_profile,
+                        prof_data.pd_info_.c_str(), duration_ms);
+                break;
+            case component_t::ukernel:
+                VPROF(prof_data.start_ms_, ukernel, exec, VERBOSE_profile,
+                        prof_data.pd_info_.c_str(), duration_ms);
+                break;
+            case component_t::primitive:
+            default:
+                VPROF(prof_data.start_ms_, primitive, exec, VERBOSE_profile,
+                        prof_data.pd_info_.c_str(), duration_ms);
+                break;
+        }
+    };
+
+    for (size_t index = 0; index < profiling_data_.size(); ++index) {
+        const auto &prof_data = profiling_data_[index];
+        const auto &evts = prof_data.prim_events_;
+        double duration_ms = 0.0;
+
+        // Handles primitives with no kernels
+        if (evts.empty()) {
+            if (!prof_data.pd_info_.empty())
+                log_profile(prof_data, duration_ms);
+            continue;
+        }
+
+        // No point in logging entries without info strings
+        if (prof_data.pd_info_.empty()) continue;
+
+        // Stop polling at the first incomplete primitive to preserve
+        // in-order logging.
+        if (!is_event_complete(evts.back())) {
+            first_pending = index;
+            break;
+        }
+
+        status_t status = get_aggregate_exec_time(index, duration_ms);
+        if (status == status::success) {
+            log_profile(prof_data, duration_ms);
+        } else {
+            VERROR(common, runtime,
+                    "%s, profiling error: failures in exec time computation",
+                    prof_data.pd_info_.c_str());
+        }
+    }
+
+    // A second pass through profiling_data_ erases the entry for all
+    // completed to avoid blowing up the size of profiling_data_
+    if (first_pending > 0) {
+        profiling_data_.erase(profiling_data_.begin(),
+                profiling_data_.begin() + first_pending);
+    }
+}
+
+void verbose_profiler_t::wait_for_pending_primitives() {
+    if (!active_) return;
+
+    // For in-order threadpool dispatch, waiting on the last event is
+    // sufficient since all prior dispatches complete before the last one.
+    // Iterate in reverse to find the last primitive with a registered event.
+    if (!profiling_data_.empty()) {
+        for (auto it = profiling_data_.rbegin(); it != profiling_data_.rend();
+                ++it) {
+            const auto &evts = it->prim_events_;
+            if (!evts.empty() && evts.back()) {
+                wait_for_event_completion(evts.back());
+                break;
+            }
+        }
+    }
+
+    check_for_completed_primitives();
+
+    // Any remaining entries after the final check indicate a profiling
+    // failure — log an error to avoid silent data loss
+    if (!profiling_data_.empty())
+        VERROR(primitive, runtime,
+                "profiling error: failed to log all pending primitives");
+}
+
+void verbose_profiler_t::cleanup() {
+    try {
+        wait_for_pending_primitives();
+    } catch (const std::bad_alloc &) {
+        VERROR(primitive, exec,
+                "profiler cleanup failed: out of memory during event "
+                "processing");
+    } catch (const std::runtime_error &e) {
+        VERROR(primitive, exec, "profiler cleanup failed: runtime error - %s",
+                e.what());
+    } catch (const std::exception &e) {
+        VERROR(primitive, exec, "profiler cleanup failed: %s", e.what());
+    } catch (...) {
+        VERROR(primitive, exec, "profiler cleanup failed: unknown error");
+    }
+}
+
+status_t verbose_profiler_t::get_aggregate_exec_time(
+        size_t index, double &duration_ms) const {
+    if (!active_) return status::success;
+
+    if (index >= profiling_data_.size()) {
+        VERROR(primitive, exec,
+                "profiling error: invalid index %zu, profiling_data size is "
+                "%zu",
+                index, profiling_data_.size());
+        return status::success;
+    }
+
+    const auto &prof_data = profiling_data_[index];
+    const auto &evts = prof_data.prim_events_;
+
+    // No event: primitive had no dispatch or profiler was paused
+    if (evts.empty()) {
+        duration_ms = 0.0;
+        return status::success;
+    }
+
+    // Delegate to the threadpool implementor for the measured execution time.
+    // exec_time_ms() is only valid after is_complete() returns true, which
+    // is guaranteed by the check in check_for_completed_primitives().
+    duration_ms = 0.0;
+    for (const auto &ev : evts) {
+        if (!ev) continue;
+        // The XPU-variant of the profiler which computes the execution time
+        // from the start time of the first event and the end time of the last
+        // event to capture wall-clock overlap between concurrent kernels.
+        // for threadpool, however, we sum exec_time_ms() directly since the
+        // threadpool interface exposes only a single measured duration per event
+        //  rather than separate start/end timestamps.
+        duration_ms += ev->exec_time_ms();
+    }
+    return status::success;
+}
+
+bool verbose_profiler_t::is_event_complete(const std::shared_ptr<
+        dnnl::threadpool_interop::threadpool_event_iface_t> &event) const {
+    if (!active_) return true;
+
+    // Empty event is treated as immediately complete (no-kernel primitive)
+    if (!event) return true;
+    return event->is_complete();
+}
+
+void verbose_profiler_t::wait_for_event_completion(const std::shared_ptr<
+        dnnl::threadpool_interop::threadpool_event_iface_t> &event) const {
+    if (!active_) return;
+    if (!event) return;
+    event->wait();
+}
+
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL

--- a/src/cpu/verbose_profiler.hpp
+++ b/src/cpu/verbose_profiler.hpp
@@ -1,0 +1,102 @@
+/*******************************************************************************
+* Copyright 2020 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_VERBOSE_PROFILER_HPP
+#define CPU_VERBOSE_PROFILER_HPP
+
+#include "common/c_types_map.hpp"
+
+#if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "common/verbose_profiler.hpp"
+#include "oneapi/dnnl/dnnl_threadpool_iface.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+
+// CPU async threadpool specialization of verbose_profiler_t.
+// Tracks primitive completion using threadpool_event_iface_t handles registered
+// with the threadpool after each parallel_for() dispatch.
+// Instantiated on the submission thread via thread_local_storage_t on the
+// CPU stream. Each submission thread maintains its own profiling_data_,
+// operating independently from other primitive threads.
+// Using a thread_local_storage_t definition is still valid as the
+// profiling operations via enqueue_primtive() and pre-exec/post-exec hooks
+// are done through a single calling thread.
+struct verbose_profiler_t : public impl::verbose_profiler_t {
+    using impl::verbose_profiler_t::verbose_profiler_t;
+
+    ~verbose_profiler_t() override { cleanup(); }
+
+    // Holds profiling metadata and threadpool event for a single pending
+    // primitive. Mirrors xpu::verbose_profiler_t::prim_profile_data_t
+    // but uses threadpool_event_iface_t in place of xpu::event_t.
+    struct prim_profile_data_t {
+        uint64_t component_kind_ = 0;
+        double start_ms_ = 0.0;
+        std::string pd_info_;
+        std::vector<std::shared_ptr<
+                dnnl::threadpool_interop::threadpool_event_iface_t>>
+                prim_events_;
+    };
+
+    void update_event_list() override { profiling_data_.emplace_back(); }
+
+    // Sets the threadpool event handle for the last entry in profiling_data_.
+    // Called from enqueue_primitive() after registering the primitive event
+    // with the threadpool.
+    // Unlike the XPU profiler which may register multiple events per
+    // primitive (one per kernel), the threadpool profiler registers a
+    // single event per primitive dispatch.
+    void register_event(const std::shared_ptr<
+            dnnl::threadpool_interop::threadpool_event_iface_t> &event) {
+        if (!event || profiling_data_.empty()) return;
+        profiling_data_.back().prim_events_.push_back(event);
+    }
+
+    void add_to_pending_primitive_list(double start_ms,
+            const std::string &pd_info, uint64_t component) override;
+
+    void check_for_completed_primitives() override;
+
+protected:
+    std::vector<prim_profile_data_t> profiling_data_;
+
+    // destructor logic to check for unlogged primitives before
+    // stream destruction
+    void cleanup();
+
+private:
+    void wait_for_pending_primitives() override;
+
+    status_t get_aggregate_exec_time(size_t index, double &duration_ms) const;
+    bool is_event_complete(const std::shared_ptr<
+            dnnl::threadpool_interop::threadpool_event_iface_t> &event) const;
+    void wait_for_event_completion(const std::shared_ptr<
+            dnnl::threadpool_interop::threadpool_event_iface_t> &event) const;
+};
+
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif // DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+#endif // CPU_VERBOSE_PROFILER_HPP

--- a/src/xpu/stream_profiler.hpp
+++ b/src/xpu/stream_profiler.hpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "common/c_types_map.hpp"
+#include "common/verbose_profiler.hpp"
 
 #include "xpu/context.hpp"
 
@@ -121,28 +122,13 @@ protected:
     void (*callback_)(uint64_t, uint64_t) = nullptr;
 };
 
-// The verbose profiler logs primitive profiling information using device-
-// measured execution times without host-to-device synchronization overhead or
-// blocking stream.wait() calls. It operates asynchronously by polling device
-// events to track primitive completion status.
-// During primitive execution, the profiler groups and registers kernel events
-// for each primitive with the associated profiling metadata. During each
-// primitive post-exec hook, it polls previously registered events to identify
-// completed primitives and logs their timing info. Pending primitives remain
-// in the profiling_data_ list until detected as complete in subsequent
-// polling cycles.
-// During profiler destruction, any remaining primitives are checked and
-// waited for to ensure no executions are left unlogged.
-// This profiler is intended to be thread-local via thread_local_storage_t,
-// ensuring thread-safety for multi-threaded execution environments. Each
-// thread maintains its own profiler instance and event tracking state,
-// operating independently from other stream profilers during primitive
-// execution.
-struct verbose_profiler_t {
-    verbose_profiler_t(const stream_t *stream)
-        : stream_(stream), active_(true) {}
-
-    virtual ~verbose_profiler_t() = default;
+// XPU (OpenCL/SYCL/L0) specialization of verbose_profiler_t.
+// Tracks primitive completion using device-side xpu::event_t handles.
+// Device-measured execution times are retrieved via get_aggregate_exec_time()
+// using runtime-specific event timestamp queries.
+// Instantiated per-thread via thread_local_storage_t on the GPU stream.
+struct verbose_profiler_t : public impl::verbose_profiler_t {
+    using impl::verbose_profiler_t::verbose_profiler_t;
 
     struct prim_profile_data_t {
         uint64_t component_kind_ = 0;
@@ -150,33 +136,8 @@ struct verbose_profiler_t {
         std::string pd_info_;
         std::vector<std::shared_ptr<xpu::event_t>> prim_events_;
     };
-    // Pausing capabilities are added to allow skipping event profiling
-    // queries when they are temporarily unavailable (example:
-    // SYCL graph execution or when queue does not have profiling enabled).
-    // These methods check and update profiler status where such force-pausing
-    // is required. Pausing action is localized to each thread for multi-
-    // threaded execution
-    bool is_active() const { return true; }
-    void start_profiling() { active_ = true; }
-    void pause_profiling() { active_ = false; }
 
-    // The profiler operates through a multi-step event tracking workflow:
-    // 1. stream->before_exec_hook() calls update_event_list()
-    //    to add a new entry for the current primitive. Since there can be
-    //    multiple `register_event` calls, this spot is a guaranteed single
-    //    call for the coming primitive.
-    // 2. During primitive execution, register_event() adds device
-    //    events to the latest primitive entry corresponding to the number of
-    //    invoked kernels.
-    // 3. add_to_pending_primitive_list() stores profiling metadata
-    //    (start_ms_, pd_info_) for the registered primitive
-    // 4. stream->after_exec_hook() calls check_for_completed_primitives()
-    //    to poll events and log completed primitives
-    // 5. Incomplete primitives remain in profiling_data_ until detected as
-    //    complete in future polling cycles
-    // This asynchronous workflow allows tracking multiple concurrent
-    // primitives without blocking execution.
-    void update_event_list() { profiling_data_.emplace_back(); }
+    void update_event_list() override { profiling_data_.emplace_back(); }
 
     // appends primitive event to the last primitive entry in profiling_data_
     void register_event(const std::shared_ptr<xpu::event_t> &event) {
@@ -186,29 +147,27 @@ struct verbose_profiler_t {
 
     // populates profiling metadata for the last primitive entry in
     // profiling_data_
-    void add_to_pending_primitive_list(
-            double start_ms, const std::string &pd_info, uint64_t component);
+    void add_to_pending_primitive_list(double start_ms,
+            const std::string &pd_info, uint64_t component) override;
 
     // Completed primitive executions are periodically checked and logged
     // during after_exec_hook() calls and during stream destruction.
     // The profiler does not wait for pending events to complete
     // and instead prints them at the next concurrent after_exec_hook()
     // call.
-    void check_for_completed_primitives();
+    void check_for_completed_primitives() override;
 
 protected:
-    const stream_t *stream_;
     std::vector<prim_profile_data_t> profiling_data_;
-    bool active_;
 
     // destructor logic to check for unlogged primitives before
     // stream destruction
     void cleanup();
 
 private:
-    // This is invoked during profiler destruction or blocking wait calls
-    //  to account for any pending primitives that have not yet been logged.
-    void wait_for_pending_primitives();
+    // This is invoked during profiler destruction to account for any
+    // pending primitives that have not yet been logged.
+    void wait_for_pending_primitives() override;
 
     void reset() { profiling_data_.clear(); }
 

--- a/tests/test_thread.cpp
+++ b/tests/test_thread.cpp
@@ -226,6 +226,60 @@ static tsl::AsyncValueRef<tsl::Chain> OkDoneEventSingleton() {
     return singleton->AsRef();
 }
 
+// Lightweight completion event exposed to oneDNN's verbose profiler.
+// start_ns_ is stamped by the first parallel_for() worker via CAS to avoid
+// races between workers. end_ns_ and complete_ are set by the AndThen
+// callback registered in get_event() when the chain resolves.
+class threadpool_event_t
+    : public dnnl::threadpool_interop::threadpool_event_iface_t {
+public:
+    threadpool_event_t() = default;
+
+    bool is_complete() const override {
+        return complete_.load(std::memory_order_acquire);
+    }
+
+    void wait() const override {
+        while (!is_complete()) {}
+    }
+
+    double exec_time_ms() const override {
+        int64_t start = start_ns_.load(std::memory_order_relaxed);
+        int64_t end = end_ns_.load(std::memory_order_relaxed);
+        return static_cast<double>(end - start) * 1e-6;
+    }
+
+    void stamp_start(int64_t ns) {
+        int64_t expected = 0;
+        start_ns_.compare_exchange_strong(
+                expected, ns, std::memory_order_relaxed);
+    }
+
+    // Called by the AndThen callback registered in get_event() when the
+    // chain resolves. Records the end timestamp and sets complete_.
+    // end_ns_ is written before complete_ to ensure exec_time_ms() is
+    // valid when is_complete() returns true.
+    void mark_complete() {
+        end_ns_.store(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                              std::chrono::high_resolution_clock::now()
+                                      .time_since_epoch())
+                              .count(),
+                std::memory_order_relaxed);
+        complete_.store(true, std::memory_order_release);
+    }
+
+private:
+    // Completion flag set by mark_complete() in the AndThen callback.
+    std::atomic<bool> complete_ {false};
+
+    // Start timestamp in nanoseconds. Stamped by the first worker via CAS.
+    std::atomic<int64_t> start_ns_ {0};
+
+    // End timestamp in nanoseconds. Written by mark_complete() before
+    // complete_ is set.
+    std::atomic<int64_t> end_ns_ {0};
+};
+
 class threadpool_t : public dnnl::threadpool_interop::threadpool_iface {
 private:
     // Original `OneDnnThreadPool` at
@@ -247,6 +301,13 @@ private:
     // ANCHOR: DUMMY_PARALLEL.
     tsl::AsyncValueRef<tsl::Chain> done_event_;
 
+    // Current profiling event created lazily in parallel_for() when
+    // verbose_profiling_ is true. Handed to the verbose profiler via
+    // get_event() after enqueue_primitive() returns.
+    // Null when profiling is disabled or get_event() has already consumed
+    // and moved it.
+    std::shared_ptr<threadpool_event_t> current_event_;
+
 public:
     explicit threadpool_t(int num_threads = 0) {
         if (num_threads <= 0) num_threads = read_num_threads_from_env();
@@ -257,13 +318,32 @@ public:
     bool get_in_parallel() const override { return false; }
     uint64_t get_flags() const override { return ASYNCHRONOUS; }
     void parallel_for(int n, const std::function<void(int, int)> &fn) override {
+
+        // Create a profiling event only when verbose profiling is
+        // enabled and no event is already pending for this primitive.
+        if (!current_event_) {
+            current_event_ = std::make_shared<threadpool_event_t>();
+        }
+
+        // Capture current_event_ by value so the lambda holds a shared_ptr
+        // reference that remains valid for the lifetime of the parallel work.
+        auto event = current_event_;
+
         // If we are using oneDNN with async support, we need to schedule the
         // parallel loop using the done_event_. This allows us to return
         // immediately and not block the caller thread.
-        auto parallelize = [this, n, fn](tsl::Chain) {
+        auto parallelize = [this, n, fn, event](tsl::Chain) {
             return xla::cpu::Worker::Parallelize(thread_pool_.get(),
-                    thread_pool_->NumThreads(), n,
-                    [fn, n](size_t i) { fn(static_cast<int>(i), n); });
+                    thread_pool_->NumThreads(), n, [fn, n, event](size_t i) {
+                if (event) {
+                    event->stamp_start(std::chrono::duration_cast<
+                                       std::chrono::nanoseconds>(
+                            std::chrono::high_resolution_clock::now()
+                                    .time_since_epoch())
+                                               .count());
+                }
+                fn(static_cast<int>(i), n);
+            });
         };
 
         done_event_ = done_event_.FlatMap(parallelize);
@@ -273,6 +353,20 @@ public:
         // notify the user that the output is ready. oneDNN will not call wait()
         // inside the library to avoid deadlock.
         tsl::BlockUntilReady(done_event_);
+    }
+
+    std::shared_ptr<dnnl::threadpool_interop::threadpool_event_iface_t>
+    get_event() override {
+        if (!current_event_) return nullptr;
+        auto event = std::move(current_event_);
+        current_event_ = nullptr;
+
+        // Register the completion callback on the current chain.
+        // AndThen fires when done_event_ resolves, i.e., when all jobs
+        // in the most recent parallel_for() have completed.
+        done_event_.AndThen([event]() { event->mark_complete(); });
+
+        return event;
     }
 
     tsl::AsyncValueRef<tsl::Chain> done_event() const { return done_event_; }


### PR DESCRIPTION
# Description

PoC Implementation for extending Asynchronous verbose profiling to CPU streams with Asynchronous Threadpool.

The implementation introduces the following updates:
- https://github.com/uxlfoundation/oneDNN/pull/5891/changes/fe0d26154d377f78957c975ff535b3f0e3575aca splits the XPU `verbose_profiler_t` abstraction into a common base and XPU-specific subclass - this allows defining non-XPU variants for async threadpool.
-  https://github.com/uxlfoundation/oneDNN/pull/5891/changes/1801877a5c45476f1b92dd9a856742e1f3cf6083, https://github.com/uxlfoundation/oneDNN/pull/5891/changes/5582ad361b28d9621c10e54de77b051b02f91c4c introduce the definitions and API for threadpool events, threadpool-specific profiler and profiling support in the CPU streams.
- https://github.com/uxlfoundation/oneDNN/pull/5891/changes/264578b39cc0dd490806a5f7aeabdf6998cdc14d add the new definitions for asynchronous threadpool for testing.

The `threadpool_event_iface_t` definitions are chosen to mirror those in PR #5757 to allow working with https://github.com/intel-innersource/frameworks.ai.openxla.xla/pull/666.  

Related RFC: [[link](https://github.com/uxlfoundation/oneDNN/pull/5791)]
Addresses [MFDNN-15436](https://jira.devtools.intel.com/browse/MFDNN-15436).