### PR TITLE
xe: ggemm: Fix binary post-op errors when unroll_n is non-pow2

### DIFF
--- a/src/gpu/intel/include/tile_ops.h
+++ b/src/gpu/intel/include/tile_ops.h
@@ -20,6 +20,8 @@
 #include "gpu/intel/include/generic_vector_ops.h"
 #include "gpu/intel/include/types.h"
 
+#define IS_POWER_OF_2(x) (((x) != 0) && (((x) & ((x) - 1)) == 0))
+
 float __builtin_IB_atomic_max_local_f32(__local float *, float);
 float __builtin_IB_atomic_add_local_f32(__local float *, float);
 float __builtin_IB_atomic_add_global_f32(__global float *, float);
@@ -1230,6 +1232,9 @@ __attribute__((enable_if(sg == 16, "wrong subgroup size"))) {
     typedef element_type \
             __attribute__((ext_vector_type(br * bc / sg))) _e_##tile_type; \
     typedef struct { \
+        _Static_assert(IS_POWER_OF_2(br * bc / sg), \
+                "Tile vector length (" #br " * " #bc " / " #sg \
+                ") must be a power of 2"); \
         _e_##tile_type x[nbr * nbc]; \
     } tile_type; \
     DECLARE_2D_TILE_OPS(tile_type, element_type, sg, br, bc, nbr, nbc)

--- a/src/gpu/intel/matmul/grouped_micro_gemm_m_axis.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm_m_axis.cl
@@ -114,7 +114,7 @@ DECLARE_2D_TILE(binary_group_chunk_in_type, BINARY_SCALE_GROUPED_TILE_DATA_T,
 #endif
 
 #if WITH_BINARY_DENSE_SCALE
-#define binary_dense_scale_br MAX(SUBGROUP_SIZE, ugemm_grouped_sg_tile_n)
+#define binary_dense_scale_br MAX(SUBGROUP_SIZE, ugemm_grouped_sg_tile_m)
 #define binary_dense_scale_bc 1
 #define binary_dense_scale_nbr 1
 #define binary_dense_scale_nbc 1


### PR DESCRIPTION
# Description

This PR fixes an issue with post-ops in grouped gemm where non-power of 2 unroll-n caused errors due to invalid results. This was because the binary_dense_tile_type was using sg_tile_n to define the M dimension of the tile. The M dimension should be a multiple of SG_SIZE and the resulting value should be a power of 2 because it is used to define the OpenCL vector size in the tile struct. I have added a static assert to ensure this is the case.

Fixes: [MFDNN-15472](https://jira.devtools.intel.com/browse/MFDNN-15472)