### PR TITLE
benchdnn: sdpa: fix ref_mem_map access in non-corr modes

### DIFF
--- a/tests/benchdnn/sdpa/sdpa.cpp
+++ b/tests/benchdnn/sdpa/sdpa.cpp
@@ -478,7 +478,8 @@ int doit(const std::vector<benchdnn_dnnl_wrapper_t<dnnl_primitive_t>> &v_prim,
     TIME_FILL(SAFE(
             init_ref_memory_args(ref_mem_map, mem_map, v_prim[0], prb, res),
             WARN));
-    if (!has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
+    if (has_bench_mode_bit(mode_bit_t::corr)
+            && !has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) {
         // Reference-only buffer holding the per-element conditioning magnitude
         // sum_k prob_k*|V_k| (same layout as the reference DST). compute_ref fills
         // it; setup_cmp reads it to size a per-element DST threshold. Forward only.


### PR DESCRIPTION
# Description
Non correctness modes would throw an uncaught exception causing segfaults:
```
tests/benchdnn/benchdnn "--mode=B" "--mode-modifier=P" "-v1" "--engine=gpu" "--sdpa" "--batch=test_sdpa_gpu"
757: run: --mode=B --mode-modifier=P --sdpa --engine=gpu --dt=f16:f16:f16:f16 1x1x4x8:1x1x8x4:1x1x4x8
757: terminate called after throwing an instance of 'std::out_of_range'
757:   what():  _Map_base::at
757: *** longjmp causes uninitialized stack frame ***: terminated
757: *** longjmp causes uninitialized stack frame ***: terminated
1/1 Test #757: test_benchdnn_modeB_sdpa_gpu_gpu ...***Exception: SegFault  1.13 sec
```
`init_ref_memory_args()` clears ref_mem_map when `mode_bit_t::corr` is unset, but `doit()` guarded its `ref_mem_map.at(DNNL_ARG_DST)` only against the no_ref_memory modifier. 
Setting `--mode=B`  would consequently throw std::out_of_range when using `at()`.  This PR adds the additional guard for `mode_bit_t::corr`.

Addresses MFDNN-15394.