### PR TITLE
x64: matmul: ir: implement transposed A case

### DIFF
--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -698,6 +698,8 @@ status_t brgemm_kernel_create(
             *brg_kernel = ir_ker.release();
             return status::success;
         }
+        if (brg.dt_a == data_type::f32 && brg.isa_impl == avx512_core)
+            return status::unimplemented;
     }
 
     if (brg.is_dgmm) {

--- a/src/cpu/x64/brgemm/brgemm.hpp
+++ b/src/cpu/x64/brgemm/brgemm.hpp
@@ -102,7 +102,7 @@ status_t DNNL_API brgemm_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
 ///
 /// @return status::success on success and a status describing the error
 ///     otherwise.
-status_t brgemv_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
+status_t DNNL_API brgemv_desc_init(brgemm_desc_t *brg, cpu_isa_t isa,
         brgemm_batch_kind_t type, impl::data_type_t dt_a,
         impl::data_type_t dt_x, bool transA, float alpha, float beta, dim_t LDA,
         dim_t INCY, dim_t M, dim_t N, bool treat_y_as_row);

--- a/src/cpu/x64/brgemm/brgemm_utils.cpp
+++ b/src/cpu/x64/brgemm/brgemm_utils.cpp
@@ -127,7 +127,8 @@ void set_isa_impl(brgemm_desc_t *brg) {
 
     if (brg->is_gemv) {
         if (everyone_is(data_type::f32, brg->dt_a, brg->dt_b)) {
-            brg->isa_impl = is_isa_ok(avx2) ? avx2 : isa_undef;
+            brg->isa_impl = utils::map(true, isa_undef, is_isa_ok(avx512_core),
+                    avx512_core, is_isa_ok(avx2), avx2);
         } else if (everyone_is(data_type::bf16, brg->dt_a, brg->dt_b)) {
             brg->isa_impl = is_isa_ok(avx512_core_bf16) ? avx512_core_bf16
                                                         : isa_undef;
@@ -814,8 +815,8 @@ status_t brgemm_blocking_tmm(brgemm_desc_t *brg) {
  *
  */
 status_t brgemm_blocking_vmm_gemv(brgemm_desc_t *brg) {
-    assert(utils::one_of(
-            brg->isa_impl, avx2, avx512_core_bf16, avx512_core_fp16));
+    assert(utils::one_of(brg->isa_impl, avx2, avx512_core, avx512_core_bf16,
+            avx512_core_fp16));
     assert(brg->load_dim == 1);
 
     const int simd_w = is_superset(brg->isa_impl, avx512_core) ? 16 : 8;

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -672,13 +672,14 @@ namespace trans {
 void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         const std::vector<ir::vreg_t> &acc, ir::vreg_t a_ptr, ir::vreg_t x_ptr,
         ir::vreg_t gemv_tail_mask, dim_t rows) {
-    const ir::vreg_t x = ir.new_vec(cfg.dt_x);
-    const ir::vreg_t a = ir.new_vec(cfg.dt_a);
-    ir.vbcast(x, x_ptr, 0);
+    const ir::vreg_t x = ir.new_vec(cfg.dt_x_reg);
+    const ir::vreg_t a = ir.new_vec(cfg.dt_a_reg);
+    ir.vbcast(x, x_ptr, 0, cfg.dt_x);
     for (int r = 0; r < (int)acc.size(); r++) {
         const int elems = acc_elems_at(cfg, r, rows);
-        ir.vload_masked(a, a_ptr, cfg.dt_sz_a * (dim_t)r * cfg.acc_elems,
-                acc_mask(cfg, elems, gemv_tail_mask), elems);
+        emit_acc_load(ir, cfg, a, a_ptr,
+            cfg.dt_sz_a * (dim_t)r * cfg.acc_elems, gemv_tail_mask,
+            elems, cfg.dt_a);
         ir.vdot(acc[r], a, x);
     }
 }
@@ -881,8 +882,13 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     VCONDCHECK_BRGEMV_IR(brg.dt_b == brg.dt_a, VERBOSE_UNSUPPORTED_DT);
     // The kernel accumulates in f32 and has no conversion on the way out.
     VCONDCHECK_BRGEMV_IR(brg.dt_c == f32, VERBOSE_UNSUPPORTED_DT);
-    VCONDCHECK_BRGEMV_IR(
-            !brg.transA, VERBOSE_UNSUPPORTED_FEATURE, "transposed A");
+        VCONDCHECK_BRGEMV_IR(IMPLICATION(brg.transA, brg.dt_a == f32),
+            VERBOSE_UNSUPPORTED_DT);
+
+    // A vector accumulator stores neighboring outputs with a single
+    // instruction, so `y` has to be contiguous.
+    VCONDCHECK_BRGEMV_IR(IMPLICATION(brg.gemv_acc_is_vector(), brg.LDC == 1),
+            VERBOSE_UNSUPPORTED_FEATURE, "strided y with a vector accumulator");
 
     // With post-ops the kernel stores to D instead of C. It cannot convert the
     // accumulator on the way out, so it takes only `dt_d == dt_c`. The check is
@@ -941,7 +947,8 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     VCONDCHECK_BRGEMV_IR(
             !brg.is_runtime_ldc, VERBOSE_UNSUPPORTED_FEATURE, "runtime ldc");
 
-    const int m_block = brg.gemv_bd_block();
+    const int m_block
+            = brg.gemv_acc_is_vector() ? brg.bd_block : brg.gemv_bd_block();
     const int dt_sz_a = brg.typesize_A;
     const int dt_sz_y = brg.typesize_C;
     const dim_t incy = brg.LDC;
@@ -949,8 +956,17 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     // Ensure indexed displacements fit in 32-bit
     auto fits = [](dim_t v) { return v <= INT32_MAX && v >= INT32_MIN; };
 
-    VCONDCHECK_BRGEMV_IR(fits(dt_sz_a * (dim_t)m_block * brg.LDA),
-            VERBOSE_UNSUPPORTED_FEATURE, "A block offset overflows int32");
+    // A is K-major when it is transposed, which swaps the M and K strides.
+    const dim_t mblk_a_off = brg.transA ? dt_sz_a * (dim_t)m_block
+                                        : dt_sz_a * (dim_t)m_block * brg.LDA;
+    const dim_t kblk_a_off = brg.transA
+            ? dt_sz_a * (dim_t)brg.rd_block * brg.LDA
+            : dt_sz_a * (dim_t)brg.rd_block;
+
+    VCONDCHECK_BRGEMV_IR(fits(mblk_a_off), VERBOSE_UNSUPPORTED_FEATURE,
+            "A block offset overflows int32");
+    VCONDCHECK_BRGEMV_IR(fits(kblk_a_off), VERBOSE_UNSUPPORTED_FEATURE,
+            "A reduction step overflows int32");
     VCONDCHECK_BRGEMV_IR(fits(dt_sz_y * (dim_t)m_block * incy),
             VERBOSE_UNSUPPORTED_FEATURE, "y block offset overflows int32");
 

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -140,6 +140,8 @@ struct brgemv_ir_conf_t {
         , kblk_a_off(acc_elems > 1 ? dt_sz_a * (dim_t)k_block * lda
                                    : dt_sz_a * (dim_t)k_block)
         , kblk_x_off(dt_sz_x * k_block)
+        , prefetch_a_off(
+                  brg.transA && brg.dt_a != data_type::f32 ? 8 * kblk_a_off : 0)
         , with_bias(brg.with_bias)
         , treat_y_as_row(brg.treat_y_as_row)
         , dt_bias(brg.dt_bias)
@@ -169,6 +171,7 @@ struct brgemv_ir_conf_t {
     const int gemv_tail;
     const dim_t mblk_a_off, mblk_y_off;
     const dim_t kblk_a_off, kblk_x_off;
+    const dim_t prefetch_a_off;
     const bool with_bias, treat_y_as_row;
     const data_type_t dt_bias;
     const int dt_sz_bias;
@@ -183,10 +186,6 @@ struct brgemv_ir_conf_t {
         return with_bias || with_injector_postops || with_src_scales
                 || with_wei_scales;
     }
-
-    // The `elems` value the post-ops injector expects for a fully occupied
-    // accumulator: a whole vector is -1, a single output is a one-element tail.
-    int full_acc_elems() const { return acc_elems > 1 ? -1 : 1; }
 };
 
 // M-loop input register classification
@@ -329,14 +328,6 @@ int acc_elems_at(const brgemv_ir_conf_t &cfg, int r, dim_t rows) {
             cfg.acc_elems, rows - (dim_t)r * cfg.acc_elems);
 }
 
-// A mask register is only needed for a partial vector. A single element and a
-// full vector lower to plain moves.
-ir::vreg_t acc_mask(
-        const brgemv_ir_conf_t &cfg, int elems, ir::vreg_t gemv_tail_mask) {
-    const bool needs_mask = elems > 1 && elems < cfg.acc_elems;
-    return needs_mask ? gemv_tail_mask : ir::vreg_t::none;
-}
-
 // Byte offset of accumulator `r` from the start of the current M block in `y`.
 dim_t acc_y_off(const brgemv_ir_conf_t &cfg, int r) {
     return cfg.dt_sz_y * (dim_t)r * cfg.acc_elems * cfg.incy;
@@ -352,10 +343,10 @@ void emit_bcast(ir::ir_t &ir, const brgemv_ir_conf_t &cfg, ir::vreg_t dst,
         ir.vload_scalar(dst, base, disp, mem_dt);
 }
 
-void emit_acc_load(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
-        ir::vreg_t dst, ir::vreg_t base, dim_t disp, ir::vreg_t mask,
-        int elems, data_type_t mem_dt) {
-    if (elems == 1)
+void emit_acc_load(ir::ir_t &ir, const brgemv_ir_conf_t &cfg, ir::vreg_t dst,
+        ir::vreg_t base, dim_t disp, ir::vreg_t mask, int elems,
+        data_type_t mem_dt) {
+    if (elems == 1 && mem_dt == data_type::f32)
         ir.vload_scalar(dst, base, disp, mem_dt);
     else if (elems == cfg.acc_elems)
         ir.vload(dst, base, disp, mem_dt);
@@ -381,7 +372,7 @@ std::vector<ir::vreg_t> init_accumulators(ir::ir_t &ir,
             ir.vzero(acc[r]);
         } else {
             const int elems = acc_elems_at(cfg, r, rows);
-                emit_acc_load(ir, cfg, acc[r], regs.advancing.y_ptr,
+            emit_acc_load(ir, cfg, acc[r], regs.advancing.y_ptr,
                     acc_y_off(cfg, r), regs.invariant.gemv_tail_mask, elems,
                     cfg.dt_y);
         }
@@ -452,7 +443,7 @@ void emit_epilogue(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         if (cfg.with_src_scales) {
             // Loaded once and applied to every output.
             const ir::vreg_t sc = ir.new_vec(cfg.dt_src_scales);
-                emit_bcast(ir, cfg, sc, regs.invariant.src_scale_ptr, 0,
+            emit_bcast(ir, cfg, sc, regs.invariant.src_scale_ptr, 0,
                     cfg.dt_src_scales);
 
             for (int r = 0; r < n_acc; r++)
@@ -465,12 +456,12 @@ void emit_epilogue(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             const ir::vreg_t sc = ir.new_vec(cfg.dt_wei_scales);
             if (cfg.single_wei_scale)
                 emit_bcast(ir, cfg, sc, regs.advancing.wei_scale_ptr, 0,
-                    cfg.dt_wei_scales);
+                        cfg.dt_wei_scales);
 
             for (int r = 0; r < n_acc; r++) {
                 if (!cfg.single_wei_scale) {
                     const int elems = acc_elems_at(cfg, r, rows);
-                        emit_acc_load(ir, cfg, sc, regs.advancing.wei_scale_ptr,
+                    emit_acc_load(ir, cfg, sc, regs.advancing.wei_scale_ptr,
                             cfg.dt_sz_wei_scales * (dim_t)r * cfg.acc_elems,
                             gemv_tail_mask, elems, cfg.dt_wei_scales);
                 }
@@ -483,13 +474,13 @@ void emit_epilogue(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             // loop. A row output loads a separate bias per output element.
             const ir::vreg_t bias = ir.new_vec(cfg.dt_bias);
             if (!cfg.treat_y_as_row)
-                emit_bcast(ir, cfg, bias, regs.advancing.bias_ptr, 0,
-                    cfg.dt_bias);
+                emit_bcast(
+                        ir, cfg, bias, regs.advancing.bias_ptr, 0, cfg.dt_bias);
 
             for (int r = 0; r < n_acc; r++) {
                 if (cfg.treat_y_as_row) {
                     const int elems = acc_elems_at(cfg, r, rows);
-                        emit_acc_load(ir, cfg, bias, regs.advancing.bias_ptr,
+                    emit_acc_load(ir, cfg, bias, regs.advancing.bias_ptr,
                             cfg.dt_sz_bias * (dim_t)r * cfg.acc_elems,
                             gemv_tail_mask, elems, cfg.dt_bias);
                 }
@@ -511,12 +502,13 @@ void emit_epilogue(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
                     full_acc.push_back(acc[r]);
                     full_off.push_back(off);
                 } else {
-                        ir.inject_postops({acc[r]}, regs.advancing.store_ptr, {off});
+                    ir.inject_postops(
+                            {acc[r]}, regs.advancing.store_ptr, {off});
                 }
             }
             if (!full_acc.empty())
                 ir.inject_postops(full_acc, regs.advancing.store_ptr, full_off,
-                    cfg.acc_elems == 1);
+                        cfg.acc_elems == 1);
         }
 
         ir.label(skip_post_ops);
@@ -526,13 +518,13 @@ void emit_epilogue(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         const int elems = acc_elems_at(cfg, r, rows);
         if (elems == 1)
             ir.vstore_scalar(regs.advancing.store_ptr, acc_y_off(cfg, r),
-                acc[r], cfg.dt_y);
+                    acc[r], cfg.dt_y);
         else if (elems == cfg.acc_elems)
             ir.vstore(regs.advancing.store_ptr, acc_y_off(cfg, r), acc[r],
-                cfg.dt_y);
+                    cfg.dt_y);
         else
             ir.vstore_masked(regs.advancing.store_ptr, acc_y_off(cfg, r),
-                acc[r], gemv_tail_mask, cfg.dt_y);
+                    acc[r], gemv_tail_mask, cfg.dt_y);
     }
 
     // Advance to next M block
@@ -677,9 +669,12 @@ void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     ir.vbcast(x, x_ptr, 0, cfg.dt_x);
     for (int r = 0; r < (int)acc.size(); r++) {
         const int elems = acc_elems_at(cfg, r, rows);
-        emit_acc_load(ir, cfg, a, a_ptr,
-            cfg.dt_sz_a * (dim_t)r * cfg.acc_elems, gemv_tail_mask,
-            elems, cfg.dt_a);
+        if (cfg.prefetch_a_off != 0)
+            ir.prefetch(a_ptr,
+                    cfg.dt_sz_a * (dim_t)r * cfg.acc_elems
+                            + cfg.prefetch_a_off);
+        emit_acc_load(ir, cfg, a, a_ptr, cfg.dt_sz_a * (dim_t)r * cfg.acc_elems,
+                gemv_tail_mask, elems, cfg.dt_a);
         ir.vdot(acc[r], a, x);
     }
 }
@@ -882,8 +877,6 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     VCONDCHECK_BRGEMV_IR(brg.dt_b == brg.dt_a, VERBOSE_UNSUPPORTED_DT);
     // The kernel accumulates in f32 and has no conversion on the way out.
     VCONDCHECK_BRGEMV_IR(brg.dt_c == f32, VERBOSE_UNSUPPORTED_DT);
-        VCONDCHECK_BRGEMV_IR(IMPLICATION(brg.transA, brg.dt_a == f32),
-            VERBOSE_UNSUPPORTED_DT);
 
     // A vector accumulator stores neighboring outputs with a single
     // instruction, so `y` has to be contiguous.
@@ -967,6 +960,9 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
             "A block offset overflows int32");
     VCONDCHECK_BRGEMV_IR(fits(kblk_a_off), VERBOSE_UNSUPPORTED_FEATURE,
             "A reduction step overflows int32");
+    VCONDCHECK_BRGEMV_IR(IMPLICATION(brg.transA && brg.dt_a != f32,
+                                 fits(8 * kblk_a_off + mblk_a_off)),
+            VERBOSE_UNSUPPORTED_FEATURE, "A prefetch offset overflows int32");
     VCONDCHECK_BRGEMV_IR(fits(dt_sz_y * (dim_t)m_block * incy),
             VERBOSE_UNSUPPORTED_FEATURE, "y block offset overflows int32");
 

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -866,11 +866,13 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     using namespace data_type;
 
     // Accepted input data type and the ISA it is built at:
-    //   f32  - avx2
+    //   f32  - avx2 or avx512_core
     //   bf16 - avx512_core_bf16
     //   f16  - avx512_core_fp16
     // GEMV blocking permits no other ISA (see `brgemm_blocking_vmm_gemv`).
-    const bool dt_isa_ok = (brg.dt_a == f32 && brg.isa_impl == avx2)
+    const bool dt_isa_ok
+            = (brg.dt_a == f32
+                      && utils::one_of(brg.isa_impl, avx2, avx512_core))
             || (brg.dt_a == bf16 && brg.isa_impl == avx512_core_bf16)
             || (brg.dt_a == f16 && brg.isa_impl == avx512_core_fp16);
     VCONDCHECK_BRGEMV_IR(dt_isa_ok, VERBOSE_UNSUPPORTED_ISA);

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -659,6 +659,90 @@ void build_gemv(const brgemm_desc_t &brg, ir::ir_t &ir) {
 
 } // namespace nontrans
 
+namespace trans {
+
+// Innermost reduction step.
+//
+// Broadcasts one element of `x`, then performs a multiply-add into every
+// accumulator using the matching slice of the current A row.
+//
+// A is K-major here, so a single K step reads one contiguous A row that spans
+// the whole M block. Each accumulator holds `acc_elems` outputs, and the last
+// one of the M tail may be only partially filled.
+void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        const std::vector<ir::vreg_t> &acc, ir::vreg_t a_ptr, ir::vreg_t x_ptr,
+        ir::vreg_t gemv_tail_mask, dim_t rows) {
+    const ir::vreg_t x = ir.new_vec(cfg.dt_x);
+    const ir::vreg_t a = ir.new_vec(cfg.dt_a);
+    ir.vbcast(x, x_ptr, 0);
+    for (int r = 0; r < (int)acc.size(); r++) {
+        const int elems = acc_elems_at(cfg, r, rows);
+        ir.vload_masked(a, a_ptr, cfg.dt_sz_a * (dim_t)r * cfg.acc_elems,
+                acc_mask(cfg, elems, gemv_tail_mask), elems);
+        ir.vdot(acc[r], a, x);
+    }
+}
+
+// One M block.
+//
+// Contains one accumulator per `acc_elems` outputs, reduced across the batch
+// and then stored.
+//
+// Finally, advances the A and x pointers to the next M block.
+void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        const m_loop_input_regs_t &regs, dim_t rows) {
+    const std::vector<ir::vreg_t> acc = init_accumulators(ir, cfg, regs, rows);
+
+    // Batch reduction over bs dimension
+    const ir::vreg_t batch_ptr = ir.new_gpr();
+    ir.mov_reg(batch_ptr, regs.invariant.batch);
+
+    auto bs_body = [&]() {
+        emit_bs_body(ir, cfg, batch_ptr, regs.advancing.a_off,
+                [&](ir::vreg_t a_ptr, ir::vreg_t x_ptr) {
+            emit_microkernel(ir, cfg, acc, a_ptr, x_ptr,
+                    regs.invariant.gemv_tail_mask, rows);
+        },
+                // A K block is a single element here, so there is no K tail.
+                [](ir::vreg_t, ir::vreg_t) {});
+    };
+    if (cfg.max_bs > 1)
+        ir::emit_loop_reg(ir, regs.invariant.bs, bs_body);
+    else
+        ir::emit_loop_imm(ir, 1, bs_body);
+
+    // Every accumulator already holds its outputs in the lanes they are stored
+    // from, so nothing is reduced horizontally.
+    emit_epilogue(ir, cfg, regs, acc, rows);
+}
+
+// Builds IR for GEMV with a transposed A matrix.
+//
+// Computes:
+//   y[i] = sum_k A[k][i] * x[k]
+//   (m = brg.bcast_dim, k = brg.reduce_dim, n = 1)
+//
+// The output is partitioned into full M blocks of `m_block` rows each, with a
+// final partial block of `m_tail` rows when m is not a multiple of m_block.
+//
+// Each M block:
+// - Maintains one accumulator per `acc_elems` neighboring outputs
+// - Accumulates over k one A row at a time across the batch, multiplying it by
+//   a broadcast element of x
+// - Stores the accumulators directly, without a horizontal reduction
+void build_gemv(const brgemm_desc_t &brg, ir::ir_t &ir) {
+    const brgemv_ir_conf_t cfg(brg);
+    const m_loop_input_regs_t regs = init_m_loop_input_regs(ir, cfg);
+
+    if (cfg.m_blocks > 0)
+        ir::emit_loop_imm(ir, cfg.m_blocks,
+                [&]() { emit_m_block(ir, cfg, regs, cfg.m_block); });
+
+    if (cfg.m_tail > 0) emit_m_block(ir, cfg, regs, cfg.m_tail);
+}
+
+} // namespace trans
+
 // generate() runs the full IR pipeline:
 //
 // - Build IR for the given `brgemm_desc_t` descriptor
@@ -679,9 +763,13 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
     const brgemm_desc_t &get_brg() const override { return brg_; }
 
     void generate() override {
-        // Build IR for non-transposed GEMV kernel
+        // Build IR for the GEMV kernel. The two A layouts differ in how the
+        // reduction feeds the accumulators, so each has its own builder.
         ir::ir_t ir;
-        nontrans::build_gemv(brg_, ir);
+        if (brg_.transA)
+            trans::build_gemv(brg_, ir);
+        else
+            nontrans::build_gemv(brg_, ir);
 
         // Scratch registers (2 gpr + 3 vec) reserved for spill code.
         const int gpr_scratch0 = 10, gpr_scratch1 = 11;

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -65,6 +65,10 @@ namespace {
 //   max_bs       - maximum batch size known at IR generation time
 //   m_block      - M rows per full block
 //   k_block      - K elements reduced per K block
+//   acc_elems    - M rows one accumulator holds: 1 when each accumulator
+//                  reduces to a single output (non-transposed A), the SIMD
+//                  width when a whole vector of outputs is accumulated at once
+//                  (transposed A)
 //   dt_sz_a/x/y  - element size in bytes of A, x, and y
 //   dt_a/x/y     - element data type of A, x, and y in memory
 //   dt_a_reg / dt_x_reg - data type of the vec vreg holding A and x. It is the
@@ -77,6 +81,10 @@ namespace {
 //   m_tail       - remaining M rows after the full blocks
 //   k_blocks     - number of full K blocks
 //   k_tail       - remaining K elements after the full blocks
+//   gemv_tail    - active elements of the only masked access shape the kernel
+//                  needs: `k_tail` for scalar accumulators, the elements live
+//                  in the last accumulator for vector ones. 0 when nothing has
+//                  to be masked
 //   mblk_*_off   - byte offset to advance A/y pointers between M blocks
 //   kblk_*_off   - byte offset to advance A/x pointers between K blocks
 //   with_bias    - whether a bias is added to the output
@@ -104,8 +112,10 @@ struct brgemv_ir_conf_t {
         , lda(brg.LDA)
         , incy(brg.LDC)
         , max_bs(brg.brgattr.max_bs)
-        , m_block(brg.gemv_bd_block())
+        , m_block(brg.gemv_acc_is_vector() ? brg.bd_block : brg.gemv_bd_block())
         , k_block(brg.rd_block)
+        , acc_elems(
+                  brg.gemv_acc_is_vector() ? m_block / brg.gemv_bd_block() : 1)
         , dt_sz_a(brg.typesize_A)
         , dt_sz_x(brg.typesize_B)
         , dt_sz_y(brg.typesize_C)
@@ -120,9 +130,15 @@ struct brgemv_ir_conf_t {
         , m_tail(m % m_block)
         , k_blocks(k / k_block)
         , k_tail(k % k_block)
-        , mblk_a_off(dt_sz_a * m_block * lda)
+        , gemv_tail(brg.gemv_tail)
+        // A is K-major when accumulators are vectors (transposed A), so the
+        // next M block is `m_block` contiguous elements away and the next K
+        // block is `k_block` rows away. Otherwise it is the other way around.
+        , mblk_a_off(acc_elems > 1 ? dt_sz_a * (dim_t)m_block
+                                   : dt_sz_a * (dim_t)m_block * lda)
         , mblk_y_off(dt_sz_y * m_block * incy)
-        , kblk_a_off(dt_sz_a * k_block)
+        , kblk_a_off(acc_elems > 1 ? dt_sz_a * (dim_t)k_block * lda
+                                   : dt_sz_a * (dim_t)k_block)
         , kblk_x_off(dt_sz_x * k_block)
         , with_bias(brg.with_bias)
         , treat_y_as_row(brg.treat_y_as_row)
@@ -143,13 +159,14 @@ struct brgemv_ir_conf_t {
 
     const dim_t m, k, lda, incy;
     const dim_t max_bs;
-    const int m_block, k_block;
+    const int m_block, k_block, acc_elems;
     const int dt_sz_a, dt_sz_x, dt_sz_y;
     const data_type_t dt_a, dt_x, dt_y;
     const data_type_t dt_a_reg, dt_x_reg;
     const data_type_t dt_acc;
     const float beta;
     const dim_t m_blocks, m_tail, k_blocks, k_tail;
+    const int gemv_tail;
     const dim_t mblk_a_off, mblk_y_off;
     const dim_t kblk_a_off, kblk_x_off;
     const bool with_bias, treat_y_as_row;
@@ -166,6 +183,10 @@ struct brgemv_ir_conf_t {
         return with_bias || with_injector_postops || with_src_scales
                 || with_wei_scales;
     }
+
+    // The `elems` value the post-ops injector expects for a fully occupied
+    // accumulator: a whole vector is -1, a single output is a one-element tail.
+    int full_acc_elems() const { return acc_elems > 1 ? -1 : 1; }
 };
 
 // M-loop input register classification
@@ -211,9 +232,9 @@ struct invariant_regs_t {
     ir::vreg_t batch = ir::vreg_t::none;
     // Batch size loop count. `none` when max_bs == 1 (single batch element).
     ir::vreg_t bs = ir::vreg_t::none;
-    // K-tail mask, shared by every masked tail load. `none` when `k_tail` is
-    // zero, which is when there is no tail load to mask.
-    ir::vreg_t k_tail_mask = ir::vreg_t::none;
+    // Mask shared by every masked access of the kernel, holding `gemv_tail`
+    // active elements. `none` when no access needs a mask register.
+    ir::vreg_t gemv_tail_mask = ir::vreg_t::none;
     // Post-ops flag (params.do_post_ops). Non-zero applies the post-ops, zero
     // stores the raw accumulator. `none` unless the kernel has a post-op to
     // apply (bias, scales, or injector post-ops).
@@ -255,11 +276,11 @@ m_loop_input_regs_t init_m_loop_input_regs(
     regs.advancing.a_off = ir.new_gpr();
     ir.mov_imm(regs.advancing.a_off, 0);
 
-    if (cfg.k_tail > 0) {
+    if (cfg.gemv_tail > 0) {
         // We only need to set the mask once per kernel. It's lifetime is
         // managed automatically by the allocator.
-        regs.invariant.k_tail_mask = ir.new_mask();
-        ir.set_mask_imm(regs.invariant.k_tail_mask, (int)cfg.k_tail);
+        regs.invariant.gemv_tail_mask = ir.new_mask();
+        ir.set_mask_imm(regs.invariant.gemv_tail_mask, cfg.gemv_tail);
     }
 
     if (cfg.with_bias) {
@@ -293,6 +314,239 @@ m_loop_input_regs_t init_m_loop_input_regs(
     }
 
     return regs;
+}
+
+// Accumulator layout of an M block covering `rows` output elements.
+//
+// A block holds one accumulator per `acc_elems` outputs. The last accumulator
+// of the M tail may be only partially filled.
+int n_accs(const brgemv_ir_conf_t &cfg, dim_t rows) {
+    return (int)utils::div_up(rows, (dim_t)cfg.acc_elems);
+}
+
+int acc_elems_at(const brgemv_ir_conf_t &cfg, int r, dim_t rows) {
+    return (int)nstl::min<dim_t>(
+            cfg.acc_elems, rows - (dim_t)r * cfg.acc_elems);
+}
+
+// A mask register is only needed for a partial vector. A single element and a
+// full vector lower to plain moves.
+ir::vreg_t acc_mask(
+        const brgemv_ir_conf_t &cfg, int elems, ir::vreg_t gemv_tail_mask) {
+    const bool needs_mask = elems > 1 && elems < cfg.acc_elems;
+    return needs_mask ? gemv_tail_mask : ir::vreg_t::none;
+}
+
+// Byte offset of accumulator `r` from the start of the current M block in `y`.
+dim_t acc_y_off(const brgemv_ir_conf_t &cfg, int r) {
+    return cfg.dt_sz_y * (dim_t)r * cfg.acc_elems * cfg.incy;
+}
+
+// Fills every element of `dst` with one value from memory. A scalar
+// accumulator uses only the first element, where a plain load is cheaper.
+void emit_bcast(ir::ir_t &ir, const brgemv_ir_conf_t &cfg, ir::vreg_t dst,
+        ir::vreg_t base, dim_t disp, data_type_t mem_dt) {
+    if (cfg.acc_elems > 1)
+        ir.vbcast(dst, base, disp, mem_dt);
+    else
+        ir.vload_scalar(dst, base, disp, mem_dt);
+}
+
+void emit_acc_load(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        ir::vreg_t dst, ir::vreg_t base, dim_t disp, ir::vreg_t mask,
+        int elems, data_type_t mem_dt) {
+    if (elems == 1)
+        ir.vload_scalar(dst, base, disp, mem_dt);
+    else if (elems == cfg.acc_elems)
+        ir.vload(dst, base, disp, mem_dt);
+    else
+        ir.vload_masked(dst, base, disp, mask, mem_dt);
+}
+
+// Creates the accumulators of one M block and seeds them as `beta` requires.
+std::vector<ir::vreg_t> init_accumulators(ir::ir_t &ir,
+        const brgemv_ir_conf_t &cfg, const m_loop_input_regs_t &regs,
+        dim_t rows) {
+    std::vector<ir::vreg_t> acc(n_accs(cfg, rows), ir::vreg_t::none);
+    for (int r = 0; r < (int)acc.size(); r++) {
+        acc[r] = ir.new_vec(cfg.dt_acc);
+
+        // The current implementation supports only 0 and 1 for beta so for the
+        // case where beta = 1 we load `y` into the accumulator registers and
+        // then the microkernel adds the results of the multiplication to them.
+        //
+        // This reads `y_ptr` while a sum post-op reads `store_ptr`, so the two
+        // never count the same value twice.
+        if (cfg.beta == 0.0f) {
+            ir.vzero(acc[r]);
+        } else {
+            const int elems = acc_elems_at(cfg, r, rows);
+                emit_acc_load(ir, cfg, acc[r], regs.advancing.y_ptr,
+                    acc_y_off(cfg, r), regs.invariant.gemv_tail_mask, elems,
+                    cfg.dt_y);
+        }
+    }
+    return acc;
+}
+
+// One batch element.
+//
+// Loads the A and x pointers of the element, then runs the reduction loop over
+// k. Each iteration calls `microkernel(a_ptr, x_ptr)` on one `k_block` chunk
+// and advances the pointers. `microkernel_tail(a_ptr, x_ptr)` reduces the
+// leftover K elements and is never called when `k_tail` is zero.
+template <typename microkernel_t, typename microkernel_tail_t>
+void emit_bs_body(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        ir::vreg_t batch_ptr, ir::vreg_t a_off, microkernel_t microkernel,
+        microkernel_tail_t microkernel_tail) {
+    const ir::vreg_t a_ptr = ir.new_gpr();
+    const ir::vreg_t x_ptr = ir.new_gpr();
+
+    ir.load(a_ptr, batch_ptr, GET_OFF_BATCH_ELEMENT(ptr.A));
+    ir.add_reg(a_ptr, a_off);
+    ir.load(x_ptr, batch_ptr, GET_OFF_BATCH_ELEMENT(ptr.B));
+    ir.add_imm(batch_ptr, sizeof(brgemm_batch_element_t));
+
+    // Advance the A and x pointers by one K block.
+    auto advance_ptrs = [&]() {
+        ir.add_imm(a_ptr, cfg.kblk_a_off);
+        ir.add_imm(x_ptr, cfg.kblk_x_off);
+    };
+
+    // Reduce the full K blocks, then the tail if any. Cases by `k_blocks`.
+    // k > 0 guarantees k_blocks and k_tail are never both zero.
+    //   *  == 0  whole reduction is the tail
+    //   *  == 1  one block, advance by hand only if a tail follows
+    //   *  >= 2  loop, advancing per iteration
+    if (cfg.k_blocks >= 2) {
+        ir::emit_loop_imm(ir, cfg.k_blocks,
+                [&]() { microkernel(a_ptr, x_ptr); }, advance_ptrs);
+    } else if (cfg.k_blocks == 1) {
+        microkernel(a_ptr, x_ptr);
+        if (cfg.k_tail > 0) advance_ptrs();
+    }
+    if (cfg.k_tail > 0) microkernel_tail(a_ptr, x_ptr);
+}
+
+// Tail of an M block, shared by every GEMV flavor.
+//
+// Applies scales, bias and injector post-ops to the reduced accumulators,
+// stores them, and advances the M-block pointers.
+void emit_epilogue(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
+        const m_loop_input_regs_t &regs, const std::vector<ir::vreg_t> &acc,
+        dim_t rows) {
+    const int n_acc = (int)acc.size();
+    const ir::vreg_t gemv_tail_mask = regs.invariant.gemv_tail_mask;
+
+    if (cfg.has_post_ops()) {
+        // The implemented order conforms to oneDNN's defined semantics for
+        // applying scales, bias and post-ops:
+        //   src scale -> weights scale -> bias -> post-ops.
+        // Scales apply to the accumulated result before the bias add and
+        // post-ops apply after bias. The two scales can swap because both are
+        // multiplies but a scale must not move past the bias and the bias must
+        // not move past the post-ops.
+        const ir::label_t skip_post_ops = ir.new_label();
+        ir.jz(regs.invariant.do_post_ops, skip_post_ops);
+
+        if (cfg.with_src_scales) {
+            // Loaded once and applied to every output.
+            const ir::vreg_t sc = ir.new_vec(cfg.dt_src_scales);
+                emit_bcast(ir, cfg, sc, regs.invariant.src_scale_ptr, 0,
+                    cfg.dt_src_scales);
+
+            for (int r = 0; r < n_acc; r++)
+                ir.vmul(acc[r], sc);
+        }
+
+        if (cfg.with_wei_scales) {
+            // The single scale is loop invariant, so load it once above the
+            // loop. The per-N case loads a separate scale per output element.
+            const ir::vreg_t sc = ir.new_vec(cfg.dt_wei_scales);
+            if (cfg.single_wei_scale)
+                emit_bcast(ir, cfg, sc, regs.advancing.wei_scale_ptr, 0,
+                    cfg.dt_wei_scales);
+
+            for (int r = 0; r < n_acc; r++) {
+                if (!cfg.single_wei_scale) {
+                    const int elems = acc_elems_at(cfg, r, rows);
+                        emit_acc_load(ir, cfg, sc, regs.advancing.wei_scale_ptr,
+                            cfg.dt_sz_wei_scales * (dim_t)r * cfg.acc_elems,
+                            gemv_tail_mask, elems, cfg.dt_wei_scales);
+                }
+                ir.vmul(acc[r], sc);
+            }
+        }
+
+        if (cfg.with_bias) {
+            // The broadcast bias is loop invariant, so load it once outside the
+            // loop. A row output loads a separate bias per output element.
+            const ir::vreg_t bias = ir.new_vec(cfg.dt_bias);
+            if (!cfg.treat_y_as_row)
+                emit_bcast(ir, cfg, bias, regs.advancing.bias_ptr, 0,
+                    cfg.dt_bias);
+
+            for (int r = 0; r < n_acc; r++) {
+                if (cfg.treat_y_as_row) {
+                    const int elems = acc_elems_at(cfg, r, rows);
+                        emit_acc_load(ir, cfg, bias, regs.advancing.bias_ptr,
+                            cfg.dt_sz_bias * (dim_t)r * cfg.acc_elems,
+                            gemv_tail_mask, elems, cfg.dt_bias);
+                }
+                ir.vadd(acc[r], bias);
+            }
+        }
+
+        if (cfg.with_injector_postops) {
+            // The output offsets match the store displacements below, so a sum
+            // post-op reads each element from the address its result is written
+            // to. One `inject_postops` carries a single active-element count,
+            // so a partially filled accumulator goes in its own operation.
+            std::vector<ir::vreg_t> full_acc;
+            std::vector<dim_t> full_off;
+            for (int r = 0; r < n_acc; r++) {
+                const int elems = acc_elems_at(cfg, r, rows);
+                const dim_t off = acc_y_off(cfg, r);
+                if (elems == cfg.acc_elems) {
+                    full_acc.push_back(acc[r]);
+                    full_off.push_back(off);
+                } else {
+                        ir.inject_postops({acc[r]}, regs.advancing.store_ptr, {off});
+                }
+            }
+            if (!full_acc.empty())
+                ir.inject_postops(full_acc, regs.advancing.store_ptr, full_off,
+                    cfg.acc_elems == 1);
+        }
+
+        ir.label(skip_post_ops);
+    }
+
+    for (int r = 0; r < n_acc; r++) {
+        const int elems = acc_elems_at(cfg, r, rows);
+        if (elems == 1)
+            ir.vstore_scalar(regs.advancing.store_ptr, acc_y_off(cfg, r),
+                acc[r], cfg.dt_y);
+        else if (elems == cfg.acc_elems)
+            ir.vstore(regs.advancing.store_ptr, acc_y_off(cfg, r), acc[r],
+                cfg.dt_y);
+        else
+            ir.vstore_masked(regs.advancing.store_ptr, acc_y_off(cfg, r),
+                acc[r], gemv_tail_mask, cfg.dt_y);
+    }
+
+    // Advance to next M block
+    ir.add_imm(regs.advancing.a_off, cfg.mblk_a_off);
+    ir.add_imm(regs.advancing.y_ptr, cfg.mblk_y_off);
+    // When `!has_post_ops()`, `store_ptr` is the same IR vreg as `y_ptr` (see
+    // `init_m_loop_input_regs`), so advancing `y_ptr` above covers both.
+    if (cfg.has_post_ops())
+        ir.add_imm(regs.advancing.store_ptr, cfg.mblk_y_off);
+
+    if (cfg.with_bias && cfg.treat_y_as_row)
+        ir.add_imm(regs.advancing.bias_ptr, cfg.mblk_bias_off);
+    if (cfg.with_wei_scales && !cfg.single_wei_scale)
+        ir.add_imm(regs.advancing.wei_scale_ptr, cfg.mblk_wei_scale_off);
 }
 
 } // namespace
@@ -341,174 +595,41 @@ void emit_microkernel_tail(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     }
 }
 
-// One batch element.
-//
-// Loads A and x pointers, then runs the reduction loop over k.
-// Each iteration processes one `k_block` chunk and advances the pointers.
-void emit_bs_body(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
-        const std::vector<ir::vreg_t> &acc, ir::vreg_t batch_ptr,
-        ir::vreg_t a_off, ir::vreg_t k_tail_mask) {
-    const ir::vreg_t a_ptr = ir.new_gpr();
-    const ir::vreg_t x_ptr = ir.new_gpr();
-
-    ir.load(a_ptr, batch_ptr, GET_OFF_BATCH_ELEMENT(ptr.A));
-    ir.add_reg(a_ptr, a_off);
-    ir.load(x_ptr, batch_ptr, GET_OFF_BATCH_ELEMENT(ptr.B));
-    ir.add_imm(batch_ptr, sizeof(brgemm_batch_element_t));
-
-    // Advance the A and x pointers by one K block.
-    auto advance_ptrs = [&]() {
-        ir.add_imm(a_ptr, cfg.kblk_a_off);
-        ir.add_imm(x_ptr, cfg.kblk_x_off);
-    };
-
-    // Reduce the full K blocks, then the tail if any. Cases by `k_blocks`.
-    // k > 0 guarantees k_blocks and k_tail are never both zero.
-    //   *  == 0  whole reduction is the tail
-    //   *  == 1  one block, advance by hand only if a tail follows
-    //   *  >= 2  loop, advancing per iteration
-    if (cfg.k_blocks >= 2) {
-        ir::emit_loop_imm(ir, cfg.k_blocks, [&]() {
-            emit_microkernel(ir, cfg, acc, a_ptr, x_ptr);
-        }, advance_ptrs);
-    } else if (cfg.k_blocks == 1) {
-        emit_microkernel(ir, cfg, acc, a_ptr, x_ptr);
-        if (cfg.k_tail > 0) advance_ptrs();
-    }
-    if (cfg.k_tail > 0)
-        emit_microkernel_tail(ir, cfg, acc, a_ptr, x_ptr, k_tail_mask);
-}
-
 // One M block.
 //
-// Contains `m_block` independent accumulators, reduced across the batch.
+// Contains `rows` independent accumulators, reduced across the batch.
 // They are then horizontally reduced to a single scalar each and stored.
 //
 // Finally, advances the A and x pointers to the next M block.
 void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
-        const m_loop_input_regs_t &regs, int m_block) {
-    std::vector<ir::vreg_t> acc(m_block, ir::vreg_t::none);
-    for (int r = 0; r < m_block; r++) {
-        acc[r] = ir.new_vec(cfg.dt_acc);
-
-        // The current implementation supports only 0 and 1 for beta so for the
-        // case where beta = 1 we load `y` into the accumulator registers and
-        // then the microkernel adds the results of the multiplication to them.
-        //
-        // This reads `y_ptr` while a sum post-op reads `store_ptr`, so the two
-        // never count the same value twice.
-        if (cfg.beta == 0.0f)
-            ir.vzero(acc[r]);
-        else
-            ir.vload_scalar(acc[r], regs.advancing.y_ptr,
-                    cfg.dt_sz_y * (dim_t)r * cfg.incy, cfg.dt_y);
-    }
+        const m_loop_input_regs_t &regs, dim_t rows) {
+    const std::vector<ir::vreg_t> acc = init_accumulators(ir, cfg, regs, rows);
 
     // Batch reduction over bs dimension
     const ir::vreg_t batch_ptr = ir.new_gpr();
     ir.mov_reg(batch_ptr, regs.invariant.batch);
 
-    if (cfg.max_bs > 1) {
-        ir::emit_loop_reg(ir, regs.invariant.bs, [&]() {
-            emit_bs_body(ir, cfg, acc, batch_ptr, regs.advancing.a_off,
-                    regs.invariant.k_tail_mask);
+    auto bs_body = [&]() {
+        emit_bs_body(ir, cfg, batch_ptr, regs.advancing.a_off,
+                [&](ir::vreg_t a_ptr, ir::vreg_t x_ptr) {
+            emit_microkernel(ir, cfg, acc, a_ptr, x_ptr);
+        }, [&](ir::vreg_t a_ptr, ir::vreg_t x_ptr) {
+            emit_microkernel_tail(
+                    ir, cfg, acc, a_ptr, x_ptr, regs.invariant.gemv_tail_mask);
         });
-    } else {
-        ir::emit_loop_imm(ir, 1, [&]() {
-            emit_bs_body(ir, cfg, acc, batch_ptr, regs.advancing.a_off,
-                    regs.invariant.k_tail_mask);
-        });
-    }
+    };
+    if (cfg.max_bs > 1)
+        ir::emit_loop_reg(ir, regs.invariant.bs, bs_body);
+    else
+        ir::emit_loop_imm(ir, 1, bs_body);
 
-    // Horizontal reduction + store
+    // Each accumulator holds the partial products of one output, so it is
+    // horizontally reduced to the single value the epilogue works on.
     const ir::vreg_t ws = ir.new_vec(cfg.dt_acc);
-    for (int r = 0; r < m_block; r++)
+    for (int r = 0; r < (int)acc.size(); r++)
         ir.vhreduce(acc[r], ws);
 
-    if (cfg.has_post_ops()) {
-        // The implemented order conforms to oneDNN's defined semantics for
-        // applying scales, bias and post-ops:
-        //   src scale -> weights scale -> bias -> post-ops.
-        // Scales apply to the accumulated result before the bias add and
-        // post-ops apply after bias. The two scales can swap because both are
-        // multiplies but a scale must not move past the bias and the bias must
-        // not move past the post-ops.
-        const ir::label_t skip_post_ops = ir.new_label();
-        ir.jz(regs.invariant.do_post_ops, skip_post_ops);
-
-        if (cfg.with_src_scales) {
-            // Loaded once and applied to every output.
-            const ir::vreg_t sc = ir.new_vec(cfg.dt_src_scales);
-            ir.vload_scalar(
-                    sc, regs.invariant.src_scale_ptr, 0, cfg.dt_src_scales);
-
-            for (int r = 0; r < m_block; r++)
-                ir.vmul(acc[r], sc);
-        }
-
-        if (cfg.with_wei_scales) {
-            // The single scale is loop invariant, so load it once above the
-            // loop. The per-N case loads a separate scale per output element.
-            const ir::vreg_t sc = ir.new_vec(cfg.dt_wei_scales);
-            if (cfg.single_wei_scale)
-                ir.vload_scalar(
-                        sc, regs.advancing.wei_scale_ptr, 0, cfg.dt_wei_scales);
-
-            for (int r = 0; r < m_block; r++) {
-                if (!cfg.single_wei_scale)
-                    ir.vload_scalar(sc, regs.advancing.wei_scale_ptr,
-                            cfg.dt_sz_wei_scales * (dim_t)r, cfg.dt_wei_scales);
-                ir.vmul(acc[r], sc);
-            }
-        }
-
-        if (cfg.with_bias) {
-            // The broadcast bias is loop invariant, so load it once outside the
-            // loop. A row output loads a separate bias per output element.
-            const ir::vreg_t bias = ir.new_vec(cfg.dt_bias);
-            if (!cfg.treat_y_as_row)
-                ir.vload_scalar(bias, regs.advancing.bias_ptr, 0, cfg.dt_bias);
-
-            for (int r = 0; r < m_block; r++) {
-                if (cfg.treat_y_as_row)
-                    ir.vload_scalar(bias, regs.advancing.bias_ptr,
-                            cfg.dt_sz_bias * (dim_t)r, cfg.dt_bias);
-                ir.vadd(acc[r], bias);
-            }
-        }
-
-        if (cfg.with_injector_postops) {
-            // Each accumulator is horizontally reduced to one scalar, which is
-            // the active element count `generate()` gives the injector. The
-            // output offset matches the store displacement below, so a sum
-            // post-op reads each element from the address its result is
-            // written to.
-            std::vector<dim_t> out_byte_off(m_block);
-            for (int r = 0; r < m_block; r++)
-                out_byte_off[r] = cfg.dt_sz_y * (dim_t)r * cfg.incy;
-
-            ir.inject_postops(acc, regs.advancing.store_ptr, out_byte_off);
-        }
-
-        ir.label(skip_post_ops);
-    }
-
-    for (int r = 0; r < m_block; r++)
-        ir.vstore_scalar(regs.advancing.store_ptr,
-                cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r], cfg.dt_y);
-
-    // Advance to next M block
-    ir.add_imm(regs.advancing.a_off, cfg.mblk_a_off);
-    ir.add_imm(regs.advancing.y_ptr, cfg.mblk_y_off);
-    // When `!has_post_ops()`, `store_ptr` is the same IR vreg as `y_ptr` (see
-    // `init_m_loop_input_regs`), so advancing `y_ptr` above covers both.
-    if (cfg.has_post_ops())
-        ir.add_imm(regs.advancing.store_ptr, cfg.mblk_y_off);
-
-    if (cfg.with_bias && cfg.treat_y_as_row)
-        ir.add_imm(regs.advancing.bias_ptr, cfg.mblk_bias_off);
-    if (cfg.with_wei_scales && !cfg.single_wei_scale)
-        ir.add_imm(regs.advancing.wei_scale_ptr, cfg.mblk_wei_scale_off);
+    emit_epilogue(ir, cfg, regs, acc, rows);
 }
 
 // Builds IR for GEMV with a non-transposed A matrix.
@@ -533,7 +654,7 @@ void build_gemv(const brgemm_desc_t &brg, ir::ir_t &ir) {
         ir::emit_loop_imm(ir, cfg.m_blocks,
                 [&]() { emit_m_block(ir, cfg, regs, cfg.m_block); });
 
-    if (cfg.m_tail > 0) emit_m_block(ir, cfg, regs, (int)cfg.m_tail);
+    if (cfg.m_tail > 0) emit_m_block(ir, cfg, regs, cfg.m_tail);
 }
 
 } // namespace nontrans

--- a/src/cpu/x64/brgemm/brgemv_ir.hpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.hpp
@@ -32,7 +32,7 @@ status_t brgemv_ir_supported(const brgemm_desc_t &brg);
 
 // Creates an IR-based GEMV kernel. Caller owns the pointer.
 // Returns `nullptr` on failure.
-brgemm_kernel_t *create_brgemv_ir_kernel(const brgemm_desc_t &brg);
+brgemm_kernel_t DNNL_API *create_brgemv_ir_kernel(const brgemm_desc_t &brg);
 
 } // namespace x64
 } // namespace cpu

--- a/src/cpu/x64/ir/README.md
+++ b/src/cpu/x64/ir/README.md
@@ -87,7 +87,9 @@ step. They are omitted above for clarity.
   operation itself carries only that index. The table also holds each
   accumulator's output offset, which a binary post-op needs to address its
   right-hand-side argument and a sum post-op needs to read the previous
-  destination value. The injector saves and restores its own registers and does
+  destination value. Each call also selects full vectors or the kernel's fixed
+  tail count, allowing a vector-accumulator kernel to handle both safely.
+  The injector saves and restores its own registers and does
   not participate in IR allocation.
 
 ### Control and Data Flow
@@ -148,6 +150,20 @@ today. A shared runner for the fixed part is a follow-up.
 The kernel-specific builders live outside this directory. For example,
 `src/cpu/x64/brgemm/brgemv_ir.{hpp,cpp}` holds the GEMV builder and shows how
 `generate()` runs the full pipeline.
+
+### GEMV Coverage
+
+The GEMV builder supports transposed and nontransposed A with matching f32,
+bf16, or f16 inputs and f32 accumulation and output. Existing GEMV ISA selection
+is unchanged: f32 uses AVX2, bf16 uses AVX-512 BF16, and f16 uses AVX-512 FP16.
+Nontransposed bf16 retains its native dot-product path. Transposed bf16 and f16
+widen inputs to f32 before FMA, with one broadcast input per reduction step.
+Output conversions and unsupported attributes continue to use the existing
+non-IR fallback. Vector accumulators require contiguous output elements.
+
+`vbcast` carries both a memory datatype and a destination-register datatype,
+like a vector load. AVX-512 can widen a bf16 or f16 scalar while broadcasting it.
+Masked widening loads preserve the input element count and zero inactive lanes.
 
 ## Developer Guidelines
 

--- a/src/cpu/x64/ir/README.md
+++ b/src/cpu/x64/ir/README.md
@@ -154,12 +154,15 @@ The kernel-specific builders live outside this directory. For example,
 ### GEMV Coverage
 
 The GEMV builder supports transposed and nontransposed A with matching f32,
-bf16, or f16 inputs and f32 accumulation and output. Existing GEMV ISA selection
-is unchanged: f32 uses AVX2, bf16 uses AVX-512 BF16, and f16 uses AVX-512 FP16.
+bf16, or f16 inputs and f32 accumulation and output. f32 prefers AVX-512 Core
+where available and otherwise uses AVX2; bf16 uses AVX-512 BF16, and f16 uses
+AVX-512 FP16.
 Nontransposed bf16 retains its native dot-product path. Transposed bf16 and f16
 widen inputs to f32 before FMA, with one broadcast input per reduction step.
 Output conversions and unsupported attributes continue to use the existing
-non-IR fallback. Vector accumulators require contiguous output elements.
+non-IR fallback, except f32 AVX-512 GEMV, which is IR-only and returns
+unimplemented when the IR kernel is unsupported. Vector accumulators require
+contiguous output elements.
 
 `vbcast` carries both a memory datatype and a destination-register datatype,
 like a vector load. AVX-512 can widen a bf16 or f16 scalar while broadcasting it.

--- a/src/cpu/x64/ir/emitter/backend_avx2.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx2.hpp
@@ -101,6 +101,15 @@ struct avx2_backend_t {
         else { JIT_ASSERT(!"vstore_scalar: dtype not implemented"); }
     }
 
+    // dst[i] = [base + disp] for every i
+    void vbcast(int d, int base, dim_t disp, data_type_t mem_dt,
+            data_type_t reg_dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
+            gen().vbroadcastss(Xbyak::Ymm(d), addr);
+        else { JIT_ASSERT(!"vbcast: dtype not implemented"); }
+    }
+
     void vadd(int d, int s, data_type_t dt) { // dst += s0
         if (dt == data_type::f32)
             gen().vaddps(Xbyak::Ymm(d), Xbyak::Ymm(d), Xbyak::Ymm(s));

--- a/src/cpu/x64/ir/emitter/backend_avx512.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx512.hpp
@@ -112,6 +112,14 @@ struct avx512_backend_t {
         else { JIT_ASSERT(!"vstore_scalar: dtype not implemented"); }
     }
 
+    void vbcast(int d, int base, dim_t disp, data_type_t mem_dt,
+            data_type_t reg_dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
+            gen().vbroadcastss(Xbyak::Zmm(d), addr);
+        else { JIT_ASSERT(!"vbcast: dtype not implemented"); }
+    }
+
     void vadd(int d, int s, data_type_t dt) { // dst += s0
         if (dt == data_type::f32)
             gen().vaddps(Xbyak::Zmm(d), Xbyak::Zmm(d), Xbyak::Zmm(s));

--- a/src/cpu/x64/ir/emitter/backend_avx512.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx512.hpp
@@ -78,6 +78,9 @@ struct avx512_backend_t {
         if (mem_dt == reg_dt
                 && utils::one_of(reg_dt, data_type::f32, data_type::bf16)) {
             gen().vmovups(Xbyak::Zmm(d), addr);
+        } else if (mem_dt == data_type::bf16 && reg_dt == data_type::f32) {
+            gen().vpmovzxwd(Xbyak::Zmm(d), addr);
+            gen().vpslld(Xbyak::Zmm(d), Xbyak::Zmm(d), 16);
         } else if (mem_dt == data_type::f16 && reg_dt == data_type::f32) {
             gen().vcvtph2ps(Xbyak::Zmm(d), addr);
         } else {
@@ -115,9 +118,17 @@ struct avx512_backend_t {
     void vbcast(int d, int base, dim_t disp, data_type_t mem_dt,
             data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
-        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32) {
             gen().vbroadcastss(Xbyak::Zmm(d), addr);
-        else { JIT_ASSERT(!"vbcast: dtype not implemented"); }
+        } else if (mem_dt == data_type::bf16 && reg_dt == data_type::f32) {
+            gen().vpbroadcastw(Xbyak::Zmm(d), addr);
+            gen().vpslld(Xbyak::Zmm(d), Xbyak::Zmm(d), 16);
+        } else if (mem_dt == data_type::f16 && reg_dt == data_type::f32) {
+            gen().vpbroadcastw(Xbyak::Ymm(d), addr);
+            gen().vcvtph2ps(Xbyak::Zmm(d), Xbyak::Ymm(d));
+        } else {
+            JIT_ASSERT(!"vbcast: dtype not implemented");
+        }
     }
 
     void vadd(int d, int s, data_type_t dt) { // dst += s0
@@ -185,6 +196,9 @@ struct avx512_backend_t {
             gen().vmovups(Xbyak::Zmm(d) | k | gen().T_z, addr);
         } else if (mem_dt == data_type::bf16 && reg_dt == data_type::bf16) {
             gen().vmovdqu16(Xbyak::Zmm(d) | k | gen().T_z, addr);
+        } else if (mem_dt == data_type::bf16 && reg_dt == data_type::f32) {
+            gen().vpmovzxwd(Xbyak::Zmm(d) | k | gen().T_z, addr);
+            gen().vpslld(Xbyak::Zmm(d), Xbyak::Zmm(d), 16);
         } else if (mem_dt == data_type::f16 && reg_dt == data_type::f32) {
             gen().vmovdqu16(Xbyak::Ymm(d) | k | gen().T_z, addr);
             gen().vcvtph2ps(Xbyak::Zmm(d), Xbyak::Ymm(d));

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -284,8 +284,8 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 JIT_ASSERT(!spilled(args.base_ptr)
                         && "inject_postops: base pointer spilled");
                 JIT_ASSERT(postops && "inject_postops: missing injector");
-                postops->inject(
-                        acc_phys, phys(args.base_ptr), args.out_byte_off);
+                postops->inject(acc_phys, phys(args.base_ptr),
+                        args.out_byte_off, args.is_tail);
                 break;
             }
 

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -225,6 +225,13 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 be.vstore_scalar(base, op.mem.disp, s, op.mem_dt, dt_of(op.s0));
                 break;
             }
+            case op_kind_t::vbcast: { // overwrites dst
+                int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                be.vbcast(d, base, op.mem.disp, op.mem_dt, dt_of(op.dst));
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
             case op_kind_t::vdot: { // rmw: reads and writes dst
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
                 if (spilled(op.dst)) spill_reload(op.dst, d);

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -220,11 +220,12 @@ void ir_t::prefetch(vreg_t base, dim_t disp) {
 }
 
 void ir_t::inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr,
-        const std::vector<dim_t> &out_byte_off) {
+        const std::vector<dim_t> &out_byte_off, bool is_tail) {
     inject_postops_args_t args;
     args.acc = acc;
     args.base_ptr = base_ptr;
     args.out_byte_off = out_byte_off;
+    args.is_tail = is_tail;
     inject_postops_args_.push_back(args);
 
     op_t op;

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -132,6 +132,16 @@ void ir_t::vstore_scalar(
     ops_.push_back(op);
 }
 
+void ir_t::vbcast(vreg_t dst, vreg_t base, dim_t disp, data_type_t mem_dt) {
+    op_t op;
+    op.kind = op_kind_t::vbcast;
+    op.dst = dst;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    op.mem_dt = mem_dt;
+    ops_.push_back(op);
+}
+
 void ir_t::vdot(vreg_t dst, vreg_t a, vreg_t b) {
     op_t op;
     op.kind = op_kind_t::vdot;
@@ -319,6 +329,7 @@ void ir_t::def_use(
         case op_kind_t::vzero: d(op.dst); break;
         case op_kind_t::vload:
         case op_kind_t::vload_scalar:
+        case op_kind_t::vbcast:
             u(op.mem.base);
             d(op.dst);
             break;

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -234,15 +234,14 @@ struct vreg_info_t {
 //
 // `base_ptr` and `out_byte_off` are unused by an eltwise-only chain.
 //
-// How many elements of an accumulator are active is not recorded here. That is
-// a detail of hooking the Xbyak injector up to the IR, not of the IR itself.
-// The count is fixed for a kernel, so the lowering takes it once instead (see
-// `postops_injector_t`), and the register that carries the pattern is
-// ISA-specific. Neither belongs in a target-neutral IR.
+// The tail count is fixed for a kernel and belongs to the lowering (see
+// `postops_injector_t`). `is_tail` selects that count for this operation;
+// otherwise all elements of its accumulators are active.
 struct inject_postops_args_t {
     std::vector<vreg_t> acc;
     vreg_t base_ptr = vreg_t::none;
     std::vector<dim_t> out_byte_off;
+    bool is_tail = true;
 };
 
 // An `ir_t` is the operation list plus, for each virtual register, its info
@@ -334,7 +333,7 @@ struct DNNL_API ir_t {
     // where each accumulator lands in the output (see
     // `inject_postops_args_t`).
     void inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr,
-            const std::vector<dim_t> &out_byte_off);
+            const std::vector<dim_t> &out_byte_off, bool is_tail = true);
 
     // control flow
     // Pass the returned op index to `loop_end` to close the loop.

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -106,6 +106,8 @@ enum class op_kind_t {
     vload_scalar,
     // [base + disp] = s0 (store one element)
     vstore_scalar,
+    // dst[i] = [base + disp] for every i (broadcast one element)
+    vbcast,
     // dst += sum_{i=0}^{N-1} (s0[i] * s1[i]), where N is the dot length
     vdot,
     // dst += s0 (vector add)
@@ -303,6 +305,9 @@ struct DNNL_API ir_t {
     void vstore(vreg_t base, dim_t disp, vreg_t src, data_type_t mem_dt);
     void vload_scalar(vreg_t dst, vreg_t base, dim_t disp, data_type_t mem_dt);
     void vstore_scalar(vreg_t base, dim_t disp, vreg_t src, data_type_t mem_dt);
+    // Unlike `vload_masked` with a single element, this fills every element of
+    // `dst`, so the value can be combined with a full-vector operand.
+    void vbcast(vreg_t dst, vreg_t base, dim_t disp, data_type_t mem_dt);
     void vdot(vreg_t dst, vreg_t a, vreg_t b);
     void vadd(vreg_t dst, vreg_t src);
     void vmul(vreg_t dst, vreg_t src);

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -124,7 +124,7 @@ void postops_injector_t::init(jit_generator_t &gen) const {
 }
 
 void postops_injector_t::inject(const std::vector<int> &acc_phys, int base_phys,
-        const std::vector<dim_t> &out_byte_off) {
+        const std::vector<dim_t> &out_byte_off, bool is_tail) {
     injector_utils::vmm_index_set_t vmm_idxs;
     for (int idx : acc_phys)
         vmm_idxs.insert(idx);
@@ -144,7 +144,7 @@ void postops_injector_t::inject(const std::vector<int> &acc_phys, int base_phys,
     // A positive `tail_elems_` means an accumulator holds fewer valid elements
     // than a full vector, so a right-hand-side load has to stop at that count
     // to stay in bounds. `init()` has put that pattern in the tail opmask.
-    const bool is_tail = tail_elems_ > 0;
+    is_tail = is_tail && tail_elems_ > 0;
 
     // Map each accumulator to its destination address. A binary post-op uses it
     // to locate the corresponding right-hand-side slice, and the sum operation

--- a/src/cpu/x64/ir/postops_injector.hpp
+++ b/src/cpu/x64/ir/postops_injector.hpp
@@ -108,7 +108,7 @@ struct postops_injector_t {
     // right-hand-side argument through it, sum reads the previous destination
     // value from it.
     void DNNL_API inject(const std::vector<int> &acc_phys, int base_phys,
-            const std::vector<dim_t> &out_byte_off);
+            const std::vector<dim_t> &out_byte_off, bool is_tail = true);
 
     // Emit the post-ops constant table. Call once, after the postamble. Only
     // eltwise and sum post-ops have a table, so this is a no-op without one.

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -302,11 +302,11 @@ status_t check_isa_with_datatype(
 status_t gemv_check_isa_with_datatype(
         const cpu_isa_t isa, const brgemm_matmul_conf_utils_t &bm_conf_utils) {
     // Valid GEMV (dt, isa) combinations:
-    // - f32  -> avx2
+    // - f32  -> avx2 or avx512_core
     // - bf16 -> avx512_core_bf16
     // - f16  -> avx512_core_fp16
     // Any other data type or isa is unsupported.
-    const bool ok = (bm_conf_utils.is_f32() && isa == avx2)
+    const bool ok = (bm_conf_utils.is_f32() && one_of(isa, avx2, avx512_core))
             || (bm_conf_utils.is_bf16() && isa == avx512_core_bf16)
             || (bm_conf_utils.is_f16() && isa == avx512_core_fp16);
 

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -384,7 +384,7 @@ TEST(IRBuilderTests, BroadcastDefUse) {
     ir.load_param(ptr, 0);
 
     const vreg_t b = ir.new_vec(data_type::f32);
-    ir.vbcast(b, ptr, (dim_t)sizeof(float));
+    ir.vbcast(b, ptr, (dim_t)sizeof(float), data_type::f32);
 
     ASSERT_EQ(ir.n_ops(), 2);
     EXPECT_EQ(ir.ops()[1].kind, op_kind_t::vbcast);
@@ -984,6 +984,56 @@ TEST(IntegrationTests, BroadcastScalesWholeVector) {
     kernel.run(&args);
     for (int index = 0; index < simd_w(); index++)
         EXPECT_FLOAT_EQ(output_data[index], input_data[index] * scales[1]);
+}
+
+TEST(IntegrationTests, NarrowBroadcastAndWideningLoads) {
+    if (!mayiuse(avx512_core)) GTEST_SKIP() << "Requires AVX-512";
+
+    struct narrow_args_t {
+        const uint16_t *input;
+        const uint16_t *scale;
+        float *output;
+    };
+
+    for (data_type_t mem_dt : {data_type::bf16, data_type::f16}) {
+        for (int elems : {1, 15, 16}) {
+            ir_t ir;
+            const vreg_t input_ptr = ir.new_gpr();
+            ir.load_param(input_ptr, offsetof(narrow_args_t, input));
+            const vreg_t scale_ptr = ir.new_gpr();
+            ir.load_param(scale_ptr, offsetof(narrow_args_t, scale));
+            const vreg_t output_ptr = ir.new_gpr();
+            ir.load_param(output_ptr, offsetof(narrow_args_t, output));
+            const vreg_t input = ir.new_vec(data_type::f32);
+            if (elems == 16) {
+                ir.vload(input, input_ptr, sizeof(uint16_t), mem_dt);
+            } else {
+                const vreg_t mask = ir.new_mask();
+                ir.set_mask_imm(mask, elems);
+                ir.vload_masked(
+                        input, input_ptr, sizeof(uint16_t), mask, mem_dt);
+            }
+            const vreg_t scale = ir.new_vec(data_type::f32);
+            ir.vbcast(scale, scale_ptr, sizeof(uint16_t), mem_dt);
+            ir.vmul(input, scale);
+            ir.vstore(output_ptr, 0, input, data_type::f32);
+
+            ir_kernel_t kernel(ir);
+            ASSERT_TRUE(kernel.run_ir_pipeline());
+            std::vector<uint16_t> input_data(17, 0x7bff);
+            for (int index = 1; index <= elems; index++)
+                input_data[index] = 0x4000;
+            const uint16_t scales[] = {0x4000, 0xc000};
+            std::vector<float> output_data(17, -12345.f);
+            narrow_args_t args {input_data.data(), scales, output_data.data()};
+            kernel.run(&args);
+            for (int index = 0; index < 16; index++)
+                EXPECT_FLOAT_EQ(output_data[index], index < elems ? -4.f : 0.f)
+                        << "datatype " << mem_dt << " tail " << elems
+                        << " element " << index;
+            EXPECT_FLOAT_EQ(output_data[16], -12345.f);
+        }
+    }
 }
 
 // Computes a dot product where one vector is multiplied by n vectors into

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -25,6 +25,8 @@
 
 #include "common/c_types_map.hpp"
 
+#include "cpu/x64/brgemm/brgemm.hpp"
+#include "cpu/x64/brgemm/brgemv_ir.hpp"
 #include "cpu/x64/ir/emitter/emitter.hpp"
 #include "cpu/x64/ir/ir.hpp"
 #include "cpu/x64/ir/postops_injector.hpp"
@@ -834,6 +836,79 @@ struct dot_args_t {
     const float *b;
     float *c;
 };
+
+TEST(GemvIRTests, F32IsaAndTails) {
+    SKIP_IF_NO_AVX2();
+    for (const auto isa : {avx2, avx512_core}) {
+        if (!mayiuse(isa)) continue;
+        for (bool transposed : {false, true})
+            for (int outputs : {1, 15, 16, 17, 127, 128, 129})
+                for (int reduction : {1, 15, 16, 17, 33})
+                    for (int batches : {1, 3})
+                        for (float beta : {0.f, 1.f}) {
+                            SCOPED_TRACE(::testing::Message()
+                                    << "isa=" << isa << " transA=" << transposed
+                                    << " outputs=" << outputs << " reduction="
+                                    << reduction << " batches=" << batches
+                                    << " beta=" << beta);
+                            brgemm_desc_t descriptor;
+                            ASSERT_EQ(impl::status::success,
+                                    brgemv_desc_init(&descriptor, isa,
+                                            brgemm_addr, data_type::f32,
+                                            data_type::f32, transposed, 1.f,
+                                            beta,
+                                            transposed ? outputs : reduction, 1,
+                                            outputs, reduction, true));
+                            ASSERT_EQ(isa, descriptor.isa_impl);
+                            brgemm_attr_t attributes;
+                            attributes.max_bs = batches;
+                            ASSERT_EQ(impl::status::success,
+                                    brgemm_desc_set_attr(
+                                            &descriptor, attributes));
+                            ASSERT_EQ(impl::status::success,
+                                    brgemm_desc_finalize(&descriptor));
+                            std::unique_ptr<brgemm_kernel_t> kernel(
+                                    create_brgemv_ir_kernel(descriptor));
+                            ASSERT_NE(nullptr, kernel);
+                            ASSERT_EQ(impl::status::success,
+                                    kernel->create_kernel());
+                            std::vector<float> matrix(
+                                    batches * outputs * reduction, 2.f);
+                            std::vector<float> vector(
+                                    batches * reduction, -3.f);
+                            std::vector<float> output(outputs + 1, 5.f);
+                            std::vector<brgemm_batch_element_t> batch(batches);
+                            for (int index = 0; index < batches; index++) {
+                                batch[index].ptr.A = matrix.data()
+                                        + index * outputs * reduction;
+                                batch[index].ptr.B
+                                        = vector.data() + index * reduction;
+                            }
+                            brgemm_kernel_execute(kernel.get(), batches,
+                                    batch.data(), output.data());
+                            for (int index = 0; index < outputs; index++)
+                                ASSERT_FLOAT_EQ(
+                                        -6.f * batches * reduction + beta * 5.f,
+                                        output[index]);
+                            ASSERT_FLOAT_EQ(5.f, output[outputs]);
+                        }
+    }
+}
+
+TEST(GemvIRTests, F32Avx512RejectsUnsupportedIR) {
+    if (!mayiuse(avx512_core)) GTEST_SKIP() << "Requires AVX-512 Core";
+    brgemm_desc_t descriptor;
+    ASSERT_EQ(impl::status::success,
+            brgemv_desc_init(&descriptor, avx512_core, brgemm_addr,
+                    data_type::f32, data_type::f32, true, 1.f, 0.5f, 17, 1, 17,
+                    33, true));
+    ASSERT_EQ(impl::status::success, brgemm_desc_finalize(&descriptor));
+    brgemm_kernel_t *kernel = nullptr;
+    const auto result = brgemm_kernel_create(&kernel, descriptor);
+    std::unique_ptr<brgemm_kernel_t> guard(kernel);
+    EXPECT_EQ(impl::status::unimplemented, result);
+    EXPECT_EQ(nullptr, kernel);
+}
 
 // Pipeline test. A dot product over two vectors' worth of elements, expressed
 // as a two-iteration loop, is built, allocated, emitted, run, and checked

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -375,6 +375,28 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
     EXPECT_NE(std::find(uses.begin(), uses.end(), (int)acc), uses.end());
 }
 
+// A broadcast reads the base pointer and overwrites its destination. Unlike an
+// accumulator it must not be reported as reading the destination, otherwise the
+// allocator would keep a dead value alive.
+TEST(IRBuilderTests, BroadcastDefUse) {
+    ir_t ir;
+    const vreg_t ptr = ir.new_gpr();
+    ir.load_param(ptr, 0);
+
+    const vreg_t b = ir.new_vec(data_type::f32);
+    ir.vbcast(b, ptr, (dim_t)sizeof(float));
+
+    ASSERT_EQ(ir.n_ops(), 2);
+    EXPECT_EQ(ir.ops()[1].kind, op_kind_t::vbcast);
+    EXPECT_EQ(ir.ops()[1].mem.base, ptr);
+    EXPECT_EQ(ir.ops()[1].mem.disp, (dim_t)sizeof(float));
+
+    std::vector<int> defs, uses;
+    ir.def_use(ir.ops()[1], defs, uses);
+    EXPECT_EQ(defs, std::vector<int>({(int)b}));
+    EXPECT_EQ(uses, std::vector<int>({(int)ptr}));
+}
+
 // Validates loop construction. A real loop links its end back to its begin and
 // shares one counter register, while a loop that would run only once is inlined
 // rather than emitted as a branch that is never taken.
@@ -933,6 +955,35 @@ TEST(IntegrationTests, MaskedAccessCoversActiveElementsOnly) {
         EXPECT_FLOAT_EQ(c_buf[i], a_buf[i] * b_buf[i]) << " at element " << i;
     for (int i = tail; i < simd_w(); i++)
         EXPECT_FLOAT_EQ(c_buf[i], sentinel) << " at element " << i;
+}
+
+TEST(IntegrationTests, BroadcastScalesWholeVector) {
+    SKIP_IF_NO_AVX2();
+
+    ir_t ir;
+    const vreg_t input_ptr = ir.new_gpr();
+    ir.load_param(input_ptr, offsetof(dot_args_t, a));
+    const vreg_t scale_ptr = ir.new_gpr();
+    ir.load_param(scale_ptr, offsetof(dot_args_t, b));
+    const vreg_t output_ptr = ir.new_gpr();
+    ir.load_param(output_ptr, offsetof(dot_args_t, c));
+    const vreg_t input = ir.new_vec(data_type::f32);
+    ir.vload(input, input_ptr, 0, data_type::f32);
+    const vreg_t scale = ir.new_vec(data_type::f32);
+    ir.vbcast(scale, scale_ptr, sizeof(float), data_type::f32);
+    ir.vmul(input, scale);
+    ir.vstore(output_ptr, 0, input, data_type::f32);
+
+    ir_kernel_t kernel(ir);
+    ASSERT_TRUE(kernel.run_ir_pipeline());
+    std::vector<float> input_data(simd_w()), output_data(simd_w(), -12345.f);
+    const float scales[] = {100.f, 3.f};
+    for (int index = 0; index < simd_w(); index++)
+        input_data[index] = (float)(index + 1);
+    dot_args_t args {input_data.data(), scales, output_data.data()};
+    kernel.run(&args);
+    for (int index = 0; index < simd_w(); index++)
+        EXPECT_FLOAT_EQ(output_data[index], input_data[index] * scales[1]);
 }
 
 // Computes a dot product where one vector is multiplied by n vectors into


### PR DESCRIPTION
Implements [MFDNN-15478](https://jira.devtools.intel.com/browse/MFDNN-15478).
- added bcast operation for IR
- added support vectorized accumulators
- implemented transposed A case
- added support of AVX512 backend (including f32, previously not supported).


Performance report: 
[gemv_nvl_perf_report.xlsx](https://github.com/user-attachments/files/32066598/gemv_nvl_perf_report.xlsx)
