### PR TITLE
build: cmake: change clang's stack protector flag from all to strong

### DIFF
--- a/cmake/SDL.cmake
+++ b/cmake/SDL.cmake
@@ -1,6 +1,7 @@
 #===============================================================================
 # Copyright 2017 Intel Corporation
 # Copyright 2021 FUJITSU LIMITED
+# Copyright 2026 Arm Ltd. and affiliates
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -68,9 +69,9 @@ if(UNIX)
                                   CMAKE_CXX_COMPILER_VERSION)
     elseif(CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
         get_filename_component(CXX_CMD_NAME ${CMAKE_CXX_COMPILER} NAME)
-        # Fujitsu CXX compiler does not support "-fstack-protector-all".
+        # Fujitsu CXX compiler does not document/guarantee operation of stack protector flags
         if(NOT CXX_CMD_NAME STREQUAL "FCC")
-            append(ONEDNN_SDL_COMPILER_FLAGS "-fstack-protector-all")
+            append(ONEDNN_SDL_COMPILER_FLAGS "-fstack-protector-strong")
         endif()
     elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
         append(ONEDNN_SDL_COMPILER_FLAGS "-fstack-protector")
@@ -98,9 +99,9 @@ elseif(WIN32)
             append(ONEDNN_SDL_COMPILER_FLAGS "-D_FORTIFY_SOURCE=2")
         endif()
         get_filename_component(CXX_CMD_NAME ${CMAKE_CXX_COMPILER} NAME)
-        # Fujitsu CXX compiler does not support "-fstack-protector-all".
+        # Fujitsu CXX compiler does not document/guarantee operation of stack protector flags
         if(NOT CXX_CMD_NAME STREQUAL "FCC")
-            append(ONEDNN_SDL_COMPILER_FLAGS "-fstack-protector-all")
+            append(ONEDNN_SDL_COMPILER_FLAGS "-fstack-protector-strong")
         endif()
         append(ONEDNN_SDL_LINKER_FLAGS "-Xlinker /NXCOMPAT")
         if(NOT UPPERCASE_CMAKE_BUILD_TYPE STREQUAL "DEBUG")


### PR DESCRIPTION
# Description
Use `-fstack-protector-strong` instead of `-fstack-protector-all` when building oneDNN with Clang.

## Justification
GCC has used `-fstack-protector-strong` since the stack-protector flags were introduced to the CMake configuration in 2016. In this [commit](https://github.com/uxlfoundation/oneDNN/commit/1b42be2c6432db0f418e2db7a75bceda74ebcf43)  the stack protector was chosen based on GCC version, Clang was given `-fstack-protector-all` unconditionally. GCC now uses `-fstack-protector-strong` unconditionally.

Clang has supported `-fstack-protector-strong` since version 3.5.

This reduces instrumentation for functions that do not meet Clang's strong-protection heuristics while retaining stack protection for selected vulnerable functions. It also aligns the Clang configuration more closely with the existing GCC configuration.

Clang documents the difference [here](https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-fstack-protector-all):
```
-fstack-protector-all
Enable stack protectors for all functions

-fstack-protector-strong
Enable stack protectors for some functions vulnerable to stack smashing. Compared to -fstack-protector, 
this uses a stronger heuristic that includes functions containing arrays of any size (and any type), as 
well as any calls to alloca or the taking of an address from a local variable
```

## Tests
All NIGHTLY tests pass when compiling with Clang 20 on AArch64.

## Performance improvements
This work was evaluated on an AArch64 c8g.12xlarge instance (48 cores) using Clang 20. Performance may also improve on other platforms and compiler versions.

Using `-fstack-protector-all` causes small functions that are called in hot loops to use stack protection and stack-canary checks. One example is `dnnl::impl::bfloat16_t::operator float()`. This function can execute once per BF16 element, so the overhead accumulates in hot loops.

With `-fstack-protector-strong`, this function is not instrumented, while functions selected by Clang's strong-protection heuristics remain protected.

The following TorchBench models showed the most improvement
`-fstack-protector-all` vs `-fstack-protector-strong`:
| Model  | 1T speedup | 40T speedup |
|---|---:|---:|
| bf16-demucs | 1.84x | 1.65x |
| bf16-doctr_reco_predictor | 2.05x | 1.35x |
| bf16-pytorch_stargan | 1.43x | 1.34x |
| bf16-resnext50_32x4d | 1.31x | 1.27x |
| bf16-doctr_det_predictor | 1.34x | 1.23x |

The largest regression observed across the 147 tested models was 5.4% higher latency which appears to have just been due to random variation after reruns.