### PR TITLE
third_party: update xbyak_aarch64

### DIFF
--- a/third_party/xbyak_aarch64/src/util_impl.cpp
+++ b/third_party/xbyak_aarch64/src/util_impl.cpp
@@ -216,6 +216,7 @@ bool Cpu::has(Type type) const { return (type & info->getType()) == type; }
 bool Cpu::isAtomicSupported() const { return has(XBYAK_AARCH64_HWCAP_ATOMIC); }
 bool Cpu::isBf16Supported() const { return has(XBYAK_AARCH64_HWCAP_BF16); }
 bool Cpu::isF16Supported() const { return has(XBYAK_AARCH64_HWCAP_FPHP); }
+bool Cpu::isFhmSupported() const { return has(XBYAK_AARCH64_HWCAP_FHM); }
 
 } // namespace util
 } // namespace Xbyak_aarch64

--- a/third_party/xbyak_aarch64/src/util_impl_linux.h
+++ b/third_party/xbyak_aarch64/src/util_impl_linux.h
@@ -420,6 +420,8 @@ private:
       type_ |= (Type)XBYAK_AARCH64_HWCAP_FP;
     if (hwcap & HWCAP_FPHP)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_FPHP;
+    if (hwcap & HWCAP_ASIMDFHM)
+      type_ |= (Type)XBYAK_AARCH64_HWCAP_FHM;
     if (hwcap & HWCAP_ASIMD)
       type_ |= (Type)XBYAK_AARCH64_HWCAP_ADVSIMD;
     if (hwcap & HWCAP_CRC32)

--- a/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h
+++ b/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_adr.h
@@ -184,7 +184,7 @@ public:
   explicit AdrScSc(const XReg &xn, const XReg &xm) : Adr(SC_SC), xn_(xn), xm_(xm), mod_(LSL), sh_(0), init_mod_(false) {}
   // AdrScSc(const AdrNoOfs &a) :Adr(SC_SC), xn_(a.getXn()), xm_(XReg(31)),
   // mod_(LSL), sh_(0) {}
-  AdrScSc(const AdrReg &a) : Adr(SC_SC), xn_(a.getXn()), xm_(a.getXm()), mod_(a.getMod()), sh_(a.getSh()) {}
+  AdrScSc(const AdrReg &a) : Adr(SC_SC), xn_(a.getXn()), xm_(a.getXm()), mod_(a.getMod()), sh_(a.getSh()), init_mod_(a.getInitSh()) {}
   const XReg &getXn() const { return xn_; }
   const XReg &getXm() const { return xm_; }
   uint32_t getSh() const { return sh_; }

--- a/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h
+++ b/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_reg.h
@@ -643,7 +643,7 @@ class ZAReg : public _ZAReg {
   uint32_t _wvIdx;
   uint32_t _offs;
 public:
-  explicit ZAReg(uint32_t index) : _ZAReg(index), s(index), d(index) {}
+  explicit ZAReg(uint32_t index) : _ZAReg(index), _wvIdx(0), _offs(0), s(index), d(index) {}
   explicit ZAReg(uint32_t index, uint32_t bits, const WReg &wv, uint32_t offs) : _ZAReg(index, bits), _wvIdx(wv.getIdx()), _offs(offs), s(index), d(index) {}
   ZAReg operator()(const WReg &wv, uint32_t offs) const { return ZAReg(getIdx(), getBit(), wv, offs); }
   uint32_t getWvIdx() const { return _wvIdx; }

--- a/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h
+++ b/third_party/xbyak_aarch64/xbyak_aarch64/xbyak_aarch64_util.h
@@ -72,6 +72,7 @@ enum hwCap_t {
   XBYAK_AARCH64_HWCAP_SME_F16F16 = 1 << 10,
   XBYAK_AARCH64_HWCAP_SME_F64F64 = 1 << 11,
   XBYAK_AARCH64_HWCAP_FPHP = 1 << 12,
+  XBYAK_AARCH64_HWCAP_FHM = 1 << 13,
 };
 
 struct implementer_t {
@@ -105,6 +106,7 @@ public:
   bool isAtomicSupported() const;
   bool isBf16Supported() const;
   bool isF16Supported() const;
+  bool isFhmSupported() const;
 };
 
 } // namespace util


### PR DESCRIPTION
Sync the vendored snapshot from v1.3.0 through upstream commit 8b043eb, including two initialization fixes and FEAT_FHM detection.

# Description

Updates third_party/xbyak_aarch64 to include:

- https://github.com/fujitsu/xbyak_aarch64/commit/8b043eb7ec41c08822eafe6608fc474a71e7c08b
- Related to oneDNN f16 PR: https://github.com/uxlfoundation/oneDNN/pull/5867
- Only files under xbyak_aarch64/src and xbyak_aarch64/xbyak_aarch64 have been added, as per the structure under oneDNN currently.


Implements `fhm` cpu support for `fmlal` operator usage within oneDNN

# Checklist

## General

- [x ] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x ] Have you formatted the code using clang-format?

