### PR TITLE
 ci: aarch64: normalise benchdnn problem keys for performance comparison

### DIFF
--- a/.github/automation/aarch64/ci.json
+++ b/.github/automation/aarch64/ci.json
@@ -3,6 +3,6 @@
         "acl": "v53.1.0",
         "gcc": "13",
         "clang": "17",
-        "onednn-base": "v3.11"
+        "onednn-base": "v3.12"
     }
 }

--- a/.github/automation/performance/benchdnn_comparison.py
+++ b/.github/automation/performance/benchdnn_comparison.py
@@ -46,6 +46,14 @@ def print_to_github_out(message):
             print(message.replace("\n", "%0A"), file=f)
 
 
+def normalize_problem_key(key):
+    """Normalize equivalent benchdnn repro lines for comparison."""
+    tokens = key.replace("_", "-").split()
+    options = sorted(token for token in tokens if token.startswith("--"))
+    operands = [token for token in tokens if not token.startswith("--")]
+    return " ".join(options + operands)
+
+
 def compare_two_benchdnn(file1, file2, out_file=None):
     """
     Compare two benchdnn output files
@@ -72,19 +80,18 @@ def compare_two_benchdnn(file1, file2, out_file=None):
     r1_ctime = defaultdict(list)
     r2_exec = defaultdict(list)
     r2_ctime = defaultdict(list)
+    r1_problem = {}
 
     for key, exec_time, ctime in r1:
-        # Older versions of benchdnn outputs underscores
-        # instead of hyphens for some ops leading to
-        # mismatches in problems with newer versions
-        key = key.replace("_", "-")
-        r1_exec[key].append(float(exec_time))
-        r1_ctime[key].append(float(ctime))
+        normalized_key = normalize_problem_key(key)
+        r1_problem.setdefault(normalized_key, key.replace("_", "-").strip())
+        r1_exec[normalized_key].append(float(exec_time))
+        r1_ctime[normalized_key].append(float(ctime))
 
     for key, exec_time, ctime in r2:
-        key = key.replace("_", "-")
-        r2_exec[key].append(float(exec_time))
-        r2_ctime[key].append(float(ctime))
+        normalized_key = normalize_problem_key(key)
+        r2_exec[normalized_key].append(float(exec_time))
+        r2_ctime[normalized_key].append(float(ctime))
 
     exec_failures, ctime_failures = [], []
     if out_file is not None:
@@ -101,14 +108,15 @@ def compare_two_benchdnn(file1, file2, out_file=None):
         with open(out_file, "w") as f:
             f.write(headers + "| :---: | :---: | :---: | :---:|\n")
 
-    for prb in r1_exec:
-        if prb not in r2_exec:
+    for normalized_key in r1_exec:
+        prb = r1_problem[normalized_key]
+        if normalized_key not in r2_exec:
             raise Exception(f"{prb} exists in {file1} but not {file2}")
 
-        exec1 = r1_exec[prb]
-        exec2 = r2_exec[prb]
-        ctime1 = r1_ctime[prb]
-        ctime2 = r2_ctime[prb]
+        exec1 = r1_exec[normalized_key]
+        exec2 = r2_exec[normalized_key]
+        ctime1 = r1_ctime[normalized_key]
+        ctime2 = r2_ctime[normalized_key]
         exec_regressed_ttest = ttest_ind(exec2, exec1, alternative="greater")
         exec_improved_ttest = ttest_ind(exec2, exec1, alternative="less")
         ctime_ttest = ttest_ind(ctime2, ctime1, alternative="greater")

--- a/.github/automation/performance/benchdnn_comparison.py
+++ b/.github/automation/performance/benchdnn_comparison.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
 # *******************************************************************************
-# Copyright 2025 Arm Limited and affiliates.
+# Copyright 2025-2026 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
## Description

Normalise benchdnn problem keys before comparing performance results.

PR #5771 intentionally changed benchdnn to print global options before the driver name. The v3.11 baseline prints the driver first, causing semantically identical problems to be treated as missing:

- `--reorder --allow-enum-tags-only=false`
- `--allow-enum-tags-only=false --reorder`

The comparison now sorts option tokens while retaining positional operands. It also preserves the original baseline problem string for diagnostics and reports.

Fixes # (github issue)

This fixes the false failure seen in:
https://github.com/uxlfoundation/oneDNN/actions/runs/32932984278/job/98069056331

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?