### PR TITLE
cpu: aarch64: fix inner product weight layout translation

### DIFF
--- a/src/cpu/aarch64/matmul_inner_product.cpp
+++ b/src/cpu/aarch64/matmul_inner_product.cpp
@@ -81,28 +81,37 @@ status_t init_unflattened_ip_weights_md(memory_desc_t &ip_wei_md,
 
     const dim_t O_dim = 0;
     const dim_t inner_k_dim = k_dims[0];
-    const int interleaved_by = inner_block(mm_wei_md, 1);
     const int block_by = inner_block(mm_wei_md, 0);
+    // Access matmul's strides and inner blocks.
+    const auto &mm_blk = mm_wei_md.format_desc.blocking;
 
     auto &blk = ip_wei_md.format_desc.blocking;
-    blk.strides[inner_k_dim] = interleaved_by * block_by;
+    // Use matmul's K stride so the expanded descriptor keeps the same
+    // physical weight layout.
+    blk.strides[inner_k_dim] = mm_blk.strides[0];
     ip_wei_md.padded_dims[inner_k_dim]
             = utils::rnd_up(ip_wei_md.dims[inner_k_dim], block_by);
 
-    dim_t outer_stride = interleaved_by * ip_wei_md.padded_dims[inner_k_dim];
+    dim_t expanded_padded_k = 1; // Total size of all padded K dimensions.
+    for (const dim_t k_dim : k_dims)
+        expanded_padded_k *= ip_wei_md.padded_dims[k_dim];
+    if (expanded_padded_k != mm_wei_md.padded_dims[0])
+        return status::unimplemented;
+
+    dim_t outer_stride
+            = mm_blk.strides[0] * ip_wei_md.padded_dims[inner_k_dim] / block_by;
     for (size_t i = 1; i < k_dims.size(); ++i) {
         const dim_t k_dim = k_dims[i];
         blk.strides[k_dim] = outer_stride;
         outer_stride *= ip_wei_md.padded_dims[k_dim];
     }
 
-    blk.strides[O_dim] = outer_stride;
-    ip_wei_md.padded_dims[O_dim]
-            = utils::rnd_up(ip_wei_md.dims[O_dim], interleaved_by);
+    // Keep the output dimension's stride and padding from matmul.
+    blk.strides[O_dim] = mm_blk.strides[1];
+    ip_wei_md.padded_dims[O_dim] = mm_wei_md.padded_dims[1];
 
     // Keep the nested matmul inner-block sequence intact. Only remap matmul's
     // 2D K/N indices to the corresponding unflattened IP dimensions.
-    const auto &mm_blk = mm_wei_md.format_desc.blocking;
     for (int i = 0; i < mm_blk.inner_nblks; ++i) {
         const dim_t mm_inner_idx = mm_blk.inner_idxs[i];
         if (!utils::one_of(mm_inner_idx, 0, 1)) return status::unimplemented;


### PR DESCRIPTION
# Description

Fix for `test_benchdnn_modeC_ip_all_cpu`

This change fixes the AArch64 inner-product weight layout when a nested matmul
chooses the physical layout for multidimensional weights.

Inner product flattens its input dimensions into `K`, so public weights such as
`[O, C, H, W]` are passed to the nested matmul as `[K, O]`. After matmul chooses
its layout, oneDNN must describe the same memory again using the public
inner-product dimensions.

The existing conversion reconstructed the weight strides from inner block
sizes. Plain `ab` and `ba` matmul layouts have no inner blocks, so this lost the
difference between output-contiguous and K-contiguous weights. The resulting
inner-product descriptor and nested matmul descriptor could assign different
offsets to the same logical weight.

For example, `[K, O] = [4, 3]` has strides `[3, 1]` in `ab` layout and
`[1, 4]` in `ba` layout, but both have inner block sizes of one. If matmul
chooses `ab`, weight `(k=0, o=1)` is at offset 1. Reconstructing it as
K-contiguous instead places that logical weight at offset 4, so the writer and
matmul access different values in the same buffer.

This patch:

- uses the nested matmul descriptor's actual K and output strides;
- preserves the nested matmul's padded output size;
- verifies that the expanded padded K size matches matmul's padded K before
  accepting the descriptor.

The change is limited to
`src/cpu/aarch64/matmul_inner_product.cpp`. It does not change the inner-product
calculation, numerical tolerances, or public API.

## Coverage Tests

Before the fix, the NIGHTLY CPU batches reported:

- 36 internal failures in `test_benchdnn_modeC_ip_all_cpu`;
- 25 failures in `test_benchdnn_modeC_ip_float16_cpu`, all overlapping the
  broader IP batch.

The failures covered F32 post-ops, plain F16, F16 post-ops, and F16-to-S8.
Validation used an AArch64 system with 256-bit SVE, the OpenMP runtime, 32
threads, and no selection-sensitive environment overrides.

### Focused cases

Five representative cases can be run to cover each affected group:

```bash
build/tests/benchdnn/benchdnn --mode=C -v1 --engine=cpu \
  --ip --dir=FWD_B --attr-post-ops=prelu:per_oc \
  ic128ih4oc1024

build/tests/benchdnn/benchdnn --mode=C -v1 --engine=cpu \
  --ip --dir=FWD_B --attr-post-ops=sum:2:0:s32 \
  ic128ih4oc1024

build/tests/benchdnn/benchdnn --mode=C -v1 --engine=cpu \
  --ip --dir=FWD_B --dt=f16:f16:f16 \
  ic128ih4oc1024

build/tests/benchdnn/benchdnn --mode=C -v1 --engine=cpu \
  --ip --dir=FWD_B --dt=f16:f16:f16 \
  --attr-post-ops=linear:1:1 ic128ih4oc1024

build/tests/benchdnn/benchdnn --mode=C -v1 --engine=cpu \
  --ip --dir=FWD_B --dt=f16:f16:s8 --stag=abcd \
  mb128ic768ih1oc768
```

Result:

```text
tests:5 passed:5 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:0
```

### Complete affected batches

```bash
ctest --test-dir build --output-on-failure \
  -R '^test_benchdnn_modeC_ip_(all|float16)_cpu$'
```

Results:

```text
test_benchdnn_modeC_ip_all_cpu       Passed  318.84 sec
test_benchdnn_modeC_ip_float16_cpu   Passed  182.03 sec

100% tests passed, 0 tests failed out of 2
```

## Performance context

No performance measurements were collected because this is a descriptor
correctness fix and does not change the execution kernel.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and
  `make test_benchdnn_*`) pass locally for each commit? The two affected
  inner-product targets and five focused cases pass; the full test set was not
  run for this focused fix.
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance
  improvements? N/A: this is a correctness fix.

### Bug fixes

- [x] Have you included information on how to reproduce the issue?
- [ ] Have you added relevant regression tests? No new test was needed, the
  existing IP-all and F16 batches reproduce the issue and pass with the fix.
