### PR TITLE
cpu: aarch64: stabilise KAI matmul kernel selection

### DIFF
--- a/src/cpu/aarch64/matmul/kai_matmul.cpp
+++ b/src/cpu/aarch64/matmul/kai_matmul.cpp
@@ -319,13 +319,12 @@ status_t kai_matmul_t::pd_t::init(const engine_t *engine) {
             post_ops_fusion.fallback_start_index));
     _has_post_ops_fallback = post_ops_fusion.has_fallback(attr_.post_ops_);
 
-    const int max_threads = dnnl_get_current_num_threads();
-    const int num_threads
-            = threads_for_kernel_execute(kernel_execute_work(*this), max_threads);
+    _kernel_max_threads = threads_for_kernel_execute(
+            kernel_execute_work(*this), dnnl_get_max_threads());
     _args = std::make_shared<kai::ops::GemmArgs>(get_cpu_info(), M(), N(), K(),
             sections, _ag_nbatches, _ag_nmulti, indirect,
-            post_ops_fusion.activation, num_threads, _fixed_format, fast_mode,
-            post_ops_fusion.accumulate, _cfg.get());
+            post_ops_fusion.activation, _kernel_max_threads, _fixed_format,
+            fast_mode, post_ops_fusion.accumulate, _cfg.get());
 
     std::unique_ptr<kai::ops::IGemmCommon> kernel = nullptr;
 
@@ -339,6 +338,26 @@ status_t kai_matmul_t::pd_t::init(const engine_t *engine) {
     }
     VDISPATCH_MATMUL(kernel, VERBOSE_UNSUPPORTED_DT_CFG);
 
+    // Copy the resulting config object constructed from kernel
+    _cfg = std::make_shared<kai::ops::GemmConfig>(kernel->get_config());
+    // Some generated filters do not match the impl list, so it ends up rejecting
+    // the second time around. This could be removed if this is fixed in KleidiAI
+    _cfg->filter.clear();
+
+    // Recreate the kernel after normalizing the selected configuration.
+    // Clearing the implementation filter can make KAI select a different
+    // kernel with different packing and workspace requirements.
+    if (is_dequant()) {
+        kai::ops::DequantizeFloat dequant(0.5);
+        kernel = create_kai_gemm_dequant(dequant);
+    } else {
+        kernel = create_kai_gemm();
+    }
+    VDISPATCH_MATMUL(kernel, VERBOSE_UNSUPPORTED_DT_CFG);
+
+    // execute() recreates from this same filter-free configuration and stored
+    // thread cap, then limits only the active thread count. This keeps kernel
+    // selection and its workspace size stable across execution contexts.
     const bool weights_are_transposed
             = !_fixed_format && helper.transB() == 'T';
     _pack_weights = !_fixed_format && kernel->B_is_pretransposed();
@@ -346,12 +365,6 @@ status_t kai_matmul_t::pd_t::init(const engine_t *engine) {
             && kernel->B_pretranspose_supports_transpose();
     _reorder_weights_ba_to_ab
             = weights_are_transposed && !_pack_transposed_weights;
-
-    // Copy the resulting config object constructed from kernel
-    _cfg = std::make_shared<kai::ops::GemmConfig>(kernel->get_config());
-    // Some generated filters do not match the impl list, so it ends up rejecting
-    // the second time around. This could be removed if this is fixed in KleidiAI
-    _cfg->filter.clear();
 
     if (_fixed_format) {
         // Logical dimension indices
@@ -445,7 +458,9 @@ status_t kai_matmul_t::init(engine_t *engine) {
 
 status_t kai_matmul_t::execute(const exec_ctx_t &ctx) const {
 
-    const int max_threads = dnnl_get_current_num_threads();
+    const int current_max_threads = dnnl_get_current_num_threads();
+    const int max_threads
+            = nstl::min(pd()->_kernel_max_threads, current_max_threads);
     int num_threads = threads_for_kernel_execute(
             kernel_execute_work(*pd()), max_threads);
 
@@ -454,9 +469,10 @@ status_t kai_matmul_t::execute(const exec_ctx_t &ctx) const {
         DEFINE_ARG_SCALES_BUFFER(src_scale, DNNL_ARG_SRC);
         DEFINE_ARG_SCALES_BUFFER(wei_scale, DNNL_ARG_WEIGHTS);
         kai::ops::DequantizeFloat dequant(src_scale[0] * wei_scale[0]);
-        _kernel = pd()->create_kai_gemm_dequant(dequant, num_threads);
+        _kernel = pd()->create_kai_gemm_dequant(
+                dequant, pd()->_kernel_max_threads);
     } else {
-        _kernel = pd()->create_kai_gemm(num_threads);
+        _kernel = pd()->create_kai_gemm(pd()->_kernel_max_threads);
     }
     if (!_kernel) return status::runtime_error;
 

--- a/src/cpu/aarch64/matmul/kai_matmul.hpp
+++ b/src/cpu/aarch64/matmul/kai_matmul.hpp
@@ -81,6 +81,7 @@ struct kai_matmul_t : public primitive_t {
         bool _reorder_dst_ab_to_ba = false;
         unsigned int _ag_nbatches = 1;
         unsigned int _ag_nmulti = 1;
+        int _kernel_max_threads = 1;
         bool _src_broadcast_batch_dims = false;
         bool _has_post_ops_fallback = false;
         enum class nested_reorder_t : memory_tracking::key_t {


### PR DESCRIPTION
# Description

Fix for `test_benchdnn_modeC_matmul_ci_cpu`

This change keeps KAI matmul kernel selection and scratchpad sizing consistent
between primitive setup and execution.

In `kai_matmul.cpp` we would create a kernel for discovery, copy its config, and then clear its implementation name (which may be too specific). Then in execution we could select a different kernel which may require a larger workspace than had been allocated, causing a segfault.

```text
setup selects driver A -> reserves A's workspace
execution selects driver B -> B needs more workspace -> out-of-bounds write
```

Fix:

After the config is copied, create another kernel, use its attributes to set up the workspace so that segfault doesn't occur in execution time. We use the max threads the kernel can be configured for during setup, and then restrict based on threads available in execution context and threads requested given the workload.


The change is limited to:

- `src/cpu/aarch64/matmul/kai_matmul.cpp`;
- `src/cpu/aarch64/matmul/kai_matmul.hpp`.

No KleidiAI submodule code or KAI driver is changed or disabled.

## Coverage Tests

Before the fix, CTest `test_benchdnn_modeC_matmul_ci_cpu` reported one failing
benchdnn case. The problem terminated with `SIGSEGV`.

### Original reproducer

```bash
build/tests/benchdnn/benchdnn --mode=C -v1 --engine=cpu \
  --matmul --stag=abx --dtag=abx \
  --attr-post-ops=clip_v2:0.25:1 --attr-fpmath=tf32 \
  3x1x1480x456:1x1x456x1
```

Result after the fix:

```text
PASSED --impl=kai+post_ops_fallback
```

### Complete affected batch

```bash
ctest --test-dir build --output-on-failure \
  -R '^test_benchdnn_modeC_matmul_ci_cpu$'
```

Result:

```text
tests:5599 passed:4002 skipped:1403 mistrusted:194 unimplemented:0
invalid_arguments:0 failed:0 listed:0
```

The complete local CTest run also passed:

```text
test_benchdnn_modeC_matmul_ci_cpu   Passed  477.91 sec
100% tests passed, 0 tests failed out of 232
```

## Performance context

No performance measurements were collected because this is a correctness and
memory-safety fix. Executions with fewer active workers may reserve workspace
for the stored selection cap, leaving part of that workspace unused.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and
  `make test_benchdnn_*`) pass locally for each commit? The targeted tests pass.
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance
  improvements? N/A: this is a correctness and memory-safety fix.

### Bug fixes

- [x] Have you included information on how to reproduce the issue?
- [ ] Have you added relevant regression tests? No new test was needed.
