### PR TITLE
tests: aarch64: align KAI Winograd data types

### DIFF
--- a/tests/gtests/test_iface_wino_convolution.cpp
+++ b/tests/gtests/test_iface_wino_convolution.cpp
@@ -56,7 +56,6 @@ protected:
 #elif DNNL_AARCH64 && DNNL_CPU_THREADING_RUNTIME != DNNL_RUNTIME_THREADPOOL
         const bool is_cpu = get_test_engine_kind() == engine::kind::cpu;
         input_f32.wino_supported = is_cpu;
-        input_f16.wino_supported = is_cpu;
 #endif
     }
 };


### PR DESCRIPTION
# Description

This change makes the AArch64 Winograd interface test match the data types
supported by the KAI implementation. KAI Winograd supports f32 convolution,
but not f16 convolution.

## Problem

CTest `test_iface_wino_convolution` failed in
`wino_conv_test_t.TestSmallPadding`. The test marked both f32 and f16
Winograd convolution as supported on AArch64, so it expected primitive
descriptor creation to succeed for both. The KAI primitive (correctly) rejected
the unsupported f16 case, causing the test assertion to fail.

The test checks whether a primitive descriptor can be created. It does not run
the convolution in this case.

## Root cause

Upstream, ACL's primitive
descriptor advertises f16 support, but upstream oneDNN deliberately skipped
the small-padding ACL f16 case:

```cpp
#if defined(DNNL_AARCH64) && defined(DNNL_AARCH64_USE_ACL)
        if (input.dat_dt == data_type::f16) continue;
#endif
```

That skip was added by upstream commit
[`fc621a4d0`](https://github.com/uxlfoundation/oneDNN/commit/fc621a4d0fff65a78d51749b70469e820694d448)
(`cpu: aarch64: fix wino conv test failure`). The public commit contains no
more detailed explanation or review comments.

When KAI Winograd was added in
[`41fceea58c`](https://github.com/uxlfoundation/oneDNN/commit/41fceea58c3bbb8dc7022520f8692d727226440d),
the ACL-specific skip was removed, but this line was retained:

```cpp
input_f16.wino_supported = is_cpu;
```

## Change

Remove the AArch64 assignment that marks f16 Winograd as supported:

```cpp
const bool is_cpu = get_test_engine_kind() == engine::kind::cpu;
input_f32.wino_supported = is_cpu;
```

The f32 case still has to create a primitive descriptor successfully. The f16
case now has to be rejected, which directly checks KAI's current capability
instead of skipping the case.

The change only touches:

- `tests/gtests/test_iface_wino_convolution.cpp`

## Testing

### Correctness

```bash
./build/tests/gtests/test_iface_wino_convolution
```

Result: all three Winograd interface tests passed:

```text
[  PASSED  ] 3 tests.
```

The focused CTest target also passed:

```bash
ctest --test-dir build --output-on-failure \
  -R '^test_iface_wino_convolution$'
```

```text
100% tests passed, 0 tests failed out of 1
```

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and
  `make test_benchdnn_*`) pass locally for each commit? Only the directly
  affected Winograd interface test was run; it passes.
- [x] Have you formatted the code using clang-format 18.1.3?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance
  improvements? N/A: this is a test correction with no runtime change.

### Bug fixes

- [x] Have you included information on how to reproduce the issue?
- [x] Have you added relevant regression tests? N/A