### PR TITLE
cpu: aarch64: stabilise KAI convolution kernel selection

### DIFF
--- a/src/cpu/aarch64/kai_convolution_base.cpp
+++ b/src/cpu/aarch64/kai_convolution_base.cpp
@@ -250,13 +250,15 @@ status_t kai_convolution_fwd_base_t::pd_t::init(const engine_t *engine) {
 
     if (fixed_format_) cfg_->weight_format = kai::ops::WeightFormat::ANY;
 
+    kernel_max_threads_ = threads_for_kernel_execute(
+            kernel_execute_work(*this), dnnl_get_max_threads());
+
     const auto make_args = [&]() {
         return std::make_shared<kai::ops::GemmArgs>(get_cpu_info(), gemm_m(),
                 OC(), gemm_k(), gemm_k_sections(), gemm_n_batches(),
                 gemm_n_multi(), uses_indirect_gemm(),
-                post_ops_fusion.activation, dnnl_get_current_num_threads(),
-                fixed_format_, fast_mode, post_ops_fusion.accumulate,
-                cfg_.get());
+                post_ops_fusion.activation, kernel_max_threads_, fixed_format_,
+                fast_mode, post_ops_fusion.accumulate, cfg_.get());
     };
 
     args_ = make_args();
@@ -278,6 +280,15 @@ status_t kai_convolution_fwd_base_t::pd_t::init(const engine_t *engine) {
     // the second time around. This could be removed if this is fixed in KleidiAI.
     cfg_->filter.clear();
 
+    // Recreate the kernel after normalizing the selected configuration.
+    // Clearing the implementation filter can make KAI select a different
+    // kernel with different packing and workspace requirements.
+    kernel = create_kai_gemm(kernel_max_threads_);
+    VDISPATCH_CONV(kernel, VERBOSE_UNSUPPORTED_DT_CFG);
+
+    // execute() recreates from this same filter-free configuration and stored
+    // thread cap, then limits only the active thread count. This keeps kernel
+    // selection and its workspace size stable across execution contexts.
     if (fixed_format_) {
         constexpr dim_t O_dim = 0;
         constexpr dim_t I_dim = 1;
@@ -355,13 +366,15 @@ status_t kai_convolution_fwd_base_t::execute(const exec_ctx_t &ctx) const {
     const dim_t OW = pd->OW();
     const auto &scratchpad = ctx.get_scratchpad_grantor();
 
-    const int max_threads = dnnl_get_current_num_threads();
+    const int current_max_threads = dnnl_get_current_num_threads();
+    const int max_threads
+            = nstl::min(pd->kernel_max_threads_, current_max_threads);
     // KAI kernels are configured for either one thread or the runtime maximum.
     int kernel_num_threads
             = threads_for_kernel_execute(kernel_execute_work(*pd), max_threads);
 
     std::unique_ptr<kai::ops::IGemmCommon> kernel
-            = pd->create_kai_gemm(kernel_num_threads);
+            = pd->create_kai_gemm(pd->kernel_max_threads_);
     if (!kernel) return status::runtime_error;
 
     if (get_verbose(verbose_t::profile_externals)) {

--- a/src/cpu/aarch64/kai_convolution_base.hpp
+++ b/src/cpu/aarch64/kai_convolution_base.hpp
@@ -60,6 +60,7 @@ struct kai_convolution_fwd_base_t : public primitive_t {
 
         std::shared_ptr<kai::ops::GemmConfig> cfg_ = nullptr;
         std::shared_ptr<kai::ops::GemmArgs> args_ = nullptr;
+        int kernel_max_threads_ = 1;
         bool fixed_format_ = false;
         bool run_weight_reorder_ = false;
         data_type_t gemm_weights_dt_ = data_type::undef;


### PR DESCRIPTION
# Description

Fix for test `test_benchdnn_modeC_conv_dt_plain_cpu` 

This change keeps KAI convolution kernel selection and scratchpad sizing
consistent between primitive setup and execution. Similar PR [cpu: aarch64: stabilise KAI matmul kernel selection - #5904
#5904](https://github.com/uxlfoundation/oneDNN/pull/5904)

During setup, oneDNN selected a KAI kernel, copied its generated configuration,
and cleared the implementation-name filter. Execution recreated a kernel from
that filter-free configuration. KAI could then select a different kernel with
different packing and workspace requirements.

For the failing case, setup selected
`sve_ffhybrid_fp32_mla_6x4VL`, which required no temporary workspace.
Execution selected `sve_ffinterleaved_fp32_mla_8x3VL`, which required 255,104
bytes. Because setup had reserved zero bytes, the second kernel wrote through
a null workspace pointer and crashed.

```text
setup selects kernel A -> reserves A's workspace
execution selects kernel B -> B needs more workspace -> invalid write
```

The fix:

- stores one workload-aware thread cap for kernel selection;
- reselects the final kernel after clearing the generated filter;
- derives packing and workspace metadata from that final kernel; and
- recreates the execution kernel with the same selection cap while allowing
  the number of active worker threads to be reduced for the execution context.

```text
setup normalizes configuration -> selects and sizes kernel B
execution uses the same selection inputs -> recreates kernel B
```

The change is limited to:

- `src/cpu/aarch64/kai_convolution_base.cpp`;
- `src/cpu/aarch64/kai_convolution_base.hpp`.

No KleidiAI submodule code or KAI driver is changed or disabled.

## Coverage Tests

Before the fix, CTest `test_benchdnn_modeC_conv_dt_plain_cpu` crashed at
internal case 2248 with `SIGSEGV`.

### Original reproducer

```bash
./build/tests/benchdnn/benchdnn --mode=C -v1 --engine=cpu \
  --conv --stag=abx --dtag=abx --skip-impl=ref \
  'ic25ih13oc24oh12kh3ph0n"tails_conv:17"'
```

Result after the fix:

```text
PASSED --impl=im2row:kai
```

### Complete affected target

```bash
ctest --test-dir build --output-on-failure \
  -R '^test_benchdnn_modeC_conv_dt_plain_cpu$'
```

Result:

```text
1/1 Test: test_benchdnn_modeC_conv_dt_plain_cpu passed in 106.30 sec
100% tests passed, 0 tests failed out of 1
```

Only the directly affected reproducer and CTest target were run for this
focused patch.

# Checklist

## General

- [ ] Do all unit and benchdnn tests (`make test` and
  `make test_benchdnn_*`) pass locally for each commit? Test targets pass.
- [x] Have you formatted the code using clang-format 18.1.3?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance
  improvements? N/A: this is a correctness and memory-safety fix.

### Bug fixes

- [x] Have you included information on how to reproduce the issue?
- [ ] Have you added relevant regression tests? No new test was needed, the
  existing NIGHTLY target contains the crashing case.
