### PR TITLE
cpu: x64: fix thread-local Xbyak error poisoning in jit_generator_t

### DIFF
--- a/.github/.licenserc.yml
+++ b/.github/.licenserc.yml
@@ -8,6 +8,7 @@ header:
       |Codeplay Software Limited
       |FUJITSU LIMITED
       |Arm (?:Ltd\.|Limited) and affiliates\.?
+      |Google LLC
       |KNS Group LLC \(YADRO\)
       |Alanna Tempest
       |YANDEX LLC

--- a/src/cpu/x64/jit_generator.hpp
+++ b/src/cpu/x64/jit_generator.hpp
@@ -158,7 +158,16 @@ constexpr Xbyak::Operand::Code abi_not_param_reg =
 
 #endif
 
-class jit_generator_t : public Xbyak::MmapAllocator,
+// Clear Xbyak's sticky thread-local error before CodeGenerator is
+// constructed so that we detect any new error thrown by its constructor.
+// Clearing any prior thread-local error now is safe because any such error
+// should already have been acted on and therefore is now stale.
+struct jit_error_reset_t {
+    jit_error_reset_t() { Xbyak::ClearError(); }
+};
+
+class jit_generator_t : private jit_error_reset_t,
+                        public Xbyak::MmapAllocator,
                         public Xbyak::CodeGenerator {
 private:
     const int xmm_len = 16;

--- a/tests/gtests/internals/CMakeLists.txt
+++ b/tests/gtests/internals/CMakeLists.txt
@@ -29,6 +29,7 @@ if(NOT DNNL_TARGET_ARCH STREQUAL "X64" OR DNNL_CPU_RUNTIME STREQUAL "NONE")
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_brgemm.cpp)
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_float8.cpp)
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_cpu_ir.cpp)
+    list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_xbyak_no_exception.cpp)
 endif()
 
 if(DNNL_ENABLE_MAX_CPU_ISA)
@@ -63,12 +64,17 @@ register_exe(${TEST_EXE}_sdpa
         "test" "dnnl_gtest")
 list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_sdpa.cpp)
 
-# Register CPU IR tests as a separate executable (X64 only)
+# Register separate-executable X64-only tests
 if(DNNL_TARGET_ARCH STREQUAL "X64" AND NOT DNNL_CPU_RUNTIME STREQUAL "NONE")
     register_exe(${TEST_EXE}_cpu_ir
             "${MAIN_SRC_GTEST};${CMAKE_CURRENT_SOURCE_DIR}/test_cpu_ir.cpp"
             "test" "dnnl_gtest")
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_cpu_ir.cpp)
+
+    register_exe(${TEST_EXE}_xbyak_no_exception
+            "${MAIN_SRC_GTEST};${CMAKE_CURRENT_SOURCE_DIR}/test_xbyak_no_exception.cpp"
+            "test" "dnnl_gtest")
+    list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test_xbyak_no_exception.cpp)
 endif()
 
 register_exe(${TEST_EXE} "${TEST_SOURCES}" "test" "dnnl_gtest")

--- a/tests/gtests/internals/test_xbyak_no_exception.cpp
+++ b/tests/gtests/internals/test_xbyak_no_exception.cpp
@@ -1,0 +1,53 @@
+/*******************************************************************************
+* Copyright 2026 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#include "tests/gtests/dnnl_test_common.hpp"
+#include "gtest/gtest.h"
+
+// Explicitly disable exceptions in Xbyak so that errors are written to TLS.
+#ifndef XBYAK_NO_EXCEPTION
+#define XBYAK_NO_EXCEPTION
+#endif
+
+#include "src/cpu/x64/jit_generator.hpp"
+
+namespace dnnl {
+namespace {
+
+struct dummy_jit_t : public impl::cpu::x64::jit_generator_t {
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(dummy_jit_t)
+
+    dummy_jit_t() : jit_generator_t(jit_name(), impl::cpu::x64::isa_all) {}
+
+    void generate() override { ret(); }
+};
+
+TEST(jit_generator_test, thread_local_error_isolation) {
+    // Pretend a prior failed JIT operation left an error on this thread.
+    Xbyak::local::SetError(Xbyak::ERR_BAD_COMBINATION);
+    ASSERT_EQ(Xbyak::GetError(), Xbyak::ERR_BAD_COMBINATION);
+
+    // A new generator should start with a clean error state.
+    dummy_jit_t generator;
+    impl::status_t status = generator.create_kernel();
+
+    EXPECT_EQ(status, impl::status::success);
+    EXPECT_NE(generator.jit_ker(), nullptr);
+    EXPECT_EQ(Xbyak::GetError(), Xbyak::ERR_NONE);
+}
+
+} // namespace
+} // namespace dnnl


### PR DESCRIPTION
When compiled with XBYAK_NO_EXCEPTION, Xbyak stores error codes in a thread-local variable instead of throwing C++ exceptions. Once set, this error state persists on the thread until explicitly cleared by Xbyak::ClearError().

In asynchronous multithreaded environments (e.g. benchdnn's threadpools), expected errors (e.g. JIT compilation errors or capability probes) leave errors in TLS that subsequent JIT ops pick up on, which leads them to fail with a status::runtime_error.

Fix this by introducing a private base class of jit_generator_t that clears the TLS error (if any) before CodeGenerator is constructed, so that every JIT op starts with a clean TLS error state.

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?