### PR TITLE
common: matmul: reject non-canonical grouped quantization layouts

### DIFF
--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -24,6 +24,8 @@
 #include "oneapi/dnnl/dnnl.h"
 
 #include "c_types_map.hpp"
+#include "primitive_exec_types.hpp"
+#include "tag_traits.hpp"
 #include "type_helpers.hpp"
 #include "utils.hpp"
 
@@ -254,6 +256,39 @@ status_t grouped_matmul_attr_check(
         }
     }
 
+    return status::success;
+}
+
+// Scales and zero points are supplied as memory objects at execution time, but
+// no API communicates their layout to the library: `quant_entry_t::get_md()`
+// derives the expected descriptor from the attribute alone and always produces
+// a dense one with `abx` stride order. The grouped matmul kernels index those
+// buffers with that layout baked in, so a descriptor laid out any other way is
+// read at the wrong offsets and the primitive silently returns wrong results.
+//
+// The number of dimensions is deliberately not constrained. Describing a
+// quantization tensor without its broadcast dimensions is legitimate and
+// handled by the kernels - a `[G, N]` descriptor for per-expert per-N weights
+// scales of a `[G, K, N]` weights tensor, say - hence only the layout of the
+// dimensions that are present is checked. `memory_desc_matches_tag()` derives
+// the reference strides from `mdw` itself and skips unit dimensions, whose
+// strides are ambiguous.
+status_t check_quant_arg_layout(
+        const memory_desc_wrapper &mdw, const char *arg_name) {
+    // An argument that was not passed maps to a zero descriptor, and a host
+    // scalar carries no layout at all.
+    if (mdw.is_zero() || mdw.is_host_scalar_desc()) return status::success;
+
+    const bool is_canonical = mdw.is_blocking_desc()
+            && !mdw.has_runtime_dims_or_strides() && mdw.offset0() == 0
+            && array_cmp(mdw.padded_dims(), mdw.dims(), mdw.ndims())
+            && mdw.matches_tag(get_abx_tag(mdw.ndims()));
+    VCONDCHECK(primitive, exec, check, matmul, is_canonical,
+            status::invalid_arguments,
+            "%s memory descriptor must be dense with `abx` strides, got `%s`",
+            arg_name,
+            mdw.is_blocking_desc() ? md2fmt_tag_str(mdw.md_).c_str()
+                                   : "non-plain");
     return status::success;
 }
 #endif // DNNL_EXPERIMENTAL_GROUPED_MEMORY
@@ -627,6 +662,24 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
 
 namespace dnnl {
 namespace impl {
+
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+status_t grouped_matmul_exec_check(const exec_ctx_t &ctx) {
+    CHECK(check_quant_arg_layout(
+            ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC), "src scales"));
+    CHECK(check_quant_arg_layout(
+            ctx.memory_mdw(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS),
+            "weights scales"));
+    CHECK(check_quant_arg_layout(
+            ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC),
+            "src zero points"));
+    CHECK(check_quant_arg_layout(
+            ctx.memory_mdw(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS),
+            "weights zero points"));
+    return status::success;
+}
+#endif // DNNL_EXPERIMENTAL_GROUPED_MEMORY
+
 status_t matmul_desc_init(matmul_desc_t *matmul_desc,
         const memory_desc_t *src_desc, const memory_desc_t *weights_desc,
         const memory_desc_t *bias_desc, const memory_desc_t *dst_desc,

--- a/src/common/matmul_pd.hpp
+++ b/src/common/matmul_pd.hpp
@@ -47,6 +47,15 @@ status_t matmul_desc_init(matmul_desc_t *matmul_desc,
         const memory_desc_t *bias_desc, const memory_desc_t *dst_desc,
         const memory_desc_t *reduce_desc, matmul_reduce_kind_t reduce_kind);
 
+#if DNNL_EXPERIMENTAL_GROUPED_MEMORY
+// Validates the execution arguments that only the grouped matmul
+// implementations consume. Namely, the quantization arguments, whose layout no
+// API communicates at primitive descriptor creation time while the kernels
+// index them assuming the dense `abx` descriptor that `quant_entry_t::get_md()`
+// synthesizes.
+status_t grouped_matmul_exec_check(const exec_ctx_t &ctx);
+#endif
+
 status_t matmul_desc_init(matmul_desc_t *matmul_desc,
         const memory_desc_t *src_desc, const memory_desc_t *weights_desc,
         const memory_desc_t *bias_desc, const memory_desc_t *dst_desc);

--- a/src/cpu/matmul/ref_grouped_gemm.cpp
+++ b/src/cpu/matmul/ref_grouped_gemm.cpp
@@ -37,6 +37,8 @@ namespace matmul {
 // 2D grouped src (variable M) x 3D dense wei -> 2D grouped dst (variable M)
 // 2D grouped src (variable K) x 2D grouped wei (variable M) -> dense 3D dst
 status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
+    CHECK(grouped_matmul_exec_check(ctx));
+
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper wei_d(pd()->weights_md(0));
     const memory_desc_wrapper dst_d(pd()->dst_md());

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -808,6 +808,8 @@ status_t grouped_micro_gemm_t::execute_k_axis(const exec_ctx_t &ctx) const {
 }
 
 status_t grouped_micro_gemm_t::execute(const exec_ctx_t &ctx) const {
+    CHECK(grouped_matmul_exec_check(ctx));
+
     switch (pd()->grouped_axis_) {
         case grouped_axis_t::m_axis: return execute_m_axis(ctx);
         case grouped_axis_t::k_axis: return execute_k_axis(ctx);

--- a/src/gpu/intel/matmul/ref_grouped_gemm.cpp
+++ b/src/gpu/intel/matmul/ref_grouped_gemm.cpp
@@ -33,6 +33,8 @@ namespace matmul {
 // 2D grouped src (variable M) x 3D dense wei -> 2D grouped dst (variable M)
 // 2D grouped src (variable K) x 2D grouped wei (variable M) -> dense 3D dst
 status_t ref_grouped_t::execute(const exec_ctx_t &ctx) const {
+    CHECK(grouped_matmul_exec_check(ctx));
+
     const memory_desc_wrapper src_d(pd()->src_md());
     const memory_desc_wrapper wei_d(pd()->weights_md(0));
     const memory_desc_wrapper dst_d(pd()->dst_md());

--- a/tests/gtests/test_iface_grouped.cpp
+++ b/tests/gtests/test_iface_grouped.cpp
@@ -763,6 +763,86 @@ TEST(iface_grouped_test_t, TestBinaryPostOpDenseShapes) {
     }
 }
 
+// The grouped matmul kernels index quantization tensors assuming the dense
+// `abx` descriptor that the library synthesizes from the attribute, so a
+// non-canonical execution descriptor has to be rejected rather than silently
+// mis-indexed.
+HANDLE_EXCEPTIONS_FOR_TEST(iface_grouped_test_t, TestGroupedMatmulScaleLayout) {
+    engine eng = get_test_engine();
+
+    // The CPU SYCL stream submits the primitive as a host task and always
+    // reports success, so an execution status cannot be observed there.
+    SKIP_IF(eng.get_kind() == engine::kind::cpu
+                    && DNNL_CPU_RUNTIME == DNNL_RUNTIME_SYCL,
+            "Test requires a stream that propagates the execution status.");
+
+    const memory::dim ngroups = 2;
+    const memory::dim total_m = 8, K = 32, N = 8;
+    const memory::dim group_k = 16;
+    const memory::dim kg = K / group_k;
+    const int wei_mask = (1 << 0) | (1 << 1) | (1 << 2);
+
+    auto src_md = memory::desc::grouped({total_m, K}, dt::f16, 0, ngroups);
+    auto wei_md = memory::desc(
+            {ngroups, K, N}, dt::f4_e2m1, memory::format_tag::abc);
+    auto dst_md = memory::desc::grouped({total_m, N}, dt::f16, 0, ngroups);
+
+    primitive_attr attr;
+    attr.set_scales(DNNL_ARG_WEIGHTS, wei_mask, {group_k, 1}, dt::f8_e4m3);
+
+    matmul::primitive_desc pd;
+    ASSERT_NO_THROW(
+            pd = matmul::primitive_desc(eng, src_md, wei_md, dst_md, attr));
+    matmul prim(pd);
+    stream strm(eng);
+
+    // Byte-level initialization keeps this independent of the data types.
+    auto set_bytes = [](const memory &mem, uint8_t value, int index = 0) {
+        auto *p = mem.map_data<uint8_t>(index);
+        std::memset(p, value, mem.get_desc().get_size(index));
+        mem.unmap_data(p, index);
+    };
+    auto set_offsets = [&](const memory &mem) {
+        auto *p = mem.map_data<int32_t>(1);
+        for (memory::dim g = 0; g < ngroups; ++g)
+            p[g] = static_cast<int32_t>((g + 1) * total_m / ngroups);
+        mem.unmap_data(p, 1);
+    };
+
+    memory src_mem(src_md, eng);
+    memory wei_mem(wei_md, eng);
+    memory dst_mem(dst_md, eng);
+    set_bytes(src_mem, 0);
+    set_bytes(wei_mem, 0);
+    set_bytes(dst_mem, 0);
+    set_offsets(src_mem);
+    set_offsets(dst_mem);
+
+    auto execute_with_scales = [&](memory::format_tag tag) {
+        memory::desc scales_md({ngroups, kg, N}, dt::f8_e4m3, tag);
+        memory scales_mem(scales_md, eng);
+        set_bytes(scales_mem, 0x38); // f8_e4m3 1.0
+        dnnl_status_t status = dnnl_success;
+        try {
+            prim.execute(strm,
+                    {{DNNL_ARG_SRC, src_mem}, {DNNL_ARG_WEIGHTS, wei_mem},
+                            {DNNL_ARG_DST, dst_mem},
+                            {DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS,
+                                    scales_mem}});
+            strm.wait();
+        } catch (const error &e) { status = e.status; }
+        return status;
+    };
+
+    // A dense `abc` scale descriptor is what the kernels expect.
+    EXPECT_EQ(execute_with_scales(memory::format_tag::abc), dnnl_success);
+
+    // The same logical tensor described as `acb` transposes the two innermost
+    // dimensions, which the kernels cannot express.
+    EXPECT_EQ(execute_with_scales(memory::format_tag::acb),
+            dnnl_invalid_arguments);
+}
+
 } // namespace dnnl
 
 #endif // DNNL_EXPERIMENTAL_GROUPED_MEMORY


### PR DESCRIPTION
## Summary

Fixes #5908.

Grouped matmul takes scales and zero points as memory objects at execution time,
but no API communicates their layout to the library. `quant_entry_t::get_md()`
derives the expected descriptor from the attribute alone and always produces a
dense descriptor with `abx` stride order
(`src/common/primitive_attr_quant.hpp:135-136`), and the grouped kernels index
those buffers with that layout baked in
(`src/gpu/intel/matmul/grouped_micro_gemm_m_axis.cl:437`,
`src/gpu/intel/matmul/ref_grouped_gemm.cl:170-173`).

The consequence is that passing a differently-laid-out scale memory is accepted,
runs, and returns wrong results with a success status. The documented requirement
exists (`doc/functional_api/primitives/matmul.md:383-389`, "Tensors must use
dense memory descriptors"), but nothing enforced it.

This validates the quantization execution arguments and returns
`dnnl_invalid_arguments` instead.

## Design notes

**The number of dimensions is deliberately not constrained.** Describing a
quantization tensor without its broadcast dimensions is legitimate and handled by
the kernels — a `[G, N]` descriptor for per-expert per-N weights scales of a
`[G, K, N]` weights tensor, for instance, which is what benchdnn produces for
`wei:5` because `md2dims(..., extend_by_ones=false, ...)` drops masked-out dims.
Comparing against the descriptor `get_md()` synthesizes would therefore have
rejected a large number of currently-working configurations. Instead the check
derives its reference strides from the supplied descriptor's own rank via
`memory_desc_matches_tag(mdw, get_abx_tag(mdw.ndims()))`, which also skips unit
dimensions whose strides are ambiguous.

**The check is at execution time, not primitive-descriptor creation time.** This
is forced: `dnnl_primitive_attr_set_scales()` carries no descriptor
(`include/oneapi/dnnl/dnnl.h:463-489`), so the layout genuinely is not knowable
at PD creation. The check lives in the common layer and is called from the three
grouped implementations that index scales as dense `abx`.

**Scope.** GPU micro (`grouped_gemm:micro:m_axis`), GPU reference, and CPU
reference grouped kernels. `src/cpu/x64/zen64/matmul/zen_grouped_matmul.cpp`
rejects scales outright and needs no check. Zero points are covered as well as
scales, since they are synthesized the same way.

## Test Plan / Results

Intel Arc Pro B70 (Battlemage G31), driver `1.15.39122+12`, NEO
`26.27.39122.12`, oneAPI 2026.1, Ubuntu 26.04. Configured with
`-DDNNL_GPU_RUNTIME=SYCL -DDNNL_GPU_VENDOR=INTEL -DDNNL_BUILD_TESTS=ON
-DDNNL_EXPERIMENTAL=ON`.

### The defect, before and after

A standalone program building a grouped `f16 : f4_e2m1 : f16` matmul with
`f8_e4m3` group-16 weight scales, comparing against a scalar f64 reference, with
the scale memory bound two ways over identical logical dims `{E, K/16, N}`:

| scale md | before | after |
|---|---|---|
| dense `abc` (canonical), f32 dst | PASS, max rel err **0.000e+00** | PASS, max rel err **0.000e+00** |
| dense `abc` (canonical), f16 dst | PASS, max rel err **4.781e-04** | PASS, max rel err **4.781e-04** |
| strided `acb` | **accepted, max rel err 9.530e+01, status success** | **rejected, `dnnl_invalid_arguments`** |

The new diagnostic, verbatim under `ONEDNN_VERBOSE=all`:

```
onednn_verbose,v1,primitive,exec:check,matmul,weights scales memory descriptor must be dense with `abx` strides, got `acb`,src/common/matmul.cpp:291
```

The returned status is `dnnl_invalid_arguments` regardless of verbose level.

### Regression

`benchdnn --matmul --engine=gpu --batch=inputs/matmul/test_matmul_grouped_ci`:

```
before:  tests:621 passed:619 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:2
after:   tests:621 passed:619 skipped:0 mistrusted:0 unimplemented:0 invalid_arguments:0 failed:2
```

**No previously-passing configuration now fails.**

The 2 failures are **pre-existing and unrelated** — they involve no scales at
all, so this check cannot reach them:

```
--dt=bf16:bf16:bf16 --grouped=0:4:8+8+8+8  --wtag=acb --attr-post-ops=swish:1+mul:f16:1 32x64:4x64x32
--dt=bf16:bf16:bf16 --grouped=0:4:8+0+16+8 --wtag=acb --attr-post-ops=swish:1+mul:f16:1 32x64:4x64x32
```

I measured them with the check compiled out to confirm they predate this change.
They look like a separate correctness problem in the grouped kernel (407/1024 and
460/1024 elements wrong); I have not investigated further and can file it
separately if useful.

A production-shaped NVFP4 case also still passes:

```
$ benchdnn --matmul --engine=gpu --mode=C --dt=f16:f4_e2m1:f16 --wtag=abc \
    --grouped=0:85:30+30+...(85 groups) --attr-scales=wei:7:f8_e4m3:16x1 \
    2550x3072:85x3072x2048
0:PASSED (5727 ms) __REPRO: ... --impl=grouped_gemm:micro:m_axis ...
tests:1 passed:1 ... failed:0
```

### New coverage

`TestGroupedMatmulScaleLayout` in `tests/gtests/test_iface_grouped.cpp`:

```
$ ./test_iface_grouped --engine=gpu --gtest_filter='*ScaleLayout*'
[       OK ] iface_grouped_test_t.TestGroupedMatmulScaleLayout (30 ms)
[  PASSED  ] 1 test.
```

It skips on a CPU SYCL engine, with the reason in the source: that stream submits
the primitive as a host task and always reports success, so an execution status
cannot be observed there. It runs and passes on GPU.

### Independent check for false positives

Separately from the above, the example added in #5909 uses a dense canonical
`{E, K/16, N}` `abc` scale descriptor. Built and run against this branch's
library it is unaffected:

```
Implementation     : grouped_gemm:micro:m_axis
Max relative error : 0
Result             : PASSED
```

`clang-format -style=file` applied to the touched files.

## Note

I would rather the library honored a supplied outer stride than rejected it —
that would let a producer holding `[E, N, K/group]` scales bind them zero-copy
instead of repacking. That is a larger change to the kernels
(`grouped_micro_gemm_m_axis.cl:437` hard-codes the per-expert extent while
already reading an inner stride via `ldweiq`), so this PR only converts the
silent wrong answer into an error. Happy to look at honoring strides as a
follow-up if that is a direction you would take.
