### PR TITLE
gpu: rnn: fix backward propagation for dhc == 1

### DIFF
--- a/src/gpu/intel/rnn/grid.cpp
+++ b/src/gpu/intel/rnn/grid.cpp
@@ -748,6 +748,16 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
     auto fpmath_mode = this->attr()->fpmath_.mode_;
     int grf_per_thread = 0;
 
+    // The matmuls below fold the weights gates and channels into a single
+    // axis. Its stride is off[4], except for dhc == 1 where off[4] is a size-1
+    // dimension carrying no layout information and off[3] is used instead.
+    auto wei_strides = [dhc](const strides_t<5> &w) -> strides_t<2> {
+        return {w[2], dhc > 1 ? w[4] : w[3]};
+    };
+    auto wei_strides_trans = [dhc](const strides_t<5> &w) -> strides_t<2> {
+        return {dhc > 1 ? w[4] : w[3], w[2]};
+    };
+
     // Each RNN matmul is expressed in natural row-major form:
     //   dst[M, N] = src[M, K] * wei[K, N]
     // with any operand transpose encoded in the strides.
@@ -800,7 +810,7 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
             VDISPATCH_RNN_SC(
                     create_matmul(matmul_layer_fwd_pd_, layer_merged_size,
                             n_gates * dhc, slc, {conf.states_ws_ld, 1},
-                            {off.weights_layer[2], off.weights_layer[4]},
+                            wei_strides(off.weights_layer),
                             {conf.scratch_gates_ld, 1}, src_type, weights_type,
                             conf.acc_data_type, 0.0),
                     "create_matmul(matmul_layer_fwd_pd_)");
@@ -810,8 +820,7 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                             create_matmul(matmul_layer_fwd_src_pd_,
                                     layer_merged_size, n_gates * dhc, slc,
                                     {off.src_layer[1], off.src_layer[2]},
-                                    {off.weights_layer[2],
-                                            off.weights_layer[4]},
+                                    wei_strides(off.weights_layer),
                                     {conf.scratch_gates_ld, 1}, src_type,
                                     weights_type, conf.acc_data_type, 0.0),
                             "create_matmul(matmul_layer_fwd_src_pd_)");
@@ -825,7 +834,7 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                         create_matmul(matmul_iter_fwd_pd_, batch,
                                 (n_gates - 1) * dhc, sic,
                                 {conf.states_ws_ld, 1},
-                                {off.weights_iter[2], off.weights_iter[4]},
+                                wei_strides(off.weights_iter),
                                 {conf.scratch_gates_ld, 1}, src_type,
                                 weights_type, conf.acc_data_type,
                                 matmul_iter_fwd_beta),
@@ -833,7 +842,7 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                 VDISPATCH_RNN_SC(
                         create_matmul(matmul_iter_fwd_2_pd_, batch, dhc, sic,
                                 {conf.states_ws_ld, 1},
-                                {off.weights_iter[2], off.weights_iter[4]},
+                                wei_strides(off.weights_iter),
                                 {conf.scratch_gates_ld, 1}, src_type,
                                 weights_type, conf.acc_data_type,
                                 matmul_iter_fwd_beta),
@@ -842,7 +851,7 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                 VDISPATCH_RNN_SC(
                         create_matmul(matmul_iter_fwd_pd_, batch, n_gates * dhc,
                                 sic, {conf.states_ws_ld, 1},
-                                {off.weights_iter[2], off.weights_iter[4]},
+                                wei_strides(off.weights_iter),
                                 {conf.gates_ws_ld, 1}, src_type, weights_type,
                                 conf.acc_data_type, matmul_iter_fwd_beta),
                         "create_matmul(matmul_iter_fwd_pd_)");
@@ -855,13 +864,13 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
             VDISPATCH_RNN_SC(create_matmul(matmul_iter_bwd_pd_, batch, sic,
                                      (n_gates - 1) * dhc,
                                      {conf.scratch_diff_gates_ld, 1},
-                                     {off.weights_iter[4], off.weights_iter[2]},
+                                     wei_strides_trans(off.weights_iter),
                                      {conf.scratch_diff_states_ld, 1}, src_type,
                                      weights_type, conf.acc_data_type, 1.0f),
                     "create_matmul(matmul_iter_bwd_pd_)");
             VDISPATCH_RNN_SC(create_matmul(matmul_iter_bwd_2_pd_, batch, sic,
                                      dhc, {conf.scratch_diff_gates_ld, 1},
-                                     {off.weights_iter[4], off.weights_iter[2]},
+                                     wei_strides_trans(off.weights_iter),
                                      {conf.scratch_diff_states_ld, 1}, src_type,
                                      weights_type, conf.acc_data_type, 0.0f),
                     "create_matmul(matmul_iter_bwd_2_pd_)");
@@ -870,23 +879,21 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                             (n_gates - 1) * dhc, iter_merged_size,
                             {1, conf.states_ws_ld},
                             {conf.scratch_diff_gates_ld, 1},
-                            {off.diff_weights_iter[2],
-                                    off.diff_weights_iter[4]},
+                            wei_strides(off.diff_weights_iter),
                             src_type, weights_type, conf.acc_data_type, 1.0f),
                     "create_matmul(matmul_diff_wei_iter_pd_)");
             VDISPATCH_RNN_SC(
                     create_matmul(matmul_diff_wei_iter_2_pd_, sic, dhc,
                             iter_merged_size, {1, conf.states_ws_ld},
                             {conf.scratch_diff_gates_ld, 1},
-                            {off.diff_weights_iter[2],
-                                    off.diff_weights_iter[4]},
+                            wei_strides(off.diff_weights_iter),
                             src_type, weights_type, conf.acc_data_type, 1.0f),
                     "create_matmul(matmul_diff_wei_iter_2_pd_)");
         } else {
             VDISPATCH_RNN_SC(
                     create_matmul(matmul_iter_bwd_pd_, batch, sic,
                             n_gates * dhc, {conf.scratch_diff_gates_ld, 1},
-                            {off.weights_iter[4], off.weights_iter[2]},
+                            wei_strides_trans(off.weights_iter),
                             {conf.scratch_diff_states_ld, 1}, src_type,
                             weights_type, conf.acc_data_type,
                             matmul_iter_bwd_beta),
@@ -895,15 +902,14 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                     create_matmul(matmul_diff_wei_iter_pd_, sic, n_gates * dhc,
                             iter_merged_size, {1, conf.states_ws_ld},
                             {conf.scratch_diff_gates_ld, 1},
-                            {off.diff_weights_iter[2],
-                                    off.diff_weights_iter[4]},
+                            wei_strides(off.diff_weights_iter),
                             src_type, weights_type, conf.acc_data_type, 1.0f),
                     "create_matmul(matmul_diff_wei_iter_pd_)");
         }
         VDISPATCH_RNN_SC(
                 create_matmul(matmul_layer_bwd_pd_, layer_merged_size, slc,
                         n_gates * dhc, {conf.scratch_diff_gates_ld, 1},
-                        {off.weights_layer[4], off.weights_layer[2]},
+                        wei_strides_trans(off.weights_layer),
                         {conf.scratch_diff_states_ld, 1}, src_type,
                         weights_type, conf.acc_data_type, 0.0f),
                 "create_matmul(matmul_layer_bwd_pd_)");
@@ -913,7 +919,7 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                         create_matmul(matmul_layer_bwd_src_pd_,
                                 layer_merged_size, slc, n_gates * dhc,
                                 {conf.scratch_diff_gates_ld, 1},
-                                {off.weights_layer[4], off.weights_layer[2]},
+                                wei_strides_trans(off.weights_layer),
                                 {off.diff_src_layer[1], 1}, src_type,
                                 weights_type, conf.acc_data_type, 0.0f),
                         "create_matmul(matmul_layer_bwd_src_pd_)");
@@ -924,7 +930,7 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                 create_matmul(matmul_diff_wei_layer_pd_, slc, n_gates * dhc,
                         layer_merged_size, {1, conf.states_ws_ld},
                         {conf.scratch_diff_gates_ld, 1},
-                        {off.diff_weights_layer[2], off.diff_weights_layer[4]},
+                        wei_strides(off.diff_weights_layer),
                         src_type, weights_type, conf.acc_data_type, 1.0f),
                 "create_matmul(matmul_diff_wei_layer_pd_)");
         if (!conf.copy_src_layer) {
@@ -933,8 +939,7 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                                          slc, n_gates * dhc, layer_merged_size,
                                          {off.src_layer[2], off.src_layer[1]},
                                          {conf.scratch_diff_gates_ld, 1},
-                                         {off.diff_weights_layer[2],
-                                                 off.diff_weights_layer[4]},
+                                         wei_strides(off.diff_weights_layer),
                                          src_type, weights_type,
                                          conf.acc_data_type, 1.0f),
                         "create_matmul(matmul_diff_wei_layer_src_pd_)");


### PR DESCRIPTION
MFDNN-15507 - GPU RNN backward is broken when dhc == 1
======================================================

Summary
-------
On a GPU engine, RNN/LSTM/GRU backward propagation is broken whenever the
hidden size is 1 (dhc == 1). There are two symptoms, both produced by the same
root cause:

  1. slc > 1  -> primitive_desc creation fails (unimplemented).
     This is the reported symptom: lstm_backward::primitive_desc throws for
     dhc == 1, slc > 1, while forward_training succeeds for the same
     dimensions and the CPU engine handles both.

  2. slc == 1 -> the primitive is created but silently computes wrong
     gradients. This symptom was found while triaging (1) and is arguably
     more dangerous, since there is no error to observe.

The CPU engine is unaffected. Reproduced on main (1e0b72ac44, v3.14.0) on both
Arc B580 (Xe2HPG) and Data Center GPU Max 1550 (PVC).

benchdnn, before the fix (VANILLA_LSTM, --prop=BWD_DW, --engine=gpu):

  l1t4mb8sic1slc1dhc1dic1   FAILED (wrong results)
  l1t4mb8sic1slc2dhc1dic1   UNIMPLEMENTED
  l1t4mb8sic1slc4dhc1dic1   UNIMPLEMENTED
  l1t4mb8sic2slc2dhc2dic2   passeda

The same descriptors all pass on --engine=cpu.

Root cause
----------
The GPU RNN implementation expresses each cell computation as a 2D matmul. The
weights are 5D (ldigo or ldgoi, dims = {l, d, ic, g, oc}), and the matmul folds
the trailing (gates, channels) pair into one axis:

    grid.cpp:  {off.weights_layer[2], off.weights_layer[4]}   // fwd
               {off.weights_layer[4], off.weights_layer[2]}   // bwd (transposed)

Folding (g, oc) into a single axis is legal because both ldigo and ldgoi
guarantee

    stride(g) == dhc * stride(oc)

so the distance between two consecutive elements of the folded axis is
stride(oc), i.e. off[4].

The strides come from get_outer_strides() / outer_strides_getter_t
(src/gpu/intel/primitive_conf.hpp). That helper intentionally does not report
the real stride of a dimension whose padded size is 1; it substitutes a value
that makes the dimension dense with respect to its neighbours:

    else if (md.padded_dims()[d] > 1) return md.strides()[d];
    else if (d == md.ndims() - 1)     return 1;
    else                              return ret[d + 1] * md.padded_dims()[d + 1];

When dhc == 1, oc is exactly such a size-1 dimension, so off[4] is forced to 1
and no longer describes the layout. The identity stride(g) == dhc * stride(oc)
therefore stops holding, and the folded axis gets the wrong step.

Concretely, backward selects ldgoi weights with a padded GEMM leading dimension,
e.g. dims [1,1,2,4,1] strides [32,32,16,1,1] on B580. The real step of the
folded axis is the gate stride 16, but off[4] reports 1:

  * slc > 1: the bwd data matmul is built with wei strides {1, 1} for a 4x2
    matrix. That descriptor is self-overlapping, so memory_desc_init_by_strides
    returns invalid_arguments and the whole pd creation fails:

      create:dispatch,rnn,gpu:0,...,create_matmul(matmul_layer_bwd_pd_),
      src/gpu/intel/rnn/grid.cpp:903

  * slc == 1: the resulting descriptor {1, 64} happens to be a valid,
    non-overlapping descriptor, so creation succeeds - but the K stride is
    still wrong and the matmul reads the weights from the wrong offsets,
    producing incorrect gradients with no diagnostic.

dhc >= 2 is unaffected because oc is no longer a size-1 dimension and off[4]
carries the true stride.

Fix
---
src/gpu/intel/rnn/grid.cpp

Compute the step of the folded (gates, channels) axis explicitly instead of
assuming off[4] is meaningful:

    auto wei_gc_stride = [dhc](const strides_t<5> &w) {
        return dhc > 1 ? w[4] : w[3];
    };

When dhc == 1 there is exactly one channel per gate, so the distance between
consecutive elements of the folded axis is the gate stride off[3], which
get_outer_strides() does report correctly. The helper is applied to all four
weights tensors (weights_layer, weights_iter, diff_weights_layer,
diff_weights_iter) in both the forward and backward matmul setup.

This is a local, layout-only correction: for dhc > 1 the generated strides are
bit-for-bit identical to before, so only the previously broken dhc == 1 cases
change behaviour.

Validation
----------
Built oneDNN main (1e0b72ac44) with DNNL_GPU_RUNTIME=OCL and ran benchdnn on
Data Center GPU Max 1550.

Previously failing cases now pass (VANILLA_LSTM, --prop=BWD_DW, --engine=gpu):

  l1t4mb8sic1slc1dhc1dic1   passed   (was FAILED - wrong results)
  l1t4mb8sic1slc2dhc1dic1   passed   (was UNIMPLEMENTED)
  l1t4mb8sic1slc4dhc1dic1   passed   (was UNIMPLEMENTED)
  l1t1mb1sic1slc2dhc1dic1   passed   (was UNIMPLEMENTED)

Other cell kinds at dhc == 1 also pass now: VANILLA_GRU, LBR_GRU.
(VANILLA_RNN at dhc == 1 reports "mistrusted" on GPU and CPU alike - a
benchdnn small-size fill artifact, not related to this change.)

No regressions: the full GPU RNN suite

  ./benchdnn --rnn --engine=gpu --batch=inputs/rnn/test_rnn_gpu

completes with 0 failed and 0 unimplemented over 3637 cases.

Additionally, a standalone GPU-vs-CPU gradient comparison (fwd_training +
backward, all backward outputs compared) matches to ~1e-6 relative error for
T=4 N=8 slc=2 dhc=1.

Notes on the original report
----------------------------
The attached reproducer states that the forward pd selects ldgoi and that
backward then rejects "the layout its own forward picked". That is not
accurate: forward selects ldigo (strides [32,32,16,1,1] on B580). The
underlying complaint is nevertheless valid - format_tag::any is the documented
and, for backward weights, the only supported way to create these primitives
(benchdnn skips any other weights tag for backward), and it did not work.

Before this fix a workaround was to pass an explicit ldigo weights descriptor
to the backward pd, which was verified to produce numerically correct
gradients. It was only a partial workaround: it does not help the silently
wrong slc == 1 case. With this fix, plain format_tag::any works and no
workaround is needed.
