### PR TITLE
x64: brgemm: support per-N matmul dst scales

### DIFF
--- a/src/cpu/matmul/gemm_based_common.hpp
+++ b/src/cpu/matmul/gemm_based_common.hpp
@@ -98,6 +98,16 @@ inline bool check_gemm_output_format(const memory_desc_t &md) {
     return mdw.is_plain() && mdw.blocking_desc().strides[ndims - 1] == 1;
 }
 
+inline bool check_gemm_dst_scales(const matmul_pd_t &pd) {
+    const auto &dst_scales = pd.attr()->scales_.get(DNNL_ARG_DST);
+    // The GEMM post-processing kernel accepts one destination scale value.
+    const bool is_degenerate_per_n = pd.N() == 1
+            && dst_scales.get_mask() == pd.dst_qmask_N()
+            && dst_scales.has_default_groups();
+    return dst_scales.has_default_values() || dst_scales.get_mask() == 0
+            || is_degenerate_per_n;
+}
+
 inline bool check_gemm_compatible_formats(const matmul_pd_t &pd) {
     return check_gemm_input_format(*(pd.src_md()))
             && check_gemm_input_format(*(pd.weights_md()))

--- a/src/cpu/matmul/gemm_bf16_matmul.cpp
+++ b/src/cpu/matmul/gemm_bf16_matmul.cpp
@@ -107,6 +107,8 @@ status_t gemm_bf16_matmul_t<dst_type>::pd_t::check_and_configure_attributes(
         const engine_t *engine) {
     auto check_attr_scales = [&]() -> status_t {
         CHECK(attr_scales_ok(engine));
+        VDISPATCH_MATMUL(gemm_based::check_gemm_dst_scales(*this),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
         if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {

--- a/src/cpu/matmul/gemm_f32_matmul.cpp
+++ b/src/cpu/matmul/gemm_f32_matmul.cpp
@@ -50,6 +50,8 @@ status_t gemm_f32_matmul_t::pd_t::init(const engine_t *engine) {
 
     auto check_attr_scales = [&]() -> status_t {
         CHECK(attr_scales_ok(engine));
+        VDISPATCH_MATMUL(gemm_based::check_gemm_dst_scales(*this),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
         if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {

--- a/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
+++ b/src/cpu/matmul/gemm_x8s8s32x_matmul.cpp
@@ -61,6 +61,8 @@ status_t gemm_x8s8s32x_matmul_t::pd_t::init(const engine_t *engine) {
 
     auto check_attr_scales = [&]() -> status_t {
         CHECK(attr_scales_ok(engine));
+        VDISPATCH_MATMUL(gemm_based::check_gemm_dst_scales(*this),
+                VERBOSE_UNSUPPORTED_SCALES_CFG);
         if (!attr()->scales_.has_default_values(DNNL_ARG_SRC)
                 && !attr()->scales_.has_default_values(DNNL_ARG_WEIGHTS)
                 && attr()->scales_.get_mask(DNNL_ARG_WEIGHTS) > 0) {

--- a/src/cpu/matmul/ref_matmul.cpp
+++ b/src/cpu/matmul/ref_matmul.cpp
@@ -315,8 +315,13 @@ status_t ref_matmul_t::execute_ref(const exec_ctx_t &ctx) const {
                             data_type::f32, d, temp_dst, temp_dst_off);
                 } else {
                     if (with_dst_scales) {
+                        const dim_t dst_scale_off
+                                = matmul_helper_t::get_quant_off(dst_dims_idx,
+                                        ndims, dst_scale_mask,
+                                        dst_scale_group_m, dst_scale_group_n,
+                                        dst_scales_md);
                         const float dst_scale = io::load_float_value(
-                                dst_scale_dt, dst_scales, 0);
+                                dst_scale_dt, dst_scales, dst_scale_off);
                         d /= dst_scale;
                     }
                     if (dst_rnd_mode == rounding_mode::stochastic)

--- a/src/cpu/matmul/ref_matmul_int8.cpp
+++ b/src/cpu/matmul/ref_matmul_int8.cpp
@@ -142,6 +142,11 @@ status_t ref_matmul_int8_t::execute_ref(const exec_ctx_t &ctx) const {
 
     const bool with_dst_scales = !attr_scales.has_default_values(DNNL_ARG_DST);
     const auto dst_scale_dt = attr_scales.get_data_type(DNNL_ARG_DST);
+    const int dst_scale_mask = attr_scales.get_mask(DNNL_ARG_DST);
+    const auto dst_scale_group_m = attr_scales.get_group(DNNL_ARG_DST, -2);
+    const auto dst_scale_group_n = attr_scales.get_group(DNNL_ARG_DST, -1);
+    memory_desc_t dst_scale_md {};
+    CHECK(attr_scales.get(DNNL_ARG_DST).get_md(dst_scale_md, *dst_d.md_));
 
     // precomputed reductions section
     const auto &attr_pr = pd()->attr()->precomputed_reductions_;
@@ -291,8 +296,11 @@ status_t ref_matmul_int8_t::execute_ref(const exec_ctx_t &ctx) const {
             ref_post_ops->execute(d, args);
 
             if (with_dst_scales) {
-                const float dst_scale
-                        = io::load_float_value(dst_scale_dt, dst_scales, 0);
+                const dim_t dst_scale_off = matmul_helper_t::get_quant_off(
+                        dst_dims_idx, ndims, dst_scale_mask, dst_scale_group_m,
+                        dst_scale_group_n, dst_scale_md);
+                const float dst_scale = io::load_float_value(
+                        dst_scale_dt, dst_scales, dst_scale_off);
                 d /= dst_scale;
             }
             if (dst_zero_points) {

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -520,12 +520,19 @@ status_t brgemm_desc_set_postops(brgemm_desc_t *brg,
 
     const auto &dst_scales = attr->scales_.get(DNNL_ARG_DST);
     brg->with_dst_scales = !dst_scales.has_default_values();
+    const bool is_per_n_dst_scales = brg->is_per_n_dst_scales
+            && dst_scales.get_mask() == (1 << (dst_md->ndims - 1));
+    const bool is_degenerate_per_n_dst_scales
+            = dst_scales.get_mask() == (1 << (dst_md->ndims - 1))
+            && dst_md->dims[dst_md->ndims - 1] == 1
+            && dst_scales.has_default_groups();
     const bool scales_ok = attr->scales_.has_default_values({DNNL_ARG_SRC,
                                    DNNL_ARG_WEIGHTS, DNNL_ARG_DST})
             && IMPLICATION(!src_scales.has_default_values(),
                     src_scales.get_mask() == 0 || brg->is_per_k_src_scales)
             && IMPLICATION(!dst_scales.has_default_values(),
-                    dst_scales.get_mask() == 0);
+                    dst_scales.get_mask() == 0 || is_per_n_dst_scales
+                            || is_degenerate_per_n_dst_scales);
     if (!scales_ok) return status::unimplemented;
 
     auto init_zp_type
@@ -888,6 +895,7 @@ int brgemm_cmp(const brgemm_desc_t &lhs, const brgemm_desc_t &rhs) {
     CMP_BRGEMM_FIELD(dt_src_scales);
     CMP_BRGEMM_FIELD(with_wei_scales);
     CMP_BRGEMM_FIELD(with_dst_scales);
+    CMP_BRGEMM_FIELD(is_per_n_dst_scales);
     CMP_BRGEMM_FIELD(dt_wei_scales);
     CMP_BRGEMM_FIELD(bs_group);
 

--- a/src/cpu/x64/brgemm/brgemm_types.hpp
+++ b/src/cpu/x64/brgemm/brgemm_types.hpp
@@ -331,10 +331,10 @@ struct brgemm_desc_t {
     // `dst_scales` passed as a bare pointer making kernel change multiplication
     // to division was proved to be significantly slower, both for pure divps
     // instruction, or for emulation through rcpps. Therefore, each
-    // implementation dealing with `dst_scales` must prepare a per thread
-    // scratchpad memory and inverse values (usually, just one) inside a
-    // parallel task.
+    // implementation dealing with `dst_scales` must prepare scratchpad memory
+    // and inverse values before executing the kernel.
     bool with_dst_scales = false;
+    bool is_per_n_dst_scales = false;
     data_type_t dt_wei_scales = data_type::undef;
     // Grouping in batch used by brdgmm kernel
     int bs_group {0};
@@ -935,9 +935,10 @@ private:
 ///     A zero point only and skip the rest post-ops.
 /// @param zp_a_val - zero point value for A, required to adjust compensation
 ///     values if do_only_zp_a_val = true.
-/// @param dst_scales - Vector of inverted scale factor values for matix C,
-///     common scale vector type only is supported, it must be broadcasted to
-///     vector of simd width length.
+/// @param dst_scales - Vector of inverted scale factor values for matrix C.
+///     Common scales must be broadcasted to a vector of SIMD width length;
+///     per-N scales are passed as a vector corresponding to the current N
+///     block.
 ///
 struct brgemm_post_ops_data_t {
     brgemm_post_ops_data_t() = default;

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -1819,12 +1819,31 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
     if (brg.with_dst_scales) {
         reg_dst_scales.restore();
         auto zmm_dst_scales = zmm_tmp_1();
-        vbroadcastss(zmm_dst_scales, ptr[reg_dst_scales]);
-        for (auto bd = bd_start; bd < bd_finish; bd++) {
-            if (!is_out_bd(bi.bdi, bdb, bd)) continue;
+        if (brg.is_per_n_dst_scales) {
+            const auto dst_scale_offset
+                    = bi.ldi->pos(ldb) * brg.ld_block * sizeof(float);
+            const auto dst_scale_addr
+                    = EVEX_compress_addr(reg_dst_scales, dst_scale_offset);
+            const auto zmm_dst_scales_masked = vmm_mask(
+                    zmm_dst_scales, bi.ldi->is_tail(ldb), false, k_mask);
+            vmovups(zmm_dst_scales_masked, dst_scale_addr);
 
-            auto zmm = accm(bd);
-            vmulps(zmm, zmm, zmm_dst_scales);
+            for (auto bd = bd_start; bd < bd_finish; bd++) {
+                if (!is_out_bd(bi.bdi, bdb, bd)) continue;
+
+                auto zmm = accm(bd);
+                const auto zmm_masked
+                        = vmm_mask(zmm, bi.ldi->is_tail(ldb), false, k_mask);
+                vmulps(zmm_masked, zmm_masked, zmm_dst_scales);
+            }
+        } else {
+            vbroadcastss(zmm_dst_scales, ptr[reg_dst_scales]);
+            for (auto bd = bd_start; bd < bd_finish; bd++) {
+                if (!is_out_bd(bi.bdi, bdb, bd)) continue;
+
+                auto zmm = accm(bd);
+                vmulps(zmm, zmm, zmm_dst_scales);
+            }
         }
     }
 

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -221,6 +221,8 @@ private:
     const reg64_savable_t reg_src_scales {regscratchpad_, rbx, r23};
     const reg64_savable_t reg_wei_scales {regscratchpad_, rbx, r22};
     const reg64_savable_t reg_dst_scales {regscratchpad_, rbx, r20};
+    const reg64_savable_t reg_dst_scales_base {
+            regscratchpad_, r10, brg.is_per_n_dst_scales};
     const reg64_savable_t reg_aux_bias {regscratchpad_, rbx, r18};
     const reg64_savable_t reg_zp_comp_a {regscratchpad_, rbx};
     const reg64_savable_t reg_aux_zp_comp_a {regscratchpad_, rbx};
@@ -953,6 +955,11 @@ void jit_brgemm_kernel_t<Wmm>::advance_ldb_post_op_regs() {
         add(reg_aux_wei_scales, wei_scales_offset(1));
         reg_aux_wei_scales.save();
     }
+    if (brg.is_per_n_dst_scales) {
+        reg_dst_scales.restore();
+        add(reg_dst_scales, brg.ld_block * sizeof(float));
+        reg_dst_scales.save();
+    }
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_a.restore();
         add(reg_aux_zp_comp_a, zp_comp_a_offset(1));
@@ -981,6 +988,11 @@ void jit_brgemm_kernel_t<Wmm>::restore_ldb_post_op_regs(int ld_block2) {
         reg_aux_wei_scales.restore();
         sub(reg_aux_wei_scales, wei_scales_offset(ld_block2 - 1));
         reg_aux_wei_scales.save();
+    }
+    if (brg.is_per_n_dst_scales) {
+        reg_dst_scales.restore();
+        sub(reg_dst_scales, (ld_block2 - 1) * brg.ld_block * sizeof(float));
+        reg_dst_scales.save();
     }
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_a.restore();
@@ -1095,6 +1107,13 @@ void jit_brgemm_kernel_t<Wmm>::ldb_regs_shift(int ld_block2, bool is_tail) {
                           : wei_scales_offset(ld_block2));
         reg_aux_wei_scales.save();
     }
+    if (brg.is_per_n_dst_scales) {
+        reg_dst_scales.restore();
+        const auto dst_scale_offset
+                = (is_tail) ? brg.ldb_tail : ld_block2 * brg.ld_block;
+        add(reg_dst_scales, dst_scale_offset * sizeof(float));
+        reg_dst_scales.save();
+    }
     if (brg.zp_type_a != brgemm_broadcast_t::none) {
         reg_aux_zp_comp_a.restore();
         add(reg_aux_zp_comp_a,
@@ -1168,6 +1187,10 @@ void jit_brgemm_kernel_t<Wmm>::copy_post_ops_stack_values_to_aux(
         if (brg.with_wei_scales) {
             reg_wei_scales.restore();
             reg_wei_scales.saveTo(reg_aux_wei_scales);
+        }
+        if (brg.is_per_n_dst_scales) {
+            reg_dst_scales_base.restoreTo(reg_dst_scales);
+            reg_dst_scales.save();
         }
 
         if (brg.zp_type_a != brgemm_broadcast_t::none) {
@@ -1256,6 +1279,7 @@ void jit_brgemm_kernel_t<Wmm>::read_params() {
     if (brg.with_dst_scales) {
         mov(reg_dst_scales, ptr[param1 + GET_OFF(ptr_dst_scales)]);
         reg_dst_scales.save();
+        if (brg.is_per_n_dst_scales) reg_dst_scales.saveTo(reg_dst_scales_base);
     }
 
     if (brg.is_runtime_ldc) {
@@ -2058,13 +2082,73 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators_apply_post_ops(int bd_block,
 
     if (brg.with_dst_scales) {
         reg_dst_scales.restore();
-        auto vmm_dst_scales = vmm_tmp(0);
-        vbroadcastss(vmm_dst_scales, ptr[reg_dst_scales]);
+        if (brg.is_per_n_dst_scales) {
+            if (brg.is_gemv) {
+                assert(ld_block2 == 1);
+                if (brg.gemv_acc_is_vector()) {
+                    const int scale_block = gemv_elems_per_vector_acc();
+                    for (int bd = 0; bd < bd_block; bd++) {
+                        const bool is_tail
+                                = gemv_is_tail_acc(bd, bd_block, is_bdb_tail);
+                        const auto dst_scales_addr = ptr[reg_dst_scales
+                                + bd * scale_block * sizeof(float)];
+                        auto vmm_dst_scales = vmm_tmp(0);
+                        if (is_tail && isa_has_masks(brg.isa_impl)) {
+                            const auto scale_mask = vmm_mask(vmm_dst_scales,
+                                    true, false, gemv_partial_mask);
+                            uni_vmovups(scale_mask, dst_scales_addr);
+                            const auto vmm = accm(1, bd, 0);
+                            const auto vmm_masked = vmm | gemv_partial_mask;
+                            vmulps(vmm_masked, vmm_masked, vmm_dst_scales);
+                        } else if (is_tail) {
+                            uni_vpxor(vmm_dst_scales, vmm_dst_scales,
+                                    vmm_dst_scales);
+                            vmaskmovps(vmm_dst_scales, vmm_tail_mask(),
+                                    dst_scales_addr);
+                            auto vmm = accm(1, bd, 0);
+                            vmulps(vmm, vmm, vmm_dst_scales);
+                        } else {
+                            uni_vmovups(vmm_dst_scales, dst_scales_addr);
+                            auto vmm = accm(1, bd, 0);
+                            vmulps(vmm, vmm, vmm_dst_scales);
+                        }
+                    }
+                } else {
+                    for (int bd = 0; bd < bd_block; bd++) {
+                        auto vmm_dst_scale = vmm_tmp(0);
+                        const auto dst_scale_addr
+                                = ptr[reg_dst_scales + bd * sizeof(float)];
+                        vbroadcastss(vmm_dst_scale, dst_scale_addr);
+                        auto vmm = accm(1, bd, 0);
+                        vmulps(vmm, vmm, vmm_dst_scale);
+                    }
+                }
+            } else {
+                for (int ld = 0; ld < ld_block2; ld++) {
+                    const bool is_tail = is_ld_tail && ld + 1 == ld_block2;
+                    const auto dst_scales_addr = ptr[reg_dst_scales
+                            + ld * brg.ld_block * sizeof(float)];
+                    auto vmm_dst_scales = vmm_tmp(0);
+                    load_scales_to_vmm(data_type::f32, vmm_dst_scales,
+                            dst_scales_addr, is_tail, false);
 
-        for_(int ld = 0; ld < ld_block2; ld++)
-        for (int bd = 0; bd < bd_block; bd++) {
-            auto vmm = accm(ld_block2, bd, ld);
-            vmulps(vmm, vmm, vmm_dst_scales);
+                    for (int bd = 0; bd < bd_block; bd++) {
+                        auto vmm = accm(ld_block2, bd, ld);
+                        const auto vmm_masked
+                                = vmm_mask(vmm, is_tail, false, k_mask);
+                        vmulps(vmm_masked, vmm_masked, vmm_dst_scales);
+                    }
+                }
+            }
+        } else {
+            auto vmm_dst_scales = vmm_tmp(0);
+            vbroadcastss(vmm_dst_scales, ptr[reg_dst_scales]);
+
+            for_(int ld = 0; ld < ld_block2; ld++)
+            for (int bd = 0; bd < bd_block; bd++) {
+                auto vmm = accm(ld_block2, bd, ld);
+                vmulps(vmm, vmm, vmm_dst_scales);
+            }
         }
     }
 
@@ -4040,6 +4124,14 @@ void jit_brgemm_kernel_t<Wmm>::bdb_loop() {
                 add(reg_wei_scales, wei_scales_offset(brg.gemv_bd_block()));
                 reg_wei_scales.save();
             }
+        }
+
+        if (brg.is_gemv && brg.is_per_n_dst_scales) {
+            const dim_t scale_offset
+                    = is_bdb_tail ? brg.bdb_tail : brg.bd_block;
+            reg_dst_scales_base.restoreTo(reg_dst_scales);
+            add(reg_dst_scales, scale_offset * sizeof(float));
+            reg_dst_scales.saveTo(reg_dst_scales_base);
         }
 
         advance_bd_block2_post_op_regs(bd_block2, is_bdb_tail);

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -230,8 +230,8 @@ status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
             VDISPATCH_MATMUL(
                     one_of(asc.get_data_type(DNNL_ARG_WEIGHTS), undef, f32),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
-            VDISPATCH_MATMUL(
-                    one_of(asc.get_data_type(DNNL_ARG_DST), undef, f32),
+            VDISPATCH_MATMUL(one_of(asc.get_data_type(DNNL_ARG_DST), undef, f32,
+                                     bf16, f16),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);
         }
         // Implementation has limited support w.r.t. scales groups.
@@ -458,6 +458,7 @@ status_t brgemm_matmul_t<isa>::pd_t::init(const engine_t *engine) {
             brg.is_per_k_wei_scales = bgmmc_.is_wei_scale_per_k;
             brg.dt_wei_scales = bgmmc_.wei_scales_dt;
         }
+        brg.is_per_n_dst_scales = bgmmc_.is_dst_scale_per_n;
         if (bgmmc_.with_src_scales) {
             brg.dt_src_scales = bgmmc_.src_scales_dt;
             if (bgmmc_.is_src_scale_per_k) {
@@ -670,11 +671,27 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
 
     const int num_threads
             = brgmm_ctx_ptr->get_num_threads_for_parallelization();
+    const auto dst_scale_dt = pd()->attr()->scales_.get_data_type(DNNL_ARG_DST);
+    const auto &bgmmc = pd()->get_brgemm_matmul_conf();
+    if (bgmmc.with_dst_scales && bgmmc.is_dst_scale_per_n)
+        parallel(num_threads, [=](int ithr, int nthr) {
+            const void *dst_scales_ptr = brgmm_ctx_ptr->get_dst_scales_ptr();
+            float *dst_scales_inv_ptr = static_cast<float *>(const_cast<void *>(
+                    brgmm_ctx_ptr->get_dst_scales_inv_ptr(0)));
+            const dim_t dst_scales_count
+                    = bgmmc.is_dst_scale_per_n ? bgmmc.N : 1;
+            dim_t start {}, end {};
+            balance211(dst_scales_count, nthr, ithr, start, end);
+            for (dim_t i = start; i < end; ++i) {
+                const float dst_scale = cpu::io::load_float_value(
+                        dst_scale_dt, dst_scales_ptr, i);
+                dst_scales_inv_ptr[i] = 1.f / dst_scale;
+            }
+        });
     parallel(num_threads,
             [= COMPAT_THIS_CAPTURE](const int ithr, const int nthr) {
         const auto &brgmm_ctx = *brgmm_ctx_ptr;
 
-        const auto &bgmmc = pd()->get_brgemm_matmul_conf();
         const bool use_buffer_a
                 = bgmmc.use_buffer_a || bgmmc.use_buffer_a_tail_only;
         const bool is_amx = isa_has_tile_accumulators(isa);
@@ -704,12 +721,13 @@ status_t brgemm_matmul_t<isa>::execute_body(const exec_ctx_t &ctx) const {
         brgemm_palettes_.maybe_tile_configure(
                 is_amx, prev_ker_idx, brgmm_ctx.get_base_brgemm_kernel_idx());
 
-        if (bgmmc.with_dst_scales) {
-            const float *dst_scales_ptr = static_cast<const float *>(
-                    brgmm_ctx.get_dst_scales_ptr());
+        if (bgmmc.with_dst_scales && !bgmmc.is_dst_scale_per_n) {
+            const void *dst_scales_ptr = brgmm_ctx.get_dst_scales_ptr();
             float *dst_scales_inv_ptr = static_cast<float *>(
                     const_cast<void *>(brgmm_ctx.get_dst_scales_inv_ptr(ithr)));
-            dst_scales_inv_ptr[0] = 1.f / dst_scales_ptr[0];
+            const float dst_scale = cpu::io::load_float_value(
+                    dst_scale_dt, dst_scales_ptr, 0);
+            dst_scales_inv_ptr[0] = 1.f / dst_scale;
         }
 
         dim_t b {0}, mc {0}, nc {0}, b_per_t {0}, mc_per_t {0}, nc_per_t {0},
@@ -956,7 +974,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
                 = bgmmc.is_wei_scale_per_k && !bgmmc.apply_scales_in_buffer_b
                 ? brgmm_ctx.get_wei_scales_ptr(b_idx, k, n)
                 : brgmm_ctx.get_wei_scales_ptr(b_idx, /*k=*/0, n);
-        const void *dst_scales = brgmm_ctx.get_dst_scales_inv_ptr(ithr);
+        const void *dst_scales = brgmm_ctx.get_dst_scales_inv_ptr(ithr, n);
         void *scratch = is_brg_amx(brg_idx)
                 ? (void *)wsp_tile
                 : (void *)brgmm_ctx.get_s8s8_comp_ptr(ithr, b_idx, n_blk_idx);
@@ -1465,7 +1483,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                             brgmm_ctx.get_zp_c_ptr(), skip_accumulation, 1,
                             false, false, brgmm_ctx.get_src_scales_ptr(b),
                             brgmm_ctx.get_wei_scales_ptr(b, 0, n),
-                            brgmm_ctx.get_dst_scales_inv_ptr(ithr)};
+                            brgmm_ctx.get_dst_scales_inv_ptr(ithr, n)};
 
                     brgemm_kernel_execute_postops(brg_kernel, 0, nullptr,
                             (void *)ptr_C, (void *)ptr_D, post_ops_data,
@@ -2461,13 +2479,14 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
 
     const void *get_dst_scales_ptr() const { return dst_scales_; }
 
-    // Since `dst_scales_inv_` is a scratchpad memory, @p ithr points to the
-    // correspondent piece of that memory.
-    const void *get_dst_scales_inv_ptr(int ithr) const {
+    // Since `dst_scales_inv_` is a scratchpad memory, it is valid for the
+    // duration of this execution.
+    const void *get_dst_scales_inv_ptr(int ithr, dim_t n = 0) const {
         if (!bgmmc_.with_dst_scales) return nullptr;
 
+        const dim_t scale_offset = bgmmc_.is_dst_scale_per_n ? n : ithr;
         return reinterpret_cast<const char *const>(dst_scales_inv_)
-                + ithr * sizeof(float);
+                + scale_offset * sizeof(float);
     }
 
     int32_t get_neg_zp_a() const {

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -2031,12 +2031,6 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
                           bgmmc.wei_scales_dt == f32),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
 
-    const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
-    bgmmc.with_dst_scales = !dst_scales.has_default_values();
-    // only common scales are supported
-    VCONDCHECK_BG(!(bgmmc.with_dst_scales && dst_scales.get_mask() > 0),
-            VERBOSE_UNSUPPORTED_SCALES_CFG);
-
     const auto &src_zp = attr.zero_points_.get(DNNL_ARG_SRC);
     const auto has_src_zp = !src_zp.has_default_values();
     if (has_src_zp) {
@@ -2195,6 +2189,24 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
 
     bgmmc.is_gemv = is_gemv_applicable(
             bgmmc, bm_conf_utils, src_md, weights_md, dst_md, attr);
+
+    const auto &dst_scales = attr.scales_.get(DNNL_ARG_DST);
+    bgmmc.with_dst_scales = !dst_scales.has_default_values();
+    const int dst_scale_mask = dst_scales.get_mask();
+    bgmmc.is_dst_scale_per_n = bgmmc.with_dst_scales
+            && dst_scale_mask == (1 << (bgmmc.ndims - 1))
+            && dst_scales.has_default_groups() && bgmmc.N > 1;
+    const bool is_degenerate_per_n_dst_scale = bgmmc.with_dst_scales
+            && dst_scale_mask == (1 << (bgmmc.ndims - 1))
+            && dst_scales.has_default_groups() && bgmmc.N == 1;
+    // Per-N scales are supported for static N only. Other non-scalar masks
+    // remain unsupported by this implementation.
+    VCONDCHECK_BG(!bgmmc.is_dst_scale_per_n || !bgmmc.is_runtime_N,
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
+    VCONDCHECK_BG(!(bgmmc.with_dst_scales && dst_scale_mask > 0
+                          && !bgmmc.is_dst_scale_per_n
+                          && !is_degenerate_per_n_dst_scale),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
 
     // At this point, GEMV applicability is known so we decide how to interpret
     // the (isa, dt) check statuses:
@@ -3022,7 +3034,9 @@ void init_scratchpad(memory_tracking::registrar_t &scratchpad,
     if (bgmmc.with_dst_scales) {
         // See brgemm_types.hpp comment for `with_dst_scales`.
         scratchpad.book(key_matmul_dst_scales,
-                static_cast<size_t>(bgmmc.nthr) * sizeof(float),
+                (bgmmc.is_dst_scale_per_n ? static_cast<size_t>(bgmmc.N)
+                                          : static_cast<size_t>(bgmmc.nthr))
+                        * sizeof(float),
                 default_data_align);
     }
 }

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.hpp
@@ -142,6 +142,7 @@ struct brgemm_matmul_conf_t {
     bool with_src_scales;
     bool with_wei_scales;
     bool with_dst_scales;
+    bool is_dst_scale_per_n = false;
     bool s8s8_compensation_required;
     bool packed_sparse_weights;
     bool with_wei_decompression;

--- a/tests/benchdnn/inputs/matmul/test_matmul_ci
+++ b/tests/benchdnn/inputs/matmul/test_matmul_ci
@@ -17,6 +17,37 @@
 --reset --dt=s8:s8:bf16 --attr-scales=src:2+wei:0:2 5x32x64:5x64x48
 --reset --dt=u8:s8:f32 --attr-scales=src:2+wei:4 3x17x64:3x64x19
 
+## Per-dimension destination scales
+--reset
+--dt=f32,bf16,f16,s8:s8:f32,s8:s8:u8
+--stag=ab --wtag=ab --dtag=ab
+--attr-scales=dst:per_dim_1
+1x64:64x65 1x64:64x129 4x8:8x4 33x77:77x55 64x64:64x1
+
+--reset
+--dt=f32
+--stag=ab --wtag=ab --dtag=ab
+--attr-scales=dst:per_dim_1:bf16,dst:per_dim_1:f16
+4x8:8x4 33x77:77x55
+
+--reset
+--dt=f32
+--stag=abc --wtag=abc --dtag=abc
+--attr-scales=dst:4
+2x4x8:1x8x4
+
+--reset
+--dt=f32,bf16,f16
+--stag=ab --wtag=ba --dtag=ab
+--attr-scales=dst:per_dim_1
+1x37:37x17 1x37:37x65
+
+--reset
+--dt=f32
+--stag=abc --wtag=abc --dtag=abc
+--attr-scales=dst:4
+5x1x64:1x64x65
+
 # Binary select post-op with broadcast
 --reset
 --dt=f32,bf16

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -344,8 +344,9 @@ static void compute_ref_matmul_chunk(const chunk_params_t &p, int64_t M,
             dst_zp = p.dst_zps->get_elem(dst_zp_idx);
         }
         if (p.has_dst_scale && !p.has_dst_dynamic) {
-            dst_scale = 1.f
-                    / p.dst_scales->get_f32_elem(p.dst_scale_mask > 0 ? n : 0);
+            const auto dscale_idx = p.dst_m->get_idx(dst_off, p.dst_scale_mask,
+                    p.dst_m->ndims(), p.dst_scale_groups);
+            dst_scale = 1.f / p.dst_scales->get_f32_elem(dscale_idx);
         }
         float dst = p.dst_m->get_f32_elem(dst_off);
         float dst_val = dst_scale * dst + dst_zp;


### PR DESCRIPTION
Fixes MFDNN-15409.

Keep supported per-N destination scales on x64 brgemm, including GEMV, tails, batches, and low-precision scale data. Correct non-scalar scale indexing in reference paths and retain safe fallback for unsupported masks.

Validation: `cmake --build build --target benchdnn -j48`; targeted `OMP_NUM_THREADS=4` benchdnn matmul coverage.