### PR TITLE
cpu: matmul: reject unsupported per-N destination scales

### DIFF
--- a/src/common/matmul.cpp
+++ b/src/common/matmul.cpp
@@ -384,6 +384,10 @@ status_t matmul_attr_check(const matmul_desc_t &desc, const engine_t *engine,
         if (!sc.has_default_values(DNNL_ARG_DST)) {
             const int mask_dst = sc.get_mask(DNNL_ARG_DST);
             VCHECK_MATMUL_UNIMPL(
+                    IMPLICATION(mask_dst > 0, dst_is_fp8 || dst_is_fp4),
+                    VERBOSE_UNSUPPORTED_SCALES_CFG);
+
+            VCHECK_MATMUL_UNIMPL(
                     utils::one_of(mask_dst, 0, dst_qmask_N, dst_qmask_M,
                             dst_qmask_N + dst_qmask_M, full_tensor_mask),
                     VERBOSE_UNSUPPORTED_SCALES_CFG);

--- a/tests/gtests/test_iface_attr_quantization.cpp
+++ b/tests/gtests/test_iface_attr_quantization.cpp
@@ -566,6 +566,10 @@ TEST_F(attr_quantization_test_t, TestMatmul) {
                             gen_attr_with_scales(arg, (1 << 1) + (1 << 0),
                                     data_type::f32, {1, 32})));
                 }
+            } else if (arg == DNNL_ARG_DST) {
+                // Static per-N destination scales are not supported.
+                CHECK_UNIMPL(matmul::primitive_desc(eng, a_md, b_md, c_md,
+                        gen_attr_with_scales(arg, 1 << 1)));
             }
         }
     }
@@ -645,7 +649,7 @@ CPU_TEST_F(attr_quantization_test_t, TestMatmulBatch) {
                         gen_attr_with_scales(
                                 arg, per_ocic_mask, data_type::f32, {1, 32})));
             } else {
-                CHECK_OK(matmul::primitive_desc(eng, a_md, b_md, c_md,
+                CHECK_UNIMPL(matmul::primitive_desc(eng, a_md, b_md, c_md,
                         gen_attr_with_scales(arg, all_dims_mask)));
             }
         }


### PR DESCRIPTION
Fixes [MFDNN-15409](https://jira.devtools.intel.com/browse/MFDNN-15409).

Rejects non-common destination scale masks for non-FP4/FP8 outputs. Common destination scale masks (`mask == 0`) are unchanged.

Updates matmul gtests for unsupported non-common destination scales.