### PR TITLE
Added function to check verbose profiling state

### DIFF
--- a/doc/performance/verbose.md
+++ b/doc/performance/verbose.md
@@ -38,6 +38,26 @@ the type of tracing information to display.
 | `ONEDNN_VERBOSE_TIMESTAMP` | **0**               | **display timestamps disabled (default)**         |
 | \                          | 1                   | display timestamps enabled                        |
 
+The oneDNN verbose can also be managed at run-time with the following
+functions:
+* @ref dnnl::set_verbose
+* @ref dnnl::verbose_profiling_enabled
+
+@warning
+User-managed SYCL or OpenCL queue must have profiling enabled for oneDNN verbose
+to report performance data:
+* `CL_QUEUE_PROFILING_ENABLE` flag for OpenCL
+* `sycl::property::queue::enable_profiling` for SYCL
+Use @ref dnnl::verbose_profiling_enabled function to query whether verbose
+profiling mode is enabled using `ONEDNN_VERBOSE` environment variable or
+@ref dnnl::set_verbose API.
+
+@warning
+Verbose mode has non-negligible performance impact on oneDNN calls when
+enabled.
+Enabling profiling on SYCL or OpenCL queue has non-negligible application level
+performance impact.
+
 The verbose flags can be combined,
 e.g. `ONEDNN_VERBOSE=profile,dispatch` will enable printing both
 performance profiling information, and information relative to why a
@@ -69,11 +89,6 @@ oneDNN supports the following legacy settings:
 | ONEDNN_VERBOSE       | 0     | no verbose output, replaced by `none`                             |
 | \                    | 1     | primitive execution profiling timings, replaced by `profile_exec` |
 | \                    | 2     | primitive creation and execution timings, replaced by `profile`   |
-
-
-The oneDNN verbose can also be managed at run-time with the following
-functions:
-* @ref dnnl_set_verbose
 
 The function setting takes precedence over the environment variable.
 
@@ -252,7 +267,3 @@ When oneDNN verbose mode is enabled for builds with
 [Compute Library for the Arm architecture](https://uxlfoundation.github.io/oneDNN/dev_guide_build.html#gcc-with-arm-compute-library-acl-on-aarch64-host),
 any failures in the validation of Compute Library primitives will be detailed
 in the verbose output.
-
-@warning
-Verbose mode has non-negligible performance impact especially on GPU or if the
-output rate is high.

--- a/include/oneapi/dnnl/dnnl.hpp
+++ b/include/oneapi/dnnl/dnnl.hpp
@@ -14100,6 +14100,16 @@ inline status set_verbose(int level) {
     return static_cast<status>(dnnl_set_verbose(level));
 }
 
+/// Checks if verbose profiling mode is enabled.
+///
+/// @returns @c true if verbose profiling is enabled and @c false
+///     otherwise.
+inline bool verbose_profiling_enabled() {
+    int enabled = 0;
+    dnnl_verbose_profiling_enabled(&enabled);
+    return enabled != 0;
+}
+
 /// @copydoc dnnl_version()
 inline const version_t *version() {
     return dnnl_version();

--- a/include/oneapi/dnnl/dnnl_common.h
+++ b/include/oneapi/dnnl/dnnl_common.h
@@ -154,6 +154,15 @@ dnnl_status_t DNNL_API dnnl_set_default_fpmath_mode(dnnl_fpmath_mode_t mode);
 ///     success.
 dnnl_status_t DNNL_API dnnl_set_verbose(int level);
 
+/// Checks if verbose profiling mode is enabled.
+///
+/// @param enabled Output flag set to 1 if any verbose profiling output is
+///     enabled and 0 otherwise.
+/// @returns #dnnl_invalid_arguments/#dnnl::status::invalid_arguments if the
+///     @p enabled pointer is NULL, and #dnnl_success/#dnnl::status::success on
+///     success.
+dnnl_status_t DNNL_API dnnl_verbose_profiling_enabled(int *enabled);
+
 /// Returns library version information.
 /// @returns Pointer to a constant structure containing
 ///  - major: major version number,

--- a/src/common/verbose.cpp
+++ b/src/common/verbose.cpp
@@ -1917,6 +1917,18 @@ dnnl_status_t dnnl_set_verbose(int level) {
     return success;
 }
 
+dnnl_status_t dnnl_verbose_profiling_enabled(int *enabled) {
+    using namespace dnnl::impl::status;
+    using namespace dnnl::impl;
+    if (enabled == nullptr) return invalid_arguments;
+
+    const uint32_t profiling
+            = verbose_t::create_profile | verbose_t::exec_profile;
+    *enabled = get_verbose(static_cast<verbose_t::flag_kind>(profiling));
+
+    return success;
+}
+
 const dnnl_version_t *dnnl_version(void) {
     static const dnnl_version_t ver
             = {DNNL_VERSION_MAJOR, DNNL_VERSION_MINOR, DNNL_VERSION_PATCH,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,6 +108,10 @@ if(NOT DNNL_ENABLE_PRIMITIVE_CACHE)
     add_definitions_with_host_compiler(-DDNNL_DISABLE_PRIMITIVE_CACHE)
 endif()
 
+if(NOT DNNL_VERBOSE)
+    add_definitions_with_host_compiler(-DDISABLE_VERBOSE)
+endif()
+
 set(TEST_THREAD ${CMAKE_CURRENT_SOURCE_DIR}/test_thread.cpp)
 
 # Switch on threading layer for GPU only configurations to speed up testing.

--- a/tests/gtests/internals/test_env_vars_dnnl.cpp
+++ b/tests/gtests/internals/test_env_vars_dnnl.cpp
@@ -153,8 +153,21 @@ TEST(dnnl_default_fpmath_mode_env_var_test, TestEnvVars) {
     EXPECT_EQ(func_got_val, dnnl_fpmath_mode_strict);
 }
 
-// There's no a separate test for VERBOSE variable as there's no programmable
-// public API to identify if it was set through env var or not.
-// Same situation with the rest of variables.
+TEST(dnnl_verbose_env_var_test, TestEnvVars) {
+    // Variables with "ONEDNN_" prefix have higher precedence, so unset a
+    // potentially set "ONEDNN_VERBOSE".
+    custom_unsetenv("ONEDNN_VERBOSE");
+    custom_setenv("DNNL_VERBOSE", "profile", 1);
+#if !defined(DISABLE_VERBOSE)
+    EXPECT_TRUE(verbose_profiling_enabled());
+#endif
+
+    // The setting function takes precedence over the environment variable.
+    EXPECT_EQ(set_verbose(0), status::success);
+    EXPECT_FALSE(verbose_profiling_enabled());
+}
+
+// The rest of the variables have no programmable public API to identify if
+// they were set through env var or not, so they are not tested here.
 
 } // namespace dnnl

--- a/tests/gtests/internals/test_env_vars_dnnl.cpp
+++ b/tests/gtests/internals/test_env_vars_dnnl.cpp
@@ -59,35 +59,35 @@ TEST(dnnl_max_cpu_isa_env_var_test, TestEnvVars) {
 
     custom_unsetenv("ONEDNN_MAX_CPU_ISA");
     custom_setenv("DNNL_MAX_CPU_ISA", "SSE41", 1);
-    auto got = dnnl_get_effective_cpu_isa();
+    auto got = get_effective_cpu_isa();
     (void)got;
 
 #if defined(DNNL_ENABLE_MAX_CPU_ISA)
     // Expect env var value to be set when env variable feature is enabled.
-    EXPECT_EQ(got, has_cpu ? dnnl_cpu_isa_sse41 : dnnl_cpu_isa_default);
+    EXPECT_EQ(got, has_cpu ? cpu_isa::sse41 : cpu_isa::isa_default);
 #elif DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
     // Native SSE41 will issue an error. Don't check for it.
     if (mayiuse(impl::cpu::x64::avx)) {
         // Otherwise, don't expect it to be set.
-        EXPECT_NE(got, dnnl_cpu_isa_sse41);
+        EXPECT_NE(got, cpu_isa::sse41);
     }
 #endif
 
     if (has_cpu) {
-        // `dnnl_get_effective_cpu_isa` freezes the isa value, any call to set
+        // `get_effective_cpu_isa` freezes the isa value, any call to set
         // it again results in invalid_arguments.
-        auto st = dnnl_set_max_cpu_isa(dnnl_cpu_isa_sse41);
-        EXPECT_EQ(st, dnnl_invalid_arguments);
+        auto st = set_max_cpu_isa(cpu_isa::sse41);
+        EXPECT_EQ(st, status::invalid_arguments);
     }
     // Check that second pass of env var doesn't take any effect.
     custom_setenv("DNNL_MAX_CPU_ISA", "AVX", 1);
-    got = dnnl_get_effective_cpu_isa();
+    got = get_effective_cpu_isa();
 #if defined(DNNL_ENABLE_MAX_CPU_ISA)
-    EXPECT_EQ(got, has_cpu ? dnnl_cpu_isa_sse41 : dnnl_cpu_isa_default);
+    EXPECT_EQ(got, has_cpu ? cpu_isa::sse41 : cpu_isa::isa_default);
 #elif DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
     if (mayiuse(impl::cpu::x64::avx2)) {
-        EXPECT_NE(got, dnnl_cpu_isa_sse41);
-        EXPECT_NE(got, dnnl_cpu_isa_avx);
+        EXPECT_NE(got, cpu_isa::sse41);
+        EXPECT_NE(got, cpu_isa::avx);
     }
 #endif
 }
@@ -100,21 +100,22 @@ TEST(dnnl_cpu_isa_hints_var_test, TestEnvVars) {
 
     custom_unsetenv("ONEDNN_CPU_ISA_HINTS");
     custom_setenv("DNNL_CPU_ISA_HINTS", "PREFER_YMM", 1);
-    auto got = dnnl_get_cpu_isa_hints();
+    auto got = get_cpu_isa_hints();
 
 #if defined(DNNL_ENABLE_CPU_ISA_HINTS)
     // Expect env var value to be set when env variable feature is enabled.
-    EXPECT_EQ(got, has_cpu ? dnnl_cpu_isa_prefer_ymm : dnnl_cpu_isa_no_hints);
+    EXPECT_EQ(
+            got, has_cpu ? cpu_isa_hints::prefer_ymm : cpu_isa_hints::no_hints);
 #else
     // Otherwise, don't expect it to be set.
-    EXPECT_NE(got, dnnl_cpu_isa_prefer_ymm);
+    EXPECT_NE(got, cpu_isa_hints::prefer_ymm);
 #endif
 
 #if (DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE)
-    // `dnnl_get_cpu_isa_hints` freezes the hints value, any call to set it
+    // `get_cpu_isa_hints` freezes the hints value, any call to set it
     // again results in runtime_error.
-    auto st = dnnl_set_cpu_isa_hints(dnnl_cpu_isa_no_hints);
-    EXPECT_EQ(st, dnnl_runtime_error);
+    auto st = set_cpu_isa_hints(cpu_isa_hints::no_hints);
+    EXPECT_EQ(st, status::runtime_error);
 #endif
 }
 #endif // DNNL_X64
@@ -140,17 +141,10 @@ TEST(dnnl_primitive_cache_capacity_env_var_test, TestEnvVars) {
 TEST(dnnl_default_fpmath_mode_env_var_test, TestEnvVars) {
     custom_unsetenv("ONEDNN_DEFAULT_FPMATH_MODE");
     custom_setenv("DNNL_DEFAULT_FPMATH_MODE", "ANY", 1);
-    dnnl_fpmath_mode_t got_val;
-    auto st = dnnl_get_default_fpmath_mode(&got_val);
-    EXPECT_EQ(st, dnnl_success);
-    EXPECT_EQ(got_val, dnnl_fpmath_mode_any);
+    EXPECT_EQ(get_default_fpmath_mode(), fpmath_mode::any);
 
-    st = dnnl_set_default_fpmath_mode(dnnl_fpmath_mode_strict);
-    EXPECT_EQ(st, dnnl_success);
-    dnnl_fpmath_mode_t func_got_val;
-    st = dnnl_get_default_fpmath_mode(&func_got_val);
-    EXPECT_EQ(st, dnnl_success);
-    EXPECT_EQ(func_got_val, dnnl_fpmath_mode_strict);
+    EXPECT_EQ(set_default_fpmath_mode(fpmath_mode::strict), status::success);
+    EXPECT_EQ(get_default_fpmath_mode(), fpmath_mode::strict);
 }
 
 TEST(dnnl_verbose_env_var_test, TestEnvVars) {

--- a/tests/gtests/internals/test_env_vars_onednn.cpp
+++ b/tests/gtests/internals/test_env_vars_onednn.cpp
@@ -138,8 +138,18 @@ TEST(onednn_default_fpmath_mode_env_var_test, TestEnvVars) {
     EXPECT_EQ(func_got_val, dnnl_fpmath_mode_strict);
 }
 
-// There's no a separate test for VERBOSE variable as there's no programmable
-// public API to identify if it was set through env var or not.
-// Same situation with the rest of variables.
+TEST(onednn_verbose_env_var_test, TestEnvVars) {
+    custom_setenv("ONEDNN_VERBOSE", "profile", 1);
+#if !defined(DISABLE_VERBOSE)
+    EXPECT_TRUE(verbose_profiling_enabled());
+#endif
+
+    // The setting function takes precedence over the environment variable.
+    EXPECT_EQ(set_verbose(0), status::success);
+    EXPECT_FALSE(verbose_profiling_enabled());
+}
+
+// The rest of the variables have no programmable public API to identify if
+// they were set through env var or not, so they are not tested here.
 
 } // namespace dnnl

--- a/tests/gtests/internals/test_env_vars_onednn.cpp
+++ b/tests/gtests/internals/test_env_vars_onednn.cpp
@@ -50,35 +50,35 @@ TEST(onednn_max_cpu_isa_env_var_test, TestEnvVars) {
     const bool has_cpu = DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE;
 
     custom_setenv("ONEDNN_MAX_CPU_ISA", "SSE41", 1);
-    auto got = dnnl_get_effective_cpu_isa();
+    auto got = get_effective_cpu_isa();
     (void)got;
 
 #if defined(DNNL_ENABLE_MAX_CPU_ISA)
     // Expect env var value to be set when env variable feature is enabled.
-    EXPECT_EQ(got, has_cpu ? dnnl_cpu_isa_sse41 : dnnl_cpu_isa_default);
+    EXPECT_EQ(got, has_cpu ? cpu_isa::sse41 : cpu_isa::isa_default);
 #elif DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
     // Native SSE41 will issue an error. Don't check for it.
     if (mayiuse(impl::cpu::x64::avx)) {
         // Otherwise, don't expect it to be set.
-        EXPECT_NE(got, dnnl_cpu_isa_sse41);
+        EXPECT_NE(got, cpu_isa::sse41);
     }
 #endif
 
     if (has_cpu) {
-        // `dnnl_get_effective_cpu_isa` freezes the isa value, any call to set
+        // `get_effective_cpu_isa` freezes the isa value, any call to set
         // again results in invalid_arguments.
-        auto st = dnnl_set_max_cpu_isa(dnnl_cpu_isa_sse41);
-        EXPECT_EQ(st, dnnl_invalid_arguments);
+        auto st = set_max_cpu_isa(cpu_isa::sse41);
+        EXPECT_EQ(st, status::invalid_arguments);
     }
     // Check that second pass of env var doesn't take any effect.
     custom_setenv("ONEDNN_MAX_CPU_ISA", "AVX", 1);
-    got = dnnl_get_effective_cpu_isa();
+    got = get_effective_cpu_isa();
 #if defined(DNNL_ENABLE_MAX_CPU_ISA)
-    EXPECT_EQ(got, has_cpu ? dnnl_cpu_isa_sse41 : dnnl_cpu_isa_default);
+    EXPECT_EQ(got, has_cpu ? cpu_isa::sse41 : cpu_isa::isa_default);
 #elif DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE
     if (mayiuse(impl::cpu::x64::avx2)) {
-        EXPECT_NE(got, dnnl_cpu_isa_sse41);
-        EXPECT_NE(got, dnnl_cpu_isa_avx);
+        EXPECT_NE(got, cpu_isa::sse41);
+        EXPECT_NE(got, cpu_isa::avx);
     }
 #endif
 }
@@ -90,21 +90,22 @@ TEST(onednn_cpu_isa_hints_var_test, TestEnvVars) {
     (void)has_cpu;
 
     custom_setenv("ONEDNN_CPU_ISA_HINTS", "PREFER_YMM", 1);
-    auto got = dnnl_get_cpu_isa_hints();
+    auto got = get_cpu_isa_hints();
 
 #if defined(DNNL_ENABLE_CPU_ISA_HINTS)
     // Expect env var value to be set when env variable feature is enabled.
-    EXPECT_EQ(got, has_cpu ? dnnl_cpu_isa_prefer_ymm : dnnl_cpu_isa_no_hints);
+    EXPECT_EQ(
+            got, has_cpu ? cpu_isa_hints::prefer_ymm : cpu_isa_hints::no_hints);
 #else
     // Otherwise, don't expect it to be set.
-    EXPECT_NE(got, dnnl_cpu_isa_prefer_ymm);
+    EXPECT_NE(got, cpu_isa_hints::prefer_ymm);
 #endif
 
 #if (DNNL_CPU_RUNTIME != DNNL_RUNTIME_NONE)
-    // `dnnl_get_cpu_isa_hints` freezes the hints value, any call to set it
+    // `get_cpu_isa_hints` freezes the hints value, any call to set it
     // again results in runtime_error.
-    auto st = dnnl_set_cpu_isa_hints(dnnl_cpu_isa_no_hints);
-    EXPECT_EQ(st, dnnl_runtime_error);
+    auto st = set_cpu_isa_hints(cpu_isa_hints::no_hints);
+    EXPECT_EQ(st, status::runtime_error);
 #endif
 }
 #endif // DNNL_X64
@@ -125,17 +126,10 @@ TEST(onednn_primitive_cache_capacity_env_var_test, TestEnvVars) {
 
 TEST(onednn_default_fpmath_mode_env_var_test, TestEnvVars) {
     custom_setenv("ONEDNN_DEFAULT_FPMATH_MODE", "BF16", 1);
-    dnnl_fpmath_mode_t got_val;
-    auto st = dnnl_get_default_fpmath_mode(&got_val);
-    EXPECT_EQ(st, dnnl_success);
-    EXPECT_EQ(got_val, dnnl_fpmath_mode_bf16);
+    EXPECT_EQ(get_default_fpmath_mode(), fpmath_mode::bf16);
 
-    st = dnnl_set_default_fpmath_mode(dnnl_fpmath_mode_strict);
-    EXPECT_EQ(st, dnnl_success);
-    dnnl_fpmath_mode_t func_got_val;
-    st = dnnl_get_default_fpmath_mode(&func_got_val);
-    EXPECT_EQ(st, dnnl_success);
-    EXPECT_EQ(func_got_val, dnnl_fpmath_mode_strict);
+    EXPECT_EQ(set_default_fpmath_mode(fpmath_mode::strict), status::success);
+    EXPECT_EQ(get_default_fpmath_mode(), fpmath_mode::strict);
 }
 
 TEST(onednn_verbose_env_var_test, TestEnvVars) {


### PR DESCRIPTION
Asynchronous verbose mode requires SYCL or OpenCL queue to have profiling enabled, otherwise we are not able to produce timing information. Turns out that OpenVINO and PyTorch are managing queues at application side and not enabling profiling by default. This PR adds a function to check if profiling is enabled so that applications can conditionally enable profiling when it's required.
