### PR TITLE
gpu, benchdnn: check for NVFP4 global scale type and harness exention

### DIFF
--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -68,11 +68,11 @@ status_t check_post_op_chain(const primitive_attr_t &attr,
                     VERBOSE_UNSUPPORTED_POSTOP);
 
             const memory_desc_wrapper po_mdw(po.entry_[i].binary.src1_desc);
-            if (po_mdw.nelems() == ngroups
-                    && po_mdw.data_type() == data_type::f32
-                    && !po_mdw.is_host_scalar_desc()) {
+            if (po_mdw.nelems() == ngroups && !po_mdw.is_host_scalar_desc()) {
                 // [G, 1] operand: one scale per group (expert), e.g. nvfp4
-                // per-expert global scale.
+                // per-expert global f32 scale
+                VCHECK_MATMUL(po_mdw.data_type() == data_type::f32,
+                        VERBOSE_UNSUPPORTED_POSTOP);
                 po_chain[i] = po_kind_t::binary_nvfp4_scale;
             } else {
                 if (po_mdw.is_grouped_desc()) {

--- a/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_grouped_2dby3d
@@ -166,14 +166,14 @@
 --attr-scales=src:3:e8m0:1x32+wei:7:e8m0:32x1
 32x128:4x128x64
 
-# NVFP4: f4_e2m1 dt with f8_e4m3 block scales + per-group global f32 scale
-# via binary mul
+# NVFP4: f4_e2m1 dt with f8_e4m3 block scales + per-group global scale
+# via binary mul (f32/f16/bf16)
 --reset
 --dt=f4_e2m1:f4_e2m1:bf16
 --wtag=abc,acb
 --grouped=0:4:8+8+8+8
 --attr-scales=src:3:f8_e4m3:1x16+wei:7:f8_e4m3:16x1
---attr-post-ops=mul:f32:0
+--attr-post-ops=mul:f32:0,mul:f16:0,mul:bf16:0
 32x128:4x128x64
 
 # DNNL_ARG_HINT_MAX_GROUP_SIZE usage
@@ -261,10 +261,10 @@
 --attr-post-ops=mul:f16:3:grouped+mul:f32:1,eltwise_swish:1.0+mul:f16:3:grouped+mul:f32:1
 32x64:4x64x32
 
-# Per-group binary_mul (mask 0) with variable group sizes
+# Per-group binary_mul (mask 0), f32 + 16-bit operands, variable group sizes
 --reset
 --dt=f32:f32:f32,bf16:bf16:bf16,f16:f16:f16
 --wtag=abc
 --grouped=0:4:10+0+50+40
---attr-post-ops=mul:f32:0
+--attr-post-ops=mul:f32:0,mul:f16:0,mul:bf16:0
 100x64:4x64x32


### PR DESCRIPTION
Small check to address one of the issues in https://github.com/uxlfoundation/oneDNN/issues/5912 