### PR TITLE
[GPU] JIT GEMM: prefer block loads for scales

### DIFF
--- a/src/gpu/intel/compute/kernel.hpp
+++ b/src/gpu/intel/compute/kernel.hpp
@@ -188,9 +188,8 @@ public:
             = 0;
 
     status_t check_alignment(const void *ptr, int arg_idx) const {
-        const int min_alignment = 64;
         auto addr = reinterpret_cast<uint64_t>(ptr);
-        if (addr % min_alignment == 0) return status::success;
+        if (addr % min_buffer_alignment == 0) return status::success;
         // Reference kernels support element-wise alignment.
         if (name().find("ref_") == 0) return status::success;
         // Report a warning otherwise.

--- a/src/gpu/intel/compute/utils.hpp
+++ b/src/gpu/intel/compute/utils.hpp
@@ -34,6 +34,9 @@ namespace gpu {
 namespace intel {
 namespace compute {
 
+// Minimum alignment for GPU buffer base pointers for non-reference kernels.
+static constexpr int min_buffer_alignment = 64;
+
 class range_t {
 public:
     static constexpr size_t max_ndims = 3;

--- a/src/gpu/intel/gemm/jit/generator/pieces/address_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/address_setup.cxx
@@ -378,8 +378,11 @@ void Generator<hw>::setupAddr(Type T, const GRFRange &addr, const BO &ptr, const
                 auto pitch = bw * bcount * block.ebytes;
                 if (pitch < 64 || pitch & 0xF) hw_unsupported();
                 mov(1, addr[0].ud(4), pitch - 1);
-            } else
+            } else {
                 add(1, addr[0].ud(4), bld, -1);
+                if (!doBaseAdjust)
+                    max_<uint32_t>(1, addr[0].ud(4), addr[0].ud(4), addr[0].ud(2));
+	    }
 
             mov(1, addr[0].ud(7), (bw - 1) | ((bh - 1) << 8) | ((bcount - 1) << 16));
 
@@ -779,7 +782,9 @@ void Generator<hw>::incAddrK(const vector<GRFRange> &addr, bool column, int k,
                              const SubregisterPair &ld, const LDIncrements &incs, const RegisterLayout &layout,
                              const CommonStrategy &strategy, CommonState &state)
 {
-    if (isColMajor(layout.addressing().layout) == column) {
+    if (layout.addressingStrategy().address2D)
+        incAddr(addr, 0, column ? 0 : k, column ? k : 0, layout, strategy, state);
+    else if (isColMajor(layout.addressing().layout) == column) {
         bool release = false;
         auto inc = lookupIncrement(incs, ld, k, strategy, state, &release);
         incAddr(addr, inc, layout, strategy, state);

--- a/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/gemm_setup.cxx
@@ -1948,15 +1948,40 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
 
     auto setupQAddr = [&](Type T, vector<GRFRange> &addrs, const RegisterLayout &layout,
                           Subregister ptr, Subregister r0, Subregister c0, Subregister ld,
+                          Subregister nr, Subregister nc, int gr, int gc,
                           Subregister base = Subregister())
     {
         auto tmpBase = state.ra.alloc_sub(ptr.getType());
-        if (!isColMajor(layout.addressing().layout)) std::swap(r0, c0);
-        if (r0.isValid()) eaddScaled(1, tmpBase, ptr, r0, T, strategy, state);
-        if (c0.isValid()) emad(1, tmpBase, r0.isValid() ? tmpBase : ptr, c0, ld, strategy, state);
-        if (r0.isInvalid() && c0.isInvalid()) emov(1, tmpBase, ptr, strategy, state);
-        if (base.isValid()) eadd(1, tmpBase, tmpBase, base, strategy, state);
-        setupAddr(addrs, tmpBase, layout, ld, strategy, state);
+        if (layout.addressingStrategy().address2D) {
+            auto qdim = [&](Subregister n, int g) {
+                auto q = state.ra.alloc_sub<uint32_t>();
+                if (g > 1) {
+                    add(1, q, n, g - 1);
+                    divDown(q, q, uint32_t(g), strategy, state);
+                } else
+                    mov(1, q, n);
+                return q;
+            };
+            Address2DParams params;
+            params.rows = qdim(nr, gr);
+            params.cols = qdim(nc, gc);
+            params.offR = r0;
+            params.offC = c0;
+            if (base.isValid())
+                eadd(1, tmpBase, ptr, base, strategy, state);
+            else
+                emov(1, tmpBase, ptr, strategy, state);
+            setupAddr(addrs, tmpBase, layout, ld, strategy, state, params);
+            state.ra.safeRelease(params.rows);
+            state.ra.safeRelease(params.cols);
+        } else {
+            if (!isColMajor(layout.addressing().layout)) std::swap(r0, c0);
+            if (r0.isValid()) eaddScaled(1, tmpBase, ptr, r0, T, strategy, state);
+            if (c0.isValid()) emad(1, tmpBase, r0.isValid() ? tmpBase : ptr, c0, ld, strategy, state);
+            if (r0.isInvalid() && c0.isInvalid()) emov(1, tmpBase, ptr, strategy, state);
+            if (base.isValid()) eadd(1, tmpBase, tmpBase, base, strategy, state);
+            setupAddr(addrs, tmpBase, layout, ld, strategy, state);
+        }
         state.ra.safeRelease(tmpBase);
     };
 
@@ -1964,40 +1989,47 @@ bool Generator<hw>::gemmAccumulateCSetup(GEMMProblem &problem, GEMMStrategy &str
         auto &i0o   = lateOffsetA ? i0qLate   : i0q;
         auto &A_h0o = lateOffsetA ? A_h0qLate : A_h0q;
         setupQAddr(Tao, state.A_offsetAddrs, state.A_offsetLayout, state.inputs.aoPtr,
-                   i0o, A_h0o, state.inputs.ldao, state.offsetAo);
+                   i0o, A_h0o, state.inputs.ldao,
+                   state.inputs.m, state.fullK, problem.aqGroupM, problem.aqGroupK, state.offsetAo);
     }
     if (as2D) {
         auto &i0s   = state.lateScale2DA ? i0qLate : i0q;
         auto &A_h0s = state.lateScale2DA ? A_h0qLate : A_h0q;
         setupQAddr(Ta_scale, state.A_scaleAddrs, state.A_scaleLayout, state.inputs.aScalePtr,
-                   i0s, A_h0s, state.inputs.ldaScale, state.offsetAs);
+                   i0s, A_h0s, state.inputs.ldaScale,
+                   state.inputs.m, state.fullK, problem.aqGroupM, problem.aqGroupK, state.offsetAs);
     }
     if (ag2D) {
         setupQAddr(Tag, state.Ag_addrs, state.Ag_layout, state.inputs.agPtr,
-                   i0qLate, A_h0qLate, state.inputs.ldag, state.inputs.offsetAg);
+                   i0qLate, A_h0qLate, state.inputs.ldag,
+                   state.inputs.m, state.fullK, problem.aqGroupM, problem.aqGroupK, state.inputs.offsetAg);
     }
     if (bo2D) {
         auto &j0o   = lateOffsetB ? j0qLate   : j0q;
         auto &B_h0o = lateOffsetB ? B_h0qLate : B_h0q;
         setupQAddr(Tbo, state.B_offsetAddrs, state.B_offsetLayout, state.inputs.boPtr,
-                   B_h0o, j0o, state.inputs.ldbo, state.offsetBo);
+                   B_h0o, j0o, state.inputs.ldbo,
+                   state.fullK, state.inputs.n, problem.bqGroupK, problem.bqGroupN, state.offsetBo);
     }
     if (bs2D) {
         auto &j0s   = state.lateScale2DB ? j0qLate   : j0q;
         auto &B_h0s = state.lateScale2DB ? B_h0qLate : B_h0q;
         setupQAddr(Tb_scale, state.B_scaleAddrs, state.B_scaleLayout, state.inputs.bScalePtr,
-                   B_h0s, j0s, state.inputs.ldbScale, state.offsetBs);
+                   B_h0s, j0s, state.inputs.ldbScale,
+                   state.fullK, state.inputs.n, problem.bqGroupK, problem.bqGroupN, state.offsetBs);
     }
     if (bg2D) {
         setupQAddr(Tbg, state.Bg_addrs, state.Bg_layout, state.inputs.bgPtr,
-                   B_h0qLate, j0qLate, state.inputs.ldbg, state.inputs.offsetBg);
+                   B_h0qLate, j0qLate, state.inputs.ldbg,
+                   state.fullK, state.inputs.n, problem.bqGroupK, problem.bqGroupN, state.inputs.offsetBg);
     }
 
     if (problem.hasCMXScale()) {
         auto i0qs = state.ra.alloc_sub(cMX_j0q.getType(), getHint(HintType::LongTerm, strategy));
         divDown(i0qs, cMX_i0q, problem.cqGroupM, strategy, state);
         setupQAddr(Type::u8, state.C_scaleAddrs, state.C_scaleLayout, state.inputs.cScalePtr,
-               i0qs, cMX_j0q, state.inputs.ldcScale, state.offsetCs);
+               i0qs, cMX_j0q, state.inputs.ldcScale,
+               state.inputs.m, state.inputs.n, problem.cqGroupM, problem.cqGroupN, state.offsetCs);
     }
 
     if (i0qLate != state.i0) state.ra.safeRelease(i0qLate);

--- a/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/quantization.cxx
@@ -166,17 +166,43 @@ bool Generator<hw>::gemmMake2DQuantizationLayouts(bool isA, const GEMMProblem &p
     }
 
     bool wantCM = state.useBDPAS ? isA : isA ^ (xqGroupMN > 1);
-    auto chooseAccess = [=](const MatrixAddressing &Xq) {
-        return (wantCM == isColMajor(Xq.layout)) ? AccessType::Block : AccessType::Scattered;
+    auto chooseAccess = [=](const MatrixAddressing &Xq, Type T, int r, int c) {
+        bool transposing = (wantCM != isColMajor(Xq.layout));
+        auto access2D = transposing ? AccessType::Block2DTranspose : AccessType::Block2D;
+        auto access1D = transposing ? AccessType::Scattered : AccessType::Block;
+        MatrixAddressingStrategy s2d;
+        s2d.accessType = access2D;
+        int xElems = isColMajor(Xq.layout) ? r : c;    // block 2D width dimension
+        if (r > 1 && c > 1 && hw >= HW::XeHPC
+                && (xElems * T) % 4 == 0
+                && Xq.alignment % block2DMinAlignment(hw, Xq, s2d) == 0)
+            return access2D;
+        return access1D;
+    };
+    auto use2DAddressing = [](MatrixAddressingStrategy &s) {
+        if (!isBlock2D(s.accessType)) return;
+        s.newDP = true;
+        s.address2D = true;
     };
 
-    X_offsetStrategy.accessType = chooseAccess(XO);
-    X_scaleStrategy.accessType  = chooseAccess(XS);
-    Xg_strategy.accessType      = chooseAccess(Xg);
+    X_offsetStrategy.accessType = chooseAccess(XO, Txo, ro,     co);
+    X_scaleStrategy.accessType  = chooseAccess(XS, Txs, rs,     cs);
+    Xg_strategy.accessType      = chooseAccess(Xg, Txg, rNoSLM, cNoSLM);
+    use2DAddressing(X_offsetStrategy);
+    use2DAddressing(X_scaleStrategy);
+    use2DAddressing(Xg_strategy);
 
-    if (xo2D && !(X_offsetLayout = RegisterLayout::tryCreate(hw, Txo, ro,     co,     XO, X_offsetStrategy, remR, remC))) return false;
-    if (xs2D &&  !(X_scaleLayout = RegisterLayout::tryCreate(hw, Txs, rs,     cs,     XS, X_scaleStrategy,  remR, remC))) return false;
-    if (xg2D &&      !(Xg_layout = RegisterLayout::tryCreate(hw, Txg, rNoSLM, cNoSLM, Xg, Xg_strategy,      remR, remC))) return false;
+    auto makeQLayout = [&](RegisterLayout &l, Type T, int r, int c, MatrixAddressing Xq,
+                           MatrixAddressingStrategy &Xq_strategy) {
+        bool is2D = isBlock2D(Xq_strategy.accessType);
+        if (!is2D) Xq.setAlignment(T.paddedSize());    // raised alignment is only for block 2D
+        l = RegisterLayout::tryCreate(hw, T, r, c, Xq, Xq_strategy, remR && !is2D, remC && !is2D);
+        if (l.empty() && is2D) stub();
+        return !l.empty();
+    };
+    if (xo2D && !makeQLayout(X_offsetLayout, Txo, ro,     co,     XO, X_offsetStrategy)) return false;
+    if (xs2D && !makeQLayout(X_scaleLayout,  Txs, rs,     cs,     XS, X_scaleStrategy))  return false;
+    if (xg2D && !makeQLayout(Xg_layout,      Txg, rNoSLM, cNoSLM, Xg, Xg_strategy))      return false;
 
     // Adjust masks for m/n grouping.
     auto adjustMask = [=](MaskInfo &mask) {

--- a/src/gpu/intel/gemm/jit/pd.cpp
+++ b/src/gpu/intel/gemm/jit/pd.cpp
@@ -17,6 +17,7 @@
 #include "gpu/intel/gemm/jit/pd.hpp"
 #include "common/c_types_map.hpp"
 #include "common/primitive_attr_quant.hpp"
+#include "gpu/intel/compute/utils.hpp"
 #include "gpu/intel/gemm/exec_types.hpp"
 #include "gpu/intel/gemm/jit/gen_kernel.hpp"
 #include "gpu/intel/gemm/utils.hpp"
@@ -757,6 +758,31 @@ status_t pd_t::init_GEMMProblem(
     if (b_quant.scales_type != data_type::undef) {
         problem.Tb_scale = convert_dnnl_to_kernel_type(b_quant.scales_type);
         problem.B_scale.setAlignment(
+                int(types::data_type_size(b_quant.scales_type)));
+    }
+
+    auto set_q_align = [](MatrixAddressing &X, dim_t ld_elems, int type_size) {
+        if (ld_elems <= 0 || ld_elems == DNNL_RUNTIME_DIM_VAL) return;
+        int a = int(math::gcd<dim_t>(
+                compute::min_buffer_alignment, ld_elems * type_size));
+        X.setAlignment(nstl::max<int>(X.alignment, a));
+    };
+    dim_t sm = swap_ab() ? desc()->n() : desc()->m();
+    dim_t sn = swap_ab() ? desc()->m() : desc()->n();
+    if (a_quant.scales_type != data_type::undef) {
+        dim_t ld = (problem.A_scale.layout == MatrixLayout::N)
+                ? utils::div_up(sm, nstl::max<dim_t>(1, a_quant.group_m))
+                : utils::div_up(
+                          desc()->k(), nstl::max<dim_t>(1, a_quant.group_k));
+        set_q_align(problem.A_scale, ld,
+                int(types::data_type_size(a_quant.scales_type)));
+    }
+    if (b_quant.scales_type != data_type::undef) {
+        dim_t ld = (problem.B_scale.layout == MatrixLayout::N)
+                ? utils::div_up(
+                          desc()->k(), nstl::max<dim_t>(1, b_quant.group_k))
+                : utils::div_up(sn, nstl::max<dim_t>(1, b_quant.group_n));
+        set_q_align(problem.B_scale, ld,
                 int(types::data_type_size(b_quant.scales_type)));
     }
 


### PR DESCRIPTION
This is an optimization to reduce the overhead of loading quantization buffers. oneDNN already requires user buffers to be 64-byte aligned, so promotion from scattered loads to block loads can be done ad hoc.