### PR TITLE
benchdnn: graph: improve memory usage estimation and check

### DIFF
--- a/tests/benchdnn/graph/allocator.hpp
+++ b/tests/benchdnn/graph/allocator.hpp
@@ -81,6 +81,22 @@ private:
     simple_memory_pool_t mem_pool_;
 };
 
+class graph_mem_check_guard_t {
+public:
+    explicit graph_mem_check_guard_t(graph_mem_manager_t &manager)
+        : manager_(manager) {
+        manager_.start_graph_mem_check();
+    }
+    ~graph_mem_check_guard_t() { manager_.stop_graph_mem_check(); }
+
+    graph_mem_check_guard_t(const graph_mem_check_guard_t &) = delete;
+    graph_mem_check_guard_t &operator=(const graph_mem_check_guard_t &)
+            = delete;
+
+private:
+    graph_mem_manager_t &manager_;
+};
+
 dnnl::graph::allocator &get_graph_allocator(bool use_host = false);
 
 } // namespace graph

--- a/tests/benchdnn/graph/custom_driver.cpp
+++ b/tests/benchdnn/graph/custom_driver.cpp
@@ -285,6 +285,55 @@ void init_memory_args_native(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
             nullptr, ref_eng);
 }
 
+// Account for the test allocation and its mapped, reference, and comparison
+// buffers. Custom operations provide dimensions separately because they do not
+// have a primitive descriptor from which the reference layout can be queried.
+void add_md_size(const_dnnl_memory_desc_t md, const dims_t &dims,
+        check_mem_size_args_t &mem_size_args) {
+    const auto mem_size = dnnl_memory_desc_get_size(md);
+    if (mem_size == 0 || mem_size == DNNL_RUNTIME_SIZE_VAL) return;
+
+    mem_size_args.sizes.push_back(mem_size);
+    mem_size_args.total_size_device += mem_size;
+
+    const bool mapped_mem_factor = !is_cpu()
+            && !has_bench_mode_modifier(mode_modifier_t::no_ref_memory);
+    mem_size_args.total_size_mapped += mapped_mem_factor * mem_size;
+
+    const auto ref_md = dnn_mem_t::init_md(
+            static_cast<int>(dims.size()), dims.data(), dnnl_f32, tag::abx);
+    const auto ref_md_size = dnnl_memory_desc_get_size(ref_md);
+    const size_t ref_mem_idx = mem_size_args.want_input ? 0 : 1;
+    mem_size_args.total_ref_md_size[ref_mem_idx] = ref_md_size;
+
+    const bool is_corr = has_bench_mode_bit(mode_bit_t::corr);
+    const bool is_bitwise = has_bench_mode_bit(mode_bit_t::bitwise);
+    mem_size_args.total_size_ref += is_corr * ref_md_size;
+
+    const bool is_output = !mem_size_args.want_input;
+    mem_size_args.total_size_compare
+            += is_output * ((is_corr || is_bitwise) + is_bitwise) * ref_md_size;
+}
+
+// Rebuild memory estimates from custom operation arguments. Unlike regular
+// drivers, custom operations do not create a primitive whose descriptors can be
+// collected by the common memory accounting path.
+void collect_mem_size(
+        check_mem_size_args_t &mem_size_args, const base_prb_t *base_prb) {
+    mem_size_args = {};
+    const auto *prb = prb_t::from(base_prb);
+    for (const auto exec_arg : prb->supported_exec_args(false)) {
+        const auto &arg_md = prb->arg_mds_.at(exec_arg);
+        const auto &tag = std::get<0>(arg_md);
+        const auto &dims = std::get<1>(arg_md);
+        const auto dt = std::get<2>(arg_md);
+        const auto md = dnn_mem_t::init_md(
+                static_cast<int>(dims.size()), dims.data(), dt, tag);
+        mem_size_args.want_input = exec_arg != DNNL_ARG_DST;
+        add_md_size(md, dims, mem_size_args);
+    }
+}
+
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         dnnl_primitive_t, const base_prb_t *base_prb, res_t *res,
         dnnl_primitive_t) {

--- a/tests/benchdnn/graph/custom_driver.hpp
+++ b/tests/benchdnn/graph/custom_driver.hpp
@@ -90,6 +90,9 @@ void init_memory_args(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
 void init_memory_args_native(dnn_mem_map_t &mem_map, const base_prb_t *base_prb,
         const graph::deserialized_op_t &base_op_ref, const engine_t &ref_eng);
 
+void collect_mem_size(
+        check_mem_size_args_t &mem_size_args, const base_prb_t *base_prb);
+
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         dnnl_primitive_t prim, const base_prb_t *base_prb, res_t *res,
         dnnl_primitive_t prim_ref = nullptr);

--- a/tests/benchdnn/graph/graph.cpp
+++ b/tests/benchdnn/graph/graph.cpp
@@ -698,16 +698,8 @@ int doit(const prb_t *prb, res_t *res) {
                 outputs, c_partitions.back(), id_to_queried_logical_tensors);
     }
 
-    // Allocate scratchpad buffer for each compiled partition.
     scratchpad_ts_all.reserve(c_partitions.size());
-    for (auto &cp : c_partitions) {
-        auto scratchpad_lt = cp.get_scratchpad_logical_tensor();
-        if (scratchpad_lt.get_mem_size() > 0) {
-            scratchpad_ts_all.emplace_back(scratchpad_lt, eng);
-        } else {
-            scratchpad_ts_all.emplace_back();
-        }
-    }
+    auto &graph_mem_mgr = graph_mem_manager_t::get_instance();
 
     if (bench_mode == bench_mode_t::init) return res->state = INITIALIZED, OK;
 
@@ -795,30 +787,41 @@ int doit(const prb_t *prb, res_t *res) {
         input_ts_all.emplace_back(input_ts);
         output_ts_all.emplace_back(output_ts);
 
-        auto &graph_mem_mgr = graph_mem_manager_t::get_instance();
-        graph_mem_mgr.start_graph_mem_check();
-        BENCHDNN_PRINT(3, "[INFO]: Start execution of partition #%zd.\n", i);
+        {
+            graph_mem_check_guard_t graph_mem_check_guard(graph_mem_mgr);
+            auto scratchpad_lt = c_partitions[i - idx_offset]
+                                         .get_scratchpad_logical_tensor();
+            if (scratchpad_lt.get_mem_size() > 0) {
+                DNN_GRAPH_SAFE(
+                        scratchpad_ts_all.emplace_back(scratchpad_lt, eng),
+                        (WARN | NEED_CLEANUP), res);
+            } else {
+                scratchpad_ts_all.emplace_back();
+            }
+            if (res->state == SKIPPED) return OK;
 
-        if (use_sycl_graph_exec(eng)) {
-            std::function<void()> record_fn = std::bind(
-                    compiled_partition_executor, c_partitions[i - idx_offset],
-                    std::ref(strm), input_ts, output_ts,
-                    scratchpad_ts_all[i - idx_offset]);
-            SAFE(execute_in_graph_mode(strm, record_fn, res), WARN);
-        } else {
-            stream_staller_t staller(strm);
-            // Need following clean-up steps as the memories have been mappped
-            // to device. Otherwise the deconstruction will fail.
-            DNN_GRAPH_SAFE(
-                    c_partitions[i - idx_offset].execute(strm, input_ts,
-                            output_ts, scratchpad_ts_all[i - idx_offset]),
-                    (WARN | NEED_CLEANUP), res);
-            staller.release();
+            BENCHDNN_PRINT(
+                    3, "[INFO]: Start execution of partition #%zd.\n", i);
 
-            DNN_GRAPH_SAFE(strm.wait(), WARN, res);
+            if (use_sycl_graph_exec(eng)) {
+                std::function<void()> record_fn
+                        = std::bind(compiled_partition_executor,
+                                c_partitions[i - idx_offset], std::ref(strm),
+                                input_ts, output_ts, scratchpad_ts_all.back());
+                SAFE(execute_in_graph_mode(strm, record_fn, res), WARN);
+            } else {
+                stream_staller_t staller(strm);
+                // Need following clean-up steps as the memories have been mappped
+                // to device. Otherwise the deconstruction will fail.
+                DNN_GRAPH_SAFE(
+                        c_partitions[i - idx_offset].execute(strm, input_ts,
+                                output_ts, scratchpad_ts_all.back()),
+                        (WARN | NEED_CLEANUP), res);
+                staller.release();
+
+                DNN_GRAPH_SAFE(strm.wait(), WARN, res);
+            }
         }
-        graph_mem_mgr.stop_graph_mem_check();
-
         // map memory from device back to host
         SAFE(map_unmap_partition_mem(partition_mem_map_v[i], inputs, MAP, res),
                 WARN);

--- a/tests/benchdnn/graph/graph_memory.hpp
+++ b/tests/benchdnn/graph/graph_memory.hpp
@@ -18,6 +18,7 @@
 #define BENCHDNN_GRAPH_MEMORY_HPP
 
 #include <mutex>
+#include <numeric>
 #include <tuple>
 #include "common.hpp"
 #include "deserialize.hpp"
@@ -93,29 +94,45 @@ public:
         return total_req;
     }
 
+    void increase_mapped_mem_req(mem_path_t path, size_t mem_req) {
+        if (path < 0 || path >= mapped_req_.size()) return;
+
+        std::lock_guard<std::mutex> guard(mutex_);
+        mapped_req_[path] += mem_req;
+    }
+
+    size_t get_mapped_mem_req() {
+        std::lock_guard<std::mutex> guard(mutex_);
+        return std::accumulate(mapped_req_.begin(), mapped_req_.end(), 0ULL);
+    }
+
     // Reset the memory request for the specific path.
     void reset_path(mem_path_t path) {
-        if (path < 0 || path > req_.front().size()) return;
+        if (path < 0 || path >= req_.front().size()) return;
 
         std::lock_guard<std::mutex> guard(mutex_);
         req_[CPU_REQ][path] = 0;
         req_[GPU_REQ][path] = 0;
+        mapped_req_[path] = 0;
     }
 
     // Reset the memory size args for both paths on all devices
     void reset_all() {
         req_ = std::vector<std::vector<size_t>>(2, std::vector<size_t>(3, 0));
+        mapped_req_ = std::vector<size_t>(3, 0);
     }
 
 private:
     graph_memory_req_args_t() {
         req_ = std::vector<std::vector<size_t>>(2, std::vector<size_t>(3, 0));
+        mapped_req_ = std::vector<size_t>(3, 0);
     }
     ~graph_memory_req_args_t() = default;
     BENCHDNN_DISALLOW_COPY_AND_ASSIGN(graph_memory_req_args_t);
 
     // The detailed memory size requrest for specific path and devices.
     std::vector<std::vector<size_t>> req_;
+    std::vector<size_t> mapped_req_;
     std::mutex mutex_;
 };
 

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -631,17 +631,14 @@ int ref_partition_t::check_partition_total_size(
     const bool is_corr = has_bench_mode_bit(mode_bit_t::corr);
     const bool is_bitwise = has_bench_mode_bit(mode_bit_t::bitwise);
 
-    // The size of reference memory with tag abx and f32.
-    size_t input_ref_mem_size = 0, output_ref_mem_size = 0;
-    if (is_corr || is_bitwise) {
-        input_ref_mem_size = check_mem_size_args.total_ref_md_size[0];
-        output_ref_mem_size = check_mem_size_args.total_ref_md_size[1];
-    }
+    // The size of output reference memory with tag abx and f32.
+    const size_t output_ref_mem_size = (is_corr || is_bitwise)
+            ? check_mem_size_args.total_ref_md_size[1]
+            : 0;
 
     // total size cpu includes:
     // 1. Memory allocated for a test obj( such as the memory for input and outputs, saved in total_size_device )
-    // 2. Memory allocated for reference computation, which will be released
-    // after reference path data filling(`C` mode only)
+    // 2. Memory allocated for reference computation (`C` mode only)
     // 3. Memory to be allocated for comparing results(`C` mode only)
     // 4. Memory to be allocated for mapping device memory(GPU backend only)
     size_t new_cpu_req = check_mem_size_args.total_size_ref
@@ -690,14 +687,7 @@ int ref_partition_t::check_partition_total_size(
                 WARN);
     }
 
-    // STEP 3: Temprorary memory release stage
-    if (is_corr) {
-        // Release reference path memory for `C` mode
-        total_cpu_req -= input_ref_mem_size;
-        total_cpu_req -= output_ref_mem_size;
-    }
-
-    // Update the required memory size
+    // STEP 3: Update the required memory size
     graph_mem_req.increase_mem_req(CPU_REQ, REF, new_cpu_req);
 
     return res->state == FAILED ? FAIL : OK;

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -25,16 +25,36 @@ namespace graph {
 
 namespace {
 
-void check_memory_fit(
-        bool fits_ram, size_t mem_req, size_t mem_limit, res_t *res) {
+int check_memory_fit(bool fits_ram, size_t mem_req, size_t mem_limit,
+        mem_platform_t memory_kind, res_t *res) {
+    const bool is_device = memory_kind == GPU_REQ;
+    const char *memory_kind_str = is_device ? "GPU" : "CPU";
     if (!fits_ram) {
-        BENCHDNN_PRINT(2,
-                "[CHECK_MEM]: Not enough %s RAM for a problem. Allocation of "
-                "size %g GB doesn't fit allocation limit of %g GB. \n",
-                (is_cpu() ? "CPU" : "GPU"), GB(mem_req), GB(mem_limit));
+        BENCHDNN_PRINT(1, "[CHECK_MEM]: Not enough %s RAM for a problem.\n",
+                memory_kind_str);
         res->state = SKIPPED;
         res->reason = reason_t::skip_not_enough_ram;
     }
+
+    size_t memory_capacity = get_cpu_ram_size();
+    size_t max_alloc_capacity = 0;
+    if (is_device) {
+        SAFE(get_gpu_ram_sizes(memory_capacity, max_alloc_capacity), WARN);
+        // verbose level is aligned with check_total_size() in dnnl_common.cpp.
+        BENCHDNN_PRINT((!fits_ram ? 1 : 6),
+                "[CHECK_MEM]: Requested: %s; graph_device_limit: %s; "
+                "device_RAM_capacity: %s; gpu_max_alloc: %s;\n",
+                smart_bytes(mem_req).c_str(), smart_bytes(mem_limit).c_str(),
+                smart_bytes(memory_capacity).c_str(),
+                smart_bytes(max_alloc_capacity).c_str());
+    } else {
+        BENCHDNN_PRINT((!fits_ram ? 1 : 6),
+                "[CHECK_MEM]: Requested: %s; graph_CPU_limit: %s; "
+                "CPU_RAM_capacity: %s;\n",
+                smart_bytes(mem_req).c_str(), smart_bytes(mem_limit).c_str(),
+                smart_bytes(memory_capacity).c_str());
+    }
+    return OK;
 }
 
 } // namespace
@@ -555,18 +575,41 @@ int ref_partition_t::check_partition_total_size(
         new_mem_req += lt_id_2_lt_.at(lt_id).create().get_mem_size();
     }
 
-    // Step 2. Check whether the memory is enough
+    // Step 2. Check whether the memory is enough.
     if (is_gpu()) {
+        // Align with check_total_size() in dnnl_common.cpp: Mapped host buffers
+        // are live together with device allocations at peak (and on some
+        // runtimes become device-resident while accessed), so account for them
+        // in the device peak used for the device RAM fit check.
         size_t total_gpu_req = graph_mem_req.get_mem_req(GPU_REQ) + new_mem_req;
-        const bool fits_device_ram = total_gpu_req <= benchdnn_device_limit;
-        check_memory_fit(
-                fits_device_ram, total_gpu_req, benchdnn_device_limit, res);
+        const size_t new_mapped_mem_req
+                = has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
+                ? 0
+                : new_mem_req;
+        const size_t total_mapped_mem_req
+                = graph_mem_req.get_mapped_mem_req() + new_mapped_mem_req;
+        const size_t device_peak_req = total_gpu_req + total_mapped_mem_req;
+        const bool fits_device_ram = device_peak_req <= benchdnn_device_limit;
+        SAFE(check_memory_fit(fits_device_ram, device_peak_req,
+                     benchdnn_device_limit, GPU_REQ, res),
+                WARN);
+
+        const size_t combined_cpu_req = graph_mem_req.get_mem_req(CPU_REQ)
+                + new_mapped_mem_req + total_gpu_req;
+        const bool fits_cpu_ram = combined_cpu_req <= benchdnn_cpu_limit;
+        SAFE(check_memory_fit(fits_cpu_ram, combined_cpu_req,
+                     benchdnn_cpu_limit, CPU_REQ, res),
+                WARN);
 
         graph_mem_req.increase_mem_req(GPU_REQ, GRAPH_USER, new_mem_req);
+        graph_mem_req.increase_mem_req(CPU_REQ, GRAPH_USER, new_mapped_mem_req);
+        graph_mem_req.increase_mapped_mem_req(GRAPH_USER, new_mapped_mem_req);
     } else {
         size_t total_cpu_req = graph_mem_req.get_mem_req(CPU_REQ) + new_mem_req;
         bool fits_cpu_ram = total_cpu_req <= benchdnn_cpu_limit;
-        check_memory_fit(fits_cpu_ram, total_cpu_req, benchdnn_cpu_limit, res);
+        SAFE(check_memory_fit(fits_cpu_ram, total_cpu_req, benchdnn_cpu_limit,
+                     CPU_REQ, res),
+                WARN);
 
         graph_mem_req.increase_mem_req(CPU_REQ, GRAPH_USER, new_mem_req);
     }
@@ -618,17 +661,32 @@ int ref_partition_t::check_partition_total_size(
 
     // STEP 2: Check whether the memory is enough
     size_t total_cpu_req = graph_mem_req.get_mem_req(CPU_REQ) + new_cpu_req;
-    bool fits_cpu_ram = total_cpu_req <= benchdnn_cpu_limit;
-    check_memory_fit(fits_cpu_ram, total_cpu_req, benchdnn_cpu_limit, res);
 
     // GPU mem size check.
     if (is_gpu()) {
         size_t total_gpu_req = graph_mem_req.get_mem_req(GPU_REQ) + new_gpu_req;
+        const size_t total_mapped_mem_req = graph_mem_req.get_mapped_mem_req()
+                + check_mem_size_args.total_size_mapped;
+        const size_t device_peak_req = total_gpu_req + total_mapped_mem_req;
 
-        const bool fits_device_ram = total_gpu_req <= benchdnn_device_limit;
-        check_memory_fit(
-                fits_device_ram, total_gpu_req, benchdnn_device_limit, res);
+        const bool fits_device_ram = device_peak_req <= benchdnn_device_limit;
+        SAFE(check_memory_fit(fits_device_ram, device_peak_req,
+                     benchdnn_device_limit, GPU_REQ, res),
+                WARN);
+
+        const size_t combined_cpu_req = total_cpu_req + total_gpu_req;
+        const bool fits_cpu_ram = combined_cpu_req <= benchdnn_cpu_limit;
+        SAFE(check_memory_fit(fits_cpu_ram, combined_cpu_req,
+                     benchdnn_cpu_limit, CPU_REQ, res),
+                WARN);
         graph_mem_req.increase_mem_req(GPU_REQ, REF, new_gpu_req);
+        graph_mem_req.increase_mapped_mem_req(
+                REF, check_mem_size_args.total_size_mapped);
+    } else {
+        const bool fits_cpu_ram = total_cpu_req <= benchdnn_cpu_limit;
+        SAFE(check_memory_fit(fits_cpu_ram, total_cpu_req, benchdnn_cpu_limit,
+                     CPU_REQ, res),
+                WARN);
     }
 
     // STEP 3: Temprorary memory release stage

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -572,6 +572,7 @@ int ref_partition_t::check_partition_total_size(
     const auto partition_in_out_lts = get_in_out_lt_ids(op);
     for (const auto &lt_id : partition_in_out_lts) {
         if (lt_id_2_lt_.find(lt_id) == lt_id_2_lt_.end()) return FAIL;
+        if (!accounted_graph_lt_ids_.insert(lt_id).second) continue;
         new_mem_req += lt_id_2_lt_.at(lt_id).create().get_mem_size();
     }
 

--- a/tests/benchdnn/graph/ref_partition.cpp
+++ b/tests/benchdnn/graph/ref_partition.cpp
@@ -578,20 +578,13 @@ int ref_partition_t::check_partition_total_size(
 
     // Step 2. Check whether the memory is enough.
     if (is_gpu()) {
-        // Align with check_total_size() in dnnl_common.cpp: Mapped host buffers
-        // are live together with device allocations at peak (and on some
-        // runtimes become device-resident while accessed), so account for them
-        // in the device peak used for the device RAM fit check.
         size_t total_gpu_req = graph_mem_req.get_mem_req(GPU_REQ) + new_mem_req;
         const size_t new_mapped_mem_req
                 = has_bench_mode_modifier(mode_modifier_t::no_ref_memory)
                 ? 0
                 : new_mem_req;
-        const size_t total_mapped_mem_req
-                = graph_mem_req.get_mapped_mem_req() + new_mapped_mem_req;
-        const size_t device_peak_req = total_gpu_req + total_mapped_mem_req;
-        const bool fits_device_ram = device_peak_req <= benchdnn_device_limit;
-        SAFE(check_memory_fit(fits_device_ram, device_peak_req,
+        const bool fits_device_ram = total_gpu_req <= benchdnn_device_limit;
+        SAFE(check_memory_fit(fits_device_ram, total_gpu_req,
                      benchdnn_device_limit, GPU_REQ, res),
                 WARN);
 
@@ -663,12 +656,8 @@ int ref_partition_t::check_partition_total_size(
     // GPU mem size check.
     if (is_gpu()) {
         size_t total_gpu_req = graph_mem_req.get_mem_req(GPU_REQ) + new_gpu_req;
-        const size_t total_mapped_mem_req = graph_mem_req.get_mapped_mem_req()
-                + check_mem_size_args.total_size_mapped;
-        const size_t device_peak_req = total_gpu_req + total_mapped_mem_req;
-
-        const bool fits_device_ram = device_peak_req <= benchdnn_device_limit;
-        SAFE(check_memory_fit(fits_device_ram, device_peak_req,
+        const bool fits_device_ram = total_gpu_req <= benchdnn_device_limit;
+        SAFE(check_memory_fit(fits_device_ram, total_gpu_req,
                      benchdnn_device_limit, GPU_REQ, res),
                 WARN);
 

--- a/tests/benchdnn/graph/ref_partition.hpp
+++ b/tests/benchdnn/graph/ref_partition.hpp
@@ -107,6 +107,9 @@ private:
     std::vector<size_t> partition_in_ids_;
     // partition out logical tensors' ids
     std::vector<size_t> partition_out_ids_;
+    // Partition input/output logical tensors already accounted to GRAPH_USER.
+    // Multiple ops may reference a port, but graph memory allocates it once.
+    std::unordered_set<size_t> accounted_graph_lt_ids_;
 
     // reference primitives for a single partition
     std::unordered_map<size_t, ::std::shared_ptr<ref_primitive_t>> ref_prims_;

--- a/tests/benchdnn/graph/ref_primitive.cpp
+++ b/tests/benchdnn/graph/ref_primitive.cpp
@@ -177,7 +177,10 @@ int ref_primitive_t::init_prb(res_t *res) {
 int ref_primitive_t::init_prim(
         const engine_t &ref_eng, res_t *res, bool force_override) {
     // The custom driver does not contain a primitive, skip this step.
-    if (driver_ == dnnl_driver_t::custom) return OK;
+    if (driver_ == dnnl_driver_t::custom) {
+        ::custom::collect_mem_size(res->mem_size_args, prb_.get());
+        return OK;
+    }
 
     const bool is_quant_or_dequant = kind_ == dnnl::graph::op::kind::Dequantize
             || kind_ == dnnl::graph::op::kind::Quantize

--- a/tests/benchdnn/graph/utils.cpp
+++ b/tests/benchdnn/graph/utils.cpp
@@ -1286,14 +1286,10 @@ engine_t make_graph_engine(bool use_host) {
         return engine_t(make_engine_with_allocator(dnnl::engine::kind::cpu,
                 static_cast<size_t>(engine_index), alloc));
     } else {
-#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL
+#if DNNL_GPU_RUNTIME == DNNL_RUNTIME_SYCL \
+        || DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
         return engine_t(make_engine_with_allocator(dnnl::engine::kind::gpu,
                 static_cast<size_t>(engine_index), alloc));
-#elif DNNL_GPU_RUNTIME == DNNL_RUNTIME_OCL
-        // needs to prepare ocl_malloc_wrapper and ocl_free_wrapper and call
-        // make_engine_with_allocator instead.
-        return engine_t(dnnl::engine(
-                dnnl::engine::kind::gpu, static_cast<size_t>(engine_index)));
 #else
         assert(!"unsupported gpu runtime");
         return engine_t(dnnl::engine {});


### PR DESCRIPTION
1. Fix a TODO for creating OpenCL engine with allocator. The allocator wrapper contains code to account partition internal memory allocation.
2. Now user scratchpad argument is used in benchdnn. Need to account it for memory usage estimation and check.
3. For GPU, mapped memory is accounted for GPU peak check.
4. Avoid duplicated inputs memory accounting - one input may feed into two operations, especially in backward patterns.
5. Clean up memory accounting in the reference path.