### PR TITLE
xe: ukernel: Refactor/remove punned type conversion macros

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/microkernel/shim.cpp
+++ b/src/gpu/intel/gemm/jit/generator/microkernel/shim.cpp
@@ -135,21 +135,21 @@ const char *typeName(
             case StructuredType::u32: return "uint";
             case StructuredType::u16: return "ushort";
             case StructuredType::u8: return "uchar";
-            case StructuredType::s4: return "uchar";
-            case StructuredType::u4: return "uchar";
+            case StructuredType::s4: return "s4";
+            case StructuredType::u4: return "u4";
             case StructuredType::f64: return "double";
             case StructuredType::f32: return "float";
             case StructuredType::f16: return "half";
             case StructuredType::bf16:
-                return (language == HostLanguage::None) ? "bfloat16" : "ushort";
+                return (language == HostLanguage::None) ? "bfloat16" : "bf16";
             case StructuredType::bf8:
-                return (language == HostLanguage::None) ? "bfloat8" : "uchar";
+                return (language == HostLanguage::None) ? "bfloat8" : "f8_e5m2";
             case StructuredType::hf8:
-                return (language == HostLanguage::None) ? "hfloat8" : "uchar";
+                return (language == HostLanguage::None) ? "hfloat8" : "f8_e4m3";
             case StructuredType::f8_e8m0:
-                return (language == HostLanguage::None) ? "e8m0" : "uchar";
+                return (language == HostLanguage::None) ? "e8m0" : "e8m0";
             case StructuredType::f4_e2m1:
-                return (language == HostLanguage::None) ? "e2m1" : "uchar";
+                return (language == HostLanguage::None) ? "e2m1" : "f4_e2m1";
             default: return "char";
         }
 }

--- a/src/gpu/intel/include/custom_types.h
+++ b/src/gpu/intel/include/custom_types.h
@@ -17,6 +17,8 @@
 #ifndef GPU_INTEL_INCLUDE_CUSTOM_TYPES_H
 #define GPU_INTEL_INCLUDE_CUSTOM_TYPES_H
 
+#include "gpu/intel/include/utils.h"
+
 // Fixed to 64 bit per the OpenCL specification to align with same type in C++
 // source code
 typedef long dim_t;
@@ -120,5 +122,22 @@ undef_data as_undef_data(char data) {
     undef_data ret = {0xba};
     return ret;
 }
+
+#define NATIVE_TYPE_CASE(t) t : (0, ((t *)0)->data)
+
+// Returns the native scalar type used to store the punned `type`.
+#define NATIVE_LAYOUT_TYPE(type) \
+    __typeof__(_Generic(*(type *)0, \
+            NATIVE_TYPE_CASE(bf16), \
+            NATIVE_TYPE_CASE(f8_e5m2), \
+            NATIVE_TYPE_CASE(f8_e4m3), \
+            NATIVE_TYPE_CASE(e8m0), \
+            NATIVE_TYPE_CASE(f4_e2m1), \
+            NATIVE_TYPE_CASE(s4), \
+            NATIVE_TYPE_CASE(u4), \
+            default: (0, *(type *)0)))
+
+// Macro to generate as_<type> function call for a given dt
+#define AS_NATIVE_LAYOUT_TYPE(dt, v) CONCAT2(as_, dt)(v)
 
 #endif

--- a/src/gpu/intel/include/tile_ops.h
+++ b/src/gpu/intel/include/tile_ops.h
@@ -20,6 +20,37 @@
 #include "gpu/intel/include/generic_vector_ops.h"
 #include "gpu/intel/include/types.h"
 
+#define def_as_native_layout(dt) \
+    NATIVE_LAYOUT_TYPE(dt) \
+    __attribute__((overloadable)) as_native_layout(dt val) { \
+        return val.data; \
+    }
+#define def_identity_native_layout_into(dt) \
+    dt __attribute__((overloadable)) as_native_layout(dt val) { \
+        return val; \
+    }
+
+def_as_native_layout(bf16);
+def_as_native_layout(f8_e5m2);
+def_as_native_layout(f8_e4m3);
+def_as_native_layout(e8m0);
+def_as_native_layout(f4_e2m1);
+def_as_native_layout(s4);
+def_as_native_layout(u4);
+
+def_identity_native_layout_into(float);
+def_identity_native_layout_into(char);
+def_identity_native_layout_into(uchar);
+def_identity_native_layout_into(short);
+def_identity_native_layout_into(ushort);
+def_identity_native_layout_into(int);
+def_identity_native_layout_into(uint);
+IF_DOUBLE_SUPPORTED(def_identity_native_layout_into(double));
+IF_HALF_SUPPORTED(def_identity_native_layout_into(half));
+
+#undef def_as_native_layout
+#undef def_identity_native_layout_into
+
 #define IS_POWER_OF_2(x) (((x) != 0) && (((x) & ((x) - 1)) == 0))
 
 float __builtin_IB_atomic_max_local_f32(__local float *, float);

--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -651,11 +651,8 @@ status_t grouped_micro_gemm_t::pd_t::init_kernel_ctx_m_axis() {
     kernel_ctx_.define_int("WITH_BINARY_NVFP4_SCALE", with_binary_nvfp4_scale);
     kernel_ctx_.add_custom_header("grouped_post_ops.h",
             generate_post_ops_microgemm_header(*attr(), po_chain_));
-    if (with_binary_grouped_scale || with_binary_dense_scale) {
-        def_data_type(
-                kernel_ctx_, binary_scale_dts_[0], "BINARY_SCALE_GROUPED");
-        def_data_type(kernel_ctx_, binary_scale_dts_[1], "BINARY_SCALE_DENSE");
-    }
+    def_data_type(kernel_ctx_, binary_scale_dts_[0], "BINARY_SCALE_GROUPED");
+    def_data_type(kernel_ctx_, binary_scale_dts_[1], "BINARY_SCALE_DENSE");
 
     return status::success;
 }

--- a/src/gpu/intel/matmul/grouped_micro_gemm_k_axis.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm_k_axis.cl
@@ -21,16 +21,11 @@
 
 #include "gemm_grouped.h"
 
-#ifdef DST_DT_BF16
-#define DST_TILE_DATA_T ushort
-#define CONVERT_TILE_DATA_T(v) (into_bf16(convert_float(v)).data)
-#else
-#define DST_TILE_DATA_T DST_DATA_T
-#define CONVERT_TILE_DATA_T CONVERT_DATA_T
-#endif
+#define CONVERT_TILE_DATA_T(v) as_native_layout(CONVERT_DATA_T(v))
+typedef NATIVE_LAYOUT_TYPE(DST_DATA_T) dst_tile_data_t;
 
 #ifndef DST_DT_F32
-DECLARE_2D_TILE(c_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(c_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
         ugemm_grouped_c_type_nblock0, ugemm_grouped_c_type_nblock1)
 #endif
@@ -43,7 +38,7 @@ void store_results(ugemm_grouped_c_type *tile, global DST_DATA_T *ptr, int m,
     c_tile_type_dst tile_dst;
     tile_convert((*tile), tile_dst, CONVERT_TILE_DATA_T);
     tile_store(
-            tile_dst, (global DST_TILE_DATA_T *)ptr, m, n, ldc, sg_i0, sg_j0);
+            tile_dst, (global dst_tile_data_t *)ptr, m, n, ldc, sg_i0, sg_j0);
 #endif
 }
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm_k_axis.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm_k_axis.cl
@@ -35,18 +35,6 @@ DECLARE_2D_TILE(c_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_grouped_c_type_nblock0, ugemm_grouped_c_type_nblock1)
 #endif
 
-#if defined(A_DT_BF16)
-#define AS_A_TILE_PTR(p) ((const global ushort *)(p))
-#else
-#define AS_A_TILE_PTR(p) (p)
-#endif
-
-#if defined(B_DT_BF16)
-#define AS_B_TILE_PTR(p) ((const global ushort *)(p))
-#else
-#define AS_B_TILE_PTR(p) (p)
-#endif
-
 void store_results(ugemm_grouped_c_type *tile, global DST_DATA_T *ptr, int m,
         int n, int ldc, int sg_i0, int sg_j0) {
 #if DST_DT_F32
@@ -100,8 +88,8 @@ grouped_micro_gemm_k_axis(const global A_DATA_T *a, long lda,
         a += k_offset * lda / A_ELEMS_PER_BYTE;
         b += k_offset * ldb / B_ELEMS_PER_BYTE;
 
-        c_tile = ugemm_grouped(AS_A_TILE_PTR(a), lda, AS_B_TILE_PTR(b), ldb, m,
-                n, kg, wg_i0, wg_j0, 0, sg_i, sg_j, slm);
+        c_tile = ugemm_grouped(
+                a, lda, b, ldb, m, n, kg, wg_i0, wg_j0, 0, sg_i, sg_j, slm);
     }
 
     store_results(&c_tile, dst, m, n, ldc, sg_i0, sg_j0);

--- a/src/gpu/intel/matmul/grouped_micro_gemm_m_axis.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm_m_axis.cl
@@ -223,61 +223,14 @@ DECLARE_2D_TILE(c_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
 #define FMA_TYPE ushort
 #endif
 
-/* Cast macros for ugemm_grouped pointer arguments: cast when the data type
- * is a struct, since the ugemm microkernels use punned scalar types. */
-/* 4-bit and 8-bit struct types (BF8=f8_e5m2, HF8=f8_e4m3) are packed in uchar.
- * bf16 uses its ushort representation (FMA_TYPE). */
-#if defined(WEI_DT_S4) || defined(WEI_DT_U4) || defined(WEI_DT_F4_E2M1) \
-        || defined(WEI_DT_BF8) || defined(WEI_DT_HF8) || defined(WEI_DT_E8M0)
-#define AS_WEI_TILE_PTR(p) ((const global uchar *)(p))
-#elif defined(WEI_DT_BF16)
-#define AS_WEI_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#else
-#define AS_WEI_TILE_PTR(p) (p)
-#endif
-
-#if defined(SRC_DT_S4) || defined(SRC_DT_U4) || defined(SRC_DT_F4_E2M1) \
-        || defined(SRC_DT_BF8) || defined(SRC_DT_HF8) || defined(SRC_DT_E8M0)
-#define AS_SRC_TILE_PTR(p) ((const global uchar *)(p))
-#elif defined(SRC_DT_BF16)
-#define AS_SRC_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#else
-#define AS_SRC_TILE_PTR(p) (p)
-#endif
-
-#if defined(WEI_SCALES_DT_BF16)
-#define AS_WEI_SCALES_PTR(p) ((const global ushort *)(p))
-#elif defined(WEI_SCALES_DT_E8M0) || defined(WEI_SCALES_DT_HF8)
-#define AS_WEI_SCALES_PTR(p) ((const global uchar *)(p))
-#else
-#define AS_WEI_SCALES_PTR(p) (p)
-#endif
-
-#if defined(SRC_SCALES_DT_BF16)
-#define AS_SRC_SCALES_PTR(p) ((const global ushort *)(p))
-#elif defined(SRC_SCALES_DT_E8M0) || defined(SRC_SCALES_DT_HF8)
-#define AS_SRC_SCALES_PTR(p) ((const global uchar *)(p))
-#else
-#define AS_SRC_SCALES_PTR(p) (p)
-#endif
-
-/* Subbyte zero-point types are packed in uchar. */
-#if defined(WEI_ZP_DT_U4) || defined(WEI_ZP_DT_S4)
-#define AS_WEI_ZP_PTR(p) ((const global uchar *)(p))
-#else
-#define AS_WEI_ZP_PTR(p) (p)
-#endif
-
 /* Optional quantization parameters */
 #define SRC_SCALE_ARGS \
-    OPTIONAL(AND(WITH_SRC_SCALES, SRC_SCALES_GROUPED), \
-            AS_SRC_SCALES_PTR(src_attr_scales))
+    OPTIONAL(AND(WITH_SRC_SCALES, SRC_SCALES_GROUPED), src_attr_scales)
 #define SRC_ZP_ARGS OPTIONAL(WITH_SRC_ZP, src_attr_zp)
 #define SRC_LD_ARGS OPTIONAL(OR(WITH_SRC_ZP, SRC_SCALES_GROUPED), ldsrcq)
 #define WEI_SCALE_ARGS \
-    OPTIONAL(AND(WITH_WEI_SCALES, WEI_SCALES_GROUPED), \
-            AS_WEI_SCALES_PTR(wei_attr_scales))
-#define WEI_ZP_ARGS OPTIONAL(WITH_WEI_ZP, AS_WEI_ZP_PTR(wei_attr_zp))
+    OPTIONAL(AND(WITH_WEI_SCALES, WEI_SCALES_GROUPED), wei_attr_scales)
+#define WEI_ZP_ARGS OPTIONAL(WITH_WEI_ZP, wei_attr_zp)
 #define WEI_LD_ARGS OPTIONAL(OR(WITH_WEI_ZP, WEI_SCALES_GROUPED), ldweiq)
 #define K_PARALLEL_LOCAL_ARGS OPTIONAL(K_PARALLEL_LOCAL, sg_k)
 
@@ -440,9 +393,8 @@ grouped_micro_gemm_m_axis(const global SRC_DATA_T *src, long ldsrc,
     wei_attr_zp += batch * n * (k / WEI_GROUP_SIZE) / WEI_ZP_ELEMS_PER_BYTE;
 #endif
 
-    ugemm_grouped_c_type c_tile = ugemm_grouped(AS_WEI_TILE_PTR(wei), ldwei,
-            AS_SRC_TILE_PTR(src), ldsrc, n, m, k, wg_i0, wg_j0, 0, sg_i,
-            sg_j K_PARALLEL_LOCAL_ARGS,
+    ugemm_grouped_c_type c_tile = ugemm_grouped(wei, ldwei, src, ldsrc, n, m, k,
+            wg_i0, wg_j0, 0, sg_i, sg_j K_PARALLEL_LOCAL_ARGS,
             slm WEI_SCALE_ARGS WEI_ZP_ARGS WEI_LD_ARGS SRC_SCALE_ARGS
                     SRC_ZP_ARGS SRC_LD_ARGS);
 

--- a/src/gpu/intel/matmul/grouped_micro_gemm_m_axis.cl
+++ b/src/gpu/intel/matmul/grouped_micro_gemm_m_axis.cl
@@ -23,6 +23,9 @@
 
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 
+#define DST_TILE_DATA_T NATIVE_LAYOUT_TYPE(DST_DATA_T)
+#define BIA_TILE_DATA_T NATIVE_LAYOUT_TYPE(BIA_DATA_T)
+
 #if WITH_BIAS
 #define bias_br ugemm_grouped_sg_tile_m
 #define bias_bc 1
@@ -36,15 +39,7 @@ DECLARE_2D_TILE_VREDUCE(ugemm_grouped_c_type, SUBGROUP_SIZE,
         ugemm_grouped_c_type_nblock0, ugemm_grouped_c_type_nblock1,
         bias_tile_type, SUBGROUP_SIZE, bias_br, bias_bc, bias_nbr, bias_nbc)
 
-/* When BIA_DATA_T is a struct it cannot be used as an ext_vector_type
- * element. Use the underlying scalar type for tile storage. */
-#ifdef BIA_DT_BF16
-#define BIA_TILE_DATA_T ushort
-#define BIA_TILE_TO_REF(v) into_float(as_bf16(v))
-#else
-#define BIA_TILE_DATA_T BIA_DATA_T
-#define BIA_TILE_TO_REF BIA_TO_REF
-#endif
+#define BIA_TILE_TO_REF(v) into_float(AS_NATIVE_LAYOUT_TYPE(BIA_DATA_T, v))
 
 #ifndef BIA_DT_F32
 DECLARE_2D_TILE(bias_in_tile_type, BIA_TILE_DATA_T, SUBGROUP_SIZE, bias_br,
@@ -64,38 +59,15 @@ void load_bias(
 }
 #endif
 
-/* Binary scale pointer types: always defined so kernel params compile.
- * BINARY_SCALE_GROUPED_DT_* / BINARY_SCALE_DENSE_DT_* are set only when the
- * corresponding binary scale post-op is active. */
-#if BINARY_SCALE_GROUPED_DT_F16
-#define BINARY_SCALE_GROUPED_TILE_DATA_T half
-#define BINARY_SCALE_GROUPED_TO_FLOAT(v) convert_float(v)
-#elif BINARY_SCALE_GROUPED_DT_BF16
-#define BINARY_SCALE_GROUPED_TILE_DATA_T ushort
-#define BINARY_SCALE_GROUPED_TO_FLOAT(v) into_float(as_bf16(v))
-#elif BINARY_SCALE_GROUPED_DT_F32
-#define BINARY_SCALE_GROUPED_TILE_DATA_T float
-#define BINARY_SCALE_GROUPED_TO_FLOAT(v) (v)
-#else
-// No grouped binary scale active; keep kernel args and helpers well-typed.
-#define BINARY_SCALE_GROUPED_TILE_DATA_T float
-#define BINARY_SCALE_GROUPED_TO_FLOAT(v) (v)
-#endif
+typedef NATIVE_LAYOUT_TYPE(
+        BINARY_SCALE_GROUPED_DATA_T) binary_scale_grouped_tile_data_t;
+#define BINARY_SCALE_GROUPED_TO_FLOAT(value) \
+    into_float(AS_NATIVE_LAYOUT_TYPE(BINARY_SCALE_GROUPED_DATA_T, value))
 
-#if BINARY_SCALE_DENSE_DT_F16
-#define BINARY_SCALE_DENSE_TILE_DATA_T half
-#define BINARY_SCALE_DENSE_TO_FLOAT(v) convert_float(v)
-#elif BINARY_SCALE_DENSE_DT_BF16
-#define BINARY_SCALE_DENSE_TILE_DATA_T ushort
-#define BINARY_SCALE_DENSE_TO_FLOAT(v) into_float(as_bf16(v))
-#elif BINARY_SCALE_DENSE_DT_F32
-#define BINARY_SCALE_DENSE_TILE_DATA_T float
-#define BINARY_SCALE_DENSE_TO_FLOAT(v) (v)
-#else
-// No dense binary scale active; keep kernel args and helpers well-typed.
-#define BINARY_SCALE_DENSE_TILE_DATA_T float
-#define BINARY_SCALE_DENSE_TO_FLOAT(v) (v)
-#endif
+typedef NATIVE_LAYOUT_TYPE(
+        BINARY_SCALE_DENSE_DATA_T) binary_scale_dense_tile_data_t;
+#define BINARY_SCALE_DENSE_TO_FLOAT(value) \
+    into_float(AS_NATIVE_LAYOUT_TYPE(BINARY_SCALE_DENSE_DATA_T, value))
 
 #if WITH_POST_OP
 #define ELTWISE_VECTOR_API
@@ -107,7 +79,7 @@ DECLARE_2D_TILE(binary_group_chunk_type, float, SUBGROUP_SIZE,
         ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
         ugemm_grouped_c_type_nblock0, 1)
 #if !BINARY_SCALE_GROUPED_DT_F32
-DECLARE_2D_TILE(binary_group_chunk_in_type, BINARY_SCALE_GROUPED_TILE_DATA_T,
+DECLARE_2D_TILE(binary_group_chunk_in_type, binary_scale_grouped_tile_data_t,
         SUBGROUP_SIZE, ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
         ugemm_grouped_c_type_nblock0, 1)
 #endif
@@ -123,7 +95,7 @@ DECLARE_2D_TILE(binary_dense_tile_type, float, SUBGROUP_SIZE,
         binary_dense_scale_nbc)
 #if !BINARY_SCALE_DENSE_DT_F32
 // Intermediate tile for loading non-float binary dense scale before converting
-DECLARE_2D_TILE(binary_dense_in_tile_type, BINARY_SCALE_DENSE_TILE_DATA_T,
+DECLARE_2D_TILE(binary_dense_in_tile_type, binary_scale_dense_tile_data_t,
         SUBGROUP_SIZE, binary_dense_scale_br, binary_dense_scale_bc,
         binary_dense_scale_nbr, binary_dense_scale_nbc)
 #endif
@@ -201,26 +173,12 @@ void find_sparse_batch(off_t *batch, int2 *src_range,
 #define slm_sparse_total_size 0
 #endif
 
-/* When DST_DATA_T is a struct it cannot be used as an ext_vector_type
- * element. Use the underlying scalar type for tile storage. */
-#ifdef DST_DT_BF16
-#define DST_TILE_DATA_T ushort
-#define CONVERT_TILE_DATA_T(v) (into_bf16(convert_float(v)).data)
-#else
-#define DST_TILE_DATA_T DST_DATA_T
-#define CONVERT_TILE_DATA_T CONVERT_DATA_T
-#endif
+#define CONVERT_TILE_DATA_T(v) as_native_layout(CONVERT_DATA_T(v))
 
 #ifndef DST_DT_F32
 DECLARE_2D_TILE(c_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
         ugemm_grouped_c_type_block0, ugemm_grouped_c_type_block1,
         ugemm_grouped_c_type_nblock0, ugemm_grouped_c_type_nblock1)
-#endif
-
-/* FMA_TYPE: scalar type used by ugemm microkernels for bf16 matrix operands.
- * bf16 is a struct in OpenCL C; the microkernel uses its punned ushort representation. */
-#if defined(WEI_DT_BF16) || defined(SRC_DT_BF16)
-#define FMA_TYPE ushort
 #endif
 
 /* Optional quantization parameters */
@@ -324,8 +282,8 @@ grouped_micro_gemm_m_axis(const global SRC_DATA_T *src, long ldsrc,
         const global WEI_SCALES_DATA_T *wei_attr_scales,
         const global WEI_ZP_DATA_T *wei_attr_zp, const long ldweiq,
         const long n, const long k, const global BIA_DATA_T *bias,
-        const global BINARY_SCALE_GROUPED_TILE_DATA_T *binary_grouped_scale,
-        const global BINARY_SCALE_DENSE_TILE_DATA_T *binary_dense_scale,
+        const global binary_scale_grouped_tile_data_t *binary_grouped_scale,
+        const global binary_scale_dense_tile_data_t *binary_dense_scale,
         const global float *binary_nvfp4_scale) {
 #if WITH_SLM
     local char slm[MAX(ugemm_grouped_slm_size, slm_sparse_total_size)];

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -15,6 +15,8 @@
 *******************************************************************************/
 
 #include "gpu/intel/matmul/grouped_post_ops_gen.hpp"
+#include "common/matmul_pd.hpp"
+#include "common/verbose.hpp"
 
 #if DNNL_EXPERIMENTAL_GROUPED_MEMORY
 
@@ -51,36 +53,49 @@ int find_po_in_chain(const po_kind_t *po_chain, po_kind_t kind) {
 status_t check_post_op_chain(const primitive_attr_t &attr,
         const memory_desc_wrapper &dst_desc, dim_t ngroups, po_kind_t *po_chain,
         data_type_t *scale_arr) {
+    constexpr int max_po_len = 3;
     auto &po = attr.post_ops_;
     scale_arr[0] = data_type::undef;
     scale_arr[1] = data_type::undef;
-    VCHECK_MATMUL(po.len() <= 3, VERBOSE_UNSUPPORTED_POSTOP);
+    VDISPATCH_MATMUL_IC(po.len() <= max_po_len,
+            VERBOSE_UNSUPPORTED_POSTOP ": chain length(%d) exceeds max(%d)",
+            po.len(), max_po_len);
     for (int i = 0; i < po.len(); ++i) {
         auto &e = po.entry_[i];
-        VCHECK_MATMUL(
-                e.is_eltwise() || e.is_binary(), VERBOSE_UNSUPPORTED_POSTOP);
+        VDISPATCH_MATMUL_IC(e.is_eltwise() || e.is_binary(),
+                VERBOSE_UNSUPPORTED_POSTOP
+                ": entry %d kind(%s) only eltwise and binary are supported",
+                i, dnnl_prim_kind2str(e.kind));
         if (e.is_eltwise()) {
-            VCHECK_MATMUL(is_eltwise_alg_supported(e.eltwise.alg),
-                    VERBOSE_UNSUPPORTED_POSTOP);
+            VDISPATCH_MATMUL_IC(is_eltwise_alg_supported(e.eltwise.alg),
+                    VERBOSE_UNSUPPORTED_POSTOP ": entry %d eltwise alg(%s)", i,
+                    dnnl_alg_kind2str(e.eltwise.alg));
             po_chain[i] = po_kind_t::eltwise;
         } else if (e.is_binary()) {
-            VCHECK_MATMUL(e.binary.alg == alg_kind::binary_mul,
-                    VERBOSE_UNSUPPORTED_POSTOP);
+            VDISPATCH_MATMUL_IC(e.binary.alg == alg_kind::binary_mul,
+                    VERBOSE_UNSUPPORTED_POSTOP
+                    ": entry %d binary alg(%s) only mul is supported",
+                    i, dnnl_alg_kind2str(e.binary.alg));
 
             const memory_desc_wrapper po_mdw(po.entry_[i].binary.src1_desc);
             if (po_mdw.nelems() == ngroups && !po_mdw.is_host_scalar_desc()) {
                 // [G, 1] operand: one scale per group (expert), e.g. nvfp4
                 // per-expert global f32 scale
-                VCHECK_MATMUL(po_mdw.data_type() == data_type::f32,
-                        VERBOSE_UNSUPPORTED_POSTOP);
+                VDISPATCH_MATMUL_IC(po_mdw.data_type() == data_type::f32,
+                        VERBOSE_UNSUPPORTED_POSTOP
+                        ": entry %d per-group scale dt(%s) must be f32",
+                        i, dnnl_dt2str(po_mdw.data_type()));
                 po_chain[i] = po_kind_t::binary_nvfp4_scale;
             } else {
                 if (po_mdw.is_grouped_desc()) {
                     // [total_tokens, N] grouped - element-wise multiply
-                    VCHECK_MATMUL(find_po_in_chain(po_chain,
-                                          po_kind_t::binary_grouped_scale)
+                    VDISPATCH_MATMUL_IC(find_po_in_chain(po_chain,
+                                                po_kind_t::binary_grouped_scale)
                                     == -1,
-                            VERBOSE_UNSUPPORTED_POSTOP);
+                            VERBOSE_UNSUPPORTED_POSTOP
+                            ": entry %d is a second grouped binary scale "
+                            "only one is supported",
+                            i);
                     po_chain[i] = po_kind_t::binary_grouped_scale;
                 } else if (!po_mdw.format_any()) {
                     // Dense tensor - check dimensions
@@ -89,16 +104,25 @@ status_t check_post_op_chain(const primitive_attr_t &attr,
                     // [total_tokens, 1] - dense scale with horizontal broadcast
                     if (ndims >= 2 && dims[ndims - 1] == 1
                             && dims[ndims - 2] > 1) {
-                        VCHECK_MATMUL(find_po_in_chain(po_chain,
-                                              po_kind_t::binary_dense_scale)
+                        VDISPATCH_MATMUL_IC(
+                                find_po_in_chain(
+                                        po_chain, po_kind_t::binary_dense_scale)
                                         == -1,
-                                VERBOSE_UNSUPPORTED_POSTOP);
+                                VERBOSE_UNSUPPORTED_POSTOP
+                                ": entry %d is a second dense binary scale "
+                                "only one is supported",
+                                i);
                         po_chain[i] = po_kind_t::binary_dense_scale;
                     }
                 }
             }
-            VCHECK_MATMUL(
-                    po_chain[i] != po_kind_t::none, VERBOSE_UNSUPPORTED_POSTOP);
+            VDISPATCH_MATMUL_IC(po_chain[i] != po_kind_t::none,
+                    VERBOSE_UNSUPPORTED_POSTOP
+                    ": entry %d binary src1 dims(%s) tag(%s) is not a "
+                    "supported scale layout; expected per-group [%d,1], "
+                    "grouped [total_tokens,N] or dense [total_tokens,1]",
+                    i, md2dim_str(&e.binary.src1_desc).c_str(),
+                    md2fmt_tag_str(&e.binary.src1_desc).c_str(), (int)ngroups);
         }
     }
 
@@ -109,14 +133,18 @@ status_t check_post_op_chain(const primitive_attr_t &attr,
             = find_po_in_chain(po_chain, po_kind_t::binary_dense_scale) != -1;
 
     if (has_grouped_scale) {
-        VCHECK_MATMUL(utils::one_of(scale_arr[0], data_type::f16,
-                              data_type::bf16, data_type::f32),
-                VERBOSE_UNSUPPORTED_POSTOP);
+        VDISPATCH_MATMUL_IC(utils::one_of(scale_arr[0], data_type::f16,
+                                    data_type::bf16, data_type::f32),
+                VERBOSE_UNSUPPORTED_POSTOP
+                ": grouped binary scale dt(%s), expected f16, bf16 or f32",
+                dnnl_dt2str(scale_arr[0]));
     }
     if (has_dense_scale) {
-        VCHECK_MATMUL(utils::one_of(scale_arr[1], data_type::f16,
-                              data_type::bf16, data_type::f32),
-                VERBOSE_UNSUPPORTED_POSTOP);
+        VDISPATCH_MATMUL_IC(utils::one_of(scale_arr[1], data_type::f16,
+                                    data_type::bf16, data_type::f32),
+                VERBOSE_UNSUPPORTED_POSTOP
+                ": dense binary scale dt(%s), expected f16, bf16 or f32",
+                dnnl_dt2str(scale_arr[1]));
     }
 
     return status::success;

--- a/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
+++ b/src/gpu/intel/matmul/grouped_post_ops_gen.cpp
@@ -150,8 +150,8 @@ std::string generate_post_ops_microgemm_header(
     std::string s = R"(
 inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, long lddst,
     off_t sg_i0, off_t sg_j0, off_t src_offset, off_t batch,
-    const global BINARY_SCALE_GROUPED_TILE_DATA_T *grouped_scale,
-    const global BINARY_SCALE_DENSE_TILE_DATA_T *dense_scale,
+    const global binary_scale_grouped_tile_data_t *grouped_scale,
+    const global binary_scale_dense_tile_data_t *dense_scale,
     const global float *nvfp4_scale) {
 )";
     const auto &po = attr.post_ops_;
@@ -171,7 +171,7 @@ inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, l
             if (po_chain[i] == po_kind_t::binary_grouped_scale) {
                 s += R"(
     {
-        const global BINARY_SCALE_GROUPED_TILE_DATA_T *group_scale_ptr
+        const global binary_scale_grouped_tile_data_t *group_scale_ptr
                 = grouped_scale + src_offset * lddst;
 #define GRP_BC ugemm_grouped_c_type_block1
 #define GRP_NBR ugemm_grouped_c_type_nblock0
@@ -202,7 +202,7 @@ inline void apply_post_ops_chain(ugemm_grouped_c_type *c_tile, long n, long m, l
                 s += utils::format(
                         R"(
 #define CONCAT_I(var) var##_%d
-    const global BINARY_SCALE_DENSE_TILE_DATA_T *CONCAT_I(dense_scale_ptr) = dense_scale + src_offset;
+    const global binary_scale_dense_tile_data_t *CONCAT_I(dense_scale_ptr) = dense_scale + src_offset;
     binary_dense_tile_type CONCAT_I(dense_scale_tile);
 #if BINARY_SCALE_DENSE_DT_F32
     tile_load(&CONCAT_I(dense_scale_tile), CONCAT_I(dense_scale_ptr), m, 1, 0, sg_j0, 0);

--- a/src/gpu/intel/rnn/grid.cpp
+++ b/src/gpu/intel/rnn/grid.cpp
@@ -830,22 +830,20 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
         }
         if (!conf.cell_fusion.gemm_iter) {
             if (conf.is_vanilla_gru) {
-                VDISPATCH_RNN_SC(
-                        create_matmul(matmul_iter_fwd_pd_, batch,
-                                (n_gates - 1) * dhc, sic,
-                                {conf.states_ws_ld, 1},
-                                wei_strides(off.weights_iter),
-                                {conf.scratch_gates_ld, 1}, src_type,
-                                weights_type, conf.acc_data_type,
-                                matmul_iter_fwd_beta),
+                VDISPATCH_RNN_SC(create_matmul(matmul_iter_fwd_pd_, batch,
+                                         (n_gates - 1) * dhc, sic,
+                                         {conf.states_ws_ld, 1},
+                                         wei_strides(off.weights_iter),
+                                         {conf.scratch_gates_ld, 1}, src_type,
+                                         weights_type, conf.acc_data_type,
+                                         matmul_iter_fwd_beta),
                         "create_matmul(matmul_iter_fwd_pd_)");
-                VDISPATCH_RNN_SC(
-                        create_matmul(matmul_iter_fwd_2_pd_, batch, dhc, sic,
-                                {conf.states_ws_ld, 1},
-                                wei_strides(off.weights_iter),
-                                {conf.scratch_gates_ld, 1}, src_type,
-                                weights_type, conf.acc_data_type,
-                                matmul_iter_fwd_beta),
+                VDISPATCH_RNN_SC(create_matmul(matmul_iter_fwd_2_pd_, batch,
+                                         dhc, sic, {conf.states_ws_ld, 1},
+                                         wei_strides(off.weights_iter),
+                                         {conf.scratch_gates_ld, 1}, src_type,
+                                         weights_type, conf.acc_data_type,
+                                         matmul_iter_fwd_beta),
                         "create_matmul(matmul_iter_fwd_2_pd_)");
             } else {
                 VDISPATCH_RNN_SC(
@@ -879,15 +877,15 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                             (n_gates - 1) * dhc, iter_merged_size,
                             {1, conf.states_ws_ld},
                             {conf.scratch_diff_gates_ld, 1},
-                            wei_strides(off.diff_weights_iter),
-                            src_type, weights_type, conf.acc_data_type, 1.0f),
+                            wei_strides(off.diff_weights_iter), src_type,
+                            weights_type, conf.acc_data_type, 1.0f),
                     "create_matmul(matmul_diff_wei_iter_pd_)");
             VDISPATCH_RNN_SC(
                     create_matmul(matmul_diff_wei_iter_2_pd_, sic, dhc,
                             iter_merged_size, {1, conf.states_ws_ld},
                             {conf.scratch_diff_gates_ld, 1},
-                            wei_strides(off.diff_weights_iter),
-                            src_type, weights_type, conf.acc_data_type, 1.0f),
+                            wei_strides(off.diff_weights_iter), src_type,
+                            weights_type, conf.acc_data_type, 1.0f),
                     "create_matmul(matmul_diff_wei_iter_2_pd_)");
         } else {
             VDISPATCH_RNN_SC(
@@ -902,8 +900,8 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                     create_matmul(matmul_diff_wei_iter_pd_, sic, n_gates * dhc,
                             iter_merged_size, {1, conf.states_ws_ld},
                             {conf.scratch_diff_gates_ld, 1},
-                            wei_strides(off.diff_weights_iter),
-                            src_type, weights_type, conf.acc_data_type, 1.0f),
+                            wei_strides(off.diff_weights_iter), src_type,
+                            weights_type, conf.acc_data_type, 1.0f),
                     "create_matmul(matmul_diff_wei_iter_pd_)");
         }
         VDISPATCH_RNN_SC(
@@ -930,18 +928,18 @@ status_t simple_common_t<aprop>::pd_t::init(const impl::engine_t *engine) {
                 create_matmul(matmul_diff_wei_layer_pd_, slc, n_gates * dhc,
                         layer_merged_size, {1, conf.states_ws_ld},
                         {conf.scratch_diff_gates_ld, 1},
-                        wei_strides(off.diff_weights_layer),
-                        src_type, weights_type, conf.acc_data_type, 1.0f),
+                        wei_strides(off.diff_weights_layer), src_type,
+                        weights_type, conf.acc_data_type, 1.0f),
                 "create_matmul(matmul_diff_wei_layer_pd_)");
         if (!conf.copy_src_layer) {
             if (off.src_layer[1] != conf.states_ws_ld)
-                VDISPATCH_RNN_SC(create_matmul(matmul_diff_wei_layer_src_pd_,
-                                         slc, n_gates * dhc, layer_merged_size,
-                                         {off.src_layer[2], off.src_layer[1]},
-                                         {conf.scratch_diff_gates_ld, 1},
-                                         wei_strides(off.diff_weights_layer),
-                                         src_type, weights_type,
-                                         conf.acc_data_type, 1.0f),
+                VDISPATCH_RNN_SC(
+                        create_matmul(matmul_diff_wei_layer_src_pd_, slc,
+                                n_gates * dhc, layer_merged_size,
+                                {off.src_layer[2], off.src_layer[1]},
+                                {conf.scratch_diff_gates_ld, 1},
+                                wei_strides(off.diff_weights_layer), src_type,
+                                weights_type, conf.acc_data_type, 1.0f),
                         "create_matmul(matmul_diff_wei_layer_src_pd_)");
             else
                 matmul_diff_wei_layer_src_pd_ = matmul_diff_wei_layer_pd_;

--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -33,32 +33,20 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define DIV_UP(x, y) (((x) + (y) - 1) / (y))
 
-/* When a data type is a struct (e.g. bf16), it cannot be used as an
- * ext_vector_type element. Use the underlying scalar type for tile storage
- * and convert at tile boundaries. */
-#ifdef DST_DT_BF16
-#define DST_TILE_DATA_T ushort
-#define CONVERT_TILE_DATA_T(v) (into_bf16(v).data)
-#else
-#define DST_TILE_DATA_T DST_DATA_T
-#define CONVERT_TILE_DATA_T CONVERT_DATA_T
-#endif
+typedef NATIVE_LAYOUT_TYPE(DST_DATA_T) dst_tile_data_t;
+typedef NATIVE_LAYOUT_TYPE(MSK_DATA_T) msk_tile_data_t;
 
-#ifdef MSK_DT_BF16
-#define MSK_TILE_DATA_T ushort
-#define CONVERT_TILE_FLOAT_MSK_T(v) into_float(as_bf16(v))
-#else
-#define MSK_TILE_DATA_T MSK_DATA_T
-#define CONVERT_TILE_FLOAT_MSK_T CONVERT_FLOAT_T
-#endif
+#define FMA_TYPE NATIVE_LAYOUT_TYPE(QRY_DATA_T)
 
-/* Punned conversion for FMA tile storage: produces FMA_TYPE (ushort when bf16)
- * rather than the bf16 struct that CONVERT_DATA_T returns. */
-#ifdef QRY_DT_BF16
-#define CONVERT_TILE_FMA_T(v) (into_bf16(convert_float(v)).data)
-#else
-#define CONVERT_TILE_FMA_T CONVERT_DATA_T
-#endif
+#define CONVERT_TILE_DATA_T(value) as_native_layout(CONVERT_DATA_T(value))
+
+#define CONVERT_TILE_FLOAT_MSK_T(value) \
+    into_float(AS_NATIVE_LAYOUT_TYPE(MSK_DATA_T, value))
+
+/* FMA tile storage, which follows the query type rather than the ambient dst
+ * type -- see FMA_TYPE below. */
+#define CONVERT_TILE_FMA_T(v) \
+    as_native_layout(CONCAT2(into_, QRY_DATA_T)(convert_float(v)))
 
 #define sg_per_wg (ugemm_kq_sg_per_wg_m * ugemm_kq_sg_per_wg_n)
 #define q_tile_sg_n DIV_UP(ugemm_kq_wg_tile_n, sg_per_wg)
@@ -127,22 +115,12 @@ inline void apply_dropout_s_tile(
 // example: Prints the entire S_tile in the (0, 1, 0) work group
 // print_tile(S_tile, "%7.2f", 0, 1, 0, ugemm_kq_sg_per_wg_m, ugemm_kq_sg_per_wg_n);
 
-#ifdef QRY_DT_F32
-#define FMA_TYPE float
-#elif QRY_DT_F16
+#ifdef QRY_DT_F16
 #define VEC_TYPE2 half2
-#define FMA_TYPE half
 #elif defined(QRY_DT_BF16)
 #define VEC_TYPE2 ushort2
-#define FMA_TYPE ushort
-#else
+#elif !defined(QRY_DT_F32)
 #error "Data type not supported for VEC_TYPE2"
-#endif
-
-#ifdef SCALE_DT_BF16
-#define SCALES_TO_FLOAT into_float
-#else
-#define SCALES_TO_FLOAT convert_float
 #endif
 
 #if USE_SYSTOLIC_UKERNEL
@@ -173,10 +151,10 @@ DECLARE_2D_TILE_LOAD_PACKED_VEC(q_tile_type, QRY_DATA_T, VEC_TYPE2,
 #endif
 
 #if BLOCK_A
-DECLARE_2D_TILE(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(a_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
 #else
-DECLARE_2D_TILE(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(a_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8)
 #endif
 
@@ -234,11 +212,11 @@ DECLARE_2D_TILE(kmask_tile_type_float, float, SUBGROUP_SIZE, ugemm_kq_sg_tile_m,
         1, 1, 1)
 
 #if WITH_ATTN_MASK
-DECLARE_2D_TILE(mask_tile_type, MSK_TILE_DATA_T, SUBGROUP_SIZE, mask_br,
+DECLARE_2D_TILE(mask_tile_type, msk_tile_data_t, SUBGROUP_SIZE, mask_br,
         mask_bc, mask_nbr, mask_nbc)
 
 #if BROADCAST_MASK_Q
-DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, MSK_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, msk_tile_data_t, SUBGROUP_SIZE,
         mask_br, mask_bc, mask_nbr, mask_nbc)
 #endif
 DECLARE_2D_TILE(mask_tile_type_float, float, SUBGROUP_SIZE, mask_br, mask_bc,
@@ -249,11 +227,11 @@ DECLARE_2D_TILE_COPY_REBLOCK(mask_tile_type, SUBGROUP_SIZE, mask_br, mask_bc,
 #endif
 
 #if BLOCK_A
-DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
 #endif
 #if BLOCK_2D_A
-DECLARE_2D_TILE_BLOCK2D_OPS(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK2D_OPS(a_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 8, 1, ugemm_vs_sg_tile_n / 8)
 #endif
 
@@ -570,7 +548,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     K_scales += k_offset / KEY_GROUP_SIZE;
 #endif
 #if KEY_SCALES == QUANTIZE_COMMON
-    float k_scale = KEY_SCALES_TO_FLOAT(*K_scales);
+    float k_scale = into_float(*K_scales);
 #endif
 #if KEY_ZERO_POINTS
     K_zp += k_offset / KEY_GROUP_SIZE / KEY_ZP_ELEMENTS_PER_BYTE;
@@ -579,7 +557,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     V_scales += v_offset / VAL_GROUP_SIZE;
 #endif
 #if VAL_SCALES == QUANTIZE_COMMON
-    float v_scale = VAL_SCALES_TO_FLOAT(*V_scales);
+    float v_scale = into_float(*V_scales);
 #endif
 #if VAL_ZERO_POINTS
     V_zp += v_offset / VAL_GROUP_SIZE / VAL_ZP_ELEMENTS_PER_BYTE;
@@ -616,10 +594,10 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #endif
 #else
 #if INVERT_SCALE
-        iscale = SCALES_TO_FLOAT(*scale_ptr);
+        iscale = into_float(*scale_ptr);
         scale = native_recip(iscale);
 #else
-        scale = SCALES_TO_FLOAT(*scale_ptr);
+        scale = into_float(*scale_ptr);
         iscale = native_recip(scale);
 #endif
 #endif
@@ -736,14 +714,14 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         mask_tile_type mask_tile;
 #if BROADCAST_MASK_Q
         if (block_msk) {
-            tile_load_block(&mask_tile, (const global MSK_TILE_DATA_T *)msk,
+            tile_load_block(&mask_tile, (const global msk_tile_data_t *)msk,
                     MSK_S2, 0, k0 + sg_i0_kq, 0);
         } else {
-            tile_load(&mask_tile, (const global MSK_TILE_DATA_T *)msk, k, 1,
+            tile_load(&mask_tile, (const global msk_tile_data_t *)msk, k, 1,
                     MSK_S2, k0 + sg_i0_kq, 0);
         }
 #else
-        tile_load_t(&mask_tile, (const global MSK_TILE_DATA_T *)msk, q, k,
+        tile_load_t(&mask_tile, (const global msk_tile_data_t *)msk, q, k,
                 MSK_S2, sg_j0_kq + wg_j0, k0 + sg_i0_kq);
 #endif
 #endif
@@ -1174,13 +1152,13 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     uint sg_j0_vs = sg_j_vs * ugemm_vs_sg_tile_n + wg_j0;
 
 #if BLOCK_2D_A
-    tile_store_block2d(A_tile_dst, (global DST_TILE_DATA_T *)A, d_v,
+    tile_store_block2d(A_tile_dst, (global dst_tile_data_t *)A, d_v,
             q_group_size, lda, sg_i0_vs, sg_j0_vs);
 #elif BLOCK_A
-    tile_store_block_rem_q(A_tile_dst, (global DST_TILE_DATA_T *)A,
+    tile_store_block_rem_q(A_tile_dst, (global dst_tile_data_t *)A,
             q_group_size, lda, sg_i0_vs, sg_j0_vs);
 #else
-    tile_store(A_tile_dst, (global DST_TILE_DATA_T *)A, d_v, q_group_size, lda,
+    tile_store(A_tile_dst, (global dst_tile_data_t *)A, d_v, q_group_size, lda,
             sg_i0_vs, sg_j0_vs);
 #endif
 }

--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -60,32 +60,6 @@
 #define CONVERT_TILE_FMA_T CONVERT_DATA_T
 #endif
 
-/* Conditional casts for ugemm pointer arguments: cast when the data type
- * is a struct, since the ugemm microkernels use punned scalar types. */
-#ifdef KEY_DT_BF16
-#define AS_KEY_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#elif defined(KEY_DT_S4) || defined(KEY_DT_U4)
-#define AS_KEY_TILE_PTR(p) ((const global uchar *)(p))
-#else
-#define AS_KEY_TILE_PTR(p) (p)
-#endif
-
-#ifdef VAL_DT_BF16
-#define AS_VAL_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#elif defined(VAL_DT_S4) || defined(VAL_DT_U4)
-#define AS_VAL_TILE_PTR(p) ((const global uchar *)(p))
-#else
-#define AS_VAL_TILE_PTR(p) (p)
-#endif
-
-#ifdef QRY_DT_BF16
-#define AS_QRY_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#define AS_QRY_SLM_TILE_PTR(p) ((const local FMA_TYPE *)(p))
-#else
-#define AS_QRY_TILE_PTR(p) (p)
-#define AS_QRY_SLM_TILE_PTR(p) (p)
-#endif
-
 #define sg_per_wg (ugemm_kq_sg_per_wg_m * ugemm_kq_sg_per_wg_n)
 #define q_tile_sg_n DIV_UP(ugemm_kq_wg_tile_n, sg_per_wg)
 
@@ -169,22 +143,6 @@ inline void apply_dropout_s_tile(
 #define SCALES_TO_FLOAT into_float
 #else
 #define SCALES_TO_FLOAT convert_float
-#endif
-
-#ifdef VAL_ATTR_SCALES_DT_BF16
-#define VAL_SCALES_TO_FLOAT into_float
-#define AS_VAL_SCALES_PTR(p) ((const global ushort *)(p))
-#else
-#define VAL_SCALES_TO_FLOAT convert_float
-#define AS_VAL_SCALES_PTR(p) (p)
-#endif
-
-#if KEY_ATTR_SCALES_DT_BF16
-#define KEY_SCALES_TO_FLOAT into_float
-#define AS_KEY_SCALES_PTR(p) ((const global ushort *)(p))
-#else
-#define KEY_SCALES_TO_FLOAT convert_float
-#define AS_KEY_SCALES_PTR(p) (p)
 #endif
 
 #if USE_SYSTOLIC_UKERNEL
@@ -460,16 +418,15 @@ inline void tile_load_src1(q_tile_type *Q_tile, const global QRY_DATA_T *Q,
 #else // FMA
 
 #if BLOCK_Q
-    tile_load_block_rem_q(
-            Q_tile, AS_QRY_TILE_PTR(Q), n, ldq, offset_r, offset_c);
+    tile_load_block_rem_q(Q_tile, Q, n, ldq, offset_r, offset_c);
 #else
-    tile_load(Q_tile, AS_QRY_TILE_PTR(Q), m, n, ldq, offset_r, offset_c);
+    tile_load(Q_tile, Q, m, n, ldq, offset_r, offset_c);
 #endif
 
 #endif
 }
 
-inline void tile_store_t_slm_src1(q_tile_type *Q_tile, local FMA_TYPE *Q_slm,
+inline void tile_store_t_slm_src1(q_tile_type *Q_tile, local QRY_DATA_T *Q_slm,
         int panel, int ld, int offset_r, int offset_c) {
 #if USE_SYSTOLIC_UKERNEL
     tile_store_t_sys_src1(
@@ -584,13 +541,13 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     local char slm[Q_slm_size + S_slm_size + S_sum_slm_size + S_max_slm_size
             + ugemm_slm_size];
 
-    local FMA_TYPE *Q_slm = (local FMA_TYPE *)&slm[0];
-    local FMA_TYPE *S_slm = (local FMA_TYPE *)&slm[Q_slm_size];
+    local QRY_DATA_T *Q_slm = (local QRY_DATA_T *)&slm[0];
+    local QRY_DATA_T *S_slm = (local QRY_DATA_T *)&slm[Q_slm_size];
     local float *S_sum_slm = (local float *)&slm[Q_slm_size + S_slm_size];
     local float *S_max_slm
             = (local float *)&slm[Q_slm_size + S_slm_size + S_sum_slm_size];
-    local uint *ugemm_slm = (local uint *)&slm[Q_slm_size + S_slm_size
-            + S_sum_slm_size + S_max_slm_size];
+    local char *ugemm_slm = (local char *)(&slm[Q_slm_size + S_slm_size
+            + S_sum_slm_size + S_max_slm_size]);
 
     const bool need_sum_barrier = (ugemm_vs_barrier_count == 0);
 
@@ -816,15 +773,14 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #else
         s_tile_type S_tile
 #endif
-                = ugemm_kq(AS_KEY_TILE_PTR(K), ldk, AS_QRY_SLM_TILE_PTR(Q_slm),
-                        D_MAX_KQ, k0end, ugemm_kq_wg_tile_n, d_qk, k0, 0, 0,
-                        sg_i_kq, sg_j_kq, (local char *)ugemm_slm
+                = ugemm_kq(K, ldk, Q_slm, D_MAX_KQ, k0end, ugemm_kq_wg_tile_n,
+                        d_qk, k0, 0, 0, sg_i_kq, sg_j_kq, ugemm_slm
 #if KEY_SCALES == QUANTIZE_2D
                         ,
-                        AS_KEY_SCALES_PTR(K_scales)
+                        K_scales
 #endif
 #if KEY_ZERO_POINTS
-                                ,
+                        ,
                         K_zp
 #endif
 #if (KEY_SCALES == QUANTIZE_2D) || KEY_ZERO_POINTS
@@ -1114,15 +1070,15 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #else
         a_tile_type A_tile1
 #endif
-                = ugemm_vs(AS_VAL_TILE_PTR(V), ldv, AS_QRY_SLM_TILE_PTR(S_slm),
-                        ugemm_kq_wg_tile_m, d_v, ugemm_kq_wg_tile_n, k_chunk, 0,
-                        0, 0, sg_i_vs, sg_j_vs, (local char *)ugemm_slm
+                = ugemm_vs(V, ldv, S_slm, ugemm_kq_wg_tile_m, d_v,
+                        ugemm_kq_wg_tile_n, k_chunk, 0, 0, 0, sg_i_vs, sg_j_vs,
+                        ugemm_slm
 #if VAL_SCALES == QUANTIZE_2D
                         ,
-                        AS_VAL_SCALES_PTR(V_scales)
+                        V_scales
 #endif
 #if VAL_ZERO_POINTS
-                                ,
+                        ,
                         V_zp
 #endif
 #if (VAL_SCALES == QUANTIZE_2D) || VAL_ZERO_POINTS

--- a/src/gpu/intel/sdpa/micro.cl
+++ b/src/gpu/intel/sdpa/micro.cl
@@ -35,8 +35,7 @@
 
 typedef NATIVE_LAYOUT_TYPE(DST_DATA_T) dst_tile_data_t;
 typedef NATIVE_LAYOUT_TYPE(MSK_DATA_T) msk_tile_data_t;
-
-#define FMA_TYPE NATIVE_LAYOUT_TYPE(QRY_DATA_T)
+typedef NATIVE_LAYOUT_TYPE(QRY_DATA_T) qry_tile_data_t;
 
 #define CONVERT_TILE_DATA_T(value) as_native_layout(CONVERT_DATA_T(value))
 
@@ -127,8 +126,8 @@ inline void apply_dropout_s_tile(
 DECLARE_2D_TILE(
         q_tile_type, uint, SUBGROUP_SIZE, D_MAX_KQ / 2, 1, 1, q_tile_sg_n)
 #else
-DECLARE_2D_TILE(
-        q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX_KQ, 1, 1, q_tile_sg_n)
+DECLARE_2D_TILE(q_tile_type, qry_tile_data_t, SUBGROUP_SIZE, D_MAX_KQ, 1, 1,
+        q_tile_sg_n)
 #endif
 
 #if BLOCK_Q
@@ -137,14 +136,14 @@ DECLARE_2D_TILE(
 DECLARE_2D_TILE_BLOCK_OPS(
         q_tile_type, uint, SUBGROUP_SIZE, D_MAX_KQ / 2, 1, 1, q_tile_sg_n)
 #else
-DECLARE_2D_TILE_BLOCK_OPS(
-        q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX_KQ, 1, 1, q_tile_sg_n)
+DECLARE_2D_TILE_BLOCK_OPS(q_tile_type, qry_tile_data_t, SUBGROUP_SIZE, D_MAX_KQ,
+        1, 1, q_tile_sg_n)
 #endif
 
 #elif Q_ALIGN < 4
 
 #if USE_SYSTOLIC_UKERNEL
-DECLARE_2D_TILE_LOAD_PACKED_VEC(q_tile_type, QRY_DATA_T, VEC_TYPE2,
+DECLARE_2D_TILE_LOAD_PACKED_VEC(q_tile_type, qry_tile_data_t, VEC_TYPE2,
         SUBGROUP_SIZE, D_MAX_KQ / 2, 1, 1, q_tile_sg_n)
 #endif
 
@@ -183,10 +182,10 @@ DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE, ugemm_vs_c_type_block0,
 DECLARE_2D_TILE(s_tile_type_packed, uint, SUBGROUP_SIZE, ugemm_kq_c_type_block0,
         ugemm_kq_c_type_block1 / 2, ugemm_kq_c_type_nblock0,
         ugemm_kq_c_type_nblock1)
-DECLARE_2D_TILE(s_tile_type_reblock, FMA_TYPE, SUBGROUP_SIZE,
+DECLARE_2D_TILE(s_tile_type_reblock, qry_tile_data_t, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_n, 1, ugemm_kq_sg_tile_n / ugemm_vs_sg_tile_n,
         ugemm_kq_sg_tile_m)
-DECLARE_2D_TILE_BLOCK_OPS(s_tile_type_reblock, FMA_TYPE, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(s_tile_type_reblock, qry_tile_data_t, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_n, 1, ugemm_kq_sg_tile_n / ugemm_vs_sg_tile_n,
         ugemm_kq_sg_tile_m)
 
@@ -396,9 +395,11 @@ inline void tile_load_src1(q_tile_type *Q_tile, const global QRY_DATA_T *Q,
 #else // FMA
 
 #if BLOCK_Q
-    tile_load_block_rem_q(Q_tile, Q, n, ldq, offset_r, offset_c);
+    tile_load_block_rem_q(Q_tile, (const global qry_tile_data_t *)Q, n, ldq,
+            offset_r, offset_c);
 #else
-    tile_load(Q_tile, Q, m, n, ldq, offset_r, offset_c);
+    tile_load(Q_tile, (const global qry_tile_data_t *)Q, m, n, ldq, offset_r,
+            offset_c);
 #endif
 
 #endif
@@ -410,13 +411,14 @@ inline void tile_store_t_slm_src1(q_tile_type *Q_tile, local QRY_DATA_T *Q_slm,
     tile_store_t_sys_src1(
             *Q_tile, (local uint *)&Q_slm[0], ld / 2, offset_r, offset_c);
 #else // FMA
-    tile_store_t_packed_src1(*Q_tile, Q_slm, panel, ld, offset_r, offset_c);
+    tile_store_t_packed_src1(*Q_tile, (local qry_tile_data_t *)Q_slm, panel, ld,
+            offset_r, offset_c);
 #endif
 }
 
 __attribute__((intel_reqd_sub_group_size(SUBGROUP_SIZE))) kernel void
 micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
-        const global VAL_DATA_T *V, global float *ws, global DST_DATA_T *A,
+        const global VAL_DATA_T *V, global float *ws, global dst_tile_data_t *A,
 #if WITH_HOST_SCALE
         float scalar_scale, float inv_scalar_scale,
 #else
@@ -429,7 +431,7 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         const global VAL_ATTR_ZP_DATA_T *V_zp, const int attn_mask_type
 #if WITH_ATTN_MASK
         ,
-        const global MSK_DATA_T *msk
+        const global msk_tile_data_t *msk
 #endif
         ,
         KEY_OFFSETS, QRY_OFFSETS, VAL_OFFSETS, DST_OFFSETS
@@ -714,15 +716,13 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         mask_tile_type mask_tile;
 #if BROADCAST_MASK_Q
         if (block_msk) {
-            tile_load_block(&mask_tile, (const global msk_tile_data_t *)msk,
-                    MSK_S2, 0, k0 + sg_i0_kq, 0);
+            tile_load_block(&mask_tile, msk, MSK_S2, 0, k0 + sg_i0_kq, 0);
         } else {
-            tile_load(&mask_tile, (const global msk_tile_data_t *)msk, k, 1,
-                    MSK_S2, k0 + sg_i0_kq, 0);
+            tile_load(&mask_tile, msk, k, 1, MSK_S2, k0 + sg_i0_kq, 0);
         }
 #else
-        tile_load_t(&mask_tile, (const global msk_tile_data_t *)msk, q, k,
-                MSK_S2, sg_j0_kq + wg_j0, k0 + sg_i0_kq);
+        tile_load_t(
+                &mask_tile, msk, q, k, MSK_S2, sg_j0_kq + wg_j0, k0 + sg_i0_kq);
 #endif
 #endif
 
@@ -911,8 +911,8 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         /* Reblock and store to SLM */
         s_tile_type_reblock S_tile_reblock;
         tile_copy_reblock(S_tile, &S_tile_reblock);
-        tile_store_block_packed(S_tile_reblock, S_slm, ugemm_vs_sg_tile_n,
-                ugemm_kq_wg_tile_m, sg_j0_kq, sg_i0_kq);
+        tile_store_block_packed(S_tile_reblock, (local qry_tile_data_t *)S_slm,
+                ugemm_vs_sg_tile_n, ugemm_kq_wg_tile_m, sg_j0_kq, sg_i0_kq);
 #endif
 
         intel_work_group_barrier_arrive(CLK_LOCAL_MEM_FENCE);
@@ -1152,13 +1152,12 @@ micro_sdpa(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
     uint sg_j0_vs = sg_j_vs * ugemm_vs_sg_tile_n + wg_j0;
 
 #if BLOCK_2D_A
-    tile_store_block2d(A_tile_dst, (global dst_tile_data_t *)A, d_v,
-            q_group_size, lda, sg_i0_vs, sg_j0_vs);
+    tile_store_block2d(
+            A_tile_dst, A, d_v, q_group_size, lda, sg_i0_vs, sg_j0_vs);
 #elif BLOCK_A
-    tile_store_block_rem_q(A_tile_dst, (global dst_tile_data_t *)A,
-            q_group_size, lda, sg_i0_vs, sg_j0_vs);
+    tile_store_block_rem_q(
+            A_tile_dst, A, q_group_size, lda, sg_i0_vs, sg_j0_vs);
 #else
-    tile_store(A_tile_dst, (global dst_tile_data_t *)A, d_v, q_group_size, lda,
-            sg_i0_vs, sg_j0_vs);
+    tile_store(A_tile_dst, A, d_v, q_group_size, lda, sg_i0_vs, sg_j0_vs);
 #endif
 }

--- a/src/gpu/intel/sdpa/micro.cpp
+++ b/src/gpu/intel/sdpa/micro.cpp
@@ -1114,8 +1114,7 @@ status_t micro_fwd_params_t::get_kernel_ctx(
     def_data_type(kernel_ctx, qry_data_t, "QRY");
     def_data_type(kernel_ctx, val_data_t, "VAL");
     def_data_type(kernel_ctx, dst_data_t, "DST");
-
-    if (with_attn_mask) { def_data_type(kernel_ctx, msk_data_t, "MSK"); }
+    def_data_type(kernel_ctx, msk_data_t, "MSK");
 
     def_data_type(kernel_ctx, key_scales_data_t, "KEY_ATTR_SCALES");
     def_data_type(kernel_ctx, value_scales_data_t, "VAL_ATTR_SCALES");
@@ -1319,8 +1318,7 @@ status_t micro_bwd_params_t::get_kernel_ctx(
     def_data_type(kernel_ctx, qry_data_t, "QRY");
     def_data_type(kernel_ctx, val_data_t, "VAL");
     def_data_type(kernel_ctx, dst_data_t, "DST");
-
-    if (with_attn_mask) { def_data_type(kernel_ctx, msk_data_t, "MSK"); }
+    def_data_type(kernel_ctx, msk_data_t, "MSK");
 
     kernel_ctx.define_int("KV_GROUP_SIZE", kv_group_size);
 

--- a/src/gpu/intel/sdpa/micro_bwd.cl
+++ b/src/gpu/intel/sdpa/micro_bwd.cl
@@ -140,39 +140,6 @@ inline void apply_dropout_dP_tile(p_tile_type *tile, int tile_offset_r,
 #define CONVERT_TILE_FLOAT_FMA_T CONVERT_FLOAT_T
 #endif
 
-/* Conditional casts for ugemm pointer arguments: cast when the data type
- * is a struct, since the ugemm microkernels use punned scalar types. */
-#ifdef KEY_DT_BF16
-#define AS_KEY_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#define AS_KEY_SLM_TILE_PTR(p) ((local FMA_TYPE *)(p))
-#elif defined(KEY_DT_S4) || defined(KEY_DT_U4)
-#define AS_KEY_TILE_PTR(p) ((const global uchar *)(p))
-#define AS_KEY_SLM_TILE_PTR(p) ((local uchar *)(p))
-#else
-#define AS_KEY_TILE_PTR(p) (p)
-#define AS_KEY_SLM_TILE_PTR(p) (p)
-#endif
-
-#ifdef VAL_DT_BF16
-#define AS_VAL_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#elif defined(VAL_DT_S4) || defined(VAL_DT_U4)
-#define AS_VAL_TILE_PTR(p) ((const global uchar *)(p))
-#else
-#define AS_VAL_TILE_PTR(p) (p)
-#endif
-
-#ifdef QRY_DT_BF16
-#define AS_QRY_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#else
-#define AS_QRY_TILE_PTR(p) (p)
-#endif
-
-#ifdef DST_DT_BF16
-#define AS_DST_TILE_PTR(p) ((const global FMA_TYPE *)(p))
-#else
-#define AS_DST_TILE_PTR(p) (p)
-#endif
-
 DECLARE_2D_TILE(q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n)
 
 DECLARE_2D_TILE(dq_tile_type, float, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n)
@@ -399,10 +366,9 @@ inline void tile_load_k(k_tile_type *K_tile, const global KEY_DATA_T *K,
     uint k0_copy = k_tile_t_sg_n * sg_ij;
     // Coalesced load from d×k column-major memory (d contiguous, k strided)
 #if BLOCK_K
-    tile_load_block(K_tile, AS_KEY_TILE_PTR(K), ldk, 0, seq_off + k0_copy);
+    tile_load_block(K_tile, K, ldk, 0, seq_off + k0_copy);
 #else
-    tile_load(K_tile, AS_KEY_TILE_PTR(K), head_size, seq_len, ldk, 0,
-            seq_off + k0_copy);
+    tile_load(K_tile, K, head_size, seq_len, ldk, 0, seq_off + k0_copy);
 #endif
 
 #else
@@ -410,10 +376,9 @@ inline void tile_load_k(k_tile_type *K_tile, const global KEY_DATA_T *K,
     uint k0_copy = dmax_tile_sg_n * sg_ij;
 #if BLOCK_K
     // can ignore load_rem due to d_full requirement
-    tile_load_block(K_tile, AS_KEY_TILE_PTR(K), ldk, seq_off, k0_copy);
+    tile_load_block(K_tile, K, ldk, seq_off, k0_copy);
 #else
-    tile_load(K_tile, AS_KEY_TILE_PTR(K), seq_len, head_size, ldk, seq_off,
-            k0_copy);
+    tile_load(K_tile, K, seq_len, head_size, ldk, seq_off, k0_copy);
 #endif
 
 #endif
@@ -426,22 +391,22 @@ inline void tile_store_k_slm(
     // Bc / n_sg -- tile is D*Bc, write transposed to SLM (Bc*D)
     uint k0_copy = k_tile_t_sg_n * sg_ij;
 #if USE_SYSTOLIC_UKERNEL
-    tile_store_t_sys_src11(*K_tile, AS_KEY_SLM_TILE_PTR(K_slm), SUBGROUP_SIZE,
-            D_MAX, D_MAX, ugemm_kq_wg_tile_m, 0, k0_copy);
+    tile_store_t_sys_src11(*K_tile, K_slm, SUBGROUP_SIZE, D_MAX, D_MAX,
+            ugemm_kq_wg_tile_m, 0, k0_copy);
 #else
-    tile_store_t_packed_src1(*K_tile, AS_KEY_SLM_TILE_PTR(K_slm),
-            ugemm_kq_sg_tile_m, D_MAX, k0_copy, 0);
+    tile_store_t_packed_src1(
+            *K_tile, K_slm, ugemm_kq_sg_tile_m, D_MAX, k0_copy, 0);
 #endif
 
 #else
 
     uint k0_copy = dmax_tile_sg_n * sg_ij;
 #if USE_SYSTOLIC_UKERNEL
-    tile_store_sys_src1(*K_tile, AS_KEY_SLM_TILE_PTR(K_slm), SUBGROUP_SIZE,
-            D_MAX, ugemm_kq_wg_tile_m, D_MAX, 0, k0_copy);
+    tile_store_sys_src1(*K_tile, K_slm, SUBGROUP_SIZE, D_MAX,
+            ugemm_kq_wg_tile_m, D_MAX, 0, k0_copy);
 #else
-    tile_store_packed_src1(*K_tile, AS_KEY_SLM_TILE_PTR(K_slm),
-            ugemm_kq_sg_tile_m, D_MAX, 0, k0_copy);
+    tile_store_packed_src1(
+            *K_tile, K_slm, ugemm_kq_sg_tile_m, D_MAX, 0, k0_copy);
 #endif
 
 #endif
@@ -696,14 +661,15 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #endif
 
     // S_slm, softmax for ugemm_vs also reused for dS
-    local FMA_TYPE *S_slm = (local FMA_TYPE *)&slm[K_slm_size];
+    local QRY_DATA_T *S_slm = (local QRY_DATA_T *)&slm[K_slm_size];
 #if USE_SYSTOLIC_UKERNEL
-    local FMA_TYPE *dSt_slm = (local FMA_TYPE *)&slm[K_slm_size + S_slm_size];
+    local QRY_DATA_T *dSt_slm
+            = (local QRY_DATA_T *)&slm[K_slm_size + S_slm_size];
 #endif
 
     // ugemm scratch space
-    local uint *ugemm_slm
-            = (local uint *)&slm[K_slm_size + S_slm_size + dSt_slm_size];
+    local char *ugemm_slm
+            = (local char *)(&slm[K_slm_size + S_slm_size + dSt_slm_size]);
 
     // used for accumulation of dK across q-loop (dV accumulates in registers)
     local float *dK_slm = (local float *)&slm[K_slm_size + S_slm_size
@@ -821,18 +787,17 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         /* Calculate S = (K^T) * Q */
 #if DO_MM
 #if K_IN_SLM
-        s_tile_type S_tile = ugemm_kq(AS_KEY_SLM_TILE_PTR(K_slm), D_MAX,
-                AS_QRY_TILE_PTR(Q + q0 * ldq), ldq, k_chunk, q_nchunk, d, 0, 0,
-                0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
+        s_tile_type S_tile = ugemm_kq(K_slm, D_MAX, Q + q0 * ldq, ldq, k_chunk,
+                q_nchunk, d, 0, 0, 0, sg_i_kq, sg_j_kq, ugemm_slm);
 #else
         s_tile_type S_tile = ugemm_kq(
 #if TRANSPOSE_K
-                AS_KEY_TILE_PTR(K + k0 * ldk),
+                K + k0 * ldk,
 #else
-                AS_KEY_TILE_PTR(K + k0),
+                K + k0,
 #endif
-                ldk, AS_QRY_TILE_PTR(Q + q0 * ldq), ldq, k_chunk, q_nchunk, d,
-                0, 0, 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
+                ldk, Q + q0 * ldq, ldq, k_chunk, q_nchunk, d, 0, 0, 0, sg_i_kq,
+                sg_j_kq, ugemm_slm);
 #endif
 #else
         s_tile_type S_tile;
@@ -946,10 +911,8 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         {
 #if DO_MM
             dv_tile_type dV_tile1;
-            dV_tile1 = ugemm_vs(AS_DST_TILE_PTR(dA + q0 * ldda), ldda,
-                    (local FMA_TYPE *)S_slm, ugemm_kq_wg_tile_n, d, k_chunk,
-                    q_nchunk, 0, 0, 0, sg_i_vs, sg_j_vs,
-                    (local char *)ugemm_slm);
+            dV_tile1 = ugemm_vs(dA + q0 * ldda, ldda, S_slm, ugemm_kq_wg_tile_n,
+                    d, k_chunk, q_nchunk, 0, 0, 0, sg_i_vs, sg_j_vs, ugemm_slm);
 #else
             dv_tile_type dV_tile1;
 #endif
@@ -963,9 +926,9 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         }
 
 #if DO_MM
-        p_tile_type dP_tile = ugemm_vtdA(AS_VAL_TILE_PTR(V + k0 * ldv), ldv,
-                AS_DST_TILE_PTR(dA + q0 * ldda), ldda, k_chunk, q_nchunk, d, 0,
-                0, 0, sg_i_kq, sg_j_kq, (local char *)ugemm_slm);
+        p_tile_type dP_tile
+                = ugemm_vtdA(V + k0 * ldv, ldv, dA + q0 * ldda, ldda, k_chunk,
+                        q_nchunk, d, 0, 0, 0, sg_i_kq, sg_j_kq, ugemm_slm);
 #else
         p_tile_type dP_tile;
 #endif
@@ -1012,8 +975,9 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
             intel_work_group_barrier_wait(CLK_LOCAL_MEM_FENCE);
 #if USE_SYSTOLIC_UKERNEL
             // softmax no longer needed, use slm to cache dS
-            tile_store_sys_src22(P_tile_reblock, dSt_slm, ugemm_ktq_sg_tile_n,
-                    ugemm_kq_wg_tile_m, ugemm_kq_wg_tile_n, sg_i0_kq, sg_j0_kq);
+            tile_store_sys_src22(P_tile_reblock, (local FMA_TYPE *)dSt_slm,
+                    ugemm_ktq_sg_tile_n, ugemm_kq_wg_tile_m, ugemm_kq_wg_tile_n,
+                    sg_i0_kq, sg_j0_kq);
             p_tile_type_packed dP_tile_packed;
             tile_copy_to_vec2_cvt(
                     dP_tile, dP_tile_packed, VEC_TYPE2, CONVERT_TILE_FMA_T);
@@ -1031,10 +995,9 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         {
 #if DO_MM
             a_tile_type dK_tile1;
-            dK_tile1 = ugemm_qdSt(S_slm, ugemm_kq_wg_tile_n,
-                    AS_QRY_TILE_PTR(Q + q0 * ldq), ldq, k_chunk, d, q_nchunk, 0,
-                    0, 0, sg_i_qdSt, sg_j_qdSt,
-                    (local char *)ugemm_slm); // dS^t * Q -> Bc x d
+            dK_tile1 = ugemm_qdSt(S_slm, ugemm_kq_wg_tile_n, Q + q0 * ldq, ldq,
+                    k_chunk, d, q_nchunk, 0, 0, 0, sg_i_qdSt, sg_j_qdSt,
+                    ugemm_slm); // dS^t * Q -> Bc x d
 #else
             a_tile_type dK_tile1;
 #endif
@@ -1063,7 +1026,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
                     ugemm_kq_wg_tile_m, sg_j0_kq, sg_i0_kq);
         }
         barrier(CLK_LOCAL_MEM_FENCE);
-        local FMA_TYPE *dSt_slm = S_slm;
+        local QRY_DATA_T *dSt_slm = S_slm;
 #endif
 
         {
@@ -1071,12 +1034,12 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #if DO_MM
             dQ_tile = ugemm_ktq(
 #if TRANSPOSE_K
-                    AS_KEY_TILE_PTR(K + k0 * ldk),
+                    K + k0 * ldk,
 #else
-                    AS_KEY_TILE_PTR(K + k0),
+                    K + k0,
 #endif
                     ldk, dSt_slm, ugemm_kq_wg_tile_m, d, q_nchunk, k_chunk, 0,
-                    0, 0, sg_i_ktq, sg_j_ktq, (local char *)ugemm_slm);
+                    0, 0, sg_i_ktq, sg_j_ktq, ugemm_slm);
 #endif
             uint sg_i0_dq = sg_i_ktq * ugemm_ktq_sg_tile_m;
             uint sg_j0_dq = sg_j_ktq * ugemm_ktq_sg_tile_n + q0;

--- a/src/gpu/intel/sdpa/micro_bwd.cl
+++ b/src/gpu/intel/sdpa/micro_bwd.cl
@@ -98,47 +98,29 @@ inline void apply_dropout_dP_tile(p_tile_type *tile, int tile_offset_r,
 #undef dropout_predicate
 #endif
 
-#ifdef QRY_DT_F32
-#define FMA_TYPE float
-#elif QRY_DT_F16
+#ifdef QRY_DT_F16
 #define VEC_TYPE2 half2
-#define FMA_TYPE half
 #elif defined(QRY_DT_BF16)
 #define VEC_TYPE2 ushort2
-#define FMA_TYPE ushort
-#else
+#elif !defined(QRY_DT_F32)
 #error "Data type not supported for VEC_TYPE2"
 #endif
 
-#ifdef SCALE_DT_BF16
-#define SCALES_TO_FLOAT into_float
-#else
-#define SCALES_TO_FLOAT convert_float
-#endif
+typedef NATIVE_LAYOUT_TYPE(DST_DATA_T) dst_tile_data_t;
+typedef NATIVE_LAYOUT_TYPE(MSK_DATA_T) msk_tile_data_t;
+#define FMA_TYPE NATIVE_LAYOUT_TYPE(QRY_DATA_T)
 
-#ifdef DST_DT_BF16
-#define DST_TILE_DATA_T ushort
-#define CONVERT_TILE_DATA_T(v) into_bf16(convert_float(v)).data
-#else
-#define DST_TILE_DATA_T DST_DATA_T
-#define CONVERT_TILE_DATA_T CONVERT_DATA_T
-#endif
+#define CONVERT_TILE_DATA_T(v) as_native_layout(CONVERT_DATA_T(v))
 
-#ifdef MSK_DT_BF16
-#define MSK_TILE_DATA_T ushort
-#define CONVERT_TILE_FLOAT_MSK_T(v) into_float(as_bf16(v))
-#else
-#define MSK_TILE_DATA_T MSK_DATA_T
-#define CONVERT_TILE_FLOAT_MSK_T CONVERT_FLOAT_T
-#endif
+#define CONVERT_TILE_FLOAT_MSK_T(v) \
+    into_float(AS_NATIVE_LAYOUT_TYPE(MSK_DATA_T, v))
 
-#if defined(QRY_DT_BF16)
-#define CONVERT_TILE_FMA_T(v) into_bf16(convert_float(v)).data
-#define CONVERT_TILE_FLOAT_FMA_T(v) into_float(as_bf16(v))
-#else
-#define CONVERT_TILE_FMA_T CONVERT_DATA_T
-#define CONVERT_TILE_FLOAT_FMA_T CONVERT_FLOAT_T
-#endif
+/* FMA tile storage, which follows the query type rather than the ambient dst
+ * type -- see FMA_TYPE above. */
+#define CONVERT_TILE_FMA_T(v) \
+    as_native_layout(CONCAT2(into_, QRY_DATA_T)(convert_float(v)))
+#define CONVERT_TILE_FLOAT_FMA_T(v) \
+    into_float(AS_NATIVE_LAYOUT_TYPE(QRY_DATA_T, v))
 
 DECLARE_2D_TILE(q_tile_type, FMA_TYPE, SUBGROUP_SIZE, D_MAX, 1, 1, q_tile_sg_n)
 
@@ -218,11 +200,11 @@ DECLARE_2D_TILE(kmask_tile_type_float, float, SUBGROUP_SIZE, ugemm_kq_sg_tile_m,
         1, 1, 1)
 
 #if WITH_ATTN_MASK
-DECLARE_2D_TILE(mask_tile_type, MSK_TILE_DATA_T, SUBGROUP_SIZE, mask_br,
+DECLARE_2D_TILE(mask_tile_type, msk_tile_data_t, SUBGROUP_SIZE, mask_br,
         mask_bc, mask_nbr, mask_nbc)
 
 #if BROADCAST_MASK_Q
-DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, MSK_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(mask_tile_type, msk_tile_data_t, SUBGROUP_SIZE,
         mask_br, mask_bc, mask_nbr, mask_nbc)
 #endif
 DECLARE_2D_TILE(mask_tile_type_float, float, SUBGROUP_SIZE, mask_br, mask_bc,
@@ -232,9 +214,9 @@ DECLARE_2D_TILE_COPY_REBLOCK(mask_tile_type, SUBGROUP_SIZE, mask_br, mask_bc,
         mask_bc, mask_nbr, mask_nbc, CONVERT_TILE_FLOAT_MSK_T)
 #endif
 
-DECLARE_2D_TILE(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(a_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_qdSt_sg_tile_m, 1, 1, ugemm_qdSt_sg_tile_n)
-DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(a_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_qdSt_sg_tile_m, 1, 1, ugemm_qdSt_sg_tile_n)
 DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE,
         ugemm_qdSt_c_type_block0, ugemm_qdSt_c_type_block1,
@@ -242,18 +224,18 @@ DECLARE_2D_TILE_COPY_REBLOCK(a_tile_type, SUBGROUP_SIZE,
         SUBGROUP_SIZE, ugemm_qdSt_sg_tile_m, 1, 1, ugemm_qdSt_sg_tile_n,
         CONVERT_TILE_DATA_T)
 
-DECLARE_2D_TILE(dv_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(dv_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
-DECLARE_2D_TILE_BLOCK_OPS(dv_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(dv_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n)
 DECLARE_2D_TILE_COPY_REBLOCK(dv_tile_type, SUBGROUP_SIZE,
         ugemm_vs_c_type_block0, ugemm_vs_c_type_block1, ugemm_vs_c_type_nblock0,
         ugemm_vs_c_type_nblock1, dv_tile_type_dst, SUBGROUP_SIZE,
         ugemm_vs_sg_tile_m, 1, 1, ugemm_vs_sg_tile_n, CONVERT_TILE_DATA_T)
 
-DECLARE_2D_TILE(dq_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE(dq_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_ktq_sg_tile_m, 1, 1, ugemm_ktq_sg_tile_n)
-DECLARE_2D_TILE_BLOCK_OPS(dq_tile_type_dst, DST_TILE_DATA_T, SUBGROUP_SIZE,
+DECLARE_2D_TILE_BLOCK_OPS(dq_tile_type_dst, dst_tile_data_t, SUBGROUP_SIZE,
         ugemm_ktq_sg_tile_m, 1, 1, ugemm_ktq_sg_tile_n)
 DECLARE_2D_TILE_COPY_REBLOCK(ktq_tile_type, SUBGROUP_SIZE,
         ugemm_ktq_c_type_block0, ugemm_ktq_c_type_block1,
@@ -460,10 +442,10 @@ inline void tile_store_dV(dv_tile_type *dV_tile_slm, global DST_DATA_T_DKDV *dV,
     dv_tile_type_dst dV_tile_dst; // convert to half
     tile_copy_reblock(*dV_tile_slm, &dV_tile_dst);
 #if BLOCK_DV
-    tile_store_block_rem_q(dV_tile_dst, (global DST_TILE_DATA_T *)dV, n, ld,
+    tile_store_block_rem_q(dV_tile_dst, (global dst_tile_data_t *)dV, n, ld,
             offset_r, offset_c, rem)
 #else
-    tile_store(dV_tile_dst, (global DST_TILE_DATA_T *)dV, m, n, ld, offset_r,
+    tile_store(dV_tile_dst, (global dst_tile_data_t *)dV, m, n, ld, offset_r,
             offset_c);
 #endif
 #endif
@@ -481,10 +463,10 @@ inline void tile_store_dK_t(dv_tile_type *dK_tile, global DST_DATA_T_DKDV *dK,
     dv_tile_type_dst dK_tile_dst;
     tile_copy_reblock(*dK_tile, &dK_tile_dst);
 #if BLOCK_DK
-    tile_store_block_rem_q(dK_tile_dst, (global DST_TILE_DATA_T *)dK, n, ld,
+    tile_store_block_rem_q(dK_tile_dst, (global dst_tile_data_t *)dK, n, ld,
             offset_r, offset_c, rem)
 #else
-    tile_store(dK_tile_dst, (global DST_TILE_DATA_T *)dK, m, n, ld, offset_r,
+    tile_store(dK_tile_dst, (global dst_tile_data_t *)dK, m, n, ld, offset_r,
             offset_c);
 #endif
 #endif
@@ -505,9 +487,9 @@ inline void tile_store_dK(a_tile_type *dK_tile, global DST_DATA_T_DKDV *dK,
     tile_copy_reblock(*dK_tile, &dK_tile_dst);
 #if BLOCK_DK
     tile_store_block(
-            dK_tile_dst, (global DST_TILE_DATA_T *)dK, ld, offset_r, offset_c);
+            dK_tile_dst, (global dst_tile_data_t *)dK, ld, offset_r, offset_c);
 #else
-    tile_store(dK_tile_dst, (global DST_TILE_DATA_T *)dK, m, n, ld, offset_r,
+    tile_store(dK_tile_dst, (global dst_tile_data_t *)dK, m, n, ld, offset_r,
             offset_c);
 #endif
 
@@ -735,10 +717,10 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
 #endif
 #else
 #if INVERT_SCALE
-        iscale = SCALES_TO_FLOAT(*scale_ptr);
+        iscale = into_float(*scale_ptr);
         scale = native_recip(iscale);
 #else
-        scale = SCALES_TO_FLOAT(*scale_ptr);
+        scale = into_float(*scale_ptr);
         iscale = native_recip(scale);
 #endif
 #endif
@@ -810,14 +792,14 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
         mask_tile_type mask_tile;
 #if BROADCAST_MASK_Q
         if (block_msk) {
-            tile_load_block(&mask_tile, (const global MSK_TILE_DATA_T *)msk,
+            tile_load_block(&mask_tile, (const global msk_tile_data_t *)msk,
                     MSK_S2, 0, k0 + sg_i0_kq, 0);
         } else {
-            tile_load(&mask_tile, (const global MSK_TILE_DATA_T *)msk, k, 1,
+            tile_load(&mask_tile, (const global msk_tile_data_t *)msk, k, 1,
                     MSK_S2, k0 + sg_i0_kq, 0);
         }
 #else
-        tile_load(&mask_tile, (const global MSK_TILE_DATA_T *)msk, k, q, MSK_S2,
+        tile_load(&mask_tile, (const global msk_tile_data_t *)msk, k, q, MSK_S2,
                 k0 + sg_i0_kq, q0 + sg_j0_kq);
 #endif
 
@@ -1048,7 +1030,7 @@ micro_sdpa_bwd(const global KEY_DATA_T *K, const global QRY_DATA_T *Q,
             dq_tile_type_dst dQ_tile_dst;
             tile_copy_reblock(dQ_tile, &dQ_tile_dst);
             if (sg_ij < sg_per_wg_BrD)
-                tile_store(dQ_tile_dst, (global DST_TILE_DATA_T *)dQ, d, q,
+                tile_store(dQ_tile_dst, (global dst_tile_data_t *)dQ, d, q,
                         lddq, sg_i0_dq, sg_j0_dq);
 #else
             if (sg_ij < sg_per_wg_BrD)


### PR DESCRIPTION
# Description

This PR refactors the way convert non-standard types (bf16,f8_*,u4/s4) into OpenCL types. Previously we were converting the data types using macros in the kernel to convert our type structs to base types used by the microkernel shim generator. This change updates the shim to use these structs instead of the base type so that we don't have to use these macros in the kernels.