### PR TITLE
Merge Graph team into Arch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,17 +36,11 @@
 
 # Tests
 /tests/benchdnn/inputs/ @uxlfoundation/onednn-maintain
-/tests/benchdnn/graph/ @uxlfoundation/onednn-graph @uxlfoundation/onednn-arch
-/tests/benchdnn/inputs/graph/ @uxlfoundation/onednn-graph @uxlfoundation/onednn-arch
-/tests/gtests/graph/ @uxlfoundation/onednn-graph
 ## Special case of internal tests
 /tests/gtests/internals/test_sdpa.cpp @uxlfoundation/onednn-gpu-intel
 /tests/gtests/internals/test_utils.cpp @uxlfoundation/onednn-gpu-intel
 /tests/gtests/internals/test_utils.hpp @uxlfoundation/onednn-gpu-intel
 /tests/gtests/internals/test_gated_mlp.cpp @uxlfoundation/onednn-gpu-intel
-
-# Graph API
-/src/graph/ @uxlfoundation/onednn-graph
 
 # Documentation
 *.md  @uxlfoundation/onednn-doc

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -114,19 +114,10 @@ Team: @uxlfoundation/onednn-arch
 | -----------------  | --------------------- | ----------------- | ---------- |
 | Denis Samoilov     | @densamoilov          | Intel Corporation | Maintainer |
 | Dmitry Zarukin     | @dzarukin             | Intel Corporation | Maintainer |
+| Tao Lv             | @TaoLv                | Intel Corporation | Maintainer |
 | Vadim Pirogov      | @vpirogov             | Intel Corporation | Maintainer |
 | Ankit Manerikar    | @avmanerikar          | Intel Corporation | Code Owner |
 | Maria Zhukova      | @mzhukova             | Intel Corporation | Code Owner |
-
-## Graph API
-
-Team: @uxlfoundation/onednn-graph
-
-| Name               | Github ID             | Affiliation       | Role       |
-| ------------------ | --------------------- | ----------------- | ---------- |
-| Tao Lv             | @TaoLv                | Intel Corporation | Maintainer |
-| Rong Zhang         | @rongzha1             | Intel Corporation | Code Owner |
-| Yixin Bao          | @ElaineBao            | Intel Corporation | Code Owner |
 
 ## CPU Engine
 


### PR DESCRIPTION
Due to assignment changes population of Graph team fell below self-sustainable level for code reviews. I propose merging Arch and Graph teams to continue uninterrupted ownership.
