### PR TITLE
cpu: x64: brgemm conv: fix padded outwork kernel lookup

### DIFF
--- a/src/cpu/x64/jit_brgemm_conv.cpp
+++ b/src/cpu/x64/jit_brgemm_conv.cpp
@@ -1069,8 +1069,9 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
                         jcp, static_cast<int>(ow), kw_s, ow_s, ow_f);
                 const auto init_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
+                const auto kw_po = kw_f > kw_s ? kw_f - 1 : kw_s;
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, static_cast<int>(ow), kw_f - 1, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_po, ow_s, ow_f);
                 const auto po_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 CHECK(add_po_kernels(i_N, init_bcast_dim, po_bcast_dim));
@@ -1094,8 +1095,9 @@ status_t brgemm_convolution_fwd_t<isa>::init(engine_t *engine) {
                         jcp, static_cast<int>(ow), kw_s, ow_s, ow_f);
                 const auto init_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
+                const auto kw_po = kw_f > kw_s ? kw_f - 1 : kw_s;
                 brgemm_convolution_utils::get_ow_range(
-                        jcp, static_cast<int>(ow), kw_f - 1, ow_s, ow_f);
+                        jcp, static_cast<int>(ow), kw_po, ow_s, ow_f);
                 const auto po_bcast_dim
                         = (i_side == 0) ? (ow_s - ow) : (ow + M - ow_f);
                 CHECK(add_po_kernels(i_N, init_bcast_dim, po_bcast_dim));

--- a/tests/benchdnn/inputs/conv/harness_conv_regression_general
+++ b/tests/benchdnn/inputs/conv/harness_conv_regression_general
@@ -417,6 +417,11 @@ mb1_g50ic50oc50_ih28oh26_kh3sh1ph0_n"dw_post-op_ngroups-tail"
 --reset
 --dir=FWD_I --dt=f32:f32:f32 --stag=acdb --wtag=any --dtag=acdb ic48oc134_ih23oh12kh2sh2dh0ph1_iw12ow4kw1sw13dw0pw14_n"brgemm_perform_outwork"
 
+# github #5942
+--reset --allow-enum-tags-only=0 --dt=f32:f32:f32 --bia-dt=f32
+--dir=FWD_D --stag=acdb --wtag=any --dtag=acdb --attr-scratchpad=user
+mb100_ic64oc1_ih1oh2kh125sh2dh0ph63_iw1ow64kw1sw2dw0pw63
+
 # tests JIT bf16 depthwise convolution with bf16 bias
 --reset
 --dt=bf16 --bia-dt=bf16 --dir=FWD_I g4mb2_ic4oc4_ih6oh4kh3sh1dh0ph0_iw6ow4kw3sw1dw0pw0_n"aarch64_jit_dw_bia_dt_bf16"


### PR DESCRIPTION
Fixes #5942 

BRGEMM convolution pre-created postwork kernels using kw_f - 1 to compute the padded output range. For fully width-padded blocks, get_kw_range() returns an empty range (kw_s == kw_f == 0), so kw_f - 1 became -1 and init generated the wrong postwork kernel variant. At runtime, perform_outwork() requested the full padded block size and hit a null postwork kernel, causing the segfault.

The fix uses kw_s when the kernel range is empty, so init and runtime compute the same output range. 

A regression for GitHub issue #5942 was added to harness_conv_regression_general.
