### PR TITLE
xe: gemm: jit: update and unify cache settings

### DIFF
--- a/src/gpu/intel/gemm/jit/dsl/ir/codegen/send.hpp
+++ b/src/gpu/intel/gemm/jit/dsl/ir/codegen/send.hpp
@@ -49,9 +49,9 @@ inline ngen::CacheSettingsLSC get_cache_settings(
                     break;
                 case ngen::HW::Xe3p:
                     if (is_store) {
-                        ret = ngen::CacheSettingsLSC::L1UC_L2WB_L3UC;
+                        ret = ngen::CacheSettingsLSC::L1WB_L2WB_L3UC;
                     } else if (is_load || is_prefetch) {
-                        ret = ngen::CacheSettingsLSC::L1C_L2C_L3C;
+                        ret = ngen::CacheSettingsLSC::L1C_L2C_L3UC;
                     }
                     break;
                 default: break;

--- a/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
@@ -118,6 +118,7 @@ void Generator<hw>::gemmStoreZeroC(GEMMProblem problem, GEMMStrategy strategy, G
             s->atomic = false;
             s->cachingW = CacheSettingsLSC::L1UC_L3WB;
         }
+        setCCachingW(strategy, state, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB);
     }
 
     auto collapse = [&](RegisterLayout &layout) {
@@ -206,6 +207,7 @@ void Generator<hw>::gemmFusedBetaScale(GEMMProblem problem, GEMMStrategy strateg
         s->atomic = false;
         s->cachingW = CacheSettingsLSC::L1UC_L3WB;
     }
+    setCCachingW(strategy, state, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB);
 
     bool nested = true;
     std::swap(nested, state.isNested);
@@ -470,6 +472,7 @@ bool Generator<hw>::gemmFusedPostOpsFinalize(Label &labelLateExit, GEMMProblem &
             s->atomic = false;
             s->cachingW = CacheSettingsLSC::L1UC_L3WB;
         }
+        setCCachingW(strategy0, state0, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB);
         if (!gemmAccessC(COperation::Store, modProblem, strategy0, state0)) return false;
         jmpi(1, labelSkipCUpdate);
         mark(lTileAccumulate);

--- a/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.hpp
@@ -20,6 +20,7 @@
 
 #include "gemmstone/problem.hpp"
 #include "gemmstone/strategy.hpp"
+#include "state.hpp"
 
 GEMMSTONE_NAMESPACE_START
 
@@ -37,6 +38,16 @@ inline int tempCThreadStride(const GEMMProblem &problem, const GEMMStrategy &str
 // Calculate per-workgroup stride within temporary C memory.
 inline int tempCWGStride(const GEMMProblem &problem, const GEMMStrategy &strategy) {
     return tempCThreadStride(problem, strategy) * strategy.wg[LoopM] * strategy.wg[LoopN];
+}
+
+// Set C write cache policy; layouts hold their own copy of the addressing strategy, so update those too.
+inline void setCCachingW(GEMMStrategy &strategy, GEMMState &state, ngen::CacheSettingsLSC caching, ngen::CacheSettingsLSC cachingExt)
+{
+    strategy.C.cachingW = caching;
+    state.Cext_strategy.cachingW = cachingExt;
+    state.C_layout.addressingStrategy().cachingW = caching;
+    for (auto *l: {&state.C_layoutExt, &state.C_layoutExtUnmasked, &state.C_layoutExtNonatomicUnmasked})
+        l->addressingStrategy().cachingW = cachingExt;
 }
 
 GEMMSTONE_NAMESPACE_END

--- a/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
@@ -18,6 +18,7 @@
 #include <numeric>
 
 #include "alloc_utils.hpp"
+#include "atomic_fusions.hpp"
 #include "gemmstone/generator.hpp"
 #include "generator/pieces/copy_plan.hpp"
 #include "hw_utils.hpp"
@@ -561,10 +562,8 @@ bool Generator<hw>::gemmUpdateCDispatch(GEMMProblem &problem, GEMMStrategy &stra
 
     checkUC = checkUC && (C_l1UCW != strategy.C.cachingW || Ce_l1UCW != state.Cext_strategy.cachingW);
 
-    if (strategy.altFusedBeta && !checkUC && !strategy.fusePostOps) {
-        strategy.C.cachingW = C_l1UCW;
-        state.Cext_strategy.cachingW = Ce_l1UCW;
-    }
+    if (strategy.altFusedBeta && !checkUC && !strategy.fusePostOps)
+        setCCachingW(strategy, state, C_l1UCW, Ce_l1UCW);
 
     // Generate the various paths needed.
     if (!checkBeta0 && !checkBeta1 && !checkTRMMBeta1 && !checkUC) {
@@ -642,10 +641,8 @@ bool Generator<hw>::gemmUpdateCDispatch(GEMMProblem &problem, GEMMStrategy &stra
                 stub(); /* need to shift addresses */
             substrategy.C.atomic = substrategy.CO.atomic = false;
             substate.Cext_strategy.atomic = false;
-            if (checkUC) {
-                substrategy.C.cachingW = C_l1UCW;
-                substate.Cext_strategy.cachingW = Ce_l1UCW;
-            }
+            if (checkUC)
+                setCCachingW(substrategy, substate, C_l1UCW, Ce_l1UCW);
 
             if (!gemmUpdateC(subproblem, substrategy, substate)) return false;
         }
@@ -688,10 +685,8 @@ bool Generator<hw>::gemmUpdateCDispatch(GEMMProblem &problem, GEMMStrategy &stra
 
             subproblem.beta = 0;
             subproblem.removeFinalSumPostOp();
-            if (checkUC) {
-                substrategy.C.cachingW = C_l1UCW;
-                substate.Cext_strategy.cachingW = Ce_l1UCW;
-            }
+            if (checkUC)
+                setCCachingW(substrategy, substate, C_l1UCW, Ce_l1UCW);
 
             substrategy.C.atomic = substrategy.CO.atomic = false;
             substate.Cext_strategy.atomic = false;

--- a/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
+++ b/src/gpu/intel/gemm/jit/generator/strategy_parser.cpp
@@ -154,11 +154,8 @@ void getCaching(std::stringstream &s, HW hw, MatrixAddressingStrategy &astrategy
 
     if (!leaveDefault) {
         cachingR = CacheSettingsLSC::L1C_L3C;
-        cachingW = CacheSettingsLSC::L1WB_L3WB;
-        if (hw >= HW::XeHPC)
-            cachingW = CacheSettingsLSC::L1UC_L3WB;
-        if (hw >= HW::Xe3p)
-            cachingR = CacheSettingsLSC::L1C_L2C_L3C;
+        cachingW = (hw == HW::XeHPC) ? CacheSettingsLSC::L1UC_L3WB
+                                     : CacheSettingsLSC::L1WB_L3WB;
     }
 
     if (s.peek() == '{') {


### PR DESCRIPTION
**TLDR:** PR updates JIT GEMM cache hints (uncached L3 loads on Xe3p, cached L1 stores on Xe2+). NVL-P gets a large win - geomean 1.24x, median 1.20x, up to 1.67x (864 improved KPIs). BMG/LNL/PTL improve +0.4-0.7% geomean (top 5% of KPIs gain 3-4%; ~100-150 KPIs/platform >1.02), with a neutral median and few regressions.

---

PR implements two changes:

1. Xe3p has no L3 cache, so use uncached loads. This improves NVL-P performance as reported in [MFDNN-15517](https://jira.devtools.intel.com/browse/MFDNN-15517])
2. For stores, `L1C` performs slightly better than `L1UC` on Xe2+. While it introduces some regressions, the overall impact is positive
    - The effect is broad: seeing improvements on LNL, BMG, PTL, NVL-P and CRI.
    - I suspect `L1UC` causes more stalls due to occupying an LSC port to write it to L3 while `L1C` results in a faster update in L1. Writeback to L3 still happens but it's more spread out over time which helps to mitigate the stalls

I also tried `L1S` - streaming write to L1 but it performed somewhat worse comparing with `L1C`.

Note that Xe3p has three cache levels in the ISA (but no physical L3) while pre-Xe3p is two levels. The nGEN cache settings values are the same so we can unify two and three levels:

- `L1C_L3C` has the same value as `L1C_L2C_L3UC`
- `L1WB_L3WB` has the same value as `L1WB_L2WB_L3UC`

Performance data is below.

<img width="2025" height="864" alt="cache_bb_branch" src="https://github.com/user-attachments/assets/50742e7b-257a-48c6-ad89-de77ad988f63" />

Couple notes:

- NVL-P gains are large (geomean 1.24x, up to 1.67x) and come from both loads (`ccc` -> `cc`) and stores (`ub` -> `bb`). LNL/BMG/PTL gains are small (+0.5% geomean, 3-4% at p95)
- ATS-M/DG2/PVC show worse (or at best less conclusive) performance with `bb`/`sb` stores vs current `ub` so I left them as is in the PR

<details>
<summary>L1WB_L3WB vs L1S_L3WB comparison</summary>

Legend:

- `cache_cc_bb`: `L1C_L3C` for loads and `L1WB_L3WB` for stores
    - On NVL-P: `L1C_L2C_L3UC` and `L1WB_L2WB_L3UC`
- `cache_cc_sb`: `L1C_L3C` for loads and `L1S_L3WB` for stores
    - On NVL-P: `L1C_L2C_L3UC` and `L1S_L2WB_L3UC`

<img width="1820" height="1430" alt="cache_bb_vs_sb" src="https://github.com/user-attachments/assets/1a39c8ed-ff1e-46c8-b48a-a74f978fa715" />

</details>

<details>
<summary>More stats</summary>

## cache_cc_bb (aff44fc vs main 9ba1daf)

| platform | #KPI | p5 | p95 | geomean | reg<0.98 | imp>1.02 | notes |
|---|---:|---:|---:|---:|---:|---:|---|
| lnx-bmg | 1174 | 0.989 | 1.027 | 1.004 | 18 | 97 | **win** - 97 KPIs >1.02 |
| lnx-bmg-g31 | 1174 | 0.993 | 1.037 | 1.006 | 25 | 151 | **win** - 151 KPIs >1.02 |
| lnx-dg2 | 1174 | 0.991 | 1.017 | 1.002 | 10 | 35 | neutral |
| lnx-lnl | 1174 | 0.987 | 1.032 | 1.005 | 31 | 131 | **win** - 131 KPIs >1.02 |
| lnx-ats-m1 | 1174 | 0.993 | 1.008 | 1.000 | 4 | 5 | neutral |
| lnx-pvc | 1299 | 0.976 | 1.013 | 0.996 | 111 | 28 | **loss** |
| win-bmg | 1174 | 0.990 | 1.036 | 1.006 | 19 | 133 | **win** - 133 KPIs >1.02 |
| win-lnl | 1174 | 0.988 | 1.031 | 1.006 | 22 | 111 | **win** - 111 KPIs >1.02 |
| win-nvl-p | 1174 | 1.000 | 1.670 | 1.236 | 9 | 864 | **big win** - up to 1.67x, 478 KPIs >1.3x (Xe3p uncached loads) |
| win-ptl | 1174 | 0.987 | 1.034 | 1.007 | 32 | 137 | **win** - 137 KPIs >1.02 |

## cache_cc_sb (f8d1d81 vs main 9ba1daf)

| platform | #KPI | p5 | p95 | geomean | reg<0.98 | imp>1.02 | notes |
|---|---:|---:|---:|---:|---:|---:|---|
| lnx-bmg | 1174 | 0.990 | 1.009 | 1.000 | 11 | 13 | neutral |
| lnx-bmg-g31 | 1174 | 0.991 | 1.017 | 1.001 | 9 | 38 | neutral |
| lnx-dg2 | 1174 | 0.985 | 1.016 | 1.000 | 23 | 22 | neutral |
| lnx-lnl | 1174 | 0.987 | 1.017 | 1.001 | 22 | 35 | neutral |
| lnx-ats-m1 | 1174 | 0.992 | 1.011 | 1.001 | 11 | 6 | neutral |
| lnx-pvc | 1299 | 0.971 | 1.011 | 0.996 | 121 | 17 | **loss** |
| win-bmg | 1174 | 0.989 | 1.012 | 1.001 | 19 | 18 | neutral |
| win-lnl | 1174 | 0.985 | 1.015 | 1.000 | 28 | 32 | neutral |
| win-nvl-p | n/a | n/a | n/a | n/a | n/a | n/a | not collected (no full-suite sb NVL-P run) |
| win-ptl | 1174 | 0.984 | 1.024 | 1.003 | 29 | 88 | neutral |

</details>
