### PR TITLE
xe: gemm: jit: do not swap A/B for dynamic-quantized int4 A 

### DIFF
--- a/src/gpu/intel/gemm/jit.hpp
+++ b/src/gpu/intel/gemm/jit.hpp
@@ -129,10 +129,10 @@ struct gen_t : public primitive_t {
             swap_ab_ = (d->m() == 1 && d->ldc() == 1 && check_lda)
                     || d->transc() == dnnl_trans;
 
-            // We cannot swap A/B if we don't have kernels to support the
-            // swapped data type/alignment requirements. Currently mostly affects
-            // weights-only compression cases, since A/B have different data types
-            swap_ab_ &= !wei_decomp_;
+            // Mixed-width kernels exist only with the narrower type in A,
+            // swapping would put it in B, where the catalog has no coverage.
+            swap_ab_ &= types::data_type_bits(d->a_type())
+                    >= types::data_type_bits(d->b_type());
 
             // No kernels with transposed C, if swap_ab is disabled (e.g. due
             // to wei_decomp_) - this case cannot be handled.

--- a/tests/benchdnn/inputs/matmul/harness_matmul_regression
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_regression
@@ -59,3 +59,5 @@
 --reset --dt=s8:s8:f32 --stag=ab --wtag=ab --dtag=ab --attr-scales=dst:common:1 --attr-post-ops=gelu_erf 8x8:8x8
 --reset --dt=f32:s4:f32 --stag=ab --wtag=ab --dtag=ba --attr-fpmath=strict:true 2x2:2x2_n"woq_with_transposed_dst"
 --reset --dt=s8:u8:f16 --attr-scales=src:common:2:f16+wei:per_oc 3x6x1x2x4:1x6x7x4x1_n"non-f32_src_scale"
+# int4 weights + dynamic quant with N=1: must not swap A/B into an unsupported swapped kernel (must dispatch to jit)
+--reset --dt=s8:u4:f16 --stag=ab --wtag=ba --dtag=ab --attr-scales=wei:per_ocic:f16:64x1 --attr-zero-points=wei:per_ocic:u8:64x1 16x64:64x1


### PR DESCRIPTION
Jira: [MFDNN-15511](https://jira.devtools.intel.com/browse/MFDNN-15511)

PR extends the no-swap-AB condition to avoid reference fallback.