### PR TITLE
xe: ggemm: add support for the any tag in grouped_micro_gemm

### DIFF
--- a/src/gpu/intel/matmul/grouped_micro_gemm.cpp
+++ b/src/gpu/intel/matmul/grouped_micro_gemm.cpp
@@ -433,8 +433,11 @@ status_t grouped_micro_gemm_t::pd_t::init_m_axis(const impl::engine_t *engine) {
     const sparse_desc_t::grouped_desc_t &dst_grouped
             = dst_d.sparse_desc().grouped_desc;
 
-    VDISPATCH_MATMUL(wei_d.matches_one_of_tag(format_tag::ab, format_tag::ba,
-                             format_tag::abc, format_tag::acb),
+    // Resolve format_any to plain dense
+    if (wei_d.format_any())
+        CHECK(memory_desc_init_by_strides(weights_md_, nullptr));
+
+    VDISPATCH_MATMUL(wei_d.matches_one_of_tag(format_tag::abc, format_tag::acb),
             VERBOSE_UNSUPPORTED_TAG_S, "weights");
 
     // Validate matching number of groups


### PR DESCRIPTION
# Description

This PR adds support for the any tag to the weights for the m_axis grouped gemm primitive.
