### PR TITLE
[RFC] gpu: gemm: xe_hp_systolic pre-empts gemmstone on int8 GEMM by list order

### DIFF
--- a/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
+++ b/src/gpu/intel/gemm/jit/selector/kernel_selector.cpp
@@ -17,8 +17,11 @@
 #include "gemmstone/kernel_selector.hpp"
 #include "gemmstone/kernel_evaluator.hpp"
 
+#include <algorithm>
 #include <cassert>
 #include <cctype>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -168,6 +171,20 @@ struct EntryData {
 const std::vector<const kcatalog::Entry *> getEntries(const kcatalog::Catalog &catalog, int npatterns, const MatchParams *patterns, const EvaluateParams &eparams, EvaluateAuxOutput &aux,  SelectionObserver * observer)
 {
     // TODO: omit evaluation if only one match, if aux output not needed.
+    static const bool dbg = []{
+        const char *s = std::getenv("OV_GEMM_DEBUG");
+        return s && s[0] == '1';
+    }();
+    if (dbg) {
+        std::fprintf(stderr,
+                "GEMMSEL prec=%s/%s/%s lay=%s/%s/%c m=%d n=%d k=%d batch=%d align=%d/%d/%d npat=%d\n",
+                patterns[0].selector.precisions[0], patterns[0].selector.precisions[1],
+                patterns[0].selector.precisions[2], patterns[0].selector.layouts[0],
+                patterns[0].selector.layouts[1], patterns[0].selector.layouts[2][0],
+                (int)patterns[0].sizes.m, (int)patterns[0].sizes.n, (int)patterns[0].sizes.k,
+                (int)patterns[0].sizes.batch, patterns[0].alignment[0], patterns[0].alignment[1],
+                patterns[0].alignment[2], npatterns);
+    }
     std::vector<EntryData> keys;
     for (int ipattern = 0; ipattern < npatterns; ipattern++) {
         for (auto it = match(catalog, patterns[ipattern]); it; it++) {
@@ -196,6 +213,28 @@ const std::vector<const kcatalog::Entry *> getEntries(const kcatalog::Catalog &c
                       return (lhs.entry < rhs.entry);
     };
     std::sort(keys.begin(), keys.end(), less);
+
+    // Experimental control: OV_GEMM_SKIP=n rotates the always-accept (score=-inf) block so
+    // each spliced variant can be measured in isolation; OV_GEMM_SKIP=99 drops it entirely
+    // to measure the pure catalog ranking. Other selection sites are unaffected either way.
+    static const int rotate_by = []{
+        const char *s = std::getenv("OV_GEMM_SKIP");
+        return s ? std::atoi(s) : 0;
+    }();
+    if (rotate_by == 99) {
+        keys.erase(std::remove_if(keys.begin(), keys.end(),
+                        [](const EntryData &k) { return k.score < -1e29; }),
+                keys.end());
+    } else if (rotate_by >= 100) {
+        int skip = rotate_by - 100;
+        if (keys.size() > 1)
+            std::rotate(keys.begin(), keys.begin() + (skip % int(keys.size())), keys.end());
+    } else if (rotate_by > 0) {
+        int nacc = 0;
+        while (nacc < (int)keys.size() && keys[nacc].score < -1e29) nacc++;
+        if (nacc > 1)
+            std::rotate(keys.begin(), keys.begin() + (rotate_by % nacc), keys.begin() + nacc);
+    }
 
     // Unpack into vector of entries (dropping score)
     std::vector<const kcatalog::Entry *> entries;

--- a/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
+++ b/src/gpu/intel/gemm/jit_xe_hp_systolic.cpp
@@ -16,6 +16,8 @@
 
 #include "gpu/intel/gemm/jit_xe_hp_systolic.hpp"
 
+#include <cstdlib>
+
 #include "common/c_types_map.hpp"
 #include "common/type_helpers.hpp"
 #include "common/verbose_msg.hpp"
@@ -41,6 +43,15 @@ status_t xe_hp_systolic_t::pd_t::init(const impl::engine_t *engine) {
 
     assert(engine->kind() == engine_kind::gpu);
     const auto *intel_engine = utils::downcast<const intel::engine_t *>(engine);
+
+    // veesion: this implementation sits AHEAD of gemmstone (gen_t) in the gemm impl list, so
+    // wherever it accepts a shape the cost model never gets to compare. gemmstone measured
+    // faster on every int8 GEMM shape this ViT runs, so skip unless explicitly re-enabled.
+    static const bool disabled = []() {
+        const char *e = std::getenv("OV_SYSTOLIC");
+        return !(e != nullptr && e[0] == '1');
+    }();
+    VDISPATCH_GEMM(!disabled, VERBOSE_UNSUPPORTED_FEATURE, "OV_SYSTOLIC");
 
     VDISPATCH_GEMM(intel_engine->mayiuse_ngen_kernels(),
             VERBOSE_UNSUPPORTED_DEVICE_FEATURE, "ngen kernels");


### PR DESCRIPTION
### The finding

`xe_hp_systolic_t` is listed ahead of the gemmstone-generated implementation (`gen_t`) in the GPU
GEMM implementation list. Wherever it accepts a shape it therefore wins by **list order**, and the
cost model never gets to compare the two.

On the int8 GEMM shapes produced by quantized transformer projections, the gemmstone kernels
measured faster on every shape tried here — but were never reached, because `xe_hp_systolic` had
already claimed the primitive. Taking it out of the way was a measurable end-to-end win on
Xe-LPG integrated graphics, and these projections are the dominant GEMM cost in that kind of
graph.

### What is in this PR, and what is not

What is here is the **measurement vehicle**, not a proposed fix:

* `jit_xe_hp_systolic.cpp` — a `VDISPATCH_GEMM` gate so the implementation can be taken out of
  the way and the comparison can happen at all. It is **off by default here and re-enabled with
  `OV_SYSTOLIC=1`**, which is the wrong polarity and the wrong mechanism for upstream.
* `kernel_selector.cpp` — two opt-in diagnostics, both inert unless their variable is set.
  `OV_GEMM_DEBUG=1` traces the selector query; `OV_GEMM_SKIP` rotates or drops the always-accept
  (`score = -inf`) block, because entries scoring `-inf` keep their catalog order and which of
  several always-accept variants actually runs is otherwise not observable from outside.

Neither belongs upstream as written, and `ONEDNN_VERBOSE=dispatch` already covers part of what
the tracing does.

### Measurement

The numbers behind this came from an internal workload that I cannot point you at, so nothing
here is reproducible on your side as it stands. The structural claim — that `xe_hp_systolic`
short-circuits the cost model by list order — is checkable from the dispatch code alone. The
question of which kernel is actually faster needs benchdnn cases over the relevant int8 shape
family, which I am happy to produce.

### Questions

1. Is `xe_hp_systolic` preceding gemmstone in the implementation list **intentional** — a known
   trade-off where it wins often enough to be worth short-circuiting the cost model — or is it a
   dispatch-ordering artifact?
2. If it is worth fixing: reorder the implementation list, extend the cost model so the two are
   compared, or narrow `xe_hp_systolic`'s acceptance condition for int8 shapes of this aspect
   ratio?
3. Which benchdnn shapes would you want as evidence?

Measured on Xe-LPG (Arc-class integrated) only. Whether the same ordering effect appears on
discrete Xe-HPG/Xe-HPC, where `xe_hp_systolic` presumably earns its position, is unverified.
