### PR TITLE
benchdnn: reorder: enhancements (prepare for generated coverage)

### DIFF
--- a/scripts/verbose_converter/src/benchdnn_generator.py
+++ b/scripts/verbose_converter/src/benchdnn_generator.py
@@ -703,7 +703,7 @@ class ReductionConverter(
         return " ".join(args)
 
 
-class ReorderConverter(StridesMixin, CommonDataTypeMixin, Converter):
+class ReorderConverter(StridesMixin, MultiDataTypeMixin, Converter):
     driver: str = "reorder"
 
     def _convert_flag(self, prefix, md: ir.MemoryDescriptor):

--- a/tests/benchdnn/brgemm/brgemm.hpp
+++ b/tests/benchdnn/brgemm/brgemm.hpp
@@ -97,10 +97,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
         , batch_kind(batch_kind) {
 
         // Broadcast data types if needed
-        if (dt.size() == 1) {
-            const auto val = dt[0]; // Need a copy here.
-            this->dt.assign(3, val);
-        }
+        broadcast_vector(this->dt, dt[0], 3);
 
         const auto &srcdims = src_dims();
         const auto &weidims = weights_dims();

--- a/tests/benchdnn/concat/concat.hpp
+++ b/tests/benchdnn/concat/concat.hpp
@@ -79,7 +79,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
         // If dst is omitted by `dtag = tag::undef`, omit `ddt` as well.
         if (dtag == tag::undef) this->ddt = dnnl_data_type_undef;
 
-        broadcast_vector(this->stag, prb_vdims.n_inputs());
+        broadcast_vector(this->stag, stag[0], prb_vdims.n_inputs());
 
         dst_dims[axis] = axis_size();
         repro = set_repro_line(); // must be last in ctor to collect right info

--- a/tests/benchdnn/conv/conv.hpp
+++ b/tests/benchdnn/conv/conv.hpp
@@ -148,10 +148,7 @@ struct prb_t : public desc_t, public base_prb_t {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
-        if (dt.size() == 1) {
-            const auto val = dt[0]; // Need a copy here.
-            this->dt.assign(3, val);
-        }
+        broadcast_vector(this->dt, dt[0], 3);
 
         count_ops();
         repro = set_repro_line(); // must be last in ctor to collect right info

--- a/tests/benchdnn/deconv/deconv.hpp
+++ b/tests/benchdnn/deconv/deconv.hpp
@@ -147,10 +147,7 @@ struct prb_t : public desc_t, public base_prb_t {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
-        if (dt.size() == 1) {
-            const auto val = dt[0]; // Need a copy here.
-            this->dt.assign(3, val);
-        }
+        broadcast_vector(this->dt, dt[0], 3);
 
         count_ops();
         repro = set_repro_line(); // must be last in ctor to collect right info

--- a/tests/benchdnn/dnn_types.cpp
+++ b/tests/benchdnn/dnn_types.cpp
@@ -1902,27 +1902,49 @@ std::string normalize_tag(const std::string &tag_, int ndims) {
         return "a";
     }
 
-    // Handle meta-tags (abx, axb, etc).
-    auto pos = tag.find("x");
-    if (pos != std::string::npos) {
-        // Non-grouped tags will start `x` from `c`, but grouped will most of
-        // times start `x` from `d`.
-        char start_x = 'c';
-        for (char c = 'a' + DNNL_MAX_NDIMS - 1; c >= 'b'; c--) {
-            if (tag.find(c) != std::string::npos) {
-                start_x = c + 1;
-                break;
-            }
-        }
-        // Adjust ndims if they are not specified.
-        int meta_ndims = (ndims == -1 ? (start_x - 'a' + 1) : ndims);
-        std::string tail;
-        for (int i = 0; i < meta_ndims - (start_x - 'a'); i++)
-            tail += (start_x + i);
-        return trim_tag(tag.replace(pos, 1, tail), meta_ndims);
+    // Handle meta-tags (abx, axb, aby, etc).
+    auto pos_x = tag.find("x");
+    auto pos_y = tag.find("y");
+    if (pos_x != std::string::npos && pos_y != std::string::npos) {
+        BENCHDNN_PRINTF(0, "%s",
+                "Error: a tag can't have both \'x\' and \'y\' letters "
+                "specified.");
+        return tag;
     }
 
-    return map_tag_letters(tag);
+    if (pos_y != std::string::npos && pos_y != tag.size() - 1) {
+        BENCHDNN_PRINTF(0, "%s",
+                "Error: a tag containing \'y\' must have it at the end.");
+        return tag;
+    }
+
+    if (pos_x == std::string::npos && pos_y == std::string::npos) {
+        return map_tag_letters(tag);
+    }
+
+    auto pos = pos_x != std::string::npos ? pos_x : pos_y;
+    // Non-grouped tags will start `x` from `c`, but grouped will most of
+    // times start `x` from `d`.
+    char start_xy = 'c';
+    for (char c = 'a' + DNNL_MAX_NDIMS - 1; c >= 'b'; c--) {
+        if (tag.find(c) != std::string::npos) {
+            start_xy = c + 1;
+            break;
+        }
+    }
+    // Adjust ndims if they are not specified.
+    int meta_ndims = (ndims == -1 ? (start_xy - 'a' + 1) : ndims);
+    std::string tail;
+    for (int i = 0; i < meta_ndims - (start_xy - 'a'); i++)
+        tail += (start_xy + i);
+    auto trimmed_tag = trim_tag(tag.replace(pos, 1, tail), meta_ndims);
+    // Transpose last two letters if 'y' was requested.
+    if (pos_y != std::string::npos) {
+        assert(trimmed_tag.size() >= 2);
+        const auto sz = trimmed_tag.size();
+        std::swap(trimmed_tag[sz - 1], trimmed_tag[sz - 2]);
+    }
+    return trimmed_tag;
 }
 
 int check_tag(const std::string &tag_, bool check_enum_tags_only) {

--- a/tests/benchdnn/doc/driver_reorder.md
+++ b/tests/benchdnn/doc/driver_reorder.md
@@ -7,10 +7,10 @@
 
 where *reorder-knobs* are:
 
- - `--sdt={f32 [default], s32, s8, u8, bf16, f16, f64}` -- src data type.
-            Refer to [data types](knobs_dt.md) for details.
- - `--ddt={f32 [default], s32, s8, u8, bf16, f16, f64}` -- dst data type.
-            Refer to [data types](knobs_dt.md) for details.
+ - `--dt={f32:f32 [default], SRC:DST}` -- source and destination data types.
+            Interface supports broadcasting, when a single input is
+            provided, e.g., `--dt=f32`, and the value will be applied for all
+            tensors. Refer to [data types](knobs_dt.md) for details.
  - `--stag={nchw [default], ...}` -- physical src memory layout.
             Refer to [tags](knobs_tag.md) for details.
  - `--dtag={nchw [default], ...}` -- physical dst memory layout.
@@ -61,9 +61,14 @@ Run two specific reorders with s8 src and dst data type, and specific input and
 output physical memory layouts. First problem without a flag; second problem
 with the `s8s8_comp` flag and mask of `1`:
 ``` sh
-    ./benchdnn --reorder --sdt=s8 --ddt=s8 --stag=hwio --dtag=OIhw4i16o4i \
+    ./benchdnn --reorder --dt=s8:s8 --stag=hwio --dtag=OIhw4i16o4i \
                32x32x3x3 \
                --oflag=s8s8_comp:1 16x32x7x5
+```
+
+Run a reorder from `f32` src to `s8` dst:
+``` sh
+    ./benchdnn --reorder --dt=f32:s8 --stag=abx --dtag=abx 32x32x3x3
 ```
 
 More examples with different driver options can be found at

--- a/tests/benchdnn/doc/knobs_tag.md
+++ b/tests/benchdnn/doc/knobs_tag.md
@@ -2,7 +2,7 @@
 
 **Benchdnn** supports three kinds of memory format tags:
 - Meta-tags (benchdnn abstraction).
-    - Examples: `abx`, `aBx16b`
+    - Examples: `abx`, `axb`, `aBx16b`, `aby`
 - Library tags (refer to `dnnl::memory::format_tag` enum).
     - Examples: `nchw`, `acdb`, `nChw8c`
 - Other valid tags not presented in `dnnl::memory::format_tag` enum (controlled
@@ -12,14 +12,24 @@
 If an unsupported tag is specified, an error will be reported. The list of
 library supported tags can be found in dnnl.hpp header file. Meta-tags are
 xD-spatial tags which adapt to the number of dimensions specified by a problem
-descriptor (for descriptor-based drivers) or dimensions. Below are examples of
-plain and blocked meta-tags:
+descriptor (for descriptor-based drivers) or dimensions.
+A typical use of a meta-tag expands the spatial dimensions, whose count varies
+with the problem's dimensionality. A letter 'x' is used to denote concatenated
+spatial dimensions. In most scenarios it will be replaced with 'c', 'cd', or
+'cde'. In case of (de-)convolutions with groups, it will be replaced with 'd',
+'de', or 'def'. There's a dedicated matmul case where the last two dimensions
+should be transposed. To support this case, letter 'y' is supported. It replaces
+'x' and denotes that last two dimensions will be transposed. The resulting tags
+are listed in the table below.
+
+Here are examples of plain and blocked meta-tags:
 
 | Plain tags   | Description
 | :---         | :---
 | abx          | Includes `a`, `ab`, `abc`, `abcd`, `abcde`, `abcdef` tags and their former names for activations and weights.
 | axb          | Includes `a`, `ab`, `acb`, `acdb`, `acdeb` tags and their former names for activations.
 | xba          | Includes `a`, `ba`, `cba`, `cdba`, `cdeba` tags and their former names for weights.
+| aby          | Includes `ba`, `acb`, `abdc`, `abced`, `abcdfe` tags and their former names for activations and weights.
 | ...          | Other plain meta-tags following the same rules.
 
 | Blocked tags | Description

--- a/tests/benchdnn/gnorm/gnorm.hpp
+++ b/tests/benchdnn/gnorm/gnorm.hpp
@@ -102,8 +102,8 @@ struct prb_t : public desc_t, public base_prb_t {
 
         if (mb) this->mb = mb;
 
-        broadcast_vector(this->dt, 2);
-        broadcast_vector(this->tag, 2);
+        broadcast_vector(this->dt, dt[0], 2);
+        broadcast_vector(this->tag, tag[0], 2);
 
         repro = set_repro_line(); // must be last in ctor to collect right info
     }

--- a/tests/benchdnn/graph/setting_handler.cpp
+++ b/tests/benchdnn/graph/setting_handler.cpp
@@ -1974,16 +1974,17 @@ bool get_reduction_p(const deserialized_op_t &base_op_ref, float &p) {
 
 namespace reorder {
 
-bool get_reorder_dt(const deserialized_op_t &base_op_ref, dnnl_data_type_t &sdt,
-        dnnl_data_type_t &ddt) {
-    sdt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
-    ddt = convert_dt(base_op_ref.out_lts_.front().get_data_type());
+bool get_reorder_dt(const deserialized_op_t &base_op_ref,
+        std::vector<dnnl_data_type_t> &dt) {
+    auto src_dt = convert_dt(base_op_ref.in_lts_.front().get_data_type());
+    auto dst_dt = convert_dt(base_op_ref.out_lts_.front().get_data_type());
 
     const auto &op_kind = base_op_ref.kind_;
     // As we always use f32 computation in the reference path, to link
     // arguments correctly in the reference path, we need to always create
     // dequantize ops with f32 output.
-    if (op_kind == "DynamicDequantize") { ddt = dnnl_f32; }
+    if (op_kind == "DynamicDequantize") { dst_dt = dnnl_f32; }
+    dt = {src_dt, dst_dt};
     return true;
 }
 
@@ -2135,9 +2136,7 @@ bool get_reorder_attrs(const deserialized_op_t &base_op_ref,
             get_prb_dims(base_op_ref, op_setting.prb_dims), res);
 
     DNN_GRAPH_CHECK_SETTINGS(
-            reorder::get_reorder_dt(base_op_ref, op_setting.sdt.front(),
-                    op_setting.ddt.front()),
-            res);
+            reorder::get_reorder_dt(base_op_ref, op_setting.dt.front()), res);
     DNN_GRAPH_CHECK_SETTINGS(
             reorder::get_reorder_stag_and_dtag(base_op_ref,
                     op_setting.stag.front(), op_setting.dtag.front()),

--- a/tests/benchdnn/ip/ip.hpp
+++ b/tests/benchdnn/ip/ip.hpp
@@ -97,10 +97,7 @@ struct prb_t : public desc_t, public base_prb_t {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
-        if (dt.size() == 1) {
-            const auto val = dt[0]; // Need a copy here.
-            this->dt.assign(3, val);
-        }
+        broadcast_vector(this->dt, dt[0], 3);
 
         count_ops();
         repro = set_repro_line(); // must be last in ctor to collect right info

--- a/tests/benchdnn/lnorm/lnorm.hpp
+++ b/tests/benchdnn/lnorm/lnorm.hpp
@@ -108,10 +108,7 @@ struct prb_t : public prb_dims_t, public base_prb_t {
             n *= dims[d];
 
         // Broadcast data types if needed
-        if (dt.size() == 1) {
-            const auto val = dt[0]; // Need a copy here.
-            this->dt.assign(2, val);
-        }
+        broadcast_vector(this->dt, dt[0], 2);
         if (tag.size() == 1) { this->tag.emplace_back(tag::any); }
         repro = set_repro_line(); // must be last in ctor to collect right info
     }

--- a/tests/benchdnn/matmul/matmul.hpp
+++ b/tests/benchdnn/matmul/matmul.hpp
@@ -97,10 +97,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
         , sparse_options(sparse_options) {
 
         // Broadcast data types if needed
-        if (dt.size() == 1) {
-            const auto val = dt[0]; // Need a copy here.
-            this->dt.assign(3, val);
-        }
+        broadcast_vector(this->dt, dt[0], 3);
 
         this->rt_dims_masks.resize(2);
         const auto &srcdims = src_dims();

--- a/tests/benchdnn/pool/pool.hpp
+++ b/tests/benchdnn/pool/pool.hpp
@@ -132,10 +132,7 @@ struct prb_t : public desc_t, public base_prb_t {
         if (mb) this->mb = mb;
 
         // Broadcast data types if needed
-        if (dt.size() == 1) {
-            const auto val = dt[0]; // Need a copy here.
-            this->dt.assign(2, val);
-        }
+        broadcast_vector(this->dt, dt[0], 2);
 
         repro = set_repro_line(); // must be last in ctor to collect right info
     }

--- a/tests/benchdnn/prelu/prelu.hpp
+++ b/tests/benchdnn/prelu/prelu.hpp
@@ -70,10 +70,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
         , sdt(sdt)
         , stag(stag) {
         // Broadcast data types if needed
-        if (sdt.size() == 1) {
-            const auto val = sdt[0]; // Need a copy here.
-            this->sdt.assign(2, val);
-        }
+        broadcast_vector(this->sdt, sdt[0], 2);
 
         repro = set_repro_line(); // must be last in ctor to collect right info
     }

--- a/tests/benchdnn/reorder/bench_reorder.cpp
+++ b/tests/benchdnn/reorder/bench_reorder.cpp
@@ -29,8 +29,14 @@ TASK_EXECUTOR_DECL_TYPES;
 
 void check_correctness(
         const settings_t &s, driver_task_executor_t &task_executor) {
-    for_(const auto &i_sdt : s.sdt)
-    for_(const auto &i_ddt : s.ddt)
+    std::vector<std::vector<dnnl_data_type_t>> dt = s.dt;
+    if (dt.empty()) {
+        for_(const auto &i_sdt : s.sdt)
+        for (const auto &i_ddt : s.ddt)
+            dt.push_back({i_sdt, i_ddt});
+    }
+
+    for_(const auto &i_dt : dt)
     for_(const auto &i_stag : s.stag)
     for_(const auto &i_dtag : s.dtag)
     for_(const auto &i_strides : s.strides)
@@ -40,9 +46,9 @@ void check_correctness(
     for_(const auto &i_ctx_init : s.ctx_init)
     for_(const auto &i_ctx_exe : s.ctx_exe)
     for (auto i_runtime_dim_mask : s.runtime_dim_mask) {
-        auto prb = std::make_shared<prb_t>(s.prb_dims, i_sdt, i_ddt, i_stag,
-                i_dtag, i_strides, i_oflag, i_cross_engine, i_runtime_dim_mask,
-                i_attr, i_ctx_init, i_ctx_exe, s.impl_filter);
+        auto prb = std::make_shared<prb_t>(s.prb_dims, i_dt, i_stag, i_dtag,
+                i_strides, i_oflag, i_cross_engine, i_runtime_dim_mask, i_attr,
+                i_ctx_init, i_ctx_exe, s.impl_filter);
         if (s.pattern && !match_regex(prb->str(), s.pattern)) return;
 
         task_executor.submit(prb, s.perf_template, createit, checkit, doit);
@@ -50,6 +56,24 @@ void check_correctness(
 }
 
 int verify_input(const settings_t &s, const settings_t &def) {
+    const bool dt_specified = s.dt != def.dt;
+    const bool sdt_ddt_specified = s.sdt != def.sdt || s.ddt != def.ddt;
+    if (dt_specified && sdt_ddt_specified) {
+        BENCHDNN_PRINT(0, "%s\n",
+                "ERROR: `--dt` can't be used together with `--sdt` or "
+                "`--ddt`.");
+        return FAIL;
+    }
+
+    for (const auto &i_dt : s.dt) {
+        if (i_dt.size() != 1 && i_dt.size() != 2) {
+            BENCHDNN_PRINT(0, "%s\n",
+                    "ERROR: `--dt` option expects a single data type or a "
+                    "`SRC:DST` pair of data types.");
+            return FAIL;
+        }
+    }
+
     for_(const auto &i_scales : s.scales)
     for (auto arg : {DNNL_ARG_SRC, DNNL_ARG_DST}) {
         if (i_scales.get(arg).policy == policy_t::PER_OC) {
@@ -148,6 +172,7 @@ int bench(int argc, char **argv) {
     for (; argc > 0; --argc, ++argv) {
         const bool parsed_options = parse_bench_settings(argv[0])
                 || parse_batch(bench, argv[0])
+                || parse_multi_dt(s.dt, def.dt, argv[0], "dt")
                 || parse_dt(s.sdt, def.sdt, argv[0], "sdt")
                 || parse_dt(s.ddt, def.ddt, argv[0], "ddt")
                 || parse_tag(s.stag, def.stag, argv[0], "stag")

--- a/tests/benchdnn/reorder/cfg.cpp
+++ b/tests/benchdnn/reorder/cfg.cpp
@@ -47,7 +47,7 @@ REG(f4_e2m1, -f16_max_exact, f16_max_exact);
 REG(s32, -BENCHDNN_S32_TO_F32_SAT_CONST, BENCHDNN_S32_TO_F32_SAT_CONST);
 REG(s8, INT8_MIN, INT8_MAX);
 REG(u8, 0, UINT8_MAX);
-REG(s4, -7, 8);
+REG(s4, -8, 7);
 REG(u4, 0, 15);
 
 #undef REG

--- a/tests/benchdnn/reorder/ref_reorder.cpp
+++ b/tests/benchdnn/reorder/ref_reorder.cpp
@@ -46,7 +46,7 @@ void compute_ref(const base_prb_t *base_prb, dir_t dir, const args_t &args,
             : 0;
     const auto &src_scale_groups = prb->attr.scales.get(DNNL_ARG_SRC).groups;
 
-    const auto dst_dt = prb->ddt;
+    const auto dst_dt = prb->dst_dt();
     const auto nelems = src.nelems();
     // This is native to reorder zero point which comes from reorder attributes.
     const bool has_src_zp = !prb->attr.zero_points.get(DNNL_ARG_SRC).is_def();

--- a/tests/benchdnn/reorder/reorder.cpp
+++ b/tests/benchdnn/reorder/reorder.cpp
@@ -155,9 +155,11 @@ dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
         if (prb->runtime_dim_mask & (1 << d)) dims[d] = DNNL_RUNTIME_DIM_VAL;
 
     auto src_d = dnn_mem_t::init_md(prb->ndims, dims.data(),
-            force_f32_dt ? dnnl_f32 : prb->sdt, prb->stag, prb->strides[0]);
+            force_f32_dt ? dnnl_f32 : prb->src_dt(), prb->stag,
+            prb->strides[0]);
     auto dst_d = dnn_mem_t::init_md(prb->ndims, dims.data(),
-            force_f32_dt ? dnnl_f32 : prb->ddt, prb->dtag, prb->strides[1]);
+            force_f32_dt ? dnnl_f32 : prb->dst_dt(), prb->dtag,
+            prb->strides[1]);
 
     // Prepare and assign extra for dst_md.
     auto &extra = static_cast<dnnl_memory_desc_t>(dst_d)->extra;
@@ -207,8 +209,8 @@ dnnl_status_t init_pd(init_pd_args_t &init_pd_args) {
 
 void prb_t::skip_unimplemented(res_t *res) const {
     const prb_t *prb = this; // Kept to avoid mass update
-    const auto sdt = prb->sdt;
-    const auto ddt = prb->ddt;
+    const auto sdt = prb->src_dt();
+    const auto ddt = prb->dst_dt();
     skip_unimplemented_data_type({sdt, ddt}, prb->dir, res);
     skip_unimplemented_sum_po(prb->attr, res, dnnl_reorder, sdt);
     skip_unimplemented_binary_po(prb->attr, res);
@@ -442,8 +444,8 @@ void prb_t::skip_unimplemented(res_t *res) const {
         };
         // Skip blocked format tags and 4 bit formats for Nvidia/AMD/Generic SYCL backends
         if (is_generic_gpu()) {
-            const bool is_4bit_format
-                    = is_subbyte_type(prb->sdt) || is_subbyte_type(prb->ddt);
+            const bool is_4bit_format = is_subbyte_type(prb->src_dt())
+                    || is_subbyte_type(prb->dst_dt());
 
             // sycl reorder implementation does not support grouped zero points / scales
             bool zero_point_has_groups = !prb->attr.scales.is_def();
@@ -486,9 +488,9 @@ void prb_t::skip_invalid(res_t *res) const {
         return;
     }
 
-    const bool is_src_zp_ok = is_integral_dt(prb->sdt)
+    const bool is_src_zp_ok = is_integral_dt(prb->src_dt())
             || prb->attr.zero_points.is_def(DNNL_ARG_SRC);
-    const bool is_dst_zp_ok = is_integral_dt(prb->ddt)
+    const bool is_dst_zp_ok = is_integral_dt(prb->dst_dt())
             || prb->attr.zero_points.is_def(DNNL_ARG_DST);
     if (!(is_src_zp_ok && is_dst_zp_ok)) {
         BENCHDNN_PRINT(2,
@@ -509,7 +511,7 @@ void setup_cmp(compare::compare_t &cmp, const base_prb_t *base_prb,
     cmp.set_zero_trust_percent(80.f);
 
     // `f8_e4m3` range is very short which makes inputs convert into NaNs.
-    cmp.set_op_output_has_nans(prb->sdt == dnnl_f8_e4m3);
+    cmp.set_op_output_has_nans(prb->src_dt() == dnnl_f8_e4m3);
 
     // Additional check to avoid false-positive result from f32->s32 conversion
     // in case of sum post-op on GPU happening when two max_dt values

--- a/tests/benchdnn/reorder/reorder.hpp
+++ b/tests/benchdnn/reorder/reorder.hpp
@@ -59,6 +59,7 @@ struct settings_t : public base_settings_t {
 
     prb_dims_t prb_dims;
 
+    std::vector<std::vector<dnnl_data_type_t>> dt {{dnnl_f32}};
     std::vector<dnnl_data_type_t> sdt {dnnl_f32}, ddt {dnnl_f32};
     std::vector<std::string> stag {tag::abx}, dtag {tag::abx};
     std::vector<vdims_t> strides {vdims_t(2)};
@@ -74,8 +75,8 @@ struct settings_t : public base_settings_t {
     void reset() { *this = settings_t(perf_template); }
 
     bool has_single_setup() const override {
-        return sdt.size() == 1 && ddt.size() == 1 && stag.size() == 1
-                && dtag.size() == 1 && strides.size() == 1 && oflag.size() == 1
+        return dt.size() == 1 && stag.size() == 1 && dtag.size() == 1
+                && strides.size() == 1 && oflag.size() == 1
                 && runtime_dim_mask.size() == 1 && cross_engine.size() == 1
                 && base_settings_t::has_single_setup();
     }
@@ -84,38 +85,44 @@ struct settings_t : public base_settings_t {
 struct prb_t : public prb_dims_t, public base_prb_t {
     // A ctor with common interface across all drivers.
     prb_t(const settings_t &s)
-        : prb_t(s.prb_dims, s.sdt[0], s.ddt[0], s.stag[0], s.dtag[0],
-                  s.strides[0], s.oflag[0], s.cross_engine[0],
-                  s.runtime_dim_mask[0], s.attributes.front(), s.ctx_init[0],
-                  s.ctx_exe[0], s.impl_filter) {
+        : prb_t(s.prb_dims, s.dt[0], s.stag[0], s.dtag[0], s.strides[0],
+                  s.oflag[0], s.cross_engine[0], s.runtime_dim_mask[0],
+                  s.attributes.front(), s.ctx_init[0], s.ctx_exe[0],
+                  s.impl_filter) {
         SAFE_V(s.has_single_setup() ? OK : FAIL);
     }
 
-    prb_t(const prb_dims_t &prb_dims, dnnl_data_type_t sdt,
-            dnnl_data_type_t ddt, const std::string &stag,
-            const std::string &dtag, const vdims_t &strides,
-            const std::vector<flag_t> &oflag, cross_engine_t cross_engine,
-            unsigned runtime_dim_mask, const attr_t &attr,
-            const thr_ctx_t &ctx_init, const thr_ctx_t &ctx_exe,
-            const impl_filter_t &impl_filter)
+    prb_t(const prb_dims_t &prb_dims, const std::vector<dnnl_data_type_t> &dt,
+            const std::string &stag, const std::string &dtag,
+            const vdims_t &strides, const std::vector<flag_t> &oflag,
+            cross_engine_t cross_engine, unsigned runtime_dim_mask,
+            const attr_t &attr, const thr_ctx_t &ctx_init,
+            const thr_ctx_t &ctx_exe, const impl_filter_t &impl_filter)
         : prb_dims_t(prb_dims)
         , base_prb_t(FLAG_FWD, false, attr, ctx_init, ctx_exe, impl_filter)
-        , sdt(sdt)
-        , ddt(ddt)
+        , dt(dt)
         , stag(stag)
         , dtag(dtag)
         , strides(strides)
         , oflag(oflag)
         , cross_engine(cross_engine)
         , runtime_dim_mask(runtime_dim_mask) {
+
+        broadcast_vector(this->dt, dt[0], 2);
+
         repro = set_repro_line(); // must be last in ctor to collect right info
     }
-    dnnl_data_type_t sdt, ddt;
+    std::vector<dnnl_data_type_t> dt;
     std::string stag, dtag;
     vdims_t strides;
     std::vector<flag_t> oflag;
     cross_engine_t cross_engine;
     unsigned runtime_dim_mask;
+
+    dnnl_data_type_t src_dt() const { return dt[0]; }
+    dnnl_data_type_t dst_dt() const { return dt[1]; }
+    dnnl_data_type_t get_dt(data_kind_t data_kind) const;
+
     bool is_reorder_with_compensation(flag_bit_t flag) const;
     dims_t get_compensation_dims(flag_bit_t flag) const;
     int get_compensation_mask(flag_bit_t flag) const;
@@ -145,7 +152,6 @@ struct perf_report_t : public base_perf_report_t {
     perf_report_t(const base_prb_t *base_prb, const char *perf_template)
         : base_perf_report_t(perf_template)
         , p_(prb_t::from(base_prb))
-        , sdt_({p_->sdt})
         , stag_({normalize_tag(p_->stag, p_->ndims)})
         , dtag_(normalize_tag(p_->dtag, p_->ndims)) {}
 
@@ -167,14 +173,14 @@ struct perf_report_t : public base_perf_report_t {
     const thr_ctx_t *ctx_init() const override { return &p_->ctx_init; }
     const thr_ctx_t *ctx_exe() const override { return &p_->ctx_exe; }
     const std::string *name() const override { return &p_->name; }
-    const std::vector<dnnl_data_type_t> *sdt() const override { return &sdt_; }
-    const dnnl_data_type_t *ddt() const override { return &p_->ddt; }
+    const std::vector<dnnl_data_type_t> *sdt() const override {
+        return &p_->dt;
+    }
     const std::vector<std::string> *stag() const override { return &stag_; }
     const std::string *dtag() const override { return &dtag_; }
 
 private:
     const prb_t *p_;
-    std::vector<dnnl_data_type_t> sdt_;
     std::vector<std::string> stag_;
     std::string dtag_;
 };

--- a/tests/benchdnn/reorder/reorder_aux.cpp
+++ b/tests/benchdnn/reorder/reorder_aux.cpp
@@ -126,10 +126,18 @@ int prb_t::get_compensation_mask(flag_bit_t flag) const {
     return mask;
 }
 
+dnnl_data_type_t prb_t::get_dt(data_kind_t data_kind) const {
+    switch (data_kind) {
+        case SRC: return src_dt();
+        case DST: return dst_dt();
+        default: assert(!"unexpected data kind!"); return dnnl_data_type_undef;
+    }
+}
+
 const dt_conf_t *prb_t::get_conf(data_kind_t kind) const {
     switch (kind) {
-        case SRC: return dt2cfg(sdt);
-        case DST: return dt2cfg(ddt);
+        case SRC: return dt2cfg(src_dt());
+        case DST: return dt2cfg(dst_dt());
         default: assert(!"unexpected data kind!"); SAFE_V(FAIL);
     }
     return dt2cfg(dnnl_f32);
@@ -145,9 +153,9 @@ benchdnn_dnnl_wrapper_t<dnnl_memory_desc_t> prb_t::get_md(int arg) const {
 
     switch (arg) {
         case DNNL_ARG_SRC:
-            return dnn_mem_t::init_md(ndims, dims.data(), sdt, stag);
+            return dnn_mem_t::init_md(ndims, dims.data(), src_dt(), stag);
         case DNNL_ARG_DST:
-            return dnn_mem_t::init_md(ndims, dims.data(), ddt, dtag);
+            return dnn_mem_t::init_md(ndims, dims.data(), dst_dt(), dtag);
         default:
             assert(!"unsupported arg");
             return make_benchdnn_dnnl_wrapper<dnnl_memory_desc_t>(nullptr);
@@ -158,8 +166,7 @@ std::string prb_t::set_repro_line() {
     stringstream_t s;
     settings_t def;
 
-    s << "--sdt=" << sdt << " ";
-    s << "--ddt=" << ddt << " ";
+    s << "--dt=" << src_dt() << ":" << dst_dt() << " ";
     s << "--stag=" << stag << " ";
     s << "--dtag=" << dtag << " ";
 

--- a/tests/benchdnn/rnn/rnn.hpp
+++ b/tests/benchdnn/rnn/rnn.hpp
@@ -331,7 +331,7 @@ struct prb_t : public desc_t, public base_prb_t {
         if (mb) this->mb = mb;
         count_ops();
 
-        broadcast_vector(this->tag, 3);
+        broadcast_vector(this->tag, tag[0], 3);
 
         wei_scales = nullptr;
         wei_proj_scales = nullptr;

--- a/tests/benchdnn/sdpa/sdpa.hpp
+++ b/tests/benchdnn/sdpa/sdpa.hpp
@@ -130,10 +130,7 @@ struct prb_t : public prb_vdims_t, public base_prb_t {
         , scale_type(scale_type) {
 
         // Broadcast data types if needed: Q,K,V,DST
-        if (this->dt.size() == 1) {
-            const auto val = this->dt[0];
-            this->dt.assign(4, val);
-        }
+        broadcast_vector(this->dt, this->dt[0], 4);
 
         const auto &qdims = q_dims();
         const auto &kdims = k_dims();

--- a/tests/benchdnn/sum/sum.hpp
+++ b/tests/benchdnn/sum/sum.hpp
@@ -78,13 +78,10 @@ struct prb_t : public prb_dims_t, public base_prb_t {
         , dtag(dtag)
         , input_scales(input_scales) {
 
-        broadcast_vector(this->stag, n_inputs());
+        broadcast_vector(this->stag, stag[0], n_inputs());
 
         // Broadcast input_scale if needed
-        if (input_scales.size() == 1) {
-            const auto val = input_scales[0]; // Need a copy here.
-            this->input_scales.assign(n_inputs(), val);
-        }
+        broadcast_vector(this->input_scales, input_scales[0], n_inputs());
 
         repro = set_repro_line(); // must be last in ctor to collect right info
     }

--- a/tests/benchdnn/utils/numeric.cpp
+++ b/tests/benchdnn/utils/numeric.cpp
@@ -225,8 +225,8 @@ float round_to_nearest_representable(dnnl_data_type_t dt, float value) {
 
 #undef CASE_ALL
 
-bool is_subbyte_type(dnnl_data_type_t type) {
-    return type == dnnl_f4_e2m1 || type == dnnl_u4 || type == dnnl_s4;
+bool is_subbyte_type(dnnl_data_type_t dt) {
+    return bits_dt(dt) < 8;
 }
 
 size_t bits_dt(dnnl_data_type_t dt) {

--- a/tests/benchdnn/utils/prb.hpp
+++ b/tests/benchdnn/utils/prb.hpp
@@ -79,6 +79,21 @@ struct base_prb_t {
     const char *str() const { return repro.c_str(); }
 
 protected:
+    // Broadcasts a single-element vector `v` to `n_inputs` copies of `val`. If
+    // `v` already contains more than one element, it is left untouched.
+    // TODO: make `n_inputs` a `prb_t` method and drop it from the signature.
+    template <typename T>
+    void broadcast_vector(std::vector<T> &v, const T &val, const int n_inputs) {
+        // If it's not a single element in vector, nothing to broadcast.
+        if (v.size() != 1) return;
+
+        // std::vector<T>::assign invalidates all iterators and references.
+        // `this->stag.assign(prb_vdims.n_inputs(), stag[0]);` line can
+        // crash depending on the implementation whether it saves `stag[0]`
+        // before invalidating or not. Windows crashed.
+        v.assign(n_inputs, val);
+    }
+
     // Collects driver-specific reproducer information into a single line. Each
     // driver provides its own implementation and must call it last in the ctor
     // to assign the result to `repro`.

--- a/tests/benchdnn/utils/settings.hpp
+++ b/tests/benchdnn/utils/settings.hpp
@@ -142,19 +142,4 @@ struct base_settings_t {
     }
 };
 
-// TODO: move to prb.hpp when it appears.
-template <typename T>
-void broadcast_vector(std::vector<T> &v, const int n_inputs) {
-    // If it's not a single element in vector, nothing to broadcast.
-    if (v.size() != 1) return;
-
-    // std::vector<T>::assign invalidates all iterators and references.
-    // `this->stag.assign(prb_vdims.n_inputs(), stag[0]);` line can
-    // crash depending on the implementation whether it saves `stag[0]`
-    // before invalidating or not. Windows didn't.
-    //NOLINTNEXTLINE(performance-unnecessary-copy-initialization)
-    const auto val = v[0];
-    v.assign(n_inputs, val);
-}
-
 #endif


### PR DESCRIPTION
* Add support for `aby` meta-tag which scales transposed weights with any number of dimensions.
* Moved `broadcast_vector` method to `base_prb_t` as a better fit.
* Added `--dt=X:Y` support for reorder moving benchdnn towards a single command-line entry for data types.