### PR TITLE
Support block wise (per-K) wei scales in fp8 matmul

### DIFF
--- a/doc/functional_api/primitives/matmul.md
+++ b/doc/functional_api/primitives/matmul.md
@@ -193,6 +193,8 @@ run-time attributes in use.
      destination data type aren't supported.
    - Configurations with floating point source data type, integer weights data
      type and floating point destination data type are not optimized.
+   - Block-wise (K-grouped, e.g. `mask = (1 << 0) | (1 << 1)`) weights scales
+     require K group size to be a multiple of 16 elements.
    - The layout of dropout mask has to be exactly the same as that of dst.
 
 ## Performance Tips

--- a/src/cpu/x64/brgemm/brgemm.cpp
+++ b/src/cpu/x64/brgemm/brgemm.cpp
@@ -668,6 +668,13 @@ status_t brgemm_desc_finalize(brgemm_desc_t *brg) {
     if (!IMPLICATION(brg->dt_b == u8, brg->is_tmm))
         return status::unimplemented;
 
+    // Per-K (block-wise) scales and per-(M,N) compensation are applied to the
+    // partial result of every brgemm call. Only the AMX uker implements that
+    // for tile accumulators; the base kernel would silently drop them.
+    if (brg->is_tmm && !brg->can_dispatch_uker()
+            && (brg->has_per_k_scales() || brg->with_per_mn_compensation))
+        return status::unimplemented;
+
     // Required for EVEX encoding for offsets
     // The kernel brgemm_amx_uker_t has support of large offsets in post-ops
     if (!brg->can_dispatch_uker()) {

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -1688,9 +1688,11 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
 
         // For K-scales (wei and/or src), convert int32->float (if not
         // already done by per-MN compensation) and apply the current
-        // K-group's scales BEFORE alpha_beta accumulation.
+        // K-group's scales BEFORE alpha_beta accumulation. Non-integer
+        // accumulators (e.g. fp8/bf16 TMUL) are already f32.
         if (brg.has_per_k_scales() && !bi.skip_accumulation) {
-            if (!brg.with_per_mn_compensation) vcvtdq2ps(zmm, zmm);
+            if (brg.is_int8 && !brg.with_per_mn_compensation)
+                vcvtdq2ps(zmm, zmm);
 
             const Xbyak::Zmm scaled_zmm = vmm_mask(zmm, true, false, k_mask);
             // Apply K-wei_scales if present (pre-loaded per-ldb vector).
@@ -3546,8 +3548,12 @@ void jit_brgemm_amx_uker_base_t::generate() {
     // if beta == 1 and C datatype is f32 it is better to perform addition by
     // reading tiles directly from C instead of by reading/writing by vectors
     // ACE palette does not support tileloadd, so we must use vector path
+    // Per-K scales / per-(M,N) compensation must be applied to the current
+    // K-block's partial result only, so previous results must not be
+    // pre-loaded into the tile accumulators.
     may_load_accumulators_ = one_of(brg.alpha, 0.f, 1.f) && brg.beta == 1.f
-            && !brg.is_ace() && brg.dt_c == brg.dt_d
+            && !brg.is_ace() && brg.dt_c == brg.dt_d && !brg.has_per_k_scales()
+            && !brg.with_per_mn_compensation
             && IMPLICATION(brg.is_input_convert(), brg.is_fp8_via_convert())
             && IMPLICATION(
                     brg.is_f32 || brg.is_bf16, brg.dt_c == data_type::f32)

--- a/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul_utils.cpp
@@ -2137,14 +2137,18 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
         bgmmc.is_wei_scale_per_k = false;
     }
 
-    // Per-K weight scales are only applied for weight decompression (integer
-    // weights) and int8 grouped quantization. Other types (e.g. fp8) pass the
-    // check above (per_ocic/per_tensor also set the per-N bit) but the
-    // K-grouping would be ignored, so reject them here. A per-K group
-    // spanning all of K was already downgraded to per-N above.
+    // Per-K (block-wise) weight scales are applied at accumulation time by the
+    // brgemm epilogue, which requires an f32 accumulator. Plain int8 (s32
+    // accumulator) is therefore only supported through the grouped
+    // quantization path. A per-K group spanning all of K was already
+    // downgraded to per-N above.
+    const bool is_wei_scale_per_k_grouped
+            = bgmmc.is_wei_scale_per_k && !wei_scales.has_default_groups();
     VCONDCHECK_BG(IMPLICATION(bgmmc.is_wei_scale_per_k,
                           bgmmc.with_wei_decompression
-                                  || bgmmc.with_int8_grouped_quantization),
+                                  || bgmmc.with_int8_grouped_quantization
+                                  || (is_wei_scale_per_k_grouped
+                                          && bgmmc.acc_dt == f32)),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
 
     // Batched (3D/4D) per-batch scales/ZP have batch bits set in the mask.
@@ -2277,6 +2281,14 @@ status_t init_brgemm_matmul_conf(cpu_isa_t isa, brgemm_matmul_conf_t &bgmmc,
             : 1;
 
     VCONDCHECK_BG(bgmmc.required_k_granularity > 0, VERBOSE_BLOCKING_FAIL, "");
+
+    // Grouped per-K quantization parameters are applied in between brgemm
+    // calls, so a K-group must be expressible as a whole number of brgemm
+    // K blocks, which are themselves multiples of the VNNI granularity.
+    const dim_t per_k_group = compute_k_group(bgmmc);
+    VCONDCHECK_BG(IMPLICATION(per_k_group > 0 && per_k_group < bgmmc.K,
+                          per_k_group % bgmmc.required_k_granularity == 0),
+            VERBOSE_UNSUPPORTED_SCALES_CFG);
 
     bgmmc.wei_k_blk = get_wei_k_blk(bgmmc.wei_dt);
 

--- a/tests/benchdnn/inputs/matmul/harness_matmul_generated_ci
+++ b/tests/benchdnn/inputs/matmul/harness_matmul_generated_ci
@@ -5001,3 +5001,7 @@
 --reset --dt=f4_e2m1:f4_e2m1:bf16 --stag=ba --dtag=abx --strides=:64x1: --attr-scales=src:per_tensor:f8_e4m3:1x16+wei:per_oc:f16 --attr-post-ops=square 2x704:704x2
 --reset --dt=s8:u8:f16 --stag=abx --wtag=acb --dtag=abx --attr-scales=src:per_tensor:f16:1x256+wei:per_tensor:bf16:64x1 --attr-post-ops=ge:u8:common --bia-dt=f32 --bia_mask=2 2x120x1280:1x1280x1708
 --reset --dt=bf16:bf16:f32 --stag=abx --wtag=abx --dtag=abx --attr-post-ops=ge:s32:per_oc 636x308:308x700
+--reset --dt=f8_e5m2:f8_e4m3:bf16 --stag=abx --dtag=abx --attr-scales=src:host_scalar:4:f32+wei:per_oc:f32 --bia-dt=bf16 2048x4096:4096x24
+--reset --dt=f8_e5m2:f8_e5m2:f32 --stag=abx --wtag=ba --dtag=abx --attr-scales=src:common:4:f32+wei:per_tensor:f16:256x1 --attr-post-ops=ge:s8:per_oc 15x256:256x1764
+--reset --dt=f8_e5m2:f8_e4m3:f32 --stag=abx --strides=::32768x512x16x1 --attr-scales=src:host_scalar:4:f16+wei:per_oc:bf16 2x1x4x128:1x3x128x4
+--reset --dt=f8_e5m2:f8_e4m3:f32 --stag=abx --wtag=abx --dtag=abx --attr-scales=src:common:4:bf16+wei:per_tensor:f32:32x1 8x128:128x2048


### PR DESCRIPTION
Fixes [MFDNN-15516](https://jira.devtools.intel.com/browse/MFDNN-15516)

Block wise scales are needed to quantize Qwen3.5 in PyTorch/SGLang. 

The logic was already implemented but [disabled](https://github.com/uxlfoundation/oneDNN/pull/5550) because of the bug with unconditional use of vcvtdq2ps even when data is already fp32. This PR fixes the bug, enables fp8 block-wise weight back and adds new test cases to cover it.

TODO: run validation after test coverage is updated
