### PR TITLE
[GPU] Use SYCL profiling tags for async verbose profiling in SYCL streams

### DIFF
--- a/cmake/SYCL.cmake
+++ b/cmake/SYCL.cmake
@@ -190,3 +190,28 @@ if(DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER)
 "SYCL implementation does not support OpenCL kernel compiler extension. Make sure that SYCL and OCLOC are correctly installed.")
     endif()
 endif()
+
+if(DNNL_EXPERIMENTAL_ENABLE_SYCL_PROFILING_TAG AND DNNL_VERBOSE AND DNNL_GPU_SYCL)
+    include(CheckCXXSourceCompiles)
+    set(CHECK_DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG_SOURCE
+    "
+        #include <sycl/sycl.hpp>
+        #ifndef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
+        #error sycl_ext_oneapi_profiling_tag not supported
+        #endif
+        int main() {
+            sycl::queue q;
+            sycl::ext::oneapi::experimental::submit_profiling_tag(q);
+            return 0;
+        }
+    ")
+    CHECK_CXX_SOURCE_COMPILES(
+        "${CHECK_DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG_SOURCE}"
+        DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG)
+    if(DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG)
+        add_definitions(-DDNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG)
+    else()
+        message(STATUS "sycl_ext_oneapi_profiling_tag extension is not available 
+        - verbose profiler will be paused without a profiling-enabled SYCL queue")
+    endif()
+endif()

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -200,6 +200,11 @@ onednn_option(EXPERIMENTAL_SYCL_KERNEL_COMPILER OFF
     "Enables experimental SYCL OpenCL kernel compiler extension. This option
     works independently from DNNL_EXPERIMENTAL.")
 
+onednn_option(EXPERIMENTAL_ENABLE_SYCL_PROFILING_TAG OFF
+    "Enable use of the experimental sycl_ext_oneapi_profiling_tag extension 
+    for verbose profiling. When disabled, verbose profiling requires a 
+    profiling-enabled SYCL queue to function.")
+
 # -------------------
 # Debug and profiling
 # -------------------

--- a/doc/advanced_topics/experimental.md
+++ b/doc/advanced_topics/experimental.md
@@ -44,13 +44,14 @@ Both kinds of experimental features can be enabled simultaneously.
 | ONEDNN_EXPERIMENTAL_BNORM_STATS_ONE_PASS | Calculate mean and variance in batch normalization(BN) in single pass ([RFC](https://github.com/uxlfoundation/oneDNN/tree/rfcs/rfcs/20210519-single-pass-bnorm)). |
 | ONEDNN_EXPERIMENTAL_GPU_CONV_V2          | Enable shapeless GPU convolution implementation (the feature is under development).                                                                            |
 
-| Build time option                        | Description                                                      |
-|:-----------------------------------------|:-----------------------------------------------------------------|
-| ONEDNN_EXPERIMENTAL_UKERNEL              | Enable experimental microkernel APIs and functionalities.        |
-| ONEDNN_EXPERIMENTAL_PROFILING            | Enable experimental profiling API.                               |
-| ONEDNN_EXPERIMENTAL_LOGGING              | Enable experimental logging support for oneDNN verbose mode.     |
-| ONEDNN_EXPERIMENTAL_SYCL_KERNEL_COMPILER | Enable SYCL OpenCL online kernel compiler extension.             |
-| ONEDNN_EXPERIMENTAL_GROUPED_MEMORY       | Enable grouped memory format and grouped GEMM for MoE workloads. |
+| Build time option                             | Description                                                      |
+|:----------------------------------------------|:-----------------------------------------------------------------|
+| ONEDNN_EXPERIMENTAL_UKERNEL                   | Enable experimental microkernel APIs and functionalities.        |
+| ONEDNN_EXPERIMENTAL_PROFILING                 | Enable experimental profiling API.                               |
+| ONEDNN_EXPERIMENTAL_LOGGING                   | Enable experimental logging support for oneDNN verbose mode.     |
+| ONEDNN_EXPERIMENTAL_SYCL_KERNEL_COMPILER      | Enable SYCL OpenCL online kernel compiler extension.             |
+| ONEDNN_EXPERIMENTAL_GROUPED_MEMORY            | Enable grouped memory format and grouped GEMM for MoE workloads. |
+| ONEDNN_EXPERIMENTAL_ENABLE_SYCL_PROFILING_TAG | Enable use of SYCL profiling tags with asynchronous verbose mode |
 
 ## Features details
 
@@ -177,3 +178,28 @@ The runtime controls for oneDNN logging are listed as follows:
 This option enables the experimental SYCL OpenCL online kernel compiler,
 allowing OpenCL kernels to be compiled without directly invoking the OpenCL
 runtime.
+
+### ONEDNN_EXPERIMENTAL_ENABLE_SYCL_PROFILING_TAG
+
+This build-time option enables asynchronous verbose profiling for oneDNN
+with SYCL runtimes using the [``sycl_ext_oneapi_profiling_tag()``](
+https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_profiling_tag.asciidoc) 
+extension.
+
+By default, asynchronous verbose profiling relies on a profiling-enabled
+SYCL queue (created with ``sycl::property::queue::enable_profiling``) to
+query timing information from queued SYCL events.
+
+The ``sycl_ext_oneapi_profiling_tag`` extension removes this requirement,
+allowing verbose profiling to function seamlessly even when queue profiling
+is not enabled, by submitting lightweight profiling tags to bracket kernel
+execution.
+
+When this option is active, the verbose profiler behaves as follows:
+
+- If the ``sycl_ext_oneapi_profiling_tag`` extension is available, SYCL
+  profiling tags are used to measure and log kernel execution times.
+- If the extension is not available but the queue has profiling enabled,
+  the profiler falls back to standard queue-based profiling.
+- If neither mechanism is available, the profiler is disabled with a
+  warning and execution times will not be reported in verbose output.

--- a/doc/performance/verbose.md
+++ b/doc/performance/verbose.md
@@ -146,8 +146,19 @@ synchronization on entry and on exit in the `dnnl::primitive::execute()` call.
 To ensure accurate tracking of timing information for GPU runtimes, the verbose
 mode uses a non-blocking approach which prints device-measured
 times for primitive execution instead of relying on the wall time
-measurements. Asynchronous profiling is currently supported only for OpenCL
-and SYCL runtimes on Intel GPUs.
+measurements. Asynchronous profiling is currently supported for OpenCL, SYCL 
+and L0 runtimes on Intel GPUs.
+
+@note
+For OpenCL and SYCL runtimes, asynchronous verbose profiling requires queue
+profiling to be enabled on the stream's queue. If queue profiling is not
+enabled, verbose profiling is silently disabled for the stream and no profiling
+logs are emitted. For SYCL, this restriction can be lifted by building with
+`-DDNNL_EXPERIMENTAL_ENABLE_SYCL_PROFILING_TAG=ON`, which uses the experimental
+`sycl_ext_oneapi_profiling_tag` extension to enable profiling on any SYCL queue
+regardless of whether queue profiling was enabled at queue creation time. Note
+that this extension is experimental and its availability is not guaranteed
+across all SYCL toolkit versions.
 
 ### Understanding why a given implementation is dispatched
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,10 @@ if(DNNL_EXPERIMENTAL_SYCL_KERNEL_COMPILER)
     message(STATUS "Experimental SYCL OpenCL kernel compiler is enabled")
 endif()
 
+if(DNNL_EXPERIMENTAL_ENABLE_SYCL_PROFILING_TAG)
+    message(STATUS "Experimental SYCL profiling tag extension is enabled for verbose profiling")
+endif()
+
 if(DNNL_ENABLE_ITT_TASKS AND NOT DNNL_CPU_RUNTIME STREQUAL "NONE")
     # Only supported for certain architectures (see src/common/CMakeLists.txt)
     if(DNNL_TARGET_ARCH STREQUAL "AARCH64" OR DNNL_TARGET_ARCH STREQUAL "X64")

--- a/src/gpu/intel/sycl/interop_kernel.cpp
+++ b/src/gpu/intel/sycl/interop_kernel.cpp
@@ -123,6 +123,20 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
     CHECK(check_scalar_arguments(arg_list));
     CHECK(check_alignment(arg_list));
 
+    xpu::sycl::verbose_profiler_t *vp = nullptr;
+    if (stream.is_verbose_profiler_enabled()) {
+        vp = utils::downcast<xpu::sycl::verbose_profiler_t *>(
+                gpu_stream->verbose_profiler());
+    }
+
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+    const bool use_tag = vp && vp->use_ext_oneapi_tag();
+    ::sycl::event start_tag, end_tag;
+    if (use_tag)
+        start_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
+                queue);
+#endif
+
     auto event = queue.submit([&](::sycl::handler &cgh) {
         cgh.depends_on(xpu::sycl::event_t::from(deps).events);
         for (int i = 0; i < arg_list.nargs(); ++i) {
@@ -179,6 +193,12 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
         }
     });
 
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+    if (use_tag)
+        end_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
+                queue);
+#endif
+
     // Event registration for profilers - carried out separately for each
     // profiler
     if (stream.is_profiling_enabled()) {
@@ -187,10 +207,16 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
                         std::vector<::sycl::event> {event}));
     }
 
-    if (stream.is_verbose_profiler_enabled()) {
-        gpu_stream->verbose_profiler()->register_event(
-                std::make_shared<xpu::sycl::event_t>(
-                        std::vector<::sycl::event> {event}));
+    if (vp) {
+        auto ev = std::make_shared<xpu::sycl::event_t>(
+                std::vector<::sycl::event> {event});
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+        if (use_tag) {
+            ev->start_tag_ = start_tag;
+            ev->end_tag_ = end_tag;
+        }
+#endif
+        vp->register_event(ev);
     }
 
     xpu::sycl::event_t::from(out_dep).events = {std::move(event)};

--- a/src/gpu/intel/sycl/interop_kernel.cpp
+++ b/src/gpu/intel/sycl/interop_kernel.cpp
@@ -129,7 +129,7 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
                 gpu_stream->verbose_profiler());
     }
 
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
     const bool use_tag = vp && vp->use_ext_oneapi_tag();
     ::sycl::event start_tag, end_tag;
     if (use_tag)
@@ -193,7 +193,7 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
         }
     });
 
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
     if (use_tag)
         end_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
                 queue);
@@ -210,7 +210,7 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
     if (vp) {
         auto ev = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {event});
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
         if (use_tag) { ev->event_tags_.emplace_back(start_tag, end_tag); }
 #endif
         vp->register_event(ev);

--- a/src/gpu/intel/sycl/interop_kernel.cpp
+++ b/src/gpu/intel/sycl/interop_kernel.cpp
@@ -211,10 +211,7 @@ status_t interop_kernel_t::parallel_for(impl::stream_t &stream,
         auto ev = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {event});
 #ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
-        if (use_tag) {
-            ev->start_tag_ = start_tag;
-            ev->end_tag_ = end_tag;
-        }
+        if (use_tag) { ev->event_tags_.emplace_back(start_tag, end_tag); }
 #endif
         vp->register_event(ev);
     }

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -99,7 +99,7 @@ status_t stream_t::init() {
 
         const bool queue_has_profiling = queue().has_property<
                 ::sycl::property::queue::enable_profiling>();
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
         const bool use_tag = queue().get_device().has(
                 ::sycl::aspect::ext_oneapi_queue_profiling_tag);
 #else

--- a/src/gpu/intel/sycl/stream.cpp
+++ b/src/gpu/intel/sycl/stream.cpp
@@ -93,14 +93,30 @@ status_t stream_t::init() {
     if (is_verbose_profiler_enabled()) {
         verbose_profiler_.set(
                 utils::make_unique<xpu::sycl::verbose_profiler_t>(this));
-        // Check if the queue has profiling enabled and pause the verbose
-        // profiler if it does not. Verbose lines are still emitted during
-        // logging, but without execution timing information.
+
+        auto *vp = utils::downcast<xpu::sycl::verbose_profiler_t *>(
+                verbose_profiler());
+
         const bool queue_has_profiling = queue().has_property<
                 ::sycl::property::queue::enable_profiling>();
-        if (!queue_has_profiling) {
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+        const bool use_tag = queue().get_device().has(
+                ::sycl::aspect::ext_oneapi_queue_profiling_tag);
+#else
+        const bool use_tag = false;
+#endif
+        vp->set_use_ext_oneapi_tag(use_tag);
+        // Verbose profiling relies on SYCL profiling tags to query profiling
+        // info from queued events for exec time computation.
+        // If the sycl_ext_oneapi_profiling_tag is not supported, the profiler
+        // falls back to using a profiling-enabled queue for the same purpose.
+        // If neither are available, the profiling is paused - verbose lines
+        // are still emitted during logging, but without execution timing
+        // information.
+        if (!queue_has_profiling && !use_tag) {
             VWARN(primitive, exec,
-                    "SYCL queue does not have profiling enabled. "
+                    "SYCL queue does not have profiling enabled and "
+                    "sycl_ext_oneapi_profiling_tag is not supported. "
                     "Verbose profiling is paused and execution times "
                     "will not be reported.");
             verbose_profiler()->pause_profiling();
@@ -126,7 +142,15 @@ void stream_t::before_exec_hook() {
                         .get());
         const bool queue_has_profiling = queue().has_property<
                 ::sycl::property::queue::enable_profiling>();
-        if (!queue_has_profiling) { profiler->pause_profiling(); }
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
+        const bool use_tag = queue().get_device().has(
+                ::sycl::aspect::ext_oneapi_queue_profiling_tag);
+#else
+        const bool use_tag = false;
+#endif
+        profiler->set_use_ext_oneapi_tag(use_tag);
+        const bool use_profiler = (queue_has_profiling || use_tag);
+        if (!use_profiler) { profiler->pause_profiling(); }
 
         // Device event profiling and SYCL graph recording are incompatible
         // because the graph execution creates a different execution context
@@ -140,10 +164,10 @@ void stream_t::before_exec_hook() {
         // graph is recording and resume thereafter to avoid runtime exceptions.
         // In this scenario, the profiler will report zero execution time for
         // the logged primitives.
-        if (!recording() && queue_has_profiling) {
+        if (!recording() && use_profiler) {
             profiler->start_profiling();
         } else {
-            if (profiler->is_active() && queue_has_profiling) {
+            if (profiler->is_active() && use_profiler) {
                 VWARN(primitive, exec,
                         "SYCL graph recording active - verbose profiling will "
                         "show zero "

--- a/src/gpu/intel/sycl/stream.hpp
+++ b/src/gpu/intel/sycl/stream.hpp
@@ -99,13 +99,14 @@ struct stream_t : public gpu::intel::stream_t {
     status_t copy(const memory_storage_t &src, const memory_storage_t &dst,
             size_t size, const xpu::event_t &deps,
             xpu::event_t &out_dep) override {
-        return impl()->copy(
-                this, src, dst, size, deps, out_dep, profiler_.get());
+        return impl()->copy(this, src, dst, size, deps, out_dep,
+                profiler_.get(), verbose_profiler());
     }
 
     status_t fill(const memory_storage_t &dst, uint8_t pattern, size_t size,
             const xpu::event_t &deps, xpu::event_t &out_dep) override {
-        return impl()->fill(dst, pattern, size, deps, out_dep, profiler_.get());
+        return impl()->fill(dst, pattern, size, deps, out_dep, profiler_.get(),
+                verbose_profiler());
     }
 
     status_t barrier() override { return impl()->barrier(); }

--- a/src/xpu/sycl/context.hpp
+++ b/src/xpu/sycl/context.hpp
@@ -63,6 +63,11 @@ struct event_t : public xpu::event_t {
     }
 
     std::vector<::sycl::event> events;
+
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+    ::sycl::event start_tag_;
+    ::sycl::event end_tag_;
+#endif
 };
 
 struct context_t final : public xpu::context_t {

--- a/src/xpu/sycl/context.hpp
+++ b/src/xpu/sycl/context.hpp
@@ -64,7 +64,7 @@ struct event_t : public xpu::event_t {
 
     std::vector<::sycl::event> events;
 
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
     std::vector<std::pair<::sycl::event, ::sycl::event>> event_tags_;
 #endif
 };

--- a/src/xpu/sycl/context.hpp
+++ b/src/xpu/sycl/context.hpp
@@ -65,8 +65,7 @@ struct event_t : public xpu::event_t {
     std::vector<::sycl::event> events;
 
 #ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
-    ::sycl::event start_tag_;
-    ::sycl::event end_tag_;
+    std::vector<std::pair<::sycl::event, ::sycl::event>> event_tags_;
 #endif
 };
 

--- a/src/xpu/sycl/stream_impl.cpp
+++ b/src/xpu/sycl/stream_impl.cpp
@@ -82,6 +82,16 @@ status_t stream_impl_t::copy(impl::stream_t *stream,
     bool usm_dst = sycl_dst->memory_kind() == xpu::sycl::memory_kind::usm;
     ::sycl::event e;
 
+    auto *vp = static_cast<xpu::sycl::verbose_profiler_t *>(verbose_profiler);
+
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+    const bool use_tag = vp && vp->use_ext_oneapi_tag();
+    ::sycl::event start_tag, end_tag;
+    if (use_tag)
+        start_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
+                *queue());
+#endif
+
     if (usm_src && usm_dst) {
         auto *usm_src
                 = utils::downcast<const xpu::sycl::usm_memory_storage_t *>(
@@ -137,6 +147,12 @@ status_t stream_impl_t::copy(impl::stream_t *stream,
         });
     }
 
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+    if (use_tag)
+        end_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
+                *queue());
+#endif
+
     // Event registration for profilers is managed to allow the
     // verbose_profiler_t operate independently from other profilers without
     // forced profiling flags or double-move issues.
@@ -149,6 +165,12 @@ status_t stream_impl_t::copy(impl::stream_t *stream,
     if (verbose_profiler) {
         auto verbose_event = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {e});
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+        if (use_tag) {
+            verbose_event->start_tag_ = start_tag;
+            verbose_event->end_tag_ = end_tag;
+        }
+#endif
         verbose_profiler->register_event(verbose_event);
     }
 
@@ -166,6 +188,16 @@ status_t stream_impl_t::fill(const memory_storage_t &dst, uint8_t pattern,
     bool usm = sycl_dst->memory_kind() == xpu::sycl::memory_kind::usm;
 
     ::sycl::event out_event;
+
+    auto *vp = static_cast<xpu::sycl::verbose_profiler_t *>(verbose_profiler);
+
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+    const bool use_tag = vp && vp->use_ext_oneapi_tag();
+    ::sycl::event start_tag, end_tag;
+    if (use_tag)
+        start_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
+                *queue());
+#endif
 
     if (usm) {
         auto *usm_dst
@@ -193,6 +225,12 @@ status_t stream_impl_t::fill(const memory_storage_t &dst, uint8_t pattern,
         });
     }
 
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+    if (use_tag)
+        end_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
+                *queue());
+#endif
+
     // Event registration for profilers is managed to allow the
     // verbose_profiler_t operate independently from other profilers without
     // forced profiling flags or double-move issues.
@@ -205,6 +243,12 @@ status_t stream_impl_t::fill(const memory_storage_t &dst, uint8_t pattern,
     if (verbose_profiler) {
         auto verbose_event = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {out_event});
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+        if (use_tag) {
+            verbose_event->start_tag_ = start_tag;
+            verbose_event->end_tag_ = end_tag;
+        }
+#endif
         verbose_profiler->register_event(verbose_event);
     }
     xpu::sycl::event_t::from(out_dep).events = {out_event};

--- a/src/xpu/sycl/stream_impl.cpp
+++ b/src/xpu/sycl/stream_impl.cpp
@@ -84,7 +84,7 @@ status_t stream_impl_t::copy(impl::stream_t *stream,
 
     auto *vp = static_cast<xpu::sycl::verbose_profiler_t *>(verbose_profiler);
 
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
     const bool use_tag = vp && vp->use_ext_oneapi_tag();
     ::sycl::event start_tag, end_tag;
     if (use_tag)
@@ -147,7 +147,7 @@ status_t stream_impl_t::copy(impl::stream_t *stream,
         });
     }
 
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
     if (use_tag)
         end_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
                 *queue());
@@ -165,7 +165,7 @@ status_t stream_impl_t::copy(impl::stream_t *stream,
     if (vp) {
         auto verbose_event = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {e});
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
         if (use_tag) {
             verbose_event->event_tags_.emplace_back(start_tag, end_tag);
         }
@@ -190,7 +190,7 @@ status_t stream_impl_t::fill(const memory_storage_t &dst, uint8_t pattern,
 
     auto *vp = static_cast<xpu::sycl::verbose_profiler_t *>(verbose_profiler);
 
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
     const bool use_tag = vp && vp->use_ext_oneapi_tag();
     ::sycl::event start_tag, end_tag;
     if (use_tag)
@@ -224,7 +224,7 @@ status_t stream_impl_t::fill(const memory_storage_t &dst, uint8_t pattern,
         });
     }
 
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
     if (use_tag)
         end_tag = ::sycl::ext::oneapi::experimental::submit_profiling_tag(
                 *queue());
@@ -242,7 +242,7 @@ status_t stream_impl_t::fill(const memory_storage_t &dst, uint8_t pattern,
     if (vp) {
         auto verbose_event = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {out_event});
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
         if (use_tag) {
             verbose_event->event_tags_.emplace_back(start_tag, end_tag);
         }

--- a/src/xpu/sycl/stream_impl.cpp
+++ b/src/xpu/sycl/stream_impl.cpp
@@ -162,13 +162,12 @@ status_t stream_impl_t::copy(impl::stream_t *stream,
         stream_profiler->register_event(std::move(profiler_event));
     }
 
-    if (verbose_profiler) {
+    if (vp) {
         auto verbose_event = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {e});
 #ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
         if (use_tag) {
-            verbose_event->start_tag_ = start_tag;
-            verbose_event->end_tag_ = end_tag;
+            verbose_event->event_tags_.emplace_back(start_tag, end_tag);
         }
 #endif
         verbose_profiler->register_event(verbose_event);
@@ -240,13 +239,12 @@ status_t stream_impl_t::fill(const memory_storage_t &dst, uint8_t pattern,
         stream_profiler->register_event(std::move(profiler_event));
     }
 
-    if (verbose_profiler) {
+    if (vp) {
         auto verbose_event = std::make_shared<xpu::sycl::event_t>(
                 std::vector<::sycl::event> {out_event});
 #ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
         if (use_tag) {
-            verbose_event->start_tag_ = start_tag;
-            verbose_event->end_tag_ = end_tag;
+            verbose_event->event_tags_.emplace_back(start_tag, end_tag);
         }
 #endif
         verbose_profiler->register_event(verbose_event);

--- a/src/xpu/sycl/stream_impl.hpp
+++ b/src/xpu/sycl/stream_impl.hpp
@@ -22,7 +22,7 @@
 #include "common/utils.hpp"
 
 #include "xpu/context.hpp"
-#include "xpu/stream_profiler.hpp"
+#include "xpu/sycl/stream_profiler.hpp"
 
 #include "xpu/sycl/compat.hpp"
 #include "xpu/sycl/context.hpp"

--- a/src/xpu/sycl/stream_profiler.cpp
+++ b/src/xpu/sycl/stream_profiler.cpp
@@ -117,10 +117,13 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
         // moment the end tag began executing, which tightly bounds the
         // kernel execution time.
         if (use_ext_oneapi_tag()) {
-            uint64_t ev_start = sycl_ev.start_tag_.get_profiling_info<
-                    event_profiling::command_end>();
-            uint64_t ev_end = sycl_ev.end_tag_.get_profiling_info<
-                    event_profiling::command_start>();
+            assert(sycl_ev.event_tags_.size() == sycl_ev.events.size());
+            uint64_t ev_start = sycl_ev.event_tags_[0]
+                                        .first.get_profiling_info<
+                                                event_profiling::command_end>();
+            uint64_t ev_end = sycl_ev.event_tags_[last_idx]
+                                      .second.get_profiling_info<
+                                              event_profiling::command_start>();
             agg_start = std::min(agg_start, ev_start);
             agg_end = std::max(agg_end, ev_end);
         } else

--- a/src/xpu/sycl/stream_profiler.cpp
+++ b/src/xpu/sycl/stream_profiler.cpp
@@ -74,7 +74,6 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
         size_t index, double &duration_ms) const {
     if (!active_) return status::success;
 
-    using namespace ::sycl::info;
     if (index >= profiling_data_.size()) {
         VERROR(primitive, exec,
                 "profiling error: invalid index %zu, profiling_data size is "
@@ -98,19 +97,45 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
     // and the end time of the last primitive event
     for (const auto &ev : evts) {
         if (!ev) continue;
+        const auto &sycl_ev = xpu::sycl::event_t::from(*ev);
+        assert(sycl_ev.size() > 0);
+        size_t last_idx = sycl_ev.size() - 1;
 
-        const auto &sycl_event = xpu::sycl::event_t::from(*ev);
-        assert(sycl_event.size() > 0);
-        size_t last_idx = sycl_event.size() - 1;
-
-        auto evbeg
-                = sycl_event[0]
-                          .get_profiling_info<event_profiling::command_start>();
-        auto evend
-                = sycl_event[last_idx]
-                          .get_profiling_info<event_profiling::command_end>();
-        agg_start = std::min(agg_start, evbeg);
-        agg_end = std::max(agg_end, evend);
+        using namespace ::sycl::info;
+#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
+        // When using the SYCL profiling trags, elapsed time is measured
+        // between two bracketing tag events that wrap all kernels:
+        // - a "start" tag submitted just before the first kernel
+        // - an "end" tag submitted just after the last kernel.
+        //
+        // event queue: ... |start_tag| |kernel| |end_tag| ...
+        //
+        // Per the sycl_ext_oneapi_profiling_tag spec, the time for the
+        // kernel event completion is calculated from:
+        // (start_tag.command_end - end_tag.command_start)
+        // i.e. from the moment the start tag finished executing to the
+        // moment the end tag began executing, which tightly bounds the
+        // kernel execution time.
+        if (use_ext_oneapi_tag()) {
+            uint64_t ev_start = sycl_ev.start_tag_.get_profiling_info<
+                    event_profiling::command_end>();
+            uint64_t ev_end = sycl_ev.end_tag_.get_profiling_info<
+                    event_profiling::command_start>();
+            agg_start = std::min(agg_start, ev_start);
+            agg_end = std::max(agg_end, ev_end);
+        } else
+#endif
+        {
+            uint64_t ev_start
+                    = sycl_ev.events[0]
+                              .get_profiling_info<
+                                      event_profiling::command_start>();
+            uint64_t ev_end = sycl_ev.events[last_idx]
+                                      .get_profiling_info<
+                                              event_profiling::command_end>();
+            agg_start = std::min(agg_start, ev_start);
+            agg_end = std::max(agg_end, ev_end);
+        }
     }
 
     if (agg_end < agg_start) { return status::runtime_error; }

--- a/src/xpu/sycl/stream_profiler.cpp
+++ b/src/xpu/sycl/stream_profiler.cpp
@@ -102,8 +102,8 @@ status_t verbose_profiler_t::get_aggregate_exec_time(
         size_t last_idx = sycl_ev.size() - 1;
 
         using namespace ::sycl::info;
-#ifdef SYCL_EXT_ONEAPI_PROFILING_TAG
-        // When using the SYCL profiling trags, elapsed time is measured
+#ifdef DNNL_USE_SYCL_EXT_ONEAPI_PROFILING_TAG
+        // When using the SYCL profiling tags, elapsed time is measured
         // between two bracketing tag events that wrap all kernels:
         // - a "start" tag submitted just before the first kernel
         // - an "end" tag submitted just after the last kernel.

--- a/src/xpu/sycl/stream_profiler.hpp
+++ b/src/xpu/sycl/stream_profiler.hpp
@@ -36,7 +36,7 @@ struct stream_profiler_t : public xpu::stream_profiler_t {
 
 struct verbose_profiler_t : public xpu::verbose_profiler_t {
     verbose_profiler_t(const impl::stream_t *stream)
-        : xpu::verbose_profiler_t(stream) {}
+        : xpu::verbose_profiler_t(stream), use_ext_oneapi_tag_(false) {}
 
     ~verbose_profiler_t() override { cleanup(); }
 
@@ -48,6 +48,12 @@ struct verbose_profiler_t : public xpu::verbose_profiler_t {
 
     void wait_for_event_completion(
             const std::shared_ptr<xpu::event_t> &event) const override;
+
+    bool use_ext_oneapi_tag() const { return use_ext_oneapi_tag_; }
+    void set_use_ext_oneapi_tag(bool flag) { use_ext_oneapi_tag_ = flag; }
+
+private:
+    bool use_ext_oneapi_tag_;
 };
 
 } // namespace sycl


### PR DESCRIPTION
# Description

When asynchronous verbose profiling is enabled in GPU streams, it requires the SYCL/OpenCL queues to have profiling properties enabled in order to query profiling info from the queued events. 
To avoid throwing querying exceptions, the profiler check for queue profiling during stream initialization and pauses operations if it is not enabled. 
Since enabling querying properties by default can add performance overhead, this PR adds an option to use SYCL `sycl_ext_oneapi_profiling_tag` for SYCL stream which allows querying profiling info from tagged events without needing the queue profiling to be enabled by default.

Addresses [MFDNN-15492](https://jira.devtools.intel.com/browse/MFDNN-15492).
