### PR TITLE
Add AVX-512 backend to IR emitter and bf16/f16 support to IR GEMV

### DIFF
--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -309,11 +309,11 @@ void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     const ir::vreg_t x = ir.new_vec(cfg.dt_x);
     const ir::vreg_t a = ir.new_vec(cfg.dt_a);
     ir.prefetch(x_ptr, gemv_pf_dist);
-    ir.vload(x, x_ptr, 0);
+    ir.vload(x, x_ptr, 0, cfg.dt_x);
     for (int i = 0; i < (int)acc.size(); i++) {
         const dim_t a_off = cfg.dt_sz_a * (dim_t)i * cfg.lda;
         ir.prefetch(a_ptr, a_off + gemv_pf_dist);
-        ir.vload(a, a_ptr, a_off);
+        ir.vload(a, a_ptr, a_off, cfg.dt_a);
         ir.vdot(acc[i], a, x);
     }
 }
@@ -326,9 +326,10 @@ void emit_microkernel_tail(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         ir::vreg_t mask) {
     const ir::vreg_t x = ir.new_vec(cfg.dt_x);
     const ir::vreg_t a = ir.new_vec(cfg.dt_a);
-    ir.vload_masked(x, x_ptr, 0, mask);
+    ir.vload_masked(x, x_ptr, 0, mask, cfg.dt_x);
     for (int i = 0; i < (int)acc.size(); i++) {
-        ir.vload_masked(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda, mask);
+        ir.vload_masked(
+                a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda, mask, cfg.dt_a);
         ir.vdot(acc[i], a, x);
     }
 }
@@ -393,7 +394,7 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             ir.vzero(acc[r]);
         else
             ir.vload_scalar(acc[r], regs.advancing.y_ptr,
-                    cfg.dt_sz_y * (dim_t)r * cfg.incy);
+                    cfg.dt_sz_y * (dim_t)r * cfg.incy, cfg.dt_y);
     }
 
     // Batch reduction over bs dimension
@@ -431,7 +432,8 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         if (cfg.with_src_scales) {
             // Loaded once and applied to every output.
             const ir::vreg_t sc = ir.new_vec(cfg.dt_src_scales);
-            ir.vload_scalar(sc, regs.invariant.src_scale_ptr, 0);
+            ir.vload_scalar(
+                    sc, regs.invariant.src_scale_ptr, 0, cfg.dt_src_scales);
 
             for (int r = 0; r < m_block; r++)
                 ir.vmul(acc[r], sc);
@@ -442,12 +444,13 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             // loop. The per-N case loads a separate scale per output element.
             const ir::vreg_t sc = ir.new_vec(cfg.dt_wei_scales);
             if (cfg.single_wei_scale)
-                ir.vload_scalar(sc, regs.advancing.wei_scale_ptr, 0);
+                ir.vload_scalar(
+                        sc, regs.advancing.wei_scale_ptr, 0, cfg.dt_wei_scales);
 
             for (int r = 0; r < m_block; r++) {
                 if (!cfg.single_wei_scale)
                     ir.vload_scalar(sc, regs.advancing.wei_scale_ptr,
-                            cfg.dt_sz_wei_scales * (dim_t)r);
+                            cfg.dt_sz_wei_scales * (dim_t)r, cfg.dt_wei_scales);
                 ir.vmul(acc[r], sc);
             }
         }
@@ -457,12 +460,12 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             // loop. A row output loads a separate bias per output element.
             const ir::vreg_t bias = ir.new_vec(cfg.dt_bias);
             if (!cfg.treat_y_as_row)
-                ir.vload_scalar(bias, regs.advancing.bias_ptr, 0);
+                ir.vload_scalar(bias, regs.advancing.bias_ptr, 0, cfg.dt_bias);
 
             for (int r = 0; r < m_block; r++) {
                 if (cfg.treat_y_as_row)
                     ir.vload_scalar(bias, regs.advancing.bias_ptr,
-                            cfg.dt_sz_bias * (dim_t)r);
+                            cfg.dt_sz_bias * (dim_t)r, cfg.dt_bias);
                 ir.vadd(acc[r], bias);
             }
         }
@@ -485,7 +488,7 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
 
     for (int r = 0; r < m_block; r++)
         ir.vstore_scalar(regs.advancing.store_ptr,
-                cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r]);
+                cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r], cfg.dt_y);
 
     // Advance to next M block
     ir.add_imm(regs.advancing.a_off, cfg.mblk_a_off);

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -66,8 +66,11 @@ namespace {
 //   m_block      - M rows per full block
 //   k_block      - K elements reduced per K block
 //   dt_sz_a/x/y  - element size in bytes of A, x, and y
-//   dt_a/x/y     - element data type of A, x, and y. Tags the vec vregs so the
-//                  emitter lowers each op to its dtype-specific instruction.
+//   dt_a/x/y     - element data type of A, x, and y in memory
+//   dt_a_reg / dt_x_reg - data type of the vec vreg holding A and x. It is the
+//                  memory type when the reduction consumes it as it is, and
+//                  f32 when the load converts. Paired with `k_block`, which is
+//                  the element count that follows from the same choice.
 //   dt_acc       - accumulation data type
 //   beta         - output scaling: 0 overwrites y, 1 accumulates into y
 //   m_blocks     - number of full M blocks
@@ -109,6 +112,8 @@ struct brgemv_ir_conf_t {
         , dt_a(brg.dt_a)
         , dt_x(brg.dt_b)
         , dt_y(brg.dt_c)
+        , dt_a_reg(brg.gemv_use_vdpbf16ps() ? brg.dt_a : data_type::f32)
+        , dt_x_reg(brg.gemv_use_vdpbf16ps() ? brg.dt_b : data_type::f32)
         , dt_acc(data_type::f32)
         , beta(brg.beta)
         , m_blocks(m / m_block)
@@ -140,7 +145,9 @@ struct brgemv_ir_conf_t {
     const dim_t max_bs;
     const int m_block, k_block;
     const int dt_sz_a, dt_sz_x, dt_sz_y;
-    const data_type_t dt_a, dt_x, dt_y, dt_acc;
+    const data_type_t dt_a, dt_x, dt_y;
+    const data_type_t dt_a_reg, dt_x_reg;
+    const data_type_t dt_acc;
     const float beta;
     const dim_t m_blocks, m_tail, k_blocks, k_tail;
     const dim_t mblk_a_off, mblk_y_off;
@@ -306,8 +313,8 @@ void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     // once and every A row. The distance is empirically tuned.
     constexpr dim_t gemv_pf_dist = 512; // bytes = 8 cache lines
 
-    const ir::vreg_t x = ir.new_vec(cfg.dt_x);
-    const ir::vreg_t a = ir.new_vec(cfg.dt_a);
+    const ir::vreg_t x = ir.new_vec(cfg.dt_x_reg);
+    const ir::vreg_t a = ir.new_vec(cfg.dt_a_reg);
     ir.prefetch(x_ptr, gemv_pf_dist);
     ir.vload(x, x_ptr, 0, cfg.dt_x);
     for (int i = 0; i < (int)acc.size(); i++) {
@@ -324,8 +331,8 @@ void emit_microkernel(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
 void emit_microkernel_tail(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         const std::vector<ir::vreg_t> &acc, ir::vreg_t a_ptr, ir::vreg_t x_ptr,
         ir::vreg_t mask) {
-    const ir::vreg_t x = ir.new_vec(cfg.dt_x);
-    const ir::vreg_t a = ir.new_vec(cfg.dt_a);
+    const ir::vreg_t x = ir.new_vec(cfg.dt_x_reg);
+    const ir::vreg_t a = ir.new_vec(cfg.dt_a_reg);
     ir.vload_masked(x, x_ptr, 0, mask, cfg.dt_x);
     for (int i = 0; i < (int)acc.size(); i++) {
         ir.vload_masked(
@@ -653,9 +660,18 @@ private:
 status_t brgemv_ir_supported(const brgemm_desc_t &brg) {
     using namespace data_type;
 
-    VCONDCHECK_BRGEMV_IR(utils::everyone_is(f32, brg.dt_a, brg.dt_b, brg.dt_c),
-            VERBOSE_UNSUPPORTED_DT);
-    VCONDCHECK_BRGEMV_IR(brg.isa_impl == avx2, VERBOSE_UNSUPPORTED_ISA);
+    // Accepted input data type and the ISA it is built at:
+    //   f32  - avx2
+    //   bf16 - avx512_core_bf16
+    //   f16  - avx512_core_fp16
+    // GEMV blocking permits no other ISA (see `brgemm_blocking_vmm_gemv`).
+    const bool dt_isa_ok = (brg.dt_a == f32 && brg.isa_impl == avx2)
+            || (brg.dt_a == bf16 && brg.isa_impl == avx512_core_bf16)
+            || (brg.dt_a == f16 && brg.isa_impl == avx512_core_fp16);
+    VCONDCHECK_BRGEMV_IR(dt_isa_ok, VERBOSE_UNSUPPORTED_ISA);
+    VCONDCHECK_BRGEMV_IR(brg.dt_b == brg.dt_a, VERBOSE_UNSUPPORTED_DT);
+    // The kernel accumulates in f32 and has no conversion on the way out.
+    VCONDCHECK_BRGEMV_IR(brg.dt_c == f32, VERBOSE_UNSUPPORTED_DT);
     VCONDCHECK_BRGEMV_IR(
             !brg.transA, VERBOSE_UNSUPPORTED_FEATURE, "transposed A");
 

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -204,8 +204,8 @@ struct invariant_regs_t {
     ir::vreg_t batch = ir::vreg_t::none;
     // Batch size loop count. `none` when max_bs == 1 (single batch element).
     ir::vreg_t bs = ir::vreg_t::none;
-    // K-tail mask, shared by every masked tail load. It's only required when
-    // `k_tail` is greater than 1.
+    // K-tail mask, shared by every masked tail load. `none` when `k_tail` is
+    // zero, which is when there is no tail load to mask.
     ir::vreg_t k_tail_mask = ir::vreg_t::none;
     // Post-ops flag (params.do_post_ops). Non-zero applies the post-ops, zero
     // stores the raw accumulator. `none` unless the kernel has a post-op to
@@ -248,7 +248,7 @@ m_loop_input_regs_t init_m_loop_input_regs(
     regs.advancing.a_off = ir.new_gpr();
     ir.mov_imm(regs.advancing.a_off, 0);
 
-    if (cfg.k_tail > 1) {
+    if (cfg.k_tail > 0) {
         // We only need to set the mask once per kernel. It's lifetime is
         // managed automatically by the allocator.
         regs.invariant.k_tail_mask = ir.new_mask();

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -473,8 +473,8 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         }
 
         if (cfg.with_injector_postops) {
-            // Each accumulator is horizontally reduced to one scalar, so the
-            // injector sees a single active element with no mask register. Its
+            // Each accumulator is horizontally reduced to one scalar, which is
+            // the active element count `generate()` gives the injector. The
             // output offset matches the store displacement below, so a sum
             // post-op reads each element from the address its result is
             // written to.
@@ -482,8 +482,7 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             for (int r = 0; r < m_block; r++)
                 out_byte_off[r] = cfg.dt_sz_y * (dim_t)r * cfg.incy;
 
-            ir.inject_postops(acc, regs.advancing.store_ptr, out_byte_off,
-                    ir::vreg_t::none, /*elems=*/1);
+            ir.inject_postops(acc, regs.advancing.store_ptr, out_byte_off);
         }
 
         ir.label(skip_post_ops);
@@ -561,6 +560,9 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         // Scratch registers (2 gpr + 3 vec) reserved for spill code.
         const int gpr_scratch0 = 10, gpr_scratch1 = 11;
         const int vec_scratch0 = 13, vec_scratch1 = 14, vec_scratch2 = 15;
+        // AVX-512 opmasks reserved for the post-ops injector, which writes both
+        // and restores neither (see `postops_injector_t`).
+        const int eltwise_opmask = 6, binary_tail_opmask = 7;
 
         const int rsp_idx = Xbyak::Operand::RSP;
         const int param_idx = abi_param1.getIdx();
@@ -568,7 +570,8 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         // Build register configuration for code emission
         const ir::reg_config_t reg_cfg = ir::make_reg_config(brg_.isa_impl,
                 param_idx, rsp_idx, {gpr_scratch0, gpr_scratch1},
-                {vec_scratch0, vec_scratch1, vec_scratch2});
+                {vec_scratch0, vec_scratch1, vec_scratch2},
+                {eltwise_opmask, binary_tail_opmask});
 
         // Register allocation
         ir::reg_alloc_result_t alloc = allocate_registers(ir, reg_cfg.pools);
@@ -576,10 +579,8 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         // The injector is created here, not in the emitter, because it spans
         // the whole codegen flow (emits during `emit()`, writes its table after
         // the postamble) and needs descriptor inputs the generic emitter lacks.
-        // The emitter drives it through the `inject_postops` operation and the
-        // callback below.
+        // The emitter drives it through the `inject_postops` operation.
         std::unique_ptr<ir::postops_injector_t> postops_injector;
-        ir::inject_postops_fn_t emit_injector;
 
         if (brg_.with_eltwise || brg_.with_binary || brg_.with_sum) {
             // A partial right-hand-side load reads the vector tail, or one
@@ -590,14 +591,8 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
             postops_injector.reset(new ir::postops_injector_t(*this,
                     brg_.isa_impl, brg_.attr()->post_ops_, *brg_.dst_md(),
                     abi_param1, GET_OFF(post_ops_binary_rhs_arg_vec),
-                    GET_OFF(data_C_ptr_), postops_tail_elems));
-
-            emit_injector = [&](const std::vector<int> &acc_phys, int base_phys,
-                                    const std::vector<dim_t> &out_byte_off,
-                                    int mask_phys, int elems) {
-                postops_injector->apply(
-                        acc_phys, base_phys, out_byte_off, mask_phys, elems);
-            };
+                    GET_OFF(data_C_ptr_), postops_tail_elems, eltwise_opmask,
+                    binary_tail_opmask));
         }
 
         preamble();
@@ -610,7 +605,7 @@ struct jit_brgemv_ir_kernel_t : public jit_base_brgemm_kernel_t {
         // The emitter may accumulate static data (e.g. the mask table) that we
         // need to write down after the postamble.
         ir::data_section_t data;
-        ir::emit(*this, ir, alloc, reg_cfg, data, emit_injector);
+        ir::emit(*this, ir, alloc, reg_cfg, data, postops_injector.get());
 
         // Stack cleanup
         if (alloc.frame_bytes > 0) add(rsp, (uint32_t)alloc.frame_bytes);

--- a/src/cpu/x64/brgemm/brgemv_ir.cpp
+++ b/src/cpu/x64/brgemm/brgemv_ir.cpp
@@ -326,10 +326,9 @@ void emit_microkernel_tail(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         ir::vreg_t mask) {
     const ir::vreg_t x = ir.new_vec(cfg.dt_x);
     const ir::vreg_t a = ir.new_vec(cfg.dt_a);
-    ir.vload_masked(x, x_ptr, 0, mask, (int)cfg.k_tail);
+    ir.vload_masked(x, x_ptr, 0, mask);
     for (int i = 0; i < (int)acc.size(); i++) {
-        ir.vload_masked(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda, mask,
-                (int)cfg.k_tail);
+        ir.vload_masked(a, a_ptr, cfg.dt_sz_a * (dim_t)i * cfg.lda, mask);
         ir.vdot(acc[i], a, x);
     }
 }
@@ -393,8 +392,8 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         if (cfg.beta == 0.0f)
             ir.vzero(acc[r]);
         else
-            ir.vload_masked(acc[r], regs.advancing.y_ptr,
-                    cfg.dt_sz_y * (dim_t)r * cfg.incy, ir::vreg_t::none, 1);
+            ir.vload_scalar(acc[r], regs.advancing.y_ptr,
+                    cfg.dt_sz_y * (dim_t)r * cfg.incy);
     }
 
     // Batch reduction over bs dimension
@@ -432,8 +431,7 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
         if (cfg.with_src_scales) {
             // Loaded once and applied to every output.
             const ir::vreg_t sc = ir.new_vec(cfg.dt_src_scales);
-            ir.vload_masked(
-                    sc, regs.invariant.src_scale_ptr, 0, ir::vreg_t::none, 1);
+            ir.vload_scalar(sc, regs.invariant.src_scale_ptr, 0);
 
             for (int r = 0; r < m_block; r++)
                 ir.vmul(acc[r], sc);
@@ -444,14 +442,12 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             // loop. The per-N case loads a separate scale per output element.
             const ir::vreg_t sc = ir.new_vec(cfg.dt_wei_scales);
             if (cfg.single_wei_scale)
-                ir.vload_masked(sc, regs.advancing.wei_scale_ptr, 0,
-                        ir::vreg_t::none, 1);
+                ir.vload_scalar(sc, regs.advancing.wei_scale_ptr, 0);
 
             for (int r = 0; r < m_block; r++) {
                 if (!cfg.single_wei_scale)
-                    ir.vload_masked(sc, regs.advancing.wei_scale_ptr,
-                            cfg.dt_sz_wei_scales * (dim_t)r, ir::vreg_t::none,
-                            1);
+                    ir.vload_scalar(sc, regs.advancing.wei_scale_ptr,
+                            cfg.dt_sz_wei_scales * (dim_t)r);
                 ir.vmul(acc[r], sc);
             }
         }
@@ -461,13 +457,12 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
             // loop. A row output loads a separate bias per output element.
             const ir::vreg_t bias = ir.new_vec(cfg.dt_bias);
             if (!cfg.treat_y_as_row)
-                ir.vload_masked(
-                        bias, regs.advancing.bias_ptr, 0, ir::vreg_t::none, 1);
+                ir.vload_scalar(bias, regs.advancing.bias_ptr, 0);
 
             for (int r = 0; r < m_block; r++) {
                 if (cfg.treat_y_as_row)
-                    ir.vload_masked(bias, regs.advancing.bias_ptr,
-                            cfg.dt_sz_bias * (dim_t)r, ir::vreg_t::none, 1);
+                    ir.vload_scalar(bias, regs.advancing.bias_ptr,
+                            cfg.dt_sz_bias * (dim_t)r);
                 ir.vadd(acc[r], bias);
             }
         }
@@ -489,8 +484,8 @@ void emit_m_block(ir::ir_t &ir, const brgemv_ir_conf_t &cfg,
     }
 
     for (int r = 0; r < m_block; r++)
-        ir.vstore_masked(regs.advancing.store_ptr,
-                cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r], ir::vreg_t::none, 1);
+        ir.vstore_scalar(regs.advancing.store_ptr,
+                cfg.dt_sz_y * (dim_t)r * cfg.incy, acc[r]);
 
     // Advance to next M block
     ir.add_imm(regs.advancing.a_off, cfg.mblk_a_off);

--- a/src/cpu/x64/ir/README.md
+++ b/src/cpu/x64/ir/README.md
@@ -55,7 +55,9 @@ step. They are omitted above for clarity.
 * **IR.** A linear list of operations over *virtual registers*. One fixed
   struct represents every operation, and an `op` kind selects which fields it
   uses. Every virtual register has a kind (`gpr`, `vec`, or `mask`), and a `vec`
-  register also carries the element data type of the values it holds.
+  register also carries the element data type it holds. A vector load or store
+  carries a second data type, `mem_dt`, for what memory holds. The two differ
+  when the access converts.
 * **Register configuration.** An ISA-aware step that produces ISA-agnostic
   register pools (integer indices per register kind) plus the reserved registers:
   the stack pointer, the kernel-argument pointer, and a few scratch registers the
@@ -83,10 +85,10 @@ step. They are omitted above for clarity.
   plugged in as a single `inject_postops` operation. Its variable-length arguments
   live in a side table indexed from the operation's immediate field, so the
   operation itself carries only that index. The table also holds each
-  accumulator's output offset and active-element count, which a binary post-op
-  needs to address its right-hand-side argument and a sum post-op needs to read
-  the previous destination value. The injector saves and restores its own
-  registers and does not participate in IR allocation.
+  accumulator's output offset, which a binary post-op needs to address its
+  right-hand-side argument and a sum post-op needs to read the previous
+  destination value. The injector saves and restores its own registers and does
+  not participate in IR allocation.
 
 ### Control and Data Flow
 
@@ -137,8 +139,9 @@ today. A shared runner for the fixed part is a follow-up.
   the spill frame.
 * `emitter/emitter.hpp`, `emitter/emitter.cpp`: the lowering pass, which walks the
   allocated IR, dispatches by ISA family, and manages the static-data section.
-* `emitter/backend_avx2.hpp`: the AVX2-family backend, the reference example of
-  per-operation instruction selection.
+* `emitter/backend_avx2.hpp`, `emitter/backend_avx512.hpp`: the per-ISA-family
+  backends, which do the per-operation instruction selection. They are peers,
+  each self-contained.
 * `postops_injector.hpp`, `postops_injector.cpp`: the driver for the JIT post-ops
   injector, which lowers the `inject_postops` operation.
 
@@ -152,8 +155,9 @@ New functionality maps to a specific layer. The IR infrastructure grows by addin
 data types, ISAs, and the fused instructions each ISA supports, and each kind of
 change belongs in one place.
 
-1. **A new data type** is a tag on a `vec` register. The builder stays the same,
-   and the emitter maps the operation and data type to the right instruction.
+1. **A new data type** is a tag on a `vec` register, plus the `mem_dt` on the
+   loads and stores that reach it. The builder stays the same, and the emitter
+   maps the operation and the data types to the right instruction.
 2. **A new ISA** adds a new emitter backend or extends an existing one, along with
    the matching register-configuration facts.
 3. **A new variant of an existing instruction** is a lowering rule in the emitter,
@@ -164,9 +168,9 @@ change belongs in one place.
    operation, with its own definition, `def_use()` entry, and lowering.
 
 To tell the third from the fourth, look at `def_use()`. If the reads and writes
-stay the same and only the emitted instructions differ (by data type, element
-count, or ISA), it is a lowering rule. If the behavior needs different reads or
-writes, it is a new operation. This keeps the set of operations target-neutral.
+stay the same and only the emitted instructions differ (by data type or ISA), it
+is a lowering rule. If the behavior needs different reads or writes, it is a new
+operation. This keeps the set of operations target-neutral.
 
 Additional rules to follow.
 

--- a/src/cpu/x64/ir/README.md
+++ b/src/cpu/x64/ir/README.md
@@ -158,8 +158,8 @@ change belongs in one place.
    the matching register-configuration facts.
 3. **A new variant of an existing instruction** is a lowering rule in the emitter,
    not a new IR operation, and is invisible to the builder. For example,
-   `vload_masked` already lowers to `vmovss`, `vmovups`, or `vmaskmovps` depending
-   on how many elements are active.
+   `vload_masked` already lowers to `vmaskmovps` on AVX2 and to `vmovups` under
+   an EVEX write mask on AVX-512.
 4. **A new behavior** that no existing operation can express becomes a new IR
    operation, with its own definition, `def_use()` entry, and lowering.
 

--- a/src/cpu/x64/ir/emitter/backend_avx2.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx2.hpp
@@ -54,26 +54,49 @@ struct avx2_backend_t {
         gen().vxorps(Xbyak::Ymm(d), Xbyak::Ymm(d), Xbyak::Ymm(d));
     }
 
-    void vload(int d, int base, dim_t disp) { // dst = [base + disp]
+    // Move a whole register to or from memory as it is. The emitter uses this
+    // for spill slots, where the bytes come back exactly as they went out, so
+    // there is no data type and never a conversion.
+    void vload_raw(int d, int base, dim_t disp) { // dst = [base + disp]
         gen().vmovups(Xbyak::Ymm(d), gen().ptr[Xbyak::Reg64(base) + (int)disp]);
     }
 
-    void vstore(int base, dim_t disp, int s) { // [base + disp] = src
+    void vstore_raw(int base, dim_t disp, int s) { // [base + disp] = src
         gen().vmovups(gen().ptr[Xbyak::Reg64(base) + (int)disp], Xbyak::Ymm(s));
     }
 
-    // Load one element and zero the rest of `dst`.
-    void vload_scalar(int d, int base, dim_t disp, data_type_t dt) {
+    // Load a full vector.
+    void vload(int d, int base, dim_t disp, data_type_t mem_dt,
+            data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
-        if (dt == data_type::f32)
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
+            gen().vmovups(Xbyak::Ymm(d), addr);
+        else { JIT_ASSERT(!"vload: dtype not implemented"); }
+    }
+
+    // Store a full vector.
+    void vstore(int base, dim_t disp, int s, data_type_t mem_dt,
+            data_type_t reg_dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
+            gen().vmovups(addr, Xbyak::Ymm(s));
+        else { JIT_ASSERT(!"vstore: dtype not implemented"); }
+    }
+
+    // Load one element and zero the rest of `dst`.
+    void vload_scalar(int d, int base, dim_t disp, data_type_t mem_dt,
+            data_type_t reg_dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
             gen().vmovss(Xbyak::Xmm(d), addr);
         else { JIT_ASSERT(!"vload_scalar: dtype not implemented"); }
     }
 
     // Store element 0 of `src`.
-    void vstore_scalar(int base, dim_t disp, int s, data_type_t dt) {
+    void vstore_scalar(int base, dim_t disp, int s, data_type_t mem_dt,
+            data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
-        if (dt == data_type::f32)
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
             gen().vmovss(addr, Xbyak::Xmm(s));
         else { JIT_ASSERT(!"vstore_scalar: dtype not implemented"); }
     }
@@ -129,11 +152,11 @@ struct avx2_backend_t {
     }
 
     // Load the elements selected by `mask` and zero the rest of `dst`.
-    void vload_masked(int d, int base, dim_t disp, int mask, data_type_t dt,
-            data_section_t & /*data*/) {
+    void vload_masked(int d, int base, dim_t disp, int mask, data_type_t mem_dt,
+            data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
 
-        if (dt == data_type::f32) {
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32) {
             gen().vmaskmovps(Xbyak::Ymm(d), Xbyak::Ymm(mask), addr);
         } else {
             // vmaskmovps applies only to f32. Other precisions need a different
@@ -143,11 +166,11 @@ struct avx2_backend_t {
     }
 
     // Store the elements of `src` selected by `mask`.
-    void vstore_masked(int base, dim_t disp, int s, int mask, data_type_t dt,
-            data_section_t & /*data*/) {
+    void vstore_masked(int base, dim_t disp, int s, int mask,
+            data_type_t mem_dt, data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
 
-        if (dt == data_type::f32) {
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32) {
             gen().vmaskmovps(addr, Xbyak::Ymm(mask), Xbyak::Ymm(s));
         } else {
             JIT_ASSERT(!"vstore_masked: dtype not implemented");

--- a/src/cpu/x64/ir/emitter/backend_avx2.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx2.hpp
@@ -26,12 +26,10 @@
 // constructs Xbyak `Ymm` registers, so each operation builds its own registers
 // from the indices it is given.
 
-#include <cassert>
 #include <utility>
 #include <vector>
 
 #include "common/c_types_map.hpp"
-#include "common/type_helpers.hpp"
 #include "cpu/x64/ir/emitter/emitter.hpp"
 #include "cpu/x64/jit_generator.hpp"
 #include "cpu/x64/utils/jit_regops.hpp"
@@ -62,6 +60,22 @@ struct avx2_backend_t {
 
     void vstore(int base, dim_t disp, int s) { // [base + disp] = src
         gen().vmovups(gen().ptr[Xbyak::Reg64(base) + (int)disp], Xbyak::Ymm(s));
+    }
+
+    // Load one element and zero the rest of `dst`.
+    void vload_scalar(int d, int base, dim_t disp, data_type_t dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (dt == data_type::f32)
+            gen().vmovss(Xbyak::Xmm(d), addr);
+        else { JIT_ASSERT(!"vload_scalar: dtype not implemented"); }
+    }
+
+    // Store element 0 of `src`.
+    void vstore_scalar(int base, dim_t disp, int s, data_type_t dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (dt == data_type::f32)
+            gen().vmovss(addr, Xbyak::Xmm(s));
+        else { JIT_ASSERT(!"vstore_scalar: dtype not implemented"); }
     }
 
     void vadd(int d, int s, data_type_t dt) { // dst += s0
@@ -114,23 +128,13 @@ struct avx2_backend_t {
         gen().vmovups(Xbyak::Ymm(d), gen().ptr[gen().rip + lbl]);
     }
 
-    // Load `n_elems` f32 elements. The count selects the simplest form:
-    //   n_elems == 1:       vmovss (no mask register needed)
-    //   n_elems == simd_w:  vmovups (no mask register needed)
-    //   otherwise:          vmaskmovps with the mask in `mask`
-    void vload_masked(int d, int base, dim_t disp, int mask, int n_elems,
-            data_type_t dt, data_section_t & /*data*/) {
-        const int simd_w = vlen / (int)types::data_type_size(dt);
-        assert(n_elems <= simd_w);
+    // Load the elements selected by `mask` and zero the rest of `dst`.
+    void vload_masked(int d, int base, dim_t disp, int mask, data_type_t dt,
+            data_section_t & /*data*/) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
 
         if (dt == data_type::f32) {
-            if (n_elems == 1)
-                gen().vmovss(Xbyak::Xmm(d), addr);
-            else if (n_elems == simd_w)
-                gen().vmovups(Xbyak::Ymm(d), addr);
-            else
-                gen().vmaskmovps(Xbyak::Ymm(d), Xbyak::Ymm(mask), addr);
+            gen().vmaskmovps(Xbyak::Ymm(d), Xbyak::Ymm(mask), addr);
         } else {
             // vmaskmovps applies only to f32. Other precisions need a different
             // mechanism here.
@@ -138,20 +142,13 @@ struct avx2_backend_t {
         }
     }
 
-    // Store `n_elems` f32 elements. Same case split as `vload_masked()`.
-    void vstore_masked(int base, dim_t disp, int s, int mask, int n_elems,
-            data_type_t dt, data_section_t & /*data*/) {
-        const int simd_w = vlen / (int)types::data_type_size(dt);
-        assert(n_elems <= simd_w);
+    // Store the elements of `src` selected by `mask`.
+    void vstore_masked(int base, dim_t disp, int s, int mask, data_type_t dt,
+            data_section_t & /*data*/) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
 
         if (dt == data_type::f32) {
-            if (n_elems == 1)
-                gen().vmovss(addr, Xbyak::Xmm(s));
-            else if (n_elems == simd_w)
-                gen().vmovups(addr, Xbyak::Ymm(s));
-            else
-                gen().vmaskmovps(addr, Xbyak::Ymm(mask), Xbyak::Ymm(s));
+            gen().vmaskmovps(addr, Xbyak::Ymm(mask), Xbyak::Ymm(s));
         } else {
             JIT_ASSERT(!"vstore_masked: dtype not implemented");
         }

--- a/src/cpu/x64/ir/emitter/backend_avx512.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx512.hpp
@@ -60,26 +60,49 @@ struct avx512_backend_t {
         gen().vpxord(Xbyak::Zmm(d), Xbyak::Zmm(d), Xbyak::Zmm(d));
     }
 
-    void vload(int d, int base, dim_t disp) { // dst = [base + disp]
+    // Move a whole register to or from memory as it is. The emitter uses this
+    // for spill slots, where the bytes come back exactly as they went out, so
+    // there is no data type and never a conversion.
+    void vload_raw(int d, int base, dim_t disp) { // dst = [base + disp]
         gen().vmovups(Xbyak::Zmm(d), gen().ptr[Xbyak::Reg64(base) + (int)disp]);
     }
 
-    void vstore(int base, dim_t disp, int s) { // [base + disp] = src
+    void vstore_raw(int base, dim_t disp, int s) { // [base + disp] = src
         gen().vmovups(gen().ptr[Xbyak::Reg64(base) + (int)disp], Xbyak::Zmm(s));
     }
 
-    // Load one element and zero the rest of `dst`.
-    void vload_scalar(int d, int base, dim_t disp, data_type_t dt) {
+    // Load a full vector.
+    void vload(int d, int base, dim_t disp, data_type_t mem_dt,
+            data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
-        if (dt == data_type::f32)
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
+            gen().vmovups(Xbyak::Zmm(d), addr);
+        else { JIT_ASSERT(!"vload: dtype not implemented"); }
+    }
+
+    // Store a full vector.
+    void vstore(int base, dim_t disp, int s, data_type_t mem_dt,
+            data_type_t reg_dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
+            gen().vmovups(addr, Xbyak::Zmm(s));
+        else { JIT_ASSERT(!"vstore: dtype not implemented"); }
+    }
+
+    // Load one element and zero the rest of `dst`.
+    void vload_scalar(int d, int base, dim_t disp, data_type_t mem_dt,
+            data_type_t reg_dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
             gen().vmovss(Xbyak::Xmm(d), addr);
         else { JIT_ASSERT(!"vload_scalar: dtype not implemented"); }
     }
 
     // Store element 0 of `src`.
-    void vstore_scalar(int base, dim_t disp, int s, data_type_t dt) {
+    void vstore_scalar(int base, dim_t disp, int s, data_type_t mem_dt,
+            data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
-        if (dt == data_type::f32)
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
             gen().vmovss(addr, Xbyak::Xmm(s));
         else { JIT_ASSERT(!"vstore_scalar: dtype not implemented"); }
     }
@@ -134,11 +157,11 @@ struct avx512_backend_t {
     // Load the elements selected by `mask` and zero the rest of `dst` (`T_z`).
     // An inactive element has to read as zero, or a tail iteration would
     // accumulate whatever the register happened to hold into the dot product.
-    void vload_masked(int d, int base, dim_t disp, int mask, data_type_t dt,
-            data_section_t & /*data*/) {
+    void vload_masked(int d, int base, dim_t disp, int mask, data_type_t mem_dt,
+            data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
 
-        if (dt == data_type::f32) {
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32) {
             gen().vmovups(
                     Xbyak::Zmm(d) | Xbyak::Opmask(mask) | gen().T_z, addr);
         } else {
@@ -148,11 +171,11 @@ struct avx512_backend_t {
 
     // Store the elements of `src` selected by `mask`. There is no `T_z` here,
     // since masking a store is already a merge into memory.
-    void vstore_masked(int base, dim_t disp, int s, int mask, data_type_t dt,
-            data_section_t & /*data*/) {
+    void vstore_masked(int base, dim_t disp, int s, int mask,
+            data_type_t mem_dt, data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
 
-        if (dt == data_type::f32) {
+        if (mem_dt == data_type::f32 && reg_dt == data_type::f32) {
             gen().vmovups(addr | Xbyak::Opmask(mask), Xbyak::Zmm(s));
         } else {
             JIT_ASSERT(!"vstore_masked: dtype not implemented");

--- a/src/cpu/x64/ir/emitter/backend_avx512.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx512.hpp
@@ -47,11 +47,7 @@ namespace ir {
 
 struct avx512_backend_t {
     avx512_backend_t(jit_generator_t &gen, cpu_isa_t isa)
-        : gen_(gen), isa(isa) {
-        // `isa` is stored for the dtype dispatch that tells the AVX-512
-        // extensions apart (e.g. avx512_core_bf16) but is not read yet.
-        MAYBE_UNUSED(this->isa);
-    }
+        : gen_(gen), isa(isa) {}
 
     jit_generator_t &gen() { return gen_; }
 
@@ -71,13 +67,22 @@ struct avx512_backend_t {
         gen().vmovups(gen().ptr[Xbyak::Reg64(base) + (int)disp], Xbyak::Zmm(s));
     }
 
-    // Load a full vector.
+    // Load a full vector. The pair of data types selects the form:
+    //   f32  -> f32   plain move
+    //   bf16 -> bf16  plain move
+    //   f16  -> f32   half a register read and widened
     void vload(int d, int base, dim_t disp, data_type_t mem_dt,
             data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
-        if (mem_dt == data_type::f32 && reg_dt == data_type::f32)
+
+        if (mem_dt == reg_dt
+                && utils::one_of(reg_dt, data_type::f32, data_type::bf16)) {
             gen().vmovups(Xbyak::Zmm(d), addr);
-        else { JIT_ASSERT(!"vload: dtype not implemented"); }
+        } else if (mem_dt == data_type::f16 && reg_dt == data_type::f32) {
+            gen().vcvtph2ps(Xbyak::Zmm(d), addr);
+        } else {
+            JIT_ASSERT(!"vload: dtype not implemented");
+        }
     }
 
     // Store a full vector.
@@ -120,12 +125,16 @@ struct avx512_backend_t {
     }
 
     // dst += a * b. The multiplicand dtype `src_dt` selects the instruction.
-    // f32 inputs use `vfmadd231ps`. The accumulator (dst) is always f32.
+    // The accumulator (dst) is always f32. An f16 multiplicand arrives here as
+    // f32, widened by the load (see `vload`).
     void vdot(int d, int a, int b, data_type_t src_dt) {
-        if (src_dt == data_type::f32)
+        if (src_dt == data_type::f32) {
             gen().vfmadd231ps(Xbyak::Zmm(d), Xbyak::Zmm(a), Xbyak::Zmm(b));
-        else {
-            // Only f32 is supported on AVX-512 today.
+        } else if (src_dt == data_type::bf16) {
+            JIT_ASSERT(is_superset(isa, avx512_core_bf16)
+                    && "vdot: bf16 needs avx512_core_bf16");
+            gen().vdpbf16ps(Xbyak::Zmm(d), Xbyak::Zmm(a), Xbyak::Zmm(b));
+        } else {
             JIT_ASSERT(!"vdot: dtype not implemented");
         }
     }
@@ -157,13 +166,20 @@ struct avx512_backend_t {
     // Load the elements selected by `mask` and zero the rest of `dst` (`T_z`).
     // An inactive element has to read as zero, or a tail iteration would
     // accumulate whatever the register happened to hold into the dot product.
+    // The mask counts elements of `mem_dt`, so a converting form masks the
+    // narrow read and widens what is left.
     void vload_masked(int d, int base, dim_t disp, int mask, data_type_t mem_dt,
             data_type_t reg_dt) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        const Xbyak::Opmask k(mask);
 
         if (mem_dt == data_type::f32 && reg_dt == data_type::f32) {
-            gen().vmovups(
-                    Xbyak::Zmm(d) | Xbyak::Opmask(mask) | gen().T_z, addr);
+            gen().vmovups(Xbyak::Zmm(d) | k | gen().T_z, addr);
+        } else if (mem_dt == data_type::bf16 && reg_dt == data_type::bf16) {
+            gen().vmovdqu16(Xbyak::Zmm(d) | k | gen().T_z, addr);
+        } else if (mem_dt == data_type::f16 && reg_dt == data_type::f32) {
+            gen().vmovdqu16(Xbyak::Ymm(d) | k | gen().T_z, addr);
+            gen().vcvtph2ps(Xbyak::Zmm(d), Xbyak::Ymm(d));
         } else {
             JIT_ASSERT(!"vload_masked: dtype not implemented");
         }

--- a/src/cpu/x64/ir/emitter/backend_avx512.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx512.hpp
@@ -1,0 +1,186 @@
+/*******************************************************************************
+* Copyright 2026 Intel Corporation
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*******************************************************************************/
+
+#ifndef CPU_X64_IR_EMITTER_BACKEND_AVX512_HPP
+#define CPU_X64_IR_EMITTER_BACKEND_AVX512_HPP
+
+// AVX-512 backend for the emitter (see `emit()` in `emitter.cpp`).
+//
+// This backend contains every vector and mask instruction for one ISA family
+// and covers all AVX-512 extensions (avx512_core, avx512_core_bf16,
+// avx512_core_fp16, and so on). The generic emitter iterates over the IR and
+// resolves each virtual register to a physical register index. The backend is
+// the only code on this path that constructs Xbyak `Zmm` and `Opmask`
+// registers, so each operation builds its own registers from the indices it is
+// given.
+//
+// A mask is a k-register, and a masked access is an EVEX write mask on the
+// access instruction itself rather than a separate instruction. A mask
+// therefore allocates from a register file of its own (see
+// `make_reg_config()`).
+
+#include <cassert>
+
+#include "common/c_types_map.hpp"
+#include "common/type_helpers.hpp"
+#include "cpu/x64/ir/emitter/emitter.hpp"
+#include "cpu/x64/jit_generator.hpp"
+#include "cpu/x64/utils/jit_regops.hpp"
+
+namespace dnnl {
+namespace impl {
+namespace cpu {
+namespace x64 {
+namespace ir {
+
+struct avx512_backend_t {
+    avx512_backend_t(jit_generator_t &gen, cpu_isa_t isa)
+        : gen_(gen), isa(isa) {
+        // `isa` is stored for the dtype dispatch that tells the AVX-512
+        // extensions apart (e.g. avx512_core_bf16) but is not read yet.
+        MAYBE_UNUSED(this->isa);
+    }
+
+    jit_generator_t &gen() { return gen_; }
+
+    // Plain vector ops.
+    void vzero(int d) { // dst = 0
+        gen().vpxord(Xbyak::Zmm(d), Xbyak::Zmm(d), Xbyak::Zmm(d));
+    }
+
+    void vload(int d, int base, dim_t disp) { // dst = [base + disp]
+        gen().vmovups(Xbyak::Zmm(d), gen().ptr[Xbyak::Reg64(base) + (int)disp]);
+    }
+
+    void vstore(int base, dim_t disp, int s) { // [base + disp] = src
+        gen().vmovups(gen().ptr[Xbyak::Reg64(base) + (int)disp], Xbyak::Zmm(s));
+    }
+
+    void vadd(int d, int s, data_type_t dt) { // dst += s0
+        if (dt == data_type::f32)
+            gen().vaddps(Xbyak::Zmm(d), Xbyak::Zmm(d), Xbyak::Zmm(s));
+        else { JIT_ASSERT(!"vadd: dtype not implemented"); }
+    }
+
+    void vmul(int d, int s, data_type_t dt) { // dst *= s0
+        if (dt == data_type::f32)
+            gen().vmulps(Xbyak::Zmm(d), Xbyak::Zmm(d), Xbyak::Zmm(s));
+        else { JIT_ASSERT(!"vmul: dtype not implemented"); }
+    }
+
+    // dst += a * b. The multiplicand dtype `src_dt` selects the instruction.
+    // f32 inputs use `vfmadd231ps`. The accumulator (dst) is always f32.
+    void vdot(int d, int a, int b, data_type_t src_dt) {
+        if (src_dt == data_type::f32)
+            gen().vfmadd231ps(Xbyak::Zmm(d), Xbyak::Zmm(a), Xbyak::Zmm(b));
+        else {
+            // Only f32 is supported on AVX-512 today.
+            JIT_ASSERT(!"vdot: dtype not implemented");
+        }
+    }
+
+    void vhreduce(int d, int ws, data_type_t dt) {
+        if (dt == data_type::f32)
+            regops::horizontal_add_ps(&gen(), Xbyak::Zmm(d), Xbyak::Zmm(ws));
+        else { JIT_ASSERT(!"vhreduce: dtype not implemented"); }
+    }
+
+    // Masked vector ops.
+    //
+    // Create a mask with `n_elems` active elements. The mask is built inside
+    // the k-register file: `kxnorq` sets all 64 bits and `kshiftrq` keeps the
+    // low `n_elems` of them. The alternative, `kmov` from an immediate in a
+    // gpr, would put mask setup on the scratch registers, and those are meant
+    // to go away. `data` is unused for the same reason.
+    //
+    // The number of active bits is `n_elems` for every element size. A widening
+    // load preserves the element count, so a narrower element type changes what
+    // one bit masks, not how many bits are set (see `vload_masked`).
+    void set_mask_imm(int d, int n_elems, data_section_t & /*data*/) {
+        assert(n_elems > 0 && n_elems < 64);
+        const Xbyak::Opmask k(d);
+        gen().kxnorq(k, k, k);
+        gen().kshiftrq(k, k, (uint8_t)(64 - n_elems));
+    }
+
+    // Load `n_elems` f32 elements. The count selects the simplest form:
+    //   n_elems == 1:       vmovss (no mask register needed)
+    //   n_elems == simd_w:  vmovups (no mask register needed)
+    //   otherwise:          vmovups under the write mask in `mask`
+    //
+    // A masked load zeroes (`T_z`). An inactive lane has to read as zero, or a
+    // tail iteration would accumulate whatever the register happened to hold
+    // into the dot product.
+    void vload_masked(int d, int base, dim_t disp, int mask, int n_elems,
+            data_type_t dt, data_section_t & /*data*/) {
+        const int simd_w = vlen / (int)types::data_type_size(dt);
+        assert(n_elems <= simd_w);
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+
+        if (dt == data_type::f32) {
+            if (n_elems == 1)
+                gen().vmovss(Xbyak::Xmm(d), addr);
+            else if (n_elems == simd_w)
+                gen().vmovups(Xbyak::Zmm(d), addr);
+            else
+                gen().vmovups(
+                        Xbyak::Zmm(d) | Xbyak::Opmask(mask) | gen().T_z, addr);
+        } else {
+            JIT_ASSERT(!"vload_masked: dtype not implemented");
+        }
+    }
+
+    // Store `n_elems` f32 elements. Same case split as `vload_masked()`, but a
+    // masked store does not zero, since masking a store is already a merge into
+    // memory.
+    void vstore_masked(int base, dim_t disp, int s, int mask, int n_elems,
+            data_type_t dt, data_section_t & /*data*/) {
+        const int simd_w = vlen / (int)types::data_type_size(dt);
+        assert(n_elems <= simd_w);
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+
+        if (dt == data_type::f32) {
+            if (n_elems == 1)
+                gen().vmovss(addr, Xbyak::Xmm(s));
+            else if (n_elems == simd_w)
+                gen().vmovups(addr, Xbyak::Zmm(s));
+            else
+                gen().vmovups(addr | Xbyak::Opmask(mask), Xbyak::Zmm(s));
+        } else {
+            JIT_ASSERT(!"vstore_masked: dtype not implemented");
+        }
+    }
+
+private:
+    // The backend is used during the emitter step, which is called from an
+    // IR-based kernel during kernel generation. The kernel owns `gen_`.
+    jit_generator_t &gen_;
+
+    // ISA is used to dispatch ISA-specific instructions (e.g. on
+    // avx512_core_bf16).
+    cpu_isa_t isa;
+
+    // Vector register width in bytes.
+    const int vlen = cpu_isa_traits_t<avx512_core>::vlen;
+};
+
+} // namespace ir
+} // namespace x64
+} // namespace cpu
+} // namespace impl
+} // namespace dnnl
+
+#endif

--- a/src/cpu/x64/ir/emitter/backend_avx512.hpp
+++ b/src/cpu/x64/ir/emitter/backend_avx512.hpp
@@ -35,7 +35,6 @@
 #include <cassert>
 
 #include "common/c_types_map.hpp"
-#include "common/type_helpers.hpp"
 #include "cpu/x64/ir/emitter/emitter.hpp"
 #include "cpu/x64/jit_generator.hpp"
 #include "cpu/x64/utils/jit_regops.hpp"
@@ -67,6 +66,22 @@ struct avx512_backend_t {
 
     void vstore(int base, dim_t disp, int s) { // [base + disp] = src
         gen().vmovups(gen().ptr[Xbyak::Reg64(base) + (int)disp], Xbyak::Zmm(s));
+    }
+
+    // Load one element and zero the rest of `dst`.
+    void vload_scalar(int d, int base, dim_t disp, data_type_t dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (dt == data_type::f32)
+            gen().vmovss(Xbyak::Xmm(d), addr);
+        else { JIT_ASSERT(!"vload_scalar: dtype not implemented"); }
+    }
+
+    // Store element 0 of `src`.
+    void vstore_scalar(int base, dim_t disp, int s, data_type_t dt) {
+        const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
+        if (dt == data_type::f32)
+            gen().vmovss(addr, Xbyak::Xmm(s));
+        else { JIT_ASSERT(!"vstore_scalar: dtype not implemented"); }
     }
 
     void vadd(int d, int s, data_type_t dt) { // dst += s0
@@ -116,49 +131,29 @@ struct avx512_backend_t {
         gen().kshiftrq(k, k, (uint8_t)(64 - n_elems));
     }
 
-    // Load `n_elems` f32 elements. The count selects the simplest form:
-    //   n_elems == 1:       vmovss (no mask register needed)
-    //   n_elems == simd_w:  vmovups (no mask register needed)
-    //   otherwise:          vmovups under the write mask in `mask`
-    //
-    // A masked load zeroes (`T_z`). An inactive lane has to read as zero, or a
-    // tail iteration would accumulate whatever the register happened to hold
-    // into the dot product.
-    void vload_masked(int d, int base, dim_t disp, int mask, int n_elems,
-            data_type_t dt, data_section_t & /*data*/) {
-        const int simd_w = vlen / (int)types::data_type_size(dt);
-        assert(n_elems <= simd_w);
+    // Load the elements selected by `mask` and zero the rest of `dst` (`T_z`).
+    // An inactive element has to read as zero, or a tail iteration would
+    // accumulate whatever the register happened to hold into the dot product.
+    void vload_masked(int d, int base, dim_t disp, int mask, data_type_t dt,
+            data_section_t & /*data*/) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
 
         if (dt == data_type::f32) {
-            if (n_elems == 1)
-                gen().vmovss(Xbyak::Xmm(d), addr);
-            else if (n_elems == simd_w)
-                gen().vmovups(Xbyak::Zmm(d), addr);
-            else
-                gen().vmovups(
-                        Xbyak::Zmm(d) | Xbyak::Opmask(mask) | gen().T_z, addr);
+            gen().vmovups(
+                    Xbyak::Zmm(d) | Xbyak::Opmask(mask) | gen().T_z, addr);
         } else {
             JIT_ASSERT(!"vload_masked: dtype not implemented");
         }
     }
 
-    // Store `n_elems` f32 elements. Same case split as `vload_masked()`, but a
-    // masked store does not zero, since masking a store is already a merge into
-    // memory.
-    void vstore_masked(int base, dim_t disp, int s, int mask, int n_elems,
-            data_type_t dt, data_section_t & /*data*/) {
-        const int simd_w = vlen / (int)types::data_type_size(dt);
-        assert(n_elems <= simd_w);
+    // Store the elements of `src` selected by `mask`. There is no `T_z` here,
+    // since masking a store is already a merge into memory.
+    void vstore_masked(int base, dim_t disp, int s, int mask, data_type_t dt,
+            data_section_t & /*data*/) {
         const auto addr = gen().ptr[Xbyak::Reg64(base) + (int)disp];
 
         if (dt == data_type::f32) {
-            if (n_elems == 1)
-                gen().vmovss(addr, Xbyak::Xmm(s));
-            else if (n_elems == simd_w)
-                gen().vmovups(addr, Xbyak::Zmm(s));
-            else
-                gen().vmovups(addr | Xbyak::Opmask(mask), Xbyak::Zmm(s));
+            gen().vmovups(addr | Xbyak::Opmask(mask), Xbyak::Zmm(s));
         } else {
             JIT_ASSERT(!"vstore_masked: dtype not implemented");
         }
@@ -172,9 +167,6 @@ private:
     // ISA is used to dispatch ISA-specific instructions (e.g. on
     // avx512_core_bf16).
     cpu_isa_t isa;
-
-    // Vector register width in bytes.
-    const int vlen = cpu_isa_traits_t<avx512_core>::vlen;
 };
 
 } // namespace ir

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -71,9 +71,10 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
     // as a vector load/store against the stack frame (rsp).
     const int rsp_idx = gen.rsp.getIdx();
     auto spill_reload
-            = [&](vreg_t vr, int p) { be.vload(p, rsp_idx, slot_off(vr)); };
-    auto spill_store
-            = [&](vreg_t vr, int p) { be.vstore(rsp_idx, slot_off(vr), p); };
+            = [&](vreg_t vr, int p) { be.vload_raw(p, rsp_idx, slot_off(vr)); };
+    auto spill_store = [&](vreg_t vr, int p) {
+        be.vstore_raw(rsp_idx, slot_off(vr), p);
+    };
 
     // Resolve a virtual register that an instruction READS (use) to a
     // concrete physical register, hiding whether the allocator spilled it:
@@ -201,27 +202,27 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
             case op_kind_t::vload: { // overwrites dst
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
-                be.vload(d, base, op.mem.disp);
+                be.vload(d, base, op.mem.disp, op.mem_dt, dt_of(op.dst));
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }
             case op_kind_t::vstore: {
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int s = vec_use(op.s0, vec_scratch0);
-                be.vstore(base, op.mem.disp, s);
+                be.vstore(base, op.mem.disp, s, op.mem_dt, dt_of(op.s0));
                 break;
             }
             case op_kind_t::vload_scalar: { // overwrites dst
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
-                be.vload_scalar(d, base, op.mem.disp, dt_of(op.dst));
+                be.vload_scalar(d, base, op.mem.disp, op.mem_dt, dt_of(op.dst));
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }
             case op_kind_t::vstore_scalar: {
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int s = vec_use(op.s0, vec_scratch0);
-                be.vstore_scalar(base, op.mem.disp, s, dt_of(op.s0));
+                be.vstore_scalar(base, op.mem.disp, s, op.mem_dt, dt_of(op.s0));
                 break;
             }
             case op_kind_t::vdot: { // rmw: reads and writes dst
@@ -293,8 +294,8 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
                 assert(!spilled(op.s1) && "vload_masked: mask spilled");
-                be.vload_masked(
-                        d, base, op.mem.disp, phys(op.s1), dt_of(op.dst), data);
+                be.vload_masked(d, base, op.mem.disp, phys(op.s1), op.mem_dt,
+                        dt_of(op.dst));
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }
@@ -302,8 +303,8 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int s = vec_use(op.s0, vec_scratch0);
                 assert(!spilled(op.s1) && "vstore_masked: mask spilled");
-                be.vstore_masked(
-                        base, op.mem.disp, s, phys(op.s1), dt_of(op.s0), data);
+                be.vstore_masked(base, op.mem.disp, s, phys(op.s1), op.mem_dt,
+                        dt_of(op.s0));
                 break;
             }
 

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -205,6 +205,25 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }
+            case op_kind_t::vstore: {
+                int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
+                int s = vec_use(op.s0, vec_scratch0);
+                be.vstore(base, op.mem.disp, s);
+                break;
+            }
+            case op_kind_t::vload_scalar: { // overwrites dst
+                int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
+                int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
+                be.vload_scalar(d, base, op.mem.disp, dt_of(op.dst));
+                if (spilled(op.dst)) spill_store(op.dst, d);
+                break;
+            }
+            case op_kind_t::vstore_scalar: {
+                int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
+                int s = vec_use(op.s0, vec_scratch0);
+                be.vstore_scalar(base, op.mem.disp, s, dt_of(op.s0));
+                break;
+            }
             case op_kind_t::vdot: { // rmw: reads and writes dst
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
                 if (spilled(op.dst)) spill_reload(op.dst, d);
@@ -273,22 +292,18 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
             case op_kind_t::vload_masked: { // overwrites dst
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int d = spilled(op.dst) ? vec_scratch0 : phys(op.dst);
-                assert((op.s1 == vreg_t::none || !spilled(op.s1))
-                        && "vload_masked: mask spilled");
-                int mask = (op.s1 != vreg_t::none) ? phys(op.s1) : -1;
-                be.vload_masked(d, base, op.mem.disp, mask, (int)op.imm,
-                        dt_of(op.dst), data);
+                assert(!spilled(op.s1) && "vload_masked: mask spilled");
+                be.vload_masked(
+                        d, base, op.mem.disp, phys(op.s1), dt_of(op.dst), data);
                 if (spilled(op.dst)) spill_store(op.dst, d);
                 break;
             }
             case op_kind_t::vstore_masked: {
                 int base = gpr_use(op.mem.base, gpr_scratch0).getIdx();
                 int s = vec_use(op.s0, vec_scratch0);
-                assert((op.s1 == vreg_t::none || !spilled(op.s1))
-                        && "vstore_masked: mask spilled");
-                int mask = (op.s1 != vreg_t::none) ? phys(op.s1) : -1;
-                be.vstore_masked(base, op.mem.disp, s, mask, (int)op.imm,
-                        dt_of(op.s0), data);
+                assert(!spilled(op.s1) && "vstore_masked: mask spilled");
+                be.vstore_masked(
+                        base, op.mem.disp, s, phys(op.s1), dt_of(op.s0), data);
                 break;
             }
 

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -19,6 +19,7 @@
 #include <unordered_map>
 
 #include "cpu/x64/ir/emitter/backend_avx2.hpp"
+#include "cpu/x64/ir/emitter/backend_avx512.hpp"
 #include "cpu/x64/ir/emitter/emitter.hpp"
 #include "cpu/x64/ir/postops_injector.hpp"
 #include "cpu/x64/utils/jit_regops.hpp"
@@ -351,7 +352,8 @@ void emit(jit_generator_t &gen, const ir_t &ir, const reg_alloc_result_t &alloc,
         postops_injector_t *postops) {
     const cpu_isa_t isa = gen.max_cpu_isa();
     if (is_superset(isa, avx512_core)) {
-        JIT_ASSERT(!"avx512 emitter is not supported");
+        avx512_backend_t be(gen, isa);
+        emit(be, ir, alloc, reg_cfg, data, postops);
     } else {
         avx2_backend_t be(gen, isa);
         emit(be, ir, alloc, reg_cfg, data, postops);

--- a/src/cpu/x64/ir/emitter/emitter.cpp
+++ b/src/cpu/x64/ir/emitter/emitter.cpp
@@ -20,6 +20,7 @@
 
 #include "cpu/x64/ir/emitter/backend_avx2.hpp"
 #include "cpu/x64/ir/emitter/emitter.hpp"
+#include "cpu/x64/ir/postops_injector.hpp"
 #include "cpu/x64/utils/jit_regops.hpp"
 
 namespace dnnl {
@@ -31,7 +32,7 @@ namespace ir {
 template <typename backend_t>
 void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
         const reg_config_t &rc, data_section_t &data,
-        const inject_postops_fn_t &inject) {
+        postops_injector_t *postops) {
 
     // The backend holds the generator.
     jit_generator_t &gen = be.gen();
@@ -126,6 +127,13 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
     //
     // This separation ensures that spilled source and destination values never
     // use the same scratch register.
+
+    // Fixed registers the injector reads are set up once, ahead of the IR,
+    // rather than at every `inject_postops` operation. The pattern does not
+    // change between operations, and an operation inside a loop would otherwise
+    // rebuild it on every iteration.
+    if (postops) postops->init(gen);
+
     for (int i = 0; i < ir.n_ops(); i++) {
         const op_t &op = ir.ops()[i];
         switch (op.kind) {
@@ -247,14 +255,9 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
                 }
                 JIT_ASSERT(!spilled(args.base_ptr)
                         && "inject_postops: base pointer spilled");
-                const bool has_mask = args.mask != vreg_t::none;
-                JIT_ASSERT(!(has_mask && spilled(args.mask))
-                        && "inject_postops: mask spilled");
-                JIT_ASSERT(
-                        inject && "inject_postops: missing injector callback");
-                const int mask_phys = has_mask ? phys(args.mask) : -1;
-                inject(acc_phys, phys(args.base_ptr), args.out_byte_off,
-                        mask_phys, args.elems);
+                JIT_ASSERT(postops && "inject_postops: missing injector");
+                postops->inject(
+                        acc_phys, phys(args.base_ptr), args.out_byte_off);
                 break;
             }
 
@@ -345,13 +348,13 @@ void emit(backend_t &be, const ir_t &ir, const reg_alloc_result_t &alloc,
 
 void emit(jit_generator_t &gen, const ir_t &ir, const reg_alloc_result_t &alloc,
         const reg_config_t &reg_cfg, data_section_t &data,
-        const inject_postops_fn_t &inject) {
+        postops_injector_t *postops) {
     const cpu_isa_t isa = gen.max_cpu_isa();
     if (is_superset(isa, avx512_core)) {
         JIT_ASSERT(!"avx512 emitter is not supported");
     } else {
         avx2_backend_t be(gen, isa);
-        emit(be, ir, alloc, reg_cfg, data, inject);
+        emit(be, ir, alloc, reg_cfg, data, postops);
     }
 }
 

--- a/src/cpu/x64/ir/emitter/emitter.hpp
+++ b/src/cpu/x64/ir/emitter/emitter.hpp
@@ -21,7 +21,6 @@
 // using a `jit_generator`.
 
 #include <deque>
-#include <functional>
 #include <utility>
 #include <vector>
 
@@ -66,29 +65,25 @@ struct data_section_t {
 // emitter appends to it and references each entry rip-relative. The caller
 // then emits the bytes with `emit_data_section()` after the `postamble()`.
 //
+// Lowers the `inject_postops` operation onto the JIT post-ops injector, which
+// is not IR-based (see `postops_injector.hpp`). Only `emit()` needs it, so a
+// forward declaration keeps this header free of post-ops specifics.
+struct postops_injector_t;
+
 // This is the main entry point for the emitter. It dispatches by ISA family to
 // the matching backend.
 //
-// `inject` lowers the `inject_postops` operation to the JIT post-ops injector.
-// It is the interoperability layer between the IR and the non-IR injector. When
-// the IR has no `inject_postops` op it is unused and may be left empty.
+// `postops` is the interoperability layer between the IR and the non-IR
+// injector, so everything specific to hooking Xbyak code up to the IR lives
+// there, including the fixed registers the injector reads. Those are
+// ISA-specific (an AVX-512 tail opmask has no AVX2 counterpart), which is why
+// neither the IR builder nor the emitter names them. It is null when the kernel
+// has no post-ops, which is also when the IR has no `inject_postops` operation.
 //
-//   acc_phys     - physical vec register indices of the accumulators, in the
-//                  order passed to `ir_t::inject_postops()`
-//   base_phys    - physical gpr index of the base (output) pointer
-//   out_byte_off - output byte offset of each accumulator from the base pointer,
-//                  parallel to `acc_phys`
-//   mask_phys    - physical register index of the active-element mask, or `-1`
-//                  when there is none
-//   elems        - active element count per accumulator, `-1` for a full vector
-using inject_postops_fn_t = std::function<void(const std::vector<int> &acc_phys,
-        int base_phys, const std::vector<dim_t> &out_byte_off, int mask_phys,
-        int elems)>;
-
 // Export for testing.
 void DNNL_API emit(jit_generator_t &gen, const ir_t &ir,
         const reg_alloc_result_t &alloc, const reg_config_t &reg_cfg,
-        data_section_t &data, const inject_postops_fn_t &inject = {});
+        data_section_t &data, postops_injector_t *postops = nullptr);
 
 // Emit the accumulated static data after the kernel's postamble. It aligns,
 // binds each label and then write the data bytes with `db`.

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -173,13 +173,11 @@ void ir_t::prefetch(vreg_t base, dim_t disp) {
 }
 
 void ir_t::inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr,
-        const std::vector<dim_t> &out_byte_off, vreg_t mask, int elems) {
+        const std::vector<dim_t> &out_byte_off) {
     inject_postops_args_t args;
     args.acc = acc;
     args.base_ptr = base_ptr;
     args.out_byte_off = out_byte_off;
-    args.mask = mask;
-    args.elems = elems;
     inject_postops_args_.push_back(args);
 
     op_t op;
@@ -306,15 +304,14 @@ void ir_t::def_use(
             break;
         case op_kind_t::inject_postops: {
             // The injector transforms the accumulators in place (read and
-            // written) and reads the base pointer and the tail mask. Report them
-            // so liveness is correct across the op.
+            // written) and reads the base pointer. Report them so liveness is
+            // correct across the op.
             const auto &args = inject_postops_args_[(int)op.imm];
             for (vreg_t v : args.acc) {
                 u(v);
                 d(v);
             }
             u(args.base_ptr);
-            u(args.mask);
             break;
         }
         case op_kind_t::set_mask_imm: d(op.dst); break;

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -90,39 +90,45 @@ void ir_t::vzero(vreg_t dst) {
     ops_.push_back(op);
 }
 
-void ir_t::vload(vreg_t dst, vreg_t base, dim_t disp) {
+void ir_t::vload(vreg_t dst, vreg_t base, dim_t disp, data_type_t mem_dt) {
     op_t op;
     op.kind = op_kind_t::vload;
     op.dst = dst;
     op.mem.base = base;
     op.mem.disp = disp;
+    op.mem_dt = mem_dt;
     ops_.push_back(op);
 }
 
-void ir_t::vstore(vreg_t base, dim_t disp, vreg_t src) {
+void ir_t::vstore(vreg_t base, dim_t disp, vreg_t src, data_type_t mem_dt) {
     op_t op;
     op.kind = op_kind_t::vstore;
     op.s0 = src;
     op.mem.base = base;
     op.mem.disp = disp;
+    op.mem_dt = mem_dt;
     ops_.push_back(op);
 }
 
-void ir_t::vload_scalar(vreg_t dst, vreg_t base, dim_t disp) {
+void ir_t::vload_scalar(
+        vreg_t dst, vreg_t base, dim_t disp, data_type_t mem_dt) {
     op_t op;
     op.kind = op_kind_t::vload_scalar;
     op.dst = dst;
     op.mem.base = base;
     op.mem.disp = disp;
+    op.mem_dt = mem_dt;
     ops_.push_back(op);
 }
 
-void ir_t::vstore_scalar(vreg_t base, dim_t disp, vreg_t src) {
+void ir_t::vstore_scalar(
+        vreg_t base, dim_t disp, vreg_t src, data_type_t mem_dt) {
     op_t op;
     op.kind = op_kind_t::vstore_scalar;
     op.s0 = src;
     op.mem.base = base;
     op.mem.disp = disp;
+    op.mem_dt = mem_dt;
     ops_.push_back(op);
 }
 
@@ -167,7 +173,8 @@ void ir_t::set_mask_imm(vreg_t mask, int n_elems) {
     ops_.push_back(op);
 }
 
-void ir_t::vload_masked(vreg_t dst, vreg_t base, dim_t disp, vreg_t mask) {
+void ir_t::vload_masked(
+        vreg_t dst, vreg_t base, dim_t disp, vreg_t mask, data_type_t mem_dt) {
     assert(mask != vreg_t::none && "vload_masked: mask is required");
 
     op_t op;
@@ -176,10 +183,12 @@ void ir_t::vload_masked(vreg_t dst, vreg_t base, dim_t disp, vreg_t mask) {
     op.s1 = mask;
     op.mem.base = base;
     op.mem.disp = disp;
+    op.mem_dt = mem_dt;
     ops_.push_back(op);
 }
 
-void ir_t::vstore_masked(vreg_t base, dim_t disp, vreg_t src, vreg_t mask) {
+void ir_t::vstore_masked(
+        vreg_t base, dim_t disp, vreg_t src, vreg_t mask, data_type_t mem_dt) {
     assert(mask != vreg_t::none && "vstore_masked: mask is required");
 
     op_t op;
@@ -188,6 +197,7 @@ void ir_t::vstore_masked(vreg_t base, dim_t disp, vreg_t src, vreg_t mask) {
     op.s1 = mask;
     op.mem.base = base;
     op.mem.disp = disp;
+    op.mem_dt = mem_dt;
     ops_.push_back(op);
 }
 

--- a/src/cpu/x64/ir/ir.cpp
+++ b/src/cpu/x64/ir/ir.cpp
@@ -14,6 +14,8 @@
 * limitations under the License.
 *******************************************************************************/
 
+#include <cassert>
+
 #include "cpu/x64/ir/ir.hpp"
 
 namespace dnnl {
@@ -97,6 +99,33 @@ void ir_t::vload(vreg_t dst, vreg_t base, dim_t disp) {
     ops_.push_back(op);
 }
 
+void ir_t::vstore(vreg_t base, dim_t disp, vreg_t src) {
+    op_t op;
+    op.kind = op_kind_t::vstore;
+    op.s0 = src;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
+void ir_t::vload_scalar(vreg_t dst, vreg_t base, dim_t disp) {
+    op_t op;
+    op.kind = op_kind_t::vload_scalar;
+    op.dst = dst;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
+void ir_t::vstore_scalar(vreg_t base, dim_t disp, vreg_t src) {
+    op_t op;
+    op.kind = op_kind_t::vstore_scalar;
+    op.s0 = src;
+    op.mem.base = base;
+    op.mem.disp = disp;
+    ops_.push_back(op);
+}
+
 void ir_t::vdot(vreg_t dst, vreg_t a, vreg_t b) {
     op_t op;
     op.kind = op_kind_t::vdot;
@@ -138,27 +167,25 @@ void ir_t::set_mask_imm(vreg_t mask, int n_elems) {
     ops_.push_back(op);
 }
 
-void ir_t::vload_masked(
-        vreg_t dst, vreg_t base, dim_t disp, vreg_t mask, int elems) {
+void ir_t::vload_masked(vreg_t dst, vreg_t base, dim_t disp, vreg_t mask) {
+    assert(mask != vreg_t::none && "vload_masked: mask is required");
+
     op_t op;
     op.kind = op_kind_t::vload_masked;
     op.dst = dst;
-    // `none` when no mask register is needed
     op.s1 = mask;
-    op.imm = elems;
     op.mem.base = base;
     op.mem.disp = disp;
     ops_.push_back(op);
 }
 
-void ir_t::vstore_masked(
-        vreg_t base, dim_t disp, vreg_t src, vreg_t mask, int elems) {
+void ir_t::vstore_masked(vreg_t base, dim_t disp, vreg_t src, vreg_t mask) {
+    assert(mask != vreg_t::none && "vstore_masked: mask is required");
+
     op_t op;
     op.kind = op_kind_t::vstore_masked;
     op.s0 = src;
-    // `none` when no mask register is needed
     op.s1 = mask;
-    op.imm = elems;
     op.mem.base = base;
     op.mem.disp = disp;
     ops_.push_back(op);
@@ -281,8 +308,14 @@ void ir_t::def_use(
             break;
         case op_kind_t::vzero: d(op.dst); break;
         case op_kind_t::vload:
+        case op_kind_t::vload_scalar:
             u(op.mem.base);
             d(op.dst);
+            break;
+        case op_kind_t::vstore:
+        case op_kind_t::vstore_scalar:
+            u(op.s0);
+            u(op.mem.base);
             break;
         case op_kind_t::vdot:
             u(op.dst);
@@ -317,12 +350,12 @@ void ir_t::def_use(
         case op_kind_t::set_mask_imm: d(op.dst); break;
         case op_kind_t::vload_masked:
             u(op.mem.base);
-            u(op.s1); // mask (-1 -> not counted, dropped by u())
+            u(op.s1); // mask
             d(op.dst);
             break;
         case op_kind_t::vstore_masked:
             u(op.s0);
-            u(op.s1); // mask (-1 -> not counted, dropped by u())
+            u(op.s1); // mask
             u(op.mem.base);
             break;
         case op_kind_t::prefetch: u(op.mem.base); break;

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -119,9 +119,8 @@ enum class op_kind_t {
     // Post-ops
     //
     // Apply post-ops via an injector to a set of accumulators. The injector is
-    // not IR-based, so lowering to it needs interoperability code (see the
-    // emitter's `postops_lowering_t`). Operands are in
-    // `inject_postops_args_t`.
+    // not IR-based, so lowering to it needs interoperability code (see
+    // `postops_injector_t`). Operands are in `inject_postops_args_t`.
     inject_postops,
 
     // Mask operations
@@ -236,8 +235,8 @@ struct vreg_info_t {
 // How many elements of an accumulator are active is not recorded here. That is
 // a detail of hooking the Xbyak injector up to the IR, not of the IR itself.
 // The count is fixed for a kernel, so the lowering takes it once instead (see
-// the emitter's `postops_lowering_t`), and the register that carries the
-// pattern is ISA-specific. Neither belongs in a target-neutral IR.
+// `postops_injector_t`), and the register that carries the pattern is
+// ISA-specific. Neither belongs in a target-neutral IR.
 struct inject_postops_args_t {
     std::vector<vreg_t> acc;
     vreg_t base_ptr = vreg_t::none;

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -192,6 +192,9 @@ struct mem_t {
 //         * set_mask_imm   -> active element count
 //         * inject_postops -> index into inject_postops_args()
 // mem   - memory address used only by load/store operations.
+// mem_dt - element data type in memory, set by every vector load and store. It
+//        is the data type of the vreg when the access moves the value as it
+//        is, and a different one when the access converts.
 // match - for loop_end, index of matching loop_begin operation.
 // label_id - target label id for label/jmp/jz. When unused it's `none`.
 // init_is_reg - for loop_begin, if true, initialize loop counter from s0
@@ -202,6 +205,7 @@ struct op_t {
     vreg_t s0 = vreg_t::none, s1 = vreg_t::none;
     dim_t imm = 0;
     mem_t mem;
+    data_type_t mem_dt = data_type::undef;
     int match = -1;
     label_t label_id = label_t::none;
     bool init_is_reg = false;
@@ -293,11 +297,13 @@ struct DNNL_API ir_t {
     void load(vreg_t dst, vreg_t base, dim_t disp);
 
     // vec
+    // `mem_dt` is the element data type in memory. Pass the data type of the
+    // vreg to move the value as it is, or a different one to convert it.
     void vzero(vreg_t dst);
-    void vload(vreg_t dst, vreg_t base, dim_t disp);
-    void vstore(vreg_t base, dim_t disp, vreg_t src);
-    void vload_scalar(vreg_t dst, vreg_t base, dim_t disp);
-    void vstore_scalar(vreg_t base, dim_t disp, vreg_t src);
+    void vload(vreg_t dst, vreg_t base, dim_t disp, data_type_t mem_dt);
+    void vstore(vreg_t base, dim_t disp, vreg_t src, data_type_t mem_dt);
+    void vload_scalar(vreg_t dst, vreg_t base, dim_t disp, data_type_t mem_dt);
+    void vstore_scalar(vreg_t base, dim_t disp, vreg_t src, data_type_t mem_dt);
     void vdot(vreg_t dst, vreg_t a, vreg_t b);
     void vadd(vreg_t dst, vreg_t src);
     void vmul(vreg_t dst, vreg_t src);
@@ -309,8 +315,10 @@ struct DNNL_API ir_t {
     // `mask` comes from `set_mask_imm` and is required. Use `vload`/`vstore`
     // for a full vector and `vload_scalar`/`vstore_scalar` for one element,
     // since neither needs a mask register.
-    void vload_masked(vreg_t dst, vreg_t base, dim_t disp, vreg_t mask);
-    void vstore_masked(vreg_t base, dim_t disp, vreg_t src, vreg_t mask);
+    void vload_masked(vreg_t dst, vreg_t base, dim_t disp, vreg_t mask,
+            data_type_t mem_dt);
+    void vstore_masked(vreg_t base, dim_t disp, vreg_t src, vreg_t mask,
+            data_type_t mem_dt);
 
     void prefetch(vreg_t base, dim_t disp);
 

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -100,6 +100,12 @@ enum class op_kind_t {
     vzero,
     // dst = [base + disp] (load full vector)
     vload,
+    // [base + disp] = s0 (store full vector)
+    vstore,
+    // dst = [base + disp] (load one element, the rest of dst reads as zero)
+    vload_scalar,
+    // [base + disp] = s0 (store one element)
+    vstore_scalar,
     // dst += sum_{i=0}^{N-1} (s0[i] * s1[i]), where N is the dot length
     vdot,
     // dst += s0 (vector add)
@@ -125,9 +131,10 @@ enum class op_kind_t {
 
     // Masked vector load/store
     //
-    // loads `imm` elements. Mask vreg = s1 or -1.
+    // dst = [base + disp] under the mask vreg s1. Masked-out elements read as
+    // zero.
     vload_masked,
-    // stores `imm` elements. Mmask vreg = s1 or -1.
+    // [base + disp] = s0 under the mask vreg s1.
     vstore_masked,
 
     // prefetch [base + disp] into cache. Reads base, writes nothing.
@@ -183,7 +190,6 @@ struct mem_t {
 //         * mov_imm        -> literal constant
 //         * loop_begin     -> loop trip count
 //         * set_mask_imm   -> active element count
-//         * vload_masked / vstore_masked -> active element count
 //         * inject_postops -> index into inject_postops_args()
 // mem   - memory address used only by load/store operations.
 // match - for loop_end, index of matching loop_begin operation.
@@ -289,6 +295,9 @@ struct DNNL_API ir_t {
     // vec
     void vzero(vreg_t dst);
     void vload(vreg_t dst, vreg_t base, dim_t disp);
+    void vstore(vreg_t base, dim_t disp, vreg_t src);
+    void vload_scalar(vreg_t dst, vreg_t base, dim_t disp);
+    void vstore_scalar(vreg_t base, dim_t disp, vreg_t src);
     void vdot(vreg_t dst, vreg_t a, vreg_t b);
     void vadd(vreg_t dst, vreg_t src);
     void vmul(vreg_t dst, vreg_t src);
@@ -297,15 +306,11 @@ struct DNNL_API ir_t {
     void vhreduce(vreg_t dst, vreg_t workspace);
 
     // vec (masked)
-    // `elems` is the number of active elements. `mask` is the mask register
-    // holding that pattern (from `set_mask_imm`), or `vreg_t::none` for a
-    // single element or a full vector, where no mask register is needed.
-    void vload_masked(
-            vreg_t dst, vreg_t base, dim_t disp, vreg_t mask, int elems);
-    // Same shape as `vload_masked`, but stores `src` to [base + disp] instead
-    // of loading.
-    void vstore_masked(
-            vreg_t base, dim_t disp, vreg_t src, vreg_t mask, int elems);
+    // `mask` comes from `set_mask_imm` and is required. Use `vload`/`vstore`
+    // for a full vector and `vload_scalar`/`vstore_scalar` for one element,
+    // since neither needs a mask register.
+    void vload_masked(vreg_t dst, vreg_t base, dim_t disp, vreg_t mask);
+    void vstore_masked(vreg_t base, dim_t disp, vreg_t src, vreg_t mask);
 
     void prefetch(vreg_t base, dim_t disp);
 

--- a/src/cpu/x64/ir/ir.hpp
+++ b/src/cpu/x64/ir/ir.hpp
@@ -114,7 +114,8 @@ enum class op_kind_t {
     //
     // Apply post-ops via an injector to a set of accumulators. The injector is
     // not IR-based, so lowering to it needs interoperability code (see the
-    // emitter's `inject_postops_fn_t`). Operands are in `inject_postops_args_t`.
+    // emitter's `postops_lowering_t`). Operands are in
+    // `inject_postops_args_t`.
     inject_postops,
 
     // Mask operations
@@ -219,22 +220,18 @@ struct vreg_info_t {
 //                  parallel to `acc`. Locates each accumulator in the
 //                  destination tensor so binary post-ops address the matching
 //                  right-hand-side slice
-//   mask, elems  - active-element descriptor of the accumulators, the same
-//                  `mask` and `elems` that `vload_masked` / `vstore_masked`
-//                  take. `elems` is the active element count and `mask` holds
-//                  that pattern, or `vreg_t::none` for a single element or a
-//                  full vector. `elems == -1` marks a full vector, every element
-//                  valid. A binary post-op reads `elems` right-hand-side
-//                  elements per accumulator, keeping the read in bounds
 //
-// `base_ptr`, `out_byte_off`, `mask`, and `elems` are unused by an eltwise-only
-// chain.
+// `base_ptr` and `out_byte_off` are unused by an eltwise-only chain.
+//
+// How many elements of an accumulator are active is not recorded here. That is
+// a detail of hooking the Xbyak injector up to the IR, not of the IR itself.
+// The count is fixed for a kernel, so the lowering takes it once instead (see
+// the emitter's `postops_lowering_t`), and the register that carries the
+// pattern is ISA-specific. Neither belongs in a target-neutral IR.
 struct inject_postops_args_t {
     std::vector<vreg_t> acc;
     vreg_t base_ptr = vreg_t::none;
     std::vector<dim_t> out_byte_off;
-    vreg_t mask = vreg_t::none;
-    int elems = -1;
 };
 
 // An `ir_t` is the operation list plus, for each virtual register, its info
@@ -316,11 +313,11 @@ struct DNNL_API ir_t {
     void set_mask_imm(vreg_t mask, int n_elems);
 
     // post-ops
-    // Apply post-ops to `acc` in place. `base_ptr`, `out_byte_off`, `mask`, and
-    // `elems` describe where each accumulator lands in the output and how many
-    // elements are active (see `inject_postops_args_t`).
+    // Apply post-ops to `acc` in place. `base_ptr` and `out_byte_off` describe
+    // where each accumulator lands in the output (see
+    // `inject_postops_args_t`).
     void inject_postops(const std::vector<vreg_t> &acc, vreg_t base_ptr,
-            const std::vector<dim_t> &out_byte_off, vreg_t mask, int elems);
+            const std::vector<dim_t> &out_byte_off);
 
     // control flow
     // Pass the returned op index to `loop_end` to close the loop.

--- a/src/cpu/x64/ir/postops_injector.cpp
+++ b/src/cpu/x64/ir/postops_injector.cpp
@@ -36,10 +36,10 @@ namespace {
 // from the host generator.
 template <typename Vmm>
 std::shared_ptr<void> create_injector(jit_generator_t &gen,
-        const post_ops_t &post_ops,
-        const binary_injector::static_params_t &bsp) {
+        const post_ops_t &post_ops, const binary_injector::static_params_t &bsp,
+        const eltwise_injector::static_params_t &esp) {
     return std::make_shared<injector_t<Vmm>>(
-            &gen, post_ops, bsp, /* inject_sum = */ true);
+            &gen, post_ops, bsp, esp, /* inject_sum = */ true);
 }
 
 template <typename Vmm>
@@ -52,9 +52,19 @@ injector_t<Vmm> *cast2tgt(void *injector) {
 postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
         const post_ops_t &post_ops, const memory_desc_t &dst_md,
         const Xbyak::Reg64 &param_reg, int rhs_arg_offset, dim_t dst_orig_off,
-        int tail_elems)
-    : is_zmm_(is_superset(isa, avx512_core)), tail_elems_(tail_elems) {
+        int tail_elems, int eltwise_opmask, int binary_tail_opmask)
+    : is_zmm_(is_superset(isa, avx512_core))
+    , tail_elems_(tail_elems)
+    , binary_tail_opmask_(binary_tail_opmask) {
     const memory_desc_wrapper dst_d(dst_md);
+
+    // The eltwise injector overwrites its mask and the binary injector reads
+    // its own across the same call, so sharing one register would destroy the
+    // tail pattern.
+    JIT_ASSERT(eltwise_opmask != binary_tail_opmask
+            && "postops_injector: eltwise and binary opmask must differ");
+    // `init()` builds the tail pattern with a 64-bit shift.
+    JIT_ASSERT(tail_elems < 64 && "postops_injector: tail is too wide");
 
     // The injector preserves the state of the gpr and vec registers it borrows.
     static constexpr bool preserve_gpr = true;
@@ -68,19 +78,26 @@ postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
     // `rhs_arg_offset` locates the argument pointer array in the parameter
     // struct. `dst_orig_off` locates the destination origin, used to turn an
     // accumulator address into its destination position. `tail_elems` is the
-    // element count a partial load reads on avx2. The avx512 opmask path is not
-    // enabled yet.
+    // element count a partial load reads, as an integer on avx2 and through
+    // `binary_tail_opmask` on avx512.
     const binary_injector::rhs_arg_static_params_t rhs_sp {
             rhs_dt_helper_vmm_idx, gen.r14, gen.r15, gen.r13, preserve_gpr,
             preserve_vmm, rhs_arg_offset, dst_orig_off, dst_d, tail_elems,
-            use_exact_tail_scalar_bcast};
+            Xbyak::Opmask(binary_tail_opmask), use_exact_tail_scalar_bcast};
 
     const binary_injector::static_params_t bsp {param_reg,
             binary_injector::get_all_strategies_supported_by_injector(),
             rhs_sp};
 
-    injector_ = is_zmm_ ? create_injector<Xbyak::Zmm>(gen, post_ops, bsp)
-                        : create_injector<Xbyak::Ymm>(gen, post_ops, bsp);
+    // Everything but the mask keeps the eltwise injector's own defaults. The
+    // mask has to be named because its default, `k1`, is a register the IR
+    // allocator hands out.
+    const eltwise_injector::static_params_t esp {/*save_state=*/true,
+            /*p_table=*/Xbyak::Reg64(Xbyak::Operand::RAX),
+            Xbyak::Opmask(eltwise_opmask)};
+
+    injector_ = is_zmm_ ? create_injector<Xbyak::Zmm>(gen, post_ops, bsp, esp)
+                        : create_injector<Xbyak::Ymm>(gen, post_ops, bsp, esp);
     assert(injector_ && "ir post-ops injector creation failed");
 
     with_eltwise_ = post_ops.find(primitive_kind::eltwise) != -1;
@@ -92,8 +109,22 @@ postops_injector_t::postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
             || post_ops.find(primitive_kind::prelu) != -1 || with_sum_;
 }
 
-void postops_injector_t::apply(const std::vector<int> &acc_phys, int base_phys,
-        const std::vector<dim_t> &out_byte_off, int mask_phys, int elems) {
+void postops_injector_t::init(jit_generator_t &gen) const {
+    // The tail opmask is read only by the binary injector. An eltwise-only
+    // chain never reaches it, and on avx2* the tail is an integer inside the
+    // injector, so neither case has anything to set up.
+    if (!is_zmm_ || !needs_rhs_args_ || tail_elems_ <= 0) return;
+
+    // `kxnorq` sets all 64 bits and `kshiftrq` keeps the low `tail_elems_` of
+    // them. Building the mask in the k-register file keeps it independent of
+    // the gpr scratch registers.
+    const Xbyak::Opmask k(binary_tail_opmask_);
+    gen.kxnorq(k, k, k);
+    gen.kshiftrq(k, k, (uint8_t)(64 - tail_elems_));
+}
+
+void postops_injector_t::inject(const std::vector<int> &acc_phys, int base_phys,
+        const std::vector<dim_t> &out_byte_off) {
     injector_utils::vmm_index_set_t vmm_idxs;
     for (int idx : acc_phys)
         vmm_idxs.insert(idx);
@@ -110,17 +141,10 @@ void postops_injector_t::apply(const std::vector<int> &acc_phys, int base_phys,
         return;
     }
 
-    // `mask_phys` is a K register (avx512 opmask). The avx512 emitter is not
-    // enabled yet, so it is currently unused.
-    MAYBE_UNUSED(mask_phys);
-
-    // `elems == -1` is a full vector. A positive count is a partial load of
-    // `elems` right-hand-side elements and must match `tail_elems_`.
-    JIT_ASSERT((elems == -1 || elems > 0)
-            && "inject_postops: elems must be -1 or a positive count");
-    const bool is_tail = elems > 0;
-    JIT_ASSERT((!is_tail || elems == tail_elems_)
-            && "inject_postops: tail count does not match the injector");
+    // A positive `tail_elems_` means an accumulator holds fewer valid elements
+    // than a full vector, so a right-hand-side load has to stop at that count
+    // to stay in bounds. `init()` has put that pattern in the tail opmask.
+    const bool is_tail = tail_elems_ > 0;
 
     // Map each accumulator to its destination address. A binary post-op uses it
     // to locate the corresponding right-hand-side slice, and the sum operation

--- a/src/cpu/x64/ir/postops_injector.hpp
+++ b/src/cpu/x64/ir/postops_injector.hpp
@@ -17,26 +17,42 @@
 #ifndef CPU_X64_IR_POSTOPS_INJECTOR_HPP
 #define CPU_X64_IR_POSTOPS_INJECTOR_HPP
 
-// Driver for the JIT-based post-ops injector. It lowers the `inject_postops` IR
-// operation (see `emitter.hpp` and `inject_postops_fn_t`).
+// Lowers the `inject_postops` IR operation onto the JIT post-ops injector,
+// which is not IR-based (see `emitter.hpp`). It owns the injector and turns the
+// operation's operands into the arguments the injector takes, so it is where
+// the IR and Xbyak worlds meet.
 //
-// The IR operation and the emitter callback that drives this
-// `postops_injector_t` are builder-independent. An IR-based kernel sets it up
-// in `generate()`:
-//   1. Create this object from the post-ops chain and the destination
-//      descriptor.
-//   2. Wrap it in a callback passed to the emitter that calls `apply()`.
+// The IR operation is builder-independent. An IR-based kernel sets this object
+// up in `generate()`:
+//   1. Create it from the post-ops chain and the destination descriptor.
+//   2. Pass it to the emitter, which calls `init()` once and then `inject()`
+//      per `inject_postops` operation.
 //   3. Call `maybe_prepare_table()` once after the postamble.
 //
 // ISA handling:
-// - The only ISA-specific detail is the vector width (Ymm or Zmm), chosen from
-//   the `isa`. The width-specific injector is stored type-erased, so IR-based
-//   kernels do not need to be templated.
+// - The vector width (Ymm or Zmm) is chosen from the `isa`. The width-specific
+//   injector is stored type-erased, so IR-based kernels do not need to be
+//   templated.
 //
 // Register handling:
-// - The injector saves and restores every register it uses, so its registers
-//   need not be reserved in the IR allocator. The save/restore cost is paid
-//   once per call.
+// - The injector saves and restores the gpr and vec registers it borrows, so
+//   those need not be reserved in the IR allocator. The save/restore cost is
+//   paid once per call.
+// - It does not do the same for opmasks. On AVX-512 the eltwise injector and
+//   the binary injector each take one as a fixed register and restore neither,
+//   so the kernel reserves both and keeps them out of the allocator's mask file
+//   (see `mask_scratch` in `make_reg_config()`):
+//     eltwise_opmask     - scratch the eltwise injector overwrites. It is
+//                          written before it is read, so it needs no setup.
+//     binary_tail_opmask - active-element pattern the binary injector reads for
+//                          a partial right-hand-side load. Binary, prelu, and
+//                          sum post-ops all route through it. `init()` writes
+//                          the pattern.
+//   The two must be different registers. An eltwise post-op ahead of a binary
+//   one would otherwise destroy the tail pattern.
+//
+//   Both are unused on AVX2*, where a mask is a vector register and the tail
+//   size is an integer inside the injector.
 
 #include <memory>
 #include <vector>
@@ -53,36 +69,46 @@ namespace ir {
 
 // Interfaces marked with DNNL_API are exported for testing purposes only.
 struct postops_injector_t {
-    // gen            - generator the injected post-op code is emitted into
-    // isa            - kernel ISA
-    // post_ops       - attribute post-ops chain to apply
-    // dst_md         - destination memory descriptor (used by binary post-ops)
-    // param_reg      - gpr holding the kernel-parameter-struct pointer (used by
-    //                  binary post-ops to reach their right-hand-side arguments)
-    // rhs_arg_offset - byte offset in the parameter struct of the binary
-    //                  right-hand-side argument pointer array
-    // dst_orig_off   - byte offset in the parameter struct of the destination
-    //                  origin pointer, used to turn an accumulator address into
-    //                  its position in the destination tensor
-    // tail_elems     - right-hand-side elements a partial (tail) load reads
+    // gen                - generator the injected post-op code is emitted into
+    // isa                - kernel ISA
+    // post_ops           - attribute post-ops chain to apply
+    // dst_md             - destination memory descriptor (used by binary
+    //                      post-ops)
+    // param_reg          - gpr holding the kernel-parameter-struct pointer
+    //                      (used by binary post-ops to reach their
+    //                      right-hand-side arguments)
+    // rhs_arg_offset     - byte offset in the parameter struct of the binary
+    //                      right-hand-side argument pointer array
+    // dst_orig_off       - byte offset in the parameter struct of the
+    //                      destination origin pointer, used to turn an
+    //                      accumulator address into its position in the
+    //                      destination tensor
+    // tail_elems         - right-hand-side elements a partial (tail) load
+    //                      reads. 0 means every accumulator holds a full vector
+    // eltwise_opmask     - AVX-512 opmask the eltwise injector uses as scratch
+    // binary_tail_opmask - AVX-512 opmask holding the `tail_elems` pattern for
+    //                      the binary injector
     DNNL_API postops_injector_t(jit_generator_t &gen, cpu_isa_t isa,
             const post_ops_t &post_ops, const memory_desc_t &dst_md,
             const Xbyak::Reg64 &param_reg, int rhs_arg_offset,
-            dim_t dst_orig_off, int tail_elems);
+            dim_t dst_orig_off, int tail_elems, int eltwise_opmask,
+            int binary_tail_opmask);
 
     postops_injector_t(const postops_injector_t &) = delete;
     postops_injector_t &operator=(const postops_injector_t &) = delete;
+
+    // Set up the fixed registers `inject()` reads. Call once, ahead of the
+    // first `inject()`, on the generator the object was created for. A no-op
+    // unless the ISA and the chain need the tail opmask.
+    void DNNL_API init(jit_generator_t &gen) const;
 
     // Apply the post-ops to the accumulators in `acc_phys` (physical vec
     // register indices). For binary and sum post-ops, `base_phys` and
     // `out_byte_off` give each accumulator's output address: binary reaches its
     // right-hand-side argument through it, sum reads the previous destination
-    // value from it. `elems` is the active element
-    // count, `-1` for a full vector, and limits how many right-hand-side
-    // elements are read. `mask_phys` is the tail opmask (a K register), used
-    // only by the avx512 emitter, which is not enabled yet.
-    void DNNL_API apply(const std::vector<int> &acc_phys, int base_phys,
-            const std::vector<dim_t> &out_byte_off, int mask_phys, int elems);
+    // value from it.
+    void DNNL_API inject(const std::vector<int> &acc_phys, int base_phys,
+            const std::vector<dim_t> &out_byte_off);
 
     // Emit the post-ops constant table. Call once, after the postamble. Only
     // eltwise and sum post-ops have a table, so this is a no-op without one.
@@ -103,6 +129,8 @@ private:
     bool needs_rhs_args_ = false;
     // Number of right-hand-side elements a tail load reads.
     int tail_elems_ = 0;
+    // AVX-512 opmask holding the `tail_elems_` pattern, written by `init()`.
+    int binary_tail_opmask_ = -1;
 };
 
 } // namespace ir

--- a/src/cpu/x64/ir/reg_config.cpp
+++ b/src/cpu/x64/ir/reg_config.cpp
@@ -65,10 +65,24 @@ reg_config_t make_reg_config(cpu_isa_t isa, int param_reg, int rsp_reg,
     // Map each register kind to a file. `reg_kind_t` order is
     // { gpr, vec, mask }.
     //  * gpr: file 0
-    //  * vec and mask: file 1 (a mask is a vector register on AVX2*).
-    //
-    // TODO: on AVX-512 add a third file of k-registers and map mask to file 2.
-    rc.pools.kind_to_file = {0, 1, 1};
+    //  * vec: file 1
+    //  * mask: file 1 on AVX2*, where a mask is a vector register, and file 2
+    //    on AVX-512, which has a dedicated k-register file.
+    if (is_superset(isa, avx512_core)) {
+        // Mask file holds `k1` to `k7`. `k0` is excluded because it cannot
+        // encode a write mask. A spill slot is 8 bytes, the width of an opmask,
+        // although the emitter never spills a mask (see `set_mask_imm` in
+        // `emitter.cpp`).
+        reg_file_t mask_file;
+        mask_file.slot_size = 8;
+        for (int i = 1; i < 8; i++)
+            mask_file.regs.push_back(i);
+
+        rc.pools.files.push_back(mask_file);
+        rc.pools.kind_to_file = {0, 1, 2};
+    } else {
+        rc.pools.kind_to_file = {0, 1, 1};
+    }
 
     return rc;
 }

--- a/src/cpu/x64/ir/reg_config.cpp
+++ b/src/cpu/x64/ir/reg_config.cpp
@@ -26,7 +26,8 @@ namespace ir {
 
 reg_config_t make_reg_config(cpu_isa_t isa, int param_reg, int rsp_reg,
         const std::vector<int> &gpr_scratch,
-        const std::vector<int> &vec_scratch) {
+        const std::vector<int> &vec_scratch,
+        const std::vector<int> &mask_scratch) {
     reg_config_t rc;
     rc.param_reg = param_reg;
     rc.gpr_scratch = gpr_scratch;
@@ -69,14 +70,15 @@ reg_config_t make_reg_config(cpu_isa_t isa, int param_reg, int rsp_reg,
     //  * mask: file 1 on AVX2*, where a mask is a vector register, and file 2
     //    on AVX-512, which has a dedicated k-register file.
     if (is_superset(isa, avx512_core)) {
-        // Mask file holds `k1` to `k7`. `k0` is excluded because it cannot
-        // encode a write mask. A spill slot is 8 bytes, the width of an opmask,
-        // although the emitter never spills a mask (see `set_mask_imm` in
-        // `emitter.cpp`).
+        // Mask file holds `k1` to `k7` minus `mask_scratch`. `k0` is excluded
+        // because it cannot encode a write mask. A spill slot is 8 bytes, the
+        // width of an opmask, although the emitter never spills a mask (see
+        // `set_mask_imm` in `emitter.cpp`).
         reg_file_t mask_file;
         mask_file.slot_size = 8;
-        for (int i = 1; i < 8; i++)
-            mask_file.regs.push_back(i);
+        for (int i = 1; i < 8; i++) {
+            if (!contains(mask_scratch, i)) mask_file.regs.push_back(i);
+        }
 
         rc.pools.files.push_back(mask_file);
         rc.pools.kind_to_file = {0, 1, 2};

--- a/src/cpu/x64/ir/reg_config.hpp
+++ b/src/cpu/x64/ir/reg_config.hpp
@@ -67,14 +67,21 @@ struct reg_config_t {
 // - `param_reg` (parameter pointer)
 // - `gpr_scratch` registers
 // - `vec_scratch` registers
+// - `mask_scratch` opmasks, on AVX-512 only
 //
-// The emitter uses these scratch registers when loading and storing spilled
-// values.
+// The emitter uses `gpr_scratch` and `vec_scratch` when loading and storing
+// spilled values.
+//
+// `mask_scratch` names the opmasks a kernel hands to code outside the IR that
+// writes them without restoring them. The JIT post-ops injector is the one such
+// consumer today (see `postops_injector_t`). On AVX2* a mask is a vector
+// register, so `mask_scratch` is ignored there.
 //
 // Export for testing.
 reg_config_t DNNL_API make_reg_config(cpu_isa_t isa, int param_reg, int rsp_reg,
         const std::vector<int> &gpr_scratch,
-        const std::vector<int> &vec_scratch);
+        const std::vector<int> &vec_scratch,
+        const std::vector<int> &mask_scratch);
 
 } // namespace ir
 } // namespace x64

--- a/src/cpu/x64/ir/reg_config.hpp
+++ b/src/cpu/x64/ir/reg_config.hpp
@@ -59,6 +59,9 @@ struct reg_config_t {
 // 32-byte spill slots, while AVX-512 uses 32 vector registers with 64-byte
 // spill slots.
 //
+// A mask allocates from the vector file on AVX2*, where a mask is a vector
+// register, and from a dedicated k-register file on AVX-512.
+//
 // Some registers are reserved and are not included in the allocatable pools:
 // - `rsp_reg` (stack pointer)
 // - `param_reg` (parameter pointer)

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -562,6 +562,44 @@ TEST(IRBuilderTests, InjectPostopsRecordsArgsAndDefUse) {
     EXPECT_NE(std::find(uses.begin(), uses.end(), (int)mask), uses.end());
 }
 
+// Register config tests
+//
+// Checks the register files `make_reg_config()` builds for each ISA. A mask is
+// a vector register on AVX2*, so the mask and vec kinds share one file. AVX-512
+// masks with k-registers, so the mask kind gets a file of its own.
+//
+// No `mayiuse` guard is needed. `make_reg_config()` reads the ISA through the
+// `cpu_isa_traits_t` tables only and generates no code, so both layouts are
+// checkable on any machine.
+TEST(RegConfigTests, MapsMaskKindToFilePerIsa) {
+    const int param_reg = 0, rsp_reg = 4;
+    const std::vector<int> gpr_scratch {10, 11};
+    const std::vector<int> vec_scratch {13, 14, 15};
+
+    {
+        const reg_config_t rc = make_reg_config(
+                avx2, param_reg, rsp_reg, gpr_scratch, vec_scratch);
+
+        ASSERT_EQ(rc.pools.files.size(), 2u);
+        EXPECT_EQ(rc.pools.kind_to_file, std::vector<int>({0, 1, 1}));
+        EXPECT_EQ(rc.pools.files[1].slot_size, 32u);
+        EXPECT_EQ(rc.pools.files[1].regs.size(), 16u - vec_scratch.size());
+    }
+
+    {
+        const reg_config_t rc = make_reg_config(
+                avx512_core, param_reg, rsp_reg, gpr_scratch, vec_scratch);
+
+        ASSERT_EQ(rc.pools.files.size(), 3u);
+        EXPECT_EQ(rc.pools.kind_to_file, std::vector<int>({0, 1, 2}));
+        EXPECT_EQ(rc.pools.files[1].slot_size, 64u);
+        EXPECT_EQ(rc.pools.files[1].regs.size(), 32u - vec_scratch.size());
+        // The mask file is k1..k7. k0 cannot encode a write mask.
+        EXPECT_EQ(rc.pools.files[2].regs,
+                std::vector<int>({1, 2, 3, 4, 5, 6, 7}));
+    }
+}
+
 // Allocator tests
 //
 // Checks that there are no register collisions. If all values are live at the

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -745,7 +745,7 @@ ir_t build_dot_ir() {
     ir.vhreduce(acc, ws);
 
     // store the reduced scalar
-    ir.vstore_masked(c_ptr, 0, acc, vreg_t::none, 1);
+    ir.vstore_scalar(c_ptr, 0, acc);
 
     return ir;
 }
@@ -852,7 +852,7 @@ TEST(IntegrationTests, BuildsLoopReduction) {
 
     const vreg_t ws = ir.new_vec(data_type::f32);
     ir.vhreduce(acc, ws);
-    ir.vstore_masked(c_ptr, 0, acc, vreg_t::none, 1);
+    ir.vstore_scalar(c_ptr, 0, acc);
 
     ir_kernel_t kernel(ir);
     ASSERT_TRUE(kernel.run_ir_pipeline());
@@ -868,6 +868,71 @@ TEST(IntegrationTests, BuildsLoopReduction) {
     kernel.run(&args);
 
     EXPECT_FLOAT_EQ(c, ref_dot(a.data(), b.data(), k));
+}
+
+// Validates masked access end to end. A mask covering `tail` elements is built
+// once and drives both a load and a store. The inputs hold large values past
+// `tail`, so a load that reads them or a store that writes them changes the
+// result.
+TEST(IntegrationTests, MaskedAccessCoversActiveElementsOnly) {
+    SKIP_IF_NO_AVX2();
+
+    const int tail = simd_w() - 3;
+    const float sentinel = -1.f;
+    const dim_t dot_off = simd_w() * (dim_t)sizeof(float);
+
+    ir_t ir;
+
+    const vreg_t a_ptr = ir.new_gpr();
+    ir.load_param(a_ptr, offsetof(dot_args_t, a));
+
+    const vreg_t b_ptr = ir.new_gpr();
+    ir.load_param(b_ptr, offsetof(dot_args_t, b));
+
+    const vreg_t c_ptr = ir.new_gpr();
+    ir.load_param(c_ptr, offsetof(dot_args_t, c));
+
+    const vreg_t mask = ir.new_mask();
+    ir.set_mask_imm(mask, tail);
+
+    const vreg_t a = ir.new_vec(data_type::f32);
+    ir.vload_masked(a, a_ptr, 0, mask);
+    const vreg_t b = ir.new_vec(data_type::f32);
+    ir.vload_masked(b, b_ptr, 0, mask);
+
+    // Reduce first. An inactive element has to read as zero, or the values
+    // past `tail` would land in the dot product.
+    const vreg_t acc = ir.new_vec(data_type::f32);
+    ir.vzero(acc);
+    ir.vdot(acc, a, b);
+
+    const vreg_t ws = ir.new_vec(data_type::f32);
+    ir.vhreduce(acc, ws);
+    ir.vstore_scalar(c_ptr, dot_off, acc);
+
+    // Then the elementwise product, stored under the same mask.
+    ir.vmul(a, b);
+    ir.vstore_masked(c_ptr, 0, a, mask);
+
+    ir_kernel_t kernel(ir);
+    ASSERT_TRUE(kernel.run_ir_pipeline());
+
+    std::vector<float> a_buf(simd_w()), b_buf(simd_w());
+    for (int i = 0; i < simd_w(); i++) {
+        const bool active = i < tail;
+        a_buf[i] = active ? (float)(i + 1) : 1e6f;
+        b_buf[i] = active ? (float)(2 * i - 3) : 1e6f;
+    }
+
+    std::vector<float> c_buf(simd_w() + 1, sentinel);
+    dot_args_t args {a_buf.data(), b_buf.data(), c_buf.data()};
+    kernel.run(&args);
+
+    EXPECT_FLOAT_EQ(c_buf[simd_w()], ref_dot(a_buf.data(), b_buf.data(), tail));
+    for (int i = 0; i < tail; i++)
+        EXPECT_FLOAT_EQ(c_buf[i], a_buf[i] * b_buf[i]) << " at element " << i;
+    for (int i = tail; i < simd_w(); i++)
+        EXPECT_FLOAT_EQ(c_buf[i], sentinel) << " at element " << i;
 }
 
 // Computes a dot product where one vector is multiplied by n vectors into
@@ -904,8 +969,7 @@ ir_t build_shared_vector_dot_ir(int n) {
         ir.vhreduce(acc[r], ws);
 
     for (int r = 0; r < n; r++)
-        ir.vstore_masked(
-                c_ptr, r * (dim_t)sizeof(float), acc[r], vreg_t::none, 1);
+        ir.vstore_scalar(c_ptr, r * (dim_t)sizeof(float), acc[r]);
 
     return ir;
 }
@@ -1002,10 +1066,10 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
     //     store b -> c
     //   end:
     ir.jz(cond, lbl_else);
-    ir.vstore_masked(c_ptr, 0, a, vreg_t::none, simd_w()); // then: c = a
+    ir.vstore(c_ptr, 0, a); // then: c = a
     ir.jmp(lbl_end);
     ir.label(lbl_else);
-    ir.vstore_masked(c_ptr, 0, b, vreg_t::none, simd_w()); // else: c = b
+    ir.vstore(c_ptr, 0, b); // else: c = b
     ir.label(lbl_end);
 
     ir_kernel_t kernel(ir);
@@ -1107,8 +1171,7 @@ TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
     ir.inject_postops(acc, c_ptr, out_byte_off);
 
     for (int r = 0; r < n; r++)
-        ir.vstore_masked(
-                c_ptr, r * (dim_t)sizeof(float), acc[r], vreg_t::none, 1);
+        ir.vstore_scalar(c_ptr, r * (dim_t)sizeof(float), acc[r]);
 
     ir_kernel_t kernel(ir);
     ir_kernel_t::postops_cfg_t cfg;

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -324,11 +324,11 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
     ir.vzero(acc);
 
     const vreg_t a = ir.new_vec(data_type::f32);
-    ir.vload(a, ptr, 0);
+    ir.vload(a, ptr, 0, data_type::f32);
 
     const vreg_t b = ir.new_vec(data_type::f32);
     // AVX2 only.
-    ir.vload(b, ptr, simd_w() * (dim_t)sizeof(float));
+    ir.vload(b, ptr, simd_w() * (dim_t)sizeof(float), data_type::f32);
 
     ir.vdot(acc, a, b);
 
@@ -428,7 +428,7 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
     const vreg_t base = ir.new_gpr();
 
     ir.load_param(base, sizeof(int));
-    ir.vload(a, base, 0);
+    ir.vload(a, base, 0, data_type::f32);
 
     const label_t lbl_else = ir.new_label();
     const label_t lbl_end = ir.new_label();
@@ -734,10 +734,10 @@ ir_t build_dot_ir() {
     ir.vzero(acc);
 
     const vreg_t a = ir.new_vec(data_type::f32);
-    ir.vload(a, a_ptr, 0);
+    ir.vload(a, a_ptr, 0, data_type::f32);
 
     const vreg_t b = ir.new_vec(data_type::f32);
-    ir.vload(b, b_ptr, 0);
+    ir.vload(b, b_ptr, 0, data_type::f32);
 
     ir.vdot(acc, a, b);
 
@@ -745,7 +745,7 @@ ir_t build_dot_ir() {
     ir.vhreduce(acc, ws);
 
     // store the reduced scalar
-    ir.vstore_scalar(c_ptr, 0, acc);
+    ir.vstore_scalar(c_ptr, 0, acc, data_type::f32);
 
     return ir;
 }
@@ -783,7 +783,7 @@ TEST(EmitterTests, EmitsValidCodeForSpilledAllocation) {
     ir.load_param(b_ptr, sizeof(void *));
 
     const vreg_t b = ir.new_vec(data_type::f32);
-    ir.vload(b, b_ptr, 0);
+    ir.vload(b, b_ptr, 0, data_type::f32);
 
     std::vector<vreg_t> acc(6, vreg_t::none);
     for (int r = 0; r < 6; r++) {
@@ -793,7 +793,7 @@ TEST(EmitterTests, EmitsValidCodeForSpilledAllocation) {
 
     for (int r = 0; r < 6; r++) {
         const vreg_t a = ir.new_vec(data_type::f32);
-        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float));
+        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float), data_type::f32);
         ir.vdot(acc[r], a, b);
     }
 
@@ -841,9 +841,9 @@ TEST(IntegrationTests, BuildsLoopReduction) {
     // Reduce one simd_w-wide chunk per iteration and advance the pointers.
     emit_loop_imm(ir, k_blocks, [&]() {
         const vreg_t a = ir.new_vec(data_type::f32);
-        ir.vload(a, a_ptr, 0);
+        ir.vload(a, a_ptr, 0, data_type::f32);
         const vreg_t b = ir.new_vec(data_type::f32);
-        ir.vload(b, b_ptr, 0);
+        ir.vload(b, b_ptr, 0, data_type::f32);
         ir.vdot(acc, a, b);
     }, [&]() {
         ir.add_imm(a_ptr, simd_w() * (dim_t)sizeof(float));
@@ -852,7 +852,7 @@ TEST(IntegrationTests, BuildsLoopReduction) {
 
     const vreg_t ws = ir.new_vec(data_type::f32);
     ir.vhreduce(acc, ws);
-    ir.vstore_scalar(c_ptr, 0, acc);
+    ir.vstore_scalar(c_ptr, 0, acc, data_type::f32);
 
     ir_kernel_t kernel(ir);
     ASSERT_TRUE(kernel.run_ir_pipeline());
@@ -896,9 +896,9 @@ TEST(IntegrationTests, MaskedAccessCoversActiveElementsOnly) {
     ir.set_mask_imm(mask, tail);
 
     const vreg_t a = ir.new_vec(data_type::f32);
-    ir.vload_masked(a, a_ptr, 0, mask);
+    ir.vload_masked(a, a_ptr, 0, mask, data_type::f32);
     const vreg_t b = ir.new_vec(data_type::f32);
-    ir.vload_masked(b, b_ptr, 0, mask);
+    ir.vload_masked(b, b_ptr, 0, mask, data_type::f32);
 
     // Reduce first. An inactive element has to read as zero, or the values
     // past `tail` would land in the dot product.
@@ -908,11 +908,11 @@ TEST(IntegrationTests, MaskedAccessCoversActiveElementsOnly) {
 
     const vreg_t ws = ir.new_vec(data_type::f32);
     ir.vhreduce(acc, ws);
-    ir.vstore_scalar(c_ptr, dot_off, acc);
+    ir.vstore_scalar(c_ptr, dot_off, acc, data_type::f32);
 
     // Then the elementwise product, stored under the same mask.
     ir.vmul(a, b);
-    ir.vstore_masked(c_ptr, 0, a, mask);
+    ir.vstore_masked(c_ptr, 0, a, mask, data_type::f32);
 
     ir_kernel_t kernel(ir);
     ASSERT_TRUE(kernel.run_ir_pipeline());
@@ -951,7 +951,7 @@ ir_t build_shared_vector_dot_ir(int n) {
 
     const vreg_t b = ir.new_vec(data_type::f32);
     // Load shared vector.
-    ir.vload(b, b_ptr, 0);
+    ir.vload(b, b_ptr, 0, data_type::f32);
 
     std::vector<vreg_t> acc(n, vreg_t::none);
     for (int r = 0; r < n; r++) {
@@ -959,7 +959,7 @@ ir_t build_shared_vector_dot_ir(int n) {
         ir.vzero(acc[r]);
 
         const vreg_t a = ir.new_vec(data_type::f32);
-        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float));
+        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float), data_type::f32);
 
         ir.vdot(acc[r], a, b);
     }
@@ -969,7 +969,8 @@ ir_t build_shared_vector_dot_ir(int n) {
         ir.vhreduce(acc[r], ws);
 
     for (int r = 0; r < n; r++)
-        ir.vstore_scalar(c_ptr, r * (dim_t)sizeof(float), acc[r]);
+        ir.vstore_scalar(
+                c_ptr, r * (dim_t)sizeof(float), acc[r], data_type::f32);
 
     return ir;
 }
@@ -1045,10 +1046,10 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
     ir.load_param(c_ptr, offsetof(select_args_t, c));
 
     const vreg_t a = ir.new_vec(data_type::f32);
-    ir.vload(a, a_ptr, 0);
+    ir.vload(a, a_ptr, 0, data_type::f32);
 
     const vreg_t b = ir.new_vec(data_type::f32);
-    ir.vload(b, b_ptr, 0);
+    ir.vload(b, b_ptr, 0, data_type::f32);
 
     const label_t lbl_else = ir.new_label();
     const label_t lbl_end = ir.new_label();
@@ -1066,10 +1067,10 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
     //     store b -> c
     //   end:
     ir.jz(cond, lbl_else);
-    ir.vstore(c_ptr, 0, a); // then: c = a
+    ir.vstore(c_ptr, 0, a, data_type::f32); // then: c = a
     ir.jmp(lbl_end);
     ir.label(lbl_else);
-    ir.vstore(c_ptr, 0, b); // else: c = b
+    ir.vstore(c_ptr, 0, b, data_type::f32); // else: c = b
     ir.label(lbl_end);
 
     ir_kernel_t kernel(ir);
@@ -1147,7 +1148,7 @@ TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
     ir.load_param(c_ptr, offsetof(binary_args_t, c));
 
     const vreg_t b = ir.new_vec(data_type::f32);
-    ir.vload(b, b_ptr, 0);
+    ir.vload(b, b_ptr, 0, data_type::f32);
 
     std::vector<vreg_t> acc(n, vreg_t::none);
     for (int r = 0; r < n; r++) {
@@ -1155,7 +1156,7 @@ TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
         ir.vzero(acc[r]);
 
         const vreg_t a = ir.new_vec(data_type::f32);
-        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float));
+        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float), data_type::f32);
         ir.vdot(acc[r], a, b);
     }
 
@@ -1171,7 +1172,8 @@ TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
     ir.inject_postops(acc, c_ptr, out_byte_off);
 
     for (int r = 0; r < n; r++)
-        ir.vstore_scalar(c_ptr, r * (dim_t)sizeof(float), acc[r]);
+        ir.vstore_scalar(
+                c_ptr, r * (dim_t)sizeof(float), acc[r], data_type::f32);
 
     ir_kernel_t kernel(ir);
     ir_kernel_t::postops_cfg_t cfg;

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -243,10 +243,14 @@ protected:
         // irrelevant. Should work fine for AVX2 and AVX-512.
         const int gpr_scratch0 = 10, gpr_scratch1 = 11;
         const int vec_scratch0 = 13, vec_scratch1 = 14, vec_scratch2 = 15;
+        // AVX-512 opmasks reserved for the post-ops injector, which writes both
+        // and restores neither (see `postops_injector_t`).
+        const int eltwise_opmask = 6, binary_tail_opmask = 7;
 
         reg_config_t reg_cfg = make_reg_config(avx2, param_idx, rsp_idx,
                 {gpr_scratch0, gpr_scratch1},
-                {vec_scratch0, vec_scratch1, vec_scratch2});
+                {vec_scratch0, vec_scratch1, vec_scratch2},
+                {eltwise_opmask, binary_tail_opmask});
 
         // Shrink the vector register pool to force spills when requested.
         if (vec_regs_limit_ >= 0) {
@@ -266,18 +270,12 @@ protected:
         // generate(). The injector saves and restores every register it borrows,
         // so it takes no part in the IR register allocation.
         std::unique_ptr<postops_injector_t> injector;
-        inject_postops_fn_t emit_injector;
         if (postops_cfg_.post_ops) {
             injector.reset(new postops_injector_t(*this, avx2,
                     *postops_cfg_.post_ops, *postops_cfg_.dst_md, abi_param1,
                     static_cast<int>(postops_cfg_.rhs_arg_offset),
-                    postops_cfg_.dst_orig_offset, postops_cfg_.tail_elems));
-            emit_injector = [&](const std::vector<int> &acc_phys, int base_phys,
-                                    const std::vector<dim_t> &out_byte_off,
-                                    int mask_phys, int elems) {
-                injector->apply(
-                        acc_phys, base_phys, out_byte_off, mask_phys, elems);
-            };
+                    postops_cfg_.dst_orig_offset, postops_cfg_.tail_elems,
+                    eltwise_opmask, binary_tail_opmask));
         }
 
         preamble();
@@ -286,7 +284,7 @@ protected:
         if (frame > 0) sub(rsp, frame);
 
         data_section_t data;
-        emit(*this, ir_, alloc, reg_cfg, data, emit_injector);
+        emit(*this, ir_, alloc, reg_cfg, data, injector.get());
 
         if (frame > 0) add(rsp, frame);
 
@@ -510,16 +508,13 @@ TEST(IRBuilderTests, ForwardEdgeControlFlow) {
 // its variable-length operands in a side table and keeps only the table index,
 // so the test checks that the side table holds exactly what the builder was
 // given. def_use must report each accumulator as read and written in place, and
-// the base pointer and mask as read, or liveness across the injected post-ops
-// would be wrong.
+// the base pointer as read, or liveness across the injected post-ops would be
+// wrong.
 TEST(IRBuilderTests, InjectPostopsRecordsArgsAndDefUse) {
     ir_t ir;
 
     const vreg_t base = ir.new_gpr();
     ir.load_param(base, 0);
-
-    const vreg_t mask = ir.new_mask();
-    ir.set_mask_imm(mask, simd_w - 1);
 
     constexpr int n = 3;
     std::vector<vreg_t> acc(n, vreg_t::none);
@@ -532,7 +527,7 @@ TEST(IRBuilderTests, InjectPostopsRecordsArgsAndDefUse) {
     for (int r = 0; r < n; r++)
         out_byte_off[r] = r * (dim_t)sizeof(float);
 
-    ir.inject_postops(acc, base, out_byte_off, mask, /*elems=*/simd_w - 1);
+    ir.inject_postops(acc, base, out_byte_off);
 
     const int idx = find_op(ir, op_kind_t::inject_postops);
     ASSERT_NE(idx, -1);
@@ -544,11 +539,9 @@ TEST(IRBuilderTests, InjectPostopsRecordsArgsAndDefUse) {
     EXPECT_EQ(args.acc, acc);
     EXPECT_EQ(args.base_ptr, base);
     EXPECT_EQ(args.out_byte_off, out_byte_off);
-    EXPECT_EQ(args.mask, mask);
-    EXPECT_EQ(args.elems, simd_w - 1);
 
     // def_use reports every accumulator as read and written, and the base
-    // pointer and mask as read.
+    // pointer as read.
     std::vector<int> defs, uses;
     ir.def_use(ir.ops()[idx], defs, uses);
 
@@ -559,7 +552,6 @@ TEST(IRBuilderTests, InjectPostopsRecordsArgsAndDefUse) {
                 << "acc " << r << " not read";
     }
     EXPECT_NE(std::find(uses.begin(), uses.end(), (int)base), uses.end());
-    EXPECT_NE(std::find(uses.begin(), uses.end(), (int)mask), uses.end());
 }
 
 // Register config tests
@@ -575,10 +567,11 @@ TEST(RegConfigTests, MapsMaskKindToFilePerIsa) {
     const int param_reg = 0, rsp_reg = 4;
     const std::vector<int> gpr_scratch {10, 11};
     const std::vector<int> vec_scratch {13, 14, 15};
+    const std::vector<int> mask_scratch {6, 7};
 
     {
-        const reg_config_t rc = make_reg_config(
-                avx2, param_reg, rsp_reg, gpr_scratch, vec_scratch);
+        const reg_config_t rc = make_reg_config(avx2, param_reg, rsp_reg,
+                gpr_scratch, vec_scratch, mask_scratch);
 
         ASSERT_EQ(rc.pools.files.size(), 2u);
         EXPECT_EQ(rc.pools.kind_to_file, std::vector<int>({0, 1, 1}));
@@ -587,16 +580,16 @@ TEST(RegConfigTests, MapsMaskKindToFilePerIsa) {
     }
 
     {
-        const reg_config_t rc = make_reg_config(
-                avx512_core, param_reg, rsp_reg, gpr_scratch, vec_scratch);
+        const reg_config_t rc = make_reg_config(avx512_core, param_reg, rsp_reg,
+                gpr_scratch, vec_scratch, mask_scratch);
 
         ASSERT_EQ(rc.pools.files.size(), 3u);
         EXPECT_EQ(rc.pools.kind_to_file, std::vector<int>({0, 1, 2}));
         EXPECT_EQ(rc.pools.files[1].slot_size, 64u);
         EXPECT_EQ(rc.pools.files[1].regs.size(), 32u - vec_scratch.size());
-        // The mask file is k1..k7. k0 cannot encode a write mask.
-        EXPECT_EQ(rc.pools.files[2].regs,
-                std::vector<int>({1, 2, 3, 4, 5, 6, 7}));
+        // The mask file is k1..k7 less the reserved ones. k0 cannot encode a
+        // write mask.
+        EXPECT_EQ(rc.pools.files[2].regs, std::vector<int>({1, 2, 3, 4, 5}));
     }
 }
 
@@ -1107,7 +1100,7 @@ TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
     std::vector<dim_t> out_byte_off(n);
     for (int r = 0; r < n; r++)
         out_byte_off[r] = r * (dim_t)sizeof(float);
-    ir.inject_postops(acc, c_ptr, out_byte_off, vreg_t::none, /*elems=*/1);
+    ir.inject_postops(acc, c_ptr, out_byte_off);
 
     for (int r = 0; r < n; r++)
         ir.vstore_masked(

--- a/tests/gtests/internals/test_cpu_ir.cpp
+++ b/tests/gtests/internals/test_cpu_ir.cpp
@@ -46,30 +46,42 @@ using namespace impl::cpu::x64::ir;
 
 // Helpers shared by the tests
 
-constexpr int simd_w = 8;
+// Scratch registers the emitter reserves for spill handling, and the opmasks
+// the post-ops injector writes without restoring. None of them is part of the
+// register pool. The indices are otherwise arbitrary and work for AVX2 and
+// AVX-512 alike.
+constexpr int gpr_scratch0 = 10, gpr_scratch1 = 11;
+constexpr int vec_scratch0 = 13, vec_scratch1 = 14, vec_scratch2 = 15;
+constexpr int eltwise_opmask = 6, binary_tail_opmask = 7;
 
-// Build a register pool with `n_gpr` GPRs plus all available vector registers.
+// ISA the kernel tests generate for. The emitter needs AVX2 as a floor, so the
+// tests run on AVX-512 wherever the machine has it and fall back to AVX2
+// otherwise.
+cpu_isa_t test_isa() {
+    return mayiuse(avx512_core) ? avx512_core : avx2;
+}
+
+// Vector width in f32 elements on `test_isa()`. The tests size their inputs
+// from it.
+int simd_w() {
+    return isa_max_vlen(test_isa()) / (int)sizeof(float);
+}
+
+// Build a register pool for `test_isa()` with the GPR file narrowed to `n_gpr`
+// registers. The vector and mask files come from `make_reg_config()`, so the
+// allocator tests see the same layout the kernel tests do, with only the GPR
+// pressure under the test's control.
 reg_pools_t make_pools(int n_gpr) {
-    reg_pools_t pools {};
+    reg_config_t rc = make_reg_config(test_isa(), /*param_reg=*/0,
+            /*rsp_reg=*/Xbyak::Operand::RSP, /*gpr_scratch=*/ {},
+            /*vec_scratch=*/ {}, /*mask_scratch=*/ {});
 
-    reg_file_t gpr_file {};
-    // Spill slot size for GPR in bytes.
-    gpr_file.slot_size = 8;
+    reg_file_t &gpr_file = rc.pools.files[0];
+    gpr_file.regs.clear();
     for (int i = 0; i < n_gpr; i++)
         gpr_file.regs.push_back(i);
 
-    reg_file_t vec_file {};
-    // Spill slot size for vector registers in bytes. AVX2 only.
-    vec_file.slot_size = 32;
-    for (int i = 0; i < 16; i++)
-        vec_file.regs.push_back(i);
-
-    pools.files = {gpr_file, vec_file};
-    // reg_kind_t order is { gpr, vec, mask }. A mask and vec kinds share the
-    // same register file on AVX2.
-    pools.kind_to_file = {/* gpr */ 0, /*vec*/ 1, /*mask*/ 1};
-
-    return pools;
+    return rc.pools;
 }
 
 // A virtual register's (vreg) live interval. Defined as [start, end]
@@ -181,8 +193,7 @@ float ref_dot(const float *a, const float *b, int n) {
 class ir_kernel_t : public impl::cpu::x64::jit_generator_t {
 public:
     ir_kernel_t(ir_t ir, int vec_regs_limit = -1)
-        // Only AVX2 is currently supported.
-        : jit_generator_t("ir_run_kernel", cpu::x64::avx2)
+        : jit_generator_t("ir_run_kernel", test_isa())
         , ir_(std::move(ir))
         , vec_regs_limit_(vec_regs_limit) {}
 
@@ -238,17 +249,8 @@ protected:
         const int rsp_idx = Xbyak::Operand::RSP;
         const int param_idx = abi_param1.getIdx();
 
-        // Scratch registers the emitter reserves for spill handling. They are
-        // not part of the register pool. The indices of the registers are
-        // irrelevant. Should work fine for AVX2 and AVX-512.
-        const int gpr_scratch0 = 10, gpr_scratch1 = 11;
-        const int vec_scratch0 = 13, vec_scratch1 = 14, vec_scratch2 = 15;
-        // AVX-512 opmasks reserved for the post-ops injector, which writes both
-        // and restores neither (see `postops_injector_t`).
-        const int eltwise_opmask = 6, binary_tail_opmask = 7;
-
-        reg_config_t reg_cfg = make_reg_config(avx2, param_idx, rsp_idx,
-                {gpr_scratch0, gpr_scratch1},
+        reg_config_t reg_cfg = make_reg_config(max_cpu_isa(), param_idx,
+                rsp_idx, {gpr_scratch0, gpr_scratch1},
                 {vec_scratch0, vec_scratch1, vec_scratch2},
                 {eltwise_opmask, binary_tail_opmask});
 
@@ -271,7 +273,7 @@ protected:
         // so it takes no part in the IR register allocation.
         std::unique_ptr<postops_injector_t> injector;
         if (postops_cfg_.post_ops) {
-            injector.reset(new postops_injector_t(*this, avx2,
+            injector.reset(new postops_injector_t(*this, max_cpu_isa(),
                     *postops_cfg_.post_ops, *postops_cfg_.dst_md, abi_param1,
                     static_cast<int>(postops_cfg_.rhs_arg_offset),
                     postops_cfg_.dst_orig_offset, postops_cfg_.tail_elems,
@@ -326,7 +328,7 @@ TEST(IRBuilderTests, OperationOrderMetadataAndDefUse) {
 
     const vreg_t b = ir.new_vec(data_type::f32);
     // AVX2 only.
-    ir.vload(b, ptr, simd_w * (dim_t)sizeof(float));
+    ir.vload(b, ptr, simd_w() * (dim_t)sizeof(float));
 
     ir.vdot(acc, a, b);
 
@@ -791,7 +793,7 @@ TEST(EmitterTests, EmitsValidCodeForSpilledAllocation) {
 
     for (int r = 0; r < 6; r++) {
         const vreg_t a = ir.new_vec(data_type::f32);
-        ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
+        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float));
         ir.vdot(acc[r], a, b);
     }
 
@@ -811,15 +813,16 @@ struct dot_args_t {
     float *c;
 };
 
-// Pipeline test. A dot product over sixteen elements, expressed as a
-// two-iteration loop, is built, allocated, emitted, run, and checked against
-// a reference. Passing it means the whole pipeline computes the right number,
-// including loop control flow and values kept live across the back-edge.
+// Pipeline test. A dot product over two vectors' worth of elements, expressed
+// as a two-iteration loop, is built, allocated, emitted, run, and checked
+// against a reference. Passing it means the whole pipeline computes the right
+// number, including loop control flow and values kept live across the
+// back-edge.
 TEST(IntegrationTests, BuildsLoopReduction) {
     SKIP_IF_NO_AVX2();
 
     constexpr int k_blocks = 2;
-    constexpr int k = k_blocks * simd_w; // 16 elements
+    const int k = k_blocks * simd_w();
 
     ir_t ir;
 
@@ -843,8 +846,8 @@ TEST(IntegrationTests, BuildsLoopReduction) {
         ir.vload(b, b_ptr, 0);
         ir.vdot(acc, a, b);
     }, [&]() {
-        ir.add_imm(a_ptr, simd_w * (dim_t)sizeof(float));
-        ir.add_imm(b_ptr, simd_w * (dim_t)sizeof(float));
+        ir.add_imm(a_ptr, simd_w() * (dim_t)sizeof(float));
+        ir.add_imm(b_ptr, simd_w() * (dim_t)sizeof(float));
     });
 
     const vreg_t ws = ir.new_vec(data_type::f32);
@@ -891,7 +894,7 @@ ir_t build_shared_vector_dot_ir(int n) {
         ir.vzero(acc[r]);
 
         const vreg_t a = ir.new_vec(data_type::f32);
-        ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
+        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float));
 
         ir.vdot(acc[r], a, b);
     }
@@ -925,11 +928,11 @@ TEST(IntegrationTests, SpillProducesEquivalentResults) {
     EXPECT_FALSE(full.spilled());
     EXPECT_TRUE(limited.spilled());
 
-    std::vector<float> a(n * simd_w), b(simd_w);
-    for (int i = 0; i < n * simd_w; i++)
+    std::vector<float> a(n * simd_w()), b(simd_w());
+    for (int i = 0; i < n * simd_w(); i++)
         a[i] = (float)(i % 7) - 3.f;
 
-    for (int i = 0; i < simd_w; i++)
+    for (int i = 0; i < simd_w(); i++)
         b[i] = (float)(i - 2);
 
     std::vector<float> c_full(n, 0.f), c_limited(n, 0.f);
@@ -941,7 +944,7 @@ TEST(IntegrationTests, SpillProducesEquivalentResults) {
     limited.run(&args_limited);
 
     for (int r = 0; r < n; r++) {
-        const float expected = ref_dot(&a[r * simd_w], b.data(), simd_w);
+        const float expected = ref_dot(&a[r * simd_w()], b.data(), simd_w());
         EXPECT_FLOAT_EQ(c_full[r], expected) << "row " << r;
         EXPECT_FLOAT_EQ(c_limited[r], expected) << "row " << r;
     }
@@ -999,17 +1002,18 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
     //     store b -> c
     //   end:
     ir.jz(cond, lbl_else);
-    ir.vstore_masked(c_ptr, 0, a, vreg_t::none, simd_w); // then: c = a
+    ir.vstore_masked(c_ptr, 0, a, vreg_t::none, simd_w()); // then: c = a
     ir.jmp(lbl_end);
     ir.label(lbl_else);
-    ir.vstore_masked(c_ptr, 0, b, vreg_t::none, simd_w); // else: c = b
+    ir.vstore_masked(c_ptr, 0, b, vreg_t::none, simd_w()); // else: c = b
     ir.label(lbl_end);
 
     ir_kernel_t kernel(ir);
     ASSERT_TRUE(kernel.run_ir_pipeline());
 
-    std::vector<float> a_data(simd_w), b_data(simd_w), c_data(simd_w, 0.f);
-    for (int i = 0; i < simd_w; i++) {
+    std::vector<float> a_data(simd_w()), b_data(simd_w()),
+            c_data(simd_w(), 0.f);
+    for (int i = 0; i < simd_w(); i++) {
         a_data[i] = (float)(10 + i);
         b_data[i] = (float)(100 + i);
     }
@@ -1017,14 +1021,14 @@ TEST(IntegrationTests, BranchSelectsCorrectValue) {
     // cond != 0 selects a.
     select_args_t args_a {1, a_data.data(), b_data.data(), c_data.data()};
     kernel.run(&args_a);
-    for (int i = 0; i < simd_w; i++)
+    for (int i = 0; i < simd_w(); i++)
         EXPECT_FLOAT_EQ(c_data[i], a_data[i]) << "lane " << i;
 
     // cond == 0 selects b.
     std::fill(c_data.begin(), c_data.end(), 0.f);
     select_args_t args_b {0, a_data.data(), b_data.data(), c_data.data()};
     kernel.run(&args_b);
-    for (int i = 0; i < simd_w; i++)
+    for (int i = 0; i < simd_w(); i++)
         EXPECT_FLOAT_EQ(c_data[i], b_data[i]) << "lane " << i;
 }
 
@@ -1087,7 +1091,7 @@ TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
         ir.vzero(acc[r]);
 
         const vreg_t a = ir.new_vec(data_type::f32);
-        ir.vload(a, a_ptr, r * simd_w * (dim_t)sizeof(float));
+        ir.vload(a, a_ptr, r * simd_w() * (dim_t)sizeof(float));
         ir.vdot(acc[r], a, b);
     }
 
@@ -1117,10 +1121,10 @@ TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
 
     ASSERT_TRUE(kernel.run_ir_pipeline());
 
-    std::vector<float> a(n * simd_w), b_data(simd_w), rhs(n), c(n, 0.f);
-    for (int i = 0; i < n * simd_w; i++)
+    std::vector<float> a(n * simd_w()), b_data(simd_w()), rhs(n), c(n, 0.f);
+    for (int i = 0; i < n * simd_w(); i++)
         a[i] = (float)(i % 5) - 2.f;
-    for (int i = 0; i < simd_w; i++)
+    for (int i = 0; i < simd_w(); i++)
         b_data[i] = (float)(i - 3);
     for (int r = 0; r < n; r++)
         rhs[r] = (float)(10 * (r + 1));
@@ -1131,7 +1135,7 @@ TEST(IntegrationTests, BinaryPostOpAddsPerElementRhs) {
 
     for (int r = 0; r < n; r++) {
         const float expected
-                = ref_dot(&a[r * simd_w], b_data.data(), simd_w) + rhs[r];
+                = ref_dot(&a[r * simd_w()], b_data.data(), simd_w()) + rhs[r];
         EXPECT_FLOAT_EQ(c[r], expected) << "row " << r;
     }
 }


### PR DESCRIPTION
This PR includes the following changes:
- Adds a new backend to the emitter to support AVX-512 lowering.
- Adds conversion support to load/store operations.
- Adds support for bf16 and f16 data types to IR-based GEMV (bf16 is native, f16 is via upconversion).
- Restructures load/store operations to avoid ambiguity related to masked kinds.
- Extends the interoperability layer for the Xbyak-based injector to support AVX-512 ISAs.

The majority of the changes in this PR are to enable the new AVX-512 backend and refine shared design decisions.

Support for bf16 and f16 is limited to `src/cpu/x64/brgemm/brgemv_ir.cpp`. Aside from some noise from updated load/store interfaces, enabling a new data type only requires passing the register and memory data types to the load operations. The emitter handles any required conversions automatically.

In other words, adding support for a new data type now requires very little kernel-specific code.