### PR TITLE
[WIP] cpu: optimize common scalar binary post-ops

### DIFF
--- a/src/cpu/binary_injector_utils.cpp
+++ b/src/cpu/binary_injector_utils.cpp
@@ -23,10 +23,11 @@ namespace impl {
 namespace cpu {
 namespace binary_injector_utils {
 
-std::vector<const void *> prepare_binary_args(const post_ops_t &post_ops,
-        const exec_ctx_t &ctx, const unsigned first_arg_idx_offset) {
-    std::vector<const void *> post_ops_binary_rhs_arg_vec;
-    if (post_ops.len() == 0) return post_ops_binary_rhs_arg_vec;
+void prepare_binary_args(const post_ops_t &post_ops, const exec_ctx_t &ctx,
+        std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        const unsigned first_arg_idx_offset) {
+    post_ops_binary_rhs_arg_vec.clear();
+    if (post_ops.len() == 0) return;
     post_ops_binary_rhs_arg_vec.reserve(post_ops.entry_.size());
 
     unsigned idx = first_arg_idx_offset;
@@ -54,8 +55,23 @@ std::vector<const void *> prepare_binary_args(const post_ops_t &post_ops,
         ++idx;
     }
 
-    post_ops_binary_rhs_arg_vec.shrink_to_fit();
+}
 
+const void *prepare_scalar_binary_arg(const post_ops_t::entry_t &post_op,
+        const exec_ctx_t &ctx, const unsigned post_op_idx) {
+    assert(post_op.is_binary() && !post_op.is_binary_with_ternary_op());
+
+    const auto *base = CTX_IN_MEM(const char *,
+            DNNL_ARG_ATTR_MULTIPLE_POST_OP(post_op_idx) | DNNL_ARG_SRC_1);
+    const memory_desc_wrapper mdw(post_op.binary.src1_desc);
+    return base + mdw.offset0() * mdw.data_type_size();
+}
+
+std::vector<const void *> prepare_binary_args(const post_ops_t &post_ops,
+        const exec_ctx_t &ctx, const unsigned first_arg_idx_offset) {
+    std::vector<const void *> post_ops_binary_rhs_arg_vec;
+    prepare_binary_args(post_ops, ctx, post_ops_binary_rhs_arg_vec,
+            first_arg_idx_offset);
     return post_ops_binary_rhs_arg_vec;
 }
 

--- a/src/cpu/binary_injector_utils.hpp
+++ b/src/cpu/binary_injector_utils.hpp
@@ -30,6 +30,26 @@ namespace impl {
 namespace cpu {
 namespace binary_injector_utils {
 /*
+ * Fills caller-owned storage with pointers to binary post-op RHS tensors.
+ *
+ * Keeping the storage owned by the caller lets hot execution paths reuse its
+ * capacity. The stored pointers have the same ordering and offset0 adjustment
+ * as the value-returning overload.
+ *
+ * The existing kernel ABI still carries a table of RHS pointers, so this
+ * helper deliberately preserves that table for compatibility. It removes
+ * avoidable shrink-to-fit churn and provides the safe boundary for future
+ * caller-owned small-buffer storage without changing nontrivial chains.
+ */
+void prepare_binary_args(const post_ops_t &post_ops,
+        const dnnl::impl::exec_ctx_t &ctx,
+        std::vector<const void *> &post_ops_binary_rhs_arg_vec,
+        const unsigned first_arg_idx_offset = 0);
+
+const void *prepare_scalar_binary_arg(const post_ops_t::entry_t &post_op,
+        const dnnl::impl::exec_ctx_t &ctx, unsigned post_op_idx);
+
+/*
  * Extracts pointers to tensors passed by user as binary postops rhs
  * (right-hand-side) arguments from execution context and advances them to
  * their memory descriptors' logical origins. Those pointers are placed in a

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -1189,6 +1189,30 @@ void jit_brgemm_amx_uker_base_t::apply_post_ops_to_range(
     const auto ldb_pos = bi.ldi->pos(ldb);
     const auto is_ld_tail = bi.ldi->is_tail(ldb);
 
+    if (brg.with_binary
+            && binary_injector::all_simple_scalar_f32_binary_postops(
+                    brg.attr()->post_ops_, memory_desc_wrapper(brg.dst_md()),
+                    binary_injector::get_all_strategies_supported_by_injector())) {
+        int rhs_arg_idx = 0;
+        bool direct_scalar_rhs = false;
+        const auto dst_d = memory_desc_wrapper(brg.dst_md());
+        const auto supported_bcast
+                = binary_injector::get_all_strategies_supported_by_injector();
+        for (const auto &post_op : brg.attr()->post_ops_.entry_) {
+            if (binary_injector::is_simple_scalar_f32_binary_postop(
+                        post_op, dst_d, supported_bcast)) {
+                rhs_arg_params.rhs_arg_idx_to_scalar_ptr_reg.emplace(
+                        rhs_arg_idx, reg_tmp_gpr);
+                direct_scalar_rhs = true;
+            }
+            if (post_op.is_like_binary()) {
+                ++rhs_arg_idx;
+                if (post_op.is_binary_with_ternary_op()) ++rhs_arg_idx;
+            }
+        }
+        rhs_arg_params.load_scalar_rhs_ptrs = direct_scalar_rhs;
+    }
+
     // Sum post-op requires binary parameters to be set.
     const bool set_for_binary = brg.with_binary && handle_binary_po_offset_;
     if (set_for_binary || brg.with_sum) {

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -237,6 +237,10 @@ private:
     const reg64_savable_t reg_do_comp {regscratchpad_, rbx};
     const reg64_savable_t reg_skip_accm {regscratchpad_, rbx};
     const reg64_t reg_tmp_gpr = rbx;
+    // The direct scalar RHS path borrows rbx only for the post-op region.
+    // Save/restore through the kernel scratchpad because rbx aliases several
+    // loop-state registers elsewhere in this kernel.
+    const reg64_savable_t reg_scalar_rhs {regscratchpad_, rbx};
     const reg64_savable_t reg_zp_a_val {regscratchpad_, rbx};
     const reg64_savable_t reg_buf {regscratchpad_, rbx, r26};
     const reg64_savable_t reg_dynamic_C_offset {regscratchpad_, rbx};
@@ -1781,6 +1785,31 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(int bd_block, int ld_block2,
 
     if (brg.with_binary) param1.restore();
 
+    bool direct_scalar_rhs = false;
+    if (brg.with_binary && is_superset(brg.isa_impl, avx512_core)
+            && binary_injector::all_simple_scalar_f32_binary_postops(
+                    brg.attr()->post_ops_, memory_desc_wrapper(brg.dst_md()),
+                    binary_injector::get_all_strategies_supported_by_injector())) {
+        int rhs_arg_idx = 0;
+        const auto dst_d = memory_desc_wrapper(brg.dst_md());
+        const auto supported_bcast
+                = binary_injector::get_all_strategies_supported_by_injector();
+        for (const auto &post_op : brg.attr()->post_ops_.entry_) {
+            if (binary_injector::is_simple_scalar_f32_binary_postop(
+                        post_op, dst_d, supported_bcast)) {
+                rhs_arg_params.rhs_arg_idx_to_scalar_ptr_reg.emplace(
+                        rhs_arg_idx, reg_scalar_rhs);
+                direct_scalar_rhs = true;
+            }
+            if (post_op.is_like_binary()) {
+                ++rhs_arg_idx;
+                if (post_op.is_binary_with_ternary_op()) ++rhs_arg_idx;
+            }
+        }
+        rhs_arg_params.load_scalar_rhs_ptrs = direct_scalar_rhs;
+        if (direct_scalar_rhs) reg_scalar_rhs.save();
+    }
+
     const int bd_block_shift = brg.is_runtime_ldd ? 1 : bd_block;
     for (int bd_block_idx = 0; bd_block_idx < bd_block;
             bd_block_idx += bd_block_shift) {
@@ -1821,6 +1850,8 @@ void jit_brgemm_kernel_t<Wmm>::apply_post_ops(int bd_block, int ld_block2,
         if (brg.is_runtime_ldd && bd_block > 1)
             reg_D_shift_bytes.addTo(reg_aux_D);
     }
+
+    if (direct_scalar_rhs) reg_scalar_rhs.restore();
 }
 
 template <typename Wmm>

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.cpp
@@ -271,6 +271,36 @@ bool any_binary_postop_rhs_per_w_broadcast(const post_ops_t &post_ops,
     });
 }
 
+bool is_simple_scalar_f32_binary_postop(
+        const post_ops_t::entry_t &post_op,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    if (!post_op.is_binary() || post_op.is_binary_with_ternary_op()
+            || post_op.is_prelu())
+        return false;
+
+    const auto src1_desc = get_src1_desc(post_op, dst_d);
+    return src1_desc.data_type == data_type::f32
+            && get_rhs_arg_broadcasting_strategy(
+                       src1_desc, dst_d, supported_strategy_set)
+                    == broadcasting_strategy_t::scalar
+            && utils::one_of(post_op.binary.alg, alg_kind::binary_add,
+                    alg_kind::binary_sub, alg_kind::binary_mul,
+                    alg_kind::binary_div, alg_kind::binary_max,
+                    alg_kind::binary_min);
+}
+
+bool all_simple_scalar_f32_binary_postops(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set) {
+    return post_ops.len() > 0
+            && std::all_of(post_ops.entry_.cbegin(), post_ops.entry_.cend(),
+                    [&](const dnnl_post_ops::entry_t &post_op) {
+                        return is_simple_scalar_f32_binary_postop(
+                                post_op, dst_d, supported_strategy_set);
+                    });
+}
+
 void extend_binary_args_per_w(const post_ops_t &post_ops,
         const std::vector<const void *> &orig_post_ops_binary_rhs_arg_vec,
         std::vector<const void *> &post_ops_binary_rhs_arg_vec,
@@ -506,6 +536,41 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(int start_idx,
 }
 
 template <typename Vmm>
+bool jit_uni_binary_injector_t<Vmm>::use_direct_scalar_rhs(int rhs_arg_idx,
+        const dnnl_post_ops::entry_t &post_op,
+        const rhs_arg_dynamic_params_t &rhs_arg_params,
+        Xbyak::Reg64 *rhs_ptr_reg) const {
+    if (!has_avx512_core_
+            || !is_simple_scalar_f32_binary_postop(
+                    post_op, rhs_arg_static_params_.dst_d,
+                    supported_strategy_set_))
+        return false;
+
+    const auto it = rhs_arg_params.rhs_arg_idx_to_scalar_ptr_reg.find(
+            rhs_arg_idx);
+    if (it == rhs_arg_params.rhs_arg_idx_to_scalar_ptr_reg.end())
+        return false;
+
+    const auto &reg = it->second;
+    if (utils::one_of(reg.getIdx(), param1_.getIdx(),
+                rhs_arg_static_params_.rhs_addr_reg.getIdx(),
+                rhs_arg_static_params_.rhs_helper_reg.getIdx(),
+                rhs_arg_static_params_.rhs_addr_cache_reg.getIdx(),
+                host_->rsp.getIdx()))
+        return false;
+
+    for (const auto &out_reg : rhs_arg_params.vmm_idx_to_out_reg)
+        if (out_reg.second.getIdx() == reg.getIdx()) return false;
+
+    if (rhs_arg_static_params_.is_tail
+            && !rhs_arg_static_params_.is_opmask_set())
+        return false;
+
+    *rhs_ptr_reg = reg;
+    return true;
+}
+
+template <typename Vmm>
 void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
         const injector_utils::vmm_index_set_t &vmm_idxs, int rhs_arg_idx,
         const dnnl_post_ops::entry_t &post_op,
@@ -576,9 +641,13 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
             = should_preserve_oc_offset_conversion_regs
             || should_preserve_w_offset_conversion_regs
             || should_preserve_spatial_offset_conversion_regs;
+    Xbyak::Reg64 direct_scalar_rhs_reg;
+    const bool use_direct_scalar_rhs_mode = use_direct_scalar_rhs(
+            rhs_arg_idx, post_op, rhs_arg_params, &direct_scalar_rhs_reg);
 
     // Phase 2 Protect temporary registers content.
-    const injector_utils::register_preserve_guard_t register_guard {host_,
+    const injector_utils::conditional_register_preserve_guard_t register_guard {
+            !use_direct_scalar_rhs_mode, host_,
             (rhs_arg_static_params_.preserve_gpr_helpers
                                     && should_preserve_w_or_oc_offset_conversion_regs
                             ? std::initializer_list<
@@ -640,6 +709,17 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
     Xbyak::Address rhs1_arg_addr {};
     Xbyak::Address rhs2_arg_addr {};
 
+    if (use_direct_scalar_rhs_mode
+            && rhs_arg_params.load_scalar_rhs_ptrs) {
+        host_->mov(direct_scalar_rhs_reg,
+                host_->ptr[param1_
+                        + rhs_arg_static_params_.abi_param_offset]);
+        host_->mov(direct_scalar_rhs_reg,
+                host_->ptr[direct_scalar_rhs_reg
+                        + rhs_arg_idx * static_cast<int>(
+                                  sizeof(const void *))]);
+    }
+
     // Phase 3 Apply binary post-op over all vmms.
     for (const auto vmm_idx : vmm_idxs) {
         const bool is_start_idx = vmm_idx == start_idx;
@@ -683,7 +763,7 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
         const bool params_differ = rhs_arg_params_differ(vmm_idx, vmm_idx - 1,
                 rhs_arg_params, rhs_broadcasting_strategy);
         const bool need_new_addr = is_start_idx || params_differ || load_addr;
-        if (need_new_addr) {
+        if (need_new_addr && !use_direct_scalar_rhs_mode) {
             const bool is_baddr_loop_invariant
                     = utils::one_of(rhs_broadcasting_strategy,
                             broadcasting_strategy_t::no_broadcast,
@@ -694,6 +774,8 @@ void jit_uni_binary_injector_t<Vmm>::compute_vector_range(
             rhs1_arg_addr = prepare_rhs_arg_addr(vmm_idx, rhs_arg_idx, post_op,
                     rhs_arg_params, rhs_broadcasting_strategy, is_first, false);
         }
+        if (use_direct_scalar_rhs_mode)
+            rhs1_arg_addr = host_->ptr_b[direct_scalar_rhs_reg];
 
         if (vmm_preservation_needed) {
             const Vmm vmm_to_preserve(local_vmm_preservation.second);

--- a/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
+++ b/src/cpu/x64/injectors/jit_uni_binary_injector.hpp
@@ -42,6 +42,7 @@ namespace x64 {
 namespace binary_injector {
 using dnnl::impl::cpu::binary_injector_utils::get_src1_desc;
 using dnnl::impl::cpu::binary_injector_utils::get_src2_desc;
+using dnnl::impl::cpu::binary_injector_utils::prepare_scalar_binary_arg;
 using dnnl::impl::cpu::binary_injector_utils::prepare_binary_args;
 
 bcast_set_t get_all_strategies_supported_by_injector();
@@ -66,6 +67,12 @@ bool all_binary_postop_rhs_per_oc_broadcast(const post_ops_t &post_ops,
         const std::function<bool(const memory_desc_wrapper &)> &predicate);
 
 bool any_binary_postop_rhs_per_w_broadcast(const post_ops_t &post_ops,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+bool is_simple_scalar_f32_binary_postop(const post_ops_t::entry_t &post_op,
+        const memory_desc_wrapper &dst_d,
+        const bcast_set_t &supported_strategy_set);
+bool all_simple_scalar_f32_binary_postops(const post_ops_t &post_ops,
         const memory_desc_wrapper &dst_d,
         const bcast_set_t &supported_strategy_set);
 
@@ -239,6 +246,14 @@ struct rhs_arg_dynamic_params_t {
     std::map<int, Xbyak::Address> vmm_idx_to_out_addr;
     std::map<int, Xbyak::Reg64> vmm_idx_to_out_reg;
     std::map<int, dim_t> vmm_idx_to_out_elem_off_val;
+    // Caller-owned registers containing preloaded RHS pointers. The values
+    // must remain valid while the generated code executes.
+    std::map<int, Xbyak::Reg64> rhs_arg_idx_to_scalar_ptr_reg;
+    // When set, the injector reloads each direct scalar pointer from the
+    // runtime RHS argument table immediately before applying that post-op.
+    // This permits one caller-owned register to be reused sequentially by a
+    // chain containing multiple eligible scalar post-ops.
+    bool load_scalar_rhs_ptrs = false;
 
     std::unordered_set<int> vmm_tail_idx_;
     tail_lode_mode_t tail_load_mode = tail_lode_mode_t::DEFAULT;
@@ -429,6 +444,11 @@ private:
     void calculate_mb_sp_blocked_partial(const dim_t *strides,
             const dim_t offset, const Xbyak::Reg64 &tmp_reg,
             dim_t elem_size_bytes) const;
+
+    bool use_direct_scalar_rhs(int rhs_arg_idx,
+            const dnnl_post_ops::entry_t &post_op,
+            const rhs_arg_dynamic_params_t &rhs_arg_params,
+            Xbyak::Reg64 *rhs_ptr_reg) const;
     void calculate_mb_sp_nspc_base(
             const dim_t *strides, const Xbyak::Reg64 &tmp_reg) const;
     void calculate_mb_sp_nspc_partial(const dim_t *strides, const dim_t offset,

--- a/src/cpu/x64/jit_brgemm_post_ops.cpp
+++ b/src/cpu/x64/jit_brgemm_post_ops.cpp
@@ -189,6 +189,30 @@ void dnnl::impl::cpu::x64::jit_brgemm_kernel_post_ops_t<
         Vmm>::inject_attr_postops(int m_block, int n_block, int tail /*= 0*/) {
     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
 
+    if (brg_.with_binary && is_superset(brg_.isa_impl, avx512_core)
+            && binary_injector::all_simple_scalar_f32_binary_postops(
+                    attr_.post_ops_, memory_desc_wrapper(brg_.dst_md()),
+                    binary_injector::get_all_strategies_supported_by_injector())) {
+        int rhs_arg_idx = 0;
+        bool direct_scalar_rhs = false;
+        const auto dst_d = memory_desc_wrapper(brg_.dst_md());
+        const auto supported_bcast
+                = binary_injector::get_all_strategies_supported_by_injector();
+        for (const auto &post_op : attr_.post_ops_.entry_) {
+            if (binary_injector::is_simple_scalar_f32_binary_postop(
+                        post_op, dst_d, supported_bcast)) {
+                rhs_arg_params.rhs_arg_idx_to_scalar_ptr_reg.emplace(
+                        rhs_arg_idx, reg_tmp);
+                direct_scalar_rhs = true;
+            }
+            if (post_op.is_like_binary()) {
+                ++rhs_arg_idx;
+                if (post_op.is_binary_with_ternary_op()) ++rhs_arg_idx;
+            }
+        }
+        rhs_arg_params.load_scalar_rhs_ptrs = direct_scalar_rhs;
+    }
+
     // Sum post-op requires binary parameters to be set.
     if (with_binary_non_scalar_bcast_ || brg_.with_sum) {
         for_(int m = 0; m < m_block; m++)

--- a/src/cpu/x64/jit_uni_softmax.cpp
+++ b/src/cpu/x64/jit_uni_softmax.cpp
@@ -115,6 +115,8 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
     bool with_eltwise_ = false;
     bool with_src_scales_ = false;
     bool with_dst_scales_ = false;
+    std::vector<int> direct_scalar_rhs_arg_idxs_;
+    bool direct_scalar_rhs_load_ = false;
     bool use_ext_aux_vmms_ = false;
 
     int unroll_regs_ = 4;
@@ -206,6 +208,43 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         }
         mov(reg_src_scales, ptr[reg_param + PARAM_OFF(src_scales)]);
         mov(reg_dst_scales, ptr[reg_param + PARAM_OFF(dst_scales)]);
+    }
+
+    void prepare_direct_scalar_rhs() {
+        const auto &post_ops = pd_->attr()->post_ops_;
+        if (!pd_->is_fwd() || !is_softmax_
+                || !is_superset(isa, avx512_core)
+                || !binary_injector::all_simple_scalar_f32_binary_postops(
+                        pd_->attr()->post_ops_, dst_d_,
+                        get_supported_bcast_strategies()))
+            return;
+
+        int rhs_arg_idx = 0;
+        for (const auto &post_op : post_ops.entry_) {
+            if (binary_injector::is_simple_scalar_f32_binary_postop(
+                        post_op, dst_d_, get_supported_bcast_strategies()))
+                direct_scalar_rhs_arg_idxs_.push_back(rhs_arg_idx);
+            if (post_op.is_like_binary()) {
+                ++rhs_arg_idx;
+                if (post_op.is_binary_with_ternary_op()) ++rhs_arg_idx;
+            }
+        }
+
+        if (direct_scalar_rhs_arg_idxs_.empty()) return;
+        direct_scalar_rhs_load_
+                = post_ops.len() != 1
+                || direct_scalar_rhs_arg_idxs_.size() != 1;
+        if (!direct_scalar_rhs_load_) {
+            const auto rhs_arg_idx = direct_scalar_rhs_arg_idxs_.front();
+            mov(reg_tmp2,
+                    ptr[reg_param
+                            + offsetof(call_params_t,
+                                    post_ops_binary_rhs_arg_vec)]);
+            mov(reg_tmp2,
+                    ptr[reg_tmp2
+                            + rhs_arg_idx * static_cast<int>(
+                                      sizeof(const void *))]);
+        }
     }
 
     Address diff_src_ptr(size_t offt = 0) {
@@ -766,6 +805,11 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                     if (with_postops_) {
                         binary_injector::rhs_arg_dynamic_params_t
                                 rhs_arg_params;
+                        for (const auto rhs_arg_idx : direct_scalar_rhs_arg_idxs_)
+                            rhs_arg_params.rhs_arg_idx_to_scalar_ptr_reg.emplace(
+                                    rhs_arg_idx, reg_tmp2);
+                        rhs_arg_params.load_scalar_rhs_ptrs
+                                = direct_scalar_rhs_load_;
                         if (with_binary_) {
                             rhs_arg_params.vmm_idx_to_out_addr.emplace(
                                     vreg_tmp_src.getIdx(), dst_ptr());
@@ -829,6 +873,11 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
                 }
                 if (with_postops_) {
                     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
+                    for (const auto rhs_arg_idx : direct_scalar_rhs_arg_idxs_)
+                        rhs_arg_params.rhs_arg_idx_to_scalar_ptr_reg.emplace(
+                                rhs_arg_idx, reg_tmp2);
+                    rhs_arg_params.load_scalar_rhs_ptrs
+                            = direct_scalar_rhs_load_;
                     if (with_binary_) {
                         rhs_arg_params.vmm_idx_to_out_addr.emplace(
                                 vreg_tmp_src.getIdx(), dst_ptr());
@@ -973,6 +1022,7 @@ struct jit_softmax_dense_kernel_t : jit_softmax_kernel_base_t,
         if (log_injector_) log_injector_->load_table_addr();
         if (axis_simd_tail_) io_.prepare_tail_mask();
         load_common_params();
+        prepare_direct_scalar_rhs();
         if (pd_->is_fwd())
             forward();
         else
@@ -1093,6 +1143,8 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
     bool with_eltwise_ = false;
     bool with_src_scales_ = false;
     bool with_dst_scales_ = false;
+    std::vector<int> direct_scalar_rhs_arg_idxs_;
+    bool direct_scalar_rhs_load_ = false;
 
     int unroll_inner_size_ = 4;
     int unroll_axis_size_ = 8;
@@ -1170,6 +1222,43 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         if (with_dst_scales_) {
             mov(reg_tmp, ptr[reg_param + PARAM_OFF(dst_scales)]);
             uni_vbroadcastss(vdst_scale, ptr[reg_tmp]);
+        }
+    }
+
+    void prepare_direct_scalar_rhs() {
+        const auto &post_ops = pd_->attr()->post_ops_;
+        if (!pd_->is_fwd() || !is_softmax_
+                || !is_superset(isa, avx512_core)
+                || !binary_injector::all_simple_scalar_f32_binary_postops(
+                        pd_->attr()->post_ops_, dst_d_,
+                        get_supported_bcast_strategies()))
+            return;
+
+        int rhs_arg_idx = 0;
+        for (const auto &post_op : post_ops.entry_) {
+            if (binary_injector::is_simple_scalar_f32_binary_postop(
+                        post_op, dst_d_, get_supported_bcast_strategies()))
+                direct_scalar_rhs_arg_idxs_.push_back(rhs_arg_idx);
+            if (post_op.is_like_binary()) {
+                ++rhs_arg_idx;
+                if (post_op.is_binary_with_ternary_op()) ++rhs_arg_idx;
+            }
+        }
+
+        if (direct_scalar_rhs_arg_idxs_.empty()) return;
+        direct_scalar_rhs_load_
+                = post_ops.len() != 1
+                || direct_scalar_rhs_arg_idxs_.size() != 1;
+        if (!direct_scalar_rhs_load_) {
+            const auto rhs_arg_idx = direct_scalar_rhs_arg_idxs_.front();
+            mov(reg_tmp2,
+                    ptr[reg_param
+                            + offsetof(call_params_t,
+                                    post_ops_binary_rhs_arg_vec)]);
+            mov(reg_tmp2,
+                    ptr[reg_tmp2
+                            + rhs_arg_idx * static_cast<int>(
+                                      sizeof(const void *))]);
         }
     }
 
@@ -1368,6 +1457,11 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
                 }
                 if (with_postops_) {
                     binary_injector::rhs_arg_dynamic_params_t rhs_arg_params;
+                    for (const auto rhs_arg_idx : direct_scalar_rhs_arg_idxs_)
+                        rhs_arg_params.rhs_arg_idx_to_scalar_ptr_reg.emplace(
+                                rhs_arg_idx, reg_tmp2);
+                    rhs_arg_params.load_scalar_rhs_ptrs
+                            = direct_scalar_rhs_load_;
                     if (with_binary_) {
                         rhs_arg_params.vmm_idx_to_out_addr.emplace(
                                 vreg_tmp_src.getIdx(), dst_ptr());
@@ -1557,6 +1651,7 @@ struct jit_softmax_strided_kernel_t : jit_softmax_kernel_base_t,
         if (log_injector_) log_injector_->load_table_addr();
         if (axis_simd_tail_) io_.prepare_tail_mask();
         load_common_params();
+        prepare_direct_scalar_rhs();
         if (pd_->is_fwd()) forward();
         postamble();
         if (exp_injector_) exp_injector_->prepare_table();
@@ -1689,12 +1784,23 @@ status_t jit_uni_softmax_fwd_t::execute(const exec_ctx_t &ctx) const {
     auto scratchpad_ptr = scratchpad.template get<char>(
             memory_tracking::names::key_softmax_interim_store);
 
-    const auto post_ops_binary_rhs_arg_vec
-            = binary_injector::prepare_binary_args(
-                    pd()->attr()->post_ops_, ctx);
+    const auto &post_ops = pd()->attr()->post_ops_;
+    const memory_desc_wrapper dst_d(pd()->dst_md());
+    const bool use_direct_scalar_rhs
+            = post_ops.len() == 1
+            && binary_injector::is_simple_scalar_f32_binary_postop(
+                    post_ops.entry_[0], dst_d,
+                    softmax_impl::get_supported_bcast_strategies());
+    const void *direct_scalar_rhs = use_direct_scalar_rhs
+            ? binary_injector::prepare_scalar_binary_arg(
+                      post_ops.entry_[0], ctx, 0)
+            : nullptr;
+    std::vector<const void *> post_ops_binary_rhs_arg_vec;
+    if (!use_direct_scalar_rhs)
+        binary_injector::prepare_binary_args(
+                post_ops, ctx, post_ops_binary_rhs_arg_vec);
 
     const memory_desc_wrapper src_d(pd()->src_md());
-    const memory_desc_wrapper dst_d(pd()->dst_md());
     const auto src_data_type_size = src_d.data_type_size();
     const auto dst_data_type_size = dst_d.data_type_size();
     const auto &bd = src_d.blocking_desc();
@@ -1784,7 +1890,10 @@ status_t jit_uni_softmax_fwd_t::execute(const exec_ctx_t &ctx) const {
         p.dst_scales = dst_scales_inv_ptr;
         // post-ops
         p.dst_orig = dst_orig_ptr;
-        p.post_ops_binary_rhs_arg_vec = post_ops_binary_rhs_arg_vec.data();
+        const void *direct_scalar_rhs_arg_vec[1] = {direct_scalar_rhs};
+        p.post_ops_binary_rhs_arg_vec = use_direct_scalar_rhs
+                ? direct_scalar_rhs_arg_vec
+                : post_ops_binary_rhs_arg_vec.data();
         (*ker_)(&p);
     });
 

--- a/src/cpu/x64/matmul/brgemm_matmul.cpp
+++ b/src/cpu/x64/matmul/brgemm_matmul.cpp
@@ -868,7 +868,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
             = brgmm_ctx.get_zp_a_compensation_ptr(ithr, b_idx, n_blk_idx);
     const auto zp_comp_b
             = brgmm_ctx.get_zp_b_compensation_result_ptr(ithr, m_blk_idx);
-    const auto &post_ops_binary_rhs_arg_vec
+    const void *post_ops_binary_rhs_arg_vec
             = brgmm_ctx.get_post_ops_binary_rhs_arg_vec();
     const bool post_ops_applicable = bgmmc.post_ops_applicable
             && (brgmm_ctx.get_num_threads_for_k() <= 1 || bgmmc.K_chunks == 1);
@@ -970,7 +970,7 @@ void brgemm_matmul_t<isa>::compute_kernel(
 
         const brgemm_post_ops_data_t post_ops_data {
                 /*bias=*/static_cast<const void *>(ptr_bias),
-                /*binary_post_ops_rhs=*/post_ops_binary_rhs_arg_vec.data(),
+                /*binary_post_ops_rhs=*/post_ops_binary_rhs_arg_vec,
                 /*oc_logical_off=*/static_cast<size_t>(n), dst_row_logical_off,
                 /*data_C_ptr_=*/brgmm_ctx.get_data_C_ptr(0, 0, 0),
                 first_mb_matrix_addr_off,
@@ -1440,7 +1440,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                     const auto zp_comp_b
                             = brgmm_ctx.get_zp_b_compensation_result_ptr(
                                     ithr, mb);
-                    const auto &post_ops_binary_rhs_arg_vec
+                    const void *post_ops_binary_rhs_arg_vec
                             = brgmm_ctx.get_post_ops_binary_rhs_arg_vec();
 
                     const size_t dst_row_logical_off
@@ -1457,7 +1457,7 @@ void brgemm_matmul_t<isa>::maybe_reduce_partial_results_and_apply_postops(
                             = brgmm_ctx.get_data_C_ptr(0, 0, 0);
                     const brgemm_post_ops_data_t post_ops_data {
                             static_cast<const void *>(ptr_bias),
-                            post_ops_binary_rhs_arg_vec.data(),
+                            post_ops_binary_rhs_arg_vec,
                             static_cast<size_t>(n), dst_row_logical_off,
                             dst_anchor_point, first_mb_matrix_addr_off,
                             static_cast<const void *>(zp_comp_a),
@@ -1787,8 +1787,20 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                           key_brgemm_primitive_per_mn_comp)
                 : nullptr;
 
-        post_ops_binary_rhs_arg_vec_ = binary_injector::prepare_binary_args(
-                pd->attr()->post_ops_, ctx);
+        const auto &post_ops = pd->attr()->post_ops_;
+        if (post_ops.len() == 1
+                && binary_injector::is_simple_scalar_f32_binary_postop(
+                        post_ops.entry_[0], dst_d_,
+                        binary_injector::
+                                get_all_strategies_supported_by_injector())) {
+            direct_scalar_rhs_arg_vec_[0]
+                    = binary_injector::prepare_scalar_binary_arg(
+                            post_ops.entry_[0], ctx, 0);
+            use_direct_scalar_rhs_ = true;
+        } else {
+            binary_injector::prepare_binary_args(
+                    post_ops, ctx, post_ops_binary_rhs_arg_vec_);
+        }
         base_brg_ker_idx_
                 = pd->get_brg_kernel_idx(false, true, 0, 0, false, false);
         vnni_factor = data_type_vnni_granularity(bgmmc.wei_dt);
@@ -2623,8 +2635,9 @@ struct brgemm_matmul_t<isa>::brg_matmul_exec_ctx_t {
                        : nullptr;
     }
 
-    const std::vector<const void *> &get_post_ops_binary_rhs_arg_vec() const {
-        return post_ops_binary_rhs_arg_vec_;
+    const void *get_post_ops_binary_rhs_arg_vec() const {
+        return use_direct_scalar_rhs_ ? direct_scalar_rhs_arg_vec_
+                                      : post_ops_binary_rhs_arg_vec_.data();
     }
 
     int get_base_brgemm_kernel_idx() const { return base_brg_ker_idx_; }
@@ -2910,6 +2923,8 @@ private:
     const void *wei_zp_ptr_;
     const void *dst_zp_ptr_;
     std::vector<const void *> post_ops_binary_rhs_arg_vec_;
+    const void *direct_scalar_rhs_arg_vec_[1] = {nullptr};
+    bool use_direct_scalar_rhs_ = false;
 
     int base_brg_ker_idx_;
     dim_t vnni_factor;

--- a/tests/benchdnn/inputs/matmul/test_matmul_scalar_binary_postops
+++ b/tests/benchdnn/inputs/matmul/test_matmul_scalar_binary_postops
@@ -1,0 +1,27 @@
+# Focused coverage for the direct scalar f32 binary post-op pointer path in
+# x64 BRGEMM matmul kernels.
+
+--reset
+--dt=f32
+--stag=ab --wtag=ab --dtag=ab
+
+# Common scalar arithmetic, including N and M tails.
+--attr-post-ops=mul:f32:common
+32x64:64x37 7x127:127x65 2x63:63x17
+--attr-post-ops=add:f32:common
+32x64:64x37 7x127:127x65
+
+# Multiple scalar post-ops must keep RHS pointers distinct or reload them
+# sequentially without changing RHS argument ordering.
+--attr-post-ops=mul:f32:common+add:f32:common
+32x64:64x37 7x127:127x65
+
+# Eligible f32 direct arithmetic mixed with an ineligible scalar s32 op.
+--attr-post-ops=mul:f32:common+add:s32:common
+32x64:64x37 7x127:127x65
+
+# Non-scalar and unsupported-dtype RHS operations remain on the generic path.
+--attr-post-ops=add:f32:per_oc
+32x64:64x37
+--attr-post-ops=add:s32:common
+32x64:64x37

--- a/tests/benchdnn/inputs/softmax/test_softmax_scalar_binary_postops
+++ b/tests/benchdnn/inputs/softmax/test_softmax_scalar_binary_postops
@@ -1,0 +1,61 @@
+# Regression coverage for the direct scalar binary post-op pointer path
+# (MFDNN-15529). The x64 softmax kernels preload a common f32 binary RHS
+# pointer into a caller-owned GPR for the repeated post-op region.
+#
+# These cases are NOT covered by test_softmax_all: there a scalar binary
+# post-op only ever appears together with an eltwise (linear). The additional
+# cases below exercise direct f32 arithmetic, generic s32 and mixed chains,
+# tails, and unsupported/fallback broadcasts.
+
+--reset
+--dir=FWD_I
+--sdt=f32
+--ddt=f32
+--alg=SOFTMAX,LOGSOFTMAX
+
+# Dense kernel: direct f32 scalar, generic s32, mixed chains, and fallback
+# broadcasts.
+--stag=ab --dtag=ab
+--attr-post-ops=mul:f32:common
+--axis=1 32x131 16x257 5x16 8x33
+--attr-post-ops=add:f32:common
+--axis=1 32x131 8x33
+--attr-post-ops=add:s32:common
+--axis=1 32x131 16x257 8x33
+--attr-post-ops=sub:s32:common
+--axis=1 32x131 8x33
+--attr-post-ops=mul:f32:common+add:s32:common
+--axis=1 32x131 16x257 8x33
+--attr-post-ops=mul:f32:common+add:f32:common
+--axis=1 32x131 8x33
+# Non-scalar broadcast must stay on the generic path.
+--attr-post-ops=add:f32:per_oc
+--axis=1 32x131
+# An eltwise chain stays on the generic path.
+--alg=SOFTMAX
+--attr-post-ops=relu+mul:f32:common
+--axis=1 32x131
+
+# Strided kernel: axis is not the dense dimension.
+--reset
+--dir=FWD_I
+--sdt=f32
+--ddt=f32
+--alg=SOFTMAX
+--stag=ba --dtag=ba
+--attr-post-ops=mul:f32:common
+--axis=1 32x131 8x33
+--attr-post-ops=add:s32:common
+--axis=1 32x131
+--attr-post-ops=mul:f32:common+add:s32:common
+--axis=1 32x131
+
+# f32 -> low precision destination still applies the scalar post-op first.
+--reset
+--dir=FWD_I
+--sdt=f32
+--ddt=bf16
+--alg=SOFTMAX
+--stag=ab --dtag=ab
+--attr-post-ops=mul:f32:common,add:s32:common
+--axis=1 32x131 8x33


### PR DESCRIPTION
## Summary

Addresses MFDNN-15529 by removing avoidable overhead for trivial common (`mask=0`) scalar binary post-ops in softmax and x64 matmul/BRGEMM paths.

(just a draft, not for review yet)