### PR TITLE
benchdnn: matmul: paneled (periodic) fast native reference (--mode-modifier=A)

### DIFF
--- a/tests/benchdnn/doc/driver_matmul.md
+++ b/tests/benchdnn/doc/driver_matmul.md
@@ -118,3 +118,35 @@ or
 
 More examples with different driver options can be found at
 inputs/matmul/test_\*.
+
+## Experimental: paneled ("periodic") fast reference
+
+`DNNL_BENCHDNN_MATMUL_PANEL_FILL` is an experimental, opt-in environment variable
+that speeds up the native CPU reference used for GPU correctness validation. When
+set to `1`, the driver fills the inputs so the result is periodic along `M` and `N`
+(the `K` dimension is kept full), computes the reference for a single representative
+`panel_m x panel_n` panel, and broadcasts it across the whole output. This reduces
+the reference cost from `O(MB*M*N*K)` to roughly `O(panel_m*panel_n*K)` while the
+GPU primitive still runs the full shape.
+
+``` sh
+    DNNL_BENCHDNN_MATMUL_PANEL_FILL=1 ./benchdnn --matmul --engine=gpu \
+        --fast-ref=false 4096x4096:4096x4096
+```
+
+Notes:
+- It only affects the *native* reference path, so it requires `--fast-ref=false`
+  (otherwise a CPU oneDNN primitive is used as the reference and the periodic fill
+  is skipped).
+- The panel width is at least 128 and is aligned to the destination scale/zero-point
+  groups so no block/group quantization parameter straddles a panel boundary.
+- The driver prints whether the periodic fill was selected (and the chosen
+  `panel_m`/`panel_n`), or the reason it fell back to the normal reference, at
+  verbose level >= 0.
+- Periodic inputs can mask bugs in `M`/`N` address arithmetic, so this mode is
+  intended for speeding up local validation of large shapes, not as a replacement
+  for the default reference in CI. It is disabled by default.
+- Unsupported configurations (dynamic destination scales, dropout/stochastic
+  rounding, sparse/grouped dimensions, and shapes too small to form a 128-wide
+  panel) automatically fall back to the normal reference. Runtime dimensions and
+  binary/prelu post-ops are supported.

--- a/tests/benchdnn/doc/driver_matmul.md
+++ b/tests/benchdnn/doc/driver_matmul.md
@@ -121,23 +121,39 @@ inputs/matmul/test_\*.
 
 ## Experimental: paneled ("periodic") fast reference
 
-`DNNL_BENCHDNN_MATMUL_PANEL_FILL` is an experimental, opt-in environment variable
-that speeds up the native CPU reference used for GPU correctness validation. When
-set to `1`, the driver fills the inputs so the result is periodic along `M` and `N`
-(the `K` dimension is kept full), computes the reference for a single representative
-`panel_m x panel_n` panel, and broadcasts it across the whole output. This reduces
-the reference cost from `O(MB*M*N*K)` to roughly `O(panel_m*panel_n*K)` while the
-GPU primitive still runs the full shape.
+The `--mode-modifier=A` option speeds up the native CPU reference used for GPU
+correctness validation. When set, the driver fills the inputs so the result is
+periodic along `M` and `N` (the `K` dimension is kept full), computes the
+reference for a single representative `panel_m x panel_n` panel, and broadcasts it
+across the whole output. This reduces the reference cost from `O(MB*M*N*K)` to
+roughly `O(panel_m*panel_n*K)` while the GPU primitive still runs the full shape.
 
 ``` sh
-    DNNL_BENCHDNN_MATMUL_PANEL_FILL=1 ./benchdnn --matmul --engine=gpu \
-        --fast-ref=false 4096x4096:4096x4096
+    ./benchdnn --matmul --mode=C --mode-modifier=A --engine=gpu \
+        --dt=f8_e4m3:f8_e4m3:f16 4096x4096:4096x4096
 ```
 
+The environment variable `DNNL_BENCHDNN_MATMUL_PANEL_FILL=1` is kept as a
+deprecated alias for the modifier.
+
 Notes:
-- It only affects the *native* reference path, so it requires `--fast-ref=false`
-  (otherwise a CPU oneDNN primitive is used as the reference and the periodic fill
-  is skipped).
+- It only accelerates the *native* reference path, and only when that path is
+  actually used, i.e. when no fast CPU primitive reference is available for the
+  problem (`--fast-ref` cannot build a CPU primitive for the config, e.g. `f8`,
+  `f4`, `mx`, some weight-decompression cases) or when `--fast-ref=false` is
+  passed. When a fast CPU primitive reference *is* available it runs the full
+  shape with vectorized kernels and is generally faster than the paneled scalar
+  native reference, so the modifier is a no-op in that case (it does not disable
+  `--fast-ref`). This avoids regressing configs that already have a fast CPU
+  reference.
+- The panel width is at least 128 and is aligned to the destination scale/zero-point
+  groups so no block/group quantization parameter straddles a panel boundary.
+- The driver prints whether the periodic fill was selected (and the chosen
+  `panel_m`/`panel_n`), or the reason it fell back to the normal reference, at
+  verbose level >= 0.
+- Periodic inputs can mask bugs in `M`/`N` address arithmetic, so this mode is
+  intended for speeding up local validation of large shapes, not as a replacement
+  for the default reference in CI. It is disabled by default.
 - The panel width is at least 128 and is aligned to the destination scale/zero-point
   groups so no block/group quantization parameter straddles a panel boundary.
 - The driver prints whether the periodic fill was selected (and the chosen

--- a/tests/benchdnn/doc/driver_matmul.md
+++ b/tests/benchdnn/doc/driver_matmul.md
@@ -146,7 +146,10 @@ Notes:
 - Periodic inputs can mask bugs in `M`/`N` address arithmetic, so this mode is
   intended for speeding up local validation of large shapes, not as a replacement
   for the default reference in CI. It is disabled by default.
-- Unsupported configurations (dynamic destination scales, dropout/stochastic
-  rounding, sparse/grouped dimensions, and shapes too small to form a 128-wide
-  panel) automatically fall back to the normal reference. Runtime dimensions and
-  binary/prelu post-ops are supported.
+- Unsupported configurations (dropout/stochastic rounding, sparse/grouped
+  dimensions, and shapes too small to form a 128-wide panel) automatically fall
+  back to the normal reference. Runtime dimensions, binary/prelu post-ops, and
+  dynamic/derived destination scales (e.g. `dst:dynamic_fp:...`, `dst:mx:e8m0:...`)
+  are supported: because the panel is a multiple of the destination-scale group,
+  the per-block dynamic scales are themselves periodic and are broadcast across the
+  full destination-scale tensor.

--- a/tests/benchdnn/doc/knobs_common.md
+++ b/tests/benchdnn/doc/knobs_common.md
@@ -167,6 +167,11 @@ Refer to [modes](benchdnn_general_info.md) for details.
   - empty for no modifiers (the default)
   - `P` or `p` for parallel backend object creation
   - `M` or `m` for disabling usage of reference memory (GPU only)
+  - `A` or `a` to accelerate the native correctness reference via a periodic
+               (paneled) input fill. Matmul driver only. Applies only when the
+               native reference is used (no fast CPU primitive reference is
+               available, or `--fast-ref=false`); it does not disable
+               `--fast-ref`. See [matmul driver](driver_matmul.md).
 
 Refer to [mode modifiers](benchdnn_general_info.md) for details.
 

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -936,6 +936,155 @@ std::vector<int> supported_exec_args(dir_t dir) {
     return exec_args;
 }
 
+// Per-axis classification used by the paneled ("periodic") fill PoC.
+enum tile_role_t { ROLE_BATCH, ROLE_M, ROLE_N, ROLE_K, ROLE_BCAST };
+
+// Rewrite `fp` in place so that its values become periodic: the value at a
+// logical coordinate `c` is replaced by the value at the canonical coordinate
+// `c'` where `c'[d] = c[d] % period[d]`. Operates on the plain f32 reference
+// memory (any layout, indexed through its physical strides), so the caller must
+// re-reorder the corresponding device memory afterwards.
+static void periodize_ref(dnn_mem_t &fp, const std::vector<tile_role_t> &roles,
+        int64_t panel_m, int64_t panel_n, bool tile_batch) {
+    const int ndims = fp.ndims();
+    const auto &dims = fp.dims();
+    const auto &strides = fp.strides();
+
+    std::vector<int64_t> period(ndims);
+    for (int d = 0; d < ndims; d++) {
+        switch (roles[d]) {
+            case ROLE_M: period[d] = MIN2(panel_m, dims[d]); break;
+            case ROLE_N: period[d] = MIN2(panel_n, dims[d]); break;
+            case ROLE_BATCH: period[d] = tile_batch ? 1 : dims[d]; break;
+            default: period[d] = dims[d]; break; // K / BCAST: left untiled.
+        }
+    }
+
+    int64_t total = 1;
+    for (int d = 0; d < ndims; d++)
+        total *= dims[d];
+
+    // Ascending row-major order guarantees every canonical element is finalized
+    // (and left untouched) before it is read, so the in-place copy is safe.
+    for (int64_t lin = 0; lin < total; lin++) {
+        int64_t rem = lin, phys = 0, phys_c = 0;
+        bool is_canon = true;
+        for (int d = ndims - 1; d >= 0; d--) {
+            const int64_t c = rem % dims[d];
+            rem /= dims[d];
+            const int64_t cc = c % period[d];
+            phys += c * strides[d];
+            phys_c += cc * strides[d];
+            if (cc != c) is_canon = false;
+        }
+        if (!is_canon) fp.set_f32_elem(phys, fp.get_f32_elem(phys_c));
+    }
+}
+
+// Make every supported input tensor periodic so that both the library and the
+// (periodic) reference produce a periodic output. Returns OK and does nothing
+// when the feature is disabled for this problem.
+static int apply_paneled_fill(dnn_mem_map_t &ref_mem_map,
+        dnn_mem_map_t &mem_map, const prb_t *prb, const cfg_t &cfg) {
+    const auto tf = make_tiled_fill(prb);
+
+    if (!tf.enabled) {
+        // Only advertise the decision when the feature was explicitly requested.
+        if (benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0))
+            BENCHDNN_PRINT(0,
+                    "[MATMUL_PANEL_FILL] periodic fill NOT selected: %s\n",
+                    tf.reason.c_str());
+        return OK;
+    }
+
+    BENCHDNN_PRINT(0,
+            "[MATMUL_PANEL_FILL] periodic fill selected: panel_m=" IFMT
+            " panel_n=" IFMT " tile_batch=%d\n",
+            tf.panel_m, tf.panel_n, (int)tf.tile_batch);
+
+    auto periodize_and_sync = [&](int arg, tile_role_t secondlast,
+                                      tile_role_t last,
+                                      dnnl_data_type_t swapped_dt) -> int {
+        auto rit = ref_mem_map.find(arg);
+        if (rit == ref_mem_map.end() || !rit->second) return OK;
+        auto &ref = rit->second;
+        const int nd = ref.ndims();
+        std::vector<tile_role_t> roles(nd, ROLE_BATCH);
+        if (nd >= 2) roles[nd - 2] = secondlast;
+        if (nd >= 1) roles[nd - 1] = last;
+        periodize_ref(ref, roles, tf.panel_m, tf.panel_n, tf.tile_batch);
+        auto mit = mem_map.find(arg);
+        if (mit != mem_map.end() && mit->second)
+            SAFE(mit->second.reorder(ref, swapped_dt), WARN);
+        return OK;
+    };
+
+    // Data tensors. Layouts: src [..,M,K], wei [..,K,N], bias [..,M,N],
+    // dst (sum) [..,M,N].
+    SAFE(periodize_and_sync(DNNL_ARG_SRC, ROLE_M, ROLE_K,
+                 cfg.get_swapped_dt(SRC)),
+            WARN);
+    SAFE(periodize_and_sync(DNNL_ARG_WEIGHTS, ROLE_K, ROLE_N,
+                 cfg.get_swapped_dt(WEI)),
+            WARN);
+    SAFE(periodize_and_sync(
+                 DNNL_ARG_BIAS, ROLE_M, ROLE_N, cfg.get_swapped_dt(BIA)),
+            WARN);
+    // dst is periodized only when it is a genuine input (sum post-op); otherwise
+    // it is pure output and compute_ref fully overwrites it.
+    if (prb->attr.post_ops.find(attr_t::post_ops_t::SUM) >= 0) {
+        SAFE(periodize_and_sync(
+                     DNNL_ARG_DST, ROLE_M, ROLE_N, cfg.get_swapped_dt(DST)),
+                WARN);
+    }
+
+    // Quantization tensors are stored in abx over their owning tensor's dims.
+    SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, ROLE_M, ROLE_K,
+                 dnnl_data_type_undef),
+            WARN);
+    SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, ROLE_K,
+                 ROLE_N, dnnl_data_type_undef),
+            WARN);
+    SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, ROLE_M, ROLE_N,
+                 dnnl_data_type_undef),
+            WARN);
+    SAFE(periodize_and_sync(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, ROLE_M,
+                 ROLE_K, dnnl_data_type_undef),
+            WARN);
+    SAFE(periodize_and_sync(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, ROLE_K,
+                 ROLE_N, dnnl_data_type_undef),
+            WARN);
+    SAFE(periodize_and_sync(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, ROLE_M,
+                 ROLE_N, dnnl_data_type_undef),
+            WARN);
+
+    // Binary/prelu post-op operands are addressed in the dst index space via
+    // `dst_m.get_idx(dst_off, mask)`, so they must be periodic on the same M/N
+    // panel grid for the broadcasted dst to stay valid. Their reference mems are
+    // f32 with the same ndims as dst (broadcast dims have extent 1, where
+    // periodize_ref is a no-op). Periodize every operand: binary src1, the
+    // ternary (select) condition src2, and prelu weights.
+    for (int i = 0; i < prb->attr.post_ops.len(); i++) {
+        const auto &e = prb->attr.post_ops.entry[i];
+        const int base = DNNL_ARG_ATTR_MULTIPLE_POST_OP(i);
+        if (e.is_binary_kind()) {
+            SAFE(periodize_and_sync(base | DNNL_ARG_SRC_1, ROLE_M, ROLE_N,
+                         dnnl_data_type_undef),
+                    WARN);
+            if (e.is_binary_kind_with_ternary_op())
+                SAFE(periodize_and_sync(base | DNNL_ARG_SRC_2, ROLE_M, ROLE_N,
+                             dnnl_data_type_undef),
+                        WARN);
+        } else if (e.is_prelu_kind()) {
+            SAFE(periodize_and_sync(base | DNNL_ARG_WEIGHTS, ROLE_M, ROLE_N,
+                         dnnl_data_type_undef),
+                    WARN);
+        }
+    }
+
+    return OK;
+}
+
 int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         dnnl_primitive_t prim, const prb_t *prb, res_t *res,
         dnnl_primitive_t prim_ref) {
@@ -1145,6 +1294,17 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         // Don't keep reference memory if it is not used further.
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();
+    }
+
+    // Paneled ("periodic") fill PoC. Only applies to the native reference path
+    // (no CPU `prim_ref`) and to correctness mode where reference memory exists.
+    if (has_bench_mode_bit(mode_bit_t::corr) && !prim_ref) {
+        SAFE(apply_paneled_fill(ref_mem_map, mem_map, prb, cfg), WARN);
+    } else if (benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0)
+            && prim_ref) {
+        BENCHDNN_PRINT(0, "%s\n",
+                "[MATMUL_PANEL_FILL] periodic fill NOT applied: a CPU primitive "
+                "reference is in use; pass --fast-ref=false to enable it");
     }
 
     if (ref_mem_map.count(

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -947,24 +947,14 @@ enum tile_role_t { ROLE_BATCH, ROLE_M, ROLE_N, ROLE_K, ROLE_BCAST };
 
 // Rewrite `fp` in place so that its values become periodic: the value at a
 // logical coordinate `c` is replaced by the value at the canonical coordinate
-// `c'` where `c'[d] = c[d] % period[d]`. Operates on the plain f32 reference
-// memory (any layout, indexed through its physical strides), so the caller must
-// re-reorder the corresponding device memory afterwards.
-static void periodize_ref(dnn_mem_t &fp, const std::vector<tile_role_t> &roles,
-        int64_t panel_m, int64_t panel_n, bool tile_batch) {
+// `c'` where `c'[d] = c[d] % period[d]`. `period` is expressed in `fp`'s own
+// physical dims. Operates on the plain f32 reference memory (any layout,
+// indexed through its physical strides), so the caller must re-reorder the
+// corresponding device memory afterwards.
+static void periodize_ref(dnn_mem_t &fp, const std::vector<int64_t> &period) {
     const int ndims = fp.ndims();
     const auto &dims = fp.dims();
     const auto &strides = fp.strides();
-
-    std::vector<int64_t> period(ndims);
-    for (int d = 0; d < ndims; d++) {
-        switch (roles[d]) {
-            case ROLE_M: period[d] = MIN2(panel_m, dims[d]); break;
-            case ROLE_N: period[d] = MIN2(panel_n, dims[d]); break;
-            case ROLE_BATCH: period[d] = tile_batch ? 1 : dims[d]; break;
-            default: period[d] = dims[d]; break; // K / BCAST: left untiled.
-        }
-    }
 
     int64_t total = 1;
     for (int d = 0; d < ndims; d++)
@@ -1027,6 +1017,71 @@ static void periodize_ref(dnn_mem_t &fp, const std::vector<tile_role_t> &roles,
     }
 }
 
+// Period (in the tensor's own physical dims) for a FULL-RANK tensor whose last
+// two dims carry `secondlast`/`last` roles and whose leading dims are batch.
+// Used for data tensors (src/wei/dst), bias and post-op operands, all of which
+// are materialized with the full logical rank (broadcast dims have extent 1).
+static std::vector<int64_t> full_rank_period(const dnn_mem_t &fp,
+        tile_role_t secondlast, tile_role_t last, const tiled_fill_t &tf) {
+    const int nd = fp.ndims();
+    const auto &dims = fp.dims();
+    std::vector<int64_t> period(nd, 1);
+    for (int d = 0; d < nd; d++) {
+        tile_role_t role = ROLE_BATCH;
+        if (d == nd - 2) role = secondlast;
+        else if (d == nd - 1) role = last;
+        switch (role) {
+            case ROLE_M: period[d] = MIN2(tf.panel_m, dims[d]); break;
+            case ROLE_N: period[d] = MIN2(tf.panel_n, dims[d]); break;
+            case ROLE_BATCH: period[d] = tf.tile_batch ? 1 : dims[d]; break;
+            default: period[d] = dims[d]; break; // K / BCAST: left untiled.
+        }
+    }
+    return period;
+}
+
+// Period for a quantization tensor (scales / zero-points). Such tensors only
+// materialize the logical dims selected by `mask` (see md2dims()), so a purely
+// positional role assignment would misalign the physical dims (e.g. treat a
+// leading batch dim as K). Here we walk the OWNER tensor's `owner_ndims`
+// logical dims, keep only the masked ones (matching the physical layout), and
+// assign each the role of its logical axis: leading dims are batch, the last
+// two are `role_2nd`/`role_last`. Group sizes (applied to the last two logical
+// dims) scale the panel period into the tensor's grouped index space.
+static std::vector<int64_t> quant_period(const dnn_mem_t &fp, int owner_ndims,
+        int mask, const std::vector<dnnl_dim_t> &groups, tile_role_t role_2nd,
+        tile_role_t role_last, const tiled_fill_t &tf) {
+    const int pnd = fp.ndims();
+    const auto &pdims = fp.dims();
+    std::vector<int64_t> period(pnd, 1);
+    int p = 0;
+    for (int d = 0; d < owner_ndims && p < pnd; d++) {
+        if (!(mask & (1 << d))) continue;
+        tile_role_t role = ROLE_BATCH;
+        if (d == owner_ndims - 2) role = role_2nd;
+        else if (d == owner_ndims - 1) role = role_last;
+        const int gdim = d - (owner_ndims - 2);
+        const int64_t g = (gdim >= 0 && (size_t)gdim < groups.size() && groups[gdim] > 0)
+                ? groups[gdim]
+                : 1;
+        int64_t per;
+        switch (role) {
+            case ROLE_M: per = MIN2(tf.panel_m / g, pdims[p]); break;
+            case ROLE_N: per = MIN2(tf.panel_n / g, pdims[p]); break;
+            case ROLE_BATCH: per = tf.tile_batch ? 1 : pdims[p]; break;
+            default: per = pdims[p]; break; // K: never tiled.
+        }
+        period[p] = MAX2((int64_t)1, per);
+        p++;
+    }
+    // If the mask did not account for every physical dim (unexpected), fall
+    // back to no periodization on the unmatched trailing dims (correct, just
+    // not collapsed) to stay safe.
+    for (; p < pnd; p++)
+        period[p] = pdims[p];
+    return period;
+}
+
 // Make every supported input tensor periodic so that both the library and the
 // (periodic) reference produce a periodic output. Returns OK and does nothing
 // when the feature is disabled for this problem.
@@ -1048,65 +1103,96 @@ static int apply_paneled_fill(dnn_mem_map_t &ref_mem_map,
             " panel_n=" IFMT " tile_batch=%d\n",
             tf.panel_m, tf.panel_n, (int)tf.tile_batch);
 
-    auto periodize_and_sync = [&](int arg, tile_role_t secondlast,
-                                      tile_role_t last,
-                                      dnnl_data_type_t swapped_dt) -> int {
-        auto rit = ref_mem_map.find(arg);
-        if (rit == ref_mem_map.end() || !rit->second) return OK;
-        auto &ref = rit->second;
-        const int nd = ref.ndims();
-        std::vector<tile_role_t> roles(nd, ROLE_BATCH);
-        if (nd >= 2) roles[nd - 2] = secondlast;
-        if (nd >= 1) roles[nd - 1] = last;
-        periodize_ref(ref, roles, tf.panel_m, tf.panel_n, tf.tile_batch);
+    // Common reorder-back-to-device step shared by both fillers.
+    auto sync_to_device = [&](int arg, dnn_mem_t &ref,
+                                  dnnl_data_type_t swapped_dt) -> int {
         auto mit = mem_map.find(arg);
         if (mit != mem_map.end() && mit->second)
             SAFE(mit->second.reorder(ref, swapped_dt), WARN);
         return OK;
     };
 
+    // Full-rank tensors (data, bias, post-op operands): last two dims carry the
+    // given roles, leading dims are batch.
+    auto periodize_data = [&](int arg, tile_role_t secondlast, tile_role_t last,
+                                  dnnl_data_type_t swapped_dt) -> int {
+        auto rit = ref_mem_map.find(arg);
+        if (rit == ref_mem_map.end() || !rit->second) return OK;
+        auto &ref = rit->second;
+        periodize_ref(ref, full_rank_period(ref, secondlast, last, tf));
+        return sync_to_device(arg, ref, swapped_dt);
+    };
+
+    // Quantization tensors (scales / zero-points): only the masked logical dims
+    // of the owning tensor are materialized, so map physical dims via the mask.
+    auto periodize_quant = [&](int arg, const attr_t::arg_scales_t *scales,
+                                   const attr_t::zero_points_t *zps,
+                                   int owner_arg, tile_role_t role_2nd,
+                                   tile_role_t role_last) -> int {
+        auto rit = ref_mem_map.find(arg);
+        if (rit == ref_mem_map.end() || !rit->second) return OK;
+        auto &ref = rit->second;
+        int mask = 0;
+        std::vector<dnnl_dim_t> groups;
+        if (scales) {
+            mask = scales->get_mask(
+                    owner_arg, dnnl_undefined_primitive, prb->ndims);
+            groups = scales->get(owner_arg).groups;
+        } else {
+            mask = zps->get_mask(
+                    owner_arg, dnnl_undefined_primitive, prb->ndims);
+            groups = zps->get(owner_arg).groups;
+        }
+        periodize_ref(ref,
+                quant_period(
+                        ref, prb->ndims, mask, groups, role_2nd, role_last, tf));
+        return sync_to_device(arg, ref, dnnl_data_type_undef);
+    };
+
     // Data tensors. Layouts: src [..,M,K], wei [..,K,N], bias [..,M,N],
     // dst (sum) [..,M,N].
-    SAFE(periodize_and_sync(DNNL_ARG_SRC, ROLE_M, ROLE_K,
-                 cfg.get_swapped_dt(SRC)),
+    SAFE(periodize_data(
+                 DNNL_ARG_SRC, ROLE_M, ROLE_K, cfg.get_swapped_dt(SRC)),
             WARN);
-    SAFE(periodize_and_sync(DNNL_ARG_WEIGHTS, ROLE_K, ROLE_N,
-                 cfg.get_swapped_dt(WEI)),
+    SAFE(periodize_data(
+                 DNNL_ARG_WEIGHTS, ROLE_K, ROLE_N, cfg.get_swapped_dt(WEI)),
             WARN);
-    SAFE(periodize_and_sync(
+    SAFE(periodize_data(
                  DNNL_ARG_BIAS, ROLE_M, ROLE_N, cfg.get_swapped_dt(BIA)),
             WARN);
     // dst is periodized only when it is a genuine input (sum post-op); otherwise
     // it is pure output and compute_ref fully overwrites it.
     if (prb->attr.post_ops.find(attr_t::post_ops_t::SUM) >= 0) {
-        SAFE(periodize_and_sync(
+        SAFE(periodize_data(
                      DNNL_ARG_DST, ROLE_M, ROLE_N, cfg.get_swapped_dt(DST)),
                 WARN);
     }
 
-    // Quantization tensors are stored in abx over their owning tensor's dims.
-    SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, ROLE_M, ROLE_K,
-                 dnnl_data_type_undef),
+    // Quantization tensors carry only the masked logical dims of their owner.
+    const attr_t::arg_scales_t *sc = &prb->attr.scales;
+    const attr_t::zero_points_t *zp = &prb->attr.zero_points;
+    SAFE(periodize_quant(DNNL_ARG_ATTR_SCALES | DNNL_ARG_SRC, sc, nullptr,
+                 DNNL_ARG_SRC, ROLE_M, ROLE_K),
             WARN);
-    SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, ROLE_K,
-                 ROLE_N, dnnl_data_type_undef),
+    SAFE(periodize_quant(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, sc, nullptr,
+                 DNNL_ARG_WEIGHTS, ROLE_K, ROLE_N),
             WARN);
     // Static dst scales are an input and must be periodized. Dynamic/derived
     // dst scales (mx, dynamic_fp) are an OUTPUT computed by the reference, so
     // they are broadcast in compute_ref_matmul_periodic instead, not here.
     if (!prb->attr.scales.get(DNNL_ARG_DST).is_dynamic()) {
-        SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, ROLE_M,
-                     ROLE_N, dnnl_data_type_undef),
+        SAFE(periodize_quant(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, sc, nullptr,
+                     DNNL_ARG_DST, ROLE_M, ROLE_N),
                 WARN);
     }
-    SAFE(periodize_and_sync(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, ROLE_M,
-                 ROLE_K, dnnl_data_type_undef),
+    SAFE(periodize_quant(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, nullptr, zp,
+                 DNNL_ARG_SRC, ROLE_M, ROLE_K),
             WARN);
-    SAFE(periodize_and_sync(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, ROLE_K,
-                 ROLE_N, dnnl_data_type_undef),
+    SAFE(periodize_quant(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_WEIGHTS, nullptr,
+                 zp, DNNL_ARG_WEIGHTS, ROLE_K, ROLE_N),
             WARN);
-    SAFE(periodize_and_sync(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, ROLE_M,
-                 ROLE_N, dnnl_data_type_undef),
+    SAFE(periodize_quant(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_DST, nullptr, zp,
+                 DNNL_ARG_DST, ROLE_M, ROLE_N),
             WARN);
 
     // Binary/prelu post-op operands are addressed in the dst index space via
@@ -1119,15 +1205,15 @@ static int apply_paneled_fill(dnn_mem_map_t &ref_mem_map,
         const auto &e = prb->attr.post_ops.entry[i];
         const int base = DNNL_ARG_ATTR_MULTIPLE_POST_OP(i);
         if (e.is_binary_kind()) {
-            SAFE(periodize_and_sync(base | DNNL_ARG_SRC_1, ROLE_M, ROLE_N,
+            SAFE(periodize_data(base | DNNL_ARG_SRC_1, ROLE_M, ROLE_N,
                          dnnl_data_type_undef),
                     WARN);
             if (e.is_binary_kind_with_ternary_op())
-                SAFE(periodize_and_sync(base | DNNL_ARG_SRC_2, ROLE_M, ROLE_N,
+                SAFE(periodize_data(base | DNNL_ARG_SRC_2, ROLE_M, ROLE_N,
                              dnnl_data_type_undef),
                         WARN);
         } else if (e.is_prelu_kind()) {
-            SAFE(periodize_and_sync(base | DNNL_ARG_WEIGHTS, ROLE_M, ROLE_N,
+            SAFE(periodize_data(base | DNNL_ARG_WEIGHTS, ROLE_M, ROLE_N,
                          dnnl_data_type_undef),
                     WARN);
         }

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -1301,15 +1301,23 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         if (!has_bench_mode_bit(mode_bit_t::corr)) ref_mem_map.clear();
     }
 
-    // Paneled ("periodic") fill PoC. Only applies to the native reference path
+    // Paneled ("periodic") fill. Only applies to the native reference path
     // (no CPU `prim_ref`) and to correctness mode where reference memory exists.
+    // This is intentional: when a fast CPU primitive reference is available it
+    // runs the full shape with vectorized kernels and is typically faster than
+    // the paneled scalar native reference, so we leave it untouched. Paneling
+    // targets exactly the configs where no fast CPU reference exists and
+    // benchdnn already falls back to the slow native `compute_ref`.
+    const bool panel_requested
+            = has_bench_mode_modifier(mode_modifier_t::ref_periodic_fill)
+            || benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0);
     if (has_bench_mode_bit(mode_bit_t::corr) && !prim_ref) {
         SAFE(apply_paneled_fill(ref_mem_map, mem_map, prb, cfg), WARN);
-    } else if (benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0)
-            && prim_ref) {
+    } else if (panel_requested && prim_ref) {
         BENCHDNN_PRINT(0, "%s\n",
-                "[MATMUL_PANEL_FILL] periodic fill NOT applied: a CPU primitive "
-                "reference is in use; pass --fast-ref=false to enable it");
+                "[MATMUL_PANEL_FILL] periodic fill not needed: a fast CPU "
+                "primitive reference is available (generally faster than the "
+                "paneled native reference). Pass --fast-ref=false to force it.");
     }
 
     if (ref_mem_map.count(

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -16,6 +16,7 @@
 
 #include <float.h>
 #include <math.h>
+#include <cstring>
 #include <random>
 #include <set>
 #include <stdio.h>
@@ -556,7 +557,8 @@ static int fill_grouped_data(data_kind_t kind, const prb_t *prb,
 #endif // DNNL_EXPERIMENTAL_GROUPED_MEMORY
 
 int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
-        const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res) {
+        const cfg_t &cfg, dnn_mem_t &mem_dt, dnn_mem_t &mem_fp, res_t *res,
+        bool skip_dt_reorder = false) {
 
     const auto nelems = mem_dt.nelems();
     if (nelems == 0) return OK;
@@ -645,7 +647,11 @@ int fill_data(data_kind_t kind, int exec_arg, const prb_t *prb,
         fill_dense_fp_values(kind, prb, cfg, mem_fp);
     }
 
-    SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
+    // Under paneled ("periodic") fill the reference f32 memory is about to be
+    // periodized in place and reordered to the device once, so skip the device
+    // reorder here to avoid a redundant full-tensor conversion.
+    if (!skip_dt_reorder)
+        SAFE(mem_dt.reorder(mem_fp, cfg.get_swapped_dt(kind)), WARN);
 
     return OK;
 }
@@ -964,6 +970,46 @@ static void periodize_ref(dnn_mem_t &fp, const std::vector<tile_role_t> &roles,
     for (int d = 0; d < ndims; d++)
         total *= dims[d];
 
+    // Fast path: when the contiguous (stride-1) dimension is not periodized,
+    // each line along it is copied wholesale from its canonical source line.
+    // Written lines (non-canonical) and read lines (canonical) are disjoint
+    // sets that never overlap, so the broadcast copy is order-independent and
+    // safe to parallelize. This is the common matmul case (src/wei keep K, the
+    // contiguous dim, full) and turns the O(total) per-element stride decode
+    // into O(total / line) contiguous memcpys.
+    int cdim = -1;
+    for (int d = 0; d < ndims; d++)
+        if (strides[d] == 1) {
+            cdim = d;
+            break;
+        }
+    if (cdim >= 0 && period[cdim] == dims[cdim] && total > 0) {
+        const int64_t line = dims[cdim];
+        const int64_t outer = total / line;
+        float *base = static_cast<float *>(fp);
+        // Mixed-radix decode of the outer index over all dims except `cdim`,
+        // in descending (row-major) order.
+        std::vector<int> odims;
+        for (int d = 0; d < ndims; d++)
+            if (d != cdim) odims.push_back(d);
+        benchdnn_parallel_nd(outer, [&](int64_t o) {
+            int64_t rem = o, phys = 0, phys_c = 0;
+            bool is_canon = true;
+            for (int i = (int)odims.size() - 1; i >= 0; i--) {
+                const int d = odims[i];
+                const int64_t c = rem % dims[d];
+                rem /= dims[d];
+                const int64_t cc = c % period[d];
+                phys += c * strides[d];
+                phys_c += cc * strides[d];
+                if (cc != c) is_canon = false;
+            }
+            if (!is_canon)
+                std::memcpy(base + phys, base + phys_c, line * sizeof(float));
+        });
+        return;
+    }
+
     // Ascending row-major order guarantees every canonical element is finalized
     // (and left untouched) before it is read, so the in-place copy is safe.
     for (int64_t lin = 0; lin < total; lin++) {
@@ -1115,6 +1161,16 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
     // Move cfg out of filling since its creation is not free.
     cfg_t cfg(prb, {SRC, WEI, BIA, DST});
 
+    // Decide once whether paneled ("periodic") fill is active for this problem.
+    // When it is, the data tensors are periodized in place and reordered to the
+    // device a single time by `apply_paneled_fill`, so their initial per-tensor
+    // device reorder in `fill_data` is redundant and skipped.
+    const bool panel_requested
+            = has_bench_mode_modifier(mode_modifier_t::ref_periodic_fill)
+            || benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0);
+    const bool paneling_on = has_bench_mode_bit(mode_bit_t::corr) && !prim_ref
+            && panel_requested && make_tiled_fill(prb).enabled;
+
     const auto src_encoding = prb->sparse_options.get_encoding(DNNL_ARG_SRC);
     const auto wei_encoding
             = prb->sparse_options.get_encoding(DNNL_ARG_WEIGHTS);
@@ -1223,15 +1279,18 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
 
         switch (exec_arg) {
             case DNNL_ARG_SRC:
-                SAFE(fill_data(SRC, exec_arg, prb, cfg, mem, ref_mem, res),
+                SAFE(fill_data(SRC, exec_arg, prb, cfg, mem, ref_mem, res,
+                             paneling_on),
                         WARN);
                 break;
             case DNNL_ARG_WEIGHTS:
-                SAFE(fill_data(WEI, exec_arg, prb, cfg, mem, ref_mem, res),
+                SAFE(fill_data(WEI, exec_arg, prb, cfg, mem, ref_mem, res,
+                             paneling_on),
                         WARN);
                 break;
             case DNNL_ARG_BIAS:
-                SAFE(fill_data(BIA, exec_arg, prb, cfg, mem, ref_mem, res),
+                SAFE(fill_data(BIA, exec_arg, prb, cfg, mem, ref_mem, res,
+                             paneling_on),
                         WARN);
                 break;
             case DNNL_ARG_DST: {
@@ -1245,7 +1304,10 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
                 const auto &po = prb->attr.post_ops;
                 const int sum_idx = po.find(attr_t::post_ops_t::SUM);
                 if (sum_idx >= 0) {
-                    SAFE(fill_data(DST, exec_arg, prb, cfg, mem, ref_mem, res),
+                    SAFE(fill_data(DST, exec_arg, prb, cfg, mem, ref_mem, res,
+                                 paneling_on
+                                         && !has_bench_mode_bit(
+                                                 mode_bit_t::bitwise)),
                             WARN);
                     // Bitwise mode for sum requires a copy due to data for
                     // post-op will be overwritten and it must be refreshed.
@@ -1308,9 +1370,6 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
     // the paneled scalar native reference, so we leave it untouched. Paneling
     // targets exactly the configs where no fast CPU reference exists and
     // benchdnn already falls back to the slow native `compute_ref`.
-    const bool panel_requested
-            = has_bench_mode_modifier(mode_modifier_t::ref_periodic_fill)
-            || benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0);
     if (has_bench_mode_bit(mode_bit_t::corr) && !prim_ref) {
         SAFE(apply_paneled_fill(ref_mem_map, mem_map, prb, cfg), WARN);
     } else if (panel_requested && prim_ref) {

--- a/tests/benchdnn/matmul/matmul.cpp
+++ b/tests/benchdnn/matmul/matmul.cpp
@@ -1045,9 +1045,14 @@ static int apply_paneled_fill(dnn_mem_map_t &ref_mem_map,
     SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_WEIGHTS, ROLE_K,
                  ROLE_N, dnnl_data_type_undef),
             WARN);
-    SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, ROLE_M, ROLE_N,
-                 dnnl_data_type_undef),
-            WARN);
+    // Static dst scales are an input and must be periodized. Dynamic/derived
+    // dst scales (mx, dynamic_fp) are an OUTPUT computed by the reference, so
+    // they are broadcast in compute_ref_matmul_periodic instead, not here.
+    if (!prb->attr.scales.get(DNNL_ARG_DST).is_dynamic()) {
+        SAFE(periodize_and_sync(DNNL_ARG_ATTR_SCALES | DNNL_ARG_DST, ROLE_M,
+                     ROLE_N, dnnl_data_type_undef),
+                WARN);
+    }
     SAFE(periodize_and_sync(DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, ROLE_M,
                  ROLE_K, dnnl_data_type_undef),
             WARN);

--- a/tests/benchdnn/matmul/matmul.hpp
+++ b/tests/benchdnn/matmul/matmul.hpp
@@ -274,6 +274,23 @@ int init_ref_memory_args(dnn_mem_map_t &ref_mem_map, dnn_mem_map_t &mem_map,
         dnnl_primitive_t prim, const prb_t *prb, res_t *res,
         dnnl_primitive_t prim_ref = nullptr);
 
+// Paneled ("periodic") fill PoC. See ref_matmul.cpp::make_tiled_fill().
+//
+// When enabled (env var DNNL_BENCHDNN_MATMUL_PANEL_FILL=1), inputs are filled so
+// that the result is periodic along M (period `panel_m`) and N (period `panel_n`)
+// and, optionally, identical across the batch dimension (`tile_batch`). The native
+// reference then computes only the representative `panel_m x panel_n` panel (and a
+// single batch when `tile_batch`) and broadcasts it across the full output, which
+// reduces the reference cost from O(MB*M*N*K) to ~O(panel_m*panel_n*K).
+struct tiled_fill_t {
+    bool enabled = false;
+    int64_t panel_m = 0; // period along M (== M when M is not tiled).
+    int64_t panel_n = 0; // period along N (== N when N is not tiled).
+    bool tile_batch = false; // collapse the batch dimension to a single slice.
+    std::string reason; // Human-readable explanation (enabled or why disabled).
+};
+tiled_fill_t make_tiled_fill(const prb_t *prb);
+
 void skip_unimplemented_prb(const prb_t *prb, res_t *res);
 void skip_invalid_prb(const prb_t *prb, res_t *res);
 void compute_ref(const prb_t *prb, dir_t dir, const args_t &args,

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -451,6 +451,180 @@ void compute_ref_matmul(const prb_t *prb, const args_t &args) {
     });
 }
 
+// ---------------------------------------------------------------------------
+// Paneled ("periodic") fill PoC.
+//
+// `make_tiled_fill` decides whether the periodic-fill fast path can be used for
+// a given problem and, if so, returns the panel periods. See matmul.hpp for the
+// high-level description.
+// ---------------------------------------------------------------------------
+
+// Smallest multiple of `base` that is >= `kMinPanel` and <= `dim`. Returns 0
+// when the dimension can't host a panel of at least `kMinPanel` (so that the
+// dimension is left untiled).
+static int64_t pick_panel(int64_t base, int64_t dim) {
+    static constexpr int64_t kMinPanel = 128;
+    if (base <= 0) base = 1;
+    if (dim < kMinPanel) return 0;
+    const int64_t p = div_up(kMinPanel, base) * base;
+    if (p > dim) return 0;
+    return p;
+}
+
+tiled_fill_t make_tiled_fill(const prb_t *prb) {
+    tiled_fill_t t;
+
+    const int enabled_env
+            = benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0);
+    if (!enabled_env) {
+        t.reason = "env DNNL_BENCHDNN_MATMUL_PANEL_FILL is not set";
+        return t;
+    }
+
+    // Compatibility gates. The PoC intentionally supports only the common
+    // matmul accuracy-validation cases; everything else falls back to the
+    // regular (full) reference.
+    if (!prb->sparse_options.is_def()) {
+        t.reason = "sparse/grouped matmul is unsupported";
+        return t;
+    }
+    // Runtime dimensions are supported: they only make the primitive descriptor
+    // use DNNL_RUNTIME_DIM_VAL placeholders. The native reference and the fill
+    // both operate on concrete `prb->m/n/k/mb` and concrete-sized, dense f32
+    // reference memory, so the periodic fill and broadcast remain valid. This
+    // assumes execute-time concrete dims equal `prb` dims (always true in
+    // benchdnn) and native ref memories stay plain logical f32.
+    if (!prb->attr.dropout.is_def()) {
+        t.reason = "dropout is unsupported";
+        return t;
+    }
+    if (!prb->attr.rounding_mode.is_def()) {
+        t.reason = "stochastic rounding is unsupported";
+        return t;
+    }
+    if (prb->attr.scales.get(DNNL_ARG_DST).is_dynamic()) {
+        t.reason = "dynamic dst scales are unsupported";
+        return t;
+    }
+    // Binary/prelu post-ops are supported: their operands are periodized on the
+    // same M/N panel grid by apply_paneled_fill (see matmul.cpp), keeping the
+    // post-op result periodic.
+
+    // Panel periods must be multiples of the dst scale groups so that no dst
+    // scale group straddles a panel boundary. K-direction groups are irrelevant
+    // because K is never tiled.
+    const auto &dsg = prb->attr.scales.get(DNNL_ARG_DST).groups;
+    const int64_t dst_M_group = !dsg.empty() ? dsg[0] : 1;
+    const int64_t dst_N_group = !dsg.empty() ? dsg[1] : 1;
+
+    const int64_t pm = pick_panel(dst_M_group, prb->m);
+    const int64_t pn = pick_panel(dst_N_group, prb->n);
+    const bool tile_batch = prb->mb > 1;
+
+    // Effective periods: a 0 from pick_panel means "leave this dimension
+    // untiled" (period == full extent).
+    const int64_t panel_m = pm == 0 ? prb->m : pm;
+    const int64_t panel_n = pn == 0 ? prb->n : pn;
+
+    const bool m_tiled = panel_m < prb->m;
+    const bool n_tiled = panel_n < prb->n;
+    if (!m_tiled && !n_tiled && !tile_batch) {
+        t.reason = "shape too small to form a >=128 panel on any dimension";
+        return t;
+    }
+
+    t.enabled = true;
+    t.panel_m = panel_m;
+    t.panel_n = panel_n;
+    t.tile_batch = tile_batch;
+    t.reason = "periodic fill selected";
+    return t;
+}
+
+// Periodic fast reference: compute only the representative
+// [0:panel_m) x [0:panel_n) panel (and a single batch when `tile_batch`) reusing
+// the regular per-chunk kernel, then broadcast the final values across the full
+// output using modulo indexing.
+static void compute_ref_matmul_periodic(
+        const prb_t *prb, const args_t &args, const tiled_fill_t &tf) {
+    {
+        const dnn_mem_t &dst_m = args.find(DNNL_ARG_DST);
+        for (int d = 0; d < dst_m.ndims(); d++) {
+            if (prb->src_dims()[d] == 0 || prb->weights_dims()[d] == 0) return;
+        }
+    }
+
+    const chunk_params_t params = make_chunk_params(prb, args);
+
+    const int64_t M = prb->m;
+    const int64_t N = prb->n;
+    const int64_t K = prb->k;
+    const int64_t MB = prb->mb;
+
+    // Representative ranges. Panels are multiples of the dst groups, so these
+    // chunk counts never spill outside the panel.
+    const int64_t repr_MB = tf.tile_batch ? 1 : MB;
+    const int64_t repr_M_chunks
+            = div_up(MIN2(tf.panel_m, M), params.dst_M_group);
+    const int64_t repr_N_chunks
+            = div_up(MIN2(tf.panel_n, N), params.dst_N_group);
+
+    const dnn_mem_t &dst_m = *params.dst_m;
+    const int batch_ndims = dst_m.ndims() - 2;
+
+    const auto src_broadcast_mask = prb->src_broadcast_mask();
+    const auto wei_broadcast_mask = prb->weights_broadcast_mask();
+    const auto bias_broadcast_mask = prb->bias_broadcast_mask();
+
+    const int wei_ndims = params.wei_m->ndims();
+    const int64_t wei_k_stride = params.wei_m->strides()[wei_ndims - 2];
+    const int64_t wei_n_stride = params.wei_m->strides()[wei_ndims - 1];
+
+    // Phase 1: compute the representative panel(s).
+    benchdnn_parallel_nd(repr_MB, repr_M_chunks, repr_N_chunks,
+            [&](int64_t mb, int64_t mc, int64_t nc) {
+        int64_t src_mb = 0;
+        int64_t wei_mb = 0;
+        if (MB > 1) {
+            src_mb = dst_m.get_idx(mb, src_broadcast_mask, batch_ndims);
+            wei_mb = dst_m.get_idx(mb, wei_broadcast_mask, batch_ndims);
+        }
+
+        int64_t bia_base = 0, bia_m_stride = 0, bia_n_stride = 0;
+        if (params.bia_dt != dnnl_data_type_undef) {
+            bia_base = dst_m.get_idx(
+                    dst_off_f(prb, mb, 0, 0), bias_broadcast_mask);
+            bia_m_stride = dst_m.get_idx(dst_off_f(prb, mb, 1, 0),
+                                   bias_broadcast_mask)
+                    - bia_base;
+            bia_n_stride = dst_m.get_idx(dst_off_f(prb, mb, 0, 1),
+                                   bias_broadcast_mask)
+                    - bia_base;
+        }
+
+        const int64_t src_row_base = src_mb * M;
+        const int64_t wei_base = wei_mb * K * N;
+        const int64_t dst_row_base = mb * M;
+
+        compute_ref_matmul_chunk(params, M, N, K, mc, nc, src_row_base,
+                wei_base, wei_k_stride, wei_n_stride, dst_row_base, bia_base,
+                bia_m_stride, bia_n_stride, prb->attr, args);
+    });
+
+    // Phase 2: broadcast the representative values across the full output.
+    const int64_t panel_m = tf.panel_m;
+    const int64_t panel_n = tf.panel_n;
+    benchdnn_parallel_nd(MB, M, N, [&](int64_t mb, int64_t m, int64_t n) {
+        const int64_t repr_mb = tf.tile_batch ? 0 : mb;
+        const int64_t repr_m = m % panel_m;
+        const int64_t repr_n = n % panel_n;
+        const int64_t dst_off = (mb * M + m) * N + n;
+        const int64_t src_off = (repr_mb * M + repr_m) * N + repr_n;
+        if (dst_off == src_off) return;
+        dst_m.set_f32_elem(dst_off, dst_m.get_f32_elem(src_off));
+    });
+}
+
 void cvt_coo_indices_to_csr_pointers(const int32_t *indices, int32_t *pointers,
         const int nnz, const int nrows) {
     for (int i = 0; i < nnz; ++i) {
@@ -579,7 +753,11 @@ void compute_ref(const prb_t *prb, dir_t dir, const args_t &args,
                     || src_encoding == dnnl_coo || wei_encoding == dnnl_coo) {
         compute_ref_sparse_matmul(prb, args);
     } else {
-        compute_ref_matmul(prb, args);
+        const auto tf = make_tiled_fill(prb);
+        if (tf.enabled)
+            compute_ref_matmul_periodic(prb, args, tf);
+        else
+            compute_ref_matmul(prb, args);
     }
 }
 

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -474,10 +474,12 @@ static int64_t pick_panel(int64_t base, int64_t dim) {
 tiled_fill_t make_tiled_fill(const prb_t *prb) {
     tiled_fill_t t;
 
-    const int enabled_env
-            = benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0);
-    if (!enabled_env) {
-        t.reason = "env DNNL_BENCHDNN_MATMUL_PANEL_FILL is not set";
+    // Enabled via `--mode-modifier=A`. The env variable
+    // `DNNL_BENCHDNN_MATMUL_PANEL_FILL` is kept as a deprecated alias.
+    const bool enabled = has_bench_mode_modifier(mode_modifier_t::ref_periodic_fill)
+            || benchdnn_getenv_int("DNNL_BENCHDNN_MATMUL_PANEL_FILL", 0);
+    if (!enabled) {
+        t.reason = "not enabled (pass --mode-modifier=A)";
         return t;
     }
 

--- a/tests/benchdnn/matmul/ref_matmul.cpp
+++ b/tests/benchdnn/matmul/ref_matmul.cpp
@@ -502,10 +502,11 @@ tiled_fill_t make_tiled_fill(const prb_t *prb) {
         t.reason = "stochastic rounding is unsupported";
         return t;
     }
-    if (prb->attr.scales.get(DNNL_ARG_DST).is_dynamic()) {
-        t.reason = "dynamic dst scales are unsupported";
-        return t;
-    }
+    // Dynamic/derived dst scales (mx, dynamic_fp) are supported: the scale is
+    // computed per dst block from that block's values, and because the periodic
+    // output repeats with a panel-aligned period, the per-block scales are
+    // periodic too. compute_ref_matmul_periodic computes them for the
+    // representative panel and broadcasts them across the whole DST_SCALES output.
     // Binary/prelu post-ops are supported: their operands are periodized on the
     // same M/N panel grid by apply_paneled_fill (see matmul.cpp), keeping the
     // post-op result periodic.
@@ -623,6 +624,34 @@ static void compute_ref_matmul_periodic(
         if (dst_off == src_off) return;
         dst_m.set_f32_elem(dst_off, dst_m.get_f32_elem(src_off));
     });
+
+    // Phase 3: for dynamic/derived dst scales, broadcast the per-block scales
+    // computed for the representative panel across the whole DST_SCALES output.
+    // Panels are multiples of the dst scale groups, so a block's representative
+    // is `block_coord % panel_blocks` along each tiled dimension.
+    if (params.has_dst_dynamic) {
+        const int64_t Mg = params.dst_M_group;
+        const int64_t Ng = params.dst_N_group;
+        const int64_t M_chunks = div_up(M, Mg);
+        const int64_t N_chunks = div_up(N, Ng);
+        const int64_t pm_chunks = div_up(MIN2(panel_m, M), Mg);
+        const int64_t pn_chunks = div_up(MIN2(panel_n, N), Ng);
+        benchdnn_parallel_nd(MB, M_chunks, N_chunks,
+                [&](int64_t mb, int64_t mc, int64_t nc) {
+            const int64_t repr_mb = tf.tile_batch ? 0 : mb;
+            const int64_t repr_mc = mc % pm_chunks;
+            const int64_t repr_nc = nc % pn_chunks;
+            const int64_t dst_off = (mb * M + mc * Mg) * N + nc * Ng;
+            const int64_t src_off = (repr_mb * M + repr_mc * Mg) * N + repr_nc * Ng;
+            if (dst_off == src_off) return;
+            const auto d_idx = dst_m.get_idx(dst_off, params.dst_scale_mask,
+                    dst_m.ndims(), params.dst_scale_groups);
+            const auto s_idx = dst_m.get_idx(src_off, params.dst_scale_mask,
+                    dst_m.ndims(), params.dst_scale_groups);
+            params.dst_scales->set_f32_elem(
+                    d_idx, params.dst_scales->get_f32_elem(s_idx));
+        });
+    }
 }
 
 void cvt_coo_indices_to_csr_pointers(const int32_t *indices, int32_t *pointers,

--- a/tests/benchdnn/utils/bench_mode.cpp
+++ b/tests/benchdnn/utils/bench_mode.cpp
@@ -46,6 +46,7 @@ std::ostream &operator<<(std::ostream &s, mode_modifier_t modifier) {
     if (modifier == mode_modifier_t::none) s << "";
     if (has_bench_mode_modifier(mode_modifier_t::par_create)) s << "P";
     if (has_bench_mode_modifier(mode_modifier_t::no_ref_memory)) s << "M";
+    if (has_bench_mode_modifier(mode_modifier_t::ref_periodic_fill)) s << "A";
     return s;
 }
 

--- a/tests/benchdnn/utils/bench_mode.hpp
+++ b/tests/benchdnn/utils/bench_mode.hpp
@@ -51,6 +51,11 @@ enum class mode_modifier_t : unsigned {
     // Disable usage of reference memories in the flow. It removes mapping,
     // unmapping and filling functionality.
     no_ref_memory = 0x2,
+    // Accelerate the native correctness reference by filling inputs so the
+    // result is periodic along M and N, computing a single representative
+    // panel and broadcasting it. Currently honored by the matmul driver only;
+    // other drivers ignore it. Requires the native reference (`--fast-ref=false`).
+    ref_periodic_fill = 0x4,
 };
 
 mode_modifier_t operator|(mode_modifier_t lhs, mode_modifier_t rhs);

--- a/tests/benchdnn/utils/parser.cpp
+++ b/tests/benchdnn/utils/parser.cpp
@@ -1705,6 +1705,10 @@ static bool parse_mode_modifier(
               "    * `M` to disable usage of reference memory.\n"
               "          It removes any overheads for mapping, unmapping and \n"
               "          reorders used in filling functions (disabled).\n"
+              "    * `A` to accelerate the native correctness reference via a\n"
+              "          periodic (paneled) input fill. Matmul driver only;\n"
+              "          applies only when the native reference is used (no fast\n"
+              "          CPU primitive reference, or `--fast-ref=false`).\n"
               "    More details at "
             + doc_url + "benchdnn_general_info.md\n";
 
@@ -1716,6 +1720,8 @@ static bool parse_mode_modifier(
                 case 'P': modifier |= mode_modifier_t::par_create; break;
                 case 'm':
                 case 'M': modifier |= mode_modifier_t::no_ref_memory; break;
+                case 'a':
+                case 'A': modifier |= mode_modifier_t::ref_periodic_fill; break;
                 default:
                     BENCHDNN_PRINT(0, "%s\n%s",
                             "Error: modifier value is invalid.", help.c_str());


### PR DESCRIPTION
## 1. Problem
benchdnn GPU matmul correctness runs can be dominated by the CPU "golden" reference. For configs with no fast CPU primitive (e.g. `f8`/`f4`/`mx`, some weight-decompression cases) benchdnn falls back to the scalar native reference, which is `O(MB·M·N·K)`. On large layers this reference alone takes **minutes per case**, making broad sweeps impractical.

Currently, in oneDNN functional testing, we have to trim large shapes significantly (see https://github.com/uxlfoundation/oneDNN/pull/4355). While it works ok, two potential issues remain:
1) There is a chance that trimmed shapes result in other strategies were selected, hence a testing gap 
2) We need to repeat this trimming every time we add a new set of models to testing

## 2. Solution
Fill the matmul inputs so the result is **periodic** along `M` and `N` (K kept full). Both the GPU primitive and the reference then produce a periodic output, so the native reference only needs to compute one representative `panel_m × panel_n` panel and broadcast it. Reference cost drops from `O(MB·M·N·K)` to `~O(panel_m·panel_n·K)`; the GPU primitive still runs the full shape. Panel width ≥128 and aligned to dst scale/zero-point groups so no block/group quantization parameter straddles a panel boundary.

Opt-in via **`--mode-modifier=A`** (env var `DNNL_BENCHDNN_MATMUL_PANEL_FILL=1` kept as a deprecated alias). It does **not** disable `--fast-ref`: paneling engages only on the native-reference path. When a fast CPU primitive reference exists it runs the full shape vectorized and is generally faster, so paneling is skipped there to avoid regressions.

Periodic inputs can mask `M`/`N` address-arithmetic bugs, so this is opt-in and not a CI replacement for the default reference.

## 3. Implementation
- `utils/bench_mode.{hpp,cpp}`, `utils/parser.cpp`: new `mode_modifier_t::ref_periodic_fill` (`A`).
- `matmul/matmul.cpp`: `apply_paneled_fill` periodizes src/wei/bias, scales/zero-points, sum and binary/prelu post-op operands on the M/N panel grid; gated on the native path (`!prim_ref`).
- `matmul/ref_matmul.cpp`: `compute_ref_matmul_periodic` computes the representative panel and broadcasts dst values and dynamic/derived dst scales (`mx`, `dynamic_fp`).
- Supported: all dtypes, per-tensor/-channel/grouped scales & zero-points, dynamic dst scales, bias, sum, eltwise, binary/prelu post-ops, precomputed-reductions, runtime dims, batch. Falls back to the full reference for sparse/grouped, dropout, and stochastic rounding.
- Docs: `doc/driver_matmul.md`, `doc/knobs_common.md`.

## 4. Validation
Validated on Intel Arc B580 (Battlemage), OpenCL GPU runtime.
- Functional PASS across dtypes (f32/f64/bf16/f16/int8/f8/f4), quantization (per-tensor/-channel/grouped scales & zero-points, dynamic `dynamic_fp` dst scales with exact `DST_SCALES` comparison), bias, sum, eltwise, binary/prelu post-ops, precomputed-reductions, runtime dims, batched.
- Coverage analysis of a full matmul nightly (15,269 cases): ~100% of large layers (≥1G MACs) are handled; the only uncovered large cases are sparse and dropout, which are non-periodic by construction and correctly fall back.
- Fast-ref-aware gating verified: with a fast CPU reference available the modifier is a no-op (prim reference used); paneling engages only on the native path.

## 5. Performance (Intel Arc B580, layers from real LLM models, naturally native path, OFF vs ON)

These are matmul layers taken from real LLM models. Their configs (weight-decompression and `mx`/`f4` scaling) have no fast CPU primitive reference, so benchdnn naturally uses the scalar native reference — exactly the slow case this feature targets. No flags force this path; `--mode-modifier=A` is the only difference between OFF and ON. All PASS.

| Layer (M×N×K) | dtype / attrs | Wall OFF | Wall ON | Wall speedup | compute_ref OFF → ON |
|---|---|---:|---:|---:|---|
| 4096×11008×4096 | s8:u4:f16 woq (grouped wei scales+zp) + swish + binary_mul | 187.9 s | 5.6 s | **33×** | 182.8 s → 0.29 s (~630×) |
| 1009×14336×4096 | f16:u4:f16 woq (grouped wei scales+zp, fpmath=f16) | 48.2 s | 5.1 s | **9.5×** | 43.5 s → 0.12 s (~360×) |
| 14558×3072×3072 | f4_e2m1 + `mx` (e8m0) src/wei scales + bias | 196.2 s | 3.7 s | **53×** | 192.9 s → 0.29 s (~665×) |

The native reference itself speeds up ~360–665×. Since the data is periodic, the input fill was optimized to compute the reference once and broadcast it: `fill_data`'s device reorder is skipped when paneling is active (the single post-periodize reorder supplies the device data), and periodization copies whole contiguous lines with `memcpy` in parallel. The remaining ON wall time is now the single unavoidable `f32→device` reorder (the GPU still runs the full shape).