### PR TITLE
common: attr: include binary select src2 in post-op identity

### DIFF
--- a/src/common/primitive_attr.hpp
+++ b/src/common/primitive_attr.hpp
@@ -430,7 +430,10 @@ struct dnnl_post_ops {
                 case primitive_kind::binary:
                     ret = binary.alg == rhs.binary.alg
                             && binary.user_src1_desc
-                                    == rhs.binary.user_src1_desc;
+                                    == rhs.binary.user_src1_desc
+                            && IMPLICATION(is_binary_with_ternary_op(),
+                                    binary.user_src2_desc
+                                            == rhs.binary.user_src2_desc);
                     break;
                 case primitive_kind::prelu:
                     ret = prelu.mask == rhs.prelu.mask;

--- a/src/common/primitive_hashing.cpp
+++ b/src/common/primitive_hashing.cpp
@@ -314,6 +314,9 @@ size_t get_attr_hash(const primitive_attr_t &attr) {
                         seed, static_cast<size_t>(entry.binary.alg));
                 seed = hash_combine(
                         seed, get_md_hash(entry.binary.user_src1_desc));
+                if (entry.is_binary_with_ternary_op())
+                    seed = hash_combine(
+                            seed, get_md_hash(entry.binary.user_src2_desc));
                 break;
             case primitive_kind::prelu:
                 seed = hash_combine(

--- a/src/common/primitive_serialization.cpp
+++ b/src/common/primitive_serialization.cpp
@@ -197,6 +197,8 @@ void serialize(serialization_stream_t &sstream, const post_ops_t &post_ops) {
             case primitive_kind::binary:
                 sstream.append(entry.binary.alg);
                 serialize(sstream, entry.binary.user_src1_desc);
+                if (entry.is_binary_with_ternary_op())
+                    serialize(sstream, entry.binary.user_src2_desc);
                 break;
             case primitive_kind::prelu: sstream.append(entry.prelu.mask); break;
             default: assert(!"unknown post_op");

--- a/tests/gtests/internals/test_comparison_operators.cpp
+++ b/tests/gtests/internals/test_comparison_operators.cpp
@@ -116,6 +116,27 @@ HANDLE_EXCEPTIONS_FOR_TEST(comparison_operators_t, TestDepthwisePostOp) {
     TEST_SELF_COMPARISON(attr);
 }
 
+HANDLE_EXCEPTIONS_FOR_TEST(comparison_operators_t, TestBinarySelectPostOp) {
+    const memory::dims dims = {2, 3};
+    memory::desc src1_md(dims, memory::data_type::f32, memory::format_tag::ab);
+    memory::desc src2_s8_md(
+            dims, memory::data_type::s8, memory::format_tag::ab);
+    memory::desc src2_u8_md(
+            dims, memory::data_type::u8, memory::format_tag::ab);
+
+    auto make_attr = [&](const memory::desc &src2_md) {
+        post_ops ops;
+        ops.append_binary(algorithm::binary_select, src1_md, src2_md);
+        primitive_attr attr;
+        attr.set_post_ops(ops);
+        return attr;
+    };
+
+    // binary_select reads its third operand, so post-ops that differ in it
+    // describe different computations and must not compare equal.
+    ASSERT_EQ(compare(make_attr(src2_s8_md), make_attr(src2_u8_md)), false);
+}
+
 TEST(comparison_operators_t, TestBatchNormDesc) {
     auto bnorm_desc = dnnl::impl::batch_normalization_desc_t();
     bnorm_desc.batch_norm_epsilon = NAN;


### PR DESCRIPTION
# Description

The identity of a binary post-op ignores the third operand, so the primitive cache hands back a primitive that was built for a different `src2` memory descriptor.

`post_ops_t::entry_t::operator==` (src/common/primitive_attr.hpp:430) compares only `binary.alg` and `binary.user_src1_desc`, and `get_attr_hash` (src/common/primitive_hashing.cpp:312) hashes only those same two fields. `serialize` for post-ops (src/common/primitive_serialization.cpp:197) writes only those two as well. For `binary_select` the third operand is a real input to the post-op, not a spare field, so two attributes that differ only in `user_src2_desc` hash to the same value and compare equal. The primitive cache key compares and hashes attributes with those functions, so the second create returns the primitive built for the first `src2` descriptor. `get_desc_hash(const binary_desc_t &)` at src/common/primitive_hashing.cpp:393 already special-cases `binary_select` and hashes `src_desc[2]`; the post-op path was never given the same treatment.

The fix compares, hashes and serializes `user_src2_desc` when `entry.is_binary_with_ternary_op()` is true. Non-ternary binary post-ops keep ignoring `user_src2_desc`, which is what `dnnl_post_ops_append_binary_v2` documents: "If the specified algorithm is not one that requires a ternary input, src2_desc will be ignored."

#5520 carries the same three hunks (its commits 17a324a and 0ff511a) inside the avx512_core select-fusion work, but without a test for the identity itself. This PR isolates the cache-key fix and adds that regression test so it can land on its own; #5520 then rebases onto it with no conflict.

## Reproducing

Create an `eltwise_forward` with a `binary_select` post-op whose third operand is `s8`, then create the same primitive with a `u8` third operand:

```cpp
auto make = [&](memory::data_type cond_dt) {
    post_ops ops;
    ops.append_binary(algorithm::binary_select, src1,
            memory::desc({2, 3}, cond_dt, memory::format_tag::ab));
    primitive_attr attr;
    attr.set_post_ops(ops);
    return eltwise_forward(eltwise_forward::primitive_desc(eng,
            prop_kind::forward_inference, algorithm::eltwise_relu, md, md,
            0.f, 0.f, attr));
};
auto p1 = make(memory::data_type::s8);
auto p2 = make(memory::data_type::u8);
```

`dnnl_test_get_primitive_cache_size` reports 1 after both creates on main, so `p2` is the primitive built for the `s8` operand. With this change it reports 2.

## Tests

`comparison_operators_t.TestBinarySelectPostOp` in tests/gtests/internals/test_comparison_operators.cpp is the regression test. It fails on unmodified main with `compare(...) Which is: true` and passes with the change.

Everything below was run on macOS 15 arm64 with Apple clang 17, configured as `cmake -DCMAKE_BUILD_TYPE=Release -DDNNL_AARCH64_USE_ACL=OFF -DONEDNN_BUILD_GRAPH=OFF -DDNNL_BUILD_EXAMPLES=OFF -DDNNL_CPU_RUNTIME=SEQ -DDNNL_BUILD_FOR_CI=ON -DONEDNN_TEST_SET=SMOKE`, on top of 6b7f1fb.

| Target | Result |
|---|---|
| `tests/gtests/internals/test_internals` | 155 passed, 0 failed |
| `tests/gtests/test_iface_attr` | 26 passed, 2 skipped (`DepthwiseFusion`, `InnerProdBlockedWeights`, skipped on main too) |
| `tests/gtests/test_iface_primitive_cache` | 8 passed |

`.github/automation/commit-msg-check.py` and `scripts/fix_header_guards.py` both pass on the commit. I ran clang-format on the four touched files; the only version I have locally is 22, so I kept its output for the new test code and reverted the two hunks it wanted in pre-existing lines of `primitive_hashing.cpp` and `primitive_serialization.cpp` that clang-format 18 leaves alone. benchdnn was not run.

# Checklist

## General

- [x] Have you formatted the code using clang-format?

### Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a github issue or in this PR)?
- [x] Have you added relevant regression tests?

