### PR TITLE
cpu: rv64: vectorize f32 softmax max reduction with RVV

### DIFF
--- a/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
@@ -41,6 +41,9 @@ using namespace Xbyak_riscv;
 #define XF16_REDUCE_MAX_OFF(field) \
     static_cast<int32_t>(offsetof( \
             jit_rvv_softmax_xf16_reduce_max_kernel_t::call_params_t, field))
+#define F32_REDUCE_MAX_OFF(field) \
+    static_cast<int32_t>(offsetof( \
+            jit_rvv_softmax_f32_reduce_max_kernel_t::call_params_t, field))
 
 namespace {
 
@@ -76,6 +79,12 @@ template <data_type_t dt>
 void dispatch_xf16_reduce_max(
         const jit_rvv_softmax_xf16_reduce_max_kernel_t::call_params_t *p) {
     static const jit_rvv_softmax_xf16_reduce_max_kernel_t kernel(dt);
+    kernel(p);
+}
+
+void dispatch_f32_reduce_max(
+        const jit_rvv_softmax_f32_reduce_max_kernel_t::call_params_t *p) {
+    static const jit_rvv_softmax_f32_reduce_max_kernel_t kernel;
     kernel(p);
 }
 
@@ -207,6 +216,13 @@ void jit_rvv_softmax_xf16_reduce_max(data_type_t dt, const void *src, dim_t len,
         dispatch_xf16_reduce_max<data_type::f16>(&p);
 }
 
+void jit_rvv_softmax_f32_reduce_max(
+        const float *src, dim_t len, float *max_val) {
+    const jit_rvv_softmax_f32_reduce_max_kernel_t::call_params_t p {
+            src, len, max_val};
+    dispatch_f32_reduce_max(&p);
+}
+
 void jit_rvv_softmax_xf16_reduce_max_kernel_t::generate() {
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
     const Reg reg_param = a0;
@@ -299,6 +315,80 @@ void jit_rvv_softmax_xf16_reduce_max_kernel_t::generate() {
     slti(reg_has, reg_tmp, 0);
     xori(reg_has, reg_has, 1);
     sw(reg_has, reg_nan_ptr, 0);
+    ret();
+#else
+    ret();
+#endif
+}
+
+jit_rvv_softmax_f32_reduce_max_kernel_t::
+        jit_rvv_softmax_f32_reduce_max_kernel_t()
+    : jit_generator_t("jit_rvv_softmax_f32_reduce_max_kernel") {
+    create_kernel();
+}
+
+// f32 Stage-1 max reduction, mirroring jit_rvv_softmax_xf16_reduce_max. The
+// scalar loop seeds max_val with -INFINITY and only ever replaces it under
+// `val > max_val`; a NaN never wins. vfredmax_vs therefore needs its own
+// -INFINITY seed, and NaN lanes must be merged to that seed before the
+// reduction so they cannot displace a valid maximum (vfredmax alone would
+// propagate a NaN). vfredmax_vs reduces only the vl active elements, so a
+// short final chunk needs no explicit tail handling.
+void jit_rvv_softmax_f32_reduce_max_kernel_t::generate() {
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    const Reg reg_param = a0;
+    const Reg reg_src = a1;
+    const Reg reg_len = a2;
+    const Reg reg_max_ptr = a3;
+    const Reg reg_vl = t0;
+    const Reg reg_bytes = t1;
+    const Reg reg_imm = t4;
+
+    const FReg f_seed = ft1;
+    const FReg f_max = ft2;
+
+    const VReg v_x(8);
+    const VReg v_red(28);
+
+    auto load_f32_bits = [&](const FReg &freg, uint32_t bits) {
+        li(reg_imm, static_cast<int64_t>(bits));
+        fmv_w_x(freg, reg_imm);
+    };
+
+    ld(reg_src, reg_param, F32_REDUCE_MAX_OFF(src));
+    ld(reg_len, reg_param, F32_REDUCE_MAX_OFF(len));
+    ld(reg_max_ptr, reg_param, F32_REDUCE_MAX_OFF(max_val));
+
+    // Seed for the max reduction: -INFINITY (0xFF800000), matching the scalar
+    // `> max_val` loop. It only ever wins when every element is -Inf or NaN.
+    load_f32_bits(f_seed, 0xFF800000u);
+
+    // Seed the vector max accumulator with -INFINITY.
+    vsetvli(reg_vl, x0, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    vfmv_v_f(v_red, f_seed);
+
+    Label loop, finish;
+    L(loop);
+    beqz(reg_len, finish);
+
+    vsetvli(reg_vl, reg_len, SEW::e32, LMUL::m4, VTA::ta, VMA::ma);
+    vle32_v(v_x, reg_src);
+    slli(reg_bytes, reg_vl, 2);
+    add(reg_src, reg_src, reg_bytes);
+
+    // Exclude NaN lanes from the max: a NaN is x != x, and merging it to the
+    // -INFINITY seed reproduces the scalar `val > max_val` contract under
+    // which a NaN never updates max_val.
+    vmfne_vv(v0, v_x, v_x);
+    vfmerge_vfm(v_x, v_x, f_seed);
+    vfredmax_vs(v_red, v_x, v_red);
+
+    sub(reg_len, reg_len, reg_vl);
+    j_(loop);
+
+    L(finish);
+    vfmv_f_s(f_max, v_red);
+    fsw(f_max, reg_max_ptr, 0);
     ret();
 #else
     ret();

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.cpp
@@ -327,7 +327,7 @@ jit_rvv_softmax_f32_reduce_max_kernel_t::
     create_kernel();
 }
 
-// f32 Stage-1 max reduction, mirroring jit_rvv_softmax_xf16_reduce_max. The
+// f32 Stage-1 max reduction, mirroring jit_rvv_softmax_f16_reduce_max. The
 // scalar loop seeds max_val with -INFINITY and only ever replaces it under
 // `val > max_val`; a NaN never wins. vfredmax_vs therefore needs its own
 // -INFINITY seed, and NaN lanes must be merged to that seed before the

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
@@ -178,6 +178,29 @@ private:
     data_type_t dt_;
 };
 
+// f32 value-only max reduction for softmax Stage 1. Computes max(src[0..len))
+// with the scalar `val > max_val` semantics: seeded with -INFINITY and NaN
+// lanes merged to the seed so a NaN never wins the reduction. The caller keeps
+// the scalar loop for reductions shorter than one LMUL=4 e32 vector.
+struct jit_rvv_softmax_f32_reduce_max_kernel_t : public jit_generator_t {
+    struct call_params_t {
+        const float *src;
+        dim_t len;
+        float *max_val;
+    };
+
+    DECLARE_CPU_JIT_AUX_FUNCTIONS(jit_rvv_softmax_f32_reduce_max_kernel_t)
+
+    jit_rvv_softmax_f32_reduce_max_kernel_t();
+
+    void operator()(const call_params_t *p) const {
+        jit_generator_t::operator()(p);
+    }
+
+protected:
+    void generate() override;
+};
+
 void jit_rvv_softmax_xf16_affine_from_xf16(data_type_t dt, const void *src,
         void *dst, dim_t len, float sub, float mul);
 
@@ -198,6 +221,9 @@ void jit_rvv_softmax_f32_exp_sub_sum(const float *src, float *dst, dim_t len,
 
 void jit_rvv_softmax_xf16_reduce_max(data_type_t dt, const void *src, dim_t len,
         float *max_val, uint32_t *has_nan);
+
+void jit_rvv_softmax_f32_reduce_max(
+        const float *src, dim_t len, float *max_val);
 
 } // namespace rv64
 } // namespace cpu

--- a/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
+++ b/src/cpu/rv64/jit_rvv_softmax_kernel.hpp
@@ -180,8 +180,8 @@ private:
 
 // f32 value-only max reduction for softmax Stage 1. Computes max(src[0..len))
 // with the scalar `val > max_val` semantics: seeded with -INFINITY and NaN
-// lanes merged to the seed so a NaN never wins the reduction. The caller keeps
-// the scalar loop for reductions shorter than one LMUL=4 e32 vector.
+// lanes merged to the seed so a NaN never wins the reduction. The caller uses
+// a platform-tuned crossover to choose between this kernel and the scalar loop.
 struct jit_rvv_softmax_f32_reduce_max_kernel_t : public jit_generator_t {
     struct call_params_t {
         const float *src;

--- a/src/cpu/rv64/rvv_softmax.cpp
+++ b/src/cpu/rv64/rvv_softmax.cpp
@@ -43,9 +43,22 @@ namespace {
 void compute_softmax_f32_rvv(const float *src, float *dst, dim_t len,
         bool is_logsoftmax, bool is_softmax_inf_as_zero,
         const jit_rvv_softmax_affine_kernel_t *affine_kernel, bool jit_exp) {
+    // Stage 1: max reduction. Use the vector vfredmax path for reductions that
+    // fill at least one LMUL=4 e32 vector (16 elements at VLEN=128), mirroring
+    // the f16 reduce-max kernel; below that the vsetvli/vfredmax setup overhead
+    // exceeds the scalar loop. The kernel seeds -INFINITY and merges NaN lanes
+    // to the seed to reproduce the scalar `val > max_val` contract.
+    constexpr dim_t reduce_max_jit_min_len = 16;
     float max_val = -INFINITY;
-    for (dim_t i = 0; i < len; ++i)
-        max_val = src[i] > max_val ? src[i] : max_val;
+#if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
+    if (len >= reduce_max_jit_min_len) {
+        jit_rvv_softmax_f32_reduce_max(src, len, &max_val);
+    } else
+#endif
+    {
+        for (dim_t i = 0; i < len; ++i)
+            max_val = src[i] > max_val ? src[i] : max_val;
+    }
 
     if (is_logsoftmax) {
         float sum_exp = 0.f;

--- a/src/cpu/rv64/rvv_softmax.cpp
+++ b/src/cpu/rv64/rvv_softmax.cpp
@@ -21,6 +21,7 @@
 #include "common/float16.hpp"
 #include "common/nstl.hpp"
 
+#include "cpu/rv64/cpu_isa_traits.hpp"
 #include "cpu/rv64/jit_rvv_softmax_kernel.hpp"
 #include "cpu/rv64/rvv_softmax.hpp"
 
@@ -42,18 +43,15 @@ namespace {
 // or memory-bound (large-stride) reductions keep the scalar exp path.
 void compute_softmax_f32_rvv(const float *src, float *dst, dim_t len,
         bool is_logsoftmax, bool is_softmax_inf_as_zero,
-        const jit_rvv_softmax_affine_kernel_t *affine_kernel, bool jit_exp) {
-    // Stage 1: max reduction. Use the vector vfredmax path for reductions that
-    // fill at least one LMUL=4 e32 vector (16 elements at VLEN=128), mirroring
-    // the f16 reduce-max kernel; below that the vsetvli/vfredmax setup overhead
-    // exceeds the scalar loop. The kernel seeds -INFINITY and merges NaN lanes
-    // to the seed to reproduce the scalar `val > max_val` contract.
-    constexpr dim_t reduce_max_jit_min_len = 16;
+        const jit_rvv_softmax_affine_kernel_t *affine_kernel, bool jit_exp,
+        bool jit_reduce_max) {
     float max_val = -INFINITY;
 #if defined(XBYAK_RISCV_V) && XBYAK_RISCV_V == 1
-    if (len >= reduce_max_jit_min_len) {
+    if (jit_reduce_max) {
         jit_rvv_softmax_f32_reduce_max(src, len, &max_val);
     } else
+#else
+    MAYBE_UNUSED(jit_reduce_max);
 #endif
     {
         for (dim_t i = 0; i < len; ++i)
@@ -297,13 +295,22 @@ status_t rvv_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                     && rsp.axis_size >= exp_jit_min_len
                     && rsp.inner_size <= exp_jit_max_inner;
 
+            // Stage 1 max reduction. Measurements show a stable RVV benefit
+            // from 15 elements on VLEN=256, while the tested VLEN=128 system
+            // regresses even for long reductions. Query VLEN once per
+            // execution, not once per row in the hot loop. The cutoff is not
+            // VLMAX: a reduction need not fill an LMUL=4 group to be
+            // profitable.
+            const bool jit_reduce_max
+                    = get_platform_vlen() >= 256 && rsp.axis_size >= 15;
+
             if (rsp.inner_size == 1) {
                 parallel_nd(rsp.outer_size, [&](dim_t outer) {
                     const dim_t base = outer * outer_stride;
                     compute_softmax_f32_rvv(src_f32 + base, dst_f32 + base,
                             rsp.axis_size, rsp.is_logsoftmax,
                             is_softmax_inf_as_zero, affine_kernel_.get(),
-                            jit_exp);
+                            jit_exp, jit_reduce_max);
                 });
             } else {
                 auto scratch = ctx.get_scratchpad_grantor().template get<char>(
@@ -329,7 +336,7 @@ status_t rvv_softmax_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
                         // contiguous kernel (in-place)
                         compute_softmax_f32_rvv(tmp, tmp, rsp.axis_size,
                                 rsp.is_logsoftmax, is_softmax_inf_as_zero,
-                                affine_kernel_.get(), jit_exp);
+                                affine_kernel_.get(), jit_exp, jit_reduce_max);
 
                         // write back
                         for (dim_t a = 0; a < rsp.axis_size; ++a)


### PR DESCRIPTION
# cpu: rv64: vectorize f32 softmax max reduction with RVV

## Description

This PR optimizes the first-stage maximum reduction in the RV64 f32 softmax and logsoftmax implementations.

Previously, the maximum along the softmax axis was computed with a scalar loop. This change introduces an RVV JIT kernel using `vfredmax.vs`.

Measurements on both VLEN=128 and VLEN=256 systems showed that the crossover is platform-dependent, so the vector path is enabled for VLEN>=256 and reduction lengths of at least 15. VLEN=128 keeps the scalar path.

The platform VLEN is queried once per primitive execution, outside the row loop. All changes are restricted to `src/cpu/rv64`; no common oneDNN interfaces or non-RISC-V implementations are modified.

## Implementation details

The new kernel uses LMUL=4, dynamically strip-mines arbitrary lengths with `vsetvli`, and handles a final partial vector. The accumulator is initialized to negative infinity.

The scalar implementation updates the maximum only when `value > max_value`, so a NaN never replaces the current maximum. The vector kernel detects NaNs by self-comparison and merges those lanes to negative infinity before `vfredmax.vs`. This preserves the scalar behavior for normal values, NaNs, infinities, and signed zero.

## Test batches

Performance was first measured with the complete built-in oneDNN softmax CI batch. It expands to 13,888 problems:

```bash
benchdnn --mode=P --engine=cpu --softmax \
    --batch=test_softmax_ci
```

Because the complete batch includes mostly unaffected data types, backward passes, and short reductions, the 128 affected f32 forward cases from `test_softmax_ci` were also measured as a group:

```bash
benchdnn --mode=P --engine=cpu --softmax \
    --batch=test_softmax_ci_f32_fwd_affected
```

That subset is too small to characterize the reduction-length crossover, so 32 contiguous and non-contiguous softmax/logsoftmax cases were added:

```bash
benchdnn --mode=P --engine=cpu --softmax \
    --batch=rvv_softmax_lmul_sweep.batch
```

Correctness used the complete built-in batch and both focused batches with `--mode=C`.

## Performance evaluation

Tests used Release builds with OpenMP and the performance governor. Lower aggregate execution time is better.

### Aggregate official and supplemental results

| System | VLEN | Batch | Threads | Baseline (ms) | Patched (ms) | Improvement |
|---|---:|---|---:|---:|---:|---:|
| Muse Pi Pro / SpacemiT X60 | 256 | built-in `test_softmax_ci` | 1 | 9637.37 | 9533.84 | +1.07% |
| Muse Pi Pro / SpacemiT X60 | 256 | built-in `test_softmax_ci` | 8 | 7829.37 | 7717.57 | +1.43% |
| Muse Pi Pro / SpacemiT X60 | 256 | affected official cases | 1 | 23.6196 | 23.4946 | +0.53% |
| Muse Pi Pro / SpacemiT X60 | 256 | affected official cases | 8 | 49.0237 | 39.9763 | +18.46% |
| Muse Pi Pro / SpacemiT X60 | 256 | supplemental | 1 | N/A | N/A | +19.18% |
| Muse Pi Pro / SpacemiT X60 | 256 | supplemental | 8 | N/A | N/A | +10.30% |
| SG2044 | 128 | built-in `test_softmax_ci`, guarded no-op | 1 | 6563.62 | 6659.02 | -1.45% |
| SG2044 | 128 | built-in `test_softmax_ci`, guarded no-op | 8 | 4564.03 | 4544.54 | +0.43% |
| SG2044 | 128 | affected official cases, guarded no-op | 1 | 12.3091 | 11.7385 | +4.64% |
| SG2044 | 128 | affected official cases, guarded no-op | 8 | 14.0190 | 14.2869 | -1.91% |
| SG2044 | 128 | supplemental | 1 | N/A | N/A | +1.44% |
| SG2044 | 128 | supplemental | 8 | N/A | N/A | +1.73% |

The complete built-in batch improves on VLEN=256 despite containing many unaffected cases. The VLEN=128 rows exercise the guarded scalar path; their changes are run-to-run variation and are not attributed to the RVV reduction.

### Muse Pi Pro supplemental cases, single thread

| Axis length | Improvement |
|---:|---:|
| 4 | -0.37% |
| 8 | +0.73% |
| 12 | -1.18% |
| 15 | +1.88% |
| 16 | +6.70% |
| 17 | +10.64% |
| 24 | +7.77% |
| 31 | +8.61% |
| 32 | +24.80% |
| 33 | +5.77% |
| 48 | +25.79% |
| 64 | +32.87% |
| 96 | +34.65% |
| 128 | +37.97% |
| 256 | +40.83% |
| 1024 | +43.73% |

### Muse Pi Pro supplemental cases, eight threads

| Axis length | Improvement |
|---:|---:|
| 4 | +1.39% |
| 8 | -1.67% |
| 12 | -2.03% |
| 15 | +1.08% |
| 16 | +9.69% |
| 17 | +7.86% |
| 24 | +7.51% |
| 31 | +5.61% |
| 32 | +20.40% |
| 33 | +3.40% |
| 48 | +19.99% |
| 64 | +18.90% |
| 96 | +16.84% |
| 128 | +19.98% |
| 256 | +19.55% |
| 1024 | +10.47% |

The VLEN=256 vector path becomes positive around the selected crossover and reaches more than 40% improvement for long single-thread reductions.

## Correctness validation

`ctest` passed.