### PR TITLE
x64: align clang narrowing warning flags to MSVC

### DIFF
--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -96,6 +96,20 @@ if (NOT DNNL_TARGET_ARCH STREQUAL "X64" OR DNNL_X64_USE_ZEN)
     endif()
 endif()
 
+# Clang/IntelLLVM counterpart of MSVC C4244/C4267, kept enabled above for x64.
+# int-to-float is excluded: MSVC reports it at /W4 only, so it is out of parity.
+# GCC is skipped: it has no equivalent sub-flag and -Wconversion is far broader.
+if (DNNL_TARGET_ARCH STREQUAL "X64" AND NOT DNNL_X64_USE_ZEN AND NOT MSVC)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "(Apple)?[Cc]lang"
+            OR CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
+        append(CMAKE_CXX_FLAGS "-Wimplicit-int-conversion -Wshorten-64-to-32")
+        append(CMAKE_CXX_FLAGS
+            "-Wimplicit-float-conversion -Wno-implicit-int-float-conversion")
+        # Keep the diagnostics scoped to oneDNN sources.
+        include_directories(SYSTEM ${PROJECT_SOURCE_DIR}/third_party/xbyak)
+    endif()
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
     # to make computations more stable and to align the jitted code
     # with the reference one use precise division and square root

--- a/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_amx_uker.cpp
@@ -1657,7 +1657,8 @@ void jit_brgemm_amx_uker_base_t::process_output_range(
         if (bi.skip_accumulation) {
             vpxord(vreg_acc, vreg_acc, vreg_acc);
         } else if (brg.is_ace()) {
-            tilemovrow(vreg_acc, Tmm(get_C_tensor(bi, bdb, ldb)), bd);
+            tilemovrow(vreg_acc, Tmm(get_C_tensor(bi, bdb, ldb)),
+                    static_cast<uint8_t>(bd));
         } else {
             vreg_acc = bi.ldi->is_tail(ldb) ? vreg_acc | ld_tail_mask | T_z
                                             : vreg_acc;
@@ -2701,7 +2702,7 @@ void jit_brgemm_amx_uker_base_t::ace_load_A_4x16bytes(
             mov(reg_tmp_gpr, cur_mask);
             kmovq(ace_load_A_mask, reg_tmp_gpr);
             vmovdqu8(xmm_tmp | ace_load_A_mask | T_z, ptr[reg_A + cur_offset]);
-            vinserti64x2(zmm, zmm, xmm_tmp, i);
+            vinserti64x2(zmm, zmm, xmm_tmp, static_cast<uint8_t>(i));
         } else {
             // Note: bind by value; assigning through a reference to
             // ace_load_A_mask would clobber the member used above.

--- a/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
+++ b/src/cpu/x64/brgemm/jit_brgemm_kernel.cpp
@@ -2510,7 +2510,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
                             for (int bd = 0; bd < adj_bd_block; bd++) {
                                 const auto vreg_idx = accm(1, bd, 0).getIdx();
                                 const auto vreg_zmm = Zmm(vreg_idx);
-                                tilemovrow(vreg_zmm, Tmm(c_tensor), bd);
+                                tilemovrow(vreg_zmm, Tmm(c_tensor),
+                                        static_cast<uint8_t>(bd));
                             }
                         } else {
                             tilestored(ptr[reg_buf + reg_stride_ld_block],
@@ -2567,7 +2568,8 @@ void jit_brgemm_kernel_t<Wmm>::store_accumulators(int bd_block2,
                                         + (bd * brg.LDC) * brg.typesize_C;
                                 const auto vreg_zmm
                                         = Zmm(31); // Use temp register
-                                tilemovrow(vreg_zmm, tmm, bd);
+                                tilemovrow(vreg_zmm, tmm,
+                                        static_cast<uint8_t>(bd));
                                 if (is_ld_tail) {
                                     uni_vmovups(ptr[reg_aux_C + c_offset]
                                                     | ld_tail_mask | T_z,
@@ -3061,7 +3063,7 @@ void jit_brgemm_kernel_t<Wmm>::ace_load_A_4x16bytes(
         mov(reg_tmp_gpr, cur_mask);
         kmovq(ace_load_A_mask, reg_tmp_gpr);
         vmovdqu8(xmm_tmp | ace_load_A_mask | T_z, ptr[reg_A + cur_offset]);
-        vinserti64x2(zmm, zmm, xmm_tmp, i);
+        vinserti64x2(zmm, zmm, xmm_tmp, static_cast<uint8_t>(i));
     }
 }
 


### PR DESCRIPTION
Enables symmetric flags for clang compiler as it's done for MSVC https://github.com/uxlfoundation/oneDNN/pull/5890. 
Eliminates specific warnings.
These changes are beneficial for early catching compiler warnings locally with clang compiler. 
