### PR TITLE
cpu: aarch64: add ASIMD 16/32-bit transpose

### DIFF
--- a/src/cpu/aarch64/reorder/jit_uni_reorder.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2024 FUJITSU LIMITED
-* Copyright 2022-2025 Arm Ltd. and affiliates
+* Copyright 2022-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -104,14 +104,15 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
     status_t prb_init_status = prb_init(prb, *src_md, *dst_md, attr);
     if (prb_init_status != status::success) return prb_init_status;
 
-    tr::prb_block_for_cache(prb);
+    int nthr = dnnl_get_max_threads();
+    prb.plain_transpose_tile_size = select_plain_transpose_kernel(prb, nthr);
+    tr::prb_block_for_cache(prb, nthr);
     DEBUG({
         verbose_printf(
                 verbose_t::debuginfo, "cache: %s\n", prb_dump(prb).c_str());
     });
 
     int ndims_ker_max {};
-    int nthr = dnnl_get_max_threads();
     tr::prb_thread_kernel_balance(prb, ndims_ker_max, nthr);
 
     if (prb.is_tail_present) prb_node_dependency(prb);

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.cpp
@@ -99,6 +99,9 @@ status_t jit_uni_reorder_kernel_f32_t::create_kernel() {
 bool jit_uni_reorder_kernel_f32_t::simple_impl_desc_init(
         const prb_t &prb, simple_impl_desc_t *desc) {
     const int ndims = prb.ndims;
+    const int transpose_tile_size = prb.plain_transpose_tile_size;
+    const size_t len_unroll_limit
+            = transpose_tile_size == 8 ? 64 * len_unroll_max : len_unroll_max;
 
     int ndims_full_unroll = 0;
     int len_last_dim_unroll = 1;
@@ -120,11 +123,11 @@ bool jit_uni_reorder_kernel_f32_t::simple_impl_desc_init(
     } else {
         for (int d = 0; d < ndims; ++d) {
             const auto &node = prb.nodes[d];
-            if (len_unroll * node.n <= len_unroll_max) {
+            if (len_unroll * node.n <= len_unroll_limit) {
                 ndims_full_unroll++;
                 len_unroll *= node.n;
             } else {
-                len_last_dim_unroll = len_unroll_max / len_unroll;
+                len_last_dim_unroll = len_unroll_limit / len_unroll;
                 while (node.n % len_last_dim_unroll)
                     --len_last_dim_unroll;
                 len_unroll *= len_last_dim_unroll;
@@ -584,6 +587,156 @@ bool jit_uni_reorder_kernel_f32_t::process_unroll_tr8x8(
     for (int off = 0; off < len; off += step_size) {
         step(off, i_off, o_off, i_off, o_off, step_size);
         tr8x8_sve256(i_off, o_off);
+    }
+
+    return true;
+}
+
+void jit_uni_reorder_kernel_f32_t::tr8x8_asimd_32bit(int i_off, int o_off) {
+    constexpr int unroll = 8;
+
+    const int node_0_input_stride = prb_.is(0);
+    for (int i = 0; i < unroll; ++i) {
+        add_imm(X_DEFAULT_ADDR, XReg(x_ptr_in_off),
+                itype_sz_ * (i_off + i * node_0_input_stride), X_TMP_0);
+        ldp(QReg(2 * i), QReg(2 * i + 1), ptr(X_DEFAULT_ADDR));
+    }
+
+    // 2x4 transposes within pairs of rows.
+    trn1(VReg4S(16), VReg4S(0), VReg4S(2));
+    trn2(VReg4S(17), VReg4S(0), VReg4S(2));
+    trn1(VReg4S(18), VReg4S(1), VReg4S(3));
+    trn2(VReg4S(19), VReg4S(1), VReg4S(3));
+    trn1(VReg4S(20), VReg4S(4), VReg4S(6));
+    trn2(VReg4S(21), VReg4S(4), VReg4S(6));
+    trn1(VReg4S(22), VReg4S(5), VReg4S(7));
+    trn2(VReg4S(23), VReg4S(5), VReg4S(7));
+    trn1(VReg4S(24), VReg4S(8), VReg4S(10));
+    trn2(VReg4S(25), VReg4S(8), VReg4S(10));
+    trn1(VReg4S(26), VReg4S(9), VReg4S(11));
+    trn2(VReg4S(27), VReg4S(9), VReg4S(11));
+    trn1(VReg4S(28), VReg4S(12), VReg4S(14));
+    trn2(VReg4S(29), VReg4S(12), VReg4S(14));
+    trn1(VReg4S(30), VReg4S(13), VReg4S(15));
+    trn2(VReg4S(31), VReg4S(13), VReg4S(15));
+
+    // 2x2 transposes across row pairs.
+    trn1(VReg2D(0), VReg2D(16), VReg2D(20));
+    trn2(VReg2D(1), VReg2D(16), VReg2D(20));
+    trn1(VReg2D(2), VReg2D(17), VReg2D(21));
+    trn2(VReg2D(3), VReg2D(17), VReg2D(21));
+    trn1(VReg2D(4), VReg2D(18), VReg2D(22));
+    trn2(VReg2D(5), VReg2D(18), VReg2D(22));
+    trn1(VReg2D(6), VReg2D(19), VReg2D(23));
+    trn2(VReg2D(7), VReg2D(19), VReg2D(23));
+    trn1(VReg2D(8), VReg2D(24), VReg2D(28));
+    trn2(VReg2D(9), VReg2D(24), VReg2D(28));
+    trn1(VReg2D(10), VReg2D(25), VReg2D(29));
+    trn2(VReg2D(11), VReg2D(25), VReg2D(29));
+    trn1(VReg2D(12), VReg2D(26), VReg2D(30));
+    trn2(VReg2D(13), VReg2D(26), VReg2D(30));
+    trn1(VReg2D(14), VReg2D(27), VReg2D(31));
+    trn2(VReg2D(15), VReg2D(27), VReg2D(31));
+
+    const int node_1_output_stride = prb_.os(1);
+    const auto store_col = [&](int col, int lo, int hi) {
+        add_imm(X_DEFAULT_ADDR, XReg(x_ptr_out_off),
+                otype_sz_ * (o_off + col * node_1_output_stride), X_TMP_0);
+        stp(QReg(lo), QReg(hi), ptr(X_DEFAULT_ADDR));
+    };
+
+    store_col(0, 0, 8);
+    store_col(1, 2, 10);
+    store_col(2, 1, 9);
+    store_col(3, 3, 11);
+    store_col(4, 4, 12);
+    store_col(5, 6, 14);
+    store_col(6, 5, 13);
+    store_col(7, 7, 15);
+}
+
+bool jit_uni_reorder_kernel_f32_t::can_do_tr8x8_asimd_32bit() {
+    return prb_.plain_transpose_tile_size == 8 && !compensation_needed_;
+}
+
+bool jit_uni_reorder_kernel_f32_t::process_unroll_tr8x8_asimd_32bit(
+        const int ndims, const int len) {
+    if (!can_do_tr8x8_asimd_32bit()) return false;
+
+    const int step_size = prb_.n(0) * prb_.n(1);
+    if (len != step_size) return false;
+
+    int i_off = 0, o_off = 0;
+    step(0, i_off, o_off, i_off, o_off, step_size);
+
+    // Emit one tile row and loop over rows at runtime. This keeps generated
+    // code compact while avoiding per-tile loop and pointer-update overhead.
+    Label row_loop;
+    mov(X_TMP_2, prb_.n(0) / 8);
+    L(row_loop);
+    mov(X_TMP_3, x_ptr_in_off);
+    mov(X_TMP_4, x_ptr_out_off);
+    for (int j = 0; j < prb_.n(1); j += 8)
+        tr8x8_asimd_32bit(i_off + j * prb_.is(1), o_off + j * prb_.os(1));
+    add_imm(x_ptr_in_off, X_TMP_3, 8 * prb_.is(0) * itype_sz_, X_TMP_0);
+    add_imm(x_ptr_out_off, X_TMP_4, 8 * prb_.os(0) * otype_sz_, X_TMP_0);
+    subs(X_TMP_2, X_TMP_2, 1);
+    b(NE, row_loop);
+
+    add_imm(x_ptr_in_off, x_ptr_in_off, -prb_.n(0) * prb_.is(0) * itype_sz_,
+            X_TMP_0);
+    add_imm(x_ptr_out_off, x_ptr_out_off, -prb_.n(0) * prb_.os(0) * otype_sz_,
+            X_TMP_0);
+
+    return true;
+}
+
+void jit_uni_reorder_kernel_f32_t::tr4x4_asimd_16bit(int i_off, int o_off) {
+    constexpr int unroll = 4;
+
+    const int node_0_input_stride = prb_.is(0);
+    for (int i = 0; i < unroll; ++i) {
+        add_imm(X_DEFAULT_ADDR, XReg(x_ptr_in_off),
+                itype_sz_ * (i_off + i * node_0_input_stride), X_TMP_0);
+        ldr(DReg(i), ptr(X_DEFAULT_ADDR));
+    }
+
+    trn1(VReg4H(4), VReg4H(0), VReg4H(1));
+    trn2(VReg4H(5), VReg4H(0), VReg4H(1));
+    trn1(VReg4H(6), VReg4H(2), VReg4H(3));
+    trn2(VReg4H(7), VReg4H(2), VReg4H(3));
+
+    trn1(VReg2S(0), VReg2S(4), VReg2S(6));
+    trn1(VReg2S(1), VReg2S(5), VReg2S(7));
+    trn2(VReg2S(2), VReg2S(4), VReg2S(6));
+    trn2(VReg2S(3), VReg2S(5), VReg2S(7));
+
+    const int node_1_output_stride = prb_.os(1);
+    for (int i = 0; i < unroll; ++i) {
+        add_imm(X_DEFAULT_ADDR, XReg(x_ptr_out_off),
+                otype_sz_ * (o_off + i * node_1_output_stride), X_TMP_0);
+        str(DReg(i), ptr(X_DEFAULT_ADDR));
+    }
+}
+
+bool jit_uni_reorder_kernel_f32_t::can_do_tr4x4_asimd_16bit() {
+    return prb_.plain_transpose_tile_size == 4 && !compensation_needed_;
+}
+
+bool jit_uni_reorder_kernel_f32_t::process_unroll_tr4x4_asimd_16bit(
+        const int ndims, const int len) {
+    if (!can_do_tr4x4_asimd_16bit()) return false;
+
+    const int step_size = prb_.n(0) * prb_.n(1);
+    if (len != step_size) return false;
+
+    int i_off = 0, o_off = 0;
+    for (int off = 0; off < len; off += step_size) {
+        step(off, i_off, o_off, i_off, o_off, step_size);
+        for (int i = 0; i < prb_.n(0); i += 4)
+            for (int j = 0; j < prb_.n(1); j += 4)
+                tr4x4_asimd_16bit(i_off + i * prb_.is(0) + j * prb_.is(1),
+                        o_off + i * prb_.os(0) + j * prb_.os(1));
     }
 
     return true;
@@ -1469,6 +1622,8 @@ void jit_uni_reorder_kernel_f32_t::compute_ker(
     optimized = optimized || process_direct_copy<sve_256>(ndims, len_unroll)
             || process_direct_copy<asimd>(ndims, len_unroll)
             || process_unroll_tr8x8(ndims, len_unroll)
+            || process_unroll_tr8x8_asimd_32bit(ndims, len_unroll)
+            || process_unroll_tr4x4_asimd_16bit(ndims, len_unroll)
             || process_unroll_tr4x8(ndims, len_unroll);
 
     if (!optimized) process_unroll_generic(ndims, len_unroll, tail_processing);

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_kernel.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -99,6 +99,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     using ZReg = Xbyak_aarch64::ZReg;
     using ZRegS = Xbyak_aarch64::ZRegS;
     using VReg = Xbyak_aarch64::VReg;
+    using VReg2D = Xbyak_aarch64::VReg2D;
+    using VReg2S = Xbyak_aarch64::VReg2S;
+    using VReg4H = Xbyak_aarch64::VReg4H;
     using VReg4S = Xbyak_aarch64::VReg4S;
     using PReg = Xbyak_aarch64::PReg;
 
@@ -152,6 +155,18 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator_t {
     bool can_do_tr8x8();
 
     bool process_unroll_tr8x8(const int ndims, const int len);
+
+    void tr8x8_asimd_32bit(int i_off, int o_off);
+
+    bool can_do_tr8x8_asimd_32bit();
+
+    bool process_unroll_tr8x8_asimd_32bit(const int ndims, const int len);
+
+    void tr4x4_asimd_16bit(int i_off, int o_off);
+
+    bool can_do_tr4x4_asimd_16bit();
+
+    bool process_unroll_tr4x4_asimd_16bit(const int ndims, const int len);
 
     template <cpu_isa_t isa>
     bool process_direct_copy(const int ndims, const int len);

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_utils.cpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_utils.cpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -68,6 +68,43 @@ bool prb_has_small_strides(const prb_t &prb) {
         if (!small_strides) return false;
     }
     return true;
+}
+
+int select_plain_transpose_kernel(const prb_t &prb, int nthr) {
+    if (!mayiuse(asimd) || prb.ndims != 2 || prb.itype != prb.otype
+            || prb.is_tail_present || prb.req_src_zp || prb.req_dst_zp
+            || prb.req_s8s8_comp || prb.req_asymmetric_comp
+            || prb.src_scale_type != scale_type_t::NONE
+            || prb.dst_scale_type != scale_type_t::NONE || prb.beta != 0.f
+            || !utils::everyone_is<ptrdiff_t>(
+                    1, prb.nodes[0].os, prb.nodes[1].is))
+        return 0;
+
+    const int tile_size = data_type_size(prb.itype) == 4 ? 8
+            : data_type_size(prb.itype) == 2             ? 4
+                                                         : 0;
+    if (tile_size == 0 || prb.nodes[0].n % tile_size != 0
+            || prb.nodes[1].n % tile_size != 0)
+        return 0;
+    // The 16-bit transpose kernel is not safe when its problem is split
+    // between multiple driver threads. Keep using the generic JIT kernel
+    // until it can support that execution model.
+    if (tile_size == 4) return 0;
+    if (tile_size == 8 && (prb.nodes[0].n < 32 || prb.nodes[1].n < 32))
+        return 0;
+    // The 8x8 kernel is exposed to the parallel driver through 32-element
+    // cache blocks. Keeping a dimension that is not a multiple of 32 in the
+    // kernel problem can make the driver start a tile outside that problem.
+    if (tile_size == 8
+            && (prb.nodes[0].n % 32 != 0 || prb.nodes[1].n % 32 != 0))
+        return 0;
+
+    // In this orientation, a strongly asymmetric problem is faster with the
+    // generic kernel's linear traversal. The opposite orientation benefits
+    // from the tiled kernel even for extreme aspect ratios.
+    if (nthr <= 8 && prb.nodes[0].n > 8 * prb.nodes[1].n) return 0;
+
+    return tile_size;
 }
 
 /** ad-hoc structure to describe blocked memory layout */
@@ -641,7 +678,38 @@ std::string prb_dump(const prb_t &p) {
     return ss.str();
 }
 
-void prb_block_for_cache(prb_t &prb) {
+namespace {
+
+bool prb_block_for_specialized_kernel(prb_t &prb, int nthr) {
+    // Give the 32-bit transpose kernel a cache-sized 2D region so its loops
+    // amortize driver and kernel-entry overhead. Expose the outer regions to
+    // the parallel driver.
+    const bool plain_transpose
+            = prb.ndims == 2 && prb.plain_transpose_tile_size == 8;
+    if (!plain_transpose) return false;
+    size_t block = 128;
+    while (block > 32) {
+        const bool can_split
+                = prb.nodes[0].n % block == 0 && prb.nodes[1].n % block == 0;
+        const size_t parallel_regions = can_split
+                ? prb.nodes[0].n / block * (prb.nodes[1].n / block)
+                : 0;
+        if (can_split && parallel_regions >= static_cast<size_t>(nthr)) break;
+        block /= 2;
+    }
+
+    prb_node_split(prb, 0, block);
+    prb_node_split(prb, 2, block);
+    prb_node_move(prb, 1, 3);
+    prb_node_dependency(prb);
+    return true;
+}
+
+} // namespace
+
+void prb_block_for_cache(prb_t &prb, int nthr) {
+    if (prb_block_for_specialized_kernel(prb, nthr)) return;
+
     // Performance improvements when doing simple inner blocking of 8 or 4
     // This covers ab->Ba8b, ab->Ba4b, ba->Ab8a, ba->Ab4a and cdba->Acdb8a
     // Split middle node, then swap to improve cache locality
@@ -784,12 +852,15 @@ void prb_thread_kernel_balance(prb_t &prb, int &ndims_ker_max, int nthr) {
     for (int d = 0; d < prb.ndims; ++d)
         size_total *= prb.nodes[d].n;
 
+    const bool plain_32bit_tr8x8 = prb.plain_transpose_tile_size == 8;
+
     /* The general expression for size_drv_thr can be written as
      * size_drv_min = C0 + FC * (nthr > 1 ? 1 : 0) + VC * (nthr - 1)
      * where FC and VC are fixed and variable costs respectively.
      * Though for now, the below heuristic seems to be good enough */
     // Note: direct copy needs only as many kernels as nthr.
     const size_t size_drv_thr = is_direct_copy(prb) ? nthr
+            : plain_32bit_tr8x8                     ? nthr
             : (nthr > 1)                            ? 16 * nthr
                                                     : 1;
 

--- a/src/cpu/aarch64/reorder/jit_uni_reorder_utils.hpp
+++ b/src/cpu/aarch64/reorder/jit_uni_reorder_utils.hpp
@@ -1,7 +1,7 @@
 /*******************************************************************************
 * Copyright 2018 Intel Corporation
 * Copyright 2020-2023 FUJITSU LIMITED
-* Copyright 2022, 2025 Arm Ltd. and affiliates
+* Copyright 2022, 2025-2026 Arm Ltd. and affiliates
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -118,9 +118,14 @@ struct prb_t {
     bool req_asymmetric_comp = false;
     bool req_src_zp = false;
     bool req_dst_zp = false;
+    int plain_transpose_tile_size = 0;
 };
 
 bool prb_has_small_strides(const prb_t &prb);
+
+/** Selects an ASIMD plain-transpose kernel and returns its tile size, or zero
+ * to use the generic kernel. */
+int select_plain_transpose_kernel(const prb_t &prb, int nthr);
 
 status_t prb_init(prb_t &prb, const memory_desc_t &imd,
         const memory_desc_t &omd, const primitive_attr_t *attr);
@@ -151,7 +156,7 @@ bool prb_has_small_strides(const prb_t &prb);
 /** dumps the problem to a string */
 std::string prb_dump(const prb_t &p);
 
-void prb_block_for_cache(prb_t &prb);
+void prb_block_for_cache(prb_t &prb, int nthr);
 
 /** finds the maximum number of dimension the kernel should process and
  * optionally splits one of the dimension to achieve better balance between


### PR DESCRIPTION
# Description

Add an bit unrolled ASIMD transpose, speeding up transpose on Graviton 4 by ~2x for big shapes. (Note that red is good on below graph.)

<img width="1342" height="1081" alt="asimd transpose" src="https://github.com/user-attachments/assets/896244bb-98e9-408b-a15a-36a62153e1db" />

# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [x] Have you submitted performance data that demonstrates performance improvements?

