### PR TITLE
benchdnn: brgemm: eliminate size_t narrowing conversion

### DIFF
--- a/tests/benchdnn/brgemm/brgemm.cpp
+++ b/tests/benchdnn/brgemm/brgemm.cpp
@@ -635,7 +635,7 @@ void init_memory_args(
     const int dt_multiplier
             = prb->wei_dt() == dnnl_f16 && !kernel_args.need_pack_
             ? 1
-            : 4 / dnnl_data_type_size(prb->wei_dt());
+            : static_cast<int>(4 / dnnl_data_type_size(prb->wei_dt()));
 
     int multiplier = 1;
     if (kernel_args.need_pack_) {


### PR DESCRIPTION
Fixes [MFDNN-15550](https://jira.devtools.intel.com/browse/MFDNN-15550). 
pragma disabling C4267 was removed in `cpu_isa_traits.hpp` which is imported in benchdnn. 