### PR TITLE
cpu: x64: zen: add f16 matmul and weight prepack support

### DIFF
--- a/src/cpu/reorder/cpu_reorder_regular_f16.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f16.cpp
@@ -26,6 +26,7 @@ const impl_list_map_t &regular_f16_impl_list_map() {
     static const impl_list_map_t the_map = REG_REORDER_P({
         // f16 ->
         {{f16, data_type::undef, 0}, {
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
             DNNL_AARCH64_ONLY(REG_SR_DIRECT_COPY(f16, f16))
 
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_copy_reorder_t))

--- a/src/cpu/reorder/cpu_reorder_regular_f32_f16.cpp
+++ b/src/cpu/reorder/cpu_reorder_regular_f32_f16.cpp
@@ -27,6 +27,7 @@ const impl_list_map_t &regular_f32_f16_impl_list_map() {
     static const impl_list_map_t the_map = REG_REORDER_P({
         // f32 -> f16
         {{f32, f16, 0}, {
+            DNNL_X64_ZEN(CPU_REORDER_INSTANCE(x64::zen::reorder::zen_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_direct_copy_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_blk_reorder_t))
             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_uni_reorder_t))

--- a/src/cpu/x64/zen64/matmul/zen_matmul.cpp
+++ b/src/cpu/x64/zen64/matmul/zen_matmul.cpp
@@ -162,16 +162,41 @@ status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
     //  1. Uniform f32:  f32 src, f32 wei, f32 dst
     //  2. Uniform bf16: bf16 src, bf16 wei, bf16 dst
     //  3. bf16 mixed:   bf16 src, bf16 wei, f32 dst
-    // Explicitly unsupported: f32 src with bf16 dst.
+    //  4. Uniform f16:  f16 src, f16 wei, f16 dst  (AVX512-FP16, acc-mode f16/any)
+    //  5. f16 mixed:    f16 src, f16 wei, f32 dst   (AVX512-FP16, acc-mode f16/any)
+    // Explicitly unsupported: f32 src with bf16/f16 dst.
     // int8 static quant is handled by the dedicated zen_lowp_matmul_t impl.
     const bool all_f32 = utils::everyone_is(f32, src_dt, wei_dt, dst_dt);
     const bool all_bf16 = utils::everyone_is(bf16, src_dt, wei_dt, dst_dt);
     const bool bf16_mixed
             = utils::everyone_is(bf16, src_dt, wei_dt) && dst_dt == f32;
-    VDISPATCH_MATMUL(utils::one_of(true, all_f32, all_bf16, bf16_mixed),
+    const bool all_f16 = utils::everyone_is(f16, src_dt, wei_dt, dst_dt);
+    const bool f16_mixed
+            = utils::everyone_is(f16, src_dt, wei_dt) && dst_dt == f32;
+    VDISPATCH_MATMUL(utils::one_of(true, all_f32, all_bf16, bf16_mixed, all_f16,
+                             f16_mixed),
             VERBOSE_UNSUPPORTED_DT_CFG);
+    // Accumulation mode must match what ZenDNN/AOCL-DLP can execute for each
+    // config. oneDNN keeps desc()->accum_data_type at the library default (f32
+    // for f16 tensors); the user's choice is attr()->acc_mode_ (e.g. benchdnn
+    // --attr-acc-mode=f16). Both uniform f16 (f16f16f16of16) and mixed
+    // f16->f32 (f16f16f16of32) use native FP16 matmul accumulation on DLP;
+    // accept f16 configs when acc-mode is f16 or any (fastest/low-precision
+    // accumulation allowed). Default strict/f32 accumulation is left to brgemm.
+    const auto acc_mode = attr()->acc_mode_;
+    const bool is_f16_gemm = all_f16 || f16_mixed;
+    const bool f16_acc_mode_ok = utils::one_of(
+            acc_mode, accumulation_mode::f16, accumulation_mode::any);
+    const bool acc_mode_ok = IMPLICATION(is_f16_gemm, f16_acc_mode_ok)
+            && IMPLICATION(all_f32 || all_bf16 || bf16_mixed,
+                    acc_mode != accumulation_mode::f16
+                            && acc_mode != accumulation_mode::s32);
+    VDISPATCH_MATMUL(acc_mode_ok, VERBOSE_UNSUPPORTED_ATTR);
+    // F16 requires AVX512-FP16 (Zen5+). Gate here so f32/bf16 configs on
+    // Zen4 still dispatch to this impl without needing FP16 ISA.
     VDISPATCH_MATMUL(
-            desc()->accum_data_type == f32, VERBOSE_UNSUPPORTED_DT_CFG);
+            IMPLICATION(all_f16 || f16_mixed, mayiuse(avx512_core_fp16)),
+            VERBOSE_UNSUPPORTED_ISA);
 
     // ---- Bias validation ----
     // Zen supports bias with matching/compatible dtypes;
@@ -181,16 +206,21 @@ status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
         const auto bia_dt = weights_md(1)->data_type;
         const bool bia_dt_ok = IMPLICATION(all_f32, bia_dt == f32)
                 && IMPLICATION(all_bf16 || bf16_mixed,
-                        utils::one_of(bia_dt, bf16, f32));
+                        utils::one_of(bia_dt, bf16, f32))
+                && IMPLICATION(
+                        all_f16 || f16_mixed, utils::one_of(bia_dt, f16, f32));
         return bia_dt_ok && is_bias_1xN();
     };
     VDISPATCH_MATMUL(check_bias(), VERBOSE_UNSUPPORTED_BIAS_CFG);
 
     // ---- Attribute validation ----
-    // For f32/bf16: post-ops (eltwise + binary + sum) are supported;
-    // fpmath_mode, scales and zero-points must be default.
-    VDISPATCH_MATMUL(attr()->has_default_values(
-                             smask_t::post_ops | smask_t::sum_dt, dst_dt),
+    // For f32/bf16/f16: post-ops (eltwise + binary + sum) are supported;
+    // fpmath_mode, scales and zero-points must be default. accumulation_mode
+    // is validated explicitly above (f16 configs require acc-mode f16 or any).
+    VDISPATCH_MATMUL(
+            attr()->has_default_values(smask_t::post_ops | smask_t::sum_dt
+                            | smask_t::accumulation_mode,
+                    dst_dt),
             VERBOSE_UNSUPPORTED_ATTR);
 
     // Sum-consistency check (catches sum.dt != dst_dt precision bugs).
@@ -243,7 +273,11 @@ status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
                 if (!utils::one_of(entry.binary.alg, binary_add, binary_mul))
                     return false;
                 const auto src1_dt = entry.binary.src1_desc.data_type;
-                if (!utils::one_of(src1_dt, f32, bf16)) return false;
+                if (!utils::one_of(src1_dt, f32, bf16, f16)) return false;
+                // F16 binary operands require AVX512-FP16 (Zen5+); without it
+                // the runtime cannot allocate/process f16 post-op buffers even
+                // when the matmul itself is f32/bf16.
+                if (src1_dt == f16 && !mayiuse(avx512_core_fp16)) return false;
             } else {
                 // Unsupported post-op kind.
                 return false;
@@ -254,7 +288,7 @@ status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
     VDISPATCH_MATMUL(check_postops(), VERBOSE_UNSUPPORTED_POSTOP);
 
     // ---- Scales / zero-points validation ----
-    // f32/bf16 path does not support scales or zero-points.
+    // f32/bf16/f16 path does not support scales or zero-points.
     VDISPATCH_MATMUL(attr()->scales_.has_default_values(),
             VERBOSE_UNSUPPORTED_SCALES_CFG);
     VDISPATCH_MATMUL(attr()->zero_points_.has_default_values(),
@@ -265,7 +299,7 @@ status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
     VDISPATCH_MATMUL(
             !has_runtime_dims_or_strides(), VERBOSE_RUNTIMEDIM_UNSUPPORTED);
 
-    // Zen f32/bf16 matmul: prepack path. When the framework leaves the
+    // Zen f32/bf16/f16 matmul: prepack path. When the framework leaves the
     // weights layout open (format_any) we advertise the dedicated opaque
     // `format_kind::zen_packed` weights format. The bytes are produced by
     // zen_reorder_t (the Zen backend packer) and consumed directly by the
@@ -293,7 +327,7 @@ status_t zen_matmul_t::pd_t::init(const engine_t *engine) {
     // produced by zen_reorder_t and consumed here with mem_format_b='r' plus a
     // per-slice batch_stride_wei.
     bool wei_zen_packed = wei_already_packed;
-    if (wei_format_any && (wei_dt == bf16 || wei_dt == f32)) {
+    if (wei_format_any && utils::one_of(wei_dt, f32, bf16, f16)) {
         VDISPATCH_MATMUL_SC(zen::init_zen_packed_md(weights_md_, src_dt, K(),
                                     N(), is_batched ? wei_batch : 1),
                 VERBOSE_UNSUPPORTED_TAG);
@@ -533,6 +567,7 @@ status_t zen_matmul_t::init(engine_t *engine) {
             switch (entry.binary.src1_desc.data_type) {
                 case f32: lpo.dtype = zd::f32; break;
                 case bf16: lpo.dtype = zd::bf16; break;
+                case f16: lpo.dtype = zd::f16; break;
                 default: return status::runtime_error;
             }
             const auto &src1_desc = entry.binary.src1_desc;
@@ -586,7 +621,10 @@ status_t zen_matmul_direct(data_type_t src_dt, data_type_t wei_dt,
     params.dtypes.wei = to_zen_dt(wei_dt);
     params.dtypes.dst = to_zen_dt(dst_dt);
     params.dtypes.bias = (bias ? to_zen_dt(bia_dt) : zd::none);
-    params.dtypes.compute = zd::f32; // always accumulate in f32
+    // pd_t::init accepts f16 src/wei only with acc-mode f16 or any (uniform and
+    // mixed); GEMM backend accumulates the matmul product in native FP16 only.
+    params.dtypes.compute
+            = utils::everyone_is(f16, src_dt, wei_dt) ? zd::f16 : zd::f32;
 
     // 'r' = pre-packed, 'n' = plain weights;
     params.mem_format_b = mem_format_b;

--- a/src/cpu/x64/zen64/matmul/zen_matmul.hpp
+++ b/src/cpu/x64/zen64/matmul/zen_matmul.hpp
@@ -44,7 +44,7 @@ struct zen_matmul_t : public primitive_t {
     struct pd_t : public ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
         using ::dnnl::impl::cpu::matmul::cpu_matmul_pd_t::cpu_matmul_pd_t;
 
-        DECLARE_COMMON_PD_T("zen:matmul:f32|bf16:amd", zen_matmul_t);
+        DECLARE_COMMON_PD_T("zen:matmul:f32|bf16|f16:amd", zen_matmul_t);
 
         status_t init(const engine_t *engine);
     };

--- a/src/cpu/x64/zen64/reorder/zen_reorder.cpp
+++ b/src/cpu/x64/zen64/reorder/zen_reorder.cpp
@@ -59,7 +59,7 @@ using zendnnl::ops::matmul_algo_t;
 
 // Zen weight prepack via reorder_direct (is_prepack=true); see
 // ZenDNN/zendnnl/src/lowoha_operators/reorder/lowoha_reorder.hpp.
-// src_dt is the matmul source dtype: for f32/bf16 it equals wei_dt, but for
+// src_dt is the matmul source dtype: for f32/bf16/f16 it equals wei_dt, but for
 // int8 configs it may differ (e.g. u8 source with s8 weights), and the AOCL-DLP
 // blocked layout can depend on it, so it is passed explicitly.
 status_t zen_weight_prepack(const void *src, void *dst, zd wei_dt, zd src_dt,
@@ -92,6 +92,24 @@ status_t f32_to_bf16_plain(const void *src, void *dst, int64_t K, int64_t N,
     zendnnl::lowoha::reorder::reorder_params_t rp;
     rp.src_dtype = zd::f32;
     rp.dst_dtype = zd::bf16;
+    rp.src_shape = {K, N};
+    rp.dst_shape = {K, N};
+    if (src_is_ab)
+        rp.src_strides = {ldb, 1};
+    else
+        rp.src_strides = {1, ldb};
+
+    return to_dnnl_status(
+            zendnnl::lowoha::reorder::reorder_direct(src, dst, rp));
+}
+
+// Plain f32 -> f16 element conversion (standard reorder_direct path).
+// Same contract as f32_to_bf16_plain() above.
+status_t f32_to_f16_plain(const void *src, void *dst, int64_t K, int64_t N,
+        int64_t ldb, bool src_is_ab) {
+    zendnnl::lowoha::reorder::reorder_params_t rp;
+    rp.src_dtype = zd::f32;
+    rp.dst_dtype = zd::f16;
     rp.src_shape = {K, N};
     rp.dst_shape = {K, N};
     if (src_is_ab)
@@ -182,7 +200,8 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
             ::dnnl::impl::cpu::x64::cpu().has(Xbyak::util::Cpu::tAMD),
             "This implementation only supports AMD CPUs");
 
-    // Zen weight prepack requires AVX-512 core support regardless of data type.
+    // Zen weight prepack requires AVX-512 core support for f32/bf16. F16
+    // prepack additionally requires avx512_core_fp16 (AVX512-FP16, Zen5+).
     VDISPATCH_REORDER_IC(mayiuse(avx512_core), VERBOSE_UNSUPPORTED_ISA);
 
     const memory_desc_wrapper id(src_md_), od(dst_md_);
@@ -199,9 +218,12 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
     const auto type_o = od.data_type();
     // Supported dtype combos:
     //   bf16 -> bf16  : reorder_direct prepack (Zen blocked algo)
+    //   f16  -> f16   : reorder_direct prepack (Zen blocked algo)
     //   f32  -> f32   : reorder_direct prepack (Zen blocked algo)
     //   f32  -> bf16  : f32->bf16 plain reorder_direct, then bf16 prepack
     //                   (avoids the backend f32->bf16 fringe-N bug; see execute)
+    //   f32  -> f16   : f32->f16 plain reorder_direct, then f16 prepack
+    //                   (same two-step pattern as f32->bf16)
     //   s8   -> s8    : int8 static-quant weight prepack (Zen blocked algo)
     //   f32  -> s8    : f32->s8 plain cast, then s8 prepack (for callers that
     //                   keep integer-valued weights in f32, e.g. benchdnn)
@@ -211,8 +233,10 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
     //                   that keep integer-valued 4-bit codes in f32, e.g.
     //                   benchdnn)
     const bool dt_ok = (type_i == data_type::bf16 && type_o == data_type::bf16)
+            || (type_i == data_type::f16 && type_o == data_type::f16)
             || (type_i == data_type::f32 && type_o == data_type::f32)
             || (type_i == data_type::f32 && type_o == data_type::bf16)
+            || (type_i == data_type::f32 && type_o == data_type::f16)
             || (type_i == data_type::s8 && type_o == data_type::s8)
             || (type_i == data_type::f32 && type_o == data_type::s8)
             || (type_i == data_type::s4 && type_o == data_type::s4)
@@ -220,6 +244,9 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
             || (type_i == data_type::f32
                     && utils::one_of(type_o, data_type::s4, data_type::u4));
     VDISPATCH_REORDER_IC(dt_ok, VERBOSE_UNSUPPORTED_DT);
+    VDISPATCH_REORDER_IC(
+            IMPLICATION(type_o == data_type::f16, mayiuse(avx512_core_fp16)),
+            VERBOSE_UNSUPPORTED_ISA);
 
     // Dispatch trigger: only fire when the dst uses the dedicated opaque
     // Zen packed format; otherwise let the regular reorder list handle it.
@@ -312,7 +339,7 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
     const auto &zpd = od.zen_packed_desc();
     // The per-slice packed size can depend on the matmul source dtype (recorded
     // in the packed descriptor as gemm_src_dt), so query with
-    // (wei=type_o, src=gemm_src_dt) -- for f32/bf16 gemm_src_dt == type_o.
+    // (wei=type_o, src=gemm_src_dt) -- for f32/bf16/f16 gemm_src_dt == type_o.
     const dim_t expected_per_slice
             = zen_prepack_size(type_o, zpd.gemm_src_dt, K, N);
     VDISPATCH_REORDER_IC(expected_per_slice > 0
@@ -331,17 +358,17 @@ status_t zen_reorder_t::pd_t::init(const engine_t *engine,
             zpd.size == zpd.per_slice_size * batch_sz && od.size() == zpd.size,
             VERBOSE_INCONSISTENT_MDS, "dst", "packed-size");
 
-    // The f32 -> {bf16, s8, s4, u4} prepack paths need a per-slice K*N
-    // conversion buffer (bf16 = 2 bytes/elem, s8 = 1 byte/elem, s4/u4 =
+    // The f32 -> {bf16, f16, s8, s4, u4} prepack paths need a per-slice K*N
+    // conversion buffer (bf16/f16 = 2 bytes/elem, s8 = 1 byte/elem, s4/u4 =
     // 2 elems/byte). Book it on the primitive scratchpad (declared here,
     // consumed in execute() via the grantor), reused across batches so
     // execution stays allocation-free.
     if (type_i == data_type::f32
-            && utils::one_of(type_o, data_type::bf16, data_type::s8,
-                    data_type::s4, data_type::u4)) {
+            && utils::one_of(type_o, data_type::bf16, data_type::f16,
+                    data_type::s8, data_type::s4, data_type::u4)) {
         const size_t nelems = static_cast<size_t>(K) * static_cast<size_t>(N);
         size_t conv_bytes;
-        if (type_o == data_type::bf16)
+        if (utils::one_of(type_o, data_type::bf16, data_type::f16))
             conv_bytes = nelems * sizeof(int16_t);
         else if (type_o == data_type::s8)
             conv_bytes = nelems * sizeof(int8_t);
@@ -435,19 +462,19 @@ status_t zen_reorder_t::execute(const exec_ctx_t &ctx) const {
     const auto *src_base = CTX_IN_MEM(const uint8_t *, DNNL_ARG_FROM);
     auto *dst_base = CTX_OUT_MEM(uint8_t *, DNNL_ARG_TO);
 
-    // f32 -> {bf16, s8, s4, u4} prepack needs a per-slice conversion buffer
-    // (booked in pd_t::init), reused across batches so execute() stays
+    // f32 -> {bf16, f16, s8, s4, u4} prepack needs a per-slice conversion
+    // buffer (booked in pd_t::init), reused across batches so execute() stays
     // allocation-free.
     void *conv = nullptr;
     if (src_dt == data_type::f32
-            && utils::one_of(dst_dt, data_type::bf16, data_type::s8,
-                    data_type::s4, data_type::u4)) {
+            && utils::one_of(dst_dt, data_type::bf16, data_type::f16,
+                    data_type::s8, data_type::s4, data_type::u4)) {
         conv = ctx.get_scratchpad_grantor().get<void>(
                 memory_tracking::names::key_reorder_space);
         if (conv == nullptr) return status::out_of_memory;
     }
 
-    // The matmul source dtype (u8/s8 for int8; f32/bf16 otherwise) is recorded
+    // The matmul source dtype (u8/s8 for int8; f32/bf16/f16 otherwise) is recorded
     // in the packed descriptor; the AOCL-DLP blocked layout can depend on it,
     // so forward it explicitly to the packer.
     const zd gemm_src = to_zen_dt(dst_d.zen_packed_desc().gemm_src_dt);
@@ -457,6 +484,10 @@ status_t zen_reorder_t::execute(const exec_ctx_t &ctx) const {
         if (src_dt == data_type::bf16 && dst_dt == data_type::bf16)
             return zen_weight_prepack(
                     src, dst, zd::bf16, zd::bf16, K, N, ldb, transposed);
+
+        if (src_dt == data_type::f16 && dst_dt == data_type::f16)
+            return zen_weight_prepack(
+                    src, dst, zd::f16, zd::f16, K, N, ldb, transposed);
 
         if (src_dt == data_type::f32 && dst_dt == data_type::f32)
             return zen_weight_prepack(
@@ -481,6 +512,17 @@ status_t zen_reorder_t::execute(const exec_ctx_t &ctx) const {
             status_t st = f32_to_bf16_plain(src, conv, K, N, ldb, src_is_ab);
             if (st == success)
                 st = zen_weight_prepack(conv, dst, zd::bf16, zd::bf16, K, N,
+                        /*ldb=*/N, /*transposed=*/false);
+            return st;
+        }
+
+        if (src_dt == data_type::f32 && dst_dt == data_type::f16) {
+            // Convert f32 -> plain f16 (contiguous `ab`), then prepack that
+            // f16 slice into the Zen blocked layout (same two-step pattern as
+            // f32->bf16).
+            status_t st = f32_to_f16_plain(src, conv, K, N, ldb, src_is_ab);
+            if (st == success)
+                st = zen_weight_prepack(conv, dst, zd::f16, zd::f16, K, N,
                         /*ldb=*/N, /*transposed=*/false);
             return st;
         }

--- a/tests/benchdnn/inputs/matmul/test_matmul_float16
+++ b/tests/benchdnn/inputs/matmul/test_matmul_float16
@@ -79,4 +79,12 @@
 2x20x30:2x30x4
 2x20x30:1x30x4
 
+# accumulation mode any
+--reset
+--skip-impl=ref
+--attr-acc-mode=any
+--dt=f16:f16:f32,f16
+--stag=ab,ba --wtag=ab,ba --dtag=ab
+--batch=shapes_2d
+
 --batch=harness_matmul_regression


### PR DESCRIPTION
Gate uniform f16 on native F16 accumulation (accum_type=f16) and AVX512-FP16; extend zen_reorder for prepack and register it in the f16 reorder impl list.


# Checklist

## General

- [x] Do all unit and benchdnn tests (`make test` and `make test_benchdnn_*`) pass locally for each commit?
- [x] Have you formatted the code using clang-format?

## Performance improvements

- [ ] Have you submitted performance data that demonstrates performance improvements?

### New features

- [ ] Have you published an RFC for the new feature?
- [ ] Was the RFC approved?
- [x] Have you added relevant tests?
