### PR TITLE
xe: gemm: jit: refactor and consolidate C caching update

### DIFF
--- a/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.cxx
@@ -114,11 +114,7 @@ void Generator<hw>::gemmStoreZeroC(GEMMProblem problem, GEMMStrategy strategy, G
 
     if (state.useTempC) {
         gemmRedirectToTempC(problem, strategy, state);
-        for (auto *s: {&strategy.C, &strategy.CO, &state.Cext_strategy}) {
-            s->atomic = false;
-            s->cachingW = CacheSettingsLSC::L1UC_L3WB;
-        }
-        setCCachingW(strategy, state, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB);
+        setCCachingW(strategy, state, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB, false);
     }
 
     auto collapse = [&](RegisterLayout &layout) {
@@ -203,11 +199,7 @@ void Generator<hw>::gemmFusedBetaScale(GEMMProblem problem, GEMMStrategy strateg
     auto &beta = problem.beta;
     bool checkBeta0 = !beta.fixed();
 
-    for (auto *s: {&strategy.C, &strategy.CO, &state.Cext_strategy}) {
-        s->atomic = false;
-        s->cachingW = CacheSettingsLSC::L1UC_L3WB;
-    }
-    setCCachingW(strategy, state, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB);
+    setCCachingW(strategy, state, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB, false);
 
     bool nested = true;
     std::swap(nested, state.isNested);
@@ -468,11 +460,7 @@ bool Generator<hw>::gemmFusedPostOpsFinalize(Label &labelLateExit, GEMMProblem &
 
         and_(1 | nz | state.flagAP, null.ud(), state.inputs.flags, FlagDidBeta);
         jmpi(1 | ~state.flagAP, lTileAccumulate);
-        for (auto *s: {&strategy0.C, &strategy0.CO, &state0.Cext_strategy}) {
-            s->atomic = false;
-            s->cachingW = CacheSettingsLSC::L1UC_L3WB;
-        }
-        setCCachingW(strategy0, state0, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB);
+        setCCachingW(strategy0, state0, CacheSettingsLSC::L1UC_L3WB, CacheSettingsLSC::L1UC_L3WB, false);
         if (!gemmAccessC(COperation::Store, modProblem, strategy0, state0)) return false;
         jmpi(1, labelSkipCUpdate);
         mark(lTileAccumulate);

--- a/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.hpp
+++ b/src/gpu/intel/gemm/jit/generator/pieces/atomic_fusions.hpp
@@ -40,9 +40,10 @@ inline int tempCWGStride(const GEMMProblem &problem, const GEMMStrategy &strateg
     return tempCThreadStride(problem, strategy) * strategy.wg[LoopM] * strategy.wg[LoopN];
 }
 
-// Set C write cache policy; layouts hold their own copy of the addressing strategy, so update those too.
-inline void setCCachingW(GEMMStrategy &strategy, GEMMState &state, ngen::CacheSettingsLSC caching, ngen::CacheSettingsLSC cachingExt)
+// Set C atomic/write cache policy; layouts hold their own copy of the addressing strategy, so update those too.
+inline void setCCachingW(GEMMStrategy &strategy, GEMMState &state, ngen::CacheSettingsLSC caching, ngen::CacheSettingsLSC cachingExt, bool atomic)
 {
+    strategy.C.atomic = strategy.CO.atomic = state.Cext_strategy.atomic = atomic;
     strategy.C.cachingW = caching;
     state.Cext_strategy.cachingW = cachingExt;
     state.C_layout.addressingStrategy().cachingW = caching;

--- a/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
+++ b/src/gpu/intel/gemm/jit/generator/pieces/c_update.cxx
@@ -563,7 +563,7 @@ bool Generator<hw>::gemmUpdateCDispatch(GEMMProblem &problem, GEMMStrategy &stra
     checkUC = checkUC && (C_l1UCW != strategy.C.cachingW || Ce_l1UCW != state.Cext_strategy.cachingW);
 
     if (strategy.altFusedBeta && !checkUC && !strategy.fusePostOps)
-        setCCachingW(strategy, state, C_l1UCW, Ce_l1UCW);
+        setCCachingW(strategy, state, C_l1UCW, Ce_l1UCW, strategy.C.atomic);
 
     // Generate the various paths needed.
     if (!checkBeta0 && !checkBeta1 && !checkTRMMBeta1 && !checkUC) {
@@ -642,7 +642,7 @@ bool Generator<hw>::gemmUpdateCDispatch(GEMMProblem &problem, GEMMStrategy &stra
             substrategy.C.atomic = substrategy.CO.atomic = false;
             substate.Cext_strategy.atomic = false;
             if (checkUC)
-                setCCachingW(substrategy, substate, C_l1UCW, Ce_l1UCW);
+                setCCachingW(substrategy, substate, C_l1UCW, Ce_l1UCW, false);
 
             if (!gemmUpdateC(subproblem, substrategy, substate)) return false;
         }
@@ -686,7 +686,7 @@ bool Generator<hw>::gemmUpdateCDispatch(GEMMProblem &problem, GEMMStrategy &stra
             subproblem.beta = 0;
             subproblem.removeFinalSumPostOp();
             if (checkUC)
-                setCCachingW(substrategy, substate, C_l1UCW, Ce_l1UCW);
+                setCCachingW(substrategy, substate, C_l1UCW, Ce_l1UCW, false);
 
             substrategy.C.atomic = substrategy.CO.atomic = false;
             substate.Cext_strategy.atomic = false;


### PR DESCRIPTION
This is a follow-up after https://github.com/uxlfoundation/oneDNN/commit/6183d823e909bf20f8eed15ab95dae2fb7f6888c.

Atomics require `L1UC_L3C` caching so when atomics and stores are used together, stores require a force update to align the caching policy. The PR refactors the original fix, no functional changes expected.